### PR TITLE
[FIX] mass_mailing: ensure images are visible in sent emails

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -1,5 +1,7 @@
 import { isBlock } from "@html_editor/utils/blocks";
 import { getAdjacentPreviousSiblings } from "@html_editor/utils/dom_traversal";
+import { loadImage } from "@html_editor/utils/image_processing";
+import { getImageSrc } from "@html_editor/utils/image";
 import { blendColors } from "@web/core/utils/colors";
 
 function parentsGet(node, root = undefined) {
@@ -869,6 +871,7 @@ function enforceImagesResponsivity(element) {
  *                            specificity: number;}>
  */
 export async function toInline(element, cssRules) {
+    await waitUntilImagesLoaded(element);
     // Fix card-img-top heights (must happen before we transform everything).
     for (const imgTop of element.querySelectorAll(".card-img-top")) {
         imgTop.style.setProperty("height", _getHeight(imgTop) + "px");
@@ -2123,4 +2126,12 @@ function correctBorderAttributes(style) {
         return style;
     }
     return style.trim().replace(/;?$/, "; border-style: solid;");
+}
+
+function waitUntilImagesLoaded(root) {
+    const promises = [];
+    for (const img of root.querySelectorAll("img")) {
+        promises.push(loadImage(getImageSrc(img)));
+    }
+    return Promise.all(promises);
 }

--- a/addons/mail/static/tests/composer/html_composer_message_field.test.js
+++ b/addons/mail/static/tests/composer/html_composer_message_field.test.js
@@ -143,7 +143,7 @@ test("media dialog: upload", async function () {
     expect("[name='attachment_ids'] .o_attachment[title='test.jpg']").toHaveCount(1);
 
     await contains(".o_form_button_save").click();
-    expect.verifySteps(["web_save"]);
+    await expect.waitForSteps(["web_save"]);
 });
 
 test("mention a partner", async () => {


### PR DESCRIPTION
Problem:
When sending an email marketing, some images are not visible in the received email.

Cause:
After 354b8f60dbabcfac690d90bf657592e1347e4f86, we clone the `editable`, append it to `processingContainer`, and call `toInline` on it.
During `toInline`, images with the `.card-img-top` class are queried and their size is fixed using `getComputedStyle`.

Because the editable is freshly cloned, images may not be loaded yet. Calling `getComputedStyle` on an unloaded image returns a height of `0`, which results in images being rendered as invisible.

Solution:
After cloning the editable, wait for all images inside it to finish loading before running `toInline`. This ensures `getComputedStyle` returns the correct dimensions.

Steps to reproduce:
- Open Email Marketing.
- Add a Columns snippet with images.
- Send the email.
- Observe that the received email is missing some images.

opw-5215534

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
