### PR TITLE
[IMP] bus: improve notification delivery reliability

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -38,7 +38,6 @@ class WebsocketController(Controller):
         elif 'is_websocket_session' not in request.session:
             raise SessionExpiredException()
         subscribe_data = request.env["ir.websocket"]._prepare_subscribe_data(channels, last)
-        request.env["ir.websocket"]._after_subscribe_data(subscribe_data)
         channels_with_db = [channel_with_db(request.db, c) for c in subscribe_data["channels"]]
         notifications = request.env["bus.bus"]._poll(channels_with_db, subscribe_data["last"])
         return {"channels": channels_with_db, "notifications": notifications}

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -7,6 +7,8 @@ import os
 import selectors
 import threading
 import time
+from collections import defaultdict
+
 from psycopg2 import InterfaceError
 from psycopg2.pool import PoolError
 
@@ -45,26 +47,27 @@ NOTIFY_PAYLOAD_MAX_LENGTH = get_notify_payload_max_length()
 SKIP_NOTIFICATION = object()
 
 
-def fetch_bus_notifications(cr, channels, last=0, ignore_ids=None):
+def fetch_bus_notifications(cr, min_id_by_channel, ignore_ids=None):
     """Fetch notifications from the bus table.
 
     :param cr: Database cursor.
-    :param channels: List of channels for which notifications should be fetched.
-        May contain channel names, model instances, or (model, string) tuples.
-    :param last: The ID of the last fetched notification. Defaults to 0.
+    :param min_id_by_channel: Dictionary mapping channels to the ID of the last fully
+        processed id. See `Websocket._notif_history`.
     :param ignore_ids: IDs to exclude.
     :return: List of notifications.
 
     """
-    conditions = [
-        SQL("channel IN %s", tuple(json_dump(channel_with_db(cr.dbname, c)) for c in channels)),
-        SQL("create_date > %s", fields.Datetime.now() - datetime.timedelta(seconds=TIMEOUT))
-        if last == 0
-        else SQL("id > %s", last),
-    ]
+    threshold = fields.Datetime.now() - datetime.timedelta(seconds=TIMEOUT)
+    channels_by_id = defaultdict(list)
+    for channel, min_id in min_id_by_channel.items():
+        channels_by_id[min_id].append(json_dump(channel_with_db(cr.dbname, channel)))
+    channel_conditions = []
+    for min_id, channels in channels_by_id.items():
+        since = SQL("create_date > %s", threshold) if min_id == 0 else SQL("id > %s", min_id)
+        channel_conditions.append(SQL("(channel IN %s AND %s)", tuple(channels), since))
+    where = SQL(" OR ").join(channel_conditions)
     if ignore_ids:
-        conditions.append(SQL("id NOT IN %s", tuple(ignore_ids)))
-    where = SQL(" AND ").join(conditions)
+        where = SQL("(%s) AND id NOT IN %s", where, tuple(ignore_ids))
     cr.execute(SQL("SELECT id, message FROM bus_bus WHERE %s ORDER BY id", where))
     return [{"id": r[0], "message": orjson.loads(r[1])} for r in cr.fetchall()]
 
@@ -204,7 +207,7 @@ class BusBus(models.Model):
 
     @api.model
     def _poll(self, channels, last=0, ignore_ids=None):
-        return fetch_bus_notifications(self.env.cr, channels, last, ignore_ids)
+        return fetch_bus_notifications(self.env.cr, {c: last for c in channels}, ignore_ids)
 
     def _bus_last_id(self):
         last = self.env['bus.bus'].search([], order='id desc', limit=1)
@@ -229,7 +232,7 @@ class ImDispatch(threading.Thread):
         channels = {hashable(channel_with_db(db, c)) for c in channels}
         for channel in channels:
             self._channels_to_ws.setdefault(channel, set()).add(websocket)
-        outdated_channels = websocket._channels - channels
+        outdated_channels = websocket._min_id_by_channel.keys() - channels
         self._clear_outdated_channels(websocket, outdated_channels)
         websocket.subscribe(channels, last)
         with contextlib.suppress(RuntimeError):
@@ -237,7 +240,7 @@ class ImDispatch(threading.Thread):
                 self.start()
 
     def unsubscribe(self, websocket):
