### PR TITLE
[FIX] website: no page flickering when going to top of RTL website

### DIFF
--- a/addons/website/static/src/interactions/header/base_header.js
+++ b/addons/website/static/src/interactions/header/base_header.js
@@ -184,12 +184,14 @@ export class BaseHeader extends Interaction {
     transformShow() {
         this.isVisible = true;
         this.el.style.transform = this.atTop ? "" : `translate(0, -${this.forcedScroll + this.topGap}px)`;
+        this.el.style.transition = this.atTop ? "none" : "";
         this.adaptToHeaderChangeLoop(1);
     }
 
     transformHide() {
         this.isVisible = false;
         this.el.style.transform = "translate(0, -100%)";
+        this.el.style.transition = "";
         this.adaptToHeaderChangeLoop(1);
     }
 


### PR DESCRIPTION
Scenario:

- install RTL language on website (eg. Arabic)
- go on mobile (eg. chrome developer tools and enable mobile) on website
- in arabic, go down to get the navbar that follow the top of viewport
- go up to the top

Result: there is a 200ms moment when all the interface is moved ~90% to
the right outside of the viewport.

Cause:

In RTL, the header has this state when going down in the page:

- the class: o_header_affixed
- the inline style "transform: translate(0px, -100%);"
- the transition
```
.o_header_affixed {
    position: fixed;
}
.o_header_affixed:not(.o_header_no_transition) {
    transition: transform 200ms;
}
```

When we go up, the o_header_affixed class is removed as well as the
inline style, but the transition causes 200ms during which we have a
transform without header having the "position: fixed".

This seems to be caused by that situation which makes the offcanvas menu
(mobile menu that appear when clicking on hamburger icon) be at
top:0/left:0 of viewport instead of being at top:0/left:-100%, this
cause all the content to be offset to the right.

Fix:

Force the transition stop if we are at the top of the page where the top
menu is shown and not the affixed menu.

opw-5173822

__PR NOTE:__

Note: I have not been able to reproduce in a small reproduction (such as jsfiddle) so I must be missing one element for the reproduction.

It is "easy" to reproduce and check what is happening when changing the animation to eg. 20000s in this line:

https://github.com/odoo/odoo/blob/d8a875dcdd1262d2d3f15ff9c414e605a7b54526/addons/website/static/src/scss/website.scss#L1493

Then you don't need to block the debugger in the 200ms to check DOM and so on.

The issue is happening in 18.0 but it has been reported in 19.0 and the code has changed between the two so I'm targeting saas-18.4 version.