### PR TITLE
[FIX] product: fix discounted price for templates

### DIFF
--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -70,7 +70,8 @@ class ProductSupplierinfo(models.Model):
     @api.depends('discount', 'price')
     def _compute_price_discounted(self):
         for rec in self:
-            rec.price_discounted = (rec.product_uom_id or rec.product_tmpl_id.uom_id)._compute_price(rec.price, rec.product_id.uom_id) * (1 - rec.discount / 100)
+            product_uom = (rec.product_id or rec.product_tmpl_id).uom_id
+            rec.price_discounted = (rec.product_uom_id or rec.product_tmpl_id.uom_id)._compute_price(rec.price, product_uom) * (1 - rec.discount / 100)
 
     @api.depends('product_id', 'product_tmpl_id', 'product_variant_count')
     def _compute_product_id(self):


### PR DESCRIPTION
Steps to reproduce:
1- Add a product that has variants to a vendor pricelist. 
2- Set the vendor's unit for this product to a one different than the product's unit.
3- Create an RFQ with from that vendor.
4- Open the catalog.

Issue:
`discounted_price` is miscalculated and causes wrong price calculation, it shows the price multiplied by its factor.
i.e if a price of pack of 6 is 10$, it will be shown as 60$.

Cause:
We only check for `product_id` not for `product_tmpl_id` when computing the `price_discounted`, so if its a template, `product_id` is false, and its sent with `_compute_price()` and the same price is returned since there's no unit and after that its sent to `_get_product_price_and_data` where its converted to the new unit.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
