### PR TITLE
[18.0][FIX] mrp: Correct assignment of components in batch produce wizard

### DIFF
--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -108,7 +108,7 @@ class MrpBatchProduct(models.TransientModel):
         lots = lots + self.env['stock.lot'].create(raw_lots)
 
         productions_to_set = OrderedSet()
-        productions.move_raw_ids.move_line_ids.unlink()
+        productions.move_raw_ids.move_line_ids.filtered(lambda ml: ml.product_id.tracking != "none").unlink()
         for production, finished_lot in zip(productions, lots):
             production.lot_producing_id = finished_lot
             self._process_components(production, components_list.pop(0))

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -108,6 +108,7 @@ class MrpBatchProduct(models.TransientModel):
         lots = lots + self.env['stock.lot'].create(raw_lots)
 
         productions_to_set = OrderedSet()
+        productions.move_raw_ids.move_line_ids.unlink()
         for production, finished_lot in zip(productions, lots):
             production.lot_producing_id = finished_lot
             self._process_components(production, components_list.pop(0))
@@ -150,8 +151,6 @@ class MrpBatchProduct(models.TransientModel):
         lots = {(l.name, l.product_id): l for  l in self.env['stock.lot'].search([('name', 'in', lot_names)])}
         mls_vals = []
         for move, mls in moves_vals.items():
-            if mls:
-                move.move_line_ids.unlink()
             for qty, lot_name in mls:
                 ml_vals = self._prepapre_move_line_vals(move, qty, lot_name, lots)
                 mls_vals.append(ml_vals)

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -108,7 +108,10 @@ class MrpBatchProduct(models.TransientModel):
         lots = lots + self.env['stock.lot'].create(raw_lots)
 
         productions_to_set = OrderedSet()
-        productions.move_raw_ids.move_line_ids.filtered(lambda ml: ml.product_id.tracking != "none").unlink()
+        # If components lots are defined in the wizard, remove any reservation
+        #  to assign the lots properly when processing components
+        if any(comps for comps in components_list):
+            productions.move_raw_ids.move_line_ids.filtered(lambda ml: ml.product_id.tracking != "none").unlink()
         for production, finished_lot in zip(productions, lots):
             production.lot_producing_id = finished_lot
             self._process_components(production, components_list.pop(0))

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -8,6 +8,7 @@ from collections import defaultdict, deque
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import OrderedSet
+from odoo.tools.float_utils import float_compare
 
 
 class MrpBatchProduct(models.TransientModel):
@@ -150,25 +151,32 @@ class MrpBatchProduct(models.TransientModel):
         mls_vals = []
         for move, mls in moves_vals.items():
             if mls:
-                mls_to_unlink |= set(move.move_line_ids.ids)
+                move.move_line_ids.unlink()
             for qty, lot_name in mls:
                 ml_vals = self._prepapre_move_line_vals(move, qty, lot_name, lots)
                 mls_vals.append(ml_vals)
-        self.env['stock.move.line'].browse(mls_to_unlink).unlink()
         self.env['stock.move.line'].create(mls_vals)
 
     def _prepapre_move_line_vals(self, move, qty, lot_name, lots):
-        ml_vals = move._prepare_move_line_vals(qty)
         lot = lots.get((lot_name, move.product_id))
-        if not lot:
-            if not move.picking_type_id.use_create_components_lots:
-                raise UserError(_('Lot %s does not exist.', lot_name))
-            lot = self.env['stock.lot'].create({
-                'name': lot_name,
-                'product_id': move.product_id.id
-            })
-            lots[(lot_name, move.product_id)] = lot
-        ml_vals['lot_id'] = lots[(lot_name, move.product_id)].id
+        ml_vals = {}
+        if lot:
+            quants = self.env["stock.quant"].sudo()._gather(move.product_id, move.location_id, lot_id=lot, strict=False)
+            available_quantity = quants._get_available_quantity(
+                move.product_id, move.location_id, lot, self.env["stock.quant.package"], self.env['res.partner'], strict=False
+            )
+            if float_compare(available_quantity, qty, precision_rounding=move.product_uom.rounding) >= 0:
+                ml_vals = move._update_reserved_quantity_vals(qty, move.location_id, lot_id=lot, strict=False)[0][0]
+        if not ml_vals:
+            ml_vals = move._prepare_move_line_vals(qty)
+            if not lot:
+                if not move.picking_type_id.use_create_components_lots:
+                    raise UserError(_('Lot %s does not exist.', lot_name))
+                lot = self.env['stock.lot'].create({
+                    'name': lot_name,
+                    'product_id': move.product_id.id
+                })
+            ml_vals['lot_id'] = lot.id
         return ml_vals
 
     def _get_lot_and_qty(self, move, text):


### PR DESCRIPTION
Currently, after splitting order through the batch produce wizard, if components were reserved in a sub location, same components are then picked from stock location.

How to reproduce:
- Create a component and a finished product tracked by serial
- Add components products in a sublocation of stock
- Create a manufacturing order for multiple pieces of finished product
- After confirming the MO and assigning the components moves, the pieces are reserved in the sublocation of the stock
- Split the MO by providing a serial numbers mapping using the batch produce wizard

Result: The components move now are using the Stock as source location.

If the MOs are confirmed without fixing this, we would have -1 quantity on the stock location and the component still available in the sub location for reservations.

This happens because the batch producing wizard did not respect the stock move assignation mechanism and was blindly creating stock move lines based on the lot numbers provided in the serial mapping.

After this commit, instead of collecting the move lines to be deleted on the original MO and to remove them at once after preparing the new move lines to create on the split MOs, we delete these move lines to remove their stock reservation before we prepare the new move lines.

This way, instead of creating blindly the move lines, we can try to reserve again the serial number that was provided in the mapping, since its reservation was just lifted by deleting the original move line. This will ensure the correct sub location will be used on the new move line, as it's the same process that happens when assigning the move in the first place. And in case we cannot reserve, we can still create the move line as it used to be done to avoid breaking anything.

OPW-5128162


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
