### PR TITLE
[FIX] l10n_*: render info correctly in report

### DIFF
--- a/addons/l10n_ca/views/report_template.xml
+++ b/addons/l10n_ca/views/report_template.xml
@@ -8,13 +8,13 @@
 
     <template id="l10n_ca_external_layout_standard" inherit_id="web.company_address_list">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <t t-if="pst_external_layout" t-call="l10n_ca.pst_external_layout"/>
+            <t t-if="not hide_pst_in_address_list" t-call="l10n_ca.pst_external_layout"/>
         </xpath>
     </template>
 
     <template id="l10n_ca_external_layout_folder" inherit_id="web.external_layout_folder">
         <xpath expr="//t[@t-call='web.company_address_list']" position="before">
-            <t t-set="pst_external_layout" t-value="False"/>
+            <t t-set="hide_pst_in_address_list" t-value="True"/>
         </xpath>
         <xpath expr="//div[hasclass('o_folder_company_info')]" position="after">
             <div t-if="company.account_fiscal_country_id.code == 'CA' and company.l10n_ca_pst">

--- a/addons/l10n_cz/views/report_template.xml
+++ b/addons/l10n_cz/views/report_template.xml
@@ -13,13 +13,13 @@
 
     <template id="l10n_cz_external_layout_standard" inherit_id="web.company_address_list">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <t t-if="registry_vat_external_layout" t-call="l10n_cz.registry_vat_external_layout"/>
+            <t t-if="not hide_registry_vat" t-call="l10n_cz.registry_vat_external_layout"/>
         </xpath>
     </template>
 
     <template id="l10n_cz_external_layout_folder" inherit_id="web.external_layout_folder">
         <xpath expr="//t[@t-call='web.company_address_list']" position="before">
-            <t t-set="registry_vat_external_layout" t-value="False"/>
+            <t t-set="hide_registry_vat" t-value="True"/>
         </xpath>
         <xpath expr="//div[hasclass('o_folder_company_info')]" position="after">
             <div t-if="company.company_registry and company.account_fiscal_country_id.code == 'CZ'">

--- a/addons/l10n_my_ubl_pint/views/report_invoice.xml
+++ b/addons/l10n_my_ubl_pint/views/report_invoice.xml
@@ -13,13 +13,13 @@
     <!-- Add the SST and TTx to the company -->
     <template id="l10n_my_ubl_pint_external_layout_standard" inherit_id="web.company_address_list">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <t t-if="sst_ttx_registration_number_external_layout" t-call="l10n_my_ubl_pint.sst_ttx_registration_number_external_layout"/>
+            <t t-if="not hide_sst_ttx_registration_number" t-call="l10n_my_ubl_pint.sst_ttx_registration_number_external_layout"/>
         </xpath>
     </template>
 
     <template id="l10n_my_ubl_pint_external_layout_folder" inherit_id="web.external_layout_folder">
         <xpath expr="//t[@t-call='web.company_address_list']" position="before">
-            <t t-set="sst_ttx_registration_number_external_layout" t-value="False"/>
+            <t t-set="hide_sst_ttx_registration_number" t-value="True"/>
         </xpath>
         <xpath expr="//div[hasclass('o_folder_company_info')]" position="after">
             <div t-if="company.sst_registration_number and company.account_fiscal_country_id.code == 'MY'">

--- a/addons/l10n_sk/views/report_template.xml
+++ b/addons/l10n_sk/views/report_template.xml
@@ -16,13 +16,13 @@
 
     <template id="l10n_sk_external_layout_standard" inherit_id="web.company_address_list">
         <xpath expr="//ul[@name='company_address_list']" position="inside">
-            <t t-if="vat_registry_tax_id_external_layout" t-call="l10n_sk.vat_registry_tax_id_external_layout"/>
+            <t t-if="not hide_vat_registry_tax_id" t-call="l10n_sk.vat_registry_tax_id_external_layout"/>
         </xpath>
     </template>
 
     <template id="l10n_sk_external_layout_folder" inherit_id="web.external_layout_folder">
         <xpath expr="//t[@t-call='web.company_address_list']" position="before">
-            <t t-set="vat_registry_tax_id_external_layout" t-value="False"/>
+            <t t-set="hide_vat_registry_tax_id" t-value="True"/>
         </xpath>
         <xpath expr="//div[hasclass('o_folder_company_info')]" position="after">
             <div t-if="company.company_registry and company.account_fiscal_country_id.code == 'SK'">


### PR DESCRIPTION
*: l10n_ca, l10n_cz, l10n_sk, l10n_my_ubl_pint

In multiple l10n the condition rendering the PST, VAT, SSTX  is always
false. The template should not render only in the folder layout. The
condition is inverted.

follow-up-4916379 (https://github.com/odoo/odoo/commit/fa55c2d1ca5db203ffaa13e10e4e4209717b7a6d)
task-5429809


| Expected result all | Expected result folder |
|--------|--------|
| <img width="605" height="834" alt="image" src="https://github.com/user-attachments/assets/81e7fe91-b29e-417b-bfc5-9eb19abec19b" /> | <img width="584" height="823" alt="image" src="https://github.com/user-attachments/assets/507a8d85-1f35-498e-889b-aabc8c64c7ca" /> | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
