### PR TITLE
[IMP] pos_self_order: add config-specific primary color for self-order UI

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -97,6 +97,7 @@ class PosConfig(models.Model):
         help="Name of the image to display on the self order screen",
     )
     has_paper = fields.Boolean("Has paper", default=True)
+    self_ordering_primary_color = fields.Char(string="Color", default=lambda self: self.env.company.email_secondary_color)
 
     def _update_access_token(self):
         self.access_token = uuid.uuid4().hex[:16]
@@ -290,10 +291,6 @@ class PosConfig(models.Model):
         record['_self_ordering_image_home_ids'] = config.self_ordering_image_home_ids.ids
         record['_self_ordering_image_background_ids'] = config.self_ordering_image_background_ids.ids
         record['_pos_special_products_ids'] = config._get_special_products().ids
-        record['_self_ordering_style'] = {
-            'primaryBgColor': self.env.company.email_secondary_color,
-            'primaryTextColor': self.env.company.email_primary_color,
-        }
         record['_self_order_pos'] = True
         return read_records
 

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -21,6 +21,7 @@ class ResConfigSettings(models.TransientModel):
     pos_self_ordering_image_brand_name = fields.Char(related="pos_config_id.self_ordering_image_brand_name", readonly=False)
     pos_self_ordering_pay_after = fields.Selection(related="pos_config_id.self_ordering_pay_after", readonly=False, required=True)
     pos_self_ordering_default_user_id = fields.Many2one(related="pos_config_id.self_ordering_default_user_id", readonly=False)
+    pos_self_ordering_primary_color = fields.Char(related="pos_config_id.self_ordering_primary_color", readonly=False)
 
     @api.onchange("pos_self_ordering_default_user_id")
     def _onchange_default_user(self):

--- a/addons/pos_self_order/static/src/app/self_order_index.js
+++ b/addons/pos_self_order/static/src/app/self_order_index.js
@@ -49,11 +49,7 @@ export class selfOrderIndex extends Component {
             document.documentElement.classList.add("kiosk");
         }
 
-        const styleConfig = this.selfOrder.config._self_ordering_style;
-        if (styleConfig) {
-            const { primaryBgColor, primaryTextColor } = styleConfig;
-            insertKioskStyle(primaryBgColor, primaryTextColor);
-        }
+        insertKioskStyle(this.selfOrder.config.self_ordering_primary_color);
 
         if (this.env.debug) {
             initDebugFormatters();

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -51,10 +51,14 @@
                             <button name="%(base.action_view_base_language_install)d" icon="oi-arrow-right" type="action" string="Add Languages" class="btn-link"/>
                         </div>
                     </setting>
-                    <setting string="Background" help="Personalize the Kiosk background" invisible="pos_self_ordering_mode == 'nothing'">
+                    <setting string="Background" help="Personalize the Interface" invisible="pos_self_ordering_mode == 'nothing'">
                         <field name="pos_self_ordering_image_background_ids"
                                class="w-100" widget="many2many_binary"
                                options="{'accepted_file_extensions': 'image/*', 'number_of_files': 1}" />
+                        <div class="py-2 d-flex align-items-center">
+                            <label for="pos_self_ordering_primary_color" class="mx-2" string="Color"/>
+                            <field name="pos_self_ordering_primary_color" widget="color"/>
+                        </div>
                     </setting>
                 </block>
             </block>


### PR DESCRIPTION
Before this commit:
===================
- The primary color used in the Kiosk and Self-Order UI was always taken from the company configuration.

After this commit:
==================
- A new primary color field is added to the POS configuration.
- The Self-Order and Kiosk UI now use this color per POS config.

Purpose:
========
- Allow different color themes for multiple configs within the same company.

Task: 5429015




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
