### PR TITLE
[IMP] event,hr_skills_event: allow reuse of onsite course on resume lines

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -95,6 +95,7 @@ class EventEvent(models.Model):
     tag_ids = fields.Many2many(
         'event.tag', string="Tags", readonly=False,
         store=True, compute="_compute_tag_ids")
+    onsite_course = fields.Boolean(string="Onsite Course")
     # properties
     registration_properties_definition = fields.PropertiesDefinition('Registration Properties')
     # Kanban fields

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -68,6 +68,7 @@
                             <field name="lang"/>
                             <field name="event_type_id" string="Template"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_quick_create': True}"/>
+                            <field name="onsite_course"/>
                         </group>
                         <group name="right_event_details">
                             <field name="organizer_id"/>

--- a/addons/hr_skills_event/models/hr_resume_line.py
+++ b/addons/hr_skills_event/models/hr_resume_line.py
@@ -9,7 +9,8 @@ class HrResumeLine(models.Model):
     event_id = fields.Many2one(
         'event.event', string="Onsite Course", compute='_compute_event_id',
         store=True, readonly=True, index='btree_not_null',
-        domain="[('is_multi_slots', '=', True), ('registration_ids', 'any', [('partner_id.employee', '=', True)])]"
+        context={'default_onsite_course': True},
+        domain="['|', ('onsite_course', '=', True), '&', ('is_multi_slots', '=', True), ('registration_ids', 'any', [('partner_id.employee', '=', True)])]"
     )
     course_type = fields.Selection(
         selection_add=[('onsite', 'Onsite')],


### PR DESCRIPTION
-Added a boolean field 'onsite_course' to display onsite courses in 'Onsite course' field while making new resume lines.

task-5427310

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
