### PR TITLE
[FIX] html_builder: prevent invalid snippet position

### DIFF
--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -71,7 +71,6 @@ export class BlockTab extends Component {
                 this.cancelDragAndDrop = this.shared.history.makeSavePoint();
                 this.dragState = {};
                 let snippetEl;
-                const baseSectionEl = snippet.content.cloneNode(true);
                 this.state.ongoingInsertion = true;
                 await new Promise((resolve) => {
                     this.snippetModel.openSnippetDialog(
@@ -80,9 +79,9 @@ export class BlockTab extends Component {
                             onSelect: (snippet) => {
                                 snippetEl = snippet.content.cloneNode(true);
 
-                                // Add the dropzones corresponding to a section and
-                                // make them invisible.
-                                const selectors = this.shared.dropzone.getSelectors(baseSectionEl);
+                                // Add the dropzones corresponding to the snippet
+                                // and make them invisible.
+                                const selectors = this.shared.dropzone.getSelectors(snippetEl);
                                 const dropzoneEls =
                                     this.shared.dropzone.activateDropzones(selectors);
                                 this.editable


### PR DESCRIPTION
Before this commit, the dropzones activated would not always be correct clicked on a group and then selected a snippet. The dropzones would be determined based on a default section and not based on the selected snippet. Therefore, even though there could be rules preventing a snippet from behing in a certain dropzone, the dropzone would still be activated because the snippet chosen would not be taken into account.

This commit fixes the issue by using the chosen snippet to activate the dropzones.

task-5428387