### PR TITLE
[FIX] hw_drivers: do not git checkout if no db

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -129,6 +129,9 @@ def check_git_branch():
     checkout to match it if needed.
     """
     server = get_odoo_server_url()
+    if not server or platform.system() == 'Windows':
+        _logger.debug('Ignoring git branch check')
+        return
     urllib3.disable_warnings()
     http = urllib3.PoolManager(cert_reqs='CERT_NONE')
     try:


### PR DESCRIPTION
This PR ignores the call to check_git_branch if no database is connected to the iot box.
