### PR TITLE
[FIX] account,l10n_in: `country_code` relation for BaseDocumentLayout

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -215,6 +215,7 @@ class ResCompany(models.Model):
         store=True,
         readonly=False,
         help="The country to use the tax reports from for this company")
+    fiscal_country_code = fields.Char(string="Fiscal Country Code", related='account_fiscal_country_id.code')
     account_fiscal_country_group_codes = fields.Json(compute="_compute_account_fiscal_country_group_codes")
 
     account_enabled_tax_country_ids = fields.Many2many(

--- a/addons/account/wizard/base_document_layout.py
+++ b/addons/account/wizard/base_document_layout.py
@@ -8,7 +8,7 @@ class BaseDocumentLayout(models.TransientModel):
     qr_code = fields.Boolean(related='company_id.qr_code', readonly=False)
     vat = fields.Char(related='company_id.vat', readonly=False,)
     account_number = fields.Char(compute='_compute_account_number', inverse='_inverse_account_number',)
-    country_code = fields.Char(related="company_id.account_fiscal_country_id.code")
+    fiscal_country_code = fields.Char(related="company_id.fiscal_country_code")
 
     def document_layout_save(self):
         """Save layout and onboarding step progress, return super() result"""

--- a/addons/l10n_in/views/base_document_layout_views.xml
+++ b/addons/l10n_in/views/base_document_layout_views.xml
@@ -7,10 +7,10 @@
         <field name="mode">extension</field>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='qr_code']" position="attributes">
-                <attribute name="invisible" separator="or" add="country_code == 'IN'"/>
+                <attribute name="invisible" separator="or" add="fiscal_country_code == 'IN'"/>
             </xpath>
             <xpath expr="//field[@name='account_number']" position="attributes">
-                <attribute name="required" separator="and" add="country_code != 'IN'"/>
+                <attribute name="required" separator="and" add="fiscal_country_code != 'IN'"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in/views/res_company_views.xml
+++ b/addons/l10n_in/views/res_company_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='currency_id']" position="after">
-                <field name="l10n_in_upi_id" invisible="country_code != 'IN'"/>
+                <field name="l10n_in_upi_id" invisible="fiscal_country_code != 'IN'"/>
             </xpath>
             <xpath expr="//label[@for='name']" position="attributes">
                 <attribute name="invisible">l10n_in_pan_type</attribute>
@@ -15,7 +15,7 @@
                <field class="o_form_label mb-0" name="l10n_in_pan_type" invisible="not l10n_in_pan_type"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="l10n_in_pan_entity_id" invisible="country_code != 'IN'"/>
+                <field name="l10n_in_pan_entity_id" invisible="fiscal_country_code != 'IN'"/>
                 <field name="l10n_in_tan" invisible="not l10n_in_pan_entity_id"/>
             </xpath>
             <xpath expr="//sheet" position="before">
@@ -24,7 +24,7 @@
                     <a name="action_update_state_as_per_gstin"
                        string="update it"
                        class="ms-1"
-                       invisible="country_code != 'IN'"
+                       invisible="fiscal_country_code != 'IN'"
                        type="object"/>
                 </div>
             </xpath>


### PR DESCRIPTION
Following the commit- https://github.com/odoo/odoo/commit/42e72d1450525c550364ffe9ec24e9dd2646972c `country_code` field was added to `base.document.layout`, but on the relation of `company_id.account_fiscal_country_id.code` but `base.document.layout` is an imposter of the `res.company` model itself, so the fields should be consistent with `res.company` model.

In this commit, we add `fiscal_country_code` to `res.company` and change the relation of country_code to `company_id.fiscal_country_code` for the consistency

task-5427375


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
