### PR TITLE
[IMP] web: beautiful duration

### DIFF
--- a/addons/hr_timesheet/static/tests/timesheet_uom.test.js
+++ b/addons/hr_timesheet/static/tests/timesheet_uom.test.js
@@ -20,7 +20,7 @@ test("hr.timesheet (form): FloatTimeField is used when current company uom uses 
         resModel: "account.analytic.line",
         resId: 1,
     });
-    expect('div[name="unit_amount"] input').toHaveValue("01:00", {
+    expect('div[name="unit_amount"] input').toHaveValue("1h", {
         message: "unit_amount should be displayed as time",
     });
 });
@@ -32,7 +32,7 @@ test("hr.timesheet (form): FloatTimeField is not dependent of timesheet_uom_fact
         resModel: "account.analytic.line",
         resId: 1,
     });
-    expect('div[name="unit_amount"] input').toHaveValue("01:00", {
+    expect('div[name="unit_amount"] input').toHaveValue("1h", {
         message: "timesheet_uom_factor shouldn't be taken into account",
     });
 });

--- a/addons/hr_timesheet/static/tests/timesheet_uom_no_toggle.test.js
+++ b/addons/hr_timesheet/static/tests/timesheet_uom_no_toggle.test.js
@@ -20,7 +20,7 @@ test("hr.timesheet (form): FloatTimeField is used when current company uom uses 
         resModel: "account.analytic.line",
         resId: 1,
     });
-    expect('div[name="unit_amount"] input').toHaveValue("01:00", {
+    expect('div[name="unit_amount"] input').toHaveValue("1h", {
         message: "unit_amount should be displayed as time",
     });
 });
@@ -32,7 +32,7 @@ test("hr.timesheet (form): FloatTimeField is not dependent of timesheet_uom_fact
         resModel: "account.analytic.line",
         resId: 1,
     });
-    expect('div[name="unit_amount"] input').toHaveValue("01:00", {
+    expect('div[name="unit_amount"] input').toHaveValue("1h", {
         message: "timesheet_uom_factor shouldn't be taken into account",
     });
 });

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -8,10 +8,10 @@
             <field name="arch" type="xml">
                 <pivot js_class="im_livechat.report_channel_pivot" string="Live Chat Support Statistics" sample="1" display_quantity="1">
                     <field name="has_call" type="measure" invisible="1"/>
-                    <field name="call_duration_hour" type="measure" widget="float_time" options="{'displaySeconds': True}"/>
+                    <field name="call_duration_hour" type="measure" widget="float_time"/>
                     <field name="partner_id" type="row"/>
                     <field name="percentage_of_calls" type="measure" widget="percentage"/>
-                    <field name="time_to_answer" string="Response Time (hh:mm:ss)" type="measure" widget="float_time" options="{'displaySeconds': True}" />
+                    <field name="time_to_answer" string="Response Time" type="measure" widget="float_time"/>
                     <field name="duration" type="measure"/>
                     <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
                     <field name="number_of_calls" string="# of calls" type="measure" widget="integer"/>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -64,7 +64,7 @@
                     <field name="livechat_lang_id" optional="show"/>
                     <field name="livechat_expertise_ids" string="Expertise" widget="many2many_tags" optional="show"/>
                     <field name="livechat_channel_id" optional="hide"/>
-                    <field name="duration" widget="float_time" options="{'displaySeconds': True}" optional="show"/>
+                    <field name="duration" widget="float_time" optional="show"/>
                     <field name="message_count" string="Messages" optional="show"/>
                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
@@ -85,7 +85,7 @@
                                 <div class="d-flex flex-column">
                                     <field class="fw-bolder" name="livechat_customer_history_ids" widget="im_livechat.one2many_names"/>
                                     <span class="fw-bold">Date: <field name="create_date" class="fw-normal"/></span>
-                                    <span class="fw-bold">Duration: <field class="d-inline fw-normal" name="duration" widget="float_time" options="{'displaySeconds': True}"/></span>
+                                    <span class="fw-bold">Duration: <field class="d-inline fw-normal" name="duration" widget="float_time"/></span>
                                     <span class="fw-bold">Messages: <field name="message_count" class="fw-normal"/></span>
                                     <field name="livechat_failure" invisible="1"/>
                                     <field name="livechat_is_escalated" invisible="1"/>

--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -24,7 +24,7 @@
                     <field name="partner_id"/>
                     <field name="chatbot_script_id"/>
                     <field name="guest_id"/>
