### PR TITLE
[FIX] sale_project: prevent project creation of 0 unit service quotation

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -120,7 +120,11 @@ class SaleOrder(models.Model):
         for project in projects:
             projects_per_so[project.sale_order_id.id or project.reinvoiced_sale_order_id.id] |= project
         for order in self:
-            projects = order.order_line.mapped('product_id.project_id')
+            projects = order.order_line.filtered(
+                lambda sol:
+                    sol.is_service
+                    and not (sol._is_line_optional() and sol.product_uom_qty == 0)
+                ).mapped('product_id.project_id')
             projects |= order.project_id
             projects |= order.order_line.mapped('project_id')
             projects |= projects_per_so[order.id or order._origin.id]

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -1891,3 +1891,32 @@ class TestSaleProject(TestSaleProjectCommon):
         })
         so.action_confirm()
         self.assertEqual(sol.task_id.allocated_hours, 10, "The allocated hours should be 10.")
+
+    def test_quotation_with_zero_unit_project_service(self):
+        """
+        Test checking that a project doesn't get created on order when ordering 0 units of the corresponding
+         product service if it is optional. If the unit is increased to 1, a project should be created.
+        """
+        sale_order_with_option = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1,
+                }),
+                Command.create({
+                    'display_type': 'line_section',
+                    'name': "Optional products",
+                    'is_optional': True,
+                }),
+                Command.create({
+                    'product_id': self.product_order_service4.id,
+                    'product_uom_qty': 0,
+                }),
+            ],
+        })
+        optional_product_line = sale_order_with_option.order_line.filtered(lambda line: not line.display_type and line._is_line_optional())
+        sale_order_with_option.action_confirm()
+        self.assertFalse(optional_product_line.project_id)
+        optional_product_line.write({'product_uom_qty': 1})
+        self.assertEqual(optional_product_line.project_id.sale_order_id, sale_order_with_option)


### PR DESCRIPTION

---
## Short functional explanation of the error
Let's say we have a prepaid service as a product, generating a project
upon order. When we order 0 units of this product as an optional
product, a project is still created.

## Reproduction Steps
1. Create a product of type Service. Set Project in the field Create On
Order. Set the Invoicing Policy at Prepaid.
2. Create a quotation containing an optional product with 0 units of this
 service and click on confirm.

### Expected behavior
The quotation is confirmed, but no project is created.

### Unexpected behavior
A project linked to the product and the quotation is created.

## Origin of the issue
When creating projects linked to order lines, we don't check if such
projects are linked to optional products.

opw-5406118