-        self._clear_outdated_channels(websocket, websocket._channels)
+        self._clear_outdated_channels(websocket, websocket._min_id_by_channel.keys())
 
     def _clear_outdated_channels(self, websocket, outdated_channels):
         """ Remove channels from channel to websocket map. """

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -60,14 +60,9 @@ class IrWebsocket(models.AbstractModel):
         last = 0 if last > self.env["bus.bus"].sudo()._bus_last_id() else last
         return {"channels": OrderedSet(self._build_bus_channel_list(list(channels))), "last": last}
 
-    def _after_subscribe_data(self, data):
-        """Function invoked after subscribe data have been processed.
-        Modules can override this method to add custom behavior."""
-
     def _subscribe(self, og_data):
         data = self._prepare_subscribe_data(og_data["channels"], og_data["last"])
         dispatch.subscribe(data["channels"], data["last"], self.env.registry.db_name, wsrequest.ws)
-        self._after_subscribe_data(data)
 
     def _on_websocket_closed(self, cookies):
         """Function invoked upon WebSocket termination.

--- a/addons/bus/static/src/services/bus_service.js
+++ b/addons/bus/static/src/services/bus_service.js
@@ -72,8 +72,10 @@ export const busService = {
                 }
                 case "BUS:NOTIFICATION": {
                     const notifications = data.map(({ id, message }) => ({ id, ...message }));
-                    state.lastNotificationId = notifications.at(-1).id;
-                    localStorage.setItem("bus.last_notification_id", state.lastNotificationId);
+                    if (notifications.at(-1).id > state.lastNotificationId) {
+                        state.lastNotificationId = notifications.at(-1).id;
+                        localStorage.setItem("bus.last_notification_id", state.lastNotificationId);
+                    }
                     for (const { id, type, payload } of notifications) {
                         notificationBus.trigger(type, { id, payload });
                         busService._onMessage(env, id, type, payload);

--- a/addons/bus/static/src/workers/bus_worker_utils.js
+++ b/addons/bus/static/src/workers/bus_worker_utils.js
@@ -156,3 +156,22 @@ export class Logger {
         });
     }
 }
+
+/**
+ * A Set that maintains a maximum size by evicting the oldest entries once the capacity
+ * threshold is exceeded.
+ */
+export class BoundedSet extends Set {
+    constructor(maxSize) {
+        super();
+        this.maxSize = maxSize;
+    }
+
+    add(item) {
+        super.add(item);
+        if (this.size > this.maxSize) {
+            this.delete(this.values().next().value);
+        }
+        return this;
+    }
+}

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -1,4 +1,4 @@
-import { debounce, Logger } from "@bus/workers/bus_worker_utils";
+import { BoundedSet, debounce, Logger } from "@bus/workers/bus_worker_utils";
 
 /**
  * Type of events that can be sent from the worker to its clients.
@@ -49,10 +49,16 @@ const logger = new Logger("bus_websocket_worker");
  * for SharedWorker and this class implements it.
  */
 export class WebsocketWorker {
-    static OUTGOING_BATCH_DELAY = 300;
+    static OUTGOING_BATCH_DELAY = 500;
     INITIAL_RECONNECT_DELAY = 1000;
     RECONNECT_JITTER = 1000;
     CONNECTION_CHECK_DELAY = 60_000;
+
+    /**
+     * @type {Set<number>} Notifications ids that were already received. Used to
+     * guaarantee at-most-once delivery.
+     */
+    seenNotificationIds = new BoundedSet(10_000);
 
     constructor(name) {
         this.active = true;
@@ -66,7 +72,7 @@ export class WebsocketWorker {
         this.isWaitingForNewUID = true;
         this.lastChannelSubscription = null;
         this.lastNotificationId = 0;
-        /** @type {{force: boolean}|null} */
+        /** @type {{force: boolean, minId: number}|null} */
         this.nextSubscribeData = null;
         this.loggingEnabled = null;
         this.messageWaitQueue = [];
@@ -363,8 +369,13 @@ export class WebsocketWorker {
         this._restartConnectionCheckInterval();
         const notifications = JSON.parse(messageEv.data);
         this._logDebug("_onWebsocketMessage", notifications);
-        this.lastNotificationId = notifications[notifications.length - 1].id;
-        this.broadcast("BUS:NOTIFICATION", notifications);
+        const newNotifications = notifications.filter((n) => !this.seenNotificationIds.has(n.id));
+        if (!newNotifications.length) {
+            return;
+        }
+        newNotifications.forEach((n) => this.seenNotificationIds.add(n.id));
+        this.lastNotificationId = Math.max(this.lastNotificationId, newNotifications.at(-1).id);
+        this.broadcast("BUS:NOTIFICATION", newNotifications);
     }
 
     async _logDebug(title, ...args) {
@@ -525,7 +536,7 @@ export class WebsocketWorker {
      * `_scheduleUpdateChannels` only.
      */
     _debouncedUpdateChannels = debounce(() => {
-        const { force } = this.nextSubscribeData;
+        const { force, minId } = this.nextSubscribeData;
         this.nextSubscribeData = null;
         const allTabsChannels = [
             ...new Set([].concat.apply([], [...this.channelsByClient.values()])),
@@ -537,7 +548,7 @@ export class WebsocketWorker {
             this.lastChannelSubscription = allTabsChannelsString;
             this._sendToServer({
                 event_name: "subscribe",
-                data: { channels: allTabsChannels, last: this.lastNotificationId },
+                data: { channels: allTabsChannels, last: minId },
             });
             this.firstSubscribeResolver.resolve();
         }
@@ -552,7 +563,7 @@ export class WebsocketWorker {
      * channel list has not changed.
      */
     _scheduleUpdateChannels({ force = false } = {}) {
-        this.nextSubscribeData ??= {};
+        this.nextSubscribeData ??= { minId: this.lastNotificationId };
         this.nextSubscribeData.force ||= force;
         this._debouncedUpdateChannels();
     }

--- a/addons/bus/static/tests/bus_service.test.js
+++ b/addons/bus/static/tests/bus_service.test.js
@@ -11,7 +11,7 @@ import {
     WebsocketWorker,
     WORKER_STATE,
 } from "@bus/workers/websocket_worker";
-import { describe, expect, test } from "@odoo/hoot";
+import { advanceTime, describe, expect, test } from "@odoo/hoot";
 import { Deferred, manuallyDispatchProgrammaticEvent, runAllTimers, waitFor } from "@odoo/hoot-dom";
 import { mockWebSocket } from "@odoo/hoot-mock";
 import {
@@ -24,6 +24,7 @@ import {
     mountWithCleanup,
     patchWithCleanup,
     restoreRegistry,
+    serverState,
 } from "@web/../tests/web_test_helpers";
 import { getWebSocketWorker, onWebsocketEvent } from "./mock_websocket";
 
@@ -562,4 +563,47 @@ test("channel is kept until deleted as many times as added", async () => {
     await expect.waitForSteps([]);
     busService.deleteChannel("foo");
     await expect.waitForSteps(["delete channel", "subscribe - []"]);
+});
+
+test("subscription last id is captured from the initial call to update channel", async () => {
+    // Large delay so lastNotificationId can advance before the subscription is sent.
+    patchWithCleanup(WebsocketWorker, { OUTGOING_BATCH_DELAY: 120_000 });
+    await makeMockEnv();
+    const worker = getWebSocketWorker();
+    patchWithCleanup(worker, {
+        _addChannel(client, channel) {
+            super._addChannel(client, channel);
+            expect.step(`add_channel - ${channel}`);
+        },
+    });
+    addBusServiceListeners(["BUS:CONNECT", () => expect.step("BUS:CONNECT")]);
+    onWebsocketEvent("subscribe", (data) =>
+        expect.step(`subscribe - [${data.channels.toString()}] - ${data.last}`)
+    );
+    await startBusService();
+    const busService = getService("bus_service");
+    await expect.waitForSteps(["BUS:CONNECT"]);
+    await advanceTime(120_000);
+    await expect.waitForSteps(["subscribe - [] - 0"]);
+    let lastReceivedId = MockServer.env["bus.bus"]._sendone(
+        serverState.partnerId,
+        "message_type",
+        "message_1"
+    );
+    await waitNotifications(["message_type", "message_1"]);
+    expect(worker.lastNotificationId).toBe(lastReceivedId);
+    const fooBusId = lastReceivedId;
+    busService.addChannel("foo");
+    await expect.waitForSteps(["add_channel - foo"]);
+    lastReceivedId = MockServer.env["bus.bus"]._sendone(
+        serverState.partnerId,
+        "message_type",
+        "message_2"
+    );
+    await waitNotifications(["message_type", "message_2"]);
+    expect(worker.lastNotificationId).toBe(lastReceivedId);
+    busService.addChannel("bar");
+    await expect.waitForSteps(["add_channel - bar"]);
+    await advanceTime(120_000);
+    await expect.waitForSteps([`subscribe - [bar,foo] - ${fooBusId}`]);
 });

--- a/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
+++ b/addons/bus/static/tests/mock_server/mock_models/bus_bus.js
@@ -14,7 +14,7 @@ export class BusBus extends models.Model {
      * @param {any} message
      */
     _sendone(channel, notificationType, message) {
-        this._sendmany([[channel, notificationType, message]]);
+        return this._sendmany([[channel, notificationType, message]]);
     }
 
     /** @param {[models.Model | string, string, any][]} notifications */
@@ -60,7 +60,10 @@ export class BusBus extends models.Model {
                 message: { payload: JSON.parse(JSON.stringify(payload)), type },
             });
         }
-        getWebSocketWorker().broadcast("BUS:NOTIFICATION", values);
+        getWebSocketWorker()._onWebsocketMessage(
+            new MessageEvent("message", { data: JSON.stringify(values) })
+        );
+        return this.lastBusNotificationId;
     }
 
     /**

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_ir_websocket
 from . import test_notify
 from . import test_websocket_caryall
 from . import test_websocket_check_session
+from . import test_websocket_dispatching
 from . import test_close_websocket_after_tour
 from . import test_websocket_controller
 from . import test_websocket_rate_limiting

--- a/addons/bus/tests/test_websocket_dispatching.py
+++ b/addons/bus/tests/test_websocket_dispatching.py
@@ -1,0 +1,74 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+from freezegun import freeze_time
+
+from odoo.addons.bus.tests.common import WebsocketCase
+from odoo.addons.bus.websocket import Websocket
+
+
+class TestWebsocketDispatching(WebsocketCase):
+    def test_receive_notifications_on_subscribed_channels(self):
+        websocket = self.websocket_connect()
+        self.subscribe(websocket, ["channel_A"], last=0)
+        self.env["bus.bus"]._sendone("channel_A", "channel_a_notification", None)
+        self.env["bus.bus"]._sendone("channel_B", "channel_b_notification", None)
+        self.trigger_notification_dispatching(["channel_A", "channel_B"])
+        notifications = json.loads(websocket.recv())
+        self.assertEqual(len(notifications), 1)
+        self.assertEqual(notifications[0]["message"]["type"], "channel_a_notification")
+
+    @freeze_time("2026-04-02", as_kwarg="clock")
+    def test_dispatch_notifications_for_new_channels(self, clock):
+        client = self.websocket_connect()
+        initial_min_id = self.env["bus.bus"]._bus_last_id()
+        self.subscribe(client, ["channel_A"], last=initial_min_id)
+        self.env["bus.bus"]._sendone("channel_B", "channel_b_notification", None)
+        self.env["bus.bus"]._sendone("channel_A", "channel_a_notification", None)
+        self.trigger_notification_dispatching(["channel_A"])
+        self.assertEqual(len(json.loads(client.recv())), 1)
+        # Make sure the min_id kept by the server advances in order to ensure the server
+        # will fetch oldest notifications for the new channel and not retrieve them by
+        # luck.
+        clock.tick(Websocket.MAX_NOTIFICATION_HISTORY_SEC + 1)
+        self.env["bus.bus"]._sendone("channel_A", "channel_a_notification", None)
+        self.trigger_notification_dispatching(["channel_A"])
+        self.assertEqual(len(json.loads(client.recv())), 1)
+        self.subscribe(client, ["channel_A", "channel_B"], last=initial_min_id)
+        notifications = json.loads(client.recv())
+        self.assertEqual(len(notifications), 1)
+        self.assertEqual(notifications[0]["message"]["type"], "channel_b_notification")
+
+    @freeze_time("2026-04-02", as_kwarg="clock")
+    def test_subscribe_to_new_channel_with_higher_id(self, clock):
+        client = self.websocket_connect()
+        self.subscribe(client, ["channel_A"], last=0)
+        self.env["bus.bus"]._sendone("channel_A", "channel_a_notification_1", None)
+        self.trigger_notification_dispatching(["channel_A"])
+        self.assertEqual(len(json.loads(client.recv())), 1)
+        # Ensure the server state advances in order to avoid fresh state luck.
+        clock.tick(Websocket.MAX_NOTIFICATION_HISTORY_SEC + 1)
+        self.env["bus.bus"]._sendone("channel_A", "channel_a_notification", None)
+        self.trigger_notification_dispatching(["channel_A"])
+        self.assertEqual(len(json.loads(client.recv())), 1)
+        # At this point, the min_id for A is equal or below the last notification. B will
+        # subscribe with an higher id. This means that the next dispatching *must* include
+        # A and *must not* include `channel_b_notification_OLD`.
+        self.env["bus.bus"]._sendone("channel_A", "channel_a_notification_2", None)
+        self.env["bus.bus"]._sendone("channel_B", "channel_b_notification_OLD", None)
+        for _ in range(200):
+            self.env["bus.bus"]._sendone("channel_C", "channel_c_notification", None)
+        self.trigger_notification_dispatching(["channel_C"])
+        # The client has an higher id. This is common since the server min_id is held
+        # back for the out-of-order commit case.
+        self.subscribe(client, ["channel_A", "channel_B"], last=self.env["bus.bus"]._bus_last_id())
+        self.trigger_notification_dispatching(["channel_A", "channel_B"])
+        notifications = json.loads(client.recv())
+        self.assertEqual(len(notifications), 1)
+        self.assertEqual(notifications[0]["message"]["type"], "channel_a_notification_2")
+        self.env["bus.bus"]._sendone("channel_B", "channel_b_notification_NEW", None)
+        self.trigger_notification_dispatching(["channel_A", "channel_B"])
+        notifications = json.loads(client.recv())
+        self.assertEqual(len(notifications), 1)
+        self.assertEqual(notifications[0]["message"]["type"], "channel_b_notification_NEW")

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -286,17 +286,17 @@ class Websocket:
     # they are requested), but the notifications are dispatched at the time of
     # the commit. This means lower id notifications might be dispatched after
     # higher id notifications.
-    # Simply incrementing the last id is sufficient to guarantee no duplicates,
+    # Simply incrementing the min id is sufficient to guarantee no duplicates,
     # but it is not sufficient to guarantee all notifications are dispatched,
     # and in particular not sufficient for those with a lower id coming after a
     # higher id was dispatched.
     # To solve the issue of missed notifications, the lowest id, stored in
-    # ``_last_notif_sent_id``, is held back by a few seconds to give time for
+    # ``_min_id_by_channel``, is held back by a few seconds to give time for
     # concurrent transactions to finish. To avoid dispatching duplicate
     # notifications, the history of already dispatched notifications during this
     # period is kept in memory in ``_notif_history`` and the corresponding
     # notifications are discarded from subsequent dispatching even if their id
-    # is higher than ``_last_notif_sent_id``.
+    # is higher than the corresponding ``_min_id_by_channel``.
     # In practice, what is important functionally is the time between the create
     # of the notification and the commit of the transaction in business code.
     # If this time exceeds this threshold, the notification will never be
@@ -326,12 +326,11 @@ class Websocket:
         # as triggering notification dispatching or terminating the connection.
         self.__cmd_queue = PollablePriorityQueue()
         self._waiting_for_dispatch = False
-        self._channels = set()
-        # For ``_last_notif_sent_id and ``_notif_history``, see
+        # For ``_min_id_by_channel and ``_notif_history``, see
         # ``MAX_NOTIFICATION_HISTORY_SEC`` for more details.
-        # id of the last sent notification that is no longer in _notif_history
-        self._last_notif_sent_id = 0
-        # history of last sent notifications in the format (notif_id, send_time)
+        # Id of the last sent notification that is no longer in ``_notif_history``, by channel.
+        self._min_id_by_channel = {}
+        # History of last sent notifications in the format (notif_id, send_time)
         # always sorted by notif_id ASC
         self._notif_history = []
         # Websocket start up
@@ -398,12 +397,9 @@ class Websocket:
         return func
 
     def subscribe(self, channels, last):
-        """ Subscribe to bus channels. """
-        self._channels = channels
-        # Only assign the last id according to the client once: the server is
-        # more reliable later on, see ``MAX_NOTIFICATION_HISTORY_SEC``.
-        if self._last_notif_sent_id == 0:
-            self._last_notif_sent_id = last
+        self._min_id_by_channel = {
+            c: self._min_id_by_channel.get(c, last) for c in channels
+        }
         # Dispatch past notifications if there are any.
         self.trigger_notification_dispatching()
 
@@ -787,18 +783,20 @@ class Websocket:
         self._waiting_for_dispatch = False
         with acquire_cursor(self._session.db) as cr:
             notifications = fetch_bus_notifications(
-                cr, self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
+                cr,
+                self._min_id_by_channel,
+                [n[0] for n in self._notif_history],
             )
         if not notifications:
             return
         for notif in notifications:
             bisect.insort(self._notif_history, (notif['id'], time.time()), key=lambda x: x[0])
         # Discard all the smallest notification ids that have expired and
-        # increment the last id accordingly. History can only be trimmed of ids
-        # that are below the new last id otherwise some notifications might be
+        # increment the min id accordingly. History can only be trimmed of ids
+        # that are below the new min id otherwise some notifications might be
         # dispatched again.
         # For example, if the theshold is 10s, and the state is:
-        # last id 2, history [(3, 8s), (6, 10s), (7, 7s)]
+        # min id 2, history [(3, 8s), (6, 10s), (7, 7s)]
         # If 6 is removed because it is above the threshold, the next query will
         # be (id > 2 AND id NOT IN (3, 7)) which will fetch 6 again.
         # 6 can only be removed after 3 reaches the threshold and is removed as
@@ -811,7 +809,21 @@ class Websocket:
             else:
                 break
         if last_index != -1:
-            self._last_notif_sent_id = self._notif_history[last_index][0]
+            new_min_id = self._notif_history[last_index][0]
+            for channel, current_min in self._min_id_by_channel.items():
+                # Ensure the min_id doesn't rollback, as lower notification ids can be
+                # fetched by other channels.
+                #
+                # For example, starting with the A channel, with 99 as its min id and the
+                # following history : [A(100, 0s)]. The client subscribes to B, with 80 as
+                # its min id. The resulting history looks like this:
+                # [B(90, 0s), B(91, 0s), A(100, 1s)].
+                #
+                # Then, the C channel is added: [B(90, 1s), B(91, 1s), C(95, 0s), A(100, 2s)].
+                # 9 seconds later, the new id considered as safe would be 91, since 10 seconds
+                # have passed. But A min_id shouldn't rollback.
+                if current_min < new_min_id:
+                    self._min_id_by_channel[channel] = new_min_id
             self._notif_history = self._notif_history[last_index + 1 :]
         self._send(notifications)
 

--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -3,12 +3,11 @@
 import logging
 import re
 from collections import defaultdict
-from datetime import datetime, timedelta
 
 from odoo import models
-from odoo.fields import Domain
 from odoo.addons.mail.tools.discuss import add_guest_to_context
 from odoo.tools.misc import verify_limited_field_access_token
+
 
 PRESENCE_CHANNEL_PREFIX = "odoo-presence-"
 PRESENCE_CHANNEL_REGEX = re.compile(
@@ -41,18 +40,19 @@ class IrWebsocket(models.AbstractModel):
             return
         self.env["mail.presence"]._try_update_presence(user or guest, inactivity_period)
 
-    def _prepare_subscribe_data(self, channels, last):
-        data = super()._prepare_subscribe_data(channels, last)
+    def _build_bus_channel_list(self, channels):
         model_ids_to_token = defaultdict(dict)
+        channels_to_clear = set()
         for channel in channels:
             if not isinstance(channel, str) or not channel.startswith(PRESENCE_CHANNEL_PREFIX):
                 continue
-            data["channels"].discard(channel)
+            channels_to_clear.add(channel)
             if not (match := re.match(PRESENCE_CHANNEL_REGEX, channel)):
                 _logger.warning("Malformed presence channel: %s", channel)
                 continue
             model, record_id, token = match.groups()
             model_ids_to_token[model][int(record_id)] = token or ""
+        channels = [c for c in channels if c not in channels_to_clear]
         # sudo - res.partner, mail.guest: can access presence targets to decide whether
         # the current user is allowed to read it or not.
         user_ids = model_ids_to_token["res.users"].keys()
@@ -69,7 +69,7 @@ class IrWebsocket(models.AbstractModel):
                 lambda p: verify_limited_field_access_token(
                     p, "im_status", model_ids_to_token["res.users"][p.id], scope="mail.presence"
                 )
-                or p.has_access("read")
+                or p.has_access("read"),
             )
             | user
         )
@@ -85,23 +85,9 @@ class IrWebsocket(models.AbstractModel):
             | guest
         )
         # sudo - res.users: can access users of allowed partners
-        data["channels"].update((user, "presence") for user in allowed_users)
-        data["channels"].update((guest, "presence") for guest in allowed_guests)
-        # There is a gap between a subscription client side (which is debounced)
-        # and the actual subcription thus presences can be missed. Send a
-        # notification to avoid missing presences during a subscription.
-        presence_domain = Domain("last_poll", ">", datetime.now() - timedelta(seconds=2)) & (
-            Domain("user_id", "in", allowed_users.ids)
-            | Domain("guest_id", "in", allowed_guests.ids)
-        )
-        # sudo: mail.presence: access to presence was validated with access token.
-        data["missed_presences"] = self.env["mail.presence"].sudo().search(presence_domain)
-        return data
-
-    def _after_subscribe_data(self, data):
-        user, guest = self.env["res.users"]._get_current_persona()
-        if user or guest:
-            data["missed_presences"]._send_presence(bus_target=user or guest)
+        channels.extend((user, "presence") for user in allowed_users)
+        channels.extend((guest, "presence") for guest in allowed_guests)
+        return super()._build_bus_channel_list(channels)
 
     def _on_websocket_closed(self, cookies):
         super()._on_websocket_closed(cookies)

--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -93,7 +93,7 @@ class MailPresence(models.Model):
             # sudo: res.users/mail.guest can update presence of accessible user/guest
             self.env["mail.presence"].sudo().create(values)
 
-    def _send_presence(self, im_status=None, bus_target=None):
+    def _send_presence(self, im_status=None):
         """Send notification related to bus presence update.
 
         :param im_status: 'online', 'away' or 'offline'
