### PR TITLE
[FIX] l10n_it_edi: Correct function signature

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_format.py
+++ b/addons/l10n_it_edi/models/account_edi_format.py
@@ -1215,7 +1215,7 @@ class AccountEdiFormat(models.Model):
 
     def _get_proxy_identification(self, company):
         if self.code != 'fattura_pa':
-            return super()._get_proxy_identification()
+            return super()._get_proxy_identification(company)
 
         if not company.l10n_it_codice_fiscale:
             raise UserError(_('Please fill your codice fiscale to be able to receive invoices from FatturaPA'))


### PR DESCRIPTION
The current call to `super()._get_proxy_identification()` was incorrect, because the parent method expects a 'company' argument.

Steps to reproduce:
 - Configure an Italian company
 - Install l10n_it_edi
 - Attempt to set up Peppol

This triggers:
TypeError: AccountEdiFormat._get_proxy_identification() missing 1 required positional argument: 'company'

The issue occurs following the addition of account_peppol, because
before that, no other EDI format existed besides fattura_pa, so the
condition in the if clause was never triggered.

Ticket [link](https://www.odoo.com/odoo/project.task/5405602)
opw-5405602