### PR TITLE
[IMP] html_builder: allow snippet search by label

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -114,6 +114,7 @@ export class SnippetViewer extends Component {
             return fuzzyLookup(this.props.state.search, snippetStructures, (snippet) => [
                 snippet.title || "",
                 snippet.name || "",
+                snippet.label || "",
                 ...(snippet.keyWords?.split(",") || ""),
                 ...getClasses(snippet),
             ]);

--- a/addons/html_builder/static/tests/block_tab/snippet_groups.test.js
+++ b/addons/html_builder/static/tests/block_tab/snippet_groups.test.js
@@ -328,6 +328,72 @@ test("search snippet by class", async () => {
     ).toEqual(snippetsDescriptionProcessed[1].content);
 });
 
+test("search snippet by label", async () => {
+    const snippets = [
+        {
+            name: "foo_bar",
+            groupName: "a",
+            innerHTML: "content 1",
+            label: "",
+        },
+        {
+            name: "foo",
+            groupName: "a",
+            innerHTML: "content 2",
+            label: "Hello World",
+        },
+        {
+            name: "bar",
+            groupName: "a",
+            innerHTML: "content 3",
+            label: "Goodbye World",
+        },
+    ];
+
+    const snippetsForSetup = createTestSnippets({ snippets, withName: false });
+    const snippetsDescriptionProcessed = createTestSnippets({ snippets, withName: true });
+
+    await setupHTMLBuilder("<div><p>Text</p></div>", {
+        snippets: {
+            snippet_groups: [
+                '<div name="A" data-oe-thumbnail="a.svg" data-oe-snippet-id="123" data-o-snippet-group="a"><section data-snippet="s_snippet_group"></section></div>',
+            ],
+            snippet_structure: snippetsForSetup.map((snippetDesc) =>
+                getSnippetStructure(snippetDesc)
+            ),
+        },
+    });
+    await click(".o-snippets-menu #snippet_groups .o_snippet_thumbnail .o_snippet_thumbnail_area");
+    await waitForSnippetDialog();
+
+    // Search "hello" -> 1 result
+    await contains(".o_add_snippet_dialog aside input[type='search']").edit("hello");
+    expect(
+        ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div"
+    ).toHaveCount(1);
+    expect(
+        queryFirst(
+            ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div"
+        ).innerHTML
+    ).toEqual(snippetsDescriptionProcessed[1].content);
+
+    // Search "world" -> 2 results
+    await contains(".o_add_snippet_dialog aside input[type='search']").edit("world");
+    expect(
+        ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap > div"
+    ).toHaveCount(2);
+    expect(
+        queryFirst(
+            ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap:first > div"
+        ).innerHTML
+    ).toEqual(snippetsDescriptionProcessed[1].content);
+    expect(
+        queryFirst(
+            ".o_add_snippet_dialog .o_add_snippet_iframe:iframe .o_snippet_preview_wrap:last > div"
+        ).innerHTML
+    ).toEqual(snippetsDescriptionProcessed[2].content);
+});
+
 test("add snippet dialog with imagePreview", async () => {
     const snippets = [
         { name: "gravy", groupName: "a", innerHTML: "content 1" },

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -73,6 +73,7 @@ export function getInnerContent({
  * @param {string} options.name - The display name of the snippet
  * @param {string} options.content - The HTML content of the snippet
  * @param {string[]} [options.keywords=[]] - Search keywords for the snippet
+ * @param {string} options.label - Search label for the snippet (tag)
  * @param {string} options.groupName - The snippet group (category) name
  * @param {string} [options.imagePreview=""] - URL to preview image
  * @param {string|number} [options.moduleId=""] - Module ID if snippet belongs to a module
@@ -83,13 +84,14 @@ export function getSnippetStructure({
     name,
     content,
     keywords = [],
+    label = "",
     groupName,
     imagePreview = "",
     moduleId = "",
     moduleDisplayName = "",
 }) {
     keywords = keywords.join(", ");
-    return `<div name="${name}" data-oe-snippet-id="123" data-o-image-preview="${imagePreview}" data-oe-keywords="${keywords}" data-o-group="${groupName}" data-module-id="${moduleId}" data-module-display-name="${moduleDisplayName}">${content}</div>`;
+    return `<div name="${name}" data-oe-snippet-id="123" data-o-image-preview="${imagePreview}" data-oe-keywords="${keywords}" data-o-label="${label}" data-o-group="${groupName}" data-module-id="${moduleId}" data-module-display-name="${moduleDisplayName}">${content}</div>`;
 }
 
 class BuilderContainer extends Component {
@@ -445,6 +447,7 @@ export function createTestSnippets({ snippets: snippetConfigs = [], withName = f
             content,
             innerHTML,
             keywords = [],
+            label = "",
             imagePreview = "",
             moduleId,
             moduleDisplayName,
@@ -465,6 +468,7 @@ export function createTestSnippets({ snippets: snippetConfigs = [], withName = f
             groupName,
             content: finalContent,
             keywords,
+            label,
             imagePreview,
             moduleId,
             moduleDisplayName,


### PR DESCRIPTION
To help the user find snippets more easily, this commits allow the label (tags on the corner of the snippet preview) to be used to search for snippets.

task-5423627