@@ -101,10 +101,14 @@ class MailPresence(models.Model):
         stores = Store.Stores()
         for presence in self:
             persona = presence.guest_id or presence.user_id
-            target = bus_target or (persona, "presence")
-            stores[target].add(persona, {"im_status": im_status or persona.im_status})
-            if bus_target is None or persona == bus_target:
-                stores[persona].add(persona, {"presence_status": im_status or presence.status})
+            stores[persona, "presence"].add(
+                persona,
+                {"im_status": im_status or persona.im_status},
+            )
+            stores[persona].add(
+                persona,
+                {"presence_status": im_status or presence.status},
+            )
         stores.bus_send()
 
     @api.autovacuum

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -112,13 +112,3 @@ class TestMailPresence(WebsocketCase, MailCommon):
             ],
         ):
             self.env["mail.presence"].with_user(bob)._update_presence(bob)
-        other_user = new_test_user(self.env, login="other_user", groups="base.group_user")
-        with self.assertBus(
-            BusResult(
-                other_user,
-                "mail.record/insert",
-                {"res.users": [{"id": bob.id, "im_status": "online"}]},
-            ),
-        ):
-            bob_presence = self.env["mail.presence"].search([("user_id", "=", bob.id)])
-            bob_presence._send_presence(bus_target=other_user)

