### PR TITLE
[IMP] pos_{,l10n_gcc_pos}: hide tax invoice title on basic receipt

### DIFF
--- a/addons/l10n_gcc_pos/__manifest__.py
+++ b/addons/l10n_gcc_pos/__manifest__.py
@@ -15,7 +15,10 @@ Adds Arabic as a secondary language on your receipt
     'assets': {
         'point_of_sale._assets_pos': [
             'l10n_gcc_pos/static/src/**/*',
-        ]
+        ],
+        'web.assets_tests': [
+            'l10n_gcc_pos/static/tests/**/*',
+        ],
     },
     'auto_install': True,
 }

--- a/addons/l10n_gcc_pos/receipt/pos_order_receipt.xml
+++ b/addons/l10n_gcc_pos/receipt/pos_order_receipt.xml
@@ -17,8 +17,8 @@
             <div name="cashier_name" position="after">
                 <t t-set="show_title" t-value="false"/>
                 <t t-set="show_simplified_title" t-value="false"/>
-                <t t-if="conditions.get('l10n_gcc_dual_language_receipt') and show_title">
-                    <div class="text-center">
+                <t t-if="conditions.get('l10n_gcc_dual_language_receipt') and show_title and not conditions['basic_receipt']">
+                    <div class="pos-receipt-header text-center">
                         <t t-if="not show_simplified_title">
                             <t t-if="conditions.get('l10n_gcc_dual_language_receipt')">
                                 <span id="title_en">Tax Invoice</span>

--- a/addons/l10n_gcc_pos/static/tests/pos/tours/gcc_receipt_header_tour.js
+++ b/addons/l10n_gcc_pos/static/tests/pos/tours/gcc_receipt_header_tour.js
@@ -1,0 +1,57 @@
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_gcc_basic_receipt_title_hidden", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            FeedbackScreen.isShown(),
+            FeedbackScreen.checkTicketData(
+                {
+                    orderlines: [
+                        {
+                            name: "Whiteboard Pen",
+                            quantity: "1",
+                        },
+                    ],
+                    total_amount: 3.68,
+                    cssRules: [
+                        {
+                            css: ".pos-receipt-header",
+                            text: "Simplified Tax Invoice / فاتورة ضريبية مبسطة",
+                            negation: false,
+                        },
+                    ],
+                },
+                false // normal receipt mode
+            ),
+            FeedbackScreen.checkTicketData(
+                {
+                    orderlines: [
+                        {
+                            name: "Whiteboard Pen",
+                            quantity: "1",
+                        },
+                    ],
+                    cssRules: [
+                        {
+                            css: ".pos-receipt-header",
+                            text: "Simplified Tax Invoice / فاتورة ضريبية مبسطة",
+                            negation: true,
+                        },
+                    ],
+                },
+                true // basic receipt mode
+            ),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/l10n_gcc_pos/tests/test_gcc_pos.py
+++ b/addons/l10n_gcc_pos/tests/test_gcc_pos.py
@@ -39,3 +39,12 @@ class TestGenericGCC(TestGenericLocalization):
         self.assertTrue("Total / اﻹجمالي" in html)
         self.assertTrue("Discount / الخصومات" in html)
         self.assertTrue("Change / الباقي" in html)
+
+    def test_gcc_basic_receipt_title_hidden(self):
+        """check the tax invoice title is hidden on basic receipts for GCC region """
+        self.main_pos_config.write({
+            'basic_receipt': True,
+            'l10n_gcc_dual_language_receipt': True,
+        })
+        self.main_pos_config.open_ui()
+        self.start_pos_tour("test_gcc_basic_receipt_title_hidden")


### PR DESCRIPTION
Before this commit:
----------
- Basic receipt displayed "Tax Invoice / Simplified Tax Invoice" even though
  prices and tax amounts are not shown.


After this commit:
----------------
- Hide tax invoice titles on basic receipts in GCC region pos.
  specific logic and preventing “Tax Invoice / Simplified Tax Invoice”
  from appearing.

Task-5406905
