### PR TITLE
[PERF] point_of_sale: fix memory while opening a session.

### DIFF
--- a/addons/point_of_sale/models/product_uom.py
+++ b/addons/point_of_sale/models/product_uom.py
@@ -1,4 +1,3 @@
-
 from odoo import api, models
 
 
@@ -9,3 +8,8 @@ class ProductUom(models.Model):
     @api.model
     def _load_pos_data_fields(self, config):
         return ['id', 'barcode', 'product_id', 'uom_id']
+
+    @api.model
+    def _load_pos_data_domain(self, data, config):
+        product_ids = [product['id'] for product in data['product.product']]
+        return [('product_id', 'in', product_ids)]

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2934,6 +2934,54 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertNotIn(children_categs[0].id, category_id, "Child category is unavailable and shouldn't appear in the POS")
         self.assertIn(children_categs[1].id, category_id, "Child category is available and should appear in the POS")
 
+    def test_available_product_uom_ids(self):
+        # Making sure that all of the non-special products that are included in the `load_data` are the ones created in this method.
+        self.env['product.template'].search([]).write({'is_favorite': False})
+
+        self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_product_count', '2')
+        uom = self.env['uom.uom'].create({
+            'name': 'Random UOM',
+            'relative_uom_id': self.env.ref('uom.product_uom_unit').id,
+        })
+        product_one, product_two, product_three = self.env['product.product'].create([{
+            'name': "product_one",
+            'available_in_pos': True,
+            'is_favorite': True,
+        },
+        {
+            'name': "product_two",
+            'available_in_pos': True,
+            'is_favorite': True,
+        },
+        {
+            'name': "product_three",
+            'available_in_pos': True,
+        }])
+
+        _, _, product_uom_three = self.env['product.uom'].create([{
+            'barcode': "product_one_barcode",
+            'uom_id': uom.id,
+            'product_id': product_one.id,
+        },
+        {
+            'barcode': "product_two_barcode",
+            'uom_id': uom.id,
+            'product_id': product_two.id,
+        },
+        {
+            'barcode': "product_three_barcode",
+            'uom_id': uom.id,
+            'product_id': product_three.id,
+        },
+        ])
+
+        self.env['product.template'].flush_model()
+        self.main_pos_config.open_ui()
+        loaded_data = self.main_pos_config.current_session_id.load_data([])
+        loaded_product_uoms = [loaded_product_uom['id'] for loaded_product_uom in loaded_data['product.uom']]
+
+        self.assertNotIn(product_uom_three.id, loaded_product_uoms, f"Product UOM {product_uom_three} shouldn't be loaded as its product {product_three} is not included in the results")
+
     def test_pos_order_shipping_date(self):
         self.env['res.partner'].create({
             'name': 'Partner Test with Address',


### PR DESCRIPTION
Before this commit, while opening a session in the POS, all the `product.uom` records were retrieved regardeless of what products were loaded. This might cause a memory error in cases where a lot of records are being retrieved. A solution for this is to retreive the records **only related to the `product.product` records being retrieved**.

opw-5408586
___
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