--- a/addons/mail/tests/test_ir_websocket.py
+++ b/addons/mail/tests/test_ir_websocket.py
@@ -9,8 +9,8 @@ except ImportError:
     ws = None
 
 from odoo.tests import new_test_user
+
 from odoo.addons.bus.tests.common import WebsocketCase
-from odoo.addons.bus.models.bus import channel_with_db, json_dump
 from odoo.addons.mail.models.mail_presence import AWAY_TIMER
 
 
@@ -62,48 +62,3 @@ class TestIrWebsocket(WebsocketCase):
             except ws._exceptions.WebSocketTimeoutException:
                 timeout_occurred = True
             self.assertTrue(timeout_occurred)
-
-    def test_receive_missed_presences_on_subscribe(self):
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        session = self.authenticate("bob_user", "bob_user")
-        websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
-        self.env["mail.presence"]._update_presence(bob)
-        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        self.subscribe(
-            websocket,
-            [f"odoo-presence-res.users_{bob.id}"],
-            self.env["bus.bus"]._bus_last_id(),
-        )
-        self.trigger_notification_dispatching([(bob, "presence")])
-        notification = json.loads(websocket.recv())[0]
-        self._close_websockets()
-        bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
-        self.assertEqual(
-            bus_record.channel,
-            json_dump(channel_with_db(self.env.cr.dbname, bob)),
-        )
-        self.assertEqual(notification["message"]["type"], "mail.record/insert")
-        self.assertEqual(notification["message"]["payload"]["res.users"][0]["im_status"], "online")
-        self.assertEqual(notification["message"]["payload"]["res.users"][0]["presence_status"], "online")
-        self.assertEqual(notification["message"]["payload"]["res.users"][0]["id"], bob.id)
-
-    def test_receive_others_missed_presences_on_subscribe(self):
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        away_user = new_test_user(self.env, login="idler", groups="base.group_user")
-        session = self.authenticate("bob_user", "bob_user")
-        websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
-        self.env["mail.presence"]._update_presence(away_user, (AWAY_TIMER + 1) * 1000)
-        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        self.subscribe(
-            websocket,
-            [f"odoo-presence-res.users_{away_user.id}"],
-            self.env["bus.bus"]._bus_last_id(),
-        )
-        notification = json.loads(websocket.recv())[0]
-        self._close_websockets()
-        bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
-        self.assertEqual(bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, bob)))
-        self.assertEqual(notification["message"]["type"], "mail.record/insert")
-        self.assertEqual(notification["message"]["payload"]["res.users"][0]["id"], away_user.id)
-        self.assertEqual(notification["message"]["payload"]["res.users"][0]["im_status"], "away")
-        self.assertNotIn("presence_status", notification["message"]["payload"]["res.users"][0])

