### PR TITLE
[FIX] web, *: Fix UI of SelectMenu in frontend cases

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -279,7 +279,7 @@ export class SelectMenu extends Component {
                 this.inputRef.el.focus();
             }
             this.menuRef.el?.addEventListener("scroll", (ev) => this.onScroll(ev));
-            const selectedElement = this.menuRef.el?.querySelectorAll(".active")[0];
+            const selectedElement = this.menuRef.el?.querySelectorAll(".selected")[0];
             if (selectedElement) {
                 scrollTo(selectedElement);
             }
@@ -299,7 +299,7 @@ export class SelectMenu extends Component {
 
     getItemClass(choice) {
         if (this.isOptionSelected(choice)) {
-            return "o_select_menu_item fw-bolder active";
+            return "o_select_menu_item fw-bolder selected";
         } else {
             return "o_select_menu_item";
         }

--- a/addons/web/static/src/core/select_menu/select_menu.scss
+++ b/addons/web/static/src/core/select_menu/select_menu.scss
@@ -33,6 +33,10 @@
     button .o_select_menu_caret {
         right: 3px;
     }
+
+    .form-select + .o_select_menu_caret {
+        display: none;
+    }
 }
 
 .o_select_menu_menu {

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -729,7 +729,7 @@ test("When multiSelect is enable, value is an array of values, multiple choices 
 
     // Select second choice
     await open();
-    expect(".o_select_menu_item:nth-of-type(1).active").toHaveCount(1);
+    expect(".o_select_menu_item:nth-of-type(1).selected").toHaveCount(1);
 
     await editSelectMenu(".o_select_menu input", { index: 1 });
     expect.verifySteps([["a", "b"]]);
@@ -737,7 +737,7 @@ test("When multiSelect is enable, value is an array of values, multiple choices 
     expect(".o_select_menu .o_tag_badge_text").toHaveCount(2);
 
     await open();
-    expect(".o_select_menu_item.active").toHaveCount(2);
+    expect(".o_select_menu_item.selected").toHaveCount(2);
 });
 
 test("When multiSelect is enable, allow deselecting elements by clicking the selected choices inside the dropdown or by clicking the tags", async () => {
@@ -778,7 +778,7 @@ test("When multiSelect is enable, allow deselecting elements by clicking the sel
     expect(".o_select_menu .o_tag_badge_text").toHaveText("B");
 
     await open();
-    expect(".o_select_menu_item.active").toHaveCount(1);
+    expect(".o_select_menu_item.selected").toHaveCount(1);
 
     await click(".o_tag .o_delete");
     await animationFrame();

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.js
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.js
@@ -6,10 +6,9 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { SelectMenu } from "@web/core/select_menu/select_menu";
 import { _t } from "@web/core/l10n/translation";
 import { SlideUploadSourceTypes } from "./slide_upload_source_types";
-import { SlideUploadSelectTags } from "./slide_upload_select_tags";
 
 export class SlideUploadCategory extends Component {
-    static components = { DropdownItem, SelectMenu, SlideUploadSelectTags, SlideUploadSourceTypes };
+    static components = { DropdownItem, SelectMenu, SlideUploadSourceTypes };
     static props = {
         alertMsg: { type: String, optional: true },
         channelId: Number,
@@ -98,13 +97,6 @@ export class SlideUploadCategory extends Component {
      */
     choiceExists(input, choices) {
         return choices.some((choice) => input.toLowerCase() === choice.label.toLowerCase());
-    }
-
-    get displayCategoryValue() {
-        return this.state.choices.categoryId
-            ? this.state.choices.categories.find((c) => c.value === this.state.choices.categoryId)
-                  .label
-            : _t("Select or create a category");
     }
 
     //--------------------------------------------------------------------------

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
@@ -93,12 +93,12 @@
         <div t-if="!state.defaultCategoryID" class="mb-3">
             <label for="category_id" class="col-form-label">Section</label>
             <SelectMenu
-                togglerClass="'form-control'"
+                togglerClass="'form-control form-select'"
                 choices="state.choices.categories"
                 value="state.choices.categoryId"
                 onSelect.bind="onCategorySelect"
+                placeholder.translate="Select or create a category"
             >
-                <t t-out="displayCategoryValue"/>
                 <t t-set-slot="bottomArea" t-slot-scope="select">
                     <DropdownItem
                             t-if="select.data.searchValue and !this.choiceExists(select.data.searchValue, select.data.choices)"
@@ -112,11 +112,13 @@
         </div>
         <div class="mb-3">
             <label for="tag_ids" class="col-form-label">Tags</label>
-            <SlideUploadSelectTags
+            <SelectMenu
+                togglerClass="'form-control form-select'"
                 choices="state.choices.tags"
                 multiSelect="true"
                 value="state.choices.tagIds"
                 onSelect.bind="onTagsSelect"
+                placeholder.translate="Select or create tags"
             >
                 <t t-set-slot="bottomArea" t-slot-scope="select">
                     <DropdownItem
@@ -127,7 +129,7 @@
                             Create New Tag "<i t-out="select.data.searchValue"/>"
                     </DropdownItem>
                 </t>
-            </SlideUploadSelectTags>
+            </SelectMenu>
         </div>
         <div class="mb-3">
             <label for="duration" class="col-form-label">Estimated Completion Time</label>

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_select_tags.js
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_select_tags.js
@@ -1,4 +1,0 @@
-import { SelectMenu } from "@web/core/select_menu/select_menu";
-
-export class SlideUploadSelectTags extends SelectMenu {}
-SlideUploadSelectTags.template = "website_slides.SlideUploadSelectTags";

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_select_tags.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_select_tags.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<templates xml:space="preserve">
-    <t t-name="website_slides.SlideUploadSelectTags" t-inherit="web.SelectMenu" t-inherit-mode="primary">
-        <xpath expr="//TagsList" position="after">
-            <t t-if="props.value.length === 0">Select or create tags</t>
-        </xpath>
-    </t>
-</templates>


### PR DESCRIPTION
*: website_slides

This commit fixes the 'selected' display of the SelectMenu component in some frontend implementations. Previously, the visual style would be broken since the 'active' class was set on the element, having a blank text and background on selected items.

The right 'selected' class is now used, to avoid difficulties to read the value, while still having some frontend specific styles working as expected. Also, the form-control and form-select classes are set using the togglerClass props. In future versions, we might be able to remove extension of the component in other modules (e.g. hr_contract_salary), ensuring the same style and behaviors accross all places.

Before: 
<img width="1566" height="1115" alt="image" src="https://github.com/user-attachments/assets/6265c615-bd7a-47f6-9353-c503dd934fed" />

After: 
<img width="791" height="350" alt="image" src="https://github.com/user-attachments/assets/939b7109-a32f-4991-a169-13f501f29eb4" />
