### PR TITLE
[FIX] website: prevent popups drop in some snippets

### DIFF
--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -34,7 +34,8 @@ class PopupOptionPlugin extends Plugin {
         dropzone_selector: {
             selector: ".s_popup",
             exclude: "#website_cookies_bar",
-            excludeAncestor: ".s_popup, .s_table_of_content, .s_tabs, .s_tabs_images",
+            excludeAncestor:
+                ".s_popup, .s_table_of_content, .s_tabs, .s_tabs_images, .position-sticky",
             dropIn: ":not(p).oe_structure:not(.oe_structure_solo):not([data-snippet] *), :not(.o_mega_menu):not(p)[data-oe-type=html]:not([data-snippet] *)",
         },
         builder_actions: {


### PR DESCRIPTION
If an popup is dropped within an element with the property "position" set to "sticky", there would visual issues with the modal. For example, if the user drop a popup below the filters in the /shop page, the images of the product would appear over the popup content when the popup is opened.

Since there shouldn't be cases where "position" is setted to sticky without having the specific class, this commit fixes the issue by adding the selector ".position-sticky" as a forbidden ancestor for popups.

task-5411329
