### PR TITLE
[FIX] pos_sale: Fix quotation from repair

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -240,6 +240,12 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                             });
                         }
                     }
+
+                    line.has_valued_move_ids = await this.orm.call(
+                        "sale.order.line",
+                        "has_valued_move_ids",
+                        [line.id]
+                    );
                     new_line.setQuantityFromSOL(line);
                     new_line.set_unit_price(line.price_unit);
                     new_line.set_discount(line.discount);

--- a/addons/pos_sale/static/src/overrides/models/models.js
+++ b/addons/pos_sale/static/src/overrides/models/models.js
@@ -72,7 +72,12 @@ patch(Orderline.prototype, {
      * @param {'sale.order.line'} saleOrderLine
      */
     setQuantityFromSOL(saleOrderLine) {
-        if (this.product.type === "service" && !['sent', 'draft'].includes(this.sale_order_origin_id.state)) {
+        if (!saleOrderLine.has_valued_move_ids) {
+            this.set_quantity(saleOrderLine.product_uom_qty);
+        } else if (
+            this.product.type === "service" &&
+            !["sent", "draft"].includes(this.sale_order_origin_id.state)
+        ) {
             this.set_quantity(saleOrderLine.qty_to_invoice);
         } else {
             this.set_quantity(

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -402,3 +402,13 @@ registry.category("web_tour.tours").add("test_import_so_to_pos_no_existing_lot",
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_pos_repair", {
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectNthOrder(1),
+            ProductScreen.selectedOrderlineHas("Test product 1", 1),
+        ].flat(),
+});


### PR DESCRIPTION
backoprt of : https://github.com/odoo/odoo/pull/186812

When opening a quotation created from a repair order in the PoS the quantity of the products would always be 0.

Steps to reproduce:
-------------------
* Create a repair order for whatever product
* Add some product to the list with the "Add" option
* Start and End the reparation
* Create a quotation for the repair order
* Open the quotation in the PoS
> Observation: The quantity of the product in the pos is 0

Why the fix:
------------
If the sale order line has no `valued_move_ids` it means that it's linked to a repair. In this case we take the product_uom_qty into account for the pos order line quantity.

opw-4261097