### PR TITLE
[FIX] website: fix replace s_picture image by a video

### DIFF
--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -96,7 +96,7 @@
                     <p style="text-align: center;">As promised, we will offer 4 free tickets to our next summit.<br/>Visit our Facebook page to know if you are one of the lucky winners.</p>
                     <div class="row s_nb_column_fixed">
                         <div class="col-lg-12" style="text-align: center;">
-                            <figure class="figure">
+                            <figure class="figure w-100">
                                 <img src="/web/image/website.library_image_18" class="figure-img img-fluid rounded" alt="Countdown is over - Firework"/>
                             </figure>
                         </div>

--- a/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.edit.test.js
@@ -47,7 +47,7 @@ const endMessage = `
                     <p style="text-align: center;">As promised, we will offer 4 free tickets to our next summit.<br/>Visit our Facebook page to know if you are one of the lucky winners.</p>
                     <div class="row s_nb_column_fixed">
                         <div class="col-lg-12" style="text-align: center;">
-                            <figure class="figure">
+                            <figure class="figure w-100">
                                 <img src="/web/image/website.library_image_18" class="figure-img img-fluid rounded" alt="Countdown is over - Firework"/>
                             </figure>
                         </div>

--- a/addons/website/static/tests/interactions/snippets/countdown.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.test.js
@@ -49,7 +49,7 @@ const endMessage = `
                     <p style="text-align: center;">As promised, we will offer 4 free tickets to our next summit.<br/>Visit our Facebook page to know if you are one of the lucky winners.</p>
                     <div class="row s_nb_column_fixed">
                         <div class="col-lg-12" style="text-align: center;">
-                            <figure class="figure">
+                            <figure class="figure w-100">
                                 <img src="/web/image/website.library_image_18" class="figure-img img-fluid rounded" alt="Countdown is over - Firework"/>
                             </figure>
                         </div>

--- a/addons/website/views/snippets/s_picture.xml
+++ b/addons/website/views/snippets/s_picture.xml
@@ -8,7 +8,7 @@
             <p style="text-align: center;">Experience unparalleled comfort, cutting-edge design, and performance-enhancing<br/>technology with this latest innovation, crafted to elevate every athlete's journey.</p>
             <div class="row">
                 <div class="col-lg-12 pt24" style="text-align: center;">
-                    <figure class="figure">
+                    <figure class="figure w-100">
                         <img src="/web/image/website.s_picture_default_image" class="figure-img img-fluid rounded" alt=""/>
                         <figcaption class="figure-caption text-muted mt-2">Where innovation meets performance</figcaption>
                     </figure>


### PR DESCRIPTION
Steps to reproduce:
- Drop "s_picture" snippet.
- Replace the image with a video.
- Video is clearly small than the original image.

This commit fixes the issue by adding a "w-100" class to the figure element wrapping the image.

task-5136212
