### PR TITLE
[FIX] account_edi_ubl_cii: Fix tax reverse charge in BIS3

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -161,6 +161,16 @@ class AccountEdiUBL(models.AbstractModel):
             return
         return tax_grouping_key
 
+    def _ubl_turn_base_lines_price_unit_as_always_positive(self, vals):
+        """ Helper to make sure the base_lines don't contain any negative price_unit.
+
+        :param vals: Some custom data.
+        """
+        for base_line in vals['base_lines']:
+            if base_line['price_unit'] < 0.0:
+                base_line['quantity'] *= -1
+                base_line['price_unit'] *= -1
+
     def _ubl_turn_emptying_taxes_as_new_base_lines(self, base_lines, company, vals):
         """ Extract emptying taxes such as "Vidanges" on bottles from the current base lines and turn them into
         additional base lines.

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -327,7 +327,7 @@ class AccountEdiUBL(models.AbstractModel):
                     else 0.0
                 )
             )
-            ubl_values['line_extension_amount'] = amount
+            ubl_values[f'line_extension_amount{suffix}'] = amount
 
     def _ubl_add_base_line_ubl_values_item(self, vals):
         """ Add 'base_line' -> '_ubl_values' -> 'item'.

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -114,6 +114,53 @@ class AccountEdiUBL(models.AbstractModel):
             'currency': tax_subtotal_grouping_key['currency'],
         }
 
+    def _ubl_default_allowance_charge_early_payment_grouping_key(self, base_line, tax_data, vals, currency):
+        """ Give the grouping key when generating the allowance/charge from an early payment discount.
+
+        :param base_line:   A base line (see '_prepare_base_line_for_taxes_computation').
+        :param tax_data:    One of the tax data in base_line['tax_details']['taxes_data'].
+        :param vals:        Some custom data.
+        :param currency:    The currency for which the grouping key is expressed.
+        :return:            A dictionary that could be used as a grouping key for the taxes helpers.
+        """
+        if not self._ubl_is_early_payment_base_line(base_line):
+            return
+
+        tax_grouping_key = self._ubl_default_tax_category_grouping_key(base_line, tax_data, vals, currency)
+        if not tax_grouping_key or tax_grouping_key['is_withholding']:
+            return
+        return tax_grouping_key
+
+    def _ubl_default_payable_amount_tax_withholding_grouping_key(self, base_line, tax_data, vals, currency):
+        """ Give the grouping key when moving the tax withholding amounts to PrepaidAmount.
+
+        :param base_line:   A base line (see '_prepare_base_line_for_taxes_computation').
+        :param tax_data:    One of the tax data in base_line['tax_details']['taxes_data'].
+        :param vals:        Some custom data.
+        :param currency:    The currency for which the grouping key is expressed.
+        :return:            A dictionary that could be used as a grouping key for the taxes helpers.
+        """
+        if not tax_data:
+            return
+        tax_grouping_key = self._ubl_default_tax_category_grouping_key(base_line, tax_data, vals, currency)
+        if not tax_grouping_key:
+            return
+        return tax_grouping_key['is_withholding']
+
+    def _ubl_default_base_line_item_classified_tax_category_grouping_key(self, base_line, tax_data, vals, currency):
+        """ Give the grouping key when computing taxes for Item -> ClassifiedTaxCategory.
+
+        :param base_line:   A base line (see '_prepare_base_line_for_taxes_computation').
+        :param tax_data:    One of the tax data in base_line['tax_details']['taxes_data'].
+        :param vals:        Some custom data.
+        :param currency:    The currency for which the grouping key is expressed.
+        :return:            A dictionary that could be used as a grouping key for the taxes helpers.
+        """
+        tax_grouping_key = self._ubl_default_tax_category_grouping_key(base_line, tax_data, vals, currency)
+        if not tax_grouping_key or tax_grouping_key['is_withholding']:
+            return
+        return tax_grouping_key
+
     def _ubl_turn_emptying_taxes_as_new_base_lines(self, base_lines, company, vals):
         """ Extract emptying taxes such as "Vidanges" on bottles from the current base lines and turn them into
         additional base lines.
@@ -350,11 +397,11 @@ class AccountEdiUBL(models.AbstractModel):
         for sub_currency, suffix in ((currency, '_currency'), (company_currency, '')):
             base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(
                 base_lines=base_lines,
-                grouping_function=lambda base_line, tax_data: self._ubl_default_tax_category_grouping_key(
-                    base_line,
-                    tax_data,
-                    vals,
-                    sub_currency,
+                grouping_function=lambda base_line, tax_data: self._ubl_default_base_line_item_classified_tax_category_grouping_key(
+                    base_line=base_line,
+                    tax_data=tax_data,
+                    vals=vals,
+                    currency=sub_currency,
                 ),
             )
             for base_line, aggregated_values in base_lines_aggregated_values:
@@ -559,6 +606,34 @@ class AccountEdiUBL(models.AbstractModel):
                         'subtotals': {},
                     }
 
+    def _ubl_add_values_payable_amount_tax_withholding(self, vals):
+        AccountTax = self.env['account.tax']
+        base_lines = vals['base_lines']
+        company = vals['company']
+        company_currency = company.currency_id
+        currency = vals['currency_id']
+
+        ubl_values = vals['_ubl_values']
+        ubl_values['payable_amount_tax_withholding'] = 0.0
+        ubl_values['payable_amount_tax_withholding_currency'] = 0.0
+        for sub_currency, suffix in ((currency, '_currency'), (company_currency, '')):
+            base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(
+                base_lines=base_lines,
+                grouping_function=lambda base_line, tax_data: self._ubl_default_payable_amount_tax_withholding_grouping_key(
+                    base_line=base_line,
+                    tax_data=tax_data,
+                    vals=vals,
+                    currency=sub_currency,
+                ),
+            )
+            values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+
+            for grouping_key, values in values_per_grouping_key.items():
+                if not grouping_key:
+                    continue
+
+                ubl_values[f'payable_amount_tax_withholding{suffix}'] -= values[f'tax_amount{suffix}']
+
     def _ubl_add_values_payable_rounding_amount(self, vals):
         """ Add
             'vals' -> '_ubl_values' -> 'payable_rounding_amount[_currency]'.
