### PR TITLE
[IMP] point_of_sale: UI improvement of close register

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -304,4 +304,16 @@ export class ClosePosPopup extends Component {
         const amounts = this.props.default_cash_details.moves.map((move) => move.amount);
         return amounts.reduce((acc, x) => acc + x, 0);
     }
+    get validPms() {
+        return this.props.non_cash_payment_methods.filter(
+            (item) => item.number == 1 && (item.type === "bank" || item.type === "cash")
+        );
+    }
+    isTheLastPM(pm) {
+        return pm === this.validPms.at(-1) && this.validPms.length % 2 === 0;
+    }
+
+    isOnePmUsed() {
+        return this.validPms.length == 0;
+    }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
@@ -59,7 +59,7 @@
                 </div>
                 <hr/>
                 <div class="row g-3">
-                    <div class="col-12 col-md-6" t-if="pos.config.cash_control">
+                    <div class="col-12" t-if="pos.config.cash_control" t-att-class="{'col-md-6': !this.isOnePmUsed()}">
                         <label class="form-label">Cash Count</label>
                         <div class="d-flex w-100 gap-2 mt-1">
                             <Input
@@ -74,9 +74,8 @@
                             />
                         </div>
                     </div>
-                    <t t-foreach="props.non_cash_payment_methods" t-as="pm" t-key="pm.id">
-                        <t t-set="_showDiff" t-value="['bank', 'cash'].includes(pm.type) and pm.number !== 0" />
-                        <div class="col-12 col-md-6" t-if="_showDiff">
+                    <t t-foreach="validPms" t-as="pm" t-key="pm.id">
+                        <div class="col-12" t-att-class="{'col-md-6': !this.isTheLastPM(pm)}">
                             <label class="form-label">
                                 <t t-esc="pm.name" /> Count
                             </label>

--- a/addons/point_of_sale/static/tests/unit/components/popup/closing_popup.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/popup/closing_popup.test.js
@@ -1,0 +1,56 @@
+import { test, expect } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { ClosePosPopup } from "@point_of_sale/app/components/popups/closing_popup/closing_popup";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+const getProps = (overrides = {}) => ({
+    orders_details: { quantity: 0, amount: 0 },
+    opening_notes: "",
+    default_cash_details: {
+        id: 1,
+        name: "Cash",
+        amount: 0,
+        opening: 0,
+        moves: [],
+        payment_amount: 0,
+    },
+    non_cash_payment_methods: [],
+    is_manager: false,
+    amount_authorized_diff: null,
+    close: () => {},
+    ...overrides,
+});
+
+test("payment method helpers", async () => {
+    await setupPosEnv();
+
+    const paymentMethods = [
+        { id: 10, name: "Card A", type: "bank", number: 1, amount: 12 },
+        { id: 11, name: "Card B", type: "bank", number: 0, amount: 20 },
+        { id: 12, name: "Cash B", type: "cash", number: 1, amount: 5 },
+        { id: 13, name: "Later", type: "pay_later", number: 1, amount: 7 },
+    ];
+
+    const popup = await mountWithCleanup(ClosePosPopup, {
+        props: getProps({ non_cash_payment_methods: paymentMethods }),
+    });
+
+    expect(popup.validPms.map((pm) => pm.id)).toEqual([10, 12]);
+    expect(popup.isTheLastPM(paymentMethods[0])).toBe(false);
+    expect(popup.isTheLastPM(paymentMethods[2])).toBe(true);
+    expect(popup.isOnePmUsed()).toBe(false);
+
+    const popupWithoutValid = await mountWithCleanup(ClosePosPopup, {
+        props: getProps({
+            non_cash_payment_methods: [
+                { id: 20, name: "Loyalty", type: "pay_later", number: 0, amount: 3 },
+            ],
+        }),
+    });
+
+    expect(popupWithoutValid.validPms).toEqual([]);
+    expect(popupWithoutValid.isOnePmUsed()).toBe(true);
+});


### PR DESCRIPTION
Little improvement of the close register popup UI. 
- If there is only the cash pm (which is always present), it takes the whole size of the popup. 
- If there is an odd number of pm, the last one takes the whole size too. 
- But if there is an even number of pm, they take half size each as befor this commit.

task-id: 5410451

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
