### PR TITLE
[FIX] website_sale: don't display "Add to Cart" button text on mobile

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -1200,7 +1200,9 @@ $_wsale_products_roundness_map: (
             --o-wsale-card-btn-aspect-ratio: 1;
             --o-wsale-card-btn-label-display: none;
             --o-wsale-card-btn-padding-x: 0;
-            --o-wsale-card-btn-submit-label-display: inline;
+            @include media-breakpoint-up(sm) {
+                --o-wsale-card-btn-submit-label-display: inline;
+            }
         }
     }
 }


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Activate Italian;
2. open website editor on homepage;
3. add a catalog block;
4. select the dynamic "latest content" carousel;
5. open webpage in mobile view in Italian.

Issue
-----
The translated "Add to Cart" text doesn't fit in the buttons.

Cause
-----
Elsewhere, media breakpoints are used to hide the label display for small viewports, but this isn't happening for the catalog.

Solution
--------
Add a media breakpoint to hide the label display for small viewports.

opw-5418675