### PR TITLE
[IMP] website: update website search sorting priority

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -12,7 +12,6 @@ from io import BytesIO
 from itertools import islice
 from textwrap import shorten
 from xml.etree import ElementTree as ET
-from collections import defaultdict
 
 import requests
 import werkzeug.urls
@@ -610,168 +609,41 @@ class Website(Home):
         order = order or 'name ASC'
         return 'is_published desc, %s, id desc' % order
 
-    def _sort_results_by_relevance(self, results, phrase, sort_by_model=False):
-        # Order of priority:
-        # name > (tags) > description
-        term_list = list({t for t in (phrase or '').lower().split() if t})
+    def word_coverage_similarity(self, search_term, target_text, multiplier=1):
+        if not search_term or not target_text:
+            return 0.0
 
-        def is_perfect_match(search_text, term):
-            return bool(re.search(rf"\b{re.escape(term)}\b", search_text, flags=re.IGNORECASE))
+        def tokenize(text):
+            return set(re.findall(r'\w+', text.lower()))
 
-        def get_position_term_pairs(term_list, text):
-            position_word_pairs = []
-            missing_word_count = 0
-            for term in term_list:
-                is_missing = True
-                start = 0
-                while True:
-                    start = text.find(term, start)
-                    if start == -1:
-                        if is_missing:
-                            missing_word_count += 1
-                        break
-                    is_missing = False
-                    position_word_pairs.append((start, term))
-                    start += len(term)
-            return [sorted(position_word_pairs), missing_word_count]  # Sort by position
+        search_tokens = tokenize(search_term)
+        target_tokens = tokenize(target_text)
 
-        def get_best_distance(position_word_pairs):
-            required_term_count = len({word for _, word in position_word_pairs})
-            if required_term_count < 2:
-                return 0
+        if not search_tokens:
+            return 0.0
 
-            left = 0
-            term_counts = defaultdict(int)
-            terms_in_current_window = 0
-            best_window_size = float('inf')
+        intersection = search_tokens.intersection(target_tokens)
+        coverage_score = len(intersection) / len(search_tokens)
+        perfect_match_score = (search_term in target_text.lower()) * 5.0
+        proximity_score = 0
+        if coverage_score > 0:
+            from difflib import SequenceMatcher
+            proximity_score = SequenceMatcher(None, search_term.lower(), target_text.lower()).ratio()
 
-            for right in range(len(position_word_pairs)):
-                right_pos, right_word = position_word_pairs[right]
+        # We multiply coverage by 10 to ensure it always outweighs proximity
+        return multiplier * ((coverage_score * 10) + perfect_match_score + proximity_score)
 
-                # Add the right-side word to our window
-                if term_counts[right_word] == 0:
-                    terms_in_current_window += 1
-                term_counts[right_word] += 1
-
-                while terms_in_current_window == required_term_count:
-                    left_pos, left_word = position_word_pairs[left]
-                    current_window_size = right_pos - (left_pos + len(left_word))
-
-                    # If this is the tightest window we've seen, save it
-                    if current_window_size < best_window_size:
-                        best_window_size = current_window_size
-
-                    # Remove the left-size word and slide the window forward
-                    term_counts[left_word] -= 1
-                    if term_counts[left_word] == 0:
-                        terms_in_current_window -= 1
-                    left += 1
-
-            return best_window_size
-
-        def get_description(result):
+    def _sort_results_by_relevance(self, results_data, term):
+        for result in results_data:
             desc_field = result.get('_mapping', {}).get('description', {}).get('name', '')
-            return result.get(desc_field) or ''
-
-        results_to_sort = []
-        for result in results:
-            description_text = get_description(result).lower()
+            desc = (result.get(desc_field) or '').lower()
             name_text = (result.get('name') or '').lower()
             tag_names = [(tag.get('name') or '').lower() for tag in result.get('tag_ids', [])]
