### PR TITLE
[FIX] im_livechat: fix crash when closing all chat windows

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_model_patch.js
@@ -15,7 +15,7 @@ const chatWindowPatch = {
         this.livechatStep = CW_LIVECHAT_STEP.NONE;
     },
     close(options = {}) {
-        if (this.channel.channel_type !== "livechat") {
+        if (this.channel?.channel_type !== "livechat") {
             return super.close(...arguments);
         }
         if (options.force) {


### PR DESCRIPTION
The setup to reproduce is not clear, but it happened when using "close all" on a fresh demo db.

Close is known to be sensitive to deleted channels.