### PR TITLE
[FIX] mail: better visibility of chat bubble unread indicator

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
         <div class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'o-active': popover.isOpen, 'o-mobile': isMobileOS }" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
-            <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
+            <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
             <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
             <ImStatus t-if="showImStatus" className="'o-mail-ChatBubble-status position-absolute'" member="thread.correspondent">


### PR DESCRIPTION
Unread indicator in discuss sidebar have been adapted [1] but chat bubble didn't had the visual improvement, which this commit fixes.

[1]: https://github.com/odoo/odoo/pull/224553

Before / After

<img width="80" height="72" alt="Screenshot 2025-12-18 at 19 56 45" src="https://github.com/user-attachments/assets/9413ca16-0476-4547-82ad-1460366edf52" /> <img width="84" height="68" alt="Screenshot 2025-12-18 at 19 57 04" src="https://github.com/user-attachments/assets/4dcfc283-88b6-4e96-b8c7-5342d615fd2c" />
