### PR TITLE
[FIX] account: quitar active_test: False del contexto en vista view_account_invoice_filter

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1290,10 +1290,9 @@
                                 '|', '|' , '|', '|',
                                 ('name', 'ilike', self), ('invoice_origin', 'ilike', self),
                                 ('ref', 'ilike', self), ('payment_reference', 'ilike', self),
-                                ('partner_id', 'child_of', self)]"
-                            context="{'active_test': False}"/>
+                                ('partner_id', 'child_of', self)]"/>
                     <field name="journal_id"/>
-                    <field name="partner_id" operator="child_of" context="{'active_test': False}" />
+                    <field name="partner_id" operator="child_of"/>
                     <field name="invoice_user_id" string="Salesperson" domain="[('share', '=', False)]" />
                     <field name="date" string="Period"/>
                     <field name="line_ids" string="Invoice Line"/>


### PR DESCRIPTION
El inconveniente se genera con este pr https://github.com/odoo/odoo/pull/218151

Necesitamos quitar active_test: False del contexto en vista view_account_invoice_filter sino nos calcula retenciones y crea alícuotas en contacto conectándose a arba/caba en casos en los cuales no corresponde porque el impuesto se encuentra archivado. De esta manera cuando llega a esta línea de código https://github.com/ingadhoc/account-payment/blob/16.0/account_withholding_automatic/models/account_payment_group.py#L90 no llega con el context active_test: False.
Ticket: 106338

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