-                    <field name="session_duration_hour" widget="float_time" options="{'displaySeconds': True}"/>
+                    <field name="session_duration_hour" widget="float_time"/>
                     <field name="livechat_member_type" string="Member Type"/>
                 </list>
             </field>
@@ -110,10 +110,10 @@
                     <field name="session_start_hour" invisible="1"/>
                     <field name="session_week_day" invisible="1"/>
                     <field name="partner_id" type="row"/>
-                    <field name="call_duration_hour" type="measure" widget="float_time" options="{'displaySeconds': True}"/>
+                    <field name="call_duration_hour" type="measure" widget="float_time"/>
                     <field name="call_percentage" type="measure" widget="percentage"/>
-                    <field name="response_time_hour" string="Response Time" type="measure" widget="float_time" options="{'displaySeconds': True}" />
-                    <field name="session_duration_hour" type="measure" widget="float_time" options="{'displaySeconds': True}"/>
+                    <field name="response_time_hour" string="Response Time" type="measure" widget="float_time" />
+                    <field name="session_duration_hour" type="measure" widget="float_time"/>
                     <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
                     <field name="call_count" type="measure" widget="integer"/>
                 </pivot>

--- a/addons/mail/views/discuss/discuss_call_history_views.xml
+++ b/addons/mail/views/discuss/discuss_call_history_views.xml
@@ -9,7 +9,7 @@
                     <field name="channel_id"/>
                     <field name="start_dt"/>
                     <field name="end_dt"/>
-                    <field name="duration_hour" widget="float_time" options="{'displaySeconds': True}"/>
+                    <field name="duration_hour" widget="float_time"/>
                 </list>
             </field>
         </record>
@@ -22,7 +22,7 @@
                         <field name="channel_id"/>
                         <field name="start_dt"/>
                         <field name="end_dt"/>
-                        <field name="duration_hour" widget="float_time" options="{'displaySeconds': True}"/>
+                        <field name="duration_hour" widget="float_time"/>
                     </group>
                 </form>
             </field>

--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -103,6 +103,7 @@ export const localizationService = {
                 break;
             }
         }
+        localization.locale = locale;
         localization.code = jsToPyLocale(locale);
         return localization;
     },

--- a/addons/web/static/src/views/fields/float_time/float_time_field.js
+++ b/addons/web/static/src/views/fields/float_time/float_time_field.js
@@ -1,38 +1,86 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { formatFloatTime } from "../formatters";
-import { parseFloatTime } from "../parsers";
+import { formatDuration } from "../formatters";
 import { useInputField } from "../input_field_hook";
 import { standardFieldProps } from "../standard_field_props";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
