### PR TITLE
[IMP] mail: improved readability of mobile discuss app

### DIFF
--- a/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.dark.scss
@@ -1,4 +1,8 @@
 .o-mail-MessagingMenu {
-    --mail-MessagingMenu-bg: #{mix($gray-100, $gray-200, 65%)};
+    --mail-MessagingMenu-bg: #{$gray-100};
     --mail-MessagingMenu-listBorderColor: #{rgba($gray-300, .25)};
+}
+
+.o-mail-MessagingMenu-navbar {
+    --mail-MessagingMenu-bg: #{$gray-100};
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -35,6 +35,7 @@
 }
 
 .o-mail-MessagingMenu-navbar {
+    background-color: var(--mail-MessagingMenu-bg, $o-view-background-color);
     container: navbar / inline-size;
 
     &.o-mail-MessagingMenu-navbar-with-4-elements {

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -76,7 +76,7 @@
             </t>
         </div>
     </div>
-    <nav t-if="ui.isSmall" t-attf-class="o-mail-MessagingMenu-navbar d-flex flex-shrink-0 bg-view border-top w-100 p-2 gap-2 o-mail-MessagingMenu-navbar-with-{{tabs.length}}-elements {{ tabs.length > 4 ? 'overflow-x-scroll' : '' }}">
+    <nav t-if="ui.isSmall" t-attf-class="o-mail-MessagingMenu-navbar d-flex flex-shrink-0 border-top w-100 p-2 gap-2 o-mail-MessagingMenu-navbar-with-{{tabs.length}}-elements {{ tabs.length > 4 ? 'overflow-x-scroll' : '' }}">
         <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-shrink-1 p-1 bg-transparent position-relative border-0" t-att-class="{
             'active': store.discuss.activeTab === tab.id,
             'pb-4': isIosPwa,

--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -1,3 +1,4 @@
 .o-mail-NotificationItem {
     --mail-NotificationItem-activeOutlineOpacity: 1;
+    --mail-NotificationItem-notInterestOpacity: .75;
 }

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -4,6 +4,7 @@
 
     &:not(.o-interest) {
         --border-opacity: .35;
+        opacity: var(--mail-NotificationItem-notInterestOpacity, .875);
     }
     &.o-active {
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));
@@ -69,6 +70,10 @@
 
 .o-mail-NotificationItem-text {
     opacity: .75;
+
+    &.o-muted {
+        opacity: .5;
+    }
 
     &:before {
         // invisible character so that typing status bar has constant height, regardless of text content.

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,14 +3,14 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 position-relative o-py-1_5 bg-transparent" t-on-click="onClick" t-ref="root" t-att-class="{
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 position-relative bg-transparent" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.important,
             'o-interest': props.muted === 0,
-            'text-muted border-secondary': props.muted === 1,
+            'border-secondary': props.muted === 1,
             'opacity-50 border-secondary': props.muted === 2,
-            'px-3 gap-1 o-small': ui.isSmall,
+            'px-3 py-2 gap-1 o-small': ui.isSmall,
             'border-top-0': props.first,
-            'o-px-2_5 gap-2': !ui.isSmall,
+            'o-px-2_5 o-py-1_5 gap-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
             <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
@@ -31,7 +31,7 @@
                     </t>
                 </div>
                 <div class="d-flex o-mail-NotificationItem-line">
-                    <div class="o-mail-NotificationItem-text" t-att-class="{ 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate, 'small': !ui.isSmall }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
+                    <div class="o-mail-NotificationItem-text" t-att-class="{ 'text-truncate': props.textTruncate, 'text-start': !props.textTruncate, 'small': !ui.isSmall, 'o-muted': props.muted }" t-att-style="props.textMaxLine !== undefined ? webkitLineClamp(props.textMaxLine) : ''">
                         <t t-slot="body-icon"/>
                         <MessageSeenIndicator t-if="message?.showSeenIndicator(props.thread)" message="message"/>
                         <t t-if="props.slots?.body" name="notificationBody" t-slot="body"/>

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.MessagingMenu.content" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-MessagingMenu-header')]" position="inside">
             <t t-if="ui.isSmall">
-                <DiscussSearch t-if="!['inbox', 'starred'].includes(store.discuss.activeTab)" class="'w-100 px-2 pb-1'"/>
+                <DiscussSearch t-if="!['inbox', 'starred'].includes(store.discuss.activeTab)" class="'w-100 px-2 py-2'"/>
             </t>
             <t t-else="">
                 <div class="flex-grow-1"/>

--- a/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
+++ b/addons/mail/static/tests/messaging_menu/messaging_menu.test.js
@@ -475,9 +475,9 @@ test("mark unread channel as read", async () => {
     onRpcBefore("/discuss/channel/mark_as_read", (args) => expect.step("mark_as_read"));
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
-    await triggerEvents(".o-mail-NotificationItem", ["mouseenter"]);
+    await triggerEvents(".o-mail-NotificationItem.o-interest", ["mouseenter"]);
     await click(".o-mail-NotificationItem [title='Mark As Read']");
-    await contains(".o-mail-NotificationItem.text-muted");
+    await contains(".o-mail-NotificationItem:not(.o-interest)");
     await expect.waitForSteps(["mark_as_read"]);
     await triggerEvents(".o-mail-NotificationItem", ["mouseenter"]);
     await contains(".o-mail-NotificationItem [title='Mark As Read']", { count: 0 });


### PR DESCRIPTION
Discuss app in mobile had poor readability. This comes essentially from:
- not enough vertical spacing between items and discuss search bar
- opacity of notification title was too low for read items
- difference between title and text opacity of read items is too small
- background color in dark theme is too light

This commit fixes the issue as follow:
- slightly more vertical spacing in mobile between items
- more opacity difference between text and title for read items.
- read items' title has less reduced opacity
- background color in dark theme is darker


Before (left) / After (right)


<img width="1133" height="1213" alt="Screenshot 2025-12-17 at 17 40 27" src="https://github.com/user-attachments/assets/a90b83d2-297c-488f-8351-63f9e5279dfe" />
<img width="1737" height="1222" alt="Screenshot 2025-12-17 at 17 40 48" src="https://github.com/user-attachments/assets/d5386d0a-9abd-4fa5-96fd-4e35e18a9425" />
<img width="1180" height="1260" alt="Screenshot 2025-12-17 at 17 41 16" src="https://github.com/user-attachments/assets/487ce2ad-ad18-4750-a14f-25279aab102e" />
<img width="1784" height="1252" alt="Screenshot 2025-12-17 at 17 41 38" src="https://github.com/user-attachments/assets/0b4ee0ad-7677-4bb8-afa1-bc2c7b7ad9a4" />
