### PR TITLE
[FIX] l10n_it: align VP14 VAT payable with VP6 computation

### DIFF
--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -313,7 +313,7 @@
                                 <field name="label">_carryover_debit</field>
                                 <field name="engine">aggregation</field>
                                 <field name="formula">VP14.debit</field>
-                                <field name="subformula">if_between(EUR(0), EUR(25.82))</field>
+                                <field name="subformula">if_between(EUR(0), EUR(100))</field>
                                 <field name="carryover_target">VP7._applied_carryover_debit</field>
                             </record>
                             <record id="tax_monthly_report_line_vp14_vp14b_credit" model="account.report.expression">

--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -85,7 +85,7 @@
                             <record id="tax_monthly_report_line_vp2_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">02</field>
+                                <field name="formula">-02</field>
                             </record>
                         </field>
                     </record>
@@ -117,7 +117,7 @@
                             <record id="tax_monthly_report_line_vp4_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">4v</field>
+                                <field name="formula">-4v</field>
                             </record>
                         </field>
                     </record>
@@ -148,14 +148,14 @@
                             <record id="tax_monthly_report_line_vp6_vp6a_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VP4.debit + VP5.credit</field>
-                                <field name="subformula">if_below(EUR(0))</field>
+                                <field name="formula">VP4.debit - VP5.credit</field>
+                                <field name="subformula">if_above(EUR(0))</field>
                                 <field name="blank_if_zero" eval="True"/>
                             </record>
                             <record id="tax_monthly_report_line_vp6_vp6b_credit" model="account.report.expression">
                                 <field name="label">credit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VP4.debit + VP5.credit</field>
+                                <field name="formula">VP5.credit - VP4.debit</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                                 <field name="blank_if_zero" eval="True"/>
                             </record>
@@ -169,7 +169,7 @@
                             <record id="tax_monthly_report_line_vp7_tag" model="account.report.expression">
                                 <field name="label">tag</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">vp7</field>
+                                <field name="formula">-vp7</field>
                             </record>
                             <record id="tax_monthly_report_line_vp7_applied_carryover" model="account.report.expression">
                                 <field name="label">_applied_carryover_debit</field>
@@ -262,7 +262,7 @@
                             <record id="tax_monthly_report_line_vp12_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">vp12</field>
+                                <field name="formula">-vp12</field>
                             </record>
                         </field>
                     </record>
@@ -291,22 +291,10 @@
                         <field name="code">VP14</field>
 
                         <field name="expression_ids">
-                            <record id="tax_monthly_report_line_vp14_vp4_vp5_dif_pos" model="account.report.expression">
-                                <field name="label">vp4_vp5_dif_pos</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VP4.debit - VP5.credit</field>
-                                <field name="subformula">if_above(EUR(0))</field>
-                            </record>
-                            <record id="tax_monthly_report_line_vp14_vp4_vp5_dif_neg" model="account.report.expression">
-                                <field name="label">vp4_vp5_dif_neg</field>
-                                <field name="engine">aggregation</field>
-                                <field name="formula">VP4.debit - VP5.credit</field>
-                                <field name="subformula">if_below(EUR(0))</field>
-                            </record>
                             <record id="tax_monthly_report_line_vp14_vp14a_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">(VP14.vp4_vp5_dif_pos + VP7.debit + VP12.debit) - (-VP14.vp4_vp5_dif_neg + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit)</field>
+                                <field name="formula">(VP6.debit + VP7.debit + VP12.debit) - (VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit)</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                             </record>
                             <record id="tax_monthly_report_line_vp14_vp14a_carryover" model="account.report.expression">
@@ -319,7 +307,7 @@
                             <record id="tax_monthly_report_line_vp14_vp14b_credit" model="account.report.expression">
                                 <field name="label">credit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">(-VP14.vp4_vp5_dif_neg + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit) - (VP14.vp4_vp5_dif_pos + VP7.debit + VP12.debit)</field>
+                                <field name="formula">(VP6.credit + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit) - (VP7.debit + VP12.debit)</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                             </record>
                             <record id="tax_monthly_report_line_vp14_vp14b_carryover" model="account.report.expression">


### PR DESCRIPTION
Commit 04155a0 correctly increased the threshold for the VP7 line
of the monthly tax report from 25.82€ to 100.00€. However, a
subsequent commit (https://github.com/odoo/odoo/commit/51a72ab42d118d6fb0eb3e3545a09e10019b9140) accidentally reverted this change to
the outdated value.

This commit restores the threshold to the expected value of 100.00€.

---

The previous fix in https://github.com/odoo/odoo/commit/4e831999ed06e0e3c2f380414c5949db645f2f19 attempted to correct VP6 (VAT due/deductible)
but relied on an incorrect assumption regarding debit signs.

In the Italian tax report, values should remain positive regardless of
whether they are debits or credits. Displaying debits as negative caused:
1. Incorrect visual representation in the report columns.
2. Inconsistent totals for VP14 (VAT payable).

This commit ensures all debit column values are displayed as positive
and restores the correct calculation logic for the report totals.

opw-5357719
opw-5411706
opw-5421779

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr