### PR TITLE
[FIX] mail: crash on mark as read from sidebar action

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -230,7 +230,7 @@ registerThreadAction("mark-read", {
         channel.self_member_id.message_unread_counter > 0 &&
         !channel.self_member_id.mute_until_dt &&
         owner.isDiscussSidebarChannelActions,
-    onSelected: ({ owner }) => owner.thread.markAsRead(),
+    onSelected: ({ channel }) => channel.markAsRead(),
     icon: "fa fa-fw fa-check",
     name: _t("Mark Read"),
     sequence: 10,


### PR DESCRIPTION
Purpose of this commit,
When executing mark as read action from the sidebar actions, it throws a traceback due to absence of the thread as it is now moved into channel. This commit adds the missing channel to the callback.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
