### PR TITLE
[FIX] web: kanban: keep progressbar filter when coming back

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -340,9 +340,6 @@ export class RelationalModel extends Model {
                         // in case there're less groups, we don't want to keep displaying groups
                         // that are no longer there => forget previous groups
                         delete this.root.config.currentGroups;
-                        // in case that the config of the groups changed (e.g. group is now folded)
-                        // we want to update the groups.
-                        this.root.config.groups = [];
                         result = await this._postprocessReadGroup(root.config, result);
                     }
                     root._setData(result);
@@ -526,13 +523,9 @@ export class RelationalModel extends Model {
                     currentConfig.domain
                 );
                 if (!currentConfig.groups[group.value]) {
-                    const isFolded =
-                        !Object.hasOwn(groupData, "__records") &&
-                        !Object.hasOwn(groupData, "__groups");
                     currentConfig.groups[group.value] = {
                         ...commonConfig,
                         groupByFieldName,
-                        isFolded: isFolded,
                         extraDomain: false,
                         value: group.value,
                         list: {
@@ -566,6 +559,7 @@ export class RelationalModel extends Model {
                 groupConfig.list.context = context;
                 groupConfig.context = context;
                 if (nextLevelGroupBy.length) {
+                    groupConfig.isFolded = !("__groups" in groupData);
                     if (!groupConfig.isFolded) {
                         const { groups, length } = groupData.__groups;
                         group.groups = await extractGroups(groupConfig.list, groups);
@@ -574,6 +568,7 @@ export class RelationalModel extends Model {
                         group.groups = [];
                     }
                 } else {
+                    groupConfig.isFolded = !("__records" in groupData);
                     if (!groupConfig.isFolded) {
                         group.records = groupData.__records;
                         group.length = groupData.__count;

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -644,16 +644,17 @@ export class SampleServer {
         }
         // Don't care another params - and no subgroup:
         // order / opening_info / unfold_read_default_limit / groupby_read_specification
+        const openAllGroups = params.auto_unfold && !this.existingGroups;
         let nbOpenedGroup = 0;
         if (params.unfold_read_specification) {
             for (const group of groups) {
-                if (params.auto_unfold || "__records" in group) {
+                if (openAllGroups || "__records" in group) {
                     // if group has a "__records" key, it means that it is an existing group, and
                     // that the real webReadGroup returned a "__records" key for that group (which
                     // is empty, otherwise we wouldn't be here), i.e. that group is opened.
                     if (nbOpenedGroup < MAX_NUMBER_OPENED_GROUPS) {
                         nbOpenedGroup++;
-                        group["__records"] = this._mockWebSearchReadUnity({
+                        group.__records = this._mockWebSearchReadUnity({
                             model: params.model,
                             specification: params.unfold_read_specification,
                             recordIds: group["id:array_agg"],

--- a/addons/web/static/tests/model/sample_server.test.js
+++ b/addons/web/static/tests/model/sample_server.test.js
@@ -254,8 +254,8 @@ describe("RPC calls", () => {
     test("'web_read_group': 2 groups", async () => {
         const server = new DeterministicSampleServer("hobbit", fields.hobbit);
         const existingGroups = [
-            { profession: "gardener", count: 0 }, // fake group
-            { profession: "adventurer", count: 0 }, // fake group
+            { profession: "gardener", count: 0, __records: [] }, // fake group
+            { profession: "adventurer", count: 0, __records: [] }, // fake group
         ];
         server.setExistingGroups(existingGroups);
         const result = await server.mockRpc({
@@ -276,9 +276,9 @@ describe("RPC calls", () => {
     test("'web_read_group': all groups", async () => {
         const server = new DeterministicSampleServer("hobbit", fields.hobbit);
         const existingGroups = [
-            { profession: "gardener", count: 0 }, // fake group
-            { profession: "brewer", count: 0 }, // fake group
-            { profession: "adventurer", count: 0 }, // fake group
+            { profession: "gardener", count: 0, __records: [] }, // fake group
+            { profession: "brewer", count: 0, __records: [] }, // fake group
+            { profession: "adventurer", count: 0, __records: [] }, // fake group
         ];
         server.setExistingGroups(existingGroups);
         const result = await server.mockRpc({


### PR DESCRIPTION
Have a kanban view with progressbar and some records. Click on a progressbar to filter a column. Then open a record and come back. From that point, the data of the filtered kanban is in cache. Now, open a record again, and make a change in the form that will have an impact in the kanban (e.g. that will move a record from a column to another). Come back to the kanban view, which will instantly show the data from the cache, and that will be then updated once the rpc returns. At that point, the view is still correct, but the cache callback has already erased the groups information (in particular, the extraDomain of the filtered column). So, if you open a record and come back a last time, the view is no longer correct: the column that is supposed to be filtered displays all records.

Introduced by [1]

This commit basically reverts [1] and fixes the original issue differently. When we receive the result of a web_read_group, we can trust it and determine that a group for which we receive records (or groups) is open.

[1] https://github.com/odoo/odoo/pull/226312

Task~5387553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
