### PR TITLE
[FIX] pos_sale_margin: fix margin calculation

### DIFF
--- a/addons/pos_sale_margin/report/sale_report.py
+++ b/addons/pos_sale_margin/report/sale_report.py
@@ -9,5 +9,5 @@ class SaleReport(models.Model):
 
     def _fill_pos_fields(self, additional_fields):
         values = super()._fill_pos_fields(additional_fields)
-        values['margin'] = 'SUM(l.price_subtotal - COALESCE(l.total_cost,0) / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END)'
+        values['margin'] = 'SUM((l.price_subtotal - COALESCE(l.total_cost,0)) / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END)'
         return values


### PR DESCRIPTION
Step to reproduce:
- create new journal and a pricelist with different currency (TWD)
- set that pricelist and journal in a pos
- have a product with sales(1000$) and cost price(300$)
- create pos and finalize the order with that product
- go to sales > reporting > sales > pivot view
- check margin for that order

Observation:
- the margin is calculated wrong due to improper brackets
- current calculation (for TWD pricelist, multiply with currency rate i.e 36.833) sale price - ( cost price / currency rate)
i.e. `1000 * 36.833 - (300* 36.833 / 36.833) = 36833 - 300 = 36533`

Fix:
- fixed the calculation, used brackets
- actual calculation
- `(1000 * 36.833 - 300 * 36.833) / 36.833 = 1000 - 300 = 700`

Note: Backkport of #239407
opw-5166714

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
