### PR TITLE
[FIX] account: distribute tax delta on net zero tax total

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1688,7 +1688,7 @@ class AccountTax(models.Model):
                 total_tax_amount = values[f'tax_amount{delta_currency_indicator}']
                 delta_total_tax_amount = rounded_raw_total_tax_amount - total_tax_amount
 
-                if raw_total_tax_amount:
+                if not delta_currency.is_zero(delta_total_tax_amount):
                     target_factors = [
                         {
                             'factor': tax_data[f'raw_tax_amount{delta_currency_indicator}'],
@@ -1718,7 +1718,7 @@ class AccountTax(models.Model):
                     total_base_amount = values[f'base_amount{delta_currency_indicator}']
                     delta_total_base_amount = rounded_raw_total_base_amount - total_base_amount
 
-                if raw_total_base_amount:
+                if not delta_currency.is_zero(delta_total_base_amount):
                     target_factors = [
                         {
                             'factor': tax_data[f'raw_base_amount{delta_currency_indicator}'],

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -764,7 +764,7 @@ export const accountTaxHelpers = {
                 const total_tax_amount = values[`tax_amount${delta_currency_indicator}`];
                 const delta_total_tax_amount = rounded_raw_total_tax_amount - total_tax_amount;
 
-                if (raw_total_tax_amount) {
+                if (!floatIsZero(delta_total_tax_amount, delta_currency.decimal_places)) {
                     const target_factors = values.base_line_x_taxes_data.flatMap(
                         ([_, taxes_data]) =>
                             taxes_data.map((tax_data) => ({
@@ -811,7 +811,7 @@ export const accountTaxHelpers = {
                     delta_total_base_amount = rounded_raw_total_base_amount - total_base_amount;
                 }
 
-                if (raw_total_base_amount) {
+                if (!floatIsZero(delta_total_base_amount, delta_currency.decimal_places)) {
                     const target_factors = values.base_line_x_taxes_data.flatMap(
                         ([_, taxes_data]) =>
                             taxes_data.map((tax_data) => ({

--- a/addons/account/tests/test_taxes_base_lines_tax_details.py
+++ b/addons/account/tests/test_taxes_base_lines_tax_details.py
@@ -4,11 +4,17 @@ from odoo.tests import tagged
 
 @tagged('post_install', '-at_install')
 class TestTaxesBaseLinesTaxDetails(TestTaxCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env.company.tax_calculation_rounding_method = 'round_globally'
+
     def test_dispatch_delta_on_base_lines(self):
         """ Make sure that the base line delta is dispatched evenly on base lines.
         Needed for BIS3 rule PEPPOL-EN16931-R120.
         """
-        self.env.company.tax_calculation_rounding_method = 'round_globally'
         tax_21 = self.percent_tax(21.0)
         document = self.populate_document(self.init_document(
             lines=[
@@ -87,3 +93,70 @@ class TestTaxesBaseLinesTaxDetails(TestTaxCommon):
         }
 
         self.assert_base_lines_tax_details(document, expected_values)
+
+    def test_dispatch_delta_on_net_zero_tax(self):
+        """Check that the base line delta still is dispatched if net tax is zero."""
+        def get_expected_values(base_values, tax):
+            expected_tax_total = sum(values[2] for values in base_expected_values)
+            self.assertTrue(
+                tax.company_id.currency_id.is_zero(expected_tax_total),
+                "Expected taxes should add up to zero.",
+            )
+            return {
+                'base_lines_tax_details': [{
+                    'delta_total_excluded': 0.0,
+                    'delta_total_excluded_currency': 0.0,
+                    'total_excluded': total_excluded,
+                    'total_excluded_currency': total_excluded,
+                    'total_included': total_included,
+                    'total_included_currency': total_included,
+                    'taxes_data': [{
+                        'base_amount': total_excluded,
+                        'base_amount_currency': total_excluded,
+                        'tax_amount': tax_amount,
+                        'tax_amount_currency': tax_amount,
+                        'tax_id': tax.id,
+                    }],
+                } for total_excluded, total_included, tax_amount in base_values],
+            }
+
+        with self.subTest("19.99% tax, 100% global discount"):
+            tax_19_99 = self.percent_tax(19.99)
+            lines_vals = [{
+                'price_unit': price,
+                'quantity': 1,
+                'tax_ids': tax_19_99,
+            } for price in (19.99, 19.99, -39.98)]
+            document = self.populate_document(self.init_document(lines_vals))
+
+            base_expected_values = [
+            #   (total_excluded, total_included, tax_amount),
+                (19.99, 23.99, 4.0),
+                (19.99, 23.99, 4.0),
+                (-39.98, -47.97, -8.0),
+            ]
+            expected_values = get_expected_values(base_expected_values, tax_19_99)
+            self.assert_base_lines_tax_details(document, expected_values)
+
+        with self.subTest("7% tax, 30% line discount, 100% global discount"):
+            tax_7 = self.percent_tax(7.0)
+            lines_vals = [{
+                'price_unit': price,
+                'quantity': 4,
+                'discount': 30,
+                'tax_ids': tax_7,
+            } for price in (1068, 46, 46, 298, 5)]
+            lines_vals.append({'price_unit': -4096.4, 'tax_ids': tax_7})  # 100% discount
+            document = self.populate_document(self.init_document(lines_vals))
+
+            base_expected_values = [
+            #   (total_excluded, total_included, tax_amount),
+                (2990.4, 3199.73, 209.33),
+                (128.8, 137.82000000000002, 9.02),
+                (128.8, 137.82000000000002, 9.02),
+                (834.4, 892.81, 58.41),
+                (14.0, 14.98, 0.98),
+                (-4096.4, -4383.15, -286.76),
+            ]
+            expected_values = get_expected_values(base_expected_values, tax_7)
+            self.assert_base_lines_tax_details(document, expected_values)


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Set tax rounding to "Round Globally";
2. create a 19.99% tax;
3. create a new sales order;
4. add a line with a $19.99 unit price & 19.99% tax;
5. add a second line with identical values;
6. apply a 100% global discount (-$38.98 subtotal, -$47.97 total).

Issue
-----
The order total is $0.01 due to VAT.

Cause
-----
The `_round_tax_details_tax_amounts` method distributes the "tax delta" across the tax details, but currently it only does this if there's a non-zero target tax amount.

In our scenario, we have a $0.01 tax delta, but because our tax total is $0.00 due to the 100% discount, the delta doesn't get distributed, leading to the $0.01 difference not getting corrected.

Solution
--------
When deciding whether to distribute a tax delta, check the tax delta value instead of the target tax amount.

opw-5345538
opw-5097907