### PR TITLE
[FIX] l10n_es_edi_verifactu_pos:  ensure qr-code is present on order reprint

### DIFF
--- a/addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -23,12 +23,8 @@ patch(PaymentScreen.prototype, {
 
     async _postPushOrderResolve(order, order_server_ids) {
         if (this.pos.config.l10n_es_edi_verifactu_required) {
-            const [orderRead] = await this.orm.read(
-                'pos.order',
-                order_server_ids,
-                ['l10n_es_edi_verifactu_qr_code'],
-            );
-            order.l10n_es_edi_verifactu_qr_code = orderRead.l10n_es_edi_verifactu_qr_code;
+            const [res] = await this.pos.selectedOrder.fetch_l10n_es_edi_verifactu_qr_code(order_server_ids);
+            order.l10n_es_edi_verifactu_qr_code = res.l10n_es_edi_verifactu_qr_code;
         }
         return super._postPushOrderResolve(...arguments);
     },

--- a/addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/reprint_receipt_button/reprint_receipt_button.js
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/overrides/components/reprint_receipt_button/reprint_receipt_button.js
@@ -1,0 +1,17 @@
+/** @odoo-module */
+
+import { patch } from "@web/core/utils/patch";
+import { ReprintReceiptButton } from "@point_of_sale/app/screens/ticket_screen/reprint_receipt_button/reprint_receipt_button";
+
+patch(ReprintReceiptButton.prototype, {
+    //@override
+    async click() {
+        if (!this.props.order) {
+            return;
+        }
+        const order = this.props.order;
+        const [res] = await order.fetch_l10n_es_edi_verifactu_qr_code([order.server_id]);
+        order.l10n_es_edi_verifactu_qr_code = res.l10n_es_edi_verifactu_qr_code;
+        return super.click();
+    },
+});

--- a/addons/l10n_es_edi_verifactu_pos/static/src/overrides/models/order.js
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/overrides/models/order.js
@@ -7,6 +7,9 @@ patch(Order.prototype, {
     wait_for_push_order() {
         return this.pos.config.l10n_es_edi_verifactu_required ? true : super.wait_for_push_order(...arguments);
     },
+    async fetch_l10n_es_edi_verifactu_qr_code(order_ids) {
+        return await this.pos.orm.read('pos.order', order_ids, ['l10n_es_edi_verifactu_qr_code']);
+    },
     //@override
     export_for_printing(baseUrl, headerData) {
         const result = super.export_for_printing(...arguments);

--- a/addons/l10n_es_edi_verifactu_pos/static/tests/tours/tour_with_refund_reason.js
+++ b/addons/l10n_es_edi_verifactu_pos/static/tests/tours/tour_with_refund_reason.js
@@ -1,5 +1,6 @@
 /** @odoo-module */
 
+import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
 import * as ReceiptScreen from "@point_of_sale/../tests/tours/helpers/ReceiptScreenTourMethods";
 import * as PaymentScreen from "@point_of_sale/../tests/tours/helpers/PaymentScreenTourMethods";
@@ -67,5 +68,31 @@ registry.category("web_tour.tours").add("l10n_es_edi_verifactu_pos.tour_invoiced
         PaymentScreen.clickPaymentMethod("Bank"),
         PaymentScreen.clickValidate(),
         ReceiptScreen.isShown(),
+    ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_es_verifactu_qr_on_reprint", {
+    test: true,
+    steps: () => [
+        ProductScreen.confirmOpeningPopup(),
+        ProductScreen.clickHomeCategory(),
+        ProductScreen.clickDisplayedProduct("verifactu_pos_product"),
+        ProductScreen.clickPayButton(),
+        PaymentScreen.clickPaymentMethod("Cash"),
+        PaymentScreen.clickValidate(),
+        Chrome.clickMenuButton(),
+        ProductScreen.clickOrderMenu(),
+        TicketScreen.selectFilter("Paid"),
+        TicketScreen.selectOrder("-0001"),
+        TicketScreen.clickControlButton("Print Receipt"),
+        [
+            {
+                trigger: ".receipt-screen .pos-receipt-order-data:contains('QR tributario:')",
+            },
+            {
+                trigger: ".receipt-screen img.pos-receipt-qrcode",
+            },
+        ],
+        Chrome.endTour(),
     ].flat(),
 });

--- a/addons/l10n_es_edi_verifactu_pos/tests/test_frontend.py
+++ b/addons/l10n_es_edi_verifactu_pos/tests/test_frontend.py
@@ -64,3 +64,12 @@ class TestL10nEsEdiVerifactuPosFrontend(TestL10nEsEdiVerifactuPosCommon, TestPoi
 
         self.assertEqual(refund_move.l10n_es_edi_verifactu_refund_reason, 'R4')
         self.assertTrue(refund_move.l10n_es_edi_verifactu_document_ids.json_attachment_id)
+
+    def test_es_verifactu_qr_on_reprint(self):
+        self.config.with_user(self.pos_user).open_ui()
+        with self._mock_zeep_registration_operation_certificate_issue():
+            self.start_tour(
+                f'/pos/ui?config_id={self.config.id}',
+                'test_es_verifactu_qr_on_reprint',
+                login='pos_user',
+            )


### PR DESCRIPTION
Step to reproduce:
- install `l10n_es_edi_verifactu_pos`
- start pos after switching company for `es`
- settle order, notice verifactu QR code is present in receipt
- from orders menu, reprint the receipt

Observation:
- when we reprint the order, qr code is missing

Cause:
- `l10n_es_edi_verifactu_qr_code` is not always present in order
- it is added later in `_postPushOrderResolve` hook (hence first time, qr code is present)
- when reprinting the invoice, this method is not called, so it is not printed

Fix:
- patch `ReprintReceiptButton` to always fetch `l10n_es_edi_verifactu_qr_code`
- so data is always present before printing

opw-5403886



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
