### PR TITLE
[FIX] pos_self_order: missing “Order Now” button after order deletion/payment

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -239,7 +239,7 @@ class PosConfig(models.Model):
             delete_record_ids[model] = browsed.filtered(lambda r: not r.exists()).ids
             # Cancelled orders must be forced deleted from the user interface.
             if model == "pos.order":
-                delete_record_ids[model] += browsed.filtered(lambda r: r.state == "cancel").ids
+                delete_record_ids[model] += browsed.exists().filtered(lambda r: r.state == "cancel").ids
 
         pos_order_data = dynamic_records.get('pos.order') or self.env['pos.order']
         data = pos_order_data.read_pos_data([], self.id)

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -133,6 +133,10 @@ export class PosData extends Reactive {
         await this.indexedDB.reset();
     }
 
+    async deleteRecordsInIndexedDB(model, ids) {
+        return await this.indexedDB.delete(model, ids);
+    }
+
     async initIndexedDB(relations) {
         // This method initializes indexedDB with all models loaded into the PoS. The default key is ID.
         // But some models have another key configured in data_service_options.js. These models are
@@ -903,7 +907,7 @@ export class PosData extends Reactive {
     }
 
     localDeleteCascade(record, removeFromServer = false) {
-        const recordModel = record.constructor.pythonModel;
+        const recordModel = record.model.name;
 
         const relationsToDelete = Object.values(this.relations[recordModel])
             .filter((rel) => this.opts.cascadeDeleteModels.includes(rel.relation))
@@ -911,9 +915,9 @@ export class PosData extends Reactive {
         const recordsToDelete = relationsToDelete.flatMap((relation) => record[relation]);
 
         // Delete all children records before main record
-        this.indexedDB.delete(recordModel, [record.uuid]);
+        this.deleteRecordsInIndexedDB(recordModel, [record.uuid]);
         for (const item of recordsToDelete) {
-            this.indexedDB.delete(item.model.name, [item.uuid]);
+            this.deleteRecordsInIndexedDB(item.model.name, [item.uuid]);
             item.delete({ silent: !removeFromServer });
         }
 

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -173,7 +173,6 @@ class PosSelfOrderController(http.Controller):
     @http.route('/pos-self-order/get-user-data', auth='public', type='jsonrpc', website=True)
     def get_orders_by_access_token(self, access_token, order_access_tokens, table_identifier=None):
         pos_config = self._verify_pos_config(access_token)
-        session = pos_config.current_session_id
         table = pos_config.env["restaurant.table"].search([('identifier', '=', table_identifier)], limit=1)
         domain = False
 
@@ -189,14 +188,18 @@ class PosSelfOrderController(http.Controller):
         for data in order_access_tokens:
             domain = expression.OR([domain, ['&',
                 ('access_token', '=', data.get('access_token')),
-                ('write_date', '>', data.get('write_date'))
+                '|',
+                ('write_date', '>', data.get('write_date')),
+                ('state', '!=', data.get('state')),
             ]])
+        orders = pos_config.env['pos.order'].search(domain)
 
-        orders = session.order_ids.filtered_domain(domain)
-        if not orders:
-            return {}
-
-        return self._generate_return_values(orders, pos_config)
+        access_tokens = set({o.get('access_token') for o in order_access_tokens})
+        existing_order_tokens = pos_config.env['pos.order'].search([('access_token', 'in', access_tokens)]).mapped('access_token')
+        if deleted_order_tokens := list(access_tokens - set(existing_order_tokens)):
+            # Remove orders that no longer exist on the server but are still shown in the self-order UI
+            pos_config._notify('REMOVE_ORDERS', {'deleted_order_tokens': deleted_order_tokens})
+        return self._generate_return_values(orders, pos_config) if orders else {}
 
     @http.route('/kiosk/payment/<int:pos_config_id>/<device_type>', auth='public', type='jsonrpc', website=True)
     def pos_self_order_kiosk_payment(self, pos_config_id, order, payment_method_id, access_token, device_type):

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -154,7 +154,13 @@ class PosConfig(models.Model):
             if (not vals.get('module_pos_restaurant') and not record.module_pos_restaurant) and vals.get('self_ordering_mode') == 'mobile':
                 vals['self_ordering_pay_after'] = 'each'
 
-            if (vals.get('self_ordering_service_mode') == 'counter' or record.self_ordering_service_mode == 'counter') and vals.get('self_ordering_mode') == 'mobile':
+            if (
+                vals.get('self_ordering_mode') == 'mobile'
+                and (
+                    vals.get('self_ordering_service_mode') == 'counter'
+                    or (record.self_ordering_service_mode == 'counter' and vals.get('self_ordering_service_mode') != 'table')
+                )
+            ):
                 vals['self_ordering_pay_after'] = 'each'
 
             if vals.get('self_ordering_mode') == 'mobile' and vals.get('self_ordering_pay_after') == 'meal':

--- a/addons/pos_self_order/static/src/app/services/data_service.js
+++ b/addons/pos_self_order/static/src/app/services/data_service.js
@@ -42,13 +42,13 @@ export const unpatchSelf = patch(PosData.prototype, {
             ? await super.getLocalDataFromIndexedDB(...arguments)
             : {};
     },
-    localDeleteCascade(record) {
-        return session.data.self_ordering_mode === "mobile"
-            ? super.localDeleteCascade(...arguments)
-            : record.delete();
-    },
     async missingRecursive(recordMap) {
         return recordMap;
     },
     async checkAndDeleteMissingOrders(results) {},
+    async deleteRecordsInIndexedDB(model, ids) {
+        return session.data.self_ordering_mode === "mobile"
+            ? await super.deleteRecordsInIndexedDB(...arguments)
+            : true;
+    },
 });

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -122,6 +122,9 @@ export class SelfOrder extends Reactive {
                 }
             });
         }
