### PR TITLE
[FIX] hr_timehsheet: time remaining value should be red when value is negative

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -103,7 +103,7 @@
                                 <label class="fw-bold text-danger" for="remaining_hours" string="Remaining Days"
                                        invisible="allocated_hours == 0.0 or not encode_uom_in_days or remaining_hours &gt;= 0"/>
                             </span>
-                            <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator"
+                            <field name="remaining_hours" widget="timesheet_uom" class="oe_subtotal_footer_separator" decoration-danger="remaining_hours &lt; 0"
                                   invisible="allocated_hours == 0.0" nolabel="1"/>
                         </group>
                     </group>


### PR DESCRIPTION
**Steps to reproduce:**
- Open project shared form view.
- Go to the Timesheets tab.
- Observe the Time Remaining value.

**Issue:**
- The Time Remaining label is red properly but its value  does not becomes red even when the value is negative.

**Fix:**
- Adjusted the logic to ensure the Time Remaining value is highlighted in red when value is negative

**Task-id: 5404009**