### PR TITLE
[FIX] resource: calendars with no company in multi-company

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -489,7 +489,7 @@ class ResourceCalendar(models.Model):
             ('resource_id', 'in', [False] + [r.id for r in resources_list]),
             ('date_from', '<=', datetime_to_string(end_dt)),
             ('date_to', '>=', datetime_to_string(start_dt)),
-            ('company_id', '=', self.company_id.id),
+            ('company_id', 'in', [False] + [self.company_id.id]),
         ]
 
         # retrieve leave intervals in (start_dt, end_dt)


### PR DESCRIPTION
This PR https://github.com/odoo/odoo/pull/236043 adds a constraint when calculating the public holidays that check for the company of the working schedule, while in some flows the working schedule has no company_id assigned. This will lead to some errors, as it won't recognize the day as a public holiday.

As an example, the public holiday will be counted as a working day when taking leaves that include that day.

opw-5401425


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
