### PR TITLE
[FIX] mail: fix chat bubble crash on channel delete

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -70,7 +70,7 @@ export class ChatBubble extends Component {
             (importantCounter) => {
                 this.state.bouncing = Boolean(importantCounter);
             },
-            () => [this.channel.importantCounter]
+            () => [this.channel?.importantCounter]
         );
         useSubEnv({ inChatBubble: true });
     }


### PR DESCRIPTION
The steps to reproduce are not clear, but it is known that chat bubble is sensitive to channel deletion.