@@ -618,14 +693,15 @@ class AccountEdiUBL(models.AbstractModel):
 
         ubl_values = vals['_ubl_values']
 
-        def grouping_function(base_line, tax_data, sub_currency):
-            if self._ubl_is_early_payment_base_line(base_line):
-                return self._ubl_default_tax_category_grouping_key(base_line, tax_data, vals, sub_currency)
-
         for sub_currency, suffix in ((currency, '_currency'), (company_currency, '')):
             base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(
                 base_lines=base_lines,
-                grouping_function=lambda base_line, tax_data: grouping_function(base_line, tax_data, sub_currency),
+                grouping_function=lambda base_line, tax_data: self._ubl_default_allowance_charge_early_payment_grouping_key(
+                    base_line=base_line,
+                    tax_data=tax_data,
+                    vals=vals,
+                    currency=sub_currency,
+                ),
             )
             values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1251,7 +1251,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'cbc:ID': {'_text': invoice.name},
             'cbc:IssueDate': {'_text': invoice.invoice_date},
             'cbc:InvoiceTypeCode': {'_text': 380} if vals['document_type'] == 'invoice' else None,
-            'cbc:Note': {'_text': html2plaintext(invoice.narration)} if invoice.narration else None,
+            'cbc:Note': {'_text': html2plaintext(invoice.narration) if invoice.narration else None},
             'cbc:DocumentCurrencyCode': {'_text': invoice.currency_id.name},
             'cac:OrderReference': {
                 # OrderReference/ID (order_reference) is mandatory inside the OrderReference node

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -984,7 +984,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 'unitCode': self._get_uom_unece_code(base_line['product_uom_id']),
             },
             'cbc:LineExtensionAmount': {
-                '_text': FloatFmt(base_line['_ubl_values']['line_extension_amount'], min_dp=currency.decimal_places),
+                '_text': FloatFmt(base_line['_ubl_values']['line_extension_amount_currency'], min_dp=currency.decimal_places),
                 'currencyID': currency.name,
             },
         })

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from odoo import _, api, models
-from odoo.tools.misc import str2bool
+from odoo.tools.misc import formatLang, str2bool, NON_BREAKING_SPACE
 from odoo.addons.account.tools import dict_to_xml
 from odoo.addons.account_edi_ubl_cii.models.account_edi_common import FloatFmt
 from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
