### PR TITLE
[FIX] mail: correct position for 'Add to Favorites' thread action

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -72,8 +72,8 @@ registerThreadAction("add-to-favorites", {
             { readonly: false, silent: false }
         );
     },
-    sequence: 5, // before notification-settings
-    sequenceGroup: 30,
+    sequence: 40,
+    sequenceGroup: 20,
 });
 registerThreadAction("remove-from-favorites", {
     /**
@@ -96,8 +96,8 @@ registerThreadAction("remove-from-favorites", {
             { readonly: false, silent: false }
         );
     },
-    sequence: 5, // before notification-settings
-    sequenceGroup: 30,
+    sequence: 40,
+    sequenceGroup: 20,
 });
 registerThreadAction("notification-settings", {
     actionPanelClose: ({ action }) => action.popover?.close(),

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -17,7 +17,7 @@ import {
 import { toRawValue } from "@mail/utils/common/local_storage";
 import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
 import { makeRecordFieldLocalId } from "@mail/model/misc";
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test, waitFor } from "@odoo/hoot";
 import { animationFrame, drag, press, queryFirst } from "@odoo/hoot-dom";
 import { Deferred, mockDate } from "@odoo/hoot-mock";
 import { Command, getService, onRpc, serverState } from "@web/../tests/web_test_helpers";
@@ -26,6 +26,7 @@ import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { rpc } from "@web/core/network/rpc";
 import { getOrigin } from "@web/core/utils/urls";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -287,7 +288,20 @@ test("sidebar: basic chat rendering", async () => {
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Demo')");
     await contains(".o-mail-DiscussSidebarChannel img[alt='Thread Image']");
     await click("[title='Chat Actions']");
-    await contains(".o-dropdown-item:text('Hide Until New Message')");
+    await waitFor(".o-dropdown-item:count(7)", { timeout: 3000 });
+    await waitFor(".o-mail-ActionList-group:count(4)");
+    const group = range(0, 4).map((i) => `.o-mail-ActionList-group:eq(${i})`);
+    await waitFor(`${group[0]} .o-dropdown-item:count(2)`);
+    await waitFor(`${group[0]} .o-dropdown-item:eq(0):text('Start Video Call')`);
+    await waitFor(`${group[0]} .o-dropdown-item:eq(1):text('Start Call')`);
+    await waitFor(`${group[1]} .o-dropdown-item:count(2)`);
+    await waitFor(`${group[1]} .o-dropdown-item:eq(0):text('Invite People')`);
+    await waitFor(`${group[1]} .o-dropdown-item:eq(1):text('Add to Favorites')`);
+    await waitFor(`${group[2]} .o-dropdown-item:count(2)`);
+    await waitFor(`${group[2]} .o-dropdown-item:eq(0):text('Notification Settings')`);
+    await waitFor(`${group[2]} .o-dropdown-item:eq(1):text('Advanced Settings')`);
+    await waitFor(`${group[3]} .o-dropdown-item:count(1)`);
+    await waitFor(`${group[3]} .o-dropdown-item:text('Hide Until New Message')`);
     await contains(".o-mail-DiscussSidebarChannel .badge", { count: 0 });
 });
 


### PR DESCRIPTION
This was placed with the settings action when this is not a "settings" action.

While the overall position is ok for this action, this shouldn't be in the same group as "settings" because this is not a "settings" action. By being in the wrong group, the separator doesn't group the settings actions together as it should.

This commit fixes the issue by moving this action to the previous group as the last item, so that this before the separator.

Task-5429921

<img width="181" height="281" alt="Screenshot 2025-12-18 at 20 25 38" src="https://github.com/user-attachments/assets/c994a7ec-7902-489f-8e34-5b5aea66738f" /> <img width="185" height="282" alt="Screenshot 2025-12-18 at 20 25 15" src="https://github.com/user-attachments/assets/2b19309c-6cb9-4736-860c-a52401708f3f" />
