### PR TITLE
[REF] mail, *: clean up channel_pin

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -948,7 +948,7 @@ class DiscussChannel(models.Model):
             )
             channel_sudo._add_next_step_message_to_store(chatbot_script_step)
             channel_sudo._broadcast(human_operator.partner_id.ids)
-            self.channel_pin(pinned=True)
+            self.self_member_id.last_interest_dt = fields.Datetime.now()
         else:
             # sudo: discuss.channel - visitor tried getting operator, outcome must be updated
             self.sudo().livechat_failure = "no_agent"

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -261,7 +261,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "discuss.channel", discuss_channel.id),
                     (self.cr.dbname, "res.partner", self.partner_employee.id),
-                    (self.cr.dbname, "res.partner", self.env.user.partner_id.id),
                 ],
                 [
                     {
@@ -384,7 +383,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                         },
                     },
                     {"type": "mail.record/insert", "payload": channel_data_emp},
-                    {"type": "mail.record/insert", "payload": channel_data},
                 ],
             )
 

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -3,7 +3,7 @@
 from markupsafe import Markup
 from werkzeug.exceptions import NotFound
 
-from odoo import http
+from odoo import fields, http
 from odoo.http import request
 from odoo.addons.mail.controllers.webclient import WebclientController
 from odoo.addons.mail.tools.discuss import Store, add_guest_to_context
@@ -54,6 +54,11 @@ class DiscussChannelWebclientController(WebclientController):
             ):
                 member.is_favorite = params["is_favorite"]
         resolve_channel = request.env["discuss.channel"]
