### PR TITLE
[FIX] mail: restore composer focus when replying to a note

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -99,6 +99,9 @@ registerMessageAction("reply-to", {
             }
         }
         owner.env.inChatter?.toggleComposer("note", { force: true });
+        if (!composer.isFocused) {
+            composer.autofocus++;
+        }
     },
     sequence: ({ message, store, thread }) =>
         thread?.eq(store.inbox) || message.isSelfAuthored ? 55 : 20,


### PR DESCRIPTION
**Current behavior before PR:**
When the composer is already open, clicking reply on a note does not refocus the composer. The user must manually click inside the composer before typing.

**Desired behavior after PR is merged:**
When clicking reply on a note, the composer is automatically focused, even if it was already open, allowing the user to continue typing immediately.

task-[5410878](https://www.odoo.com/odoo/project/1519/tasks/5410878)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
