### PR TITLE
[FIX] html_builder, website: remove horizontal cursor between cards

### DIFF
--- a/addons/html_builder/static/src/core/core_plugins.js
+++ b/addons/html_builder/static/src/core/core_plugins.js
@@ -45,6 +45,7 @@ const mainEditorPluginsToRemove = [
     "BannerPlugin",
     "MoveNodePlugin",
     "FontFamilyPlugin",
+    "SelectionPlaceholderPlugin",
     // Replaced plugins:
     "ColorUIPlugin",
     "ImagePlugin",

--- a/addons/website/static/src/builder/plugins/options/card_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/card_option_plugin.js
@@ -20,11 +20,16 @@ export class WebsiteBackgroundCardOption extends BaseWebsiteBackgroundOption {
     };
 }
 
-class CardOptionPlugin extends Plugin {
+export class CardOptionPlugin extends Plugin {
     static id = "cardOption";
 
     /** @type {import("plugins").WebsiteResources} */
     resources = {
+        content_editable_selectors: [
+            `${CardOption.selector} > *`,
+            `${CardOption.selector} figure > img`,
+        ],
+        content_not_editable_selectors: `${CardOption.selector} figure`,
         builder_options: [
             CardOption,
             CardWithoutWidthOption,

--- a/addons/website/static/tests/builder/options/card_option.test.js
+++ b/addons/website/static/tests/builder/options/card_option.test.js
@@ -1,11 +1,18 @@
 import { expect, test } from "@odoo/hoot";
+import { tick } from "@odoo/hoot-mock";
 import {
     defineWebsiteModels,
     setupWebsiteBuilder,
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { contains } from "@web/../tests/web_test_helpers";
-import { animationFrame, click, queryOne, setInputRange, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, click, press, queryOne, setInputRange, waitFor } from "@odoo/hoot-dom";
+import { getContent } from "@html_editor/../tests/_helpers/selection";
+import {
+    insertText,
+    simulateArrowKeyPress,
+    splitBlock,
+} from "@html_editor/../tests/_helpers/user_actions";
 
 defineWebsiteModels();
 
@@ -290,4 +297,63 @@ test("cover image ratio option only act on the right card when two of them are n
     await click(".dropdown-menu [data-class-action='ratio o_card_img_ratio_custom']");
     await waitFor("[data-label='Custom Ratio'] input[type='range']");
     expect(":iframe figure.o_card_img_ratio_custom").toHaveCount(1);
+});
+
+test.tags("desktop");
+// Because up/down arrows are tested within a full page width layout.
+test("navigate between cards with keyboard", async () => {
+    const { getEditor } = await setupWebsiteBuilderWithSnippet("s_cards_grid");
+    const editor = getEditor();
+    const h2El = await waitFor(":iframe h2");
+    const rowEl = await waitFor(":iframe div.row");
+    await contains(":iframe .s_cards_grid :contains()").click(); // click on text
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await tick(); // await selectionchange
+    await simulateArrowKeyPress(editor, "ArrowLeft");
+    await tick(); // await selectionchange
+    expect(getContent(h2El)).toMatch(/^.+\[\]$/);
+    await splitBlock(editor);
+    expect(":iframe p[data-selection-placeholder]").toHaveCount(0);
+
+    await insertText(editor, "/table");
+    await press("Enter");
+    await waitFor(".o-we-tablepicker");
+    await press("Enter");
+    await tick(); // await selectionchange
+    expect(":iframe p[data-selection-placeholder]").toHaveCount(0);
+
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await tick(); // await selectionchange
+    expect(":iframe p[data-selection-placeholder]").toHaveCount(0);
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await tick(); // await selectionchange
+    expect(":iframe p[data-selection-placeholder]").toHaveCount(0);
+    await simulateArrowKeyPress(editor, "ArrowDown"); // exit table
+    await tick(); // await selectionchange
+    expect(":iframe p[data-selection-placeholder]").toHaveCount(0);
+    expect(getContent(rowEl)).toMatch(/>Q\[\]uality/);
+
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await tick(); // await selectionchange
+    expect(getContent(rowEl)).toMatch(/>W\[\]e provide/);
+
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await tick(); // await selectionchange
+    expect(getContent(rowEl)).toMatch(/>E\[\]xpertise/);
+
+    await simulateArrowKeyPress(editor, "ArrowUp");
+    await tick(); // await selectionchange
+    expect(getContent(rowEl)).toMatch(/>W\[\]e provide/);
+
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await tick(); // await selectionchange
+    await simulateArrowKeyPress(editor, "ArrowLeft");
+    await tick(); // await selectionchange
+    await simulateArrowKeyPress(editor, "ArrowLeft");
+    await tick(); // await selectionchange
+    expect(getContent(rowEl)).toMatch(/finish.\[\]<\/p>/);
+
+    await simulateArrowKeyPress(editor, "ArrowRight");
+    await tick(); // await selectionchange
+    expect(getContent(rowEl)).toMatch(/>\[\]Expertise/);
 });


### PR DESCRIPTION
Since [1] when the selection placeholder plugin was introduced, a horizontal cursor is displayed between cards in website, while that area is not supposed to be editable.

This commit disables the `SelectionPlaceholderPlugin` inside the `html_builder`.
It also makes the `<figure>` element around images non editable - in order to be able to write a test that does not enforce it to be wrong.

Steps to reproduce:

- Drop an `s_cards_grid`` block
- Put the cursor in a card
- Move the cursor with the arrow keys until you leave the card

=> The cursor was displayed between cards.

[1]: https://github.com/odoo/odoo/commit/edf7f7bb0c62978640c181eccb4934855d5d872d

task-5383957