### PR TITLE
[FIX] point_of_sale: avoid duplicate call to `sync_from_ui`

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1850,9 +1850,17 @@ export class PosStore extends WithLazyGetterTrap {
             this.printOptions
         );
         if (!printBillActionTriggered) {
-            order.nb_print = order.nb_print ? order.nb_print + 1 : 1;
-            if (typeof order.id === "number" && result) {
-                await this.data.write("pos.order", [order.id], { nb_print: order.nb_print });
+            if (result) {
+                const count = order.nb_print ? order.nb_print + 1 : 1;
+                if (typeof order.id === "number") {
+                    const wasDirty = order.isDirty();
+                    await this.data.write("pos.order", [order.id], { nb_print: count });
+                    if (!wasDirty) {
+                        order._dirty = false;
+                    }
+                } else {
+                    order.nb_print = count;
+                }
             }
         } else if (!order.nb_print) {
             order.nb_print = 0;


### PR DESCRIPTION
Backport of what have be none in this PR: https://github.com/odoo/odoo/pull/231719

- Before this commit, after doing `await this.data.write("pos.order", [order.id], { nb_print: order.nb_print });` the order was marked as dirty. This was causing issue for the next `sync_from_ui` causing this order to be resynced and then send twice to the blackbox.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
