### PR TITLE
[IMP] website: add size multiplicator for scroll down button

### DIFF
--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
@@ -25,6 +25,15 @@
                 <BuilderSelectItem classAction="'anim-heartbeat'">Heartbeat</BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>
+        <BuilderRow label.translate="Size" level="1" applyTo="':scope > .o_scroll_button > i'">
+            <BuilderButtonGroup>
+                <BuilderButton classAction="'fa-1x'" title.translate="Size 1x">1x</BuilderButton>
+                <BuilderButton classAction="'fa-2x'" title.translate="Size 2x">2x</BuilderButton>
+                <BuilderButton classAction="'fa-3x'" title.translate="Size 3x">3x</BuilderButton>
+                <BuilderButton classAction="'fa-4x'" title.translate="Size 4x">4x</BuilderButton>
+                <BuilderButton classAction="'fa-5x'" title.translate="Size 5x">5x</BuilderButton>
+            </BuilderButtonGroup>
+        </BuilderRow>
         <BuilderRow label.translate="Colors" level="1" applyTo="':scope > .o_scroll_button'">
             <BuilderColorPicker styleAction="'background-color'" title.translate="Apply a background color"/>
             <BuilderColorPicker styleAction="'color'" title.translate="Apply an icon color"/>

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2314,8 +2314,13 @@ span.list-inline-item.o_add_language:last-child {
 .o_scroll_button {
     @include o-position-absolute(auto, 0, 0, 0);
     display: flex;
-    width: 50px;
-    height: 50px;
+    // Need to update button size based on icon size.
+    @for $i from 1 through 5 {
+        &:has(i.fa-#{$i}x) {
+            width: #{$i}em;
+            height: #{$i}em;
+        }
+    }
 
     &, &:hover {
         text-decoration: none;

--- a/addons/website/static/tests/builder/website_builder/size_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/size_option.test.js
@@ -1,0 +1,26 @@
+import { expect, test } from "@odoo/hoot";
+import { queryOne, waitFor } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilderWithSnippet,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("Size option should be present when scroll down button is enabled", async () => {
+    const sizeOptionSelector = ".hb-row-sublevel-1[data-label='Size']";
+    await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
+    await contains(":iframe img").click();
+    await contains("[data-label='Height'] [data-action-param='o_full_screen_height']").click();
+    await contains("[data-label='Scroll Down Button'] input").click();
+    await waitFor(sizeOptionSelector);
+    expect(`${sizeOptionSelector} .o-hb-button-group button`).toHaveCount(5);
+    await contains(`[data-class-action='fa-2x']`).click();
+    const scrollDownButtonEl = queryOne(":iframe .o_scroll_button");
+    const angleDownIconEl = scrollDownButtonEl.querySelector(".fa-angle-down");
+    const computedStyle = getComputedStyle(scrollDownButtonEl);
+    const iconFontSize = getComputedStyle(angleDownIconEl).fontSize;
+    expect(computedStyle.width).toBe(iconFontSize);
+    expect(computedStyle.height).toBe(iconFontSize);
+});


### PR DESCRIPTION
This PR adds a size multiplicator option for the scroll down button when it is enabled. The option applies font awesome size classes (_fa-1x_ to _fa-5x_) to the icon via a `classAction`. The scroll down button adapts its dimensions _(width_ and _height)_ based on the corresponding "**font-size**" of the icon.

task: 5429265