-
-            tag_matched_count = 0
-            imperfect_match_in_name_count = 0
-            imperfect_match_in_desc_count = 0
-            for term in term_list:
-                has_tag_match = any(term in tag_name for tag_name in tag_names)
-                if has_tag_match:
-                    tag_matched_count += 1
-
-                term_matches_in_name = name_text.find(term, 0)
-                term_matches_in_desc = description_text.find(term, 0)
-
-                if term_matches_in_name != -1 and not is_perfect_match(name_text, term):
-                    imperfect_match_in_name_count += 1
-                if term_matches_in_desc != -1 and not is_perfect_match(description_text, term):
-                    imperfect_match_in_desc_count += 1
-
-            name_pos_term_pairs, missing_word_in_name_count = get_position_term_pairs(term_list, name_text)
-            desc_pos_term_pairs, missing_word_in_desc_count = get_position_term_pairs(term_list, description_text)
-            name_best_distance = 0
-            desc_best_distance = 0
-
-            if len(term_list) - missing_word_in_name_count >= 2:
-                name_best_distance = get_best_distance(name_pos_term_pairs)
-            if len(term_list) - missing_word_in_desc_count >= 2:
-                desc_best_distance = get_best_distance(desc_pos_term_pairs)
-
-            is_perfect_name = missing_word_in_name_count == 0 and imperfect_match_in_name_count == 0
-            is_perfect_desc = missing_word_in_desc_count == 0 and imperfect_match_in_desc_count == 0
-            has_imperfect_name_without_missing = missing_word_in_name_count == 0 and imperfect_match_in_name_count > 0
-            has_imperfect_desc_without_missing = missing_word_in_desc_count == 0 and imperfect_match_in_desc_count > 0
-            if is_perfect_name:
-                rank = 0
-                imperfect_match_count = 0
-                distance = name_best_distance
-            elif is_perfect_desc:
-                rank = 2
-                imperfect_match_count = 0
-                distance = desc_best_distance
-            elif has_imperfect_name_without_missing:
-                rank = 4
-                imperfect_match_count = imperfect_match_in_name_count
-                distance = name_best_distance
-            elif has_imperfect_desc_without_missing:
-                rank = 6
-                imperfect_match_count = imperfect_match_in_desc_count
-                distance = desc_best_distance
-            else:
-                rank = 8
-                if missing_word_in_name_count < missing_word_in_desc_count:
-                    imperfect_match_count = missing_word_in_name_count
-                    distance = name_best_distance
-                elif missing_word_in_desc_count < missing_word_in_name_count:
-                    # description is more penalized compared to name
-                    imperfect_match_count = missing_word_in_desc_count + 1
-                    distance = desc_best_distance
-                else:
-                    imperfect_match_count = missing_word_in_name_count
-                    distance = min(name_best_distance, desc_best_distance)
-            # We want tags to make the result superior when present and matching
-            if tag_matched_count:
-                if tag_matched_count == len(term_list):
-                    rank = min(rank, 1)
-                else:
-                    rank = max(0, rank - 1)
-                imperfect_match_count -= tag_matched_count
-
-            results_to_sort.append({
-                'result': result,
-                'rank': rank,
-                'imperfect_match_count': imperfect_match_count,
-                'distance': distance,
-            })
-
-        results = [sorted_result['result'] for sorted_result in sorted(
-            results_to_sort,
-            key=lambda x: (
-                x['rank'],
-                x['imperfect_match_count'],
-                x['distance'],
-            ),
-        )]
-        if sort_by_model:
-            # When sorted by model, we group all the results by model
-            # The model with the best result score first, and so on
-            models = []
-            for res in results:
-                if res.get('model') not in models:
-                    models.append(res.get('model'))
-            results_by_model = []
-            for model in models:
-                results_by_model += [res for res in results if res.get('model') == model]
-            return results_by_model
-        return results
+            name_score = self.word_coverage_similarity(term, name_text, 3)
+            desc_score = self.word_coverage_similarity(term, desc, 1)
+            tag_score = self.word_coverage_similarity(term, ' '.join(tag_names), 2)
+            result['score'] = sum([name_score, desc_score, tag_score])
+        return sorted(results_data, key=lambda i: i['score'], reverse=True)
 
     @http.route('/website/snippet/autocomplete', type='jsonrpc', auth='public', website=True, readonly=True)
     def autocomplete(self, search_type=None, term=None, order=None, offset=0, limit=6, max_nb_chars=999, options=None):
