### PR TITLE
[FIX] website, html_builder: stop saving body background as base64

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -85,6 +85,7 @@ export class BackgroundImageOptionPlugin extends Plugin {
             const onClose = this.dependencies.media.openMediaDialog({
                 onlyImages: true,
                 node: editingElement,
+                skipImagePostProcess: true,
                 save: async (imageEl) => {
                     resolve(imageEl);
                 },

--- a/addons/html_builder/static/src/plugins/image/image_size.js
+++ b/addons/html_builder/static/src/plugins/image/image_size.js
@@ -36,7 +36,7 @@ export class ImageSize extends BaseOptionComponent {
         return `${(size / 1024).toFixed(1)} kB`;
     }
 }
-function isBase64ImageSrc(src) {
+export function isBase64ImageSrc(src) {
     // Check if it's a data URL with base64 encoding
     return src && src.startsWith("data:image/") && src.includes(";base64,");
 }

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -59,7 +59,10 @@ class ImageToolOptionPlugin extends Plugin {
             SetNewWindowAction,
             AltAction,
         },
-        on_media_dialog_saved_handlers: async (elements, { node }) => {
+        on_media_dialog_saved_handlers: async (elements, { node, skipImagePostProcess }) => {
+            if (skipImagePostProcess) {
+                return;
+            }
             for (const image of elements) {
                 if (image && image.tagName === "IMG") {
                     const imgInfo = await loadImageInfo(image);

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -205,7 +205,10 @@ export class MediaPlugin extends Plugin {
                     : [selection]
                 : [];
             for (const onMediaDialogSaved of this.getResource("on_media_dialog_saved_handlers")) {
-                await onMediaDialogSaved(elements, { node: params.node });
+                await onMediaDialogSaved(elements, {
+                    node: params.node,
+                    skipImagePostProcess: params.skipImagePostProcess,
+                });
             }
             return oldSave(...args);
         };

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -13,11 +13,13 @@ import { withSequence } from "@html_editor/utils/resource";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { renderToElement } from "@web/core/utils/render";
 import { CompositeAction } from "@html_builder/core/composite_action_plugin";
+import { isBase64ImageSrc } from "@html_builder/plugins/image/image_size";
 
 /**
  * @typedef { Object } CustomizeWebsiteShared
  * @property { CustomizeWebsitePlugin['customizeWebsiteColors'] } customizeWebsiteColors
  * @property { CustomizeWebsitePlugin['customizeWebsiteVariables'] } customizeWebsiteVariables
+ * @property { CustomizeWebsitePlugin['getBase64ImageData'] } getBase64ImageData
  * @property { CustomizeWebsitePlugin['loadTemplateKey'] } loadTemplateKey
  * @property { CustomizeWebsitePlugin['makeSCSSCusto'] } makeSCSSCusto
  * @property { CustomizeWebsitePlugin['toggleTemplate'] } toggleTemplate
@@ -41,6 +43,7 @@ export class CustomizeWebsitePlugin extends Plugin {
     static shared = [
         "customizeWebsiteColors",
         "customizeWebsiteVariables",
+        "getBase64ImageData",
         "loadTemplateKey",
         "makeSCSSCusto",
         "toggleTemplate",
@@ -78,7 +81,29 @@ export class CustomizeWebsitePlugin extends Plugin {
             }
         }),
         save_handlers: this.onSave.bind(this),
+        before_save_handlers: this.normalizeBodyBackgroundImage.bind(this),
     };
+
+    async normalizeBodyBackgroundImage() {
+        // Some websites since 18.4 could have a base64 body backgrounds,
+        // this resolve them to an existing attachment URL.
+        const bodyImage = this.getWebsiteVariableValue("body-image");
+        const imageData = this.getBase64ImageData(bodyImage);
+        if (!imageData) {
+            return;
+        }
+        const attachment = await rpc("/html_editor/attachment/add_data", {
+            name: null,
+            data: imageData,
+            is_image: true,
+        });
+        if (attachment && !attachment.error) {
+            await this.customizeWebsiteVariables({
+                "body-image-type": "'image'",
+                "body-image": `'${attachment.image_src}'`,
+            });
+        }
+    }
 
     async onSave() {
         if (this.viewsToEnableOnSave.size || this.viewsToDisableOnSave.size) {
@@ -161,6 +186,23 @@ export class CustomizeWebsitePlugin extends Plugin {
         if (reloadBundles) {
             await this.reloadBundles();
         }
+    }
+    getBase64ImageData(value) {
+        if (!value) {
+            return;
+        }
+        let normalizedSrc = value;
+        if (normalizedSrc.startsWith("'") && normalizedSrc.endsWith("'")) {
+            normalizedSrc = normalizedSrc.substring(1, normalizedSrc.length - 1);
+        }
+        if (!isBase64ImageSrc(normalizedSrc)) {
+            return;
+        }
+        const [, imageData] = normalizedSrc.split("base64,");
+        if (!imageData) {
+            return;
+        }
+        return imageData;
     }
     debouncedSCSSVariablesCusto = debounce(async (nullValue) => {
         const variables = this.variablesToCustomize;
@@ -504,9 +546,13 @@ export class CustomizeBodyBgTypeAction extends BuilderAction {
                 "body-image": "",
             });
         } else {
-            const imageEl = historyImageSrc || (await getAction("replaceBgImage").load({ el }));
-            if (imageEl) {
-                imageSrc = imageEl.src;
+            if (historyImageSrc) {
+                imageSrc = historyImageSrc;
+            } else {
+                const imageEl = await getAction("replaceBgImage").load({ el });
+                imageSrc = imageEl?.src || null;
+            }
+            if (imageSrc) {
                 await this.dependencies.customizeWebsite.customizeWebsiteVariables({
                     "body-image-type": `'${value}'`,
                     "body-image": `'${imageSrc}'`,


### PR DESCRIPTION
Since saas-18.4, body background images are saved as base64 in `body-image` instead of an URL. This affects the performance of the website.

To reproduce:

- Install Website
- Open the website builder
- go on the theme tab
- website > background > choose an image
- In the CSS file or in the style tab of the dev tools > `body-image` value is a base64 image

To fix:
We save the base64 webp image as a modified of the original and set is as image source directly after selecting the desired image for the background.

To retro fix databases that would maybe have base64 backgrounds, `normalizeBodyBackgroundImage` have been added to replace them with the correct URL.
This function activates when the user clicks save in the website builder.

task-5365270