### PR TITLE
[IMP] mail, im_livechat: add docstring about chatHub.initPromise

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -48,7 +48,8 @@ export class LivechatChannelInfoList extends Component {
         });
     }
 
-    openVisitorProfile() {
+    async openVisitorProfile() {
+        await this.store.chatHub.initPromise;
         if (this.ui.isSmall) {
             this.props.thread.channel.chatWindow?.fold();
         } else {

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -6,6 +6,13 @@ import { Deferred, Mutex } from "@web/core/utils/concurrency";
 export const CHAT_HUB_KEY = "mail.ChatHub";
 const CHAT_HUB_COMPACT_LS = "mail.user_setting.chathub_compact";
 
+/**
+ * @typedef AwaitChatHubInit
+ * ⚠️ Always wait for `store.chatHub.initPromise` before reading or writing this field inside methods
+ * to avoid race conditions with ChatHub initialization. Using it directly inside a template (or
+ * other reactive callback) is fine as reactivity will re-render (or re-compute) when needed.
+ */
+
 export class ChatHub extends Record {
     BUBBLE = 56; // same value as $o-mail-ChatHub-bubblesWidth
     BUBBLE_START = 15; // same value as $o-mail-ChatHub-bubblesStart

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -285,11 +285,12 @@ export class Store extends BaseStore {
     }
 
     async startMeeting() {
+        /** @type {import("models").DiscussChannel} */
         const channel = await this.createGroupChat({
             default_display_mode: "video_full_screen",
             partners_to: [this.self.id],
         });
-        await this.store.chatHub.initPromise;
+        await this.chatHub.initPromise;
         channel.chatWindow?.update({ autofocus: 0 });
         await this.env.services["discuss.rtc"].toggleCall(channel, { camera: true });
         if (this.rtc.selfSession) {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -6,6 +6,8 @@ import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { Deferred } from "@web/core/utils/concurrency";
 
+/** @import { AwaitChatHubInit } from "@mail/core/common/chat_hub_model" */
+
 /**
  * @typedef SuggestedRecipient
  * @property {string} email
@@ -122,6 +124,7 @@ export class Thread extends Record {
         }
         return this.message_needaction_counter;
     }
+    /** ⚠️ {@link AwaitChatHubInit} */
     isDisplayed = fields.Attr(false, {
         compute() {
             return this.computeIsDisplayed();

--- a/addons/mail/static/src/discuss/call/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/call/common/@types/models.d.ts
@@ -33,7 +33,7 @@ declare module "models" {
     export interface Thread {
         activeRtcSession: RtcSession;
         cancelRtcInvitationTimeout: number|undefined;
-        focusAvailableVideo: () => void;
+        focusAvailableVideo: () => Promise<void>;
         focusStack: RtcSession[];
         hadSelfSession: boolean;
         isCallDisplayedInChatWindow: Readonly<boolean>;

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -3,6 +3,8 @@ import { Thread } from "@mail/core/common/thread_model";
 
 import { patch } from "@web/core/utils/patch";
 
+/** @import { AwaitChatHubInit } from "@mail/core/common/chat_hub_model" */
+
 export const CALL_PROMOTE_FULLSCREEN = Object.freeze({
     INACTIVE: "INACTIVE",
     ACTIVE: "ACTIVE",
@@ -156,13 +158,15 @@ const ThreadPatch = {
             },
         });
     },
+    /** ⚠️ {@link AwaitChatHubInit} */
     get isCallDisplayedInChatWindow() {
         return this.channel.chatWindow?.isOpen && !this.store.meetingViewOpened;
     },
     get showCallView() {
         return !this.store.rtc.isFullscreen && this.rtc_session_ids.length > 0;
     },
-    focusAvailableVideo() {
+    async focusAvailableVideo() {
+        await this.store.chatHub.initPromise;
         if (
             !this.store.settings.useCallAutoFocus ||
             !(

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -6,6 +6,8 @@ import { Deferred } from "@web/core/utils/concurrency";
 import { rpc } from "@web/core/network/rpc";
 import { compareDatetime, effectWithCleanup } from "@mail/utils/common/misc";
 
+/** @import { AwaitChatHubInit } from "@mail/core/common/chat_hub_model" */
+
 export class DiscussChannel extends Record {
     static _name = "discuss.channel";
     static _inherits = { "mail.thread": "thread" };
@@ -123,6 +125,7 @@ export class DiscussChannel extends Record {
     });
     /** @type {"chat"|"channel"|"group"|"livechat"|"whatsapp"|"ai_chat"|"ai_composer"} */
     channel_type;
+    /** ⚠️ {@link AwaitChatHubInit} */
     chatWindow = fields.One("ChatWindow", {
         inverse: "channel",
     });
@@ -241,6 +244,7 @@ export class DiscussChannel extends Record {
     }
     /** @type {Number|undefined} */
     member_count;
+    /** ⚠️ {@link AwaitChatHubInit} */
     get shouldSubscribeToBusChannel() {
         return this.chatWindow?.isOpen;
     }


### PR DESCRIPTION
It is particularly important to never read/write the chat window field until ChatHub is initialized. Indeed reading might miss not yet loaded values, and writing might overwrite all existing chat window.

This was already checked in most places but a more obvious warning is now added and remaining occurrences are fixed.