### PR TITLE
[FIX] mail: save chathub in `closeChatWindow`

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -710,7 +710,7 @@ export class Thread extends Record {
 
     async closeChatWindow(options = {}) {
         await this.store.chatHub.initPromise;
-        await this.channel?.chatWindow?.close({ notifyState: false, ...options });
+        await this.channel?.chatWindow?.close(options);
     }
 
     addOrReplaceMessage(message, tmpMsg) {


### PR DESCRIPTION
`notifyState` means save ChatHub state. It's not clear why closing a chat window through this method should not save the state.

The method is mainly here to be a wrapper to wait `chatHub.initPromise`.