### PR TITLE
[FIX] website: no overflowing Sales 3 menu


### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1597,9 +1597,15 @@ header {
         @include o-apply-colors('header-sales_three-custom');
         @include o-add-gradient('menu-secondary-gradient');
     }
-    #wrapwrap header .o_header_sales_three_small_links {
-        // Force small links to be proportional to header font size
-        --nav-link-font-size: MAX(12px, .75em);
+    #wrapwrap header {
+        .o_header_sales_three_small_links {
+            // Force small links to be proportional to header font size
+            --nav-link-font-size: MAX(12px, .75em);
+        }
+        .ms-auto:has(> .o_header_sales_three_small_links + .top_menu.o_menu_loading) {
+            // Fix menu auto hide by preventing parent overflow
+            overflow: hidden !important;
+        }
     }
 } @else if o-website-value('header-template') == 'sales_four' {
     #wrapwrap .o_header_sales_four_bot {


### PR DESCRIPTION
Scenario:

- edit the website navbar and set template "Sales - 3" (penultimate)
- edit menu to add several menu items that will be larger than possible

Result: the menu overflows

Cause: a parent element of the menu doesn't overflow, so when computing
autoHideMenu where we compute what overflow the list of menu, nothing
overflows it since the overflow already happened in the limitless
parent element.

Fix: using CSS to prevent the parent from overflowing.

opw-5178552

__pr note:__ this is happening in 17.0 but I'm targeting 18.0 since the ticket is in 18.0 and code is the same in 18.0 up to master.