@@ -877,11 +749,7 @@ class Website(Home):
                 for group_key, group in result.items()
                 for record in group['data']
             ]
-            ranked_results = self._sort_results_by_relevance(
-                ranked_results,
-                term,
-                sort_by_model=options.get('sort_by_model', False),
-            )
+            ranked_results = self._sort_results_by_relevance(ranked_results, term)
             if options.get('sort_by_model'):
                 grouped_result = {}
                 for record in ranked_results:

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from itertools import islice
 from textwrap import shorten
 from xml.etree import ElementTree as ET
+from collections import defaultdict
 
 import requests
 import werkzeug.urls
@@ -589,6 +590,169 @@ class Website(Home):
         order = order or 'name ASC'
         return 'is_published desc, %s, id desc' % order
 
+    def _sort_results_by_relevance(self, results, phrase, sort_by_model=False):
+        # Order of priority:
+        # name > (tags) > description
+        term_list = list({t for t in (phrase or '').lower().split() if t})
+
+        def is_perfect_match(search_text, term):
+            return bool(re.search(rf"\b{re.escape(term)}\b", search_text, flags=re.IGNORECASE))
+
+        def get_position_term_pairs(term_list, text):
+            position_word_pairs = []
+            missing_word_count = 0
+            for term in term_list:
+                is_missing = True
+                start = 0
+                while True:
+                    start = text.find(term, start)
+                    if start == -1:
+                        if is_missing:
+                            missing_word_count += 1
+                        break
+                    is_missing = False
+                    position_word_pairs.append((start, term))
+                    start += len(term)
+            return [sorted(position_word_pairs), missing_word_count]  # Sort by position
+
+        def get_best_distance(position_word_pairs):
+            required_term_count = len({word for _, word in position_word_pairs})
+            if required_term_count < 2:
+                return 0
+
+            left = 0
+            term_counts = defaultdict(int)
+            terms_in_current_window = 0
+            best_window_size = float('inf')
+
+            for right in range(len(position_word_pairs)):
+                right_pos, right_word = position_word_pairs[right]
+
+                # Add the right-side word to our window
+                if term_counts[right_word] == 0:
+                    terms_in_current_window += 1
+                term_counts[right_word] += 1
+
+                while terms_in_current_window == required_term_count:
+                    left_pos, left_word = position_word_pairs[left]
+                    current_window_size = right_pos - (left_pos + len(left_word))
+
+                    # If this is the tightest window we've seen, save it
+                    if current_window_size < best_window_size:
+                        best_window_size = current_window_size
+
+                    # Remove the left-size word and slide the window forward
+                    term_counts[left_word] -= 1
+                    if term_counts[left_word] == 0:
+                        terms_in_current_window -= 1
+                    left += 1
+
+            return best_window_size
+
+        def get_description(result):
+            desc_field = result.get('_mapping', {}).get('description', {}).get('name', '')
+            return result.get(desc_field) or ''
+
+        results_to_sort = []
+        for result in results:
+            description_text = get_description(result).lower()
+            name_text = (result.get('name') or '').lower()
+            tag_names = [(tag.get('name') or '').lower() for tag in result.get('tag_ids', [])]
+
+            tag_matched_count = 0
+            imperfect_match_in_name_count = 0
+            imperfect_match_in_desc_count = 0
+            for term in term_list:
+                has_tag_match = any(term in tag_name for tag_name in tag_names)
+                if has_tag_match:
+                    tag_matched_count += 1
+
+                term_matches_in_name = name_text.find(term, 0)
+                term_matches_in_desc = description_text.find(term, 0)
+
+                if term_matches_in_name != -1 and not is_perfect_match(name_text, term):
+                    imperfect_match_in_name_count += 1
+                if term_matches_in_desc != -1 and not is_perfect_match(description_text, term):
+                    imperfect_match_in_desc_count += 1
+
+            name_pos_term_pairs, missing_word_in_name_count = get_position_term_pairs(term_list, name_text)
+            desc_pos_term_pairs, missing_word_in_desc_count = get_position_term_pairs(term_list, description_text)
+            name_best_distance = 0
+            desc_best_distance = 0
+
+            if len(term_list) - missing_word_in_name_count >= 2:
+                name_best_distance = get_best_distance(name_pos_term_pairs)
+            if len(term_list) - missing_word_in_desc_count >= 2:
+                desc_best_distance = get_best_distance(desc_pos_term_pairs)
+
+            is_perfect_name = missing_word_in_name_count == 0 and imperfect_match_in_name_count == 0
+            is_perfect_desc = missing_word_in_desc_count == 0 and imperfect_match_in_desc_count == 0
+            has_imperfect_name_without_missing = missing_word_in_name_count == 0 and imperfect_match_in_name_count > 0
+            has_imperfect_desc_without_missing = missing_word_in_desc_count == 0 and imperfect_match_in_desc_count > 0
+            if is_perfect_name:
+                rank = 0
+                imperfect_match_count = 0
+                distance = name_best_distance
+            elif is_perfect_desc:
+                rank = 2
+                imperfect_match_count = 0
+                distance = desc_best_distance
+            elif has_imperfect_name_without_missing:
+                rank = 4
+                imperfect_match_count = imperfect_match_in_name_count
+                distance = name_best_distance
+            elif has_imperfect_desc_without_missing:
+                rank = 6
+                imperfect_match_count = imperfect_match_in_desc_count
+                distance = desc_best_distance
+            else:
+                rank = 8
+                if missing_word_in_name_count < missing_word_in_desc_count:
+                    imperfect_match_count = missing_word_in_name_count
+                    distance = name_best_distance
+                elif missing_word_in_desc_count < missing_word_in_name_count:
+                    # description is more penalized compared to name
+                    imperfect_match_count = missing_word_in_desc_count + 1
+                    distance = desc_best_distance
+                else:
+                    imperfect_match_count = missing_word_in_name_count
+                    distance = min(name_best_distance, desc_best_distance)
+            # We want tags to make the result superior when present and matching
+            if tag_matched_count:
+                if tag_matched_count == len(term_list):
+                    rank = min(rank, 1)
+                else:
+                    rank = max(0, rank - 1)
+                imperfect_match_count -= tag_matched_count
+
+            results_to_sort.append({
+                'result': result,
+                'rank': rank,
+                'imperfect_match_count': imperfect_match_count,
+                'distance': distance,
+            })
+
+        results = [sorted_result['result'] for sorted_result in sorted(
+            results_to_sort,
+            key=lambda x: (
+                x['rank'],
+                x['imperfect_match_count'],
+                x['distance'],
+            ),
+        )]
+        if sort_by_model:
+            # When sorted by model, we group all the results by model
+            # The model with the best result score first, and so on
+            models = []
+            for res in results:
+                if res.get('model') not in models:
+                    models.append(res.get('model'))
+            results_by_model = []
+            for model in models:
+                results_by_model += [res for res in results if res.get('model') == model]
+            return results_by_model
+        return results
+
     @http.route('/website/snippet/autocomplete', type='jsonrpc', auth='public', website=True, readonly=True)
     def autocomplete(self, search_type=None, term=None, order=None, limit=5, max_nb_chars=999, options=None):
         """
@@ -602,6 +766,7 @@ class Website(Home):
         :param dict options: options map containing
             allowFuzzy: enables the fuzzy matching when truthy
             fuzzy (boolean): True when called after finding a name through fuzzy matching
+            sort_by_relevance: True if we want to sort results by relevance
 
         :returns: dict (or False if no result) containing
             - 'results' (list): results (only their needed field values)
@@ -634,6 +799,8 @@ class Website(Home):
         if search_type == 'all':
             # Only supported order for 'all' is on name
             results_data.sort(key=lambda r: r.get('name', ''), reverse='name desc' in order)
+        if options.get('sort_by_relevance'):
+            results_data = self._sort_results_by_relevance(results_data, term)
         results_data = results_data[:limit]
         result = []
         for record in results_data:

--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -42,11 +42,13 @@ export class SearchBar extends Interaction {
         const dataset = this.inputEl.dataset;
         this.options = {
             displayImage: dataset.displayImage && JSON.parse(dataset.displayImage),
-            displayDescription: dataset.displayDescription && JSON.parse(dataset.displayDescription),
+            displayDescription:
+                dataset.displayDescription && JSON.parse(dataset.displayDescription),
             displayExtraLink: dataset.displayExtraLink && JSON.parse(dataset.displayExtraLink),
             displayDetail: dataset.displayDetail && JSON.parse(dataset.displayDetail),
             // Make it easy for customization to disable fuzzy matching on specific searchboxes
             allowFuzzy: !(dataset.noFuzzy && JSON.parse(dataset.noFuzzy)),
+            sort_by_relevance: true,
         };
         for (const fieldEl of form.querySelectorAll("input[type='hidden']")) {
             this.options[fieldEl.name] = fieldEl.value;

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -215,6 +215,112 @@ class TestAutoComplete(TransactionCase):
             "Should center around first token 'fox' when exact phrase 'fox runs' not found"
         )
 
+    def test_sort_results_by_relevance(self):
+        """Ensure relevance sorting handles source priority and proximity."""
+        sort_results = self.WebsiteController._sort_results_by_relevance
+
+        def _result(name, website_url, description_text='', tag_ids=None, desc_field_name='description', model=None):
+            data = {
+                'name': name,
+                'website_url': website_url,
+                'tag_ids': tag_ids or [],
+                '_mapping': {
+                    'description': {
+                        'html': True,
+                        'match': True,
+                        'name': desc_field_name,
+                        'type': 'text',
+                    },
+                },
+                desc_field_name: description_text,
+            }
+            if model is not None:
+                data['model'] = model
+            return data
+
+        def _urls(records):
+            return [record['website_url'] for record in records]
+
+        # General test
+        results = [
+            _result(name='alpha beta gamma', website_url='/distance-title-best', desc_field_name='content'),
+            _result(name='alphas beta gamma', website_url='/distance-title-best-with-unperfect', desc_field_name='content'),
+            _result(name='alpha x beta y gamma', website_url='/distance-title-mid', desc_field_name='arch'),
+            _result(name='alpha beta', website_url='/one-word-missing-title', desc_field_name='arch'),
+            _result(name='alpha ' + 'x ' * 20 + 'beta ' + 'y ' * 20 + 'gamma', website_url='/distance-title-far', desc_field_name='description'),
+            _result(name='alpha ' + 'x ' * 20 + 'gamma', website_url='/distance-title-far-missing', desc_field_name='description'),
+            _result(name='generic result', website_url='/distance-desc-best', description_text='x ' * 200 + 'alpha beta gamma ' + 'y ' * 200, desc_field_name='arch'),
+            _result(name='generic result', website_url='/distance-desc-best-disordered', description_text='x ' * 200 + 'beta alpha gamma ' + 'y ' * 200, desc_field_name='arch'),
+            _result(name='generic result', website_url='/distance-desc-mid', description_text='x ' * 200 + 'alpha xxxxxx beta xxxxxx gamma ' + 'y ' * 200, desc_field_name='arch'),
+            _result(name='alpha beta', website_url='/distance-desc-best-missing-title', description_text='x ' * 200 + 'alpha beta gamma ' + 'y ' * 200, desc_field_name='arch'),
+            _result(name='alpha beta', website_url='/one-word-missing-title-with-tag', tag_ids=[{'name': 'gamma'}], desc_field_name='content'),
+        ]
+
+        ordered_results = sort_results(list(reversed(results)), 'alpha beta gamma')   
+        self.assertEqual(
+            ['/distance-title-best', '/distance-title-mid', '/distance-title-far',
+            '/distance-desc-best-missing-title', '/distance-desc-best', '/distance-desc-best-disordered',
+            '/distance-desc-mid', '/distance-title-best-with-unperfect', '/one-word-missing-title-with-tag',
+            '/one-word-missing-title', '/distance-title-far-missing'],
+            _urls(ordered_results),
+            "The results order is not correct.",
+        )
+
+        # 1/ Single-word priority: name > tag > description.
+        single_word_results = [
+            _result(name='one result', website_url='/name-hit', desc_field_name='description'),
+            _result(name='generic result', website_url='/tag-hit', tag_ids=[{'name': 'one featured'}], desc_field_name='content'),
+            _result(name='generic result', website_url='/desc-hit', description_text='one appears in description only', desc_field_name='arch'),
+        ]
+        ordered_single_word = sort_results(list(reversed(single_word_results)), 'one')
+        self.assertEqual(
+            ['/name-hit', '/tag-hit', '/desc-hit'],
+            _urls(ordered_single_word),
+            "Single-word search should prioritize name matches before tags, then description.",
+        )
+
+        # 2/ Multi-word (3 terms): best proximity should rank first.
+        multi_word_results = [
+            _result(name='alpha beta gamma', website_url='/distance-best', desc_field_name='content'),
+            _result(name='alpha x beta y gamma', website_url='/distance-mid', desc_field_name='arch'),
+            _result(name='alpha ' + 'x ' * 20 + 'beta ' + 'y ' * 20 + 'gamma', website_url='/distance-far', desc_field_name='description'),
+        ]
+        ordered_multi_word = sort_results(list(reversed(multi_word_results)), 'alpha beta gamma')
+        self.assertEqual(
+            ['/distance-best', '/distance-mid', '/distance-far'],
+            _urls(ordered_multi_word),
+            "For 3-word searches, closer term proximity should rank higher.",
+        )
+
+        # 3/ Multi-word with missing words: complete matches first, then fewer missing terms.
+        missing_word_results = [
+            _result(name='alpha beta gamma', website_url='/all-terms-best', desc_field_name='arch'),
+            _result(name='alpha x beta y gamma', website_url='/all-terms-far', desc_field_name='description'),
+            _result(name='alpha beta', website_url='/missing-one', desc_field_name='content'),
+            _result(name='alpha', website_url='/missing-two', desc_field_name='arch'),
+        ]
+        ordered_missing_words = sort_results(list(reversed(missing_word_results)), 'alpha beta gamma')
+        self.assertEqual(
+            ['/all-terms-best', '/all-terms-far', '/missing-one', '/missing-two'],
+            _urls(ordered_missing_words),
+            "Results containing all terms must rank before those missing terms.",
+        )
+
+        # 4/ sort_by_model=True: results should be grouped by model order.
+        grouped_by_model_results = [
+            _result(name='one top result', website_url='/m1-top', desc_field_name='description', model='model 1'),
+            _result(name='someone second result', website_url='/m2-top', desc_field_name='content', model='model 2'),
+            _result(name='generic', website_url='/m1-desc', description_text='one appears here', desc_field_name='arch', model='model 1'),
+            _result(name='generic', website_url='/m2-desc', description_text='one appears here too', desc_field_name='description', model='model 2'),
+            _result(name='generic', website_url='/m2-missing', description_text='no hit', desc_field_name='content', model='model 2'),
+        ]
+        ordered_grouped_by_model = sort_results(list(reversed(grouped_by_model_results)), 'one', sort_by_model=True)
+        self.assertEqual(
+            ['/m1-top', '/m1-desc', '/m2-desc', '/m2-top', '/m2-missing'],
+            _urls(ordered_grouped_by_model),
+            "With sort_by_model enabled, results should be grouped by model while preserving intra-model relevance order.",
+        )
+
     def test_01_few_results(self):
         """ Tests an autocomplete with exact match and less than the maximum number of results """
         suggestions = self._autocomplete("few")


### PR DESCRIPTION
[IMP] website: update website search sorting priority

Search results in user's websites now have a priority mechanism.
The overall priority is name > tags > description.

more specifically:
- Exact matches in sequence should be on top, exact match in the name
rank higher than in the descrpition
- Exact match not in sequence (the search terms are separated by other
words) should be next
- Partial match are ranked last

The ranking gets worst the further apart the words are, and the more 
there is missing words.

For example, user search with 3 words:
- 3 out of 3 words in sequence in name is first
- 3 out of 3 words in tags is second
- 3 out of 3 words in sequence in description is third
- 3 out of 3 words not in sequence is forth
- and 2 out of 3 words is last

You can also, by setting the `sort_by_model` parameter to True, sort
the result by model. So the model with the best result will come first
followed by all the results with the same model, in the same priority
order. Then it will take the second best model with the best result and
so on.

linked to odoo/enterprise#106186

task-5366564