### PR TITLE
[FIX] iot_drivers: add additional exceptions

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -238,7 +238,7 @@ class PrinterDriverBase(Driver, ABC):
                     return False
                 elif paper_status == 1:
                     self.send_status(status='warning', message='WARNING_LOW_PAPER')
-        except (escpos.exceptions.Error, OSError, AssertionError):
+        except (escpos.exceptions.Error, OSError, AssertionError, TypeError):
             self.escpos_device = None
             _logger.warning("Failed to query ESC/POS status")
 


### PR DESCRIPTION
With python escpos library we are currently not catching some exceptions.

This PR adds more exceptions to catch to keep the printer working

Additional exception caught for >=v19.0 in https://github.com/odoo/odoo/pull/240429