### PR TITLE
[IMP] test_website: hide drag_image_preview_test thumbnail

### DIFF
--- a/addons/test_website/__manifest__.py
+++ b/addons/test_website/__manifest__.py
@@ -38,6 +38,9 @@ models which only purpose is to run tests.""",
         'web.assets_frontend': [
             'test_website/static/src/interactions/**/*',
         ],
+        'website.website_builder_assets': [
+            'test_website/static/src/website_builder/**/*',
+        ],
         'web.assets_tests': [
             'test_website/static/tests/tours/*',
         ],

--- a/addons/test_website/static/src/website_builder/builder.scss
+++ b/addons/test_website/static/src/website_builder/builder.scss
@@ -1,0 +1,5 @@
+.o-snippets-menu {
+    .o_snippet:has([data-snippet="s_drag_image_preview_test"]) {
+        display: none;
+    }
+}

--- a/addons/test_website/static/tests/builder/drag_and_drop.test.js
+++ b/addons/test_website/static/tests/builder/drag_and_drop.test.js
@@ -11,7 +11,8 @@ defineWebsiteModels();
 test("Drag and drop an inner snippet having a drag image preview", async () => {
     await setupWebsiteBuilderWithSnippet(["s_text_image"]);
     const dragUtils = await contains(
-        "#snippet_content [name='Drag Image Preview Test'] .o_snippet_thumbnail"
+        "#snippet_content [name='Drag Image Preview Test'] .o_snippet_thumbnail",
+        { visible: false }
     ).drag();
     await dragUtils.moveTo(":iframe .s_text_image .oe_drop_zone");
     expect(":iframe .s_drag_image_preview_test").toHaveClass("o_snippet_previewing_on_drag");

--- a/addons/test_website/views/templates.xml
+++ b/addons/test_website/views/templates.xml
@@ -95,7 +95,7 @@
     <template id="snippets" inherit_id="website.snippets">
         <xpath expr="//snippets[@id='snippet_content']" position="inside">
             <t t-snippet="test_website.s_drag_image_preview_test" string="Drag Image Preview Test"
-               t-thumbnail="/website/static/src/img/snippets_thumbs/s_instagram_preview.svg"
+                t-thumbnail="/website/static/src/img/snippets_thumbs/s_instagram_page.svg"
                 t-drag-image-preview="/website/static/src/img/snippets_previews/s_instagram_preview.webp"/>
         </xpath>
     </template>

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -41,6 +41,7 @@ class TestSnippets(HttpCase):
             's_icon',  # Avoid specific case where the media dialog opens on drop
             's_snippet_group',  # Snippet groups are not snippets
             's_inline_text',
+            's_drag_image_preview_test',
         ]
         snippets_names = ','.join({
             f"{el.attrib['data-oe-snippet-key']}:{el.attrib.get('data-o-group', '')}"


### PR DESCRIPTION
Since the test “Drag and drop an inner snippet having a drag image preview” was added with this commit [1], on the runbot, when the "test_website" module is installed, the test thumbnail appears in the "inner snippets" list of the sidebar. This is confusing because it is not a real snippet.

With this commit, we add a "display: none" on this thumbnail so that it is no longer visible.

[1]: https://github.com/odoo/odoo/commit/aadaca13a9cd8ae8d9732070c4ba1ced6a708ead