### PR TITLE
[FIX] mail: avoid error on service worker push subscription change

### DIFF
--- a/addons/mail/models/web_push.py
+++ b/addons/mail/models/web_push.py
@@ -54,6 +54,9 @@ class WebPush(models.Model):
                 )
             except DeviceUnreachableError:
                 devices_to_unlink.add(device.id)
+            except Exception as e:  # noqa: BLE001
+                # Avoid blocking the whole cron just for a notification exception
+                _logger.error('An error occurred while trying to send web push: %s', e)
 
         # clean up notif
         web_push_notifications_sudo.unlink()

--- a/addons/mail/static/src/service_worker.js
+++ b/addons/mail/static/src/service_worker.js
@@ -16,6 +16,9 @@ self.addEventListener("push", (event) => {
     self.registration.showNotification(notification.title, notification.options || {});
 });
 self.addEventListener("pushsubscriptionchange", async (event) => {
+    if (!event.oldSubscription) {
+        return;
+    }
     const subscription = await self.registration.pushManager.subscribe(
         event.oldSubscription.options
     );

--- a/addons/mail/web_push.py
+++ b/addons/mail/web_push.py
@@ -123,6 +123,11 @@ def push_to_end_point(base_url, device, payload, vapid_private_key, vapid_public
     """
     endpoint = device["endpoint"]
     url = urlsplit(endpoint)
+    # The TDL ".invalid" is intended for use in online construction of domain names that are sure to be invalid and
+    # which it is obvious at a glance are invalid.
+    # https://datatracker.ietf.org/doc/html/rfc2606#section-2
+    if url.netloc.endswith(".invalid"):
+        raise DeviceUnreachableError("Device Unreachable")
     jwt_claims = {
         # aud: The “Audience” is a JWT construct that indicates the recipient scheme and host
         # e.g. for an endpoint like https://updates.push.services.mozilla.com/wpush/v2/gAAAAABY...,

--- a/addons/test_mail_full/tests/test_web_push.py
+++ b/addons/test_mail_full/tests/test_web_push.py
@@ -354,6 +354,34 @@ class TestWebPushNotification(SMSCommon):
         notification_count = self.env['mail.partner.device'].search_count([('endpoint', '=', 'https://test.odoo.com/webpush/user2')])
         self.assertEqual(notification_count, 0)
 
+    @patch.object(odoo.addons.mail.models.mail_thread.Session, 'post',
+                  return_value=SimpleNamespace(status_code=201, text='Ok'))
+    def test_push_notifications_device_invalid_tld_domain(self, post):
+        self.env['mail.partner.device'].sudo().create([{
+            'endpoint': 'https://test.odoo.invalid/webpush/user',
+            'expiration_time': None,
+            'keys': json.dumps({
+                'p256dh': 'BGbhnoP_91U7oR59BaaSx0JnDv2oEooYnJRV2AbY5TBeKGCRCf0HcIJ9bOKchUCDH4cHYWo9SYDz3U-8vSxPL_A',
+                'auth': 'DJFdtAgZwrT6yYkUMgUqow'
+            }),
+            'partner_id': self.user_inbox.partner_id.id,
+        }])
+
+        device_count = self.env['mail.partner.device'].search_count([('endpoint', '=', 'https://test.odoo.invalid/webpush/user')])
+        self.assertEqual(device_count, 1)
+
+        self.record_simple.with_user(self.user_email).message_notify(
+            partner_ids=self.user_inbox.partner_id.ids,
+            body='Test message send via Web Push',
+            subject='Test Activity',
+            record_name=self.record_simple._name,
+        )
+
+        self._assert_notification_count_for_cron(0)
+        post.assert_called_once()
+        # Test that the device with the invalid TLD is deleted from the DB
+        device_count = self.env['mail.partner.device'].search_count([('endpoint', '=', 'https://test.odoo.invalid/webpush/user')])
+        self.assertEqual(device_count, 0)
 
     @patch.object(odoo.addons.mail.models.mail_thread.Session, 'post', side_effect=ConnectionError("Oops, network error"))
     def test_push_notifications_device_raise_exception(self, post):


### PR DESCRIPTION
[FIX] mail: avoid error on service worker push subscription change

Sometimes, the `pushsubscriptionchange` event is called without an
`oldSubscription` defined, which can lead to an error occurring inside
the  service worker.

Steps to reproduce:

1. Enable notification in Odoo.
2. Reset the permission in the Chrome interface
3. Re-enable the permission inside the discuss systray by clicking on
the Odoobot message.
=> The pushsubscriptionchange is called without an oldSubscription


[FIX] mail: ir_cron_web_push_notification are now more robust

With a user having 5 registered devices for push notifications
if a browser registers with an endpoint that has a wrong domain
such as https://permanently-removed.invalid/fcm/send/XXXXXXXXXXXXX
the cron job cannot resolve the invalid domain of the endpoint and ends
up disabling it.


[FIX] mail: push_to_end_point method to support .invalid TLD

if a browser registers with an endpoint that has a TLD `.invalid`
such as https://permanently-removed.invalid/fcm/send/XXXXXXXXXXXXX

The TLD `.invalid`[1] is intended for use in online construction of
domain names that are sure to be invalid and which it is obvious at a
glance are invalid. The cron job cannot resolve the invalid domain of
the endpoint and ends up disabling it.

So we need to unregister a device with an endpoint with a `.invalid`
TLD.

[1]: https://datatracker.ietf.org/doc/html/rfc2606#section-2


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
