### PR TITLE
[FIX] account_peppol: no focusing on eas field

### DIFF
--- a/addons/account_peppol/static/src/components/peppol_filterable_selection/peppol_non_focusable_selection.js
+++ b/addons/account_peppol/static/src/components/peppol_filterable_selection/peppol_non_focusable_selection.js
@@ -1,0 +1,13 @@
+import { registry } from "@web/core/registry";
+import { SelectionField, selectionField } from "@web/views/fields/selection/selection_field";
+
+class NonFocusableSelectionField extends SelectionField {
+    static template = "account_peppol.NonFocusableSelectionField";
+}
+
+export const nonFocusableSelectionField = {
+    ...selectionField,
+    component: NonFocusableSelectionField,
+};
+
+registry.category("fields").add("peppol_non_focusable_selection", nonFocusableSelectionField);

--- a/addons/account_peppol/static/src/components/peppol_filterable_selection/peppol_non_focusable_selection.xml
+++ b/addons/account_peppol/static/src/components/peppol_filterable_selection/peppol_non_focusable_selection.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="account_peppol.NonFocusableSelectionField" t-inherit="web.SelectionField" t-inherit-mode="primary">
+        <xpath expr="//select" position="attributes">
+            <attribute name="tabindex">-1</attribute>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/account_peppol/wizard/peppol_registration_views.xml
+++ b/addons/account_peppol/wizard/peppol_registration_views.xml
@@ -23,6 +23,7 @@
                                 <field name="peppol_eas"
                                        placeholder="Peppol ID"
                                        nolabel="1"
+                                       widget="peppol_non_focusable_selection"
                                        class="o_field_peppol_eas_selection"/>
                                 <field name="peppol_endpoint" nolabel="1"/>
                                 <field name="contact_email" string="Email"/>


### PR DESCRIPTION
During registration on Peppol, the eas field is focused first, which makes no sense as it's supposed to be correctly preselected, and users aren't supposed to touch it

So this commit makes it non-focusable

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
