### PR TITLE
[FIX] mass_mailing: fix Media List rendering in Outlook mobile

### DIFF
--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -48,7 +48,9 @@ class TestMailingTest(TestMassMailCommon):
         # not great but matches send_mail_test, maybe that should be a method
         # on mailing_test?
         record = self.env[mailing.mailing_model_real].search([], limit=1)
-        first_child = lxml.html.fromstring(self._mails.pop()['body']).xpath('//body/*[1]')[0]
+        # we consider first_child the element just after style because style
+        # will be always there to be properly loaded in outlook
+        first_child = lxml.html.fromstring(self._mails.pop()['body']).xpath('//body/*[2]')[0]
         self.assertEqual(first_child.tag, 'div')
         self.assertIn('display:none', first_child.get('style'),
                       "the preview node should be hidden")


### PR DESCRIPTION
Problem:
When sending an email containing the Media List block, the block is not displayed correctly in Outlook mobile.

Cause:
Outlook mobile removes `<style>` tags from the `<head>`, which causes the CSS required for the Media List layout to be lost.

Solution:
As a workaround, move the required styles to the `<body>` so they are preserved by Outlook and the email renders correctly.

Steps to reproduce:
- Open Email Marketing.
- Add a Media List block.
- Send the email to an Outlook recipient.
- Open the email in Outlook mobile.
- Observe that the images are not correctly aligned.

opw-5364095

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
