### PR TITLE
[FIX] l10n_it: correct VP4 sign and VAT carryover in monthly VAT report

### DIFF
--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -117,7 +117,7 @@
                             <record id="tax_monthly_report_line_vp4_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">4v</field>
+                                <field name="formula">-4v</field>
                             </record>
                         </field>
                     </record>
@@ -148,15 +148,15 @@
                             <record id="tax_monthly_report_line_vp6_vp6a_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VP4.debit + VP5.credit</field>
-                                <field name="subformula">if_below(EUR(0))</field>
+                                <field name="formula">VP4.debit - VP5.credit</field>
+                                <field name="subformula">if_above(EUR(0))</field>
                                 <field name="blank_if_zero" eval="True"/>
                             </record>
                             <record id="tax_monthly_report_line_vp6_vp6b_credit" model="account.report.expression">
                                 <field name="label">credit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VP4.debit + VP5.credit</field>
-                                <field name="subformula">if_above(EUR(0))</field>
+                                <field name="formula">VP4.debit - VP5.credit</field>
+                                <field name="subformula">if_below(EUR(0))</field>
                                 <field name="blank_if_zero" eval="True"/>
                             </record>
                         </field>
@@ -313,7 +313,7 @@
                                 <field name="label">_carryover_debit</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">VP14.debit</field>
-                                <field name="subformula">if_between(EUR(0), EUR(25.82))</field>
+                                <field name="subformula">if_between(EUR(0), EUR(100.00))</field>
                                 <field name="carryover_target">VP7._applied_carryover_debit</field>
                             </record>
                             <record id="tax_monthly_report_line_vp14_vp14b_credit" model="account.report.expression">


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **l10n_it** and **accounting** modules.
* Use an **Italian company**.
* Create and post a customer invoice with **4% VAT** (tax tag *4v*).
* Generate the **Italian Monthly VAT Report** for the invoice period.
* Validate the tax return and generate the report for the next month.

**Observed behavior:**
* **VP4 (VAT due)** is displayed with an incorrect sign.
* **VP6 (VAT due/deductible)** is computed incorrectly.
* **VP14 (VAT payable)** does not carry over amounts **≤ 100.00 EUR**.
* Amounts that should be reported in **VP7** of the following period remain at **0**.

**Cause:**
* The VP4 formula used `4v` instead of `-4v`, resulting in a wrong sign.
* The VP6 formula used `VP4.debit + VP5.credit` with inverted subformulas, leading to incorrect debit/credit classification.
* The carryover threshold regressed from **100.00 EUR** to **25.82 EUR**, blocking carryover for amounts between those values.

**Fix:**
* Update the VP4 formula to `-4v` to match Italian VAT requirements.
* Correct the VP6 computation to `VP4.debit - VP5.credit` with proper debit/credit subformulas.
* Restore the carryover threshold to **EUR 100.00** in line with current Italian legislation.

opw-5357719