### PR TITLE
[IMP] mail: reword invitation text to 'Invite to Meeting' for meetings

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -238,11 +238,14 @@ export class ChannelInvitation extends Component {
         if (!this.props.channel) {
             return "";
         }
-        if (this.props.channel?.channel_type === "channel") {
+        if (this.props.channel.default_display_mode === "video_full_screen") {
+            return _t("Invite to Meeting");
+        }
+        if (this.props.channel.channel_type === "channel") {
             return _t("Invite");
-        } else if (this.props.channel?.channel_type === "group") {
+        } else if (this.props.channel.channel_type === "group") {
             return _t("Invite to Group Chat");
-        } else if (this.props.channel?.channel_type === "chat") {
+        } else if (this.props.channel.channel_type === "chat") {
             if (this.props.channel.correspondent?.persona.eq(this.store.self)) {
                 if (this.selectedPartners.length === 0) {
                     return _t("Invite");

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -360,7 +360,7 @@ test("'New Meeting' in mobile", async () => {
     await click("button:text('Chats')");
     await click("button[title='New Meeting']");
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Partner 2'))");
-    await click("button:not([disabled]):text('Invite to Group Chat')");
+    await click("button:not([disabled]):text('Invite to Meeting')");
     await contains(".o-discuss-Call");
     await click("[title='Exit Fullscreen']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1120,7 +1120,11 @@ function _process_request_for_all(store, name, params, context = {}) {
         store.resolve_data_request({ channel: mailDataHelpers.Store.one(channelId) });
     }
     if (name === "/discuss/create_group") {
-        const channelId = DiscussChannel._create_group(params.partners_to, params.name);
+        const channelId = DiscussChannel._create_group(
+            params.partners_to,
+            params.default_display_mode,
+            params.name
+        );
         store.resolve_data_request({ channel: mailDataHelpers.Store.one(channelId) });
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -560,11 +560,13 @@ export class DiscussChannel extends models.ServerModel {
 
     /**
      * @param {number[]} partners_to
+     * @param {boolean} default_display_mode
      * @param {string} name
      * */
-    _create_group(partners_to, name) {
-        const kwargs = getKwArgs(arguments, "partners_to", "name");
+    _create_group(partners_to, default_display_mode, name) {
+        const kwargs = getKwArgs(arguments, "partners_to", "default_display_mode", "name");
         partners_to = kwargs.partners_to || [];
+        default_display_mode = kwargs.default_display_mode || false;
         name = kwargs.name || "";
 
         /** @type {import("mock_models").DiscussChannel} */
@@ -578,6 +580,7 @@ export class DiscussChannel extends models.ServerModel {
             channel_member_ids: partners.map((partner) =>
                 Command.create({ partner_id: partner.id })
             ),
+            default_display_mode,
             name,
         });
         this._broadcast(


### PR DESCRIPTION
The invitation text in meetings now displays 'Invite to Meeting' for better clarity and relevance.

Part of Task-5382653

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
