### PR TITLE
[FIX] point_of_sale: allow pos manager to create products from POS

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -15,7 +15,6 @@ import { Input } from "@point_of_sale/app/generic_components/inputs/input/input"
 import { isBarcodeScannerSupported } from "@web/core/barcode/barcode_video_scanner";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { user } from "@web/core/user";
 import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
 import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
 import { _t } from "@web/core/l10n/translation";
@@ -44,7 +43,7 @@ export class Navbar extends Component {
         this.isDisplayStandalone = isDisplayStandalone();
         this.isBarcodeScannerSupported = isBarcodeScannerSupported;
         onMounted(async () => {
-            this.isSystemUser = await user.hasGroup("base.group_system");
+            this.hasProductCreationAccess = await this.pos.allowProductCreation();
         });
     }
     onClickScan() {
@@ -114,7 +113,7 @@ export class Navbar extends Component {
     }
 
     get showCreateProductButton() {
-        return this.isSystemUser;
+        return this.hasProductCreationAccess;
     }
 
     async showSaleDetails() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1937,7 +1937,7 @@ export class PosStore extends Reactive {
         );
     }
     async allowProductCreation() {
-        return await user.hasGroup("base.group_system");
+        return await user.checkAccessRight("product.product", "create");
     }
     orderDetailsProps(order) {
         return {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -679,9 +679,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         '''Consider this test method to contain a test tour with miscellaneous tests/checks that require admin access.
         '''
         self.product_a.available_in_pos = True
-        self.pos_admin.write({
-            'groups_id': [Command.link(self.env.ref('base.group_system').id)],
-        })
         self.assertFalse(self.product_a.is_storable)
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")

--- a/addons/pos_hr/static/src/overrides/models/pos_store.js
+++ b/addons/pos_hr/static/src/overrides/models/pos_store.js
@@ -139,7 +139,7 @@ patch(PosStore.prototype, {
     },
     async allowProductCreation() {
         if (this.config.module_pos_hr) {
-            return this.employeeIsAdmin;
+            return this.employeeIsAdmin && (await super.allowProductCreation());
         }
         return await super.allowProductCreation();
     },


### PR DESCRIPTION
Before this commit, only system users could create products from the POS interface. This limited the ability of store managers.

opw-5418727

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
