### PR TITLE
[IMP] _monkeypatches: whitelist ARIA attributes in lxml cleaner

### DIFF
--- a/odoo/_monkeypatches/lxml.py
+++ b/odoo/_monkeypatches/lxml.py
@@ -1,13 +1,43 @@
-import lxml.html.clean
 import re
-
 from importlib.metadata import version
 
 from odoo.tools import parse_version
 
+ARIA_ATTRIBUTES = frozenset([
+    "aria-activedescendant", "aria-atomic", "aria-autocomplete",
+    "aria-braillelabel", "aria-brailleroledescription", "aria-busy",
+    "aria-checked", "aria-colcount", "aria-colindex", "aria-colindextext",
+    "aria-colspan", "aria-controls", "aria-current", "aria-describedby",
+    "aria-description", "aria-details", "aria-disabled", "aria-dropeffect",
+    "aria-errormessage", "aria-expanded", "aria-flowto", "aria-grabbed",
+    "aria-haspopup", "aria-hidden", "aria-invalid", "aria-keyshortcuts",
+    "aria-label", "aria-labelledby", "aria-level", "aria-live", "aria-modal",
+    "aria-multiline", "aria-multiselectable", "aria-orientation", "aria-owns",
+    "aria-placeholder", "aria-posinset", "aria-pressed", "aria-readonly",
+    "aria-relevant", "aria-required", "aria-roledescription", "aria-rowcount",
+    "aria-rowindex", "aria-rowindextext", "aria-rowspan", "aria-selected",
+    "aria-setsize", "aria-sort", "aria-valuemax", "aria-valuemin",
+    "aria-valuenow", "aria-valuetext", "role", "tabindex",
+])
+
 
 def patch_module():
-    # between these versions having a couple data urls in a style attribute
-    # or style node removes the attribute or node erroneously
-    if parse_version("4.6.0") <= parse_version(version('lxml')) < parse_version("5.2.0"):
+    """
+    Patches lxml to:
+    1. Add ARIA attributes to the allowed whitelist for lxml.html.clean (versions < 7.0.0).
+    2. Fix an issue where data URLs in style attributes are removed erroneously (versions 4.6.0 - 5.2.0).
+    """
+    lxml_version = parse_version(version("lxml"))
+
+    # 1. Add missing ARIA attributes
+    if lxml_version < parse_version("7.0.0"):
+        import lxml.html.defs  # noqa: PLC0415
+        lxml.html.defs.safe_attrs |= ARIA_ATTRIBUTES
+
+    # 2. Fix Regex for Data URLs
+    # Between these versions, the regex is too greedy, resulting in erroneously
+    # removing style attributes or nodes with multiple data URLs.
+    if parse_version("4.6.0") <= lxml_version < parse_version("5.2.0"):
+        # ⚠️ Keep this import *after* the patch to lxml.html.defs
+        import lxml.html.clean  # noqa: PLC0415
         lxml.html.clean._find_image_dataurls = re.compile(r'data:image/(.+?);base64,').findall

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -37,6 +37,7 @@ from . import test_ir_sequence
 from . import test_ir_sequence_date_range
 from . import test_ir_embedded_actions
 from . import test_ir_default
+from . import test_lxml
 from . import test_mail
 from . import test_menu
 from . import test_mimetypes

--- a/odoo/addons/base/tests/test_lxml.py
+++ b/odoo/addons/base/tests/test_lxml.py
@@ -1,0 +1,15 @@
+from lxml.html.clean import Cleaner
+
+from odoo.tests.common import TransactionCase
+
+
+class TestLxml(TransactionCase):
+
+    def test_aria_preserved(self):
+        """
+        Ensures that the HTML Cleaner preserves ARIA attributes.
+        """
+        cleaner = Cleaner()
+        html_input = """<div role="alert" aria-live="assertive">Error message</div>"""
+
+        self.assertEqual(cleaner.clean_html(html_input), """<div role="alert" aria-live="assertive">Error message</div>""")


### PR DESCRIPTION
Before this commit, `lxml.html.clean.Cleaner` strips all ARIA attributes (e.g., `aria-label`, `aria-hidden`, `role`) by default. This is because they are not included in the "safe attributes" whitelist. This behavior caused sanitized HTML to lose semantic meaning for assistive technologies (screen readers), making the output non-compliant with WCAG standards.

This commit patches `lxml.html.defs.safe_attrs` to add the ARIA attributes to the allowed whitelist, so the Cleaner will no longer filter them out. This change ensures that developers using features based on lxml Cleaner (e.g., `html_sanitize` or `fields.Html`) will not accidentally strip accessibility features while maintaining protection against XSS.