### PR TITLE
[FIX] account: move asset display logic to helper method

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -893,6 +893,14 @@ class AccountAccount(models.Model):
             self.name = name
             self.code = code
 
+    def _should_display_asset_tag(self):
+        """
+        Hook method to determine whether the 'Asset' tag should be displayed in the account display name.
+        To be overridden in account_asset module.
+        """
+        self.ensure_one()
+        return False
+
     @api.depends_context('company', 'formatted_display_name', 'from_bill')
     @api.depends('code')
     def _compute_display_name(self):
@@ -907,11 +915,10 @@ class AccountAccount(models.Model):
             preferred_account_ids = self._order_accounts_by_frequency_for_partner(self.env.company.id, partner, move_type)
         for account in self:
             if formatted_display_name and account.code:
-                display_asset_tag = account.asset_model_ids and self.env.context.get('from_bill')
                 account.display_name = (
                     f"""{account.code if self.env.user.has_group('account.group_account_readonly') else ''} {account.name}"""
                     f"""{f' `{_("Suggested")}`' if account.id in preferred_account_ids else ''}"""
-                    f"""{f' `{_("Asset")}`' if display_asset_tag else ''}"""
+                    f"""{f' `{_("Asset")}`' if account._should_display_asset_tag() else ''}"""
                     f"""{f'{new_line}--{account.description}--' if account.description else ''}"""
                 )
             else:


### PR DESCRIPTION
Move the asset display computation behind a dedicated helper method to avoid directly accessing `asset_model_ids` from Community code.

The default Community implementation returns `False`, ensuring that no asset-related logic is applied when the Enterprise `account_asset` module is not installed and preventing tracebacks.
