### PR TITLE
[IMP] purchase_requisition: add missing hotkeys

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -139,7 +139,7 @@
                     <button name="action_receive" class="btn-primary" type="object" string="Receive" data-hotkey="e" invisible="not show_receive_button"/>
                     <widget name="purchase_file_uploader" invisible="state != 'purchase'"/>
                     <button name="action_rfq_send" invisible="state != 'purchase'" string="Send PO" type="object" context="{'send_rfq':False}" data-hotkey="g"/>
-                    <button name="action_acknowledge" string="Acknowledge" type="object" invisible="acknowledged or state != 'purchase'"/>
+                    <button name="action_acknowledge" string="Acknowledge" type="object" invisible="acknowledged or state != 'purchase'" data-hotkey="a"/>
                     <button name="button_draft" invisible="state != 'cancel'" string="Set to Draft" type="object" data-hotkey="o"/>
                     <button name="print_quotation" string="Print" type="object" groups="base.group_user" data-hotkey="k" invisible="state == 'purchase'"/>
                     <button name="%(purchase.action_report_purchase_order)d" string="Print" type="action" groups="base.group_user" data-hotkey="k" invisible="state != 'purchase'"/>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -38,11 +38,11 @@
                 <button name="%(action_purchase_requisition_to_so)d" type="action"
                     string="New Quotation" class="btn-primary"
                     context="{'default_currency_id': currency_id, 'default_user_id': user_id}"
-                    invisible="state != 'confirmed'"/>
-                <button name="action_confirm" invisible="state != 'draft'" string="Confirm" type="object" class="btn-primary"/>
-                <button name="action_done" invisible="state != 'confirmed' or requisition_type == 'purchase_template'" string="Close" type="object" class="btn-primary"/>
-                <button name="action_draft" invisible="state != 'cancel'" string="Reset to Draft" type="object"/>
-                <button name="action_cancel" invisible="state not in ('draft', 'confirmed')" string="Cancel" type="object"/>
+                    invisible="state != 'confirmed'" data-hotkey="q"/>
+                <button name="action_confirm" invisible="state != 'draft'" string="Confirm" type="object" class="btn-primary" data-hotkey="v"/>
+                <button name="action_done" invisible="state != 'confirmed' or requisition_type == 'purchase_template'" string="Close" type="object" class="btn-primary" data-hotkey="z"/>
+                <button name="action_draft" invisible="state != 'cancel'" string="Reset to Draft" type="object" data-hotkey="o"/>
+                <button name="action_cancel" invisible="state not in ('draft', 'confirmed')" string="Cancel" type="object" data-hotkey="x"/>
                 <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done" invisible="requisition_type == 'purchase_template'"/>
             </header>
             <sheet>


### PR DESCRIPTION
This commit adds some shortcuts to the Purchase Agreements form, allowing users to navigate and work more efficiently.

Task: 5420786

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
