### PR TITLE
[IMP] account_edi_ubli_cii: Split fixed taxes into allowance charges or additional invoice lines.

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -240,6 +240,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'tax_subtotal_vals': [],
         }
 
+        _fixed_taxes, emptying_taxes = self._split_fixed_taxes(taxes_vals)
+
         # If it's not on the whole invoice, don't manage the EPD.
         epd_tax_to_discount = {}
         if not taxes_vals.get('invoice_line'):
@@ -257,6 +259,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                         amounts['base_amount_currency'] * percentage / 100.0)
                     epd_accounted_tax_amount += amounts['tax_amount_currency']
 
+        # first, we add the non-fixed taxes to tax_subtotal_vals
         for grouping_key, vals in taxes_vals['tax_details'].items():
             if grouping_key['tax_amount_type'] != 'fixed':
                 subtotal = {
@@ -275,6 +278,25 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                         'taxable_amount': taxable_amount_after_epd,
                     })
                 tax_totals_vals['tax_subtotal_vals'].append(subtotal)
+
+        # then, we add the emptying taxes to it
+        for grouping_key, vals in emptying_taxes:
+            subtotal = {
+                'currency': invoice.currency_id,
+                'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
+                'taxable_amount': vals['tax_amount_currency'],
+                'tax_amount': 0.0,
+                'percent': 0.0,
+                'tax_category_vals': {
+                    'id': 'E',
+                    'percent': 0.0,
+                    'tax_scheme_vals': {
+                        'id': "VAT",
+                    },
+                    'tax_exemption_reason': "Exempt from tax",
+                },
+            }
+            tax_totals_vals['tax_subtotal_vals'].append(subtotal)
 
         if epd_tax_to_discount:
             # early payment discounts: hence, need to add a subtotal section
