### PR TITLE
[FIX] mail: fix avatar name width

### DIFF
--- a/addons/mail/static/src/views/web/fields/avatar/avatar.xml
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.xml
@@ -7,7 +7,7 @@
                 t-att-src="this.src"
                 t-on-click.stop.prevent="this.onClickAvatar"
             />
-            <span t-if="this.props.displayName" class="text-truncate w-0 flex-grow-1" t-out="this.props.displayName"/>
+            <span t-if="this.props.displayName" class="text-truncate flex-grow-1" t-out="this.props.displayName"/>
         </div>
     </t>
 


### PR DESCRIPTION
This commit fix the width of the displayName option of the Avatar component which was fixed to zero (bootstrap class 'w-0')




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
