### PR TITLE
[IMP] purchase: recompute date_planned if overdue

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -690,6 +690,18 @@ class PurchaseOrder(models.Model):
     def button_unlock(self):
         self.locked = False
 
+    def button_reset_date_order(self):
+        self.ensure_one()
+        previous_date_order = self.date_order
+        self.date_order = fields.Datetime.now()
+        for line in self.order_line:
+            # If there's no seller i.e no lead time, we keep the same difference with the new deadline
+            if not line.selected_seller_id and line.date_planned:
+                diff = line.date_planned - previous_date_order
+                line.date_planned = self.date_order + diff if diff.days >= 0 else self.date_order
+            else:
+                line.date_planned = line._get_date_planned(line.selected_seller_id)
+
     def _confirmation_error_message(self):
         """ Return whether order can be confirmed or not if not then return error message. """
         self.ensure_one()

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -217,7 +217,22 @@
                             <field name="tax_calculation_rounding_method" invisible="1"/>
                         </group>
                         <group>
-                            <field name="date_order" invisible="state  == 'purchase'" readonly="state in ['cancel', 'purchase']"/>
+                            <label for="date_order" invisible="state == 'purchase'"/>
+                            <div class="o_row d-flex" invisible="state == 'purchase'">
+                                <field name="date_order"
+                                    nolabel="1"
+                                    readonly="state == 'cancel'"
+                                    class="flex-grow-0"
+                                    style=" width: auto !important;"
+                                    decoration-danger="date_order and date_order &lt; context_today().strftime('%Y-%m-%d')"/>
+                                <button title="Reset to today's date to recompute expected arrival based on available lead time
+                                    and previous information from the RFQ."
+                                    name="button_reset_date_order"
+                                    type="object"
+                                    icon="fa-refresh"
+                                    class="btn-link p-0 ms-2"
+                                    invisible="date_order and date_order &gt;= context_today().strftime('%Y-%m-%d')"/>
+                            </div>
                             <label for="date_planned"/>
                             <div name="date_planned_div">
                                 <field name="date_planned" readonly="state not in ('draft', 'sent', 'to approve', 'purchase')"/>

--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -117,16 +117,9 @@ class PurchaseOrderLine(models.Model):
 
             pol.price_unit = line.uom_id._compute_price(line.price_unit, pol.uom_id)
             partner = pol.order_id.partner_id or pol.order_id.requisition_id.vendor_id
-            params = {'order_id': pol.order_id}
-            seller = pol.product_id._select_seller(
-                partner_id=partner,
-                quantity=pol.product_qty,
-                date=pol.order_id.date_order and pol.order_id.date_order.date(),
-                uom_id=line.uom_id,
-                params=params)
-            if not pol.date_planned:
-                pol.date_planned = pol._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
-            product_ctx = {'seller_id': seller.id, 'lang': get_lang(pol.env, partner.lang).code}
+            if pol.selected_seller_id or not pol.date_planned:
+                pol.date_planned = pol._get_date_planned(pol.selected_seller_id)
+            product_ctx = {'seller_id': pol.selected_seller_id.id, 'lang': get_lang(pol.env, partner.lang).code}
             name = pol._get_product_purchase_description(pol.product_id.with_context(product_ctx))
             if line.product_description_variants:
                 name += '\n' + line.product_description_variants


### PR DESCRIPTION
This commit facilitates the re-computation of `date_planned`
for users that didn't confirm the RFQ before the order deadline,
in that case the `date_planned` is no longer valid and needs
to be recomputed. The user is left with the choice to recompute it
or not by clicking the refresh icon next to the `date_planned`

The `date_planned` will be highlighted in red when the date is
less than today's date to warn the user.

Tool tip has been added to the icon to describe what its used for.

Task: 5379743




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
