### PR TITLE
[FIX] mail: fix style of thread icon in discuss sidebar

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
@@ -11,7 +11,7 @@
             </t>
         </Dropdown>
         <t t-else="" t-call="mail.DiscussSidebarCategory.main"/>
-        <div class="o-mail-DiscussSidebarCategory-channels">
+        <div class="o-mail-DiscussSidebarCategory-channels bg-inherit">
             <t t-if="category.is_open">
                 <DiscussSidebarChannel t-foreach="category.channels.filter((channel) => channel.isDisplayInSidebar)" t-as="channel" t-key="channel.localId" channel="channel"/>
             </t>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/240027

PR above introduced a new div without `bg-inherit`, which had the side-effect to not render thread icon in discuss sidebar correctly, such as the globe icon for public channels.

Before / After

<img width="295" height="1100" alt="Screenshot 2025-12-17 at 15 36 18" src="https://github.com/user-attachments/assets/9028f85b-565b-4d01-94e1-1c0e0f015488" /> <img width="295" height="1100" alt="Screenshot 2025-12-17 at 15 36 12" src="https://github.com/user-attachments/assets/93838a92-bee6-4b61-b450-e9bd535eb222" />
