### PR TITLE
[FIX] survey: handle filter interaction on paginated results

### DIFF
--- a/addons/survey/static/src/interactions/survey_result.js
+++ b/addons/survey/static/src/interactions/survey_result.js
@@ -8,6 +8,7 @@ export class SurveyResult extends Interaction {
 
     dynamicContent = {
         ".o_survey_results_topbar_clear_filters": { "t-on-click": this.onClearFiltersClick },
+        ".o_survey_results_data_tab:not(.active)": { "t-on-click": this.updateContent },
         ".filter-add-answer": { "t-on-click": this.onFilterAddAnswerClick },
         "i.filter-remove-answer": { "t-on-click": this.onFilterRemoveAnswerClick },
         "a.filter-finished-or-not": { "t-on-click": this.onFilterFinishedOrNotClick },


### PR DESCRIPTION
Step to reproduce:
1. Install `survey`
2. Create a survey containing a "Date" type question
3. Share the survey and generate multiple responses
4. Go to the survey results analysis page.
5. In the `User Responses` table, try to filter by clicking the filter icon.

Issue:
Nothing happens when clicking the filter icon.

Cause:
https://github.com/odoo/odoo/commit/dfc1c742e35f75f2c386c4ef50d5584537ac1ed4 This recent refactoring moved interactions to the `SurveyResult` class. However, the table rows in the results view are rendered dynamically by a separate interaction, `SurveyResultPagination`,  which replaces the DOM content using `t-out`. Because these elements are created dynamically after the `SurveyResult` interaction has started, the event listeners for `filter-add-answer` are not attached to them.

Solution:
- Reapply the interactions on tab change

opw-5366346