### PR TITLE
[FIX] mail: prevent error when previewing XML files

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -117,7 +117,7 @@ export class Attachment extends FileModelMixin(Record) {
                 assignDefined({}, { access_token: this.ownership_token })
             )
         );
-        if (isPdfValid !== undefined) {
+        if (isPdfValid) {
             rpc(
                 `/mail/attachment/update_thumbnail`,
                 assignDefined(


### PR DESCRIPTION
Steps to reproduce:
1. Install `documents`
2. Upload an XML file that contains an embedded PDF in base64.
3. Click on the `Info & Tags` icon on the top right in the Documents kanban view
4. Open the imported XML file

Issue:
- An `Invalid Operation: Only PDF files can have thumbnail` error occurs.

Cause:
- The `Attachment` model attempts to generate a thumbnail for the XML file because
  it contains PDF data. However, as of now, thumbnails are only generated for valid PDFs,
  so the `generatePdfThumbnail` function returns `isPdfValid: false` but `setPdfThumbnail`
  method fails to handle this `false` value in resulting invalid rpc call.

Solution:
- Update the condition in `setPdfThumbnail` to consider only valid PDFs.

File: [Link](https://drive.google.com/file/d/19OxVJeqj9i-VgH9D6Aqk0P9Tuf6zlPwB/view?usp=sharing)

opw-5374529