### PR TITLE
[REF] core: move DummyRLock to tests

### DIFF
--- a/addons/auth_ldap/tests/test_auth_ldap.py
+++ b/addons/auth_ldap/tests/test_auth_ldap.py
@@ -1,23 +1,14 @@
 import re
-import requests
 from unittest.mock import patch
 
 import odoo
-from odoo.modules.registry import Registry, DummyRLock
-from odoo.tests.common import BaseCase, tagged, get_db_name
+from odoo.tests.common import HttpCase, tagged
 
 
 @tagged("-standard", "-at_install", "post_install", "database_breaking")
-class TestAuthLDAP(BaseCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.registry = Registry(get_db_name())
-
+class TestAuthLDAP(HttpCase):
     def setUp(self):
         super().setUp()
-        self.patch(Registry, "_lock", DummyRLock())  # prevent deadlock (see #161438)
-        self.opener = requests.Session()
 
         def remove_ldap_user():
             with self.registry.cursor() as cr:

--- a/odoo/modules/registry/__init__.py
+++ b/odoo/modules/registry/__init__.py
@@ -1,3 +1,3 @@
 # ruff: noqa: F401
 # Exposed here so that exist code is unaffected.
-from odoo.orm.registry import DummyRLock, Registry, _REGISTRY_CACHES, _CACHES_BY_KEY
+from odoo.orm.registry import Registry, _REGISTRY_CACHES, _CACHES_BY_KEY

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -90,8 +90,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
     There is one registry instance per database.
 
     """
-    _lock: threading.RLock | DummyRLock = threading.RLock()
-    _saved_lock: threading.RLock | DummyRLock | None = None
+    _lock = threading.RLock()
 
     @lazy_classproperty
     def registries(cls) -> LRU[str, Registry]:
@@ -1157,18 +1156,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     _logger.warning("Failed to open a readonly cursor, falling back to read-write cursor for %dmin %dsec", *divmod(_REPLICA_RETRY_TIME, 60))
             threading.current_thread().cursor_mode = 'ro->rw'
         return self._db.cursor()
-
-
-class DummyRLock(object):
-    """ Dummy reentrant lock, to be used while running rpc and js tests """
-    def acquire(self):
-        pass
-    def release(self):
-        pass
-    def __enter__(self):
-        self.acquire()
-    def __exit__(self, type, value, traceback):
-        self.release()
 
 
 class TriggerTree(dict['Field', 'TriggerTree']):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -62,7 +62,7 @@ import odoo.orm.registry
 from odoo import api
 from odoo.exceptions import AccessError
 from odoo.fields import Command
-from odoo.modules.registry import Registry, DummyRLock
+from odoo.modules.registry import Registry
 from odoo.sql_db import Cursor, Savepoint
 from odoo.tools import config, float_compare, mute_logger, profiler, SQL, DotDict
 from odoo.tools.mail import single_email_re
@@ -281,9 +281,29 @@ def _normalize_arch_for_assert(arch_string, parser_method="xml"):
     arch_string = etree.fromstring(arch_string, parser=parser)
     return etree.tostring(arch_string, pretty_print=True, encoding='unicode')
 
+
 class BlockedRequest(requests.exceptions.ConnectionError):
     pass
+
+
 _super_send = requests.Session.send
+
+
+class DummyRLock:
+    """ Dummy reentrant lock, to be used while running rpc and js tests """
+    def acquire(self):
+        pass
+
+    def release(self):
+        pass
+
+    def __enter__(self):
+        self.acquire()
+
+    def __exit__(self, *args):
+        self.release()
+
+
 class BaseCase(case.TestCase):
     """ Subclass of TestCase for Odoo-specific code. This class is abstract and
     expects self.registry, self.cr and self.uid to be initialized by subclasses.


### PR DESCRIPTION
The lock is not needed for normal execution. We are moving it to tests.

This PR also fixes `TestAuthLDAP` which is not working (using inexisting functions and classmethod on setup).



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
