### PR TITLE
[IMP] im_livechat: show invite link on closed live chats

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -123,21 +123,21 @@ class DiscussChannelMember(models.Model):
     def _inverse_livechat_member_type(self):
         # sudo - im_livechat.channel.member: creating/updating history following
         # "livechat_member_type" modification is acceptable.
-        self.sudo()._create_or_update_history(
+        self.sudo().filtered(lambda m: not m.channel_id.livechat_end_dt)._create_or_update_history(
             {member: {"livechat_member_type": member.livechat_member_type} for member in self},
         )
 
     def _inverse_chatbot_script_id(self):
         # sudo - im_livechat.channel.member: creating/updating history following
         # "chatbot_script_id" modification is acceptable.
-        self.sudo()._create_or_update_history(
+        self.sudo().filtered(lambda m: not m.channel_id.livechat_end_dt)._create_or_update_history(
             {member: {"chatbot_script_id": member.chatbot_script_id.id} for member in self}
         )
 
     def _inverse_agent_expertise_ids(self):
         # sudo - im_livechat.channel.member.history: creating/udpating history following
         # "agent_expetise_ids" modification is acceptable.
-        self.sudo()._create_or_update_history(
+        self.sudo().filtered(lambda m: not m.channel_id.livechat_end_dt)._create_or_update_history(
             {member: {"agent_expertise_ids": member.agent_expertise_ids.ids} for member in self}
         )
 

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -35,6 +35,9 @@ const discussChannelPatch = {
         }
         return super._computeCanHide(...arguments);
     },
+    get hasChannelInviteSearch() {
+        return super.hasChannelInviteSearch && !this.livechat_end_dt;
+    },
     get isHideUntilNewMessageSupported() {
         if (this.livechat_end_dt) {
             return false;

--- a/addons/im_livechat/static/src/core/common/thread_actions_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_actions_patch.js
@@ -21,15 +21,6 @@ patch(ThreadAction.prototype, {
     },
 });
 
-patch(threadActionsRegistry.get("invite-people"), {
-    condition({ channel }) {
-        if (channel?.channel_type === "livechat") {
-            return super.condition(...arguments) && !channel.livechat_end_dt;
-        }
-        return super.condition(...arguments);
-    },
-});
-
 patch(threadActionsRegistry.get("notification-settings"), {
     condition({ channel }) {
         if (channel?.channel_type === "livechat") {

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -38,7 +38,7 @@
                 <ExpertiseTagsAutocomplete channel="props.thread.channel" disabled="!store.has_access_livechat"/>
             </div>
             <t t-name="extra_infos"/>
-            <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="props.thread.livechat_end_dt and store.has_access_livechat" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Send conversation</h6>
                 <TranscriptSender thread="props.thread"/>
                 <a class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="props.thread.transcriptUrl"><i class="pe-2 fa fa-download"/>Download</a>

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -199,6 +199,9 @@ test("Manage expertises from channel info list", async () => {
 
 test("Can download transcript from channel info panel", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write([serverState.userId], {
+        group_ids: [serverState.groupLivechatManagerId, serverState.groupLivechatId],
+    });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor #20" });
     const channelId = pyEnv["discuss.channel"].create({
         channel_member_ids: [

--- a/addons/im_livechat/static/tests/transcript_sender.test.js
+++ b/addons/im_livechat/static/tests/transcript_sender.test.js
@@ -10,6 +10,9 @@ defineLivechatModels();
 
 test("agent can send conversation after livechat ends", async () => {
     const pyEnv = await startServer();
+    pyEnv["res.users"].write([serverState.userId], {
+        group_ids: [serverState.groupLivechatManagerId, serverState.groupLivechatId],
+    });
     const demoPartnerId = pyEnv["res.partner"].create({
         name: "Awesome partner",
         email: "awesome@example.com",

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -45,12 +45,12 @@ export class ChannelInvitation extends Component {
             250
         );
         onWillStart(() => {
-            if (this.store.self_user) {
+            if (this.hasSearch) {
                 this.fetchPartnersToInvite();
             }
         });
         onMounted(() => {
-            if (this.store.self_user && this.props.channel) {
+            if (this.hasSearch) {
                 this.inputRef.el.focus();
             }
         });
@@ -62,6 +62,17 @@ export class ChannelInvitation extends Component {
             },
             () => [this.props.autofocus]
         );
+    }
+
+    get hasSearch() {
+        return (
+            this.store.self_user &&
+            (!this.props.channel || this.props.channel.hasChannelInviteSearch)
+        );
+    }
+
+    get title() {
+        return this.hasSearch ? _t("Invite People") : _t("Share Conversation");
     }
 
     get selectablePartners() {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelInvitation">
-        <ActionPanel t-if="props.channel" title.translate="Invite people" resizable="!!env.inMeetingView" minWidth="env.inMeetingView ? 300 : undefined" initialWidth="env.inMeetingView ? 400 : undefined" icon="'oi oi-user-plus'">
+        <ActionPanel t-if="props.channel" title="title" resizable="!!env.inMeetingView" minWidth="env.inMeetingView ? 300 : undefined" initialWidth="env.inMeetingView ? 400 : undefined" icon="'oi oi-user-plus'">
             <t t-call="discuss.ChannelInvitation.main"/>
         </ActionPanel>
         <t t-else="" t-call="discuss.ChannelInvitation.main"/>
@@ -10,7 +10,7 @@
 
     <t t-name="discuss.ChannelInvitation.main">
         <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.channel }">
-            <t t-if="store.self_user">
+            <t t-if="hasSearch">
                 <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 and state.selectableEmails.length === 0 }">
                     <div t-if="selectablePartners.length === 0 and state.selectableEmails.length === 0" class="smaller text-muted mx-1 opacity-50">
@@ -32,7 +32,7 @@
                 </ul>
             </t>
             <div class="o-discuss-ChannelInvitation-invitationBox pt-0 pb-1 bg-inherit">
-                <t t-if="store.self_user" >
+                <t t-if="hasSearch" >
                     <div t-if="selectedPartners.length > 0 or state.selectedEmails.length > 0" class="pt-2">
                         <div class="o-discuss-ChannelInvitation-selectedList d-flex flex-wrap overflow-auto o-scrollbar-thin">
                             <t t-foreach="selectedPartners" t-as="selectedPartner" t-key="selectedPartner.id">
@@ -51,7 +51,7 @@
                         <t t-esc="invitationButtonText"/>
                     </button>
                 </t>
-                <hr t-if="props.channel?.invitationLink" class="border-dark-subtle"/>
+                <hr t-if="props.channel?.invitationLink and hasSearch" class="border-dark-subtle"/>
                 <div t-if="props.channel?.invitationLink" class="input-group">
                     <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="props.channel.invitationLink" readonly="" disabled="" t-on-focus="onFocusInvitationLinkInput"/>
                     <button class="btn btn-primary px-2 o-py-0_5" t-on-click="onClickCopy">

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -376,6 +376,10 @@ export class DiscussChannel extends Record {
         }
     }
 
+    get hasChannelInviteSearch() {
+        return true;
+    }
+
     async markAsFetched() {
         await this.store.env.services.orm.silent.call("discuss.channel", "channel_fetched", [
             [this.id],

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -182,7 +182,10 @@ registerThreadAction("invite-people", {
     condition: ({ channel, owner }) =>
         channel && (!owner.props.chatWindow || owner.props.chatWindow.isOpen),
     icon: "oi oi-fw oi-user-plus",
-    name: _t("Invite People"),
+    name: ({ channel, store }) =>
+        store.self_user && channel.hasChannelInviteSearch
+            ? _t("Invite People")
+            : _t("Share Conversation"),
     sequence: ({ owner }) => (owner.isDiscussSidebarChannelActions ? 20 : 10),
     sequenceGroup: 20,
     setup({ owner }) {

--- a/addons/mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sidebar_in_public_page_tour.js
@@ -42,7 +42,7 @@ registry.category("web_tour.tours").add("sidebar_in_public_page_tour", {
             run: "hover && click [title='Channel Actions']",
         },
         {
-            trigger: ".o-dropdown-item:contains('Invite People')",
+            trigger: ".o-dropdown-item:contains('Share Conversation')",
             run: "click",
         },
     ],


### PR DESCRIPTION
Invite link is hidden on closed live chat but it doesn't make
sense. Internal users still want to invite collegues to the chat
(e.g. inviting salesperson to the chat). Morever, the link is hidden
but nothing prevents users to user it technically.

This commit shows the invite panel, even on closed live chats.

part of task-4873812