### PR TITLE
[FIX] mail: fix some UX issues with new channel 'hide' feature

### DIFF
--- a/addons/mail/controllers/discuss/search.py
+++ b/addons/mail/controllers/discuss/search.py
@@ -27,13 +27,5 @@ class SearchController(http.Controller):
             query = channels._search(Domain('id', 'not in', channels.ids) & domain, limit=remaining_limit)
             channels |= channels.browse(query)
         store.add(channels, "_store_channel_fields")
-        # sudo: discuss.channel.member: sudo for performance. Checking existence of unpinned
-        # channels is acceptable, even if the channel is no longer accessible to the user.
-        store.add_global_values(
-            has_unpinned_channels=request.env["discuss.channel.member"]
-            .sudo()
-            .search_count([("is_self", "=", True), ("is_pinned", "=", False)], limit=1)
-            > 0,
-        )
         request.env["res.partner"]._search_for_channel_invite(store, search_term=term, limit=limit)
         return store.get_result()

--- a/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.js
@@ -32,6 +32,10 @@ export class DiscussSidebar extends Component {
         return discussSidebarItemsRegistry.getAll();
     }
 
+    onClickViewHiddenConversations() {
+        this.env.services.action.doAction("mail.discuss_my_conversations_action");
+    }
+
     onResize(width) {
         if (!this.mounted) {
             return; // ignore resize from mount not triggered by user

--- a/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.xml
@@ -13,6 +13,11 @@
                         'o-px-2_5': !store.discuss.isSidebarCompact or ui.isSmall,
                     }"/>
                     <t t-foreach="discussSidebarItems" t-as="item" t-key="item_index" t-component="item"/>
+                    <t t-set="VIEW_HIDDEN_CONVERSATIONS">View hidden conversations</t>
+                    <button t-if="store.has_unpinned_channels" class="btn btn-secondary btn-sm border-0 mb-1 opacity-100-hover rounded-3 d-flex align-items-center justify-content-center" t-att-class="{ 'p-2 mx-2 mt-1 opacity-75': store.discuss.isSidebarCompact, 'mx-4 mt-2 opacity-50': !store.discuss.isSidebarCompact }" t-on-click="onClickViewHiddenConversations" t-att-title="store.discuss.isSidebarCompact ? VIEW_HIDDEN_CONVERSATIONS : undefined">
+                        <i class="fa fa-eye-slash" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact, 'me-2': !store.discuss.isSidebarCompact }"/>
+                        <span t-if="!store.discuss.isSidebarCompact" class="text-truncate" t-esc="VIEW_HIDDEN_CONVERSATIONS"/>
+                    </button>
                 </div>
             </ResizablePanel>
         </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -53,6 +53,7 @@ export class ChannelMember extends Record {
      */
     channel_role;
     threadAsSelf = fields.One("mail.thread", {
+        /** @this {import("models").ChannelMember} */
         compute() {
             if (this.store.self?.eq(this.persona)) {
                 return this.channel_id?.thread;

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -245,7 +245,7 @@ registerThreadAction("hide", {
         (channel?.canHide ||
             channel?.sub_channel_ids.some((subThread) => subThread.channel.canHide)) &&
         !owner.isDiscussContent,
-    icon: "fa fa-fw fa-times-circle",
+    icon: "fa fa-fw fa-eye-slash",
     /**
      * @param {Object} param0
      * @param {import("models").DiscussChannel} param0.channel
@@ -257,9 +257,8 @@ registerThreadAction("hide", {
      * @param {import("models").DiscussChannel} param0.channel
      */
     onSelected: ({ channel }) => channel.unpinChannel(),
-    partition: ({ owner }) => owner.env.inChatWindow,
     sequence: 10,
-    sequenceGroup: 40,
+    sequenceGroup: 35,
 });
 registerThreadAction("leave", {
     /**
@@ -280,7 +279,6 @@ registerThreadAction("leave", {
      * @param {import("models").DiscussChannel} param0.channel
      */
     onSelected: ({ channel }) => channel.leaveChannel(),
-    partition: ({ owner }) => owner.env.inChatWindow,
     sequence: 20,
     sequenceGroup: 40,
     tags: ACTION_TAGS.DANGER,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
@@ -155,12 +155,12 @@ const discussChannelPatch = {
         }
     },
     /** @override */
-    openChannel() {
+    _openChannel() {
         if (this.store.discuss.isActive && !this.store.env.services.ui.isSmall) {
             this.setAsDiscussThread();
             return true;
         }
-        return super.openChannel();
+        return super._openChannel();
     },
     get shouldSubscribeToBusChannel() {
         return super.shouldSubscribeToBusChannel || this.isLocallyPinned;

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -844,6 +844,54 @@ test("Can unpin chat channel", async () => {
     await click("[title='Chat Actions']");
     await click(".o-dropdown-item:text('Hide Until New Message')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mitchell Admin')", { count: 0 });
+    await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))");
+});
+
+test("opening a hidden channel re-pins it", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create([
+        {
+            channel_type: "channel",
+            name: "InitialChannel",
+        },
+        {
+            channel_type: "chat",
+            channel_member_ids: [
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    unpin_dt: "2021-01-01 12:00:00",
+                }),
+            ],
+        },
+        {
+            channel_type: "channel",
+            channel_member_ids: [
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    unpin_dt: "2021-01-01 12:00:00",
+                }),
+            ],
+            name: "General",
+        },
+    ]);
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-DiscussSidebarChannel");
+    await contains(".o-mail-DiscussSidebarChannel:has(:text('InitialChannel'))");
+    await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))");
+    await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mitchell Admin')", { count: 0 });
+    await click("input[placeholder='Search conversations']");
+    await insertText("input[placeholder='Search a conversation']", "Mitchell Admin");
+    await click(".o-mail-DiscussCommand-nameContainer:text('Mitchell Admin')");
+    await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mitchell Admin')");
+    await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))");
+    await click("input[placeholder='Search conversations']");
+    await insertText("input[placeholder='Search a conversation']", "General");
+    await click(".o-mail-DiscussCommand-nameContainer:text('General')");
+    await contains(".o-mail-DiscussSidebarChannel-itemName:text('General')");
+    await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))", {
+        count: 0,
+    });
 });
 
 test("Can leave channel", async () => {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1078,6 +1078,16 @@ function _process_request_for_all(store, name, params, context = {}) {
             ),
             ["is_favorite"]
         );
+        store.add({
+            has_unpinned_channels:
+                DiscussChannelMember.search_count(
+                    [
+                        ["is_self", "=", true],
+                        ["is_pinned", "=", false],
+                    ],
+                    makeKwArgs({ limit: 1 })
+                ) > 0,
+        });
     }
     if (name === "mail.thread") {
         store.add(
@@ -1110,6 +1120,16 @@ function _process_request_for_all(store, name, params, context = {}) {
             ["is_self", "=", true],
         ]);
         DiscussChannelMember._channel_pin(memberIds, params.pinned);
+        store.add({
+            has_unpinned_channels:
+                DiscussChannelMember.search_count(
+                    [
+                        ["is_self", "=", true],
+                        ["is_pinned", "=", false],
+                    ],
+                    makeKwArgs({ limit: 1 })
+                ) > 0,
+        });
     }
     if (name === "/discuss/get_or_create_chat") {
         const channelId = DiscussChannel._get_or_create_chat(params.partners_to);

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -86,7 +86,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - fetch res_users
     #       - search discuss_channel_member
     #       - fetch discuss_channel
-    #   1: channels_as_member
+    #   2: channels_as_member
+    #       - search_fetch channel (channels)
+    #       - search_count member (has_unpinned_channels)
     #   34: store add channel:
     #       - read group member (prefetch _compute_self_member_id from _compute_is_member)
     #       - read group member (_compute_invited_member_ids)
@@ -149,7 +151,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search user (author)
     #       - fetch user (author)
     #       - fetch discuss_call_history
-    _query_count_discuss_channels = 62
+    _query_count_discuss_channels = 63
 
     def setUp(self):
         super().setUp()
@@ -623,6 +625,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 self._res_for_user(self.user_root),
                 self._res_for_user(self.users[1]),
             ),
+            "Store": {"has_unpinned_channels": False},
             "hr.employee": [
                 self._res_for_employee(self.users[0].employee_ids[0]),
                 self._res_for_employee(self.users[14].employee_ids[0]),


### PR DESCRIPTION
1. Discoverability of "hidden channels" was poor in just ctrl-k
=> Added a new button at bottom of discuss sidebar with "View hidden conversations".

2. When opening a hidden conversation, it's not possible to "undo" the hide.
=> Automatically repin conversation when opening the conversation.

3. Hide action was in same group as "Leaving", which is confusing because the actions are quite different as shown by color.
=> Moved "Hide conversation" action in its own group just above the highly destructive action like "Leave" but below settings actions.

4. Iconography of action is poor with a cross icon
=> use fa-eye(-slash) that matches more the semantics of action.

Task-5431819

<img width="506" height="857" alt="Screenshot 2025-12-19 at 15 34 35" src="https://github.com/user-attachments/assets/453258bb-e83d-49db-986e-9c1c74eafc8d" />
