### PR TITLE
[FIX] requirements: Update PyPDF2 version for python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,8 +56,7 @@ psycopg2==2.9.10 ; python_version >= '3.13' # (Trixie)
 pydot==1.4.2
 pyopenssl==21.0.0 ; python_version < '3.12'
 pyopenssl==24.1.0 ; python_version >= '3.12' # (Noble) min 23.2.0, pinned for compatibility with cryptography==42.0.8 and security patches
-PyPDF2==1.26.0 ; python_version <= '3.10'
-PyPDF2==2.12.1 ; python_version > '3.10' and python_version < '3.13' # (Noble and below)
+PyPDF2==2.12.1 ; python_version < '3.13' # (Noble and below)
 PyPDF==5.4.0 ; python_version >= '3.13' # (Trixie)
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.5


### PR DESCRIPTION
The feature of printing PDF with custom header / footer pages does not work
with the old version of PyPDF2 on python 3.10.
Bump to newer version of PyPDF2 2.12.1.

Description of the issue/feature this PR addresses:

Current behavior before PR:
Detail error message with old PyPDF2 version (Ubuntu 20.04 - python 3.10):
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/opt/odoo/17.0/addons/web/controllers/[report.py](https://report.py/)", line 113, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
  File "/opt/odoo/17.0/odoo/[http.py](https://http.py/)", line 786, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/17.0/addons/web/controllers/[report.py](https://report.py/)", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
  File "/opt/odoo/17.0/addons/account/models/[ir_actions_report.py](https://ir_actions_report.py/)", line 58, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "/opt/odoo/17.0/odoo/addons/base/models/[ir_actions_report.py](https://ir_actions_report.py/)", line 925, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/opt/odoo/17.0/addons/sale_pdf_quote_builder/models/[ir_actions_report.py](https://ir_actions_report.py/)", line 57, in _render_qweb_pdf_prepare_streams
    pdf.fill_form_fields_pdf(writer, form_fields=form_fields)
  File "/opt/odoo/17.0/odoo/tools/pdf/[__init__.py](https://__init__.py/)", line 167, in fill_form_fields_pdf
    writer.update_page_form_field_values(page, form_fields)
  File "/opt/python3.10-venv/odoo17/lib/python3.10/site-packages/pypdf/[_writer.py](https://_writer.py/)", line 978, in update_page_form_field_values
    raise PyPdfError("No /Fields dictionary in Pdf in PdfWriter Object")
pypdf.errors.PyPdfError: No /Fields dictionary in Pdf in PdfWriter Object
```

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
