### PR TITLE
[IMP] web: calendar: allow unscheduling events via drag and drop

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -54,6 +54,15 @@ $o-cw-filter-avatar-size: 20px;
 
     flex: 0 0 auto;
 
+    .o_calendar_unschedule_zone {
+        width: $o-datetime-picker-width;
+        height: stretch;
+        min-height: 200px; // Fallback for firefox < 146
+        border: 1px solid rgba($o-enterprise-action-color, 0.4);
+        border-radius: 10px;
+        background-color: mix($o-enterprise-action-color, $o-view-background-color, 10%);
+    }
+
     .o_calendar_sidebar {
         @include o-webclient-padding($top: $o-horizontal-padding/2);
         width: calc(#{$o-datetime-picker-width} + 2 * #{map-get($spacers, 3)});

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -1,23 +1,23 @@
+import { browser } from "@web/core/browser/browser";
+import { makeContext } from "@web/core/context";
+import { Domain } from "@web/core/domain";
 import {
-    serializeDate,
-    serializeDateTime,
     deserializeDate,
     deserializeDateTime,
+    serializeDate,
+    serializeDateTime,
 } from "@web/core/l10n/dates";
-import { Domain } from "@web/core/domain";
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
-import { KeepLast } from "@web/core/utils/concurrency";
-import { Model } from "@web/model/model";
-import { extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
-import { browser } from "@web/core/browser/browser";
-import { makeContext } from "@web/core/context";
 import { groupBy, intersection } from "@web/core/utils/arrays";
 import { Cache } from "@web/core/utils/cache";
+import { KeepLast } from "@web/core/utils/concurrency";
 import { formatFloat } from "@web/core/utils/numbers";
 import { useDebounced } from "@web/core/utils/timing";
+import { Model } from "@web/model/model";
+import { extractFieldsFromArchInfo } from "@web/model/relational_model/utils";
 import { computeAggregatedValue } from "@web/views/utils";
 
 const { DateTime } = luxon;
@@ -740,6 +740,18 @@ export class CalendarModel extends Model {
         await this.orm.write(this.meta.resModel, [eventId], {
             [date_stop]: serializeDateTime(end),
             [date_start]: serializeDateTime(start),
+        });
+        await this.load();
+    }
+    /**
+     * @protected
+     * @param {Number} eventId
+     */
+    async unscheduleEvent(eventId) {
+        const { date_start, date_stop } = this.meta.fieldMapping;
+        await this.orm.write(this.meta.resModel, [eventId], {
+            [date_stop]: false,
+            [date_start]: false,
         });
         await this.load();
     }

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
@@ -1,5 +1,6 @@
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { DateTimePicker } from "@web/core/datetime/datetime_picker";
+import { useBus } from "@web/core/utils/hooks";
 import { CalendarFilterSection } from "@web/views/calendar/calendar_filter_section/calendar_filter_section";
 import { CalendarScheduleSection } from "@web/views/calendar/calendar_schedule_section/calendar_schedule_section";
 
@@ -11,6 +12,13 @@ export class CalendarSidePanel extends Component {
     };
     static template = "web.CalendarSidePanel";
     static props = ["model", "editRecord"];
+
+    setup() {
+        this.state = useState({ isDragging: false });
+        useBus(this.props.model.bus, "CALENDAR_EVENT_DRAG", ({ detail }) => {
+            this.state.isDragging = detail.dragging;
+        });
+    }
 
     get datePickerProps() {
         return {

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -2,7 +2,10 @@
 <templates xml:space="preserve">
     <t t-name="web.CalendarSidePanel">
         <div class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
-            <div class="o_calendar_sidebar">
+            <div t-if="props.model.meta.canScheduleEvents and state.isDragging" class="d-flex o_calendar_unschedule_zone m-3 align-items-center justify-content-center">
+                <b>Drop here to unschedule</b>
+            </div>
+            <div class="o_calendar_sidebar" t-att-class="{ 'd-none': props.model.meta.canScheduleEvents and state.isDragging }">
                 <DatePicker t-if="showDatePicker" t-props="datePickerProps" />
                 <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
                     <FilterSection model="props.model" section="section"/>


### PR DESCRIPTION
Previously, unscheduling an event required opening the form view or dialog and manually clearing the dates.

This commit improves the user experience by allowing users to unschedule events simply by dragging and dropping them into the "event scheduling" section of the side panel. This action automatically removes the start and stop dates.

task-5410979
