### PR TITLE
[FIX] account_payment: wip

### DIFF
--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -14,7 +14,7 @@ class PaymentProvider(models.Model):
         compute='_compute_journal_id',
         inverse='_inverse_journal_id',
         check_company=True,
-        domain='[("type", "=", "bank")]',
+        domain='[("type", "in", ("bank", "credit"))]',
         copy=False,
     )
 
@@ -97,7 +97,7 @@ class PaymentProvider(models.Model):
                 provider.journal_id = self.env['account.journal'].search(
                     [
                         ('company_id', '=', provider.company_id.id),
-                        ('type', '=', 'bank'),
+                        ('type', 'in', ('bank', 'credit')),
                     ],
                     limit=1,
                 )


### PR DESCRIPTION
Steps to reproduce:
1. Install account_payment.
2. Go to Payment Providers and install the demo provider.
3. Create a journal with type Credit Card.
4. Open Payment Provider → Demo → Under Payment Follow-up.
5. Try to select a payment journal.

Issue:
Only journals of type Bank are displayed.
Journals with type Credit Card are not selectable in the payment provider.

Cause:
Since credit card journals share the same posting behavior as bank journals for payments, they should also be allowed. Credit card journals were not selectable in payment providers because the journal domain was restricted to journals of type bank, excluding credit journals.

Solution:
Extend the journal domain to include journals of type credit, allowing credit card journals to be selected in payment providers.

opw-5411748
