### PR TITLE
[FIX] point_of_sale: cashier selection popup "More" btn

### DIFF
--- a/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.js
+++ b/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.js
@@ -12,14 +12,14 @@ export class CashierSelectionPopup extends Component {
     };
 
     setup() {
+        this.initialLimit = 5;
         this.pos = usePos();
-        this.state = useState({ visibleOptions: 5 });
+        this.state = useState({ showAll: false });
     }
 
     get displayableOptions() {
-        return this.state.visibleOptions
-            ? this.props.employees.slice(0, this.state.visibleOptions)
-            : this.props.employees;
+        const employees = this.props.employees;
+        return this.state.showAll ? employees : employees.slice(0, this.initialLimit);
     }
 
     async lock() {
@@ -28,5 +28,8 @@ export class CashierSelectionPopup extends Component {
     selectEmployee(employee) {
         this.props.getPayload(employee);
         this.props.close();
+    }
+    get displayMoreButton() {
+        return !this.state.showAll && this.props.employees.length > this.initialLimit;
     }
 }

--- a/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.xml
+++ b/addons/pos_hr/static/src/app/components/popups/cashier_selection_popup/cashier_selection_popup.xml
@@ -42,9 +42,9 @@
                 <i class="oi oi-chevron-right"/>
             </button>
             <button
-                t-if="state.visibleOptions !== 0"
+                t-if="this.displayMoreButton"
                 class="cashier-selection-item d-flex align-items-center justify-content-between btn btn-outline-secondary p-2 p-sm-3 text-start"
-                t-on-click="() => this.state.visibleOptions = 0">
+                t-on-click="() => this.state.showAll = true">
                 <div class="d-flex flex-column">
                     <span>More...</span>
                 </div>

--- a/addons/pos_hr/static/tests/unit/components/popups/cashier_selection_popup.test.js
+++ b/addons/pos_hr/static/tests/unit/components/popups/cashier_selection_popup.test.js
@@ -18,12 +18,12 @@ test("displayableOptions", async () => {
     });
     // Default state: visibleOptions = 5
     // shows employees up to visibleOptions (extra ones go under "more..." button)
-    comp.state.visibleOptions = 1;
+    comp.initialLimit = 1;
     const limitedEmp = comp.displayableOptions;
     expect(limitedEmp.length).toBe(1);
 
     //To shows all employees set visibleOptions to 0
-    comp.state.visibleOptions = 0;
+    comp.state.showAll = true;
     const allEmp = comp.displayableOptions;
     expect(allEmp.length).toBe(2);
 });


### PR DESCRIPTION
When using "Log in with employees", "More..." button is supposed to be shown only if there is more than 5 employees.

Before this commit, when there was exactly 5 employees or less, the button was still shown and click on it, does not display more employees.

task-id: 5411086

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr