### PR TITLE
[FIX] web: traceback on initial shift+space kanban selection

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -502,7 +502,7 @@ export class KanbanRenderer extends Component {
     }
 
     toggleSelection(record, isRange = false) {
-        if (isRange) {
+        if (isRange && this.lastCheckedRecord) {
             this.toggleRangeSelection(record);
         } else {
             record.toggleSelection();

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13750,6 +13750,35 @@ test("selection can be enabled by pressing 'space' key", async () => {
 });
 
 test.tags("desktop");
+test("selection can be enabled by pressing 'shift + space' key", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+                <kanban>
+                    <templates>
+                        <t t-name="card">
+                            <field name="foo"/>
+                        </t>
+                    </templates>
+                </kanban>`,
+    });
+    expect(".o_selection_box").toHaveCount(0);
+    await press("ArrowDown");
+    await keyDown("Shift");
+    await press("Space");
+    await animationFrame();
+    expect(".o_record_selected").toHaveCount(1);
+    await keyUp("Shift");
+    await press("ArrowDown");
+    await press("ArrowDown");
+    await keyDown("Shift");
+    await press("Space");
+    await animationFrame();
+    expect(".o_record_selected").toHaveCount(3);
+});
+
+test.tags("desktop");
 test("drag and drop records and quickly open a record", async () => {
     Partner._views.kanban = /* xml */ `
         <kanban>


### PR DESCRIPTION
Before this commit:
When navigating the kanban view using the keyboard, pressing `shift+space` for the first time to select a kanban record caused a traceback.

After this commit:
The traceback no longer occurs, and the kanban record is correctly selected.

task-5410164

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
