### PR TITLE
[IMP] base: allow to skip check of primary siblings

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -441,7 +441,8 @@ actual arch.
                 combined_arch = view._get_combined_arch()
 
                 # check primary view that extends this current view
-                if view.inherit_id or view.inherit_children_ids:
+                # keep a way to skip this check to avoid marking too many views as failed during an upgrade
+                if not self.env.context.get('_skip_primary_extensions_check') and (view.inherit_id or view.inherit_children_ids):
                     root = view
                     while root.inherit_id and root.mode != 'primary':
                         root = root.inherit_id


### PR DESCRIPTION
We recently added an extra check for primary siblings when a view is edited. This prevents errors that could break primary siblings.

The issue is that during a major upgrade some breaking changes are expected for custom views. If we keep checking all primary siblings too many views (essentially all primary views in the same tree) could be marked as broken.

In this patch we propose to allow to keep checking the views as before. By chopping the inheritance tree at primary views we simplify the check and fix of views during the upgrade.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
