### PR TITLE
[FIX] mail: fix small issues in sidebar channel template

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -35,7 +35,7 @@
                     <img class="w-100 h-100 rounded-2 object-fit-cover" t-att-class="threadAvatarAttClass" t-att-src="channel.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="channel.channel_type?.includes('chat') or (channel.channel_type === 'channel' and !channel.group_public_id)" thread="channel.thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
                 </div>
-                <div t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden mx-2 text-start lh-sm opacity-trigger-hove flex-grow-1" t-att-class="itemNameAttClass">
+                <div t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden mx-2 text-start lh-sm flex-grow-1" t-att-class="itemNameAttClass">
                     <div class="d-flex justify-content-between align-items-baseline o-min-width-0">
                         <span class="text-truncate" t-esc="channel.displayName"/>
                         <div class="d-flex" t-if="!store.discuss.isSidebarCompact" t-ref="displayNameAdditionalContent"/>
@@ -59,7 +59,6 @@
         <div class="o-mail-DiscussSidebarChannel-actions" t-att-class="{
             'd-none': !showingActions.isOpen,
             'd-flex': showingActions.isOpen,
-            'mx-1': channel.importantCounter === 0,
             'ms-1': channel.importantCounter > 0,
         }">
             <Dropdown state="showingActions" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu o-discuss-dropdownMenu border-secondary my-0 min-w-0 mx-1 ' + store.discussDropdownMenuClass(this)">


### PR DESCRIPTION
`opacity-trigger-hove` has a typo so it is effectively dead code. It doesn't look useful to have either way.

mx-1 implies margin end, which is incorrect: when there is no counter on the line that is hovered, this make the more menu not aligned with the rest.

<img width="42" height="139" alt="image" src="https://github.com/user-attachments/assets/30d9bd65-bdb1-4243-8a2f-cca5422c46e3" />
 -> 
<img width="83" height="86" alt="image" src="https://github.com/user-attachments/assets/a86ebe68-217b-4997-8f11-ce17f4e8fd71" />

