### PR TITLE
Update the google maps snippet

### DIFF
--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.js
@@ -21,6 +21,9 @@ export class GoogleMapsOption extends BaseOptionComponent {
         /** @type {{ formattedAddress: string }} */
         this.state = useState({
             formattedAddress: this.env.getEditingElement().dataset.pinAddress || "",
+            isContainedInOtherSnippet: this.env
+                .getEditingElement()
+                .matches("[data-snippet] :not(.oe_structure) > [data-snippet]"),
         });
         useEffect(
             () => {
@@ -29,7 +32,7 @@ export class GoogleMapsOption extends BaseOptionComponent {
             () => [this.state.formattedAddress]
         );
         onMounted(async () => {
-            this.initializeAutocomplete(this.inputRef.el);
+            await this.initializeAutocomplete(this.inputRef.el);
         });
         onWillDestroy(() => {
             if (this.autocompleteListener) {
@@ -48,27 +51,33 @@ export class GoogleMapsOption extends BaseOptionComponent {
      *
      * @param {Element} inputEl
      */
-    initializeAutocomplete(inputEl) {
+    async initializeAutocomplete(inputEl) {
         if (!this.googleMapsAutocomplete && this.getMapsAPI()) {
-            const mapsAPI = this.getMapsAPI();
-            this.googleMapsAutocomplete = new mapsAPI.places.Autocomplete(inputEl, {
-                types: ["geocode"],
-            });
-            this.autocompleteListener = mapsAPI.event.addListener(
-                this.googleMapsAutocomplete,
-                "place_changed",
-                this.onPlaceChanged.bind(this)
-            );
-            if (!this.state.formattedAddress) {
-                const editingElement = this.env.getEditingElement();
-                /** @type {Coordinates} */
-                const coordinates = editingElement.dataset.mapGps;
-                this.getPlace(editingElement, coordinates).then((place) => {
-                    if (place?.formatted_address) {
-                        this.state.formattedAddress = place.formatted_address;
-                    }
-                });
-            }
+            inputEl.addEventListener("input", this._OnInput.bind(this));
+            // const mapsAPI = this.getMapsAPI();
+            // const { Autocomplete } = await mapsAPI.importLibrary("places");
+            // this.googleMapsAutocomplete = new Autocomplete(inputEl, {
+            //     types: ["geocode", "establishment"],
+            //     fields: ["geometry", "formatted_address"],
+            // });
+            // const { event } = await mapsAPI.importLibrary("core");
+            // event.addListener(
+            //     this.googleMapsAutocomplete,
+            //     "place_changed",
+            //     this.onPlaceChanged.bind(this)
+            // );
+            // if (!this.state.formattedAddress) {
+            //     const editingElement = this.env.getEditingElement();
+            //     /** @type {Coordinates} */
+            //     const coordinates = editingElement.dataset.mapGps;
+            //     this.getPlace(editingElement, coordinates).then((place) => {
+            //         const formattedAddress =
+            //             place?.formatted_address || place?.Eg?.formattedAddress;
+            //         if (formattedAddress) {
+            //             this.state.formattedAddress = formattedAddress;
+            //         }
+            //     });
+            // }
         }
     }
 
@@ -80,7 +89,171 @@ export class GoogleMapsOption extends BaseOptionComponent {
     onPlaceChanged() {
         /** @type {Place | undefined} */
         const place = this.googleMapsAutocomplete.getPlace();
-        this.onPlaceChanged(this.env.getEditingElement(), place);
-        this.state.formattedAddress = place?.formatted_address || "";
+        // this.props.onPlaceChanged(this.env.getEditingElement(), place);
+        const formattedAddress = place?.formatted_address || place?.Eg?.formattedAddress;
+        this.state.formattedAddress = formattedAddress || "";
+    }
+    /**
+     * Creates or retrieves the suggestion box for Google Maps autocomplete.
+     * If it doesn't exist yet, it is appended to the DOM.
+     *
+     * @private
+     * @returns {HTMLElement} The suggestion box element.
+     */
+    _getOrCreateSuggestionBox() {
+        if (!this.suggestionBoxEl) {
+            this.suggestionBoxEl = document.createElement("div");
+            this.suggestionBoxEl.className = "s_google_map_suggestion_box";
+            this.inputRef.el.parentNode.appendChild(this.suggestionBoxEl);
+            this.inputRef.el.parentNode.style.position = "relative";
+        }
+        this.suggestionBoxEl.classList.remove("d-none");
+        return this.suggestionBoxEl;
+    }
+    /**
+     * Clears all suggestions and hides the suggestion box.
+     *
+     * @private
+     */
+    _clearSuggestions() {
+        this._suggestionItems = [];
+        this._selectedIndex = -1;
+        if (this.suggestionBoxEl) {
+            this.suggestionBoxEl.innerHTML = "";
+            this.suggestionBoxEl.classList.add("d-none");
+        }
+    }
+    /**
+     * Updates the visual highlight for the currently selected suggestion.
+     *
+     * @private
+     */
+    _updateHighlight() {
+        this._suggestionItems.forEach((itemEl, index) => {
+            itemEl.classList.toggle(
+                "s_google_map_suggestion_item_selected",
+                index === this._selectedIndex
+            );
+        });
+    }
+    /**
+     * Highlights a specific suggestion item in the list.
+     *
+     * @private
+     * @param {HTMLElement} itemEl - The DOM element to highlight.
+     */
+    _highlightItem(itemEl) {
+        const index = this._suggestionItems.indexOf(itemEl);
+        if (index >= 0) {
+            this._selectedIndex = index;
+            this._updateHighlight();
+        }
+    }
+    /**
+     * Creates a DOM element for a place suggestion.
+     *
+     * @private
+     * @param {Object} placePrediction - The prediction object for the place.
+     * @returns {HTMLElement} The suggestion item DOM element.
+     */
+    _createSuggestionItem(placePrediction) {
+        const itemEl = document.createElement("div");
+        itemEl.className = "s_google_map_suggestion_item";
+        itemEl.style.cursor = "pointer";
+        const iconSpanEl = document.createElement("span");
+        iconSpanEl.className = "s_google_map_suggestion_icon s_google_map_suggestion_icon_marker";
+        itemEl.appendChild(iconSpanEl);
+        const text = document.createTextNode(placePrediction.text.toString());
+        itemEl.appendChild(text);
+        itemEl.addEventListener("mouseenter", () => this._highlightItem(itemEl));
+        itemEl.addEventListener("mousedown", () => this._selectPlace(placePrediction));
+        return itemEl;
+    }
+    /**
+     * Selects a place from the suggestions and updates the input field accordingly.
+     * Fetches additional fields for the selected place.
+     *
+     * @private
+     * @param {Object} placePrediction - The selected place prediction object.
+     * @returns {Promise<void>}
+     */
+    async _selectPlace(placePrediction) {
+        const place = placePrediction.toPlace();
+        await place.fetchFields({
+            fields: ["displayName", "formattedAddress", "location"],
+        });
+        this.inputRef.el.value =
+            place.formattedAddress || place.displayName || placePrediction.text;
+        this._gmapAutocompletePlace = place;
+        this._clearSuggestions();
+        this._onPlaceChanged();
+    }
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onPlaceChanged(ev) {
+        const gmapPlace = this._gmapAutocompletePlace;
+        if (gmapPlace && gmapPlace.location) {
+            this._gmapPlace = gmapPlace;
+            const placeLocation = this._gmapPlace.location;
+            const oldValue = this._value;
+            this._value = `(${placeLocation.lat()},${placeLocation.lng()})`;
+            this._gmapCacheGPSToPlace[this._value] = gmapPlace;
+            if (oldValue !== this._value) {
+                this._onUserValueChange(ev);
+            }
+        }
+    }
+    /**
+     * @override
+     */
+    _onInputBlur() {
+        this._clearSuggestions();
+    }
+    async _OnInput(ev) {
+        const inputValue = ev.currentTarget.value.trim();
+        this._clearSuggestions();
+        if (inputValue.length < 1) {
+            return;
+        }
+        const { AutocompleteSuggestion } = await this.window.google.maps.importLibrary("places");
+        const result = await AutocompleteSuggestion.fetchAutocompleteSuggestions({
+            input: inputValue,
+        });
+        this._suggestions = result.suggestions || [];
+        const suggestionBoxEl = this._getOrCreateSuggestionBox();
+        this._suggestions.forEach((suggestion) => {
+            const item = this._createSuggestionItem(suggestion.placePrediction);
+            suggestionBoxEl.appendChild(item);
+            this._suggestionItems.push(item);
+        });
+    }
+    async _OnKeyDown(ev) {
+        if (!this._suggestionItems.length) {
+            return;
+        }
+        if (ev.key === "ArrowDown") {
+            ev.preventDefault();
+            this._selectedIndex = (this._selectedIndex + 1) % this._suggestionItems.length;
+            this._updateHighlight();
+        } else if (ev.key === "ArrowUp") {
+            ev.preventDefault();
+            this._selectedIndex =
+                (this._selectedIndex - 1 + this._suggestionItems.length) %
+                this._suggestionItems.length;
+            this._updateHighlight();
+        } else if (ev.key === "Enter") {
+            ev.preventDefault();
+            if (this._selectedIndex >= 0 && this._suggestions[this._selectedIndex]) {
+                const placePrediction = this._suggestions[this._selectedIndex].placePrediction;
+                await this._selectPlace(placePrediction);
+            }
+        }
     }
 }

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.scss
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.scss
@@ -53,3 +53,51 @@
         }
     }
 }
+
+.s_google_map_suggestion_box {
+    z-index: $zindex-modal-backdrop; // > $o-we-zindex
+    position: absolute;
+    top: 110%;
+    right: 0;
+    width: ceil($o-we-sidebar-width * 0.9) !important;
+    font-size: $o-we-sidebar-font-size;
+    border: $o-we-sidebar-content-field-border-width solid $o-we-sidebar-content-field-dropdown-border-color;
+    border-top: none;
+    border-radius: $o-we-item-border-radius;
+    overflow: hidden;
+    background-color: $o-we-sidebar-content-field-dropdown-bg;
+    box-shadow: $o-we-sidebar-content-field-dropdown-shadow;
+
+    &:after {
+        display: none;
+    }
+
+    .s_google_map_suggestion_item {
+        @include o-text-overflow(block);
+        line-height: $o-we-sidebar-content-field-dropdown-item-height;
+        color: $o-we-sidebar-content-field-clickable-color;
+        padding: 0 1em 0 (2 * $o-we-sidebar-content-field-control-item-spacing + $o-we-sidebar-content-field-control-item-size);
+        border-top: $o-we-sidebar-content-field-border-width solid lighten($o-we-sidebar-content-field-dropdown-border-color, 15%);
+        border-radius: $o-we-sidebar-content-field-border-radius;
+        background-color: $o-we-sidebar-content-field-clickable-bg;
+        color: $o-we-sidebar-content-field-clickable-color;
+        font-size: $o-we-sidebar-font-size;
+        position: relative;
+        z-index: 999999999999999999999999999;
+
+        &:hover, &:focus, &.s_google_map_suggestion_item_selected {
+            background-color: $o-we-sidebar-content-field-dropdown-item-bg-hover;
+            cursor: pointer;
+        }
+
+        .s_google_map_suggestion_icon_marker {
+            position: absolute;
+            margin-left: -1em;
+
+            &::after {
+                content: '\f041';
+                font-family: FontAwesome;
+            }
+        }
+    }
+}

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
@@ -25,7 +25,7 @@
             <BuilderSelectItem dataAttributeActionValue="'HYBRID'">Hybrid</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="&#8985; Style" preview="false" t-if="this.isActiveItem('roadmap_opt')">
+    <!-- <BuilderRow label.translate="&#8985; Style" preview="false" t-if="this.isActiveItem('roadmap_opt')">
         <BuilderSelect dataAttributeAction="'mapColor'">
             <BuilderSelectItem dataAttributeActionValue="">
                 <Image src="'/website/static/src/snippets/s_google_map/img/thumbs/map-default.jpg'"/>
@@ -58,6 +58,9 @@
                 <Image src="'/website/static/src/snippets/s_google_map/img/thumbs/map-bw.jpg'"/>
             </BuilderSelectItem>
         </BuilderSelect>
+    </BuilderRow> -->
+    <BuilderRow label.translate="Height" t-if="this.state.isContainedInOtherSnippet">
+        <BuilderNumberInput styleAction="{ mainParam: 'height', force: true, allowImportant: true }" unit="'px'" min="0"/>
     </BuilderRow>
     <BuilderRow label.translate="Zoom" preview="false">
         <BuilderNumberInput dataAttributeAction="'mapZoom'" default="12" step="1" min="0" max="22"/>

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.js
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.js
@@ -14,7 +14,9 @@ export class ScrollButtonOption extends BaseOptionComponent {
                 editingElement.dataset.snippet === "s_image_gallery"
                     ? _t("Min-Height")
                     : _t("Height"),
-            heightFieldEnabled: editingElement.dataset.snippet === "s_image_gallery",
+            heightFieldEnabled:
+                editingElement.dataset.snippet === "s_image_gallery" ||
+                editingElement.dataset.snippet === "s_google_map",
         }));
     }
 

--- a/addons/website/static/src/core/website_map_service.js
+++ b/addons/website/static/src/core/website_map_service.js
@@ -1,4 +1,3 @@
-import { loadJS } from "@web/core/assets";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
@@ -15,13 +14,6 @@ export const websiteMapService = {
         const promiseKeys = {};
         const promiseKeysResolves = {};
         let lastKey;
-        window.odoo_gmap_api_post_load = async function odoo_gmap_api_post_load() {
-            for (const el of document.querySelectorAll("section.s_google_map")) {
-                publicInteractions.stopInteractions(el);
-                publicInteractions.startInteractions(el);
-            }
-            promiseKeysResolves[lastKey]?.();
-        }.bind(this);
         return {
             /**
              * @param {boolean} [refetch=false]
@@ -54,11 +46,60 @@ export const websiteMapService = {
                                 promiseKeys[key] = new Promise((resolve) => {
                                     promiseKeysResolves[key] = resolve;
                                 });
-                                await loadJS(
-                                    `https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=odoo_gmap_api_post_load&key=${encodeURIComponent(
-                                        key
-                                    )}`
-                                );
+                                ((g) => {
+                                    var h,
+                                        a,
+                                        k,
+                                        p = "The Google Maps JavaScript API",
+                                        c = "google",
+                                        l = "importLibrary",
+                                        q = "__ib__",
+                                        m = document,
+                                        b = window;
+                                    b = b[c] || (b[c] = {});
+                                    var d = b.maps || (b.maps = {}),
+                                        r = new Set(),
+                                        e = new URLSearchParams(),
+                                        u = () =>
+                                            h ||
+                                            // eslint-disable-next-line no-async-promise-executor
+                                            (h = new Promise(async (f, n) => {
+                                                await (a = m.createElement("script"));
+                                                e.set("libraries", [...r] + "");
+                                                for (k in g) {
+                                                    e.set(
+                                                        k.replace(
+                                                            /[A-Z]/g,
+                                                            (t) => "_" + t[0].toLowerCase()
+                                                        ),
+                                                        g[k]
+                                                    );
+                                                }
+                                                e.set("callback", c + ".maps." + q);
+                                                a.src =
+                                                    `https://maps.${c}apis.com/maps/api/js?` + e;
+                                                d[q] = f;
+                                                a.onerror = () =>
+                                                    (h = n(Error(p + " could not load.")));
+                                                var script = m.querySelector("script[nonce]");
+                                                a.nonce = script ? script.nonce : "";
+                                                m.head.append(a);
+                                            }));
+                                    d[l]
+                                        ? console.warn(p + " only loads once. Ignoring:", g)
+                                        : (d[l] = (f, ...n) =>
+                                              r.add(f) && u().then(() => d[l](f, ...n)));
+                                })({
+                                    key: key,
+                                    v: "weekly",
+                                });
+                                for (const el of document.querySelectorAll(
+                                    "section.s_google_map"
+                                )) {
+                                    publicInteractions.stopInteractions(el);
+                                    publicInteractions.startInteractions(el);
+                                }
+                                promiseKeysResolves[lastKey]?.();
                             }
                             await promiseKeys[key];
                             return key;

--- a/addons/website/static/src/snippets/s_google_map/000.scss
+++ b/addons/website/static/src/snippets/s_google_map/000.scss
@@ -31,4 +31,38 @@ $s-google-map-desc-alpha: 0.80 !default;
             margin-left: 10px;
         }
     }
+    // &:hover .description {
+    //     background: $s-google-map-desc-hover-bg;
+    //     background: rgba($s-google-map-desc-hover-bg, $s-google-map-desc-hover-alpha);
+    //     color: color-contrast(rgba($s-google-map-desc-hover-bg, $s-google-map-desc-hover-alpha));
+    // }
+
+    @keyframes s_google_map_drop {
+      0% {
+        transform: translateY(-200px) scaleY(0.9);
+        opacity: 0;
+      }
+      5% {
+        opacity: 0.7;
+      }
+      50% {
+        transform: translateY(0px) scaleY(1);
+        opacity: 1;
+      }
+      65% {
+        transform: translateY(-17px) scaleY(0.9);
+        opacity: 1;
+      }
+      75% {
+        transform: translateY(-22px) scaleY(0.9);
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(0px) scaleY(1);
+        opacity: 1;
+      }
+    }
+    .s_google_map_drop {
+      animation: s_google_map_drop 0.3s linear forwards 0.5s;
+    }
 }

--- a/addons/website/static/src/snippets/s_google_map/google_map.js
+++ b/addons/website/static/src/snippets/s_google_map/google_map.js
@@ -15,26 +15,26 @@ export class GoogleMap extends Interaction {
         },
     };
 
-    mapColors = {
-        // prettier-ignore
-        lightMonoMap: [{ "featureType": "administrative.locality", "elementType": "all", "stylers": [{ "hue": "#2c2e33" }, { "saturation": 7 }, { "lightness": 19 }, { "visibility": "on" }] }, { "featureType": "landscape", "elementType": "all", "stylers": [{ "hue": "#ffffff" }, { "saturation": -100 }, { "lightness": 100 }, { "visibility": "simplified" }] }, { "featureType": "poi", "elementType": "all", "stylers": [{ "hue": "#ffffff" }, { "saturation": -100 }, { "lightness": 100 }, { "visibility": "off" }] }, { "featureType": "road", "elementType": "geometry", "stylers": [{ "hue": "#bbc0c4" }, { "saturation": -93 }, { "lightness": 31 }, { "visibility": "simplified" }] }, { "featureType": "road", "elementType": "labels", "stylers": [{ "hue": "#bbc0c4" }, { "saturation": -93 }, { "lightness": 31 }, { "visibility": "on" }] }, { "featureType": "road.arterial", "elementType": "labels", "stylers": [{ "hue": "#bbc0c4" }, { "saturation": -93 }, { "lightness": -2 }, { "visibility": "simplified" }] }, { "featureType": "road.local", "elementType": "geometry", "stylers": [{ "hue": "#e9ebed" }, { "saturation": -90 }, { "lightness": -8 }, { "visibility": "simplified" }] }, { "featureType": "transit", "elementType": "all", "stylers": [{ "hue": "#e9ebed" }, { "saturation": 10 }, { "lightness": 69 }, { "visibility": "on" }] }, { "featureType": "water", "elementType": "all", "stylers": [{ "hue": "#e9ebed" }, { "saturation": -78 }, { "lightness": 67 }, { "visibility": "simplified" }] }],
-        // prettier-ignore
-        lillaMap: [{ elementType: "labels", stylers: [{ saturation: -20 }] }, { featureType: "poi", elementType: "labels", stylers: [{ visibility: "off" }] }, { featureType: 'road.highway', elementType: 'labels', stylers: [{ visibility: "off" }] }, { featureType: "road.local", elementType: "labels.icon", stylers: [{ visibility: "off" }] }, { featureType: "road.arterial", elementType: "labels.icon", stylers: [{ visibility: "off" }] }, { featureType: "road", elementType: "geometry.stroke", stylers: [{ visibility: "off" }] }, { featureType: "transit", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.government", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.sport_complex", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.attraction", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.business", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "transit", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "transit.station", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "landscape", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "road", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "road.highway", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "water", elementType: "geometry", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }],
-        // prettier-ignore
-        blueMap: [{ stylers: [{ hue: "#00ffe6" }, { saturation: -20 }] }, { featureType: "road", elementType: "geometry", stylers: [{ lightness: 100 }, { visibility: "simplified" }] }, { featureType: "road", elementType: "labels", stylers: [{ visibility: "off" }] }],
-        // prettier-ignore
-        retroMap: [{ "featureType": "administrative", "elementType": "all", "stylers": [{ "visibility": "on" }, { "lightness": 33 }] }, { "featureType": "landscape", "elementType": "all", "stylers": [{ "color": "#f2e5d4" }] }, { "featureType": "poi.park", "elementType": "geometry", "stylers": [{ "color": "#c5dac6" }] }, { "featureType": "poi.park", "elementType": "labels", "stylers": [{ "visibility": "on" }, { "lightness": 20 }] }, { "featureType": "road", "elementType": "all", "stylers": [{ "lightness": 20 }] }, { "featureType": "road.highway", "elementType": "geometry", "stylers": [{ "color": "#c5c6c6" }] }, { "featureType": "road.arterial", "elementType": "geometry", "stylers": [{ "color": "#e4d7c6" }] }, { "featureType": "road.local", "elementType": "geometry", "stylers": [{ "color": "#fbfaf7" }] }, { "featureType": "water", "elementType": "all", "stylers": [{ "visibility": "on" }, { "color": "#acbcc9" }] }],
-        // prettier-ignore
-        flatMap: [{ "stylers": [{ "visibility": "off" }] }, { "featureType": "road", "stylers": [{ "visibility": "on" }, { "color": "#ffffff" }] }, { "featureType": "road.arterial", "stylers": [{ "visibility": "on" }, { "color": "#fee379" }] }, { "featureType": "road.highway", "stylers": [{ "visibility": "on" }, { "color": "#fee379" }] }, { "featureType": "landscape", "stylers": [{ "visibility": "on" }, { "color": "#f3f4f4" }] }, { "featureType": "water", "stylers": [{ "visibility": "on" }, { "color": "#7fc8ed" }] }, {}, { "featureType": "road", "elementType": "labels", "stylers": [{ "visibility": "on" }] }, { "featureType": "poi.park", "elementType": "geometry.fill", "stylers": [{ "visibility": "on" }, { "color": "#83cead" }] }, { "elementType": "labels", "stylers": [{ "visibility": "on" }] }, { "featureType": "landscape.man_made", "elementType": "geometry", "stylers": [{ "weight": 0.9 }, { "visibility": "off" }] }],
-        // prettier-ignore
-        cobaltMap: [{ "featureType": "all", "elementType": "all", "stylers": [{ "invert_lightness": true }, { "saturation": 10 }, { "lightness": 30 }, { "gamma": 0.5 }, { "hue": "#435158" }] }],
-        // prettier-ignore
-        cupertinoMap: [{ "featureType": "water", "elementType": "geometry", "stylers": [{ "color": "#a2daf2" }] }, { "featureType": "landscape.man_made", "elementType": "geometry", "stylers": [{ "color": "#f7f1df" }] }, { "featureType": "landscape.natural", "elementType": "geometry", "stylers": [{ "color": "#d0e3b4" }] }, { "featureType": "landscape.natural.terrain", "elementType": "geometry", "stylers": [{ "visibility": "off" }] }, { "featureType": "poi.park", "elementType": "geometry", "stylers": [{ "color": "#bde6ab" }] }, { "featureType": "poi", "elementType": "labels", "stylers": [{ "visibility": "off" }] }, { "featureType": "poi.medical", "elementType": "geometry", "stylers": [{ "color": "#fbd3da" }] }, { "featureType": "poi.business", "stylers": [{ "visibility": "off" }] }, { "featureType": "road", "elementType": "geometry.stroke", "stylers": [{ "visibility": "off" }] }, { "featureType": "road", "elementType": "labels", "stylers": [{ "visibility": "off" }] }, { "featureType": "road.highway", "elementType": "geometry.fill", "stylers": [{ "color": "#ffe15f" }] }, { "featureType": "road.highway", "elementType": "geometry.stroke", "stylers": [{ "color": "#efd151" }] }, { "featureType": "road.arterial", "elementType": "geometry.fill", "stylers": [{ "color": "#ffffff" }] }, { "featureType": "road.local", "elementType": "geometry.fill", "stylers": [{ "color": "black" }] }, { "featureType": "transit.station.airport", "elementType": "geometry.fill", "stylers": [{ "color": "#cfb2db" }] }],
-        // prettier-ignore
-        carMap: [{ "featureType": "administrative", "stylers": [{ "visibility": "off" }] }, { "featureType": "poi", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "road", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "water", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "transit", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "landscape", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "road.highway", "stylers": [{ "visibility": "off" }] }, { "featureType": "road.local", "stylers": [{ "visibility": "on" }] }, { "featureType": "road.highway", "elementType": "geometry", "stylers": [{ "visibility": "on" }] }, { "featureType": "water", "stylers": [{ "color": "#84afa3" }, { "lightness": 52 }] }, { "stylers": [{ "saturation": -77 }] }, { "featureType": "road" }],
-        // prettier-ignore
-        bwMap: [{ stylers: [{ hue: "#00ffe6" }, { saturation: -100 }] }, { featureType: "road", elementType: "geometry", stylers: [{ lightness: 100 }, { visibility: "simplified" }] }, { featureType: "road", elementType: "labels", stylers: [{ visibility: "off" }] }],
-    };
+    // mapColors = {
+    //     // prettier-ignore
+    //     lightMonoMap: [{ "featureType": "administrative.locality", "elementType": "all", "stylers": [{ "hue": "#2c2e33" }, { "saturation": 7 }, { "lightness": 19 }, { "visibility": "on" }] }, { "featureType": "landscape", "elementType": "all", "stylers": [{ "hue": "#ffffff" }, { "saturation": -100 }, { "lightness": 100 }, { "visibility": "simplified" }] }, { "featureType": "poi", "elementType": "all", "stylers": [{ "hue": "#ffffff" }, { "saturation": -100 }, { "lightness": 100 }, { "visibility": "off" }] }, { "featureType": "road", "elementType": "geometry", "stylers": [{ "hue": "#bbc0c4" }, { "saturation": -93 }, { "lightness": 31 }, { "visibility": "simplified" }] }, { "featureType": "road", "elementType": "labels", "stylers": [{ "hue": "#bbc0c4" }, { "saturation": -93 }, { "lightness": 31 }, { "visibility": "on" }] }, { "featureType": "road.arterial", "elementType": "labels", "stylers": [{ "hue": "#bbc0c4" }, { "saturation": -93 }, { "lightness": -2 }, { "visibility": "simplified" }] }, { "featureType": "road.local", "elementType": "geometry", "stylers": [{ "hue": "#e9ebed" }, { "saturation": -90 }, { "lightness": -8 }, { "visibility": "simplified" }] }, { "featureType": "transit", "elementType": "all", "stylers": [{ "hue": "#e9ebed" }, { "saturation": 10 }, { "lightness": 69 }, { "visibility": "on" }] }, { "featureType": "water", "elementType": "all", "stylers": [{ "hue": "#e9ebed" }, { "saturation": -78 }, { "lightness": 67 }, { "visibility": "simplified" }] }],
+    //     // prettier-ignore
+    //     lillaMap: [{ elementType: "labels", stylers: [{ saturation: -20 }] }, { featureType: "poi", elementType: "labels", stylers: [{ visibility: "off" }] }, { featureType: 'road.highway', elementType: 'labels', stylers: [{ visibility: "off" }] }, { featureType: "road.local", elementType: "labels.icon", stylers: [{ visibility: "off" }] }, { featureType: "road.arterial", elementType: "labels.icon", stylers: [{ visibility: "off" }] }, { featureType: "road", elementType: "geometry.stroke", stylers: [{ visibility: "off" }] }, { featureType: "transit", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.government", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.sport_complex", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.attraction", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "poi.business", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "transit", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "transit.station", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "landscape", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "road", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "road.highway", elementType: "geometry.fill", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }, { featureType: "water", elementType: "geometry", stylers: [{ hue: '#2d313f' }, { visibility: "on" }, { lightness: 5 }, { saturation: -20 }] }],
+    //     // prettier-ignore
+    //     blueMap: [{ stylers: [{ hue: "#00ffe6" }, { saturation: -20 }] }, { featureType: "road", elementType: "geometry", stylers: [{ lightness: 100 }, { visibility: "simplified" }] }, { featureType: "road", elementType: "labels", stylers: [{ visibility: "off" }] }],
+    //     // prettier-ignore
+    //     retroMap: [{ "featureType": "administrative", "elementType": "all", "stylers": [{ "visibility": "on" }, { "lightness": 33 }] }, { "featureType": "landscape", "elementType": "all", "stylers": [{ "color": "#f2e5d4" }] }, { "featureType": "poi.park", "elementType": "geometry", "stylers": [{ "color": "#c5dac6" }] }, { "featureType": "poi.park", "elementType": "labels", "stylers": [{ "visibility": "on" }, { "lightness": 20 }] }, { "featureType": "road", "elementType": "all", "stylers": [{ "lightness": 20 }] }, { "featureType": "road.highway", "elementType": "geometry", "stylers": [{ "color": "#c5c6c6" }] }, { "featureType": "road.arterial", "elementType": "geometry", "stylers": [{ "color": "#e4d7c6" }] }, { "featureType": "road.local", "elementType": "geometry", "stylers": [{ "color": "#fbfaf7" }] }, { "featureType": "water", "elementType": "all", "stylers": [{ "visibility": "on" }, { "color": "#acbcc9" }] }],
+    //     // prettier-ignore
+    //     flatMap: [{ "stylers": [{ "visibility": "off" }] }, { "featureType": "road", "stylers": [{ "visibility": "on" }, { "color": "#ffffff" }] }, { "featureType": "road.arterial", "stylers": [{ "visibility": "on" }, { "color": "#fee379" }] }, { "featureType": "road.highway", "stylers": [{ "visibility": "on" }, { "color": "#fee379" }] }, { "featureType": "landscape", "stylers": [{ "visibility": "on" }, { "color": "#f3f4f4" }] }, { "featureType": "water", "stylers": [{ "visibility": "on" }, { "color": "#7fc8ed" }] }, {}, { "featureType": "road", "elementType": "labels", "stylers": [{ "visibility": "on" }] }, { "featureType": "poi.park", "elementType": "geometry.fill", "stylers": [{ "visibility": "on" }, { "color": "#83cead" }] }, { "elementType": "labels", "stylers": [{ "visibility": "on" }] }, { "featureType": "landscape.man_made", "elementType": "geometry", "stylers": [{ "weight": 0.9 }, { "visibility": "off" }] }],
+    //     // prettier-ignore
+    //     cobaltMap: [{ "featureType": "all", "elementType": "all", "stylers": [{ "invert_lightness": true }, { "saturation": 10 }, { "lightness": 30 }, { "gamma": 0.5 }, { "hue": "#435158" }] }],
+    //     // prettier-ignore
+    //     cupertinoMap: [{ "featureType": "water", "elementType": "geometry", "stylers": [{ "color": "#a2daf2" }] }, { "featureType": "landscape.man_made", "elementType": "geometry", "stylers": [{ "color": "#f7f1df" }] }, { "featureType": "landscape.natural", "elementType": "geometry", "stylers": [{ "color": "#d0e3b4" }] }, { "featureType": "landscape.natural.terrain", "elementType": "geometry", "stylers": [{ "visibility": "off" }] }, { "featureType": "poi.park", "elementType": "geometry", "stylers": [{ "color": "#bde6ab" }] }, { "featureType": "poi", "elementType": "labels", "stylers": [{ "visibility": "off" }] }, { "featureType": "poi.medical", "elementType": "geometry", "stylers": [{ "color": "#fbd3da" }] }, { "featureType": "poi.business", "stylers": [{ "visibility": "off" }] }, { "featureType": "road", "elementType": "geometry.stroke", "stylers": [{ "visibility": "off" }] }, { "featureType": "road", "elementType": "labels", "stylers": [{ "visibility": "off" }] }, { "featureType": "road.highway", "elementType": "geometry.fill", "stylers": [{ "color": "#ffe15f" }] }, { "featureType": "road.highway", "elementType": "geometry.stroke", "stylers": [{ "color": "#efd151" }] }, { "featureType": "road.arterial", "elementType": "geometry.fill", "stylers": [{ "color": "#ffffff" }] }, { "featureType": "road.local", "elementType": "geometry.fill", "stylers": [{ "color": "black" }] }, { "featureType": "transit.station.airport", "elementType": "geometry.fill", "stylers": [{ "color": "#cfb2db" }] }],
+    //     // prettier-ignore
+    //     carMap: [{ "featureType": "administrative", "stylers": [{ "visibility": "off" }] }, { "featureType": "poi", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "road", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "water", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "transit", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "landscape", "stylers": [{ "visibility": "simplified" }] }, { "featureType": "road.highway", "stylers": [{ "visibility": "off" }] }, { "featureType": "road.local", "stylers": [{ "visibility": "on" }] }, { "featureType": "road.highway", "elementType": "geometry", "stylers": [{ "visibility": "on" }] }, { "featureType": "water", "stylers": [{ "color": "#84afa3" }, { "lightness": 52 }] }, { "stylers": [{ "saturation": -77 }] }, { "featureType": "road" }],
+    //     // prettier-ignore
+    //     bwMap: [{ stylers: [{ hue: "#00ffe6" }, { saturation: -100 }] }, { featureType: "road", elementType: "geometry", stylers: [{ lightness: 100 }, { visibility: "simplified" }] }, { featureType: "road", elementType: "labels", stylers: [{ visibility: "off" }] }],
+    // };
 
     setup() {
         this.canStart = false;
@@ -55,63 +55,101 @@ export class GoogleMap extends Interaction {
         this.canStart = true;
     }
 
-    start() {
+    async start() {
         if (!this.canStart) {
             return;
         }
         // Define a default map's colors set
-        const std = [];
-        new google.maps.StyledMapType(std, { name: "Std Map" });
+        const p = this.el.dataset.mapGps.substring(1).slice(0, -1).split(",");
+        this.gps = { lat: Number(p[0]), lng: Number(p[1]) };
 
         // Default options, will be overwritten by the user
         const myOptions = {
             zoom: 12,
-            center: new google.maps.LatLng(50.854975, 4.3753899),
-            mapTypeId: google.maps.MapTypeId.ROADMAP,
+            center: this.gps,
+            mapId: "DEMO_MAP_ID",
+            mapTypeId: "roadmap",
             panControl: false,
             zoomControl: false,
             mapTypeControl: false,
             streetViewControl: false,
             scrollwheel: false,
             mapTypeControlOptions: {
-                mapTypeIds: [google.maps.MapTypeId.ROADMAP, "map_style"],
+                mapTypeIds: ["roadmap", "map_style"],
             },
         };
 
         // Render Map
         const mapC = this.el.querySelector(".map_container");
-        const map = new google.maps.Map(mapC, myOptions);
+        const [{ Map }, { AdvancedMarkerElement }] = await Promise.all([
+            google.maps.importLibrary("maps"),
+            google.maps.importLibrary("marker"),
+        ]);
+        const map = new Map(mapC, myOptions);
 
-        // Update GPS position
-        const p = this.el.dataset.mapGps.substring(1).slice(0, -1).split(",");
-
-        this.gps = new google.maps.LatLng(p[0], p[1]);
         map.setCenter(this.gps);
+
+        let markerIcon;
+        if (this.el.dataset.pinStyle === "flat") {
+            markerIcon = document.createElement("img");
+            markerIcon.src = "/website/static/src/img/snippets_thumbs/s_google_map_marker.png";
+            // Handle the drop animation of the marker
+            const intersectionObserver = new IntersectionObserver((entries) => {
+                for (const entry of entries) {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add("s_google_map_drop");
+                        intersectionObserver.unobserve(entry.target);
+                    }
+                }
+            });
+            intersectionObserver.observe(markerIcon);
+            markerIcon.style.opacity = "0";
+            markerIcon.addEventListener(
+                "animationend",
+                () => {
+                    markerIcon.classList.remove("s_google_map_drop");
+                    markerIcon.style.opacity = "1";
+                },
+                { once: true }
+            );
+        } else {
+            const { PinElement } = await google.maps.importLibrary("marker");
+            markerIcon = new PinElement();
+        }
 
         // Create Marker & Infowindow
         const markerOptions = {
-            map: map,
-            animation: google.maps.Animation.DROP,
-            position: new google.maps.LatLng(p[0], p[1]),
+            map,
+            position: { lat: Number(p[0]), lng: Number(p[1]) },
+            content: markerIcon,
         };
-        if (this.el.dataset.pinStyle === "flat") {
-            markerOptions.icon = "/website/static/src/img/snippets_thumbs/s_google_map_marker.png";
-        }
-        new google.maps.Marker(markerOptions);
+
+        new AdvancedMarkerElement(markerOptions);
+
+        // Other option to keep the drop animation on both pin (default and flat)
+        // google.maps.event.addListenerOnce(map, "idle", () => {
+        //     markerIcon.style.opacity = "0";
+        //     markerIcon.classList.add("s_google_map_drop");
+        //     new AdvancedMarkerElement(markerOptions);
+        //     setTimeout(() => {
+        //         markerIcon.classList.remove("s_google_map_drop");
+        //         markerIcon.style.opacity = "1";
+        //     }, 800);
+        // });
 
         map.setMapTypeId(google.maps.MapTypeId[this.el.dataset.mapType]); // Update Map Type
         map.setZoom(parseInt(this.el.dataset.mapZoom)); // Update Map Zoom
 
         // Update Map Color
-        const mapColorAttr = this.el.dataset.mapColor;
-        if (mapColorAttr) {
-            const mapColor = this.mapColors[mapColorAttr];
-            map.mapTypes.set(
-                "map_style",
-                new google.maps.StyledMapType(mapColor, { name: "Styled Map" })
-            );
-            map.setMapTypeId("map_style");
-        }
+        // const mapColorAttr = this.el.dataset.mapColor;
+        // if (mapColorAttr) {
+        //     const mapColor = this.mapColors[mapColorAttr];
+        //     map.mapTypes.set(
+        //         "map_style",
+        //         new google.maps.StyledMapType(mapColor, { name: "Styled Map" })
+        //     );
+        //     map.setMapTypeId("map_style");
+        // }
         this.map = map;
     }
 }

--- a/addons/website/views/snippets/s_google_map.xml
+++ b/addons/website/views/snippets/s_google_map.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template name="Google Map" id="s_google_map">
-    <section class="s_google_map pt256 pb256 o_not_editable" data-map-type="ROADMAP" data-map-color="" data-map-zoom="12" data-map-gps="(50.854975,4.3753899)" data-pin-style="flat" data-vxml="001">
+    <section class="s_google_map pt24 pb24" data-map-type="ROADMAP" data-map-color="" data-map-zoom="12" data-map-gps="(50.854975,4.3753899)" data-pin-style="flat" style="height: 512px;">
         <div class="map_container"/>
     </section>
 </template>


### PR DESCRIPTION
The goal of this PR is to update the loading and usage of the API of google maps for the s_google_map snippet in the website_builder. 
Previously the task was supposed to do it on 17.0 but given the context, it was decided that it was best to do it in master. And in the case where google really removed deprecated feature (after a 1 year notice), it would then be necessary to create a new task to handle the suppression of the old API in the previous supported version. (old PR : https://github.com/odoo/odoo/pull/199537)
They are now multiple deprecated features still in use in the snippet : 

1. Loading of the API (https://developers.google.com/maps/documentation/javascript/load-maps-js-api)
2. markers (pin), (https://developers.google.com/maps/documentation/javascript/advanced-markers/migration)
3. Places API, (https://developers.google.com/maps/documentation/javascript/place)
4. Place Autocomplete, (https://developers.google.com/maps/documentation/javascript/place-autocomplete-overview)
5. map style, (https://developers.google.com/maps/documentation/javascript/map-ids/mapid-over)


Most of them just need to update the code without visual change for the user. 
Yet there is 2 more complex case : 
1. To use the new markers we are required to define an ID on the map (It can be a demo id that works without any setup). But once we define an ID we shouldn't define a style on the map the way we were doing it previously. We are supposed to define a style in the google cloud console and we can apply it on a map via the ID of the map. 
2. Now the autoComplete widget has it's own style and it was decided to instead use the autocomplete data api and to create a custom input autocomplete with our own style. 