### PR TITLE
[FIX] mail: pulse effect shouldn't be re-triggered when opening fullscreen mode

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -188,17 +188,18 @@ export const blurBackgroundAction = {
     sequenceGroup: 200,
 };
 registerCallAction("fullscreen", {
-    btnClass: ({ owner, thread }) =>
+    btnClass: ({ thread }) =>
         attClassObjectToString({
             "o-discuss-CallActionList-pulse": Boolean(
-                !owner.env.pipWindow && thread.promoteFullscreen === CALL_PROMOTE_FULLSCREEN.ACTIVE
+                thread.promoteFullscreen === CALL_PROMOTE_FULLSCREEN.ACTIVE
             ),
         }),
     condition: ({ thread }) => thread?.isSelfInCall,
     name: ({ store }) => (store.rtc.state.isFullscreen ? _t("Exit Fullscreen") : _t("Fullscreen")),
     isActive: ({ store }) => store.rtc.state.isFullscreen,
     icon: ({ action }) => (action.isActive ? "fa fa-compress" : "fa fa-expand"),
-    onSelected: ({ store }) => {
+    onSelected: ({ store, thread }) => {
+        thread.promoteFullscreen = CALL_PROMOTE_FULLSCREEN.DISCARDED;
         if (store.rtc.state.isFullscreen) {
             store.rtc.exitFullscreen();
         } else {
@@ -220,7 +221,8 @@ registerCallAction("picture-in-picture", {
         store.rtc?.state.isPipMode ? _t("Exit Picture in Picture") : _t("Picture in Picture"),
     isActive: ({ store }) => store.rtc?.state.isPipMode,
     icon: "oi oi-launch",
-    onSelected: ({ owner, store }) => {
+    onSelected: ({ owner, store, thread }) => {
+        thread.promoteFullscreen = CALL_PROMOTE_FULLSCREEN.DISCARDED;
         const isPipMode = store.rtc?.state.isPipMode;
         if (isPipMode) {
             store.rtc.closePip();

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -1,6 +1,7 @@
 import { fields, Record } from "@mail/core/common/record";
 import { BlurManager } from "@mail/discuss/call/common/blur_manager";
 import { CallPermissionDialog } from "@mail/discuss/call/common/call_permission_dialog";
+import { CALL_PROMOTE_FULLSCREEN } from "@mail/discuss/call/common/thread_model_patch";
 import { monitorAudio } from "@mail/utils/common/media_monitoring";
 import { rpc } from "@web/core/network/rpc";
 import { assignDefined, closeStream, onChange } from "@mail/utils/common/misc";
@@ -252,6 +253,11 @@ export class Rtc extends Record {
                 this.localSession ||
                 this.store["discuss.channel.rtc.session"].get(this._remotelyHostedSessionId)
             );
+        },
+        onDelete() {
+            if (this.channel) {
+                this.channel.promoteFullscreen = CALL_PROMOTE_FULLSCREEN.INACTIVE;
+            }
         },
     });
     channel = fields.One("Thread", {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -1174,6 +1174,26 @@ test("auto-focus participant video in one-to-one call in chat window", async () 
     await contains(".o-discuss-CallParticipantCard", { count: 2 }); // card does not get focused in meeting view
 });
 
+test("show pulse effect on fullscreen mode only when another participant's camera is on", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const aliceMemberId = pyEnv["discuss.channel.member"].create({
+        channel_id: channelId,
+        partner_id: pyEnv["res.partner"].create({ name: "Alice" }),
+    });
+    setupChatHub({ opened: [channelId] });
+    const env = await start();
+    const network = await makeMockRtcNetwork({ env, channelId });
+    const aliceRemote = network.makeMockRemote(aliceMemberId);
+    await click("[title='Join Call']");
+    await aliceRemote.updateConnectionState("connected");
+    await contains(".o-discuss-Call");
+    await aliceRemote.updateInfo({ is_camera_on: true });
+    await contains(".o-discuss-CallActionList-pulse[title='Fullscreen']");
+    await aliceRemote.updateInfo({ is_camera_on: false });
+    await contains(".o-discuss-CallActionList-pulse[title='Fullscreen']", { count: 0 });
+});
+
 test.tags("focus required");
 test("open conversation from call invitation (chat window)", async () => {
     const pyEnv = await startServer();


### PR DESCRIPTION
**Current behavior before PR:**

The pulse effect could reappear during a call, even after the user
had already interacted with fullscreen or picture-in-picture.
This resulted in a repetitive and overly insistent visual cue.

**Desired behavior after PR is merged:**

This PR refines the promotion logic so the pulse effect is shown
only until the user explicitly interacts with fullscreen or pip mode.
Once the user does so, the promotion is permanently discarded for
the duration of the current call session and cannot be reactivated by
subsequent camera or UI state changes.

task-[5468368](https://www.odoo.com/odoo/project/1519/tasks/5468368)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
