### PR TITLE
[FIX] point_of_sale: make sure refunds have negative order Lines

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -196,8 +196,8 @@ export class PosOrderAccounting extends Base {
         this.amount_total = this.currency.round(this.priceIncl);
         this.amount_return = this.change; // Already rounded by the getter
         this.lines.forEach((line) => {
-            line.price_subtotal = line.priceExcl;
-            line.price_subtotal_incl = line.priceIncl;
+            line.price_subtotal = line.priceExcl * line.order_id.orderSign;
+            line.price_subtotal_incl = line.priceIncl * line.order_id.orderSign;
         });
     }
     /**

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -506,12 +506,12 @@ describe("pos_store.js", () => {
             expect(order.amount_tax).toEqual(-2.85);
             expect(order.lines[0].qty).toEqual(-3);
             expect(order.lines[0].price_unit).toEqual(3);
-            expect(order.lines[0].price_subtotal).toEqual(9);
-            expect(order.lines[0].price_subtotal_incl).toEqual(10.35);
+            expect(order.lines[0].price_subtotal).toEqual(-9);
+            expect(order.lines[0].price_subtotal_incl).toEqual(-10.35);
             expect(order.lines[1].qty).toEqual(-2);
             expect(order.lines[1].price_unit).toEqual(3);
-            expect(order.lines[1].price_subtotal).toEqual(6);
-            expect(order.lines[1].price_subtotal_incl).toEqual(7.5);
+            expect(order.lines[1].price_subtotal).toEqual(-6);
+            expect(order.lines[1].price_subtotal_incl).toEqual(-7.5);
         });
     });
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1272,6 +1272,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'FiscalPositionNoTaxRefund', login="pos_user")
         order = self.env['pos.order'].search([])
         self.assertTrue(order[0].name == order[1].name + " REFUND")
+        # The refunded order line should be negative
+        self.assertTrue(order[0].lines.price_subtotal == -100)
+        self.assertTrue(order[0].lines.price_subtotal_incl == -100)
 
     def test_lot_refund(self):
 
@@ -1588,7 +1591,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'refund_multiple_products_amounts_compliance', login="pos_user")
 
         refund_order = current_session.order_ids.filtered(lambda order: order.is_refund)
-        self.assertEqual(refund_order.lines[0].price_subtotal, 2 * test_product.list_price)
+        self.assertEqual(refund_order.lines[0].price_subtotal, -2 * test_product.list_price)
         total_cash_payment = sum(current_session.mapped('order_ids.payment_ids').filtered(
             lambda payment: payment.payment_method_id.type == 'cash').mapped('amount')
         )

--- a/addons/pos_discount/tests/test_taxes_global_discount.py
+++ b/addons/pos_discount/tests/test_taxes_global_discount.py
@@ -113,7 +113,7 @@ class TestTaxesGlobalDiscountPOS(TestTaxCommonPOS, TestTaxesGlobalDiscount):
         self.assertAlmostEqual(refund_order.amount_total, -2.85)
         self.assertEqual(len(refund_order.lines), 2)
         self.assertEqual(refund_order.lines[1].product_id.id, self.main_pos_config.discount_product_id.id)
-        self.assertAlmostEqual(refund_order.lines[1].price_subtotal_incl, -0.15)
+        self.assertAlmostEqual(refund_order.lines[1].price_subtotal_incl, 0.15)
         pos_order = orders[1]
         self.assertAlmostEqual(pos_order.amount_total, 2.85)
         self.assertEqual(len(pos_order.lines), 2)


### PR DESCRIPTION
Before this commit, when creating a refund in the PoS, the order lines were created with positive price_subtotal and price_subtotal_incl. This let to incorrect data in the PoS reports.

opw-5415639

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