@@ -546,6 +546,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         # Call the parent method from UBL 2.1
         super()._add_invoice_header_nodes(document_node, vals)
         invoice = vals['invoice']
+        ubl_values = vals['_ubl_values']
 
         # Override specific BIS3 values
         document_node.update({
@@ -554,6 +555,16 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             'cbc:ProfileID': {'_text': 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0'},
             'cbc:TaxCurrencyCode': {'_text': vals['tax_currency_code']},
         })
+
+        if tax_withholding_amount := ubl_values['payable_amount_tax_withholding_currency']:
+            note = _(
+                "The prepaid amount of %s corresponds to the withholding tax applied.",
+                formatLang(self.env, tax_withholding_amount, currency_obj=vals['currency_id']).replace(NON_BREAKING_SPACE, ''),
+            )
+            narration_note = document_node['cbc:Note']['_text']
+            if narration_note:
+                note = f'{note} {narration_note}'
+            document_node['cbc:Note']['_text'] = note
 
         # [NL-R-001] For suppliers in the Netherlands, if the document is a creditnote, the document MUST
         # contain an invoice reference (cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID)
@@ -780,7 +791,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 break
 
         for line in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section')):
-            if len(line.tax_ids.flatten_taxes_hierarchy().filtered(lambda t: t.amount_type not in ('fixed', 'code'))) != 1:
+            if len(line.tax_ids.flatten_taxes_hierarchy().filtered(lambda t: t.amount_type not in ('fixed', 'code') and t.amount >= 0.0)) != 1:
                 # [UBL-SR-48]-Invoice lines shall have one and only one classified tax category.
                 # /!\ exception: possible to have any number of ecotaxes (fixed tax) with a regular percentage tax
                 constraints.update({'cen_en16931_tax_line': _("Each invoice line shall have one and only one tax.")})
@@ -891,14 +902,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
     # EXPORT: Gathering data
     # -------------------------------------------------------------------------
 
-    def _ubl_default_tax_subtotal_tax_category_grouping_key(self, tax_grouping_key, vals):
-        # EXTENDS
-        return {
-            **super()._ubl_default_tax_subtotal_tax_category_grouping_key(tax_grouping_key, vals),
-            # Temporary solution to have withholding taxes merged with others until we know how to manage them.
-            'is_withholding': False,
-        }
-
     def _setup_base_lines(self, vals):
         # OVERRIDE
         AccountTax = self.env['account.tax']
@@ -956,6 +959,9 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
         # Add 'tax_totals'.
         self._ubl_add_values_tax_totals(vals)
+
+        # Add 'payable_amount' to manage withholding taxes.
+        self._ubl_add_values_payable_amount_tax_withholding(vals)
 
         # Add 'allowance_charge_early_payment' to manage the early payment discount.
         self._ubl_add_values_allowance_charge_early_payment(vals)
@@ -1090,6 +1096,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             if allowance_charge['cbc:ChargeIndicator']['_text'] == 'true'
         )
         payable_rounding_amount = ubl_values['payable_rounding_amount_currency']
