### PR TITLE
[FIX] html_builder: restore quality slider on images with shape

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_format_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_format_option.js
@@ -22,7 +22,10 @@ export class ImageFormatOption extends BaseOptionComponent {
                 this.computeMaxDisplayWidth.bind(this)
             );
             const hasSrc = !!getImageSrc(editingElement);
-            const mimetype = getMimetype(editingElement);
+            const mimetype =
+                editingElement.dataset.formatMimetype ||
+                editingElement.dataset.mimetypeBeforeConversion ||
+                getMimetype(editingElement);
             const compressionUnsupported =
                 mimetype === "image/webp" && this.webpCompressionUnuspported();
             return {


### PR DESCRIPTION
Before this commit, the quality option would not work properly for images with a shape applied by default. After changing an option, the DOM would be updated and the slider disappeared because the image format would not be considered valid anymore.

Steps to reproduce the issue :
- Drop a snippet with an image with a shape (.s_cta_mockup, ...)
- Do one of the following:
    - Move the quality slider
    - Change an shape option
=> The Quality slider disappeared.

If the user replaces an image with a png, sets the format to "webp" and adds a shape, the dataset would have the following :
- format-mimetype: the value of the format option ("image/webp")
- mimetype-before-conversion: the original format ("image/png")
- mimetype: the mimetype of an image with shape ("image/svg+xml")

We first evaluate "data-format-mimetype", as it indicates the current format of the image (if it was changed by the user). Otherwise, we check "data-mimetype-before-conversion" since the mimetype for an image with shape is always "image/svg+xml" and doesn't correspond to the real image format. Finally, default to getMimetype to avoid issue for images on which nothing no option was changed.

task-5358952