### PR TITLE
[FIX] web_editor: consider background image when toggling grid mode

### DIFF
--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -169,10 +169,10 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
         // Finding out if the images are alone in their column.
         let isImageColumn = _checkIfImageColumn(columnEl);
         const imageEl = columnEl.querySelector('img');
-        // Checking if the column has a background color to take that into
+        // Checking if the column has a background color/image to take that into
         // account when computing its size and padding (to make it look good).
-        const hasBackgroundColor = columnEl.classList.contains("o_cc");
-        const isImageWithoutPadding = isImageColumn && !hasBackgroundColor;
+        const hasBackground = columnEl.matches(".o_cc, .oe_img_bg");
+        const isImageWithoutPadding = isImageColumn && !hasBackground;
 
         // Placing the column.
         const style = window.getComputedStyle(columnEl);
@@ -188,9 +188,9 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
         // Getting the width of the column.
         const paddingLeft = parseFloat(style.paddingLeft);
         let width = isImageWithoutPadding ? parseFloat(imageEl.scrollWidth)
-            : parseFloat(columnEl.scrollWidth) - (hasBackgroundColor ? 0 : 2 * paddingLeft);
+            : parseFloat(columnEl.scrollWidth) - (hasBackground ? 0 : 2 * paddingLeft);
         const borderX = borderLeft + parseFloat(style.borderRight);
-        width += borderX + (hasBackgroundColor || isImageColumn ? 0 : 2 * defaultGridPadding);
+        width += borderX + (hasBackground || isImageColumn ? 0 : 2 * defaultGridPadding);
         let columnSpan = Math.round((width + columnGap) / (columnSize + columnGap));
         if (columnSpan < 1) {
             columnSpan = 1;
@@ -207,11 +207,11 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
         const rowOffsetTop = Math.floor((paddingTop + rowGap) / (rowSize + rowGap));
         // Getting the height of the column.
         let height = isImageWithoutPadding ? parseFloat(imageEl.scrollHeight)
-            : parseFloat(columnEl.scrollHeight) - (hasBackgroundColor ? 0 : paddingTop + paddingBottom);
+            : parseFloat(columnEl.scrollHeight) - (hasBackground ? 0 : paddingTop + paddingBottom);
         const borderY = borderTop + parseFloat(style.borderBottom);
-        height += borderY + (hasBackgroundColor || isImageColumn ? 0 : 2 * defaultGridPadding);
+        height += borderY + (hasBackground || isImageColumn ? 0 : 2 * defaultGridPadding);
         const rowSpan = Math.ceil((height + rowGap) / (rowSize + rowGap));
-        const rowStart = Math.round(columnTop / (rowSize + rowGap)) + 1 + (hasBackgroundColor || isImageWithoutPadding ? 0 : rowOffsetTop);
+        const rowStart = Math.round(columnTop / (rowSize + rowGap)) + 1 + (hasBackground || isImageWithoutPadding ? 0 : rowOffsetTop);
         const rowEnd = rowStart + rowSpan;
 
         columnEl.style.gridArea = `${rowStart} / ${columnStart} / ${rowEnd} / ${columnEnd}`;
@@ -222,7 +222,7 @@ function _placeColumns(columnEls, rowSize, rowGap, columnSize, columnGap) {
         // Setting the initial z-index.
         columnEl.style.zIndex = zIndex++;
         // Setting the paddings.
-        if (hasBackgroundColor) {
+        if (hasBackground) {
             columnEl.style.setProperty("--grid-item-padding-y", `${paddingTop}px`);
             columnEl.style.setProperty("--grid-item-padding-x", `${paddingLeft}px`);
         }


### PR DESCRIPTION
Steps to reproduce:
===================
- In website edit mode, drop the "Split Intro" snippet.
- Toggle it to grid mode.
  => the image column is smaller than expected.
- Switch to mobile view
  => the image column is really small.

Cause & solution:
=================
When toggling a snippet to grid mode, when computing the size of the
grid items, the padding of a column is taken into account only if it has
a background color (`o_cc` class), in order to look as close as possible
as before. The background images are therefore not considered, so the
size is computed without the padding, resulting in a grid-area smaller
than expected, and the default grid item padding (which is why it is
that small in mobile view).

This commit fixes that by including the background image class
(`oe_img_bg`) in the check used to consider the padding.

opw-5374492