### PR TITLE
[FIX] point_of_sale: prevent error when adding lot-tracked product

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -927,7 +927,7 @@ export class PosStore extends WithLazyGetterTrap {
         if (configure) {
             this.numberBuffer.reset();
         }
-        const selectedOrderline = order.getSelectedOrderline();
+        let selectedOrderline = order.getSelectedOrderline();
         if (options.draftPackLotLines && configure) {
             selectedOrderline.setPackLotLines({
                 ...options.draftPackLotLines,
@@ -938,6 +938,7 @@ export class PosStore extends WithLazyGetterTrap {
         // Merge orderline if needed
         this.tryMergeOrderline(order, line, merge, selectedOrderline);
 
+        selectedOrderline = order.getSelectedOrderline();
         if (values.product_id.tracking === "lot") {
             const productTemplate = values.product_id.product_tmpl_id;
             const related_lines = [];
@@ -947,7 +948,7 @@ export class PosStore extends WithLazyGetterTrap {
                 values.price_extra,
                 false,
                 values.product_id,
-                line,
+                selectedOrderline,
                 related_lines
             );
             related_lines.forEach((line) => line.setUnitPrice(price));

--- a/addons/point_of_sale/static/tests/pos/tours/OrderWithLots_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/OrderWithLots_tour.js
@@ -37,3 +37,15 @@ registry.category("web_tour.tours").add("test_03_pos_with_lots", {
             ProductScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_lot_tracking_without_lot_creation", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Monitor Stand"),
+            ProductScreen.totalAmountIs("3.19"),
+            ProductScreen.clickDisplayedProduct("Monitor Stand"),
+            ProductScreen.totalAmountIs("6.38"),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3264,6 +3264,22 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_exclusion_attribute_values')
 
+    def test_lot_tracking_without_lot_creation(self):
+        pricelist = self.env['product.pricelist'].create({
+            'name': 'Test Pricelist',
+        })
+        self.main_pos_config.write({
+            'available_pricelist_ids': [(6, 0, [pricelist.id])],
+            'pricelist_id': pricelist.id,
+        })
+        self.main_pos_config.picking_type_id.write({
+            "use_create_lots": False,
+            "use_existing_lots": False,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.monitor_stand.tracking = 'lot'
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_lot_tracking_without_lot_creation', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
When adding a lot-tracked product to an orderline, if the picking type does not set to create lots or use existing ones, an error was raised when adding the lot-tracked product twice.

opw-5385476

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
