### PR TITLE
[FIX] hr: employee version timeline auto save

### DIFF
--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.js
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.js
@@ -51,12 +51,11 @@ export class VersionsTimeline extends StatusBarField {
     }
 
     async createVersion(date) {
+        await this.props.record.save();
         const version_id = await this.orm.call('hr.employee', 'create_version',
             [this.props.record.evalContext.id, {'date_version': date}]);
 
         // TODO: why chat button and org chart button disappear
-        const { record } = this.props;
-        await record.save();
         await this.props.record.model.load({
             context: {
                 ...this.props.record.model.env.searchModel.context,

--- a/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
+++ b/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
@@ -1,0 +1,78 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("version_timeline_auto_save_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Employees app",
+            trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
+            run: "click",
+        },
+        {
+            content: "Open an Employee Profile",
+            trigger: ".o_kanban_record:contains('Bob M.')",
+            run: "click",
+        },
+        {
+            content: "Open Payroll Page",
+            trigger: ".o_notebook_headers a[name='payroll_information']",
+            run: "click",
+        },
+        {
+            content: "Open contract start date",
+            trigger: ".o_field_widget[name='contract_date_start'] .o_input",
+            run: "click",
+        },
+        {
+            content: "Go to the next month",
+            trigger: ".o_next",
+            run: "click",
+        },
+        {
+            content: "Choose any date X",
+            trigger: ".o_date_item_cell:nth-child(10)",
+            run: "click",
+        },
+        {
+            content: "saving the form",
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Open contract end date",
+            trigger: ".o_field_widget[name='contract_date_end'] .o_input",
+            run: "click",
+        },
+        {
+            content: "Go to the next month",
+            trigger: ".o_next",
+            run: "click",
+        },
+        {
+            content: "Choose date X + 1",
+            trigger: ".o_date_item_cell:nth-child(11) > div",
+            run: "click",
+        },
+        {
+            content: "Open Create New Version",
+            trigger: ".o_field_widget[name='version_id'] > button",
+            run: "click",
+        },
+        {
+            content: "Go to the next month",
+            trigger: ".o_next",
+            run: "click",
+        },
+        {
+            content: "Choose date X + 2",
+            trigger: ".o_date_item_cell:nth-child(12) > div",
+            run: "click",
+        },
+        {
+            content: "Wait until the form is saved",
+            trigger: "body .o_form_saved",
+        },
+    ],
+});

--- a/addons/hr/tests/test_ui.py
+++ b/addons/hr/tests/test_ui.py
@@ -2,7 +2,8 @@
 
 from odoo.tests import HttpCase, tagged, new_test_user
 
-@tagged('-at_install', 'post_install')
+
+@tagged('-at_install', 'post_install', 'is_tour')
 class TestEmployeeUi(HttpCase):
     def test_employee_profile_tour(self):
         user = new_test_user(self.env, login='davidelora', groups='base.group_user')
@@ -17,3 +18,24 @@ class TestEmployeeUi(HttpCase):
         }])
 
         self.start_tour("/odoo", 'hr_employee_tour', login="davidelora")
+
+    def test_version_timeline_auto_save_tour(self):
+        # as payroll tap access will be overridden by hr_payroll
+        is_payroll_installed = self.env['ir.module.module'].search_count([
+            ('name', '=', 'hr_payroll'), ('state', '=', 'installed')])
+        group = 'hr_payroll.group_hr_payroll_manager' if is_payroll_installed else 'hr.group_hr_manager'
+        user = new_test_user(self.env, login='alice', groups=group)
+        bob_user = new_test_user(self.env, login="Bob", name="Bob M.")
+
+        self.env['hr.employee'].create([{
+            'name': 'Alice',
+            'user_id': user.id,
+        }])
+
+        bob_employee = self.env['hr.employee'].create([{
+            'name': 'Bob M.',
+            "user_id": bob_user.id,
+        }])
+
+        self.start_tour("/odoo", 'version_timeline_auto_save_tour', login="alice")
+        self.assertFalse(bob_employee.version_ids[-1].contract_date_start)


### PR DESCRIPTION
To reproduce:
install hr_payroll
open an employee form view > payroll
make sure the employee_version you are on doesn't have a contract end date
set the end date to X
and without saving create a new employee version
from the plus sign with date greater than X

The Bug:
when following the above flow
a contract will be created for both employee versions it shouldn't be the case for the second version
as version date is greater than contract end date

opw-5427769
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