+        if name == "/discuss/channel/pin":
+            if member := request.env["discuss.channel.member"].search_fetch(
+                [("channel_id", "=", params["channel_id"]), ("is_self", "=", True)],
+            ):
+                member.unpin_dt = False if params["pinned"] else fields.Datetime.now()
         if name == "/discuss/get_or_create_chat":
             resolve_channel = request.env["discuss.channel"]._get_or_create_chat(
                 params["partners_to"],

--- a/addons/mail/static/src/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/core/public_web/thread_model_patch.js
@@ -68,13 +68,10 @@ const threadModelPatch = {
         if (this.discussAppAsThread) {
             router.replaceState({ active_id: undefined });
         }
-        if (this.channel && this.self_member_id?.is_pinned !== false) {
-            await this.store.env.services.orm.silent.call(
-                "discuss.channel",
-                "channel_pin",
-                [this.id],
-                { pinned: false }
-            );
+        await this.store.chatHub.initPromise;
+        this.channel?.chatWindow?.close();
+        if (this.channel?.self_member_id?.is_pinned !== false) {
+            await this.channel.pinRpc({ pinned: false });
         }
     },
     /** @param {string} body */

--- a/addons/mail/static/src/discuss/core/common/channel_commands.js
+++ b/addons/mail/static/src/discuss/core/common/channel_commands.js
@@ -11,6 +11,10 @@ commandRegistry
     .add("leave", {
         help: _t("Leave this channel"),
         methodName: "execute_command_leave",
+        /** @param {import("models").DiscussChannel} channel */
+        onExecute(channel) {
+            channel.chatWindow?.close();
+        },
     })
     .add("who", {
         channel_types: ["channel", "chat", "group"],

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -389,6 +389,14 @@ export class DiscussChannel extends Record {
         return false;
     }
 
+    pinRpc({ pinned = true } = {}) {
+        return this.store.fetchStoreData(
+            "/discuss/channel/pin",
+            { channel_id: this.id, pinned },
+            { readonly: false }
+        );
+    }
+
     /** @param {string} name */
     async rename(name) {
         const newName = name.trim();

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -258,6 +258,7 @@ const threadPatch = {
         return this.self_member_id?.message_unread_counter_ui > 0;
     },
     executeCommand(command, body = "") {
+        command.onExecute?.(this.channel);
         return this.store.env.services.orm.call(
             "discuss.channel",
             command.methodName,

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -335,29 +335,6 @@ test("sidebar: open channel and leave it", async () => {
     await expect.waitForSteps(["action_unfollow"]);
 });
 
-test("sidebar: unpin chat from bus", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId }),
-            Command.create({ partner_id: partnerId }),
-        ],
-        channel_type: "chat",
-    });
-    await start();
-    await openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel", { text: "Demo" });
-    await click(".o-mail-DiscussSidebarChannel", { text: "Demo" });
-    await contains(".o-mail-Composer-input[placeholder='Message Demo…']");
-    await contains(".o-mail-DiscussContent-threadName", { value: "Demo" });
-    // Simulate receiving a unpin chat notification
-    // (e.g. from user interaction from another device or browser tab)
-    pyEnv["discuss.channel"].channel_pin([channelId], false);
-    await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Demo" });
-    await contains(".o-mail-DiscussContent-threadName", { count: 0, value: "Demo" });
-});
-
 test.tags("focus required");
 test("chat - channel should count unread message", async () => {
     const pyEnv = await startServer();

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1104,6 +1104,13 @@ function _process_request_for_all(store, name, params, context = {}) {
             DiscussChannelMember.write(memberIds, { is_favorite: params.is_favorite });
         }
     }
+    if (name === "/discuss/channel/pin") {
+        const memberIds = DiscussChannelMember.search([
+            ["channel_id", "=", params.channel_id],
+            ["is_self", "=", true],
+        ]);
+        DiscussChannelMember._channel_pin(memberIds, params.pinned);
+    }
     if (name === "/discuss/get_or_create_chat") {
         const channelId = DiscussChannel._get_or_create_chat(params.partners_to);
         store.resolve_data_request({ channel: mailDataHelpers.Store.one(channelId) });

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -17,7 +17,6 @@ class TestDiscussSubChannels(HttpCase):
         parent._create_sub_channel()
         sub_channel = parent.sub_channel_ids[0]
         sub_channel._add_members(users=self.env.user)
-        sub_channel.channel_pin(pinned=True)
         self_member = sub_channel.channel_member_ids.filtered(lambda m: m.is_self)
         self.assertTrue(self_member.is_pinned)
         # Last interrest of the member is older than 2 days, no activity on the
@@ -31,7 +30,6 @@ class TestDiscussSubChannels(HttpCase):
             frozen_time.tick(delta=timedelta(days=1))
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
             self.assertEqual(self_member.unpin_dt, unpin_dt)
-        sub_channel.channel_pin(pinned=True)
         with freeze_time(two_days_later_dt) as frozen_time:
             # Last interrest older than 2 days, activity on the channel: should be kept.
             message = sub_channel.with_user(bob).message_post(body="Hey!", message_type="comment")
@@ -48,7 +46,6 @@ class TestDiscussSubChannels(HttpCase):
             self.assertFalse(self_member.is_pinned)
         # Ensure regular channels are not impacted.
         channel = self.env["discuss.channel"].create({"name": "General"})
-        channel.channel_pin(pinned=True)
         with freeze_time(two_days_later_dt):
             self.env["discuss.channel.member"]._gc_unpin_outdated_sub_channels()
             self.assertTrue(channel.channel_member_ids.filtered("is_self").is_pinned)

--- a/addons/website_livechat/models/__init__.py
+++ b/addons/website_livechat/models/__init__.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import chatbot_script
 from . import chatbot_script_step
 from . import im_livechat_channel
 from . import ir_http
 from . import discuss_channel
+from . import discuss_channel_member
 from . import res_config_settings
 from . import website
 from . import website_visitor

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -14,18 +14,6 @@ class DiscussChannel(models.Model):
     )
     livechat_visitor_id = fields.Many2one('website.visitor', string='Visitor', index='btree_not_null')
 
-    def channel_pin(self, pinned=False):
-        """ Override to clean an empty livechat channel.
-         This is typically called when the operator send a chat request to a website.visitor
-         but don't speak to them and closes the chatter.
-         This allows operators to send the visitor a new chat request.
-         If active empty livechat channel,
-         delete discuss_channel as not useful to keep empty chat
-         """
-        super().channel_pin(pinned=pinned)
-        if self.channel_type == "livechat" and not pinned and not self.message_ids:
-            self.sudo().unlink()
-
     def _store_channel_fields(self, res: Store.FieldList):
         super()._store_channel_fields(res)
         res.one(

--- a/addons/website_livechat/models/discuss_channel_member.py
+++ b/addons/website_livechat/models/discuss_channel_member.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class DiscussChannelMember(models.Model):
+    _inherit = "discuss.channel.member"
+
+    def _write_after_hook(self, vals):
+        """Override to clean an empty live chat conversation. This is typically called when the
+        agent sends a chat request to a website.visitor but does not speak to them and hides the
+        conversation."""
+        super()._write_after_hook(vals)
+        if any(field in vals for field in ["last_interest_dt", "unpin_dt"]):
+            # sudo: discuss.channel - empty live chat request can be unlinked
+            self.filtered(
+                lambda member: not member.is_pinned
+                and member.channel_id.is_pending_chat_request
+                and not member.channel_id.message_count,
+            ).channel_id.sudo().unlink()


### PR DESCRIPTION
\* = im_livechat, website_livechat

- now done with store rpc
- channel_pin() is replaced by writing unpin_dt or last_interest_dt
- is_pinned now automatically sync (and only if necessary)
- closing chat window no longer done cross devices when unpinning

Part of task-4606867
Part of task-5408790

https://github.com/odoo/enterprise/pull/102351