### PR TITLE
[18.0][FIX] hr_expense: fix UserError on digitizing expense

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -615,7 +615,7 @@ class HrExpense(models.Model):
     def write(self, vals):
         if (
                 'state' in vals
-                and vals['state'] != 'submitted'
+                and vals['state'] not in {'draft', 'submitted'}
                 and not (self.env.user.has_group('hr_expense.group_hr_expense_manager') or self.env.su)
                 and any(state == 'draft' for state in self.mapped('state'))
         ):

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -40,6 +40,15 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
         with self.assertRaises(UserError):
             expense.with_user(self.expense_user_employee).state = 'approved'
 
+        # The expense employee should always be able to modify his draft expense sheet.
+        # In some cases, the expense state can be reset to draft on modification
+        # In such case the UserError should not block the modification
+        expense.with_user(self.expense_user_employee).write({
+            'state': 'draft',
+            'name': 'modified expense_1',
+        })
+        self.assertEqual(expense.name, 'modified expense_1')
+
         # Employee can report & submit their expense
         expense_sheet = self.env['hr.expense.sheet'].with_user(self.expense_user_employee).create({
             'name': 'expense sheet for employee',


### PR DESCRIPTION
When a regular user tries to digitize the receipt attached to an expense, the `UserError(_("You don't have the rights to bypass the validation process of this expense."))` is raised. It seems that currently, the user needs to be in the Expenses Administrator group (`group_hr_expense_manager`) to digitize the receipt, which doesn't seem correct.

This PR solves the issue by skipping the check of the user's group if the expense is in draft state, as suggested by @JulienAlardot: https://github.com/odoo/enterprise/pull/101011#pullrequestreview-3558220264


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
