### PR TITLE
[FIX] [18.0] account: Doesn't allow to select payment method lines on archived journals

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -625,7 +625,11 @@ class ResPartner(models.Model):
     property_outbound_payment_method_line_id = fields.Many2one(
         comodel_name='account.payment.method.line',
         company_dependent=True,
-        domain=lambda self: [('payment_type', '=', 'outbound'), ('company_id', 'parent_of', self.env.company.id)],
+        domain=lambda self: [
+            ('journal_id.active', '=', True),
+            ('payment_type', '=', 'outbound'),
+            ('company_id', 'parent_of', self.env.company.id),
+        ],
         help="Preferred payment method when buying from this vendor. This will be set by default on all"
              " outgoing payments created for this vendor",
     )
@@ -633,7 +637,11 @@ class ResPartner(models.Model):
     property_inbound_payment_method_line_id = fields.Many2one(
         comodel_name='account.payment.method.line',
         company_dependent=True,
-        domain=lambda self: [('payment_type', '=', 'inbound'), ('company_id', 'parent_of', self.env.company.id)],
+        domain=lambda self: [
+            ('journal_id.active', '=', True),
+            ('payment_type', '=', 'inbound'),
+            ('company_id', 'parent_of', self.env.company.id),
+        ],
         help="Preferred payment method when selling to this customer. This will be set by default on all"
              " incoming payments created for this customer",
     )


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When selecting a payment method line on a contact, lines related to journals still appear even if the journal has been archived. This can lead to the accidental use of payment method lines that should no longer be available. There should be no need to delete payment method lines when archiving a journal; doing so causes a loss of configuration if the journal is reactivated later, and leads to data duplication when having to recreate them.

**Current behavior before PR:**
When selecting a payment method line on a contact, lines from archived journals are still visible. Currently, payment method lines must be manually deleted from archived journals to prevent them from appearing in the selection list.
Payment Method Line domain doesn't include `('journal_id.active', '=', True)` domain part.

**Desired behavior after PR is merged:**
Archiving a journal is now sufficient to stop its payment method lines from appearing as selectable options on contacts.

https://www.loom.com/share/05981419c7dd4584b67d27d84e27892a

OPW-5413309 MT-13011 @moduon @rafaelbn @EmilioPascual @Gelojr @yajo please review if you want 😄 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
