### PR TITLE
[FIX] hr_skills: prevent duplicate skill creation after validation error

### DIFF
--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.js
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.js
@@ -78,7 +78,9 @@ export class SkillsX2ManyField extends X2ManyField {
             getList: () => this.list,
             saveRecord: async (record) => {
                 await saveRecord(record);
-                await this.props.record.save();
+                await this.props.record.save({
+                    onError: (e) => {this.list.delete(record); throw e;}
+                });
             },
             updateRecord: updateRecord,
             withParentId: this.props.widget !== "many2many",

--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -151,5 +151,44 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
         trigger: ".o_data_row td.o_data_cell:contains('Oh Mary')",
         run: () => {},
     },
+    {
+        content: "Add a new Skill",
+        trigger: ".o_field_skills_one2many button:contains('ADD')",
+    },
+    {
+        content: "Select a song",
+        trigger: ".o_field_widget[name='skill_id'] input",
+        run: "text Mary",
+    },
+    {
+        content: "Choose the song",
+        trigger: '.ui-autocomplete .ui-menu-item a:contains("Oh Mary")',
+        run: "click",
+    },
+    {
+        content: "Save new skill",
+        trigger: ".o_form_button_save",
+        in_modal: true,
+        run: "click",
+    },
+    {
+        content: "Close validation error popup",
+        trigger: ".modal-footer .btn-primary",
+        run: "click",
+    },
+    {
+        content: "Close skill dialog",
+        trigger: ".modal-header .btn-close",
+        run: "click",
+    },
+    {
+        content: "Check that no duplicate skill was added",
+        trigger: ".o_data_row td.o_data_cell:contains('Oh Mary')",
+        run: function() {
+            if ($(".o_data_row td.o_data_cell:contains('Fortunate Son')").length !== 1) {
+                console.error("Duplicate skill was added while having validation error");
+            }
+        },
+    },
     ...stepUtils.saveForm(),
 ]});

--- a/addons/hr_skills/tests/test_ui.py
+++ b/addons/hr_skills/tests/test_ui.py
@@ -1,9 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
+from odoo.tools import mute_logger
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class SkillsTestUI(odoo.tests.HttpCase):
+
+    @mute_logger('odoo.http', 'odoo.sql_db')
     def test_ui(self):
         levels = self.env['hr.skill.level'].create([{
             'name': f'Level {x}',


### PR DESCRIPTION
Steps to reproduce:
---------------------------------
1. Install `hr_skills` module
2. Open the Employees app and open any employee record
3. Go to the Resume tab
4. In the Skills section, click Add for any skill type
5. Select a skill that is already added to the resume
6. Click Save & Close in the Select Skills wizard
7. A validation error is displayed, click Close
8. Close the Select Skills wizard.

Observation:
---------------------------------
After closing the wizard, another default skill is added to the resume even though a validation error was raised.

Issue:
---------------------------------
In the following code:
https://github.com/odoo/odoo/blob/57c1c510425dcd491c794a0262063db398348640/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.js#L79-L82 During record save, the validation error scenario was not handled properly. When a validation error occurred, changes made to the virtual record were not discarded, causing the initial (invalid) changes to be incorrectly retained instead of being rolled back

Solution:
---------------------------------
When a validation error occurs while adding a skill, discard all changes made to
the virtual record before throwing the error. This ensures that no unintended
skill is added.

opw-5423196