--- a/addons/mail/tests/test_websocket_controller.py
+++ b/addons/mail/tests/test_websocket_controller.py
@@ -6,7 +6,6 @@ from odoo.http.session import SESSION_ROTATION_INTERVAL
 from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
@@ -32,38 +31,6 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         self.assertEqual(self_notif["message"]["type"], "mail.record/insert")
         self.assertEqual(self_notif["message"]["payload"]["res.users"][0]["id"], self.user_demo.id)
         self.assertEqual(self_notif["message"]["payload"]["res.users"][0]["presence_status"], "offline")
-
-    def test_receive_missed_presences_on_peek_notifications(self):
-        self.authenticate("demo", "demo")
-        self.env["mail.presence"]._update_presence(self.user_demo)
-        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        # First request will get notifications and trigger the creation
-        # of the missed presences one.
-        last_id = self.env["bus.bus"]._bus_last_id()
-        self.make_jsonrpc_request(
-            "/websocket/peek_notifications",
-            {
-                "channels": [f"odoo-presence-res.users_{self.user_demo.id}"],
-                "last": last_id,
-                "is_first_poll": True,
-            },
-        )
-        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        notif = self.make_jsonrpc_request(
-            "/websocket/peek_notifications",
-            {
-                "channels": [f"odoo-presence-res.users_{self.user_demo.id}"],
-                "last": last_id,
-                "is_first_poll": True,
-            },
-        )["notifications"][0]
-        bus_record = self.env["bus.bus"].search([("id", "=", int(notif["id"]))])
-        self.assertEqual(
-            bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, self.user_demo)),
-        )
-        self.assertEqual(notif["message"]["type"], "mail.record/insert")
-        self.assertEqual(notif["message"]["payload"]["res.users"][0]["id"], self.user_demo.id)
-        self.assertEqual(notif["message"]["payload"]["res.users"][0]["im_status"], "online")
 
     @freeze_time("2026-03-03", as_kwarg='clock')
     def test_do_not_rotate_session_when_updating_presence(self, clock):


### PR DESCRIPTION
When a client subscribes to a new channel, timing gaps
between the subscription request and the server processing it can
cause updates to be missed. Moreover, only relying on the server to
track what a client has received is unreliable for newly added channels,
which can result in missed messages or receiving past notifications.

This commit aims for a more reliable delivery mechanism:
- The last known id sent by the client is used when subscribing to new
channels, as the server might have advanced its `_last_sent_id` cursor,
leading to missed notifications between the subscription request and
processing.
- The `last_sent_id` is now tracked by channel to avoid sending
notifications that were sent before the client subscription.
- The client filters out duplicates to guarantee business code that
notifications will only be received once, which can happen in rare
edge cases.

task-[6092804](https://www.odoo.com/odoo/1519/tasks/6092804)