### PR TITLE
[FIX] point_of_sale: prevent gaps in pos references when closing session

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -15,10 +15,6 @@ export class PosOrder extends PosOrderAccounting {
 
         if (!this.session_id?.id && (!this.finalized || !this.isSynced)) {
             this.session_id = this.session;
-
-            if (this.state === "draft" && this.lines.length == 0 && this.payment_ids.length == 0) {
-                this._isResidual = true;
-            }
         }
 
         // Data present in python model

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -668,10 +668,6 @@ export class PosStore extends WithLazyGetterTrap {
             this.addPendingOrder(paidUnsyncedOrderIds);
         }
 
-        this.data.models["pos.order"]
-            .filter((order) => order._isResidual)
-            .forEach((order) => (order.state = "cancel"));
-
         const openOrders = this.data.models["pos.order"].filter((order) => !order.finalized);
         await this.syncAllOrders();
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2080,6 +2080,11 @@ class TestUi(TestPointOfSaleHttpCommon):
             {'amount': 20.0, 'payment_method_id': self.bank_payment_method.id, 'is_change': False},
         ])
 
+        # References should not have gaps
+        references = self.env['pos.order'].search([], order="pos_reference").mapped("pos_reference")
+        for i in range(len(references) - 1):
+            self.assertEqual(int(references[i + 1].split('-')[-1]), int(references[i].split('-')[-1]) + 1, "There is a gap in the pos references")
+
     def test_reload_page_before_payment_with_customer_account(self):
         self.customer_account_payment_method = self.env['pos.payment.method'].create({
             'name': 'Customer Account',


### PR DESCRIPTION
Before this commit, when closing the POS session, if there were draft orders without any lines or payments, they were removed and caused gaps in the pos_reference sequence.

opw-5216954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
