### PR TITLE
[IMP] survey: add upload file question type

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -93,7 +93,8 @@ class SurveyQuestion(models.Model):
         ('scale', 'Scale'),
         ('date', 'Date'),
         ('datetime', 'Datetime'),
-        ('matrix', 'Matrix')], string='Question Type',
+        ('matrix', 'Matrix'),
+        ('upload_file', 'Upload File')], string='Question Type',
         compute='_compute_question_type', readonly=False, store=True)
     is_scored_question = fields.Boolean(
         'Scored', compute='_compute_is_scored_question',

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -289,6 +289,146 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
     .o_survey_main_title_fade {
         transition: opacity 0.4s ease-in-out;
     }
+
+    .o_survey_upload_container {
+        padding: 0;
+    }
+
+    .o_survey_upload_area {
+        min-height: 200px;
+        padding: 40px 20px;
+
+        background-color: rgba($primary, 0.05);
+        border: 2px dashed rgba($primary, 0.3);
+        border-radius: 10px;
+        text-align: center;
+
+        transition: background-color .2s, border-color .2s, box-shadow .2s;
+        cursor: pointer;
+    }
+
+    /* Drag-over highlight (you toggle this class from JS) */
+    .o_survey_upload_area.drag-over {
+        border-color: $primary;
+        background-color: rgba($primary, 0.15);
+        box-shadow: 0 0 6px rgba($primary, .2);
+    }
+
+    .o_survey_upload_area.drag-over {
+        border-color: $primary;
+        background-color: rgba($primary, 0.15);
+        box-shadow: 0 0 6px rgba($primary, .2);
+    }
+
+    .o_survey_upload_area:hover {
+        border-color: $primary;
+        background-color: rgba($primary, 0.15);
+        box-shadow: 0 0 6px rgba($primary, .2);
+    }
+
+    /* Prevent flicker only during drag */
+    /* Child elements shouldn't steal drag events */
+    .o_survey_upload_area.drag-mode * {
+        pointer-events: none;
+    }
+
+    .o_survey_upload_label {
+        display: inline-block;
+        user-select: none;
+        cursor: pointer;
+
+        .fa {
+            color: $primary;
+            margin-bottom: 10px;
+        }
+    }
+
+    .o_survey_upload_text {
+        margin: 0;
+        font-size: 1.1rem;
+        color: #1f2937;
+    }
+
+    .o_survey_upload_hint {
+        display: block;
+        margin-top: 8px;
+        font-size: 0.8rem;
+        color: #6b7280;
+    }
+
+    .o_survey_file_input {
+        position: absolute;
+        left: -9999px;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+    }
+
+    /* Container for uploaded items */
+    .o_survey_uploaded_files {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    /* Each uploaded file row */
+    .o_survey_uploaded_file_item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+
+        background-color: rgba($primary, 0.05);
+        border: 1px solid rgba($primary, 0.2);
+        border-radius: 6px;
+
+        padding: 8px 12px;
+        font-size: 14px;
+
+        transition: background-color .2s, border-color .2s;
+    }
+
+    /* Hover effect */
+    .o_survey_uploaded_file_item:hover {
+        background-color: rgba($primary, 0.1);
+        border-color: rgba($primary, 0.4);
+    }
+
+    /* Left side: icon + filename */
+    .o_survey_uploaded_file_info {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        overflow: hidden;
+    }
+
+    /* File icon */
+    .o_survey_uploaded_file_icon {
+        font-size: 20px;
+        color: $primary;
+    }
+
+    /* Filename (truncate long names) */
+    .o_survey_uploaded_file_name {
+        font-weight: 500;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        max-width: 300px;
+    }
+
+    /* Delete button */
+    .o_survey_uploaded_file_remove {
+        font-size: 16px;
+        color: $danger;
+        cursor: pointer;
+        padding: 4px;
+
+        transition: color .15s;
+    }
+
+    .o_survey_uploaded_file_remove:hover {
+        color: darken($danger, 10%);
+    }
 }
 
 /**********************************************************

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -35,6 +35,7 @@
                                 'datetime': 'fa-calendar',
                                 'time': 'fa-clock-o',
                                 'matrix': 'fa-th',    
+                                'upload_file': 'fa-upload',
                             }}"/>
                     </div>
                     <div class="oe_title">
@@ -61,7 +62,7 @@
                         <field name="random_questions_count"/>
                     </group>
                     <notebook>
-                        <page string="Answers" name="answers" invisible="is_page or question_type == 'text_box' or scoring_type == 'no_scoring' and question_type in ['numerical_box', 'date', 'datetime']">
+                        <page string="Answers" name="answers" invisible="is_page or question_type in ['text_box', 'upload_file'] or scoring_type == 'no_scoring' and question_type in ['numerical_box', 'date', 'datetime']">
                             <group>
                                 <group invisible="question_type != 'scale'">
                                     <label for="scale_min" string="Scale Range"/>
@@ -181,9 +182,9 @@
                                     <field name="question_placeholder"
                                            invisible="question_type not in ['text_box', 'char_box', 'date', 'datetime', 'numerical_box']"
                                            placeholder="Help Participants know what to write"/>
-                                    <field name="comments_allowed" invisible="question_type not in ['simple_choice', 'multiple_choice', 'matrix']"/>
+                                    <field name="comments_allowed" invisible="question_type not in ['simple_choice', 'multiple_choice', 'matrix', 'upload_file']"/>
                                     <field name="comments_message"
-                                           invisible="question_type not in ['simple_choice', 'multiple_choice', 'matrix'] or not comments_allowed"
+                                           invisible="question_type not in ['simple_choice', 'multiple_choice', 'matrix', 'upload_file'] or not comments_allowed"
                                            placeholder="If other, please specify:"/>
                                     <field name='comment_count_as_answer'
                                         invisible="question_type not in ['simple_choice', 'multiple_choice', 'matrix'] or not comments_allowed"/>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -374,9 +374,38 @@
             <t t-if="question.question_type == 'scale'" t-call="survey.question_scale"/>
             <t t-if="question.question_type == 'multiple_choice'" t-call="survey.question_multiple_choice"/>
             <t t-if="question.question_type == 'matrix'" t-call="survey.question_matrix"/>
+            <t t-if="question.question_type == 'upload_file'" t-call="survey.question_upload_file"/>
             <div t-attf-class="o_survey_question_error d-flex align-items-center justify-content-between overflow-hidden
                  border-0 py-0 px-3 alert alert-danger mt-2 #{'slide_in' if is_post_submit_question else ''}" role="alert">
                 <span t-if="is_post_submit_question" t-out="question.constr_error_msg or default_constr_error_msg"/>
+            </div>
+        </div>
+    </template>
+
+    <template id="question_upload_file" name="Question: upload file">
+        <div class="o_survey_upload_container">
+            <div class="o_survey_upload_area">
+                <input type="file"
+                    t-att-data-question-type="question.question_type"
+                    id="fileInput"
+                    t-att-name="question.id"
+                    class="d-none o_survey_file_input"
+                    accept="image/*,application/pdf"/>
+
+                <label class="o_survey_upload_label">
+                    <i class="fa fa-cloud-upload fa-3x"></i>
+                    <p class="o_survey_upload_text">
+                        <strong>Choose file</strong> or drag here
+                    </p>
+                    <small class="o_survey_upload_hint">Max 1 file • 10MB • JPG, PNG, PDF</small>
+                </label>
+            </div>
+
+            <div class="o_survey_uploaded_files mt-3"></div>
+            <div t-if='question.comments_allowed'>
+                <textarea type="text" class="form-control o_survey_question_text_box o_survey_comment bg-transparent rounded-0 p-0 mt-3"
+                        t-att-placeholder="question.comments_message or default_comments_message if not survey_form_readonly else ''"
+                        t-att-name="'%s_%s' % (question.id, 'comment')"><t t-out="comment_line.value_char_box if comment_line else ''"/></textarea>
             </div>
         </div>
     </template>


### PR DESCRIPTION
Add a new survey question type allowing participants to upload files. Uploaded documents are attached to the survey participation and shown in the chatter, along with a dedicated frontend UI for file uploads.

Task-5241848
