### PR TITLE
[FIX] mail: display embedded PDF thumbnail for Peppol XML

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -143,7 +143,7 @@ class AttachmentController(ThreadController):
             raise request.not_found()
         # sudo: ir.attachment: access check is done above, sudo necessary for guests
         attachment_sudo = attachment.sudo()
-        if attachment_sudo.mimetype != "application/pdf":
+        if not attachment_sudo._allow_thumbnail():
             raise UserError(request.env._("Only PDF files can have thumbnail."))
         if not thumbnail:
             with file_open("web/static/img/mimetypes/unknown.svg") as unknown_svg:

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -118,3 +118,6 @@ class IrAttachment(models.Model):
     def _get_thumbnail_token(self):
         self.ensure_one()
         return limited_field_access_token(self, "thumbnail", scope="binary")
+
+    def _allow_thumbnail(self):
+        return self.mimetype == "application/pdf"


### PR DESCRIPTION
**Steps To Reproduce**
- Go to Documents app
- Upload a Peppol XML file containing an embedded PDF (e.g., invoice with attached PDF)
- Open the document

**Issue**
Opening a Peppol XML document with an embedded PDF causes: `UserError: Only PDF files can have a thumbnail`

The kanban view also shows raw XML code instead of the PDF preview.

**Cause**
Since this commit:
https://github.com/odoo/odoo/commit/37e38b8cd34e

The mail module's `mail_attachement_update_thumbnail` route has a strict mimetype check that rejects thumbnail updates for XML files:

https://github.com/odoo/odoo/blob/c350592b85001b5f36ea6aaf803ee3974e5ebfc1/addons/mail/controllers/attachment.py#L146-L147

Additionally, the documents thumbnail service only generates thumbnails for files where `isPdf()` returns true:

https://github.com/odoo/enterprise/blob/60881b65991cbd2594492b25900ab4bb8c166250/documents/static/src/views/helper/documents_client_thumbnail_service.js#L27-L35

**Solution**
Add `_allow_thumbnail()` hook to allow overriding the mimetype check

And from this PR, I see that a proper thumbnail is the proper behavior:
https://github.com/odoo/enterprise/pull/49111

Which required the thumbnail generation flow multiple overrides:
1. **`isPdf()` check**: The documents thumbnail service only generates thumbnails for files where `isPdf()` returns true. XML files return false, so thumbnail generation is never triggered: https://github.com/odoo/enterprise/blob/60881b65991cbd2594492b25900ab4bb8c166250/documents/static/src/views/helper/documents_client_thumbnail_service.js#L28-L35

2. **`pdf_first_page`**: When thumbnail generation runs, it fetches the first page of the PDF via these routes. For XML with embedded PDFs, the routes must extract and return the embedded PDF bytes instead of the raw XML content: https://github.com/odoo/odoo/blob/c350592b85001b5f36ea6aaf803ee3974e5ebfc1/addons/mail/controllers/attachment.py#L120-L127 https://github.com/odoo/enterprise/blob/60881b65991cbd2594492b25900ab4bb8c166250/documents/controllers/documents.py#L515-L528

3. **`isTextualDocument` in kanban**: XML files are treated as textual documents and displayed showing raw XML code, even when they contain an embedded PDF that should be previewed instead: https://github.com/odoo/enterprise/blob/60881b65991cbd2594492b25900ab4bb8c166250/documents/views/documents_document_views.xml#L106

opw-5252946

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
