### PR TITLE
[IMP] pos_loyalty: increase coupon barcode size on receipt

### DIFF
--- a/addons/pos_loyalty/static/src/app/components/receipt/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/app/components/receipt/order_receipt/order_receipt.xml
@@ -32,10 +32,10 @@
                     <t t-foreach="order.new_coupon_info" t-as="coupon_info" t-key="coupon_info.code">
                         <div class="coupon-container">
                             <div class="row g-2">
-                                <div class="col-6">
+                                <div class="col-4">
                                     <t t-out="coupon_info['program_name']"/>
                                 </div>
-                                <div class="col-6">
+                                <div class="col-8">
                                     <img style="transform: translateX(13%);" t-att-src="'/report/barcode/Code128/'+coupon_info['code']" class="img-fluid" alt="Barcode"/>
                                 </div>
                                 <div class="col-6">


### PR DESCRIPTION
In this commit,
Increased the coupon code barcode size on the receipt to improve readability and scanning reliability.

Task-5406988



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
