### PR TITLE
[FIX] hr_attendance: allow approvers to modify attendances

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -350,7 +350,7 @@ class HrAttendance(models.Model):
                 overtime_vals_list.extend(
                     ruleset.rule_ids._generate_overtime_vals(employee, attendances, version_map)
                 )
-        self.env['hr.attendance.overtime.line'].create(overtime_vals_list)
+        self.env['hr.attendance.overtime.line'].sudo().create(overtime_vals_list)
         self.env.add_to_compute(self._fields['overtime_hours'], all_attendances)
 
     @api.model_create_multi

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -199,7 +199,7 @@
                             </group>
                         </group>
                     </group>
-                    <notebook invisible="not overtime_status">
+                    <notebook invisible="not overtime_status" groups="hr_attendance.group_hr_attendance_manager">
                         <page string="Overtime Details">
                             <field name="linked_overtime_ids">
                                 <list editable="bottom">


### PR DESCRIPTION
Employees set as themselves as approvers couldn't modify their attendances due to permission issues with other models.

task-5427553