### PR TITLE
[FIX] pos_restaurant: update correct product qty on ticket screen

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -52,4 +52,11 @@ patch(OrderSummary.prototype, {
             !currentOrder.hasCourses()
         );
     },
+    async updateSelectedOrderline({ buffer, key }) {
+        await super.updateSelectedOrderline(...arguments);
+
+        if (this.pos.getOrder() && this.pos.config.module_pos_restaurant) {
+            this.pos.addPendingOrder([this.pos.getOrder().id]);
+        }
+    },
 });

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -71,3 +71,25 @@ registry.category("web_tour.tours").add("OrderNumberConflictTour", {
             TicketScreen.nthRowContains(2, "T 103"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_sync_lines_qty_update_ticket_screen", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            Chrome.clickRegister(),
+            ProductScreen.addOrderline("Coca-Cola", "1"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("A powerful Pos man!"),
+
+            Chrome.clickOrders(),
+            TicketScreen.selectOrder("001"),
+            TicketScreen.loadSelectedOrder(),
+
+            ProductScreen.clickOrderline("Coca-Cola", "1"),
+            ProductScreen.clickNumpad("3"),
+            ProductScreen.selectedOrderlineHas("Coca-Cola", "3"),
+            Chrome.clickOrders(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -706,6 +706,12 @@ class TestFrontend(TestFrontendCommon):
         order = self.pos_config.current_session_id.order_ids[0]
         self.assertEqual(order.lines[0].qty, 3)
 
+    def test_sync_lines_qty_update_ticket_screen(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_sync_lines_qty_update_ticket_screen')
+        order = self.pos_config.current_session_id.order_ids[0]
+        self.assertEqual(order.lines[0].qty, 3, "Quantity should be updated to 3 in the backend")
+
     def test_sync_set_partner(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_sync_set_partner')


### PR DESCRIPTION
Currently, modifying a loaded order (e.g., changing product quantity) does not save the changes, and the old order without modifications is shown on the ticket screen.

### **Steps to Reproduce:**
1) Install the POS Restaurant app with demo data.
2) Open a Restaurant Session.
3) Click on 'Register' to create a Direct Sale.
4) Add a product (e.g., Water with Qty 2) and a customer (e.g., 'Billy Fox'). 
5) Click on 'Orders' from the navbar and load the recently created order. 
6) Update the quantity of Water from 2 to 5 and click on 'Orders' again.

### **Error:**
The quantity of Water is not updated, the order line still shows a quantity of 2.

Ref video: https://drive.google.com/file/d/1XR5W5Klyyll3KujirKb3UuAELjMcA7yD/view

### **Root Cause:**
Clicking on 'Orders' calls `syncAllOrders` (see [1]), which is responsible for updating the orders. However, `this.getPendingOrder()` returns null in this scenario, causing the orders array to be empty and the function to return early without syncing.

### **Fix:**
Override `updateSelectedOrderline` in `OrderSummary`. This method is
invoked whenever the Numpad modifies an orderline. By calling
`addPendingOrder` within this method, we ensure that Numpad modifications
are correctly registered. This allows `syncAllOrders` to properly sync
the updated order with the server when navigating away.

[1]- https://github.com/odoo/odoo/blob/7fd5f90fe8fce4de49ec10c683f92e7a3557981a/addons/point_of_sale/static/src/app/services/pos_store.js#L1485-L1512

opw-5405402
