### PR TITLE
[FIX] mrp: use work center availability to compute total expected workorder duration

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5239,6 +5239,92 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(unbuild_order.state, 'done')
         self.assertEqual(unbuild_order.product_qty, 1.23456)
 
+    def test_compute_date_finished_with_workcenter_calendar(self):
+        """
+        Test that finished date of the production depends properly on the workcenter availability.
+
+        Have two wokcenters: WC1 (op 1) opened 8/5, WC2 opened 24/5 (op 2, 3)
+
+        Check finish date for a production of:
+            - 1 unit
+            - 10 units (exceeds one day of work for WC1)
+        """
+        calendars = self.env['resource.calendar'].sudo().create([
+            {
+                'attendance_ids': [
+                    Command.create({
+                        'dayofweek': str(weekday),
+                        'day_period': period,
+                        'hour_from': am_start if period == 'morning' else pm_start,
+                        'hour_to': am_end if period == 'morning' else pm_end,
+                        'name': f'Day {weekday} {period} H {f"{am_start} {am_end}" if period == "morning" else f"{pm_start} {pm_end}"}',
+                    })
+                    for weekday in range(5)
+                    for period in ('morning', 'afternoon')
+                ],
+                'leave_ids': [Command.create({
+                    'date_from': datetime(2024, 1, 8, 0, 0, 0),
+                    'date_to': datetime(2024, 1, 9, 0, 0, 0),
+                })],
+                'name': name,
+                'tz': 'UTC',
+            }
+            for am_start, am_end, pm_start, pm_end, name in [
+                (8, 12, 13, 17, 'Test calendar 40h'),
+                (0, 12, 12, 24, 'Test full calendar 24h/5d')
+            ]
+        ])
+        workcenters = self.env['mrp.workcenter'].create([
+            {
+                'name': f'Simple Workcenter {i}',
+                'default_capacity': 1,
+                'time_start': 0,
+                'time_stop': 0,
+                'time_efficiency': time_efficiency,
+                'resource_calendar_id': calendars[i].id,
+            }
+            for i, time_efficiency in enumerate([50, 100])
+        ])
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_6.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'operation_ids': [
+                Command.create({'name': 'Op 1', 'workcenter_id': workcenters[0].id,
+                        'time_mode_batch': 1, 'time_mode': "auto", 'time_cycle_manual': 18}),
+                Command.create({'name': 'Op 2', 'workcenter_id': workcenters[1].id,
+                        'time_mode_batch': 1, 'time_mode': "auto", 'time_cycle_manual': 24}),
+                Command.create({'name': 'Op 3', 'workcenter_id': workcenters[1].id,
+                        'time_mode_batch': 1, 'time_mode': "auto", 'time_cycle_manual': 66}),
+            ],
+            'type': 'normal',
+            'bom_line_ids': [
+                Command.create({'product_id': self.product_1.id, 'product_qty': 1}),
+            ]
+        })
+        production = self.env['mrp.production'].create(
+            {
+                'product_id': self.product_6.id,
+                'bom_id': bom.id,
+                'product_qty': 1,
+                'date_start': datetime(2024, 1, 1, 8, 0, 0),
+            },
+        )
+        production.action_confirm()
+        self.assertAlmostEqual(production.date_finished, datetime(2024, 1, 1, 9, 30, 0), delta=timedelta(seconds=2))
+
+        production.write({'date_start': datetime(2024, 1, 1, 10, 0, 0), 'product_qty': 10})
+        # First WC finished on the first day, the second one still has 1 hour to do
+        self.assertAlmostEqual(production.date_finished, datetime(2024, 1, 2, 1, 0, 0), delta=timedelta(seconds=2))
+
+        production.write({'date_start': datetime(2024, 1, 1, 16, 0, 0)})
+        # Start at 16pm, so still 5h to do the next day
+        self.assertAlmostEqual(production.date_finished, datetime(2024, 1, 2, 14, 0, 0), delta=timedelta(seconds=2))
+
+        production.write({'date_start': datetime(2024, 1, 5, 16, 0, 0)})
+        # The workcenter does not work in the weekend + the monday is a leave
+        self.assertAlmostEqual(production.date_finished, datetime(2024, 1, 9, 14, 0, 0), delta=timedelta(seconds=2))
+
+
     def test_workorders_without_worcenter_planned_slots(self):
         """
         Test that updating a workorder duration does not crash when others are unplanned.

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta
+from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.tests import Form
@@ -980,6 +981,7 @@ class TestProcurement(TestMrpCommon):
         self.assertRecordValues(mo.move_raw_ids, expected_vals)
         self.assertRecordValues(mo.picking_ids.move_ids, expected_vals)
 
+    @freeze_time("2025-11-3")
     def test_consecutive_pickings(self):
         """ Test that when we generate several procurements for a product in a raw
             we do not create demand for the same quantities several times """
@@ -1040,17 +1042,17 @@ class TestProcurement(TestMrpCommon):
                     'location_dest_id': self.env.ref('stock.stock_location_customers').id,
                     'name': 'picking move',
                     'product_id': product_1.id,
-                    'product_uom_qty': 15,
+                    'product_uom_qty': 8,
                     'product_uom': self.uom_unit.id,
                 })],
             })
             picking.action_confirm()
             if not mo:
                 mo = self.env['mrp.production'].search([('product_id', '=', product_1.id)])
-            self.assertEqual(delta_hours(mo.date_finished - mo.date_start), i * 15)
+            self.assertEqual(delta_hours(mo.date_finished - mo.date_start), i * 24)
 
         # Check the generated MO
-        self.assertEqual(mo.product_qty, 45)
+        self.assertEqual(mo.product_qty, 24)
 
     def test_update_mo_producing_qty_with_mtso_rule_and_some_available_stock(self):
         """


### PR DESCRIPTION
**Issue**
The scheduled end date of a manufacturing order incorrectly assumes that the work center operates 24 hours a day.

**Steps to reproduce**
1. Create a manufacturing order with:
   - A work order with an expected duration of 1440 minutes.
   - A work center configured to work 8 hours per day.
2. Observe that the scheduled end date is computed as if the work center operates 24h/day resulting in an end date 1 day instead of 4 after the starting date.

**Cause**
The `date_finish` computation:
https://github.com/odoo/odoo/blob/680085b55728dcb000e7bb4277bb83b0e4e2ce91/addons/mrp/models/mrp_production.py#L745C1-L746C105
does not take into account neither the work center’s calendar nor the workorder dependency when estimating the duration.

**Solution**
Use `_get_first_available_slot`:
https://github.com/odoo/odoo/blob/5d75037d4f81d71a50394c3d390c420967766731/addons/mrp/models/mrp_workcenter.py#L332
to consider workcenter availability, inspired from when a workorder is planned:
https://github.com/odoo/odoo/blob/5d75037d4f81d71a50394c3d390c420967766731/addons/mrp/models/mrp_workorder.py#L527
**Additionnal notes**
- If a workcenter of at least one workorder is unavailable, just fallback on the previous computation.
- The solution does not take workorder dependencies into account due to related technical limitation see https://github.com/odoo/odoo/pull/232805 for an earlier attempt to handle dependencies.
- Our test rely on the assertAlmostEqual for the same reason than https://github.com/odoo/odoo/commit/e6c958ca226bd8ef7e518243c93e40b92b9b5919

opw-[5084120](https://www.odoo.com/web#id=5084120&view_type=form&model=project.task)