### PR TITLE
[IMP] point_of_sale: allow text selection in error popup

### DIFF
--- a/addons/point_of_sale/static/src/app/pos_app.scss
+++ b/addons/point_of_sale/static/src/app/pos_app.scss
@@ -95,3 +95,7 @@ input::-webkit-inner-spin-button {
         transform: translateY(0);
     }
 }
+
+.pos .o_error_detail {
+    user-select: text;
+}


### PR DESCRIPTION
Before this commit, it was not possible to select and copy text from the error popup shown in the POS interface. This limitation hindered users from easily copying error messages for reporting or troubleshooting purposes.

task-id: 5411067
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
