### PR TITLE
[FIX] marketing_automation: add correct lang context when running cron

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -104,7 +104,7 @@ class ir_cron(models.Model):
         for cron in self:
             cron._try_lock()
             _logger.info('Manually starting job `%s`.', cron.name)
-            cron.with_user(cron.user_id).with_context({'lastcall': cron.lastcall}).ir_actions_server_id.run()
+            cron.with_user(cron.user_id).with_context({'lastcall': cron.lastcall}).ir_actions_server_id.with_context(lang=self.env.user.lang).run()
             self.env.flush_all()
             _logger.info('Job `%s` done.', cron.name)
             cron.lastcall = fields.Datetime.now()
@@ -390,7 +390,7 @@ class ir_cron(models.Model):
             odoo.netsvc.log(_logger, logging.DEBUG, 'cron.object.execute', (self._cr.dbname, self._uid, '*', cron_name, server_action_id), depth=log_depth)
             _logger.info('Starting job `%s`.', cron_name)
             start_time = time.time()
-            self.env['ir.actions.server'].browse(server_action_id).run()
+            self.env['ir.actions.server'].browse(server_action_id).with_context(lang=self.env.user.lang).run()
             self.env.flush_all()
             end_time = time.time()
             _logger.info('Job done: `%s` (%.3fs).', cron_name, end_time - start_time)


### PR DESCRIPTION
We have a dynamic placeholder in the marketing automation's mail template like object.title.name. Odoobot's preferred language is, let's say "Dutch".

When the marketing automation is tested manually, with the user whose language is "Dutch", the field is translated fine. But when ran vai cron,"Marketing Automation: execute activities", the field isn't translated properly, because the context with lang Dutch gets overwritten earlier in the process.

To fix this, we add a lang context right before the execution.

Step To Reproduce:
1.Create a marketing automation.
2.In the mail template, add a dynamic placeholder with field object.title.name. 3.Switch the Odoobot's preferred language to anything but English. But here let's say "Dutch". 4.Now, switch to superuser, and then run the cron
manually.
5.We can see that the title didn't get translated
properly.

opw-5062328