### PR TITLE
[IMP] l10n_fr_facturx_chorus_pro: add Chorus fields to invoice PDF

### DIFF
--- a/addons/l10n_fr_facturx_chorus_pro/__manifest__.py
+++ b/addons/l10n_fr_facturx_chorus_pro/__manifest__.py
@@ -16,6 +16,7 @@ Add support to fill three optional fields used when using Chorus Pro, especially
     ],
     'data': [
         'views/account_move_views.xml',
+        'views/report_invoice.xml',
     ],
     'license': 'LGPL-3',
 }

--- a/addons/l10n_fr_facturx_chorus_pro/views/report_invoice.xml
+++ b/addons/l10n_fr_facturx_chorus_pro/views/report_invoice.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+        <xpath expr="//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
+            <div t-if="o.buyer_reference">
+                Buyer Reference: <span t-field="o.buyer_reference"/>
+            </div>
+            <div t-if="o.contract_reference">
+                Contract Reference: <span t-field="o.contract_reference"/>
+            </div>
+            <div t-if="o.purchase_order_reference">
+                Purchase Order Reference: <span t-field="o.purchase_order_reference"/>
+            </div>
+        </xpath>
+        <xpath expr="//div[@name='address_same_as_shipping']//t[@t-set='address']" position="inside">
+            <div t-if="o.buyer_reference">
+                Buyer Reference: <span t-field="o.buyer_reference"/>
+            </div>
+            <div t-if="o.contract_reference">
+                Contract Reference: <span t-field="o.contract_reference"/>
+            </div>
+            <div t-if="o.purchase_order_reference">
+                Purchase Order Reference: <span t-field="o.purchase_order_reference"/>
+            </div>
+        </xpath>
+        <xpath expr="//div[@name='no_shipping']//t[@t-set='address']" position="inside">
+            <div t-if="o.buyer_reference">
+                Buyer Reference: <span t-field="o.buyer_reference"/>
+            </div>
+            <div t-if="o.contract_reference">
+                Contract Reference: <span t-field="o.contract_reference"/>
+            </div>
+            <div t-if="o.purchase_order_reference">
+                Purchase Order Reference: <span t-field="o.purchase_order_reference"/>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This commit:
- Add three reference fields to invoice PDF for Chorus Pro compliance: Buyer Reference, Contract Reference, and Purchase Order Reference. These fields appear in the invoice header when set on the invoice.

task-5410836
