### PR TITLE
[FIX] iot_drivers: try/except on aiortc import

### DIFF
--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -67,7 +67,8 @@ class EventManager:
             'iot_box_identifier': helpers.get_identifier(),
             **data,
         })
-        webrtc_client.send(event)
+        if webrtc_client:
+            webrtc_client.send(event)
         self.events.append(event)
         for session in self.sessions:
             session_devices = self.sessions[session]['devices']

--- a/addons/iot_drivers/webrtc_client.py
+++ b/addons/iot_drivers/webrtc_client.py
@@ -3,7 +3,11 @@ import json
 import logging
 from threading import Thread
 import time
-from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
+try:
+    from aiortc import RTCDataChannel, RTCPeerConnection, RTCSessionDescription
+    webrtc_client = True
+except ImportError:
+    webrtc_client = None
 
 from odoo.addons.iot_drivers import main
 from odoo.addons.iot_drivers.tools import helpers
@@ -111,5 +115,6 @@ class WebRtcClient(Thread):
         self.event_loop.run_forever()
 
 
-webrtc_client = WebRtcClient()
-webrtc_client.start()
+if webrtc_client:
+    webrtc_client = WebRtcClient()
+    webrtc_client.start()

--- a/addons/iot_drivers/websocket_client.py
+++ b/addons/iot_drivers/websocket_client.py
@@ -104,6 +104,8 @@ class WebsocketClient(Thread):
                     ws.close()
                     helpers.odoo_restart()
                 case 'webrtc_offer':
+                    if not webrtc_client:
+                        continue
                     answer = webrtc_client.offer(payload['offer'])
                     send_to_controller({
                         'iot_box_identifier': helpers.get_identifier(),


### PR DESCRIPTION
Before this commit, if an IoT box built in master where WebRTC has been removed checkout out 19.0, Odoo would fail to start due to the missing `aiortc` package.

After this commit, we guard the import and simply disable the WebRTC client if the package is not available.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
