### PR TITLE
[IMP] mail: add keyboard shortcut for raise/lower hand in calls

### DIFF
--- a/addons/mail/static/src/core/common/action_list.js
+++ b/addons/mail/static/src/core/common/action_list.js
@@ -83,7 +83,7 @@ export class ActionList extends Component {
                     return [actualPropName, this.props[actualPropName]];
                 })
             ),
-            style: `z-index: ${group.length - index}`,
+            style: `z-index: ${group.length - index + (action.hotkey ? 1 : 0)}`,
         };
     }
 

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -74,6 +74,7 @@ export class Call extends Component {
         });
         useHotkey("shift+d", () => this.rtc.toggleDeafen());
         useHotkey("shift+m", () => this.rtc.toggleMicrophone());
+        useHotkey("shift+h", () => this.rtc.raiseHand(!this.rtc.selfSession.raisingHand));
         useInDiscussCallView();
     }
 

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -146,6 +146,7 @@ registerCallAction("raise-hand", {
     isActive: ({ store }) => store.rtc.selfSession?.raisingHand,
     isTracked: true,
     icon: "fa fa-hand-paper-o",
+    hotkey: "shift+h",
     onSelected: ({ store }) => store.rtc.raiseHand(!store.rtc.selfSession.raisingHand),
     sequence: 50,
     sequenceGroup: 200,


### PR DESCRIPTION
Before this commit, the raise/lower hand action in RTC calls could only be triggered through the UI and had no dedicated keyboard shortcut.

This commit adds a new hotkey (Shift+H) to toggle the hand state for the current user. To ensure consistent behavior regardless of the order in which modifier keys are pressed, hotkey matching is normalized by sorting both pressed and registered sequences before comparison.

Task-4967139