### PR TITLE
[REF] im_livechat, mail: simplify chat window close

### DIFF
--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -23,7 +23,8 @@ declare module "models" {
         livechat_member_type: "agent"|"bot"|"visitor";
     }
     export interface ChatWindow {
-        livechatStep: undefined|"CONFIRM_CLOSE"|"FEEDBACK";
+        confirmCloseResolver: PromiseWithResolvers<boolean>;
+        feedbackDoneResolver: PromiseWithResolvers<void>;
     }
     export interface DataResponse {
         chatbot_step: ChatbotStep;
@@ -35,6 +36,7 @@ declare module "models" {
         livechat_channel_member_history_ids: LivechatChannelMemberHistory[];
         livechat_customer_history_ids: LivechatChannelMemberHistory[];
         livechat_looking_for_help_since_dt: import("luxon").DateTime;
+        livechatShouldAskLeaveConfirmation: Readonly<boolean>;
     }
     export interface LivechatChannel {
         channel_ids: DiscussChannel[];

--- a/addons/im_livechat/static/src/core/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.js
@@ -2,19 +2,4 @@ import { CloseConfirmation } from "@im_livechat/core/common/close_confirmation";
 
 import { ChatWindow } from "@mail/core/common/chat_window";
 
-import { patch } from "@web/core/utils/patch";
-import { CW_LIVECHAT_STEP } from "./chat_window_model_patch";
-
 Object.assign(ChatWindow.components, { CloseConfirmation });
-
-patch(ChatWindow.prototype, {
-    setup() {
-        super.setup(...arguments);
-        this.CW_LIVECHAT_STEP = CW_LIVECHAT_STEP;
-    },
-    onCloseConfirmationDialog() {
-        this.props.chatWindow.autofocus++;
-        this.props.chatWindow.actionsDisabled = false;
-        this.props.chatWindow.livechatStep = CW_LIVECHAT_STEP.NONE;
-    },
-});

--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -3,9 +3,7 @@
     <t t-inherit="mail.ChatWindow" t-inherit-mode="extension">
         <xpath expr="//*[@name='thread content']" position="replace">
             <t>$0</t>
-            <t t-if="props.chatWindow.livechatStep === CW_LIVECHAT_STEP.CONFIRM_CLOSE">
-                <CloseConfirmation onCloseConfirmationDialog.bind="onCloseConfirmationDialog" onClickLeaveConversation.bind="close"/>
-            </t>
+            <CloseConfirmation t-if="props.chatWindow.confirmCloseResolver" onCloseConfirmationDialog="() => this.props.chatWindow.confirmCloseResolver.resolve(false)" onClickLeaveConversation="() => this.props.chatWindow.confirmCloseResolver.resolve(true)"/>
         </xpath>
         <xpath expr="//Composer" position="replace">
             <div t-if="channel.composerHidden" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerHiddenContainer">

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -41,6 +41,15 @@ const discussChannelPatch = {
         }
         return super.isHideUntilNewMessageSupported;
     },
+    get livechatShouldAskLeaveConfirmation() {
+        if (this.isTransient || this.livechat_end_dt || !this.self_member_id) {
+            return false;
+        }
+        return (
+            this.self_member_id.livechat_member_type === "visitor" ||
+            this.channel_member_ids.length <= 2
+        );
+    },
     get typesAllowingCalls() {
         return [...super.typesAllowingCalls, "livechat"];
     },

--- a/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/thread_model_patch.js
@@ -41,12 +41,7 @@ patch(Thread.prototype, {
         }
     },
     async leaveChannel() {
-        if (
-            this.channel?.channel_type === "livechat" &&
-            this.channel?.channel_member_ids.length <= 2 &&
-            this.channel.self_member_id &&
-            !this.livechat_end_dt
-        ) {
+        if (this.channel?.livechatShouldAskLeaveConfirmation) {
             await this.askLeaveConfirmation(
                 _t("Leaving will end the live chat. Do you want to proceed?")
             );

--- a/addons/im_livechat/static/src/embed/common/chat_window_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_model_patch.js
@@ -1,13 +1,24 @@
-import { patch } from "@web/core/utils/patch";
 import { ChatWindow } from "@mail/core/common/chat_window_model";
-import { CW_LIVECHAT_STEP } from "@im_livechat/core/common/chat_window_model_patch";
 
-patch(ChatWindow.prototype, {
-    close() {
-        super.close(...arguments);
-        if (this.livechatStep === CW_LIVECHAT_STEP.FEEDBACK) {
-            this.store.env.services["im_livechat.livechat"].leave(this.channel.thread);
-            this.channel.chatbot?.stop();
+import { rpc } from "@web/core/network/rpc";
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").ChatWindow} */
+const chatWindowModelPatch = {
+    async _onBeforeClose() {
+        await super._onBeforeClose(...arguments);
+        if (
+            !this.exists() ||
+            this.isTransient ||
+            this.channel.self_member_id?.livechat_member_type !== "visitor" ||
+            this.feedbackDoneResolver
+        ) {
+            return;
         }
+        rpc("/im_livechat/visitor_leave_session", { channel_id: this.channel.id });
+        this.channel.chatbot?.stop();
+        this.feedbackDoneResolver = Promise.withResolvers();
+        await this.feedbackDoneResolver.promise.finally(() => (this.feedbackDoneResolver = null));
     },
-});
+};
+patch(ChatWindow.prototype, chatWindowModelPatch);

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -1,8 +1,6 @@
-import { CW_LIVECHAT_STEP } from "@im_livechat/core/common/chat_window_model_patch";
 import { FeedbackPanel } from "@im_livechat/embed/common/feedback_panel/feedback_panel";
 
 import { ChatWindow } from "@mail/core/common/chat_window";
-import { useState } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
@@ -13,15 +11,10 @@ patch(ChatWindow.prototype, {
     setup() {
         super.setup(...arguments);
         this.livechatService = useService("im_livechat.livechat");
-        this.livechatState = useState({ showCloseConfirmation: false });
     },
     async onClickNewSession() {
-        await this.close();
+        this.props.chatWindow.feedbackDoneResolver.resolve();
         await this.livechatService.open();
-    },
-    onClickFeedback() {
-        this.props.chatWindow.livechatStep = CW_LIVECHAT_STEP.CONFIRM_CLOSE; // Skip the confirmation step.
-        this.close();
     },
     get showGiveFeedbackBtn() {
         if (this.channel.channel_type !== "livechat") {

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ChatWindow" t-inherit-mode="extension">
         <xpath expr="//*[@name='thread content']" position="replace">
-           <FeedbackPanel t-if="props.chatWindow.livechatStep === CW_LIVECHAT_STEP.FEEDBACK" onClickClose="() => this.close()" onClickNewSession="() => this.onClickNewSession()" thread="channel.thread"/>
+           <FeedbackPanel t-if="props.chatWindow.feedbackDoneResolver" onClickClose="() => this.props.chatWindow.feedbackDoneResolver.resolve()" onClickNewSession="() => this.onClickNewSession()" thread="channel.thread"/>
            <t t-else="">
             <t>$0</t>
            </t>
@@ -14,7 +14,7 @@
             <attribute name="t-attf-style" add="color: {{ livechatService.options.title_color }}; --o-mail-livechat-btn-color: {{ livechatService.options.title_color }}; background-color: {{ livechatService.options.header_background_color }} !important;" separator=" "/>
         </xpath>
         <xpath expr="//*[@t-ref='composerHiddenContainer']" position="inside">
-            <button t-if="showGiveFeedbackBtn" class="btn btn-link p-0" title="Give your feedback" t-on-click="() => this.onClickFeedback()">Continue</button>
+            <button t-if="showGiveFeedbackBtn" class="btn btn-link p-0" title="Give your feedback" t-on-click="() => this.props.chatWindow.requestClose()">Continue</button>
         </xpath>
         <xpath expr="//*[@t-ref='composerHiddenContainer']" position="attributes">
             <attribute name="t-attf-class" add="{{ showGiveFeedbackBtn ? 'px-2' : '' }}" separator=" "/>

--- a/addons/im_livechat/static/src/embed/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/discuss_channel_model_patch.js
@@ -38,5 +38,10 @@ const discussChannelPatch = {
     get showImStatus() {
         return (this.channel_type === "livechat" && this.correspondent) || super.showImStatus;
     },
+    _onDeleteChatWindow() {
+        if (this.isTransient && this.channel_type === "livechat") {
+            this.delete();
+        }
+    },
 };
 patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -69,14 +69,9 @@ export class LivechatService {
             return thread;
         }
         const temporaryThread = thread;
-        const deleteTemporary = async () => {
-            await this.store.chatHub.initPromise;
-            temporaryThread.channel.chatWindow?.close({ force: true });
-            temporaryThread?.delete();
-        };
         const savedChannel = await this._createChannel({ originThread: thread, persist: true });
         if (!savedChannel) {
-            await deleteTemporary();
+            temporaryThread.channel.chatWindow?.close();
             return;
         }
         savedChannel.fetchNewMessages();
@@ -85,11 +80,11 @@ export class LivechatService {
             if (!savedChannel?.exists()) {
                 return;
             }
-            // Do not load unread messaes: new messages were loaded to avoid
+            // Do not load unread messages: new messages were loaded to avoid
             // flickering, we do not want another load that would result in the
             // same issue.
             savedChannel.scrollUnread = false;
-            deleteTemporary();
+            temporaryThread.channel.chatWindow?.close();
             savedChannel.openChatWindow({ focus: true });
         });
         return savedChannel;

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -4,9 +4,9 @@
         <div t-if="props.chatWindow?.channel" class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.channel.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'o-active': state.isPopoverOpen, 'o-mobile': isMobileOS }" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !channel.isUnread or channel.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="channel.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="channel.importantCounter"/>
-            <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
+            <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.requestClose()"><i class="oi oi-close"/></button>
             <ImStatus t-if="showImStatus" className="'o-mail-ChatBubble-status position-absolute'" member="channel.correspondent">
-                <t t-set-slot="pre_icon">
+                <t t-set-slot="pre_icon" t-if="channel">
                     <i style="font-size: 18px; right: -2px; bottom: -2px; z-index: -1;" t-att-class="{
                         'bg-success rounded-pill position-absolute': channel.correspondent?.isTyping,
                         'fa fa-circle position-absolute text-100': !channel.correspondent?.isTyping,

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -68,7 +68,7 @@ export class ChatHub extends Record {
         await this.initPromise;
         const promises = [];
         for (const chatWindow of [...this.opened, ...this.folded]) {
-            promises.push(chatWindow.close({ notifyState: false }));
+            promises.push(chatWindow.requestClose({ notifyState: false }));
         }
         await Promise.all(promises);
         this.save(); // sync only once at the end
@@ -111,7 +111,7 @@ export class ChatHub extends Record {
         // close first to make room for others
         for (const chatWindow of [...this.opened, ...this.folded]) {
             if (chatWindow.notIn(toOpen) && chatWindow.notIn(toFold)) {
-                chatWindow.close({ force: true, notifyState: false });
+                chatWindow.close({ notifyState: false });
             }
         }
         // folded before opened because if there are too many opened they will be added to folded

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -154,8 +154,7 @@ export class ChatWindow extends Component {
     }
 
     close(options) {
-        const chatWindow = toRaw(this.props.chatWindow);
-        chatWindow.close(options);
+        this.props.chatWindow.requestClose(options);
     }
 
     get actionsMenuTitleText() {

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatWindow">
-    <t t-if="props.chatWindow.exists()">
+    <t t-if="props.chatWindow.exists() and channel.exists()">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
     <div class="o-mail-ChatWindow fixed-bottom overflow-hidden d-flex flex-column shadow bg-100"
         t-att-style="style"

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -83,7 +83,7 @@ export class Thread extends Record {
         onUpdate() {
             if (this.close_chat_window) {
                 this.close_chat_window = undefined;
-                this.closeChatWindow({ force: true });
+                this.closeChatWindow();
             }
         },
     });
@@ -702,9 +702,9 @@ export class Thread extends Record {
         return this.channel.chatWindow;
     }
 
-    async closeChatWindow(options = {}) {
+    async closeChatWindow() {
         await this.store.chatHub.initPromise;
-        await this.channel?.chatWindow?.close(options);
+        this.channel?.chatWindow?.close();
     }
 
     addOrReplaceMessage(message, tmpMsg) {

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -125,6 +125,9 @@ export class DiscussChannel extends Record {
     channel_type;
     chatWindow = fields.One("ChatWindow", {
         inverse: "channel",
+        onDelete() {
+            this._onDeleteChatWindow();
+        },
     });
     get chatChannelTypes() {
         return ["chat", "group"];
@@ -312,8 +315,10 @@ export class DiscussChannel extends Record {
         return (this.member_count ?? 0) - (this.channel_member_ids.length ?? 0);
     }
 
+    _onDeleteChatWindow() {}
+
     delete() {
-        this.chatWindow?.close({ force: true });
+        this.chatWindow?.close();
         super.delete(...arguments);
     }
 
@@ -516,7 +521,7 @@ export class DiscussChannel extends Record {
     }
 
     async _unpinExecute() {
-        this.chatWindow?.close({ force: true });
+        this.chatWindow?.close();
         if (this.self_member_id?.is_pinned) {
             await this.pinRpc({ pinned: false });
         }

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -63,7 +63,7 @@ export class DiscussCoreCommon {
      * @param {{ notifId: number}} metadata
      */
     async _handleNotificationChannelDelete(thread, metadata) {
-        await thread.closeChatWindow({ force: true });
+        await thread.closeChatWindow();
         thread.messages.splice(0, thread.messages.length);
         thread.delete();
     }

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageSeenIndicator">
-        <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-25': !props.message.hasEveryoneSeen, 'o-hasEveryoneSeen opacity-75': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
+        <span t-if="props.message.channel_id?.exists()" class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-25': !props.message.hasEveryoneSeen, 'o-hasEveryoneSeen opacity-75': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
             <t t-if="!props.message.isMessagePreviousToLastSelfMessageSeenByEveryone">
                 <i t-if="props.message.hasSomeoneFetched or props.message.hasSomeoneSeen" class="fa fa-check ps-1"/>
                 <i t-if="props.message.hasSomeoneSeen" class="o-second start-0 fa fa-check position-absolute"/>


### PR DESCRIPTION
Previously, chat window close was heavily overridden (e.g, to confirm
leaving or request visitor feedback), creating complex and hard to maintain
behavior. This change introduces `executeCloseLifecycles` to make the close
process predictable. Two hooks allow customization:
- `_canClose`: decide if the window can be closed.
- `_onBeforeClose`: run logic before closing (e.g, feedback panels).

enterprise: https://github.com/odoo/enterprise/pull/102490