### PR TITLE
[IMP] mail: remove useless calls to channel pin in sub channel test

### DIFF
--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -17,7 +17,6 @@ class TestDiscussSubChannels(HttpCase):
         parent._create_sub_channel()
         sub_channel = parent.sub_channel_ids[0]
         sub_channel._add_members(users=self.env.user)
-        sub_channel.channel_pin(pinned=True)
         self_member = sub_channel.channel_member_ids.filtered(lambda m: m.is_self)
         self.assertTrue(self_member.is_pinned)
         # Last interrest of the member is older than 2 days, no activity on the
@@ -31,7 +30,6 @@ class TestDiscussSubChannels(HttpCase):
             frozen_time.tick(delta=timedelta(days=1))
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
             self.assertEqual(self_member.unpin_dt, unpin_dt)
-        sub_channel.channel_pin(pinned=True)
         with freeze_time(two_days_later_dt) as frozen_time:
             # Last interrest older than 2 days, activity on the channel: should be kept.
             message = sub_channel.with_user(bob).message_post(body="Hey!", message_type="comment")
@@ -48,7 +46,6 @@ class TestDiscussSubChannels(HttpCase):
             self.assertFalse(self_member.is_pinned)
         # Ensure regular channels are not impacted.
         channel = self.env["discuss.channel"].create({"name": "General"})
-        channel.channel_pin(pinned=True)
         with freeze_time(two_days_later_dt):
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
             self.assertTrue(channel.channel_member_ids.filtered("is_self").is_pinned)


### PR DESCRIPTION
The `test_01_gc_unpin_outdated_sub_channels` ensures that sub-channels and only sub-channels are unpinned by the garbage collect. However, the calls to `channel_pin` are useless: member is pinned initially and again when sending the message. This commit removes the useless calls.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
