### PR TITLE
[FIX] account: fix invoice_origin missed in reverse move

### DIFF
--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1796,6 +1796,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         }])
 
     def test_out_invoice_create_refund(self):
+        self.invoice.write({'invoice_origin': 'S00001'})
         self.invoice.action_post()
 
         bank1 = self.env['res.partner.bank'].create({
@@ -1864,6 +1865,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'ref': 'Reversal of: %s, %s' % (self.invoice.name, move_reversal.reason),
             'payment_state': 'not_paid',
             'partner_bank_id': bank1.id,
+            'invoice_origin': 'S00001'
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -104,6 +104,7 @@ class AccountMoveReversal(models.TransientModel):
             'invoice_payment_term_id': mixed_payment_term,
             'invoice_user_id': move.invoice_user_id.id,
             'auto_post': 'at_date' if reverse_date > fields.Date.context_today(self) else 'no',
+            'invoice_origin': move.invoice_origin,
         }
 
     def reverse_moves(self, is_modify=False):


### PR DESCRIPTION
### Issue:
Reverse moves miss `invoice_origin` field.

#### To reproduce:
1- Create a SO.
2- Create an invoice and confirm.
3- In invoice list view make the `Source Document` visible.
4- Create a credit note and reverse the move.

From invoice list view, you can observe that `Source Document` is empty for reverse move.

### Cause:

This is a regression introduced by #236656.

opw-5362055