+        this.data.connectWebSocket("REMOVE_ORDERS", (data) => {
+            this.removeOrdersByAccessTokens(data.deleted_order_tokens);
+        });
         barcode.bus.addEventListener("barcode_scanned", (ev) => {
             if (!this.ordering) {
                 this.notification.add(_t("We're currently closed"), {
@@ -570,6 +573,13 @@ export class SelfOrder extends Reactive {
         }
     }
 
+    removeOrdersByAccessTokens(orderAccessTokens = []) {
+        // Remove orders and their dependent records locally and from IndexedDB
+        this.models["pos.order"]
+            .filter((o) => orderAccessTokens.includes(o.access_token))
+            .forEach((o) => this.data.localDeleteCascade(o));
+    }
+
     cancelOrder() {
         if (
             this.config.self_ordering_mode === "kiosk" &&
@@ -686,12 +696,12 @@ export class SelfOrder extends Reactive {
     async getUserDataFromServer(tokens = []) {
         const tableIdentifier = this.router.getTableIdentifier([]);
         const dbAccessToken = this.models["pos.order"]
-            .filter((o) => o.state === "draft" && typeof o.id === "number")
+            .filter((o) => o.state === "draft" && typeof o.id === "number" && o.access_token)
             .map((order) => ({
                 access_token: order.access_token,
+                state: order.state,
                 write_date: serializeDateTime(order.write_date.plus({ seconds: 1 })),
-            }))
-            .filter((order) => order.access_token);
+            }));
 
         // Token given in argument are probably not in the local database
         // so write_date is set to 1970-01-01 00:00:00

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import { registry } from "@web/core/registry";
 import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
@@ -5,6 +7,7 @@ import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { rpc } from "@web/core/network/rpc";
 
 registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_in", {
     steps: () => [
@@ -465,5 +468,31 @@ registry.category("web_tour.tours").add("self_order_mobile_no_access_token", {
             Utils.checkIsNoBtn("My Order"),
             Utils.clickBtn("Order Now"),
             Utils.negateStep(Utils.checkBtn("Order")),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_delete_mobile_order_from_backend", {
+    steps: () =>
+        [
+            Utils.checkIsNoBtn("My Order"),
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Coca-Cola"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+            Utils.clickBtn("Order"),
+            ConfirmationPage.isShown(),
+            Utils.clickBtn("Ok"),
+            Utils.checkIsNoBtn("Order Now"),
+            {
+                trigger: "body",
+                run: async () => {
+                    // Simulate mobile self-order deletion from the backend
+                    await rpc(`/pos-self-order/test-delete-order-from-backend/`, {
+                        order_ids: [posmodel.currentOrder.id],
+                    });
+                },
+            },
+            Utils.clickBtn("Order Now"),
+            ProductPage.isShown(),
         ].flat(),
 });

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -180,3 +180,10 @@ export function checkProductOutOfStock(productName) {
         trigger: `.o_self_product_box:has(span:contains('${productName}')):has(div:contains('Out of stock'))`,
     };
 }
+
+export function isShown() {
+    return {
+        content: "Check whether the Product List page is displayed",
+        trigger: ".o_self_product_list_page",
+    };
+}

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -1,11 +1,12 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+from odoo import http
 
 from urllib.parse import urlparse
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
 from unittest.mock import patch
+from odoo.addons.pos_self_order.controllers.orders import PosSelfOrderController
 
 
 @odoo.tests.tagged("post_install", "-at_install")
@@ -329,3 +330,27 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         })
 
         self.start_tour(self_route, "test_self_order_table_sharing-meal_mode")
+
+    def test_delete_mobile_order_from_backend(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+            'use_presets': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, '')
+        self_route = self.pos_config._get_self_order_route()
+
+        @http.route('/pos-self-order/test-delete-order-from-backend/', auth='public', type='jsonrpc', website=True)
+        def delete_mobile_order_from_backend(self, order_ids):
+            self.env['pos.order'].sudo().browse(order_ids).unlink()
+
+        with patch.object(
+            PosSelfOrderController,
+            'delete_mobile_order_from_backend',
+            delete_mobile_order_from_backend,
+            create=True,
+        ):
+            self.start_tour(self_route, 'test_delete_mobile_order_from_backend')


### PR DESCRIPTION
**Issues:**
1. Order deleted from backend When a self-order is deleted from the backend, the customer self-order UI is not updated, causing the “Order Now” button to be missing.

2. Order sent and paid from POS UI Steps:
    - Create a self-order from mobile
    - Load the order in the POS UI
    - Add additional items (eligible for preparation)
    - Proceed to payment and validate
    - Click Order in the Send for preparation popup Problem: After order validation, the customer self-order UI is not refreshed and the “Order Now” button does not reappear.

**Fixes:**
 - Ensures order deletion triggers notify calls to refresh both POS and self-order UIs
 - Synchronize deleted orders with the customer self-order UI
 - Fix the case where setting Service at = `Table` and Pay after = `Meal` in a single operation resets Pay after to `each`.

Task-5373116

Related: https://github.com/odoo/enterprise/pull/103052
