### PR TITLE
[FIX] l10n_dk_nemhandel: corrects schemeID value for EndpointID

### DIFF
--- a/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
@@ -19,6 +19,13 @@ UBL_TO_OIOUBL_TAX_CATEGORY_ID_MAPPING = {
     'M': 'ZeroRated',
 }
 
+SCHEME_ID_MAPPING = {
+    '0088': 'GLN',
+    '0184': 'DK:CVR',
+    '9918': 'IBAN',
+    '0198': 'DK:SE',
+}
+
 
 def format_vat_number(partner, vat):
     vat = (vat or '').replace(' ', '')
@@ -155,7 +162,7 @@ class AccountEdiXmlOIOUBL21(models.AbstractModel):
             prefix = 'DK' if partner.nemhandel_identifier_type == '0184' else ''
             party_node['cbc:EndpointID'] = {
                 '_text': f'{prefix}{partner.nemhandel_identifier_value}',
-                'schemeID': partner.nemhandel_identifier_type,
+                'schemeID': SCHEME_ID_MAPPING[partner.nemhandel_identifier_type],
             }
 
         return party_node

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_discount.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_discount.xml
@@ -21,7 +21,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -79,7 +79,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
@@ -23,7 +23,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -84,7 +84,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0088">5798009811512</cbc:EndpointID>
+      <cbc:EndpointID schemeID="GLN">5798009811512</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>SUPER BELGIAN PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
@@ -21,7 +21,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -79,7 +79,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0088">5798009811639</cbc:EndpointID>
+      <cbc:EndpointID schemeID="GLN">5798009811639</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>SUPER FRENCH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
@@ -21,7 +21,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -79,7 +79,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
@@ -20,7 +20,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -78,7 +78,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0088">5798009811639</cbc:EndpointID>
+      <cbc:EndpointID schemeID="GLN">5798009811639</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>SUPER FRENCH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
@@ -20,7 +20,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -78,7 +78,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0184">DK12345674</cbc:EndpointID>
+      <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>
       </cac:PartyName>


### PR DESCRIPTION
**PROBLEM**
Generated OIOUBL files don't pass schematrons validations.

**STEP TO REPRODUCE**
1. Install the l10n_dk module.
2. Create a dk partner with an adress, and VAT number (DK12345674 for example, don't forget to add a street number for the DK Company address).
3. Create an invoice for the DK partner, and download the xml.
4. Use this validator https://oioubl.nemhandel.dk/validation (Odoo Peppol IAP validator tests oioubl version 3.0 which is not the version we want to test).

**CAUSE**
We used [wrong codelist](https://oioubl-demo.nemhandel.dk/oioubl/kodelister/ElectronicAddressSchemeCode-3.0.html) (oiubl3.0) for schemeID instead of the [one we should use](https://oioubl21.oioubl.dk/Codelists/en/urn_oioubl_scheme_endpointid-1.1.html) (oioubl2.1).

opw-5379474