+        payable_amount_tax_withholding_currency = ubl_values['payable_amount_tax_withholding_currency']
 
         document_node[monetary_total_tag] = {
             'cbc:LineExtensionAmount': {
@@ -1113,7 +1120,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 'currencyID': vals['currency_name'],
             } if total_charge else None,
             'cbc:PrepaidAmount': {
-                '_text': FloatFmt(invoice.amount_total - invoice.amount_residual, min_dp=vals['currency_dp']),
+                '_text': FloatFmt(payable_amount_tax_withholding_currency + invoice.amount_total - invoice.amount_residual, min_dp=vals['currency_dp']),
                 'currencyID': vals['currency_name'],
             },
             'cbc:PayableRoundingAmount': {

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -908,10 +908,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         company = vals['company']
 
         # Avoid negative unit price.
-        for base_line in vals['base_lines']:
-            if base_line['price_unit'] < 0.0:
-                base_line['quantity'] *= -1
-                base_line['price_unit'] *= -1
+        self._ubl_turn_base_lines_price_unit_as_always_positive(vals)
 
         # Manage taxes for emptying.
         vals['base_lines'] = self._ubl_turn_emptying_taxes_as_new_base_lines(vals['base_lines'], company, vals)

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_reverse_charge.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_reverse_charge.xml
@@ -5,6 +5,7 @@
 	<cbc:IssueDate>___ignore___</cbc:IssueDate>
 	<cbc:DueDate>___ignore___</cbc:DueDate>
 	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:Note>The prepaid amount of 106.70€ corresponds to the withholding tax applied.</cbc:Note>
 	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
 	<cac:OrderReference>
 		<cbc:ID>___ignore___</cbc:ID>
@@ -98,7 +99,7 @@
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
 	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="EUR">199.33</cbc:TaxAmount>
+		<cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>
 			<cbc:TaxableAmount currencyID="EUR">1000.00</cbc:TaxableAmount>
 			<cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
@@ -110,24 +111,13 @@
 				</cac:TaxScheme>
 			</cac:TaxCategory>
 		</cac:TaxSubtotal>
-		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">-10.67</cbc:TaxAmount>
-			<cac:TaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>-10.67</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:TaxCategory>
-		</cac:TaxSubtotal>
 	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
-		<cbc:LineExtensionAmount currencyID="EUR">1100.00</cbc:LineExtensionAmount>
-		<cbc:TaxExclusiveAmount currencyID="EUR">1100.00</cbc:TaxExclusiveAmount>
-		<cbc:TaxInclusiveAmount currencyID="EUR">1299.33</cbc:TaxInclusiveAmount>
-		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-		<cbc:PayableAmount currencyID="EUR">1299.33</cbc:PayableAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">1000.00</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">1000.00</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">1210.00</cbc:TaxInclusiveAmount>
+		<cbc:PrepaidAmount currencyID="EUR">106.70</cbc:PrepaidAmount>
+		<cbc:PayableAmount currencyID="EUR">1103.30</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
@@ -146,25 +136,6 @@
 		</cac:Item>
 		<cac:Price>
 			<cbc:PriceAmount currencyID="EUR">1000.0</cbc:PriceAmount>
-		</cac:Price>
-	</cac:InvoiceLine>
-	<cac:InvoiceLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>Test Product</cbc:Description>
-			<cbc:Name>Test Product</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>-10.67</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">100.0</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 </Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -123,14 +123,10 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
     def test_invoice_tax_reverse_charge(self):
         tax_21 = self.percent_tax(21.0)
         tax_minus_10_67 = self.percent_tax(-10.67)
-        product_1 = self._create_product(lst_price=1000.0, taxes_id=tax_21)
-        product_2 = self._create_product(lst_price=100.0, taxes_id=tax_minus_10_67)
-        invoice = self._create_invoice(
+        product = self._create_product(lst_price=1000.0, taxes_id=tax_21 + tax_minus_10_67)
+        invoice = self._create_invoice_one_line(
+            product_id=product,
             partner_id=self.partner_be,
-            invoice_line_ids=[
-                self._prepare_invoice_line(product_id=product_1),
-                self._prepare_invoice_line(product_id=product_2),
-            ],
             post=True,
         )
 


### PR DESCRIPTION
There is no WithholdingTaxTotal node in BIS3.
You cannot report any negative tax amount as taxes.
You can only report VAT taxes but tax reverse charge are not considered
as VAT.
This commit reports the tax reverse charge amount as a PrepaidAmount instead.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
