### PR TITLE
[IMP] product: Improve product formatted display name

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -811,7 +811,7 @@ class ProductProduct(models.Model):
         def get_display_name(name, code):
             if self.env.context.get('display_default_code', True) and code:
                 if self.env.context.get('formatted_display_name'):
-                    return f'{name}\t--{code}--'
+                    return f'{name}\v--{code}--'
                 return f'[{code}] {name}'
             return name
 


### PR DESCRIPTION
This commit uses the new markup \v instead of the old one \t to align products codes to the end in a list view.

task-5418874



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
