### PR TITLE
[FIX] purchase: prevent product display name change in purchase lines

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -245,7 +245,7 @@
                                         readonly="state in ('purchase', 'to approve', 'done', 'cancel') or is_downpayment"
                                         required="not display_type and not is_downpayment"
                                         optional="show"
-                                        context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
+                                        context="{'partner_id':partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>
                                     <field name="date_planned" optional="hide" required="not display_type and not is_downpayment" force_save="1" readonly="is_downpayment"/>


### PR DESCRIPTION
**Steps to reproduce:**
* Install the *Purchase* module
* Create a product and set an *Reference* and
  Under the *Purchase* tab, add a vendor and define a *Vendor Product Code*.
* Create a Purchase Order with the same vendor set as on the product.
* Add the configured product to the *Purchase Order Lines*.
* Add the same product again on a second line and save the order.
* Activate debug mode
* Go to the view:Form and add a limit to have only 1 POL per page
* Return to your PO
* Go to the second page

**Observed behavior:**
* The *product display name* in the purchase order lines is different on
  the second page compared to the first page.

**Cause:**
* On the first page, purchase order lines are fetched via a web_read on the
purchase order.
* On subsequent pages, lines are fetched via a web_read directly on the
purchase order lines.
* The client requests both name and product_id.display_name.
product field context includes partner_id, causing
product_id.display_name to be computed as the vendor name.
* As both values resolve to the vendor name, the original product
name is lost, leading to inconsistent display across pages.

**Note:**

A similar issue was addressed in this commit : https://github.com/odoo/odoo/commit/28d53e0e565e266ca3fa2b67e359b4383fa42c36
* but its consequence it breaks the search using the vendor code/name in POL.

* That change was reverted in this commit duo to the there consequence : https://github.com/odoo/odoo/commit/c9e8a802315be27a076ae677b9191c075e4c239d

**Fix:**
* This ensures the product name is propagated correctly in the form
view while preserving search by vendor code or name.

---

opw-5170924
