### PR TITLE
[FIX] html_editor: add button to convert syntax highlight to paragraph

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -69,6 +69,21 @@ export class BannerPlugin extends Plugin {
                     this.insertBanner(_t("Banner Danger"), "❌", "danger");
                 },
             },
+            {
+                id: "banner_monospace",
+                title: _t("Monospace"),
+                description: _t("Insert a monospace banner"),
+                icon: "fa-laptop",
+                isAvailable,
+                run: () => {
+                    this.insertBanner(
+                        _t("Monospace Banner"),
+                        undefined,
+                        "secondary",
+                        "font-monospace"
+                    );
+                },
+            },
         ],
         powerbox_categories: withSequence(20, { id: "banner", name: _t("Banner") }),
         powerbox_items: [
@@ -86,6 +101,10 @@ export class BannerPlugin extends Plugin {
             },
             {
                 commandId: "banner_danger",
+                categoryId: "banner",
+            },
+            {
+                commandId: "banner_monospace",
                 categoryId: "banner",
             },
         ],
@@ -122,12 +141,17 @@ export class BannerPlugin extends Plugin {
             fillShrunkPhrasingParent(baseContainer);
         }
         const baseContainerHtml = baseContainer.outerHTML;
+        const emojiHtml = emoji
+            ? `<i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="${htmlEscape(
+                  title
+              )}">${emoji}</i>`
+            : "";
         const bannerElement = parseHTML(
             this.document,
-            `<div class="${containerClass}o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" data-oe-role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="${htmlEscape(
-                    title
-                )}">${emoji}</i>
+            `<div class="${containerClass}o_editor_banner user-select-none o-contenteditable-false ${
+                emoji ? "lh-1 " : ""
+            }d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" data-oe-role="status">
+                ${emojiHtml}
                 <div class="${contentClass}o_editor_banner_content o-contenteditable-true w-100 px-3">
                     ${baseContainerHtml}
                 </div>

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.js
@@ -29,6 +29,7 @@ export class CodeToolbar extends Component {
         getContent: { type: Function },
         onLanguageChange: { type: Function },
         currentLanguage: { type: String },
+        convertToParagraph: { type: Function },
     };
     static components = { Dropdown, DropdownItem, CopyButton };
 

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.xml
@@ -19,6 +19,11 @@
                     </t>
                 </Dropdown>
                 <CopyButton content="props.getContent" copyText.translate="Copy" successText.translate="Code copied to the clipboard."/>
+                <button class="text-nowrap btn"
+                    t-on-click="this.props.convertToParagraph"
+                >
+                    <span class="mx-1 fa fa-paragraph" title="Convert to paragraph"></span>
+                </button>
             </div>
         </div>
     </t>

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
@@ -20,6 +20,7 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
         value: { type: String },
         languageId: { type: String },
         onTextareaFocus: { type: Function },
+        convertToParagraph: { type: Function },
         host: { type: Object },
     };
 

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
@@ -3,7 +3,9 @@
     <!-- syntax highlighting template -->
     <t t-name="html_editor.EmbeddedSyntaxHighlighting">
         <CodeToolbar target="state.host" currentLanguage="embeddedState.languageId"
-            getContent="() => this.textarea.value" onLanguageChange="onLanguageChange.bind(this)"/>
+            getContent="() => this.textarea.value" onLanguageChange="onLanguageChange.bind(this)"
+            convertToParagraph="this.props.convertToParagraph"
+        />
         <pre t-ref="pre"/>
         <textarea t-ref="textarea" class="o_prism_source" contenteditable="true"
             t-on-input="onInput"

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -116,6 +116,22 @@ export class SyntaxHighlightingPlugin extends Plugin {
         if (name === "syntaxHighlighting") {
             Object.assign(props, {
                 onTextareaFocus: () => this.dependencies.history.stageFocus(),
+                convertToParagraph: ({ target }) => {
+                    this.dependencies.history.stageSelection();
+                    const component = target.closest(`[data-embedded='${name}']`);
+                    const embeddedProps = getEmbeddedProps(component);
+                    const value = embeddedProps.value;
+                    const p = this.document.createElement("div");
+                    p.classList.add("o-paragraph");
+                    p.textContent = value;
+                    component.before(p);
+                    component.remove();
+                    newlinesToLineBreaks(p);
+                    this.dependencies.selection.setSelection({
+                        anchorNode: p,
+                    });
+                    this.dependencies.history.addStep();
+                },
             });
             props.host.removeAttribute("data-syntax-highlighting-autofocus");
         }

--- a/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
+++ b/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
@@ -105,6 +105,7 @@ const TOOLBAR = (language) =>
                 <span class="mx-1 fa fa-clipboard"></span>
                 <span>Copy</span>
             </button>
+            <button class="text-nowrap btn"><span class="mx-1 fa fa-paragraph" title="Convert to paragraph"></span></button>
         </div>
     </div>`
     );

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -299,3 +299,20 @@ test("Inserting a banner should not remove the next sibling block", async () => 
             </div><p>b</p>`
     );
 });
+
+test("Monospace banner should have no emoji", async () => {
+    const { el, editor } = await setupEditor("<p>test[]</p>");
+    await insertText(editor, "/monospace");
+    await press("enter");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div class="font-monospace o_editor_banner user-select-none o-contenteditable-false d-flex align-items-center alert alert-secondary pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                    <p>test[]</p>
+                </div>
+            </div>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+});

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -89,7 +89,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(25);
+        expect(commandNames(el).length).toBe(26);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -99,7 +99,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(25);
+        expect(commandNames(el).length).toBe(26);
         await insertText(editor, "title");
         await animationFrame();
         const commands = commandNames(el);
@@ -112,7 +112,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(25);
+        expect(commandNames(el).length).toBe(26);
         expect(".o-we-category").toHaveCount(6);
         expect(queryAllTexts(".o-we-category")).toEqual([
             "FORMAT",
@@ -134,7 +134,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(25);
+        expect(commandNames(el).length).toBe(26);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -186,7 +186,7 @@ describe("search", () => {
         await insertText(editor, "/");
         await animationFrame();
         await expectElementCount(".o-we-powerbox", 1);
-        expect(commandNames(el).length).toBe(25);
+        expect(commandNames(el).length).toBe(26);
 
         await insertText(editor, "headx");
         await animationFrame();

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1134,3 +1134,15 @@ test("can write in a highlighted code block within a nested list", async () => {
         ),
     });
 });
+
+test("restore paragraph from code block", async () => {
+    await testEditor({
+        contentBefore: "<pre>[]abc</pre>",
+        stepFunction: async () => {
+            await click(".o_code_toolbar span.fa-paragraph");
+        },
+        contentAfterEdit: '<div class="o-paragraph">[]abc</div>',
+        contentAfter: `<div>[]abc</div>`,
+        config: configWithEmbeddings,
+    });
+});


### PR DESCRIPTION
When syntax highlighting is activated on code blocks, neither the powerbox nor the toolbar is available inside the block, making it impossible to convert it back into a paragraph.

This commit adds a button to convert such code blocks back into paragraphs.

Steps to reproduce:
- Go to a "To Do" note
- Insert a code block with `/code`

=> There was no way to convert it back to a paragraph

task-5241467
