### PR TITLE
[FIX] base: get correct wkhtmltopdf version

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -80,6 +80,7 @@ class WkhtmlInfo(typing.NamedTuple):
     dpi_zoom_ratio: bool
     bin: str
     version: str
+    is_patched_qt: bool
     wkhtmltoimage_bin: str
     wkhtmltoimage_version: tuple[str, ...] | None
 
@@ -89,6 +90,7 @@ def _wkhtml() -> WkhtmlInfo:
     state = 'install'
     bin_path = 'wkhtmltopdf'
     version = ''
+    is_patched_qt = False
     dpi_zoom_ratio = False
     try:
         bin_path = find_in_path('wkhtmltopdf')
@@ -101,6 +103,8 @@ def _wkhtml() -> WkhtmlInfo:
         _logger.info('Will use the Wkhtmltopdf binary at %s', bin_path)
         out, _err = process.communicate()
         version = out.decode('ascii')
+        if '(with patched qt)' in version:
+            is_patched_qt = True
         match = re.search(r'([0-9.]+)', version)
         if match:
             version = match.group(0)
@@ -144,6 +148,7 @@ def _wkhtml() -> WkhtmlInfo:
         dpi_zoom_ratio=dpi_zoom_ratio,
         bin=bin_path,
         version=version,
+        is_patched_qt=is_patched_qt,
         wkhtmltoimage_bin=image_bin_path,
         wkhtmltoimage_version=wkhtmltoimage_version,
     )
@@ -617,8 +622,7 @@ class IrActionsReport(models.Model):
                     pass
                 case 1:
                     if body_idx:
-                        wk_version = _wkhtml().version
-                        if '(with patched qt)' not in wk_version:
+                        if not _wkhtml().is_patched_qt:
                             if modules.module.current_test:
                                 raise unittest.SkipTest("Unable to convert multiple documents via wkhtmltopdf using unpatched QT")
                             raise UserError(_("Tried to convert multiple documents in wkhtmltopdf using unpatched QT"))


### PR DESCRIPTION
When getting a wkhtmltopdf version, we only get version number, not the part where it mentions whether or not we have QT patch.

This commit fixes this issue.

Before:
version = '0.12.6.1'
When checking if '(with patched qt)' not in wk_version, it breaks and we get an error.

Now:
we check '(with patched qt)' beforehand and save it in is_patched_qt property. we use this value
instead of version when checking for qt later on.


opw-5263921



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
