### PR TITLE
[FIX] point_of_sale: display attributes in combo line

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -30,9 +30,11 @@ export const computeComboItems = (
         if (comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id) {
             priceUnit += remainingTotal;
         }
-        const attribute_value_ids = conf.configuration?.attribute_value_ids?.map(
-            (id) => productTemplateAttributeValueById[id]
-        );
+        const attribute_value_ids = conf.configuration
+            ? conf.configuration.attribute_value_ids?.map(
+                  (id) => productTemplateAttributeValueById[id]
+              )
+            : conf.combo_item_id.product_id.product_template_attribute_value_ids;
 
         const totalPriceExtra =
             priceUnit + getAttributesPriceExtra(attribute_value_ids) + comboItem.extra_price;
@@ -49,9 +51,11 @@ export const computeComboItems = (
     for (const extra of childLineExtra) {
         const comboItem = extra.combo_item_id;
         const priceUnit = ProductPrice.round(comboItem.combo_id.base_price);
-        const attribute_value_ids = extra.configuration?.attribute_value_ids.map(
-            (id) => productTemplateAttributeValueById[id]
-        );
+        const attribute_value_ids = extra.configuration
+            ? extra.configuration.attribute_value_ids.map(
+                  (id) => productTemplateAttributeValueById[id]
+              )
+            : extra.combo_item_id.product_id.product_template_attribute_value_ids;
 
         const totalPriceExtra =
             priceUnit + getAttributesPriceExtra(attribute_value_ids) + comboItem.extra_price;

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -105,12 +105,12 @@ registry.category("web_tour.tours").add("ProductComboPriceCheckTour", {
             Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Desk Combo"),
             inLeftSide([
-                ...ProductScreen.selectedOrderlineHasDirect("Desk Combo", "1", "7.00"),
+                ...ProductScreen.selectedOrderlineHasDirect("Desk Combo", "1", "9.00"),
                 ...ProductScreen.orderLineHas("Desk Organizer", "1"),
                 ...ProductScreen.orderLineHas("Desk Pad", "1"),
                 ...ProductScreen.orderLineHas("Whiteboard Pen", "1"),
             ]),
-            ProductScreen.totalAmountIs("7.00"),
+            ProductScreen.totalAmountIs("9.00"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
@@ -246,5 +246,21 @@ registry.category("web_tour.tours").add("test_combo_item_image_not_display", {
             combo.checkImgAndSelect("Combo Product 4", false),
             combo.checkImgAndSelect("Combo Product 6", false),
             Dialog.confirm(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_display_line_attribute_combo", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Donut Combo"),
+            combo.select("Donut (Sugar)"),
+            combo.select("Donut (Chocolate)"),
+            Dialog.confirm(),
+            inLeftSide([
+                ...ProductScreen.orderComboLineHas("Donut", "1.0", "", "Sugar"),
+                ...ProductScreen.orderComboLineHas("Donut", "1.0", "", "Chocolate"),
+            ]),
         ].flat(),
 });


### PR DESCRIPTION
**Steps to reproduce:**
- Create a combo including products with different variants
- The variants should be set to "Instantly"
- Go to PoS and click on that combo
- When confirming, the lines do not show the selected variant
- The ticket on the receipt screen does not show it either

**Why the fix:**
We were trying to map the combo lines using the line's configuration, but the configuration did not always contain the needed information, in this case the attribute_value_ids. This happens because when clicking on a combo, we are setting the configuration as the configuration popup is displaying, meaning we do not know which variants are going to be chosen.

Instead, we now access the correct variants using the current combo line directly if the configuration is not set.

An existing test had to be changed because before this fix, as we did not care for variants in certain cases, we did not
add the price_extra from the variant to the combo's price, which seems to be the behavior we want.

opw-5392530