### PR TITLE
[IMP] hr_work_entry: added overtime pay to work entry type categories

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -24,10 +24,10 @@ class HrWorkEntryType(models.Model):
     )
     country_code = fields.Char(related='country_id.code')
     category = fields.Selection(
-        [("working_time", "Working Time"), ("absence", "Absence")],
+        [("working_time", "Working Time"), ("absence", "Absence"), ("overtime_pay", "Overtime Pay")],
         default="working_time",
         required=True,
-        help="Determines if the entry counts as working time or absence.",
+        help="Determines if the entry counts as working time, overtime pay or absence.",
     )
     amount_rate = fields.Float(
         string="Rate",


### PR DESCRIPTION
For the category choices of WorkEntryType model, a new choice was added representing Overtime Pay

task-5428737

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
