### PR TITLE
[FIX] stock: ensure write access to sequence of product's lot numbers

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1020,6 +1020,9 @@ Please change the quantity done or the rounding precision in your settings.""",
                         'id': value,
                         'display_name': self.env['stock.move.line'][key].browse(value).display_name
                     }
+        first_number = product.lot_sequence_id.number_next_actual - product.lot_sequence_id.number_increment
+        if (first_lot and first_lot == product.lot_sequence_id.get_next_char(first_number)):
+            product.lot_sequence_id.sudo().write({'number_next_actual': first_number + len(lot_qties)})
         return vals_list
 
     def _push_apply(self):

--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -100,9 +100,6 @@ export class GenerateDialog extends Component {
         ]));
         lines._currentIds.push(...newlines.map((record) => record._virtualId));
         await lines._onUpdate();
-        if (this.sequence && this.nextSerial.el.value === this.nextCustomSerialNumber) {
-            await this.orm.write("ir.sequence", [this.sequence.id], {number_next_actual: this.sequence.number_next_actual + newlines.length});
-        }
         this.props.close();
     }
 }

--- a/addons/stock/tests/test_generate_serial_numbers.py
+++ b/addons/stock/tests/test_generate_serial_numbers.py
@@ -3,7 +3,7 @@
 
 from odoo import Command
 from odoo.exceptions import ValidationError
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, new_test_user
 
 
 class StockGenerateCommon(TransactionCase):
@@ -422,4 +422,55 @@ class StockGenerateCommon(TransactionCase):
             {'quantity': 1, 'lot_id': sn_t2_03.id},
             {'quantity': 1, 'lot_id': sn_t2_04.id},
             {'quantity': 1, 'lot_id': sn_t2_05.id},
+        ])
+
+    def test_sequence_serial_numbers_access_rights(self):
+        """
+        This test ensures that when a user has access to generating serial numbers,
+        no Sequence access error is raised.
+        """
+        receipt_picking = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.in_type_id.id,
+            'location_id': self.env.ref('stock.stock_location_suppliers').id,
+            'location_dest_id': self.warehouse.lot_stock_id.id,
+        })
+
+        # Simulate context provided from JS side, cf addons/stock/static/src/widgets/generate_serial.js:63-68
+        action_context = {
+            'default_company_id': self.env.company.id,
+            'default_picking_id': receipt_picking.id,
+            'default_picking_type_id': self.warehouse.in_type_id.id,
+            'default_location_id': receipt_picking.location_id.id,
+            'default_location_dest_id': receipt_picking.location_dest_id.id,
+            'default_product_id': self.product_serial.id,
+            'default_tracking': 'serial',
+        }
+
+        inventory_user = new_test_user(
+            self.env,
+            login='user_without_sn_generation_rights',
+            groups='stock.group_stock_user',
+        )
+        first_num = self.product_serial.lot_sequence_id.number_next_actual
+        self.product_serial.lot_sequence_id.invalidate_recordset(['number_next_actual'])
+        move_line_vals = self.env['stock.move'].with_user(inventory_user.id).action_generate_lot_line_vals(
+            action_context, 'generate', self.product_serial.lot_sequence_id.next_by_id(), 5, False
+        )
+        self.assert_move_line_vals_values(move_line_vals, [
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 1)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 2)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 3)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 4)},
+        ])
+
+        move_line_vals = self.env['stock.move'].with_user(inventory_user.id).action_generate_lot_line_vals(
+            action_context, 'generate', self.product_serial.lot_sequence_id.next_by_id(), 5, False
+        )
+        self.assert_move_line_vals_values(move_line_vals, [
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 5)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 6)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 7)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 8)},
+            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 9)},
         ])


### PR DESCRIPTION
**Behavior:**
Behavior:
When logged in as a user with group_user access (member), trying to generate the next few serial numbers for a tracked product from receipts will cause an access error.

This happens because there is a write operation on the ir.sequence linked to the serial number at the end of the process that happens only when the 'New' button was previously pressed.
And since access rights to ir.sequence are dependant on the base group of the user, changing the user Inventory rights to admin will not resolve the issue.

A test has been created to ensure no access error is created when generating sequence numbers as a lower access user, this test would pass without the fix since it is focused on the python function.

**Steps to reproduce:**
- Create a product that is tracked by serial number
- Log in as a user with group_user access (member role)
- Go to Inventory -> Operations -> Receipts
- Create a new picking and add the product
- After clicking on Mark as Todo you'll see Details pop up in the product line
- After clicking Details, select Generate Serial/Lots
- Click New, then Generate, and you'll get an access error for ir.Sequence

opw-5368553
