### PR TITLE
[FIX] account,sale: order line price subtotal rounding

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -840,8 +840,14 @@ class AccountMoveLine(models.Model):
 
             base_line = line.move_id._prepare_product_base_line_for_taxes_computation(line)
             AccountTax._add_tax_details_in_base_line(base_line, line.company_id)
-            line.price_subtotal = base_line['tax_details']['raw_total_excluded_currency']
-            line.price_total = base_line['tax_details']['raw_total_included_currency']
+            AccountTax._round_base_lines_tax_details([base_line], line.company_id)
+            tax_totals = AccountTax._get_tax_totals_summary(
+                base_lines=[base_line],
+                currency=line.currency_id,
+                company=line.company_id,
+            )
+            line.price_subtotal = tax_totals['base_amount_currency']
+            line.price_total = tax_totals['total_amount_currency']
 
     @api.depends('product_id', 'product_uom_id')
     def _compute_price_unit(self):


### PR DESCRIPTION
Steps to reproduce:
- Enable Rounding Method 'Round Globally'
- Create a Sales Order
- Add a product with price 69.99 @ 20% tax included in price
- Confirm order

Issue:
While on the order line a price subtotal of 58.33 is shown, the order
subtotal will display 58.32
This occurs because, in global rounding we set the raw total on the
line, but the total will still be rounded and eventually error corrected,
which may introduce a 1 cent difference when dealing with amounts near
the rounding threshold.

opw-5106971