### PR TITLE
[IMP] account: layout break when tax group name is too long

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.xml
+++ b/addons/account/static/src/components/tax_totals/tax_totals.xml
@@ -4,7 +4,7 @@
     <t t-name="account.TaxGroupComponent">
         <tr>
             <td class="o_td_label">
-                <label class="o_form_label o_tax_total_label" t-out="props.taxGroup.tax_group_name"/>
+                <label class="o_form_label o_tax_total_label text-wrap" t-out="props.taxGroup.tax_group_name"/>
             </td>
 
             <td  class="o_tax_group">


### PR DESCRIPTION
When tax group names or tax-related content are too long, they break
the layout of the tax totals component, causing display issues and
making the interface difficult to read.

This change adds the Bootstrap `text-wrap` class to the tax group label
to enable text wrapping, ensuring that long content is properly
contained within the table cell and the layout remains intact.

The `text-wrap` utility class applies `word-wrap: break-word` and
`word-break: break-word`, which allows long text to wrap to multiple
lines instead of overflowing and breaking the table layout.

Before:

<img width="1920" height="868" alt="image" src="https://github.com/user-attachments/assets/cdf770ca-a586-487e-9283-45463ef4dc0e" />


After
<img width="1920" height="793" alt="image" src="https://github.com/user-attachments/assets/24b9781c-d209-4a69-824c-13a59a8c9bc7" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
