### PR TITLE
[FIX] mail: discuss sidebar category hover effect also on chevron

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.scss
@@ -26,7 +26,7 @@
         .o-mail-DiscussSidebarCategory-title {
             color: $text-muted;
         }
-        &:has(.o-mail-DiscussSidebarCategory-chevronCompact) .o-mail-DiscussSidebarCategory-toggler {
+        .o-mail-DiscussSidebarCategory-toggler {
             color: $text-muted !important;
         }
     }


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/issues/239537

PR Above improve style of category title. One of the change is reduce opacity of title when not hovered.

The chevron icon was not taken into account, which makes the category title line more visible than intended.

This commit put same condition to reduce opacity of category title when not mouse-hovering on the chevron icon.

Before / After
<img width="297" height="854" alt="Screenshot 2025-12-18 at 15 59 43" src="https://github.com/user-attachments/assets/90e9c49f-7105-4f35-965c-0be5c5822a39" /> <img width="297" height="853" alt="Screenshot 2025-12-18 at 15 58 59" src="https://github.com/user-attachments/assets/65246008-b5b8-4d94-b095-544c99e1e3aa" />


<img width="304" height="858" alt="Screenshot 2025-12-18 at 16 00 30" src="https://github.com/user-attachments/assets/9c5bdaac-b113-45f3-9bd6-fb9171eaa260" /> <img width="300" height="858" alt="Screenshot 2025-12-18 at 16 00 51" src="https://github.com/user-attachments/assets/47f26fe0-bdb4-45f8-af2d-125dfe72f59a" />
