### PR TITLE
[FIX] mail: empty emojis list

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -57,7 +57,7 @@ export class MessageReactionMenu extends Component {
     }
 
     getEmojiShortcode(reaction) {
-        return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[reaction.content][0] ?? "?";
+        return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[reaction.content]?.[0] ?? "?";
     }
 
     get contentClass() {

--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -73,7 +73,7 @@ export class QuickReactionMenu extends Component {
     }
 
     getEmojiShortcode(emoji) {
-        return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[emoji][0] ?? "?";
+        return this.store.emojiLoader.loaded?.emojiValueToShortcodes?.[emoji]?.[0] ?? "?";
     }
 
     onClick() {


### PR DESCRIPTION
By default `emojiValueToShortcodes` is empty, combine to `?.` that can lead to empty list when getting the reaction content. Avoid error by propagating the null safety call

Issue founded during an investigation to put text as reaction and not only emojis. Easily reproducable with this git diff
https://gist.github.com/GaetanVandenBergh/772f3bfdc382c11ae9d629c79e669239