### PR TITLE
[FIX] mail, *: open chat window in current device

### DIFF
--- a/addons/crm_livechat/models/crm_lead.py
+++ b/addons/crm_livechat/models/crm_lead.py
@@ -2,7 +2,6 @@
 
 from odoo import api, fields, models
 from odoo.exceptions import AccessError
-from odoo.addons.mail.tools.discuss import Store
 
 
 class CrmLead(models.Model):
@@ -37,6 +36,4 @@ class CrmLead(models.Model):
         return super().write(vals)
 
     def action_open_livechat(self):
-        store = Store(bus_channel=self.env.user)
-        store.add(self.origin_channel_id, "_store_open_chat_window_fields")
-        store.bus_send()
+        return self.origin_channel_id.open_chat_window_action()

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -418,10 +418,6 @@ class DiscussChannel(models.Model):
             predicate=is_livechat_channel,
         )
 
-    def _store_open_chat_window_fields(self, res: Store.FieldList):
-        self._store_channel_fields(res)
-        res.attr("open_chat_window", True)
-
     def _store_channel_fields(self, res: Store.FieldList):
         super()._store_channel_fields(res)
         res.attr("chatbot_current_step")

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1425,6 +1425,10 @@ class DiscussChannel(models.Model):
         """
         self._add_members(users=self.env.user)
 
+    def open_chat_window_action(self):
+        """Return an action the web client can use to open this channel."""
+        return Store().add(self, "_store_open_chat_window_fields").get_client_action()
+
     @api.model
     def _create_channel(self, name, group_id):
         """ Create a channel and add the current partner, broadcast it (to make the user directly
@@ -1564,6 +1568,10 @@ class DiscussChannel(models.Model):
 
     def _store_message_update_extra_fields(self, res: Store.FieldList):
         res.one("parent_id", "_store_message_fields")
+
+    def _store_open_chat_window_fields(self, res: Store.FieldList):
+        self._store_channel_fields(res)
+        res.attr("open_chat_window", True)
 
     # ------------------------------------------------------------
     # COMMANDS

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -1,9 +1,10 @@
-import { fields } from "@mail/model/export";
 import { Store } from "@mail/core/common/store_service";
+import { fields } from "@mail/model/export";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 
 import { patch } from "@web/core/utils/patch";
+import { registry } from "@web/core/registry";
 
 const unread_store = (() => {
     if (!window.idbKeyval) {
@@ -183,3 +184,7 @@ const StorePatch = {
     onLinkFollowed(fromThread) {},
 };
 patch(Store.prototype, StorePatch);
+
+registry.category("actions").add("mail.store_insert", function storeInsertAction(env, action) {
+    env.services["mail.store"].insert(action.params);
+});

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -191,6 +191,14 @@ class Store:
             self.data[model_name][index]["_DELETE"] = True
         return self
 
+    def get_client_action(self):
+        """Gets client action to insert this store in the client."""
+        return {
+            "params": self.get_result(),
+            "tag": "mail.store_insert",
+            "type": "ir.actions.client",
+        }
+
     def get_result(self):
         """Gets resulting data built from adding all data together."""
         res = {}

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -102,10 +102,8 @@ class WebsiteVisitor(models.Model):
                 'livechat_visitor_id': visitor.id,
             })
         discuss_channels = self.env['discuss.channel'].create(discuss_channel_vals_list)
-        # Open empty channel to allow the operator to start chatting with the visitor
-        store = Store(bus_channel=self.env.user)
-        store.add(discuss_channels, "_store_open_chat_window_fields")
-        store.bus_send()
+        # Open empty channel to allow the agent to start chatting with the visitor
+        return discuss_channels.open_chat_window_action()
 
     def _merge_visitor(self, target):
         """ Copy sessions of the secondary visitors to the main partner visitor. """


### PR DESCRIPTION
\* = crm_livechat, im_livechat, website_livechat

Chat window are now stored locally, which is nice. But some actions that go through the server still send the open/close action on the bus, which is received by all devices/tabs and more problematically all connected users on the same runbot.

Some are unavoidable, such as receiving a new chat, which should show in all devices/tabs.

But others, such as closing a chat window do not need to propagate to all devices.

The problematic flow in particular:

- create a lead from a live chat conversation
- visit the lead
- click on the "view chat", which opens the chat for all users/devices : it should open only for the current user/device
- close the chat window opened at the previous step, it also closes on all users/devices: it should only close on the current user/device

task-5408790

https://github.com/odoo/enterprise/pull/102341