### PR TITLE
[IMP] mail: modify activity list view

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -284,9 +284,9 @@
                     <button name="action_reschedule_nextweek" type="object" string="Next Week" icon="fa-calendar-o"/>
                 </header>
                 <field name="summary" string="Summary"/>
-                <field name="activity_type_id"/>
-                <field name="user_id" widget="many2one_avatar_user"/>
                 <field name="res_name" string="Linked to"/>
+                <field name="activity_type_id" optional="hide"/>
+                <field name="user_id" widget="many2one_avatar_user" optional="hide"/>
                 <field name="date_deadline" widget="remaining_days"/>
                 <field name="date_done" string="Done Date" optional="hide"/>
                 <field name="feedback" optional="hide"/>


### PR DESCRIPTION
This PR makes the user_id and activity_type_id fields optional and moves the res_name field next to the summary.

Task-5226414