+import { parseDuration, parseFloatDuration } from "../parsers";
 
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
+import { usePopover } from "@web/core/popover/popover_hook";
 
 export class FloatTimeField extends Component {
     static template = "web.FloatTimeField";
     static props = {
         ...standardFieldProps,
-        inputType: { type: String, optional: true },
-        displaySeconds: { type: Boolean, optional: true },
+        showSeconds: { type: Boolean, optional: true },
+        numeric: { type: Boolean, optional: true },
+        unit: { type: ["hours", "minutes", "seconds"], optional: true },
     };
     static defaultProps = {
-        inputType: "text",
+        showSeconds: true,
+        numeric: false,
+        unit: "hours",
     };
 
     setup() {
         this.inputFloatTimeRef = useInputField({
             getValue: () => this.formattedValue,
             refName: "numpadDecimal",
-            parse: (v) => parseFloatTime(v),
+            parse: (v) => parseFloatDuration(v, this.props.unit),
+        });
+
+        this.state = useState({
+            formattedResult: "",
+        });
+        this.resultPopover = usePopover(DurationPopover, {
+            position: "bottom",
         });
         useNumpadDecimal();
     }
 
-    get formattedValue() {
-        return formatFloatTime(this.props.record.data[this.props.name], {
-            displaySeconds: this.props.displaySeconds,
+    onValueChange(ev) {
+        const currentInput = ev.target.value;
+        this.state.formattedResult = formatDuration(parseDuration(currentInput, this.props.unit), {
+            showSeconds: this.props.showSeconds,
+            numeric: this.props.numeric,
+            unit: this.props.unit,
         });
     }
+
+    openPopover() {
+        const duration = parseDuration(this.inputFloatTimeRef.el.value, this.props.unit);
+        this.state.formattedResult = formatDuration(duration, {
+            showSeconds: this.props.showSeconds,
+            numeric: this.props.numeric,
+            unit: this.props.unit,
+        });
+        this.resultPopover.open(this.inputFloatTimeRef.el, {
+            state: this.state,
+        });
+    }
+
+    closePopover() {
+        this.resultPopover.close();
+    }
+
+    get formattedValue() {
+        const value = {};
+        value[this.props.unit] = this.props.record.data[this.props.name];
+        return formatDuration(value, {
+            showSeconds: this.props.showSeconds,
+            numeric: this.props.numeric,
+            unit: this.props.unit,
+        });
+    }
+}
+
+class DurationPopover extends Component {
+    static template = "web.DurationPopover";
+    static props = {
+        state: { type: Object, optional: true },
+        close: { type: Function, optional: true },
+    };
 }
 
 export const floatTimeField = {
@@ -40,9 +88,10 @@ export const floatTimeField = {
     displayName: _t("Time"),
     supportedOptions: [
         {
-            label: _t("Display seconds"),
-            name: "display_seconds",
+            label: _t("Show seconds"),
+            name: "show_seconds",
             type: "boolean",
+            default: true,
         },
         {
             label: _t("Type"),
@@ -50,12 +99,29 @@ export const floatTimeField = {
             type: "string",
             default: "text",
         },
+        {
+            label: _t("Numeric"),
+            name: "numeric",
+            type: "boolean",
+        },
+        {
+            label: _t("Unit"),
+            name: "unit",
+            type: "selection",
+            default: "hours",
+            choices: [
+                { label: _t("Hours"), value: "hours" },
+                { label: _t("Minutes"), value: "minutes" },
+                { label: _t("Seconds"), value: "seconds" },
+            ],
+        },
     ],
     supportedTypes: ["float"],
     isEmpty: () => false,
     extractProps: ({ options }) => ({
-        displaySeconds: options.displaySeconds,
-        inputType: options.type,
+        showSeconds: options.show_seconds,
+        numeric: options.numeric,
+        unit: options.unit,
     }),
 };
 

--- a/addons/web/static/src/views/fields/float_time/float_time_field.xml
+++ b/addons/web/static/src/views/fields/float_time/float_time_field.xml
@@ -2,8 +2,22 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="web.FloatTimeField">
-        <span t-if="props.readonly" t-esc="formattedValue" />
-        <input t-else="" t-att-id="props.id" t-att-type="props.inputType" t-ref="numpadDecimal" class="o_input" autocomplete="off" />
+        <time t-if="props.readonly" t-esc="formattedValue" />
+        <input t-else="" 
+            t-att-id="props.id" 
+            t-att-type="props.inputType" 
+            t-ref="numpadDecimal" 
+            t-on-focus="() => this.openPopover()"
+            t-on-focusout="() => this.closePopover()"
+            t-on-input="(ev) => this.onValueChange(ev)"
+            class="o_input" 
+            autocomplete="off" />
+    </t>
+    
+    <t t-name="web.DurationPopover">
+        <div class="o_duration_popover p-1">
+            <time t-esc="props.state.formattedResult" />
+        </div>
     </t>
 
 </templates>

--- a/addons/web/static/tests/_framework/mock_functions.hoot.js
+++ b/addons/web/static/tests/_framework/mock_functions.hoot.js
@@ -1,0 +1,46 @@
+// ! WARNING: this module cannot depend on modules not ending with ".hoot" (except libs) !
+
+import { after } from "@odoo/hoot";
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * @param {string} name
+ * @param {OdooModuleFactory} factory
+ */
+export function mockFunctionsFactory(name, { fn }) {
+    return (...args) => {
+        function clearMemoizeCaches() {
+            for (const cache of memoizeCaches) {
+                cache.clear();
+            }
+        }
+
+        function mockMemoize(func) {
+            const cache = new Map();
+            memoizeCaches.push(cache);
+            const funcName = func.name ? func.name + " (memoized)" : "memoized";
+            return {
+                [funcName](...args) {
+                    if (!cache.size) {
+                        after(cache.clear.bind(cache));
+                    }
+                    if (!cache.has(args[0])) {
+                        cache.set(args[0], func(...args));
+                    }
+                    return cache.get(...args);
+                },
+            }[funcName];
+        }
+
+        const functionsModule = fn(...args);
+        const memoizeCaches = [];
+
+        functionsModule.memoize = mockMemoize;
+        functionsModule.clearMemoizeCaches = clearMemoizeCaches;
+
+        return functionsModule;
+    };
+}

--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -16,6 +16,7 @@ import {
 import { mockBrowserFactory } from "./mock_browser.hoot";
 import { mockCurrencyFactory } from "./mock_currency.hoot";
 import { mockIndexedDB } from "./mock_indexed_db.hoot";
+import { mockFunctionsFactory } from "./mock_functions.hoot";
 import { mockSessionFactory } from "./mock_session.hoot";
 import { makeTemplateFactory } from "./mock_templates.hoot";
 import { mockUserFactory } from "./mock_user.hoot";
@@ -519,6 +520,7 @@ const MODULE_MOCKS_BY_NAME = new Map([
     ["@web/core/currency", mockCurrencyFactory],
     ["@web/core/templates", makeTemplateFactory],
     ["@web/core/user", mockUserFactory],
+    ["@web/core/utils/functions", mockFunctionsFactory],
     ["@web/session", mockSessionFactory],
 ]);
 const MODULE_MOCKS_BY_REGEX = new Map([

--- a/addons/web/static/tests/views/fields/float_time_field.test.js
+++ b/addons/web/static/tests/views/fields/float_time_field.test.js
@@ -18,7 +18,7 @@ class Partner extends models.Model {
 defineModels([Partner]);
 
 test("FloatTimeField in form view", async () => {
-    expect.assertions(4);
+    expect.assertions(5);
     onRpc("partner", "web_save", ({ args }) => {
         // 48 / 60 = 0.8
         expect(args[1].qux).toBe(-11.8, {
@@ -32,18 +32,19 @@ test("FloatTimeField in form view", async () => {
         arch: `
             <form>
                 <sheet>
-                    <field name="qux" widget="float_time"/>
+                    <field name="qux" widget="float_time" options="{ 'numeric': true, 'show_seconds': false }"/>
                 </sheet>
             </form>`,
         resId: 5,
     });
 
     // 9 + 0.1 * 60 = 9.06
-    expect(".o_field_float_time[name=qux] input").toHaveValue("09:06", {
+    expect(".o_field_float_time[name=qux] input").toHaveValue("9:06", {
         message: "The value should be rendered correctly in the input.",
     });
 
     await contains(".o_field_float_time[name=qux] input").edit("-11:48");
+    expect(".o_duration_popover").toHaveText("-11:48");
     expect(".o_field_float_time[name=qux] input").toHaveValue("-11:48", {
         message: "The new value should be displayed properly in the input.",
     });
@@ -71,17 +72,17 @@ test("FloatTimeField value formatted on blur", async () => {
         resId: 5,
     });
 
-    expect(".o_field_widget input").toHaveValue("09:06", {
+    expect(".o_field_widget input").toHaveValue("9h 6m", {
         message: "The formatted time value should be displayed properly.",
     });
 
     await contains(".o_field_float_time[name=qux] input").edit("9.5");
-    expect(".o_field_float_time[name=qux] input").toHaveValue("09:30", {
+    expect(".o_field_float_time[name=qux] input").toHaveValue("9h 30m", {
         message: "The new value should be displayed properly in the input.",
     });
 
     await clickSave();
-    expect(".o_field_widget input").toHaveValue("09:30", {
+    expect(".o_field_widget input").toHaveValue("9h 30m", {
         message: "The new value should be saved and displayed properly.",
     });
 });
@@ -97,15 +98,13 @@ test("FloatTimeField with invalid value", async () => {
     });
 
     await contains(".o_field_float_time[name=qux] input").edit("blabla");
+    expect(".o_duration_popover").toHaveText("0h");
     await clickSave();
-    expect(".o_notification_content").toHaveText("Missing required fields");
-    expect(".o_notification_bar").toHaveClass("bg-danger");
-    expect(".o_field_float_time[name=qux]").toHaveClass("o_field_invalid");
-
+    expect(".o_field_float_time[name=qux] input").toHaveValue("0h");
+    
+    
     await contains(".o_field_float_time[name=qux] input").edit("6.5");
-    expect(".o_field_float_time[name=qux] input").not.toHaveClass("o_field_invalid", {
-        message: "date field should not be displayed as invalid now",
-    });
+    expect(".o_duration_popover").toHaveText("6h 30m");
 });
 
 test("float_time field does not have an inputmode attribute", async () => {

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -19,6 +19,7 @@ import {
     formatX2many,
     formatDate,
     formatDateTime,
+    formatDuration,
 } from "@web/views/fields/formatters";
 
 const { DateTime } = luxon;
@@ -33,6 +34,7 @@ beforeEach(() => {
         decimalPoint: ".",
         thousandsSep: ",",
         grouping: [3, 0],
+        locale: "en-US",
     });
 });
 
@@ -54,23 +56,23 @@ test("formatFloatTime", () => {
     expect(formatFloatTime(3.5)).toBe("03:30");
     expect(formatFloatTime(0.25)).toBe("00:15");
     expect(formatFloatTime(0.58)).toBe("00:35");
-    expect(formatFloatTime(2 / 60, { displaySeconds: true })).toBe("00:02:00");
-    expect(formatFloatTime(2 / 60 + 1 / 3600, { displaySeconds: true })).toBe("00:02:01");
-    expect(formatFloatTime(2 / 60 + 2 / 3600, { displaySeconds: true })).toBe("00:02:02");
-    expect(formatFloatTime(2 / 60 + 3 / 3600, { displaySeconds: true })).toBe("00:02:03");
-    expect(formatFloatTime(0.25, { displaySeconds: true })).toBe("00:15:00");
-    expect(formatFloatTime(0.25 + 15 / 3600, { displaySeconds: true })).toBe("00:15:15");
-    expect(formatFloatTime(0.25 + 45 / 3600, { displaySeconds: true })).toBe("00:15:45");
-    expect(formatFloatTime(56 / 3600, { displaySeconds: true })).toBe("00:00:56");
+    expect(formatFloatTime(2 / 60, { showSeconds: true })).toBe("00:02:00");
+    expect(formatFloatTime(2 / 60 + 1 / 3600, { showSeconds: true })).toBe("00:02:01");
+    expect(formatFloatTime(2 / 60 + 2 / 3600, { showSeconds: true })).toBe("00:02:02");
+    expect(formatFloatTime(2 / 60 + 3 / 3600, { showSeconds: true })).toBe("00:02:03");
+    expect(formatFloatTime(0.25, { showSeconds: true })).toBe("00:15:00");
+    expect(formatFloatTime(0.25 + 15 / 3600, { showSeconds: true })).toBe("00:15:15");
+    expect(formatFloatTime(0.25 + 45 / 3600, { showSeconds: true })).toBe("00:15:45");
+    expect(formatFloatTime(56 / 3600, { showSeconds: true })).toBe("00:00:56");
     expect(formatFloatTime(-0.5)).toBe("-00:30");
 
     const options = { noLeadingZeroHour: true };
     expect(formatFloatTime(2, options)).toBe("2:00");
     expect(formatFloatTime(3.5, options)).toBe("3:30");
-    expect(formatFloatTime(3.5, { ...options, displaySeconds: true })).toBe("3:30:00");
-    expect(formatFloatTime(3.5 + 15 / 3600, { ...options, displaySeconds: true })).toBe("3:30:15");
-    expect(formatFloatTime(3.5 + 45 / 3600, { ...options, displaySeconds: true })).toBe("3:30:45");
-    expect(formatFloatTime(56 / 3600, { ...options, displaySeconds: true })).toBe("0:00:56");
+    expect(formatFloatTime(3.5, { ...options, showSeconds: true })).toBe("3:30:00");
+    expect(formatFloatTime(3.5 + 15 / 3600, { ...options, showSeconds: true })).toBe("3:30:15");
+    expect(formatFloatTime(3.5 + 45 / 3600, { ...options, showSeconds: true })).toBe("3:30:45");
+    expect(formatFloatTime(56 / 3600, { ...options, showSeconds: true })).toBe("0:00:56");
     expect(formatFloatTime(-0.5, options)).toBe("-0:30");
 });
 
@@ -232,4 +234,59 @@ test("formatDateTime", () => {
     expect(formatDateTime(DateTime.fromObject({ day: 22, month: 1, hour: 10, minute: 30 }))).toBe(
         "Jan 22, 10:30 AM"
     );
+});
+
+test("formatDuration", () => {
+    expect(formatDuration({ hours: 2 })).toBe("2h");
+    expect(formatDuration({ hours: 3.5 })).toBe("3h 30m");
+    expect(formatDuration({ hours: 0.25 })).toBe("0h 15m");
+    expect(formatDuration({ minutes: 35 })).toBe("0h 35m");
+    expect(formatDuration({ minutes: 35 }, { unit: "minutes" })).toBe("35m");
+    expect(formatDuration({ hours: 2, seconds: 15 })).toBe("2h 0m 15s");
+    expect(formatDuration({ seconds: 15 })).toBe("0h 0m 15s");
+    expect(formatDuration({ hours: 2 }, { unit: "seconds" })).toBe("2h 0m 0s");
+    expect(formatDuration({ minutes: 2, seconds: 15 })).toBe("0h 2m 15s");
+    expect(formatDuration({ seconds: 135 }, { showSeconds: false })).toBe("0h 2m");
+    expect(formatDuration({ minutes: 2, seconds: 15 }, { showSeconds: false, unit: "minutes" })).toBe("2m");
+    expect(formatDuration({ minutes: -30 })).toBe("-0h 30m");
+    expect(formatDuration({ minutes: -30 }, { unit: "minutes" })).toBe("-30m");
+
+    const options = { numeric: true };
+    expect(formatDuration({ hours: 3.5 }, options)).toBe("3:30:00");
+    expect(formatDuration({ hours: 3, seconds: 30 }, options)).toBe("3:00:30");
+    expect(formatDuration({ minutes: 3, seconds: 30 }, {...options, unit: "minutes"})).toBe("0:03:30");
+    expect(formatDuration({ hours: 0.25 }, options)).toBe("0:15:00");
+    expect(formatDuration({ minutes: 35 }, options)).toBe("0:35:00");
+    expect(formatDuration({ minutes: 2, seconds: 15 }, options)).toBe("0:02:15");
+    expect(formatDuration({ seconds: 135 }, { ...options, showSeconds: false })).toBe("0:02");
+    expect(formatDuration({ minutes: -30 }, options)).toBe("-0:30:00");
+    expect(formatDuration({ hours: -0.5 }, { ...options, showSeconds: false })).toBe("-0:30");
+});
+
+test("formatDuration special cases", () => {
+    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2h 5m 30s");
+
+    localization.locale = "fr-FR";
+    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2h 5min 30s");
+
+    localization.locale = "zh-CN";
+    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2小时 5分钟 30秒");
+    expect(formatDuration({ minutes: 120 })).toBe("2小时");
+
+    localization.locale = "ar-SY";
+    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("٢س ٥د ٣٠ث");
+    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 }, { numeric: true })).toBe(
+        "2:05:30"
+    );
+    expect(formatDuration({ minutes: 120 })).toBe("٢س");
+
+    localization.locale = "th-TH";
+    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2ชม. 5นาที 30วิ");
+    expect(formatDuration({ minutes: 120 })).toBe("2ชม.");
+    expect(formatDuration({ seconds: 30 }, { unit: "seconds" })).toBe("30วิ");
+
+    localization.locale = "hi-IN";
+    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2घं 5मि 30से");
+    expect(formatDuration({ minutes: 120 })).toBe("2घं");
+    expect(formatDuration({ seconds: 30 }, { unit: "seconds" })).toBe("30से");
 });

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -304,11 +304,11 @@ test("pivot rendering with widget and options", async () => {
         resModel: "partner",
         arch: `
 			<pivot string="Partners">
-                <field name="foo" type="measure" widget="float_time" options="{'displaySeconds': True}"/>
+                <field name="foo" type="measure" widget="float_time"/>
 			</pivot>
 		`,
     });
-    expect("td.o_pivot_cell_value:contains(32:00:00)").toHaveCount(1);
+    expect("td.o_pivot_cell_value:contains(32:00)").toHaveCount(1);
 });
 
 test("pivot rendering with widget and options from model field", async () => {


### PR DESCRIPTION
In this commit I change the format of the durations (float_time). Now they are displayed as follow by default: 12h 30m 25s You can also specify the unit of time, like that you can specify to float_time what value it's reading. For example, if the unit of time is "minutes" and that you give it 30, it will translated to 30m. The value set to 0 are removed from the result. 0h 30m 0s => 30m

There is also a bottom popover on float_time fields that display how the typed value will be interpreted.

The format hh:mm:ss can be forced by putting the option "numeric" to true. The seconds are shown by default, they can be hide by putting the option "showSeconds" to false.

TASK-5347051

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
