### PR TITLE
[FIX] iot_box_builder: flashing error message on boot

### DIFF
--- a/setup/iot_box_builder/overwrite_before_init/etc/init_image.sh
+++ b/setup/iot_box_builder/overwrite_before_init/etc/init_image.sh
@@ -221,6 +221,7 @@ systemctl disable systemd-timesyncd.service
 systemctl unmask hostapd.service
 systemctl disable hostapd.service
 systemctl disable cups-browsed.service
+systemctl disable userconfig.service
 systemctl enable labwc.service
 systemctl enable odoo.service
 systemctl enable odoo-led-manager.service


### PR DESCRIPTION
Before this commit, when the IoT box boots, just before the GUI starts an error message can be seen several times in the top left corner of the screen. This error was caused by the `userconfig.service`, which is enabled by default on the Raspberry Pi to prompt you to change the default password on first boot. Due to it not working properly in the ramdisk environment, it didn't prevent booting but did cause the aforementioned error messages.

After this commit, we disable the `userconfig.service`, preventing the error message from appearing, and also keeping the system usable even if the ramdisk service fails to start.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
