### PR TITLE
[FIX] point_of_sale: fit longer language in optional button

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
@@ -32,8 +32,7 @@
                         <t t-if="!optional_product.qty">
                             <button
                                 type="button"
-                                class="btn btn-primary"
-                                style="width: 80px; height: 40px;"
+                                class="btn btn-primary py-2"
                                 t-on-click="() => this.changeQuantity(optional_product, true)">
                                 + Add
                             </button>


### PR DESCRIPTION
**Steps to reproduce:**
- Make a product that has some optional products
- Switch the language to German
- Open the PoS and order the product
- The "+ Add" button will be cut and not shown correctly

**Why the fix:**
Whenever the translation for "Add" was too long, it didn't fit in the button anymore and was unreadable. We now changed the width of the button to be flexible as to accept longer words.

opw-5385398