### PR TITLE
[FIX] website, *: correct preview rendering for primary/secondary buttons

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -609,7 +609,7 @@ export class LinkPlugin extends Plugin {
             document: this.document,
             linkElement,
             isImage: isImage,
-            containerElement: selection.anchorNode.parentElement,
+            containerElement: closestElement(selection.anchorNode),
             ignoreDOMMutations: this.dependencies.history.ignoreDOMMutations,
             onApply: (...args) => {
                 delete this._isNavigatingByMouse;

--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -194,7 +194,7 @@ patch(LinkPopover.prototype, {
 
         const stylePrefixRegex = /(outline|fill)/;
 
-        if (buttonContainerEl.tagName === "A") {
+        if (buttonContainerEl.classList.contains("btn")) {
             sizeClasses = [...buttonContainerEl.classList].filter((cls) =>
                 ["btn-lg", "btn-sm"].includes(cls)
             );


### PR DESCRIPTION
*: html_editor

Issue:
1. Button previews displayed incorrectly after converting button type to link
2. Link preview displayed incorrect theme colors when parent and ancestor elements had different themes applied


Steps to reproduce (Issue 1):
1. Add a button component
2. Set it to primary and modify its size/shape
3. Convert the button type to link
4. Re-open the button type dropdown
5. Observe incorrect button preview

Steps to reproduce (Issue 2):
1. Add the `s_text_cover` snippet
2. Apply theme 1 (o_cc1) to Text Cover and theme 2 (o_cc2) to Column
3. Press Enter after the button
4. Start typing `/link` to create a link
5. Observe that the link preview in the powerbox dropdown shows incorrect theme colors

After this commit:
1. Preview now correctly calculates based on previously configured button properties, even after type conversion
2. Link preview now correctly inherits theme styles from its direct parent element



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
