### PR TITLE
[FIX] point_of_sale: filtering partners in frontend supports ilike SQL patterns

### DIFF
--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -485,8 +485,24 @@ registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
             ProductScreenPartnerList.searchCustomerValueAndClear("United States"),
             ProductScreenPartnerList.searchCustomerValueAndClear("9898989899"),
             ProductScreenPartnerList.searchCustomerValueAndClear("0987654321"),
+            ProductScreenPartnerList.searchCustomerValueAndClear("john@doe.com"),
+            // Test wildcard search ('j%hn d%e' -> john doe)
             ProductScreen.clickPartnerButton(),
-            PartnerList.searchCustomerValue("john@doe.com"),
+            {
+                isActive: ["mobile"],
+                content: `Click search field`,
+                trigger: `.fa-search.undefined`,
+                run: `click`,
+            },
+            {
+                content: `Search customer with "j%hn d%e"`,
+                trigger: `.modal-dialog .input-group input`,
+                run: `edit j%hn d%e`,
+            },
+            {
+                content: `Check "John Doe" is shown`,
+                trigger: `.partner-list .partner-info:nth-child(1):contains("John Doe")`,
+            },
         ].flat(),
 });
 


### PR DESCRIPTION
When the client typed `a%t%` into the search bar and pressed 'Enter', we load the partners from the backend using `getNewPartners` and showed a dialog "x partners found", however, we never show those results in the partner list since the search bar didn't support the wildcard ilike pattern.

This commit adds support for searching wildcard patterns, to match the SQL behavior more or less. Clients now won't be confused by seeing "x partners loaded" and at the same time seeing an empty list.

opw-5395340