### PR TITLE
[IMP] hr: departure notice wizard improvement

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -137,6 +137,18 @@ class HrVersion(models.Model):
                                           groups="hr.group_hr_user", copy=False, ondelete='restrict', tracking=1)
     departure_description = fields.Html(string="Additional Information", groups="hr.group_hr_user", copy=False)
     departure_date = fields.Date(string="Departure Date", groups="hr.group_hr_user", copy=False, tracking=1)
+    dismissal_date = fields.Date(groups="hr.group_hr_user", copy=False)
+    use_seniority_at_hiring = fields.Boolean(groups="hr.group_hr_user", copy=False)
+    salary_december_2013 = fields.Selection([
+        ('inferior', 'Gross annual salary < 32.254 €'),
+        ('superior', 'Gross annual salary > 32.254 €'),
+        ], groups="hr.group_hr_user", copy=False)
+    salary_visibility = fields.Boolean(groups="hr.group_hr_user", copy=False)
+    notice_respect = fields.Selection([
+        ('with', 'Employee works during his notice period'),
+        ('partial', 'Employee works partially during his notice period'),
+        ('without', "Employee doesn't work during his notice period"),
+        ], groups="hr.group_hr_user", copy=False)
 
     resource_calendar_id = fields.Many2one('resource.calendar', inverse='_inverse_resource_calendar_id', check_company=True, string="Working Hours", tracking=1)
     is_flexible = fields.Boolean(compute='_compute_is_flexible', store=True, groups="hr.group_hr_user")

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -188,9 +188,9 @@
                                                    placeholder="e.g. Building 2, Remote, etc."/>
                                         </group>
                                         <group name="departure" string="Departure" invisible="active">
-                                            <field name="departure_reason_id" options="{'no_edit': True, 'no_create': True, 'no_open': True}"/>
-                                            <field name="departure_description"/>
-                                            <field name="departure_date"/>
+                                            <field name="departure_reason_id" options="{'no_edit': True, 'no_create': True, 'no_open': True}" readonly="1"/>
+                                            <field name="departure_description" readonly="1"/>
+                                            <field name="departure_date" readonly="1"/>
                                         </group>
                                         <group string="Note" name="note" groups="hr.group_hr_user">
                                             <field name="additional_note" placeholder="Provide additional information about this version..." colspan="2" nolabel="1"/>


### PR DESCRIPTION
- Added departure wizard fields to employee version to persist departure wizard data and reload it when reopening the wizard
- Set departure fields on the employee form to readonly since the wizard is now the single source of truth

Task: 5407737
