### PR TITLE
[FIX] web: settingsTabRef missing in mobile

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
@@ -85,9 +85,11 @@ export class SettingsPage extends Component {
 
     scrollToSelectedTab() {
         const key = this.state.selectedTab;
-        this.settingsTabRef.el
-            .querySelector(`[data-key='${key}']`)
-            .scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+        if (this.settingsTabRef.el) {
+            this.settingsTabRef.el
+                .querySelector(`[data-key='${key}']`)
+                .scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
+        }
     }
 
     onSettingTabClick(key) {


### PR DESCRIPTION
Fix an owl traceback in mobile view.

Step to reproduce, in mobile view:
1 - Open Settings App
2 - Type any character in the search bar
3 - Traceback

This is because `settingsTabRef.el` is undefined in `scrollToSelectedTab` method,
as it's supposed to be `useRef("settings_tab")`, but "settings_tab" is not
present in the DOM on mobile.

This commit add an if to check first if `settingsTabRef.el` is not undefined.

no-task