@@ -385,17 +407,18 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         :param line:    An invoice line.
         :return:        A list of python dictionaries.
         """
+        fixed_taxes_charge_list, _emptying_taxes = self._split_fixed_taxes(tax_values_list)
         fixed_tax_charge_vals_list = []
-        for grouping_key, tax_details in tax_values_list['tax_details'].items():
-            if grouping_key['tax_amount_type'] == 'fixed':
-                fixed_tax_charge_vals_list.append({
-                    'currency_name': line.currency_id.name,
-                    'currency_dp': self._get_currency_decimal_places(line.currency_id),
-                    'charge_indicator': 'true',
-                    'allowance_charge_reason_code': 'AEO',
-                    'allowance_charge_reason': tax_details['tax_name'],
-                    'amount': tax_details['tax_amount_currency'],
-                })
+
+        for tax_key, tax_details in fixed_taxes_charge_list:
+            fixed_tax_charge_vals_list.append({
+                'currency_name': line.currency_id.name,
+                'currency_dp': self._get_currency_decimal_places(line.currency_id),
+                'charge_indicator': 'true',
+                'allowance_charge_reason_code': 'AEO',
+                'allowance_charge_reason': tax_details['tax_name'],
+                'amount': tax_details['tax_amount_currency'],
+            })
 
         if not line.discount:
             return fixed_tax_charge_vals_list
@@ -505,11 +528,16 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         # Rounding amounts belonging to a tax ('biggest_tax' strategy) are included already in the tax amounts.
         rounding_amls = invoice.line_ids.filtered(lambda line: line.display_type == 'rounding' and not line.tax_line_id)
         payable_rounding_amount = invoice.direction_sign * sum(rounding_amls.mapped('amount_currency'))
+
+        # sum the tax amounts of emptying taxes
+        _fixed_taxes, emptying_taxes = self._split_fixed_taxes(taxes_vals)
+        sum_emptying_taxes = sum(emptying_vals['tax_amount_currency'] for emptying_key, emptying_vals in emptying_taxes)
+
         return {
             'currency': invoice.currency_id,
             'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
             'line_extension_amount': line_extension_amount,
-            'tax_exclusive_amount': taxes_vals['base_amount_currency'],
+            'tax_exclusive_amount': taxes_vals['base_amount_currency'] + sum_emptying_taxes,
             'tax_inclusive_amount': invoice.amount_total - payable_rounding_amount,
             'allowance_total_amount': allowance_total_amount or None,
             'charge_total_amount': charge_total_amount or None,
@@ -543,6 +571,33 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 tax_to_discount[tax.amount] += line.amount_currency
         return tax_to_discount
 
+    def _split_fixed_taxes(self, taxes_vals):
+        # Fixed Taxes: filter them on the document level, and adapt the totals
+        # Fixed taxes are not supposed to be taxes in real life. However, this is the way in Odoo to manage recupel
+        # taxes in Belgium. Since only one tax is allowed, the fixed tax is removed from totals of lines but added
+        # as an extra charge/allowance.
+        fixed_taxes_charge_list = []
+
+        # taxes that are FIXED but don't affect the base, will be considered as emptying taxes and added as extra invoice lines
+        emptying_taxes_lines_list = []
+
+        for key in list(taxes_vals['tax_details']):
+            if key['tax_amount_type'] == 'fixed' and key['include_base_amount']:
+                fixed_tax = taxes_vals['tax_details'].pop(key)
+                taxes_vals['tax_amount_currency'] -= fixed_tax['tax_amount_currency']
+                taxes_vals['tax_amount'] -= fixed_tax['tax_amount']
+                taxes_vals['base_amount_currency'] += fixed_tax['tax_amount_currency']
+                taxes_vals['base_amount'] += fixed_tax['tax_amount']
+                fixed_taxes_charge_list.append((key, fixed_tax))
+
+            elif key['tax_amount_type'] == 'fixed' and not key['include_base_amount']:
+                emptying_tax = taxes_vals['tax_details'][key]
+                taxes_vals['tax_amount_currency'] -= emptying_tax['tax_amount_currency']
+                taxes_vals['tax_amount'] -= emptying_tax['tax_amount']
+                emptying_taxes_lines_list.append((key, emptying_tax))
+
+        return fixed_taxes_charge_list, emptying_taxes_lines_list
+
     def _export_invoice_vals(self, invoice):
         def grouping_key_generator(base_line, tax_values):
             tax = tax_values['tax_repartition_line'].tax_id
@@ -552,6 +607,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 'tax_category_percent': tax_category_vals['percent'],
                 '_tax_category_vals_': tax_category_vals,
                 'tax_amount_type': tax.amount_type,
+                'include_base_amount': tax.include_base_amount,
             }
             # If the tax is fixed, we want to have one group per tax
             # s.t. when the invoice is imported, we can try to guess the fixed taxes
@@ -569,17 +625,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             filter_invl_to_apply=self._apply_invoice_line_filter,
         )
 
-        # Fixed Taxes: filter them on the document level, and adapt the totals
-        # Fixed taxes are not supposed to be taxes in real live. However, this is the way in Odoo to manage recupel
-        # taxes in Belgium. Since only one tax is allowed, the fixed tax is removed from totals of lines but added
-        # as an extra charge/allowance.
-        fixed_taxes_keys = [k for k in taxes_vals['tax_details'] if k['tax_amount_type'] == 'fixed']
-        for key in fixed_taxes_keys:
-            fixed_tax_details = taxes_vals['tax_details'].pop(key)
-            taxes_vals['tax_amount_currency'] -= fixed_tax_details['tax_amount_currency']
-            taxes_vals['tax_amount'] -= fixed_tax_details['tax_amount']
-            taxes_vals['base_amount_currency'] += fixed_tax_details['tax_amount_currency']
-            taxes_vals['base_amount'] += fixed_tax_details['tax_amount']
+        _fixed_taxes, emptying_taxes = self._split_fixed_taxes(taxes_vals)
 
         # Compute values for invoice lines.
         line_extension_amount = 0.0
@@ -587,12 +633,45 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         invoice_lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section') and line._check_edi_line_tax_required())
         document_allowance_charge_vals_list = self._get_document_allowance_charge_vals_list(invoice)
         invoice_line_vals_list = []
+        # actual invoice lines are added to invoice_line_vals_list
         for line_id, line in enumerate(invoice_lines):
             line_taxes_vals = taxes_vals['tax_details_per_record'][line]
             line_vals = self._get_invoice_line_vals(line, line_id, {**line_taxes_vals, 'invoice_line': line})
             invoice_line_vals_list.append(line_vals)
 
             line_extension_amount += line_vals['line_extension_amount']
+
+        # add emptying taxes as extra invoice lines
+        for tax_key, tax_vals in emptying_taxes:
+            invoice_line_vals_list.append({
+                'currency': invoice.currency_id,
+                'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
+                'id': len(invoice_line_vals_list) + 1,
+                'line_quantity': 1,
+                'line_quantity_attrs': {'unitCode': 'C62'},
+                'line_extension_amount': tax_vals['tax_amount_currency'],
+                'allowance_charge_vals': [],
+                'tax_total_vals': [],
+                'item_vals': {
+                    'name': tax_key['tax_name'],
+                    'description': tax_key['tax_name'],
+                    'classified_tax_category_vals': [{
+                        'id': 'E',
+                        'percent': 0.0,
+                        'tax_scheme_vals': {'id': 'VAT'},
+                    }],
+                },
+                'price_vals': {
+                    'currency': invoice.currency_id,
+                    'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
+                    'price_amount': tax_vals['tax_amount_currency'],
+                    'base_quantity': None,
+                    'base_quantity_attrs': {'unitCode': 'C62'},
+                    'product_price_dp': self.env['decimal.precision'].precision_get('Product Price'),
+                },
+                'invoice_period_vals_list': []
+            })
+            line_extension_amount += tax_vals['tax_amount_currency']
 
         # Compute the total allowance/charge amounts.
         allowance_total_amount = 0.0

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -747,3 +747,82 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             "rsm": "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100",
         })
         self.assertEqual(node[0].text, company.vat, "Company VAT fallback")
+
+    def test_ubl_split_fixed_taxes_into_allowance_charges_or_extra_invoice_lines(self):
+        """Test that fixed taxes are split correctly:
+        - fixed taxes that affect the base are exported as AllowanceCharge.
+        - fixed taxes that not affect the base are exported as extra invoice lines."""
+
+        self.partner_a.country_id = self.env.ref('base.be')
+        standard_vat_21 = self.company_data['default_tax_sale']
+
+        # fixed AND include_base_amount => this should be treated as allowance charge
+        ecotax = self.env['account.tax'].create({
+            'name': 'Eco Tax',
+            'amount_type': 'fixed',
+            'amount': 3.0,
+            'include_base_amount': True,
+            'type_tax_use': 'sale',
+        })
+
+        # fixed AND not include_base_amount => this should be treated as extra invoice line
+        vidange = self.env['account.tax'].create({
+            'name': 'Tax Vidange',
+            'amount_type': 'fixed',
+            'amount': 5.0,
+            'include_base_amount': False,
+            'type_tax_use': 'sale',
+        })
+
+        invoice = self.env['account.move'].create({
+            'partner_id': self.partner_a.id,
+            'move_type': 'out_invoice',
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.place_prdct.id,
+                'product_uom_id': self.uom_units.id,
+                'quantity': 1.0,
+                'price_unit': 100.0,
+                'tax_ids': [Command.set((standard_vat_21 | ecotax | vidange).ids)],
+            })],
+        })
+        invoice.action_post()
+
+        xml_bytes = self.env["account.edi.xml.ubl_bis3"]._export_invoice(invoice)[0]
+        xml_tree = etree.fromstring(xml_bytes)
+
+        ns = {
+            'cbc': "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
+            'cac': "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2",
+        }
+
+        vidange_lines = xml_tree.xpath(
+            "./cac:InvoiceLine[cac:Item/cbc:Name='Tax Vidange']",
+            namespaces=ns,
+        )
+        self.assertTrue(vidange_lines)
+
+        ecotax_allowance_charge = xml_tree.xpath(
+            "./cac:InvoiceLine/cac:AllowanceCharge[cbc:AllowanceChargeReason='Eco Tax']",
+            namespaces=ns,
+        )
+        self.assertTrue(ecotax_allowance_charge)
+
+        # there should be a TaxSubtotal with VAT category 'E' for emptying taxes
+        subtotals = xml_tree.xpath(
+            "./cac:TaxTotal/cac:TaxSubtotal[cac:TaxCategory/cbc:ID='E']",
+            namespaces=ns,
+        )
+        self.assertTrue(subtotals)
+
+        # check TaxTotal ?= sum(TaxSubtotal)
+        tax_total_amount = float(xml_tree.xpath("string(./cac:TaxTotal/cbc:TaxAmount)", namespaces=ns) or 0.0)
+        subtotal_amounts = [
+            float(x) for x in xml_tree.xpath("./cac:TaxTotal/cac:TaxSubtotal/cbc:TaxAmount/text()", namespaces=ns)
+        ]
+        self.assertAlmostEqual(
+            tax_total_amount,
+            sum(subtotal_amounts),
+            places=2,
+            msg="TaxTotal != sum(TaxSubtotal)",
+        )


### PR DESCRIPTION
Context :
In v18+, fixed taxes are handled differently depending on whether they affect the tax base or not.

Before this commit :
All fixed taxes were systematically converted into allowance charges during UBL exports. This behaviour was incorrect, as some fixed taxes (e.g., recupel) do not affect the tax base and should instead be represented as separate invoice lines.

This commit aligns the v17 behavior with the logic introduced in v18+ by distinguishing between the two cases:
- Fixed taxes that affect the base are converted into allowance charges.
- Fixed taxes that do not affect the base are converted into additional invoice lines.

task-5405115
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
