### PR TITLE
[FIX] hr_holidays: Incorrect Display of allocated days

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -379,7 +379,7 @@ class HrLeaveType(models.Model):
             # leave counts is based on employee_id, would be inaccurate if not based on correct employee
             return super()._compute_display_name()
         # use sudo() to get the correct remaining leaves
-        for record in self.sudo():
+        for record in self:
             name = record.name
             if record.requires_allocation:
                 remaining_time = float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -322,8 +322,11 @@ class TestAllocations(TestHrHolidaysCommon):
         shown correctly in the dropdown menu or not
         :return:
         """
+        self.env.user.write({
+            'company_ids': [(4, self.employee.company_id.id)]
+        })
         leave_type = self.env.ref('hr_holidays.leave_type_compensatory_days')
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].create({
             'name': 'Alloc',
             'employee_id': self.employee.id,
             'holiday_status_id': leave_type.id,
@@ -334,7 +337,7 @@ class TestAllocations(TestHrHolidaysCommon):
         })
         allocation.action_approve()
 
-        second_allocation = self.env['hr.leave.allocation'].sudo().create({
+        second_allocation = self.env['hr.leave.allocation'].create({
             'name': 'Alloc2',
             'employee_id': self.employee.id,
             'holiday_status_id': leave_type.id,
@@ -347,7 +350,7 @@ class TestAllocations(TestHrHolidaysCommon):
 
         # _compute_leaves depends on the context that is getting cleared
         self.env['hr.leave.type'].invalidate_model(['max_leaves', 'leaves_taken', 'virtual_remaining_leaves'])
-        result = self.env['hr.leave.type'].with_context(
+        result = self.env['hr.leave.type'].with_company(self.employee.company_id).with_context(
             employee_id=self.employee.id,
             leave_date_from='2024-08-18 06:00:00',  # for _compute_leaves
             default_date_from='2024-08-18 06:00:00',


### PR DESCRIPTION
Bug :
	- Create a new employee (also works with old employees)
	- Create an allocation of Paid Time Off that is available in the future.
	- Create a Time Off request for this employee in the future.
	- When Selecting Time off type you'll see that he has (0 remaining out of 0 days) even though he has just be allocated leaves.
Reason :
In the _compute_display_name we access the record using self.sudo(), changing to the super Usern thus invalidating the correct compuating that were done using the previous user, yealding differant record set with incorrect data.

Fix :
remove the sudo() and use the current user instead.

-------------------------------------------------------------------------------

Fixed the Test test_allocation_dropdown_after_period :

Bug : Test fails after removing sudo from _compute_display_name, showing (0 remaining out of 0) instead of (9 remaining out of 9)

Reason :
	The test user (Admin) did not have the Employee's company in their allowed companies,The name_search method triggers _compute_display_name,
	which in turn triggers the computation of virtual_remaining_leaves. In the previous implementation (before the fix for incorrect display), _compute_display_name utilized sudo.
	This propagated superuser privileges down to _compute_leaves and get_allocation_data, masking the fact that the test user lacked access to the employee's company resources (Multi-Company Rule).
	By removing sudo() to fix the display bug, the user didn't have access to the allocation when running the name_search, causing the test to fail.
Fix :
	Add the employee company to the users company_ids, this allows the allocations and name_search to run without sudo.
task - 5417323