### PR TITLE
[FIX] website: replace `.o_small` with `.o_small-fs` in snippets

### DIFF
--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option.xml
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option.xml
@@ -5,7 +5,7 @@
     <BuilderRow label.translate="Descriptions">
         <BuilderCheckbox
             action="'togglePriceListDescription'"
-            actionParam="{ itemClass:'s_pricelist_boxed_item', descriptionClass: 's_pricelist_boxed_item_description', descriptionExtraClass: 'o_small' }"/>
+            actionParam="{ itemClass:'s_pricelist_boxed_item', descriptionClass: 's_pricelist_boxed_item_description', descriptionExtraClass: 'o_small-fs' }"/>
     </BuilderRow>
     <BuilderContext applyTo="'.s_pricelist_boxed_item_line'">
         <BorderConfigurator withRoundCorner="false" withBSClass="false" label.translate="Separator" direction="'top'"/>

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_option.xml
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_option.xml
@@ -5,7 +5,7 @@
     <BuilderRow label.translate="Descriptions">
         <BuilderCheckbox
             action="'togglePriceListDescription'"
-            actionParam="{ itemClass:'s_pricelist_cafe_item', descriptionClass: 's_pricelist_cafe_item_description', descriptionExtraClass: 'o_small' }"/>
+            actionParam="{ itemClass:'s_pricelist_cafe_item', descriptionClass: 's_pricelist_cafe_item_description', descriptionExtraClass: 'o_small-fs' }"/>
     </BuilderRow>
     <BuilderContext applyTo="'.s_pricelist_cafe_item_line'">
         <BorderConfigurator withRoundCorner="false" withBSClass="false" label.translate="Separator" direction="'top'"/>

--- a/addons/website/static/tests/interactions/snippets/faq_horizontal.test.js
+++ b/addons/website/static/tests/interactions/snippets/faq_horizontal.test.js
@@ -28,7 +28,7 @@ const getTemplate = function (headerType) {
                         <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 79.9773px; max-height: calc(-119.977px + 100vh);">
                                 <h3 class="h5-fs">Getting Started</h3>
-                                <p class="o_small text-muted">Getting started with our product is a breeze, thanks to our well-structured and comprehensive onboarding process.</p>
+                                <p class="o_small-fs text-muted">Getting started with our product is a breeze, thanks to our well-structured and comprehensive onboarding process.</p>
                             </div>
                         </hgroup>
                         <span class="col-lg-7 offset-lg-1 d-block">
@@ -45,7 +45,7 @@ const getTemplate = function (headerType) {
                         <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 79.9773px; max-height: calc(-119.977px + 100vh);">
                                 <h3 class="h5-fs">Updates and Improvements</h3>
-                                <p class="o_small text-muted">We are committed to continuous improvement, regularly releasing updates and new features based on user feedback and technological advancements.</p>
+                                <p class="o_small-fs text-muted">We are committed to continuous improvement, regularly releasing updates and new features based on user feedback and technological advancements.</p>
                             </div>
                         </hgroup>
                         <span class="col-lg-7 offset-lg-1 d-block">
@@ -63,7 +63,7 @@ const getTemplate = function (headerType) {
                         <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 79.9773px; max-height: calc(-119.977px + 100vh);">
                                 <h3 class="h5-fs">Support and Resources</h3>
-                                <p class="o_small text-muted">We are committed to providing exceptional support and resources to help you succeed with our platform.</p>
+                                <p class="o_small-fs text-muted">We are committed to providing exceptional support and resources to help you succeed with our platform.</p>
                             </div>
                         </hgroup>
                         <span class="col-lg-7 offset-lg-1 d-block">

--- a/addons/website/views/snippets/s_avatars.xml
+++ b/addons/website/views/snippets/s_avatars.xml
@@ -11,7 +11,7 @@
                 <p class="m-0">10+</p>
             </div>
         </div>
-        <p class="s_avatars_label o_small m-0 o-contenteditable-true">
+        <p class="s_avatars_label o_small-fs m-0 o-contenteditable-true">
             <strong>100+</strong><br/>
             Happy customers
         </p>

--- a/addons/website/views/snippets/s_banner.xml
+++ b/addons/website/views/snippets/s_banner.xml
@@ -28,7 +28,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
                             <img src="/web/image/website.s_blockquote_default_image" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>Paul Dawson</strong><br/>
                                     <span>CEO of MyCompany</span>
                                 </span>

--- a/addons/website/views/snippets/s_bento_grid_avatars.xml
+++ b/addons/website/views/snippets/s_bento_grid_avatars.xml
@@ -43,7 +43,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
                             <img src="/web/image/website.s_blockquote_default_image" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>Paul Dawson</strong><br/>
                                     <span class="text-muted">Furniture Design Specialist</span>
                                 </span>

--- a/addons/website/views/snippets/s_blockquote.xml
+++ b/addons/website/views/snippets/s_blockquote.xml
@@ -11,7 +11,7 @@
         <div class="s_blockquote_infos d-flex gap-2 flex-row align-items-start justify-content-start w-100 text-start">
             <img src="/web/image/website.s_blockquote_default_image" class="s_blockquote_avatar img rounded-circle" alt=""/>
             <div class="s_blockquote_author">
-                <span class="o_small">
+                <span class="o_small-fs">
                     <strong>Paul Dawson</strong><br/>
                     <span class="text-muted">CEO of MyCompany</span>
                 </span>

--- a/addons/website/views/snippets/s_faq_horizontal.xml
+++ b/addons/website/views/snippets/s_faq_horizontal.xml
@@ -16,7 +16,7 @@
                         <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 16px">
                                 <h3 class="h5-fs">Getting Started</h3>
-                                <p class="o_small text-muted">Getting started with our product is a breeze, thanks to our well-structured and comprehensive onboarding process.</p>
+                                <p class="o_small-fs text-muted">Getting started with our product is a breeze, thanks to our well-structured and comprehensive onboarding process.</p>
                             </div>
                         </hgroup>
                         <span class="col-lg-7 offset-lg-1 d-block">
@@ -33,7 +33,7 @@
                         <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 16px">
                                 <h3 class="h5-fs">Updates and Improvements</h3>
-                                <p class="o_small text-muted">We are committed to continuous improvement, regularly releasing updates and new features based on user feedback and technological advancements.</p>
+                                <p class="o_small-fs text-muted">We are committed to continuous improvement, regularly releasing updates and new features based on user feedback and technological advancements.</p>
                             </div>
                         </hgroup>
                         <span class="col-lg-7 offset-lg-1 d-block">
@@ -54,7 +54,7 @@
                         <hgroup class="col-lg-4" role="heading" aria-level="3">
                             <div class="s_faq_horizontal_entry_title position-lg-sticky pb-lg-3 transition-base overflow-auto" style="top: 16px">
                                 <h3 class="h5-fs">Support and Resources</h3>
-                                <p class="o_small text-muted">We are committed to providing exceptional support and resources to help you succeed with our platform.</p>
+                                <p class="o_small-fs text-muted">We are committed to providing exceptional support and resources to help you succeed with our platform.</p>
                             </div>
                         </hgroup>
                         <span class="col-lg-7 offset-lg-1 d-block">

--- a/addons/website/views/snippets/s_numbers_charts.xml
+++ b/addons/website/views/snippets/s_numbers_charts.xml
@@ -48,7 +48,7 @@
                     <!-- End of placeholder -->
                     <p><br/></p>
                     <p class="display-1-fs" style="text-align: center;">75%</p>
-                    <p class="o_small text-600" style="text-align: center;">75% of clients have been using the service for over a decade consistently.</p>
+                    <p class="o_small-fs text-600" style="text-align: center;">75% of clients have been using the service for over a decade consistently.</p>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_opening_hours.xml
+++ b/addons/website/views/snippets/s_opening_hours.xml
@@ -15,15 +15,15 @@
                     <p class="lead"><u>info@yourcompany.example.com</u></p>
                 </div>
                 <div class="o_grid_item o_cc o_cc1 g-col-lg-2 g-height-7 col-lg-2 col-6" style="grid-area: 1 / 8 / 8 / 10; z-index: 4; --grid-item-padding-y: 32px; --grid-item-padding-x: 40px;">
-                    <p class="o_small"><u>Monday</u><br/>8.00am-6.00pm</p>
-                    <p class="o_small"><u>Tuesday</u><br/>8.00am-6.00pm</p>
-                    <p class="o_small"><u>Wednesday</u><br/>8.00am-12.00am</p>
-                    <p class="o_small"><u>Thursday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small-fs"><u>Monday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small-fs"><u>Tuesday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small-fs"><u>Wednesday</u><br/>8.00am-12.00am</p>
+                    <p class="o_small-fs"><u>Thursday</u><br/>8.00am-6.00pm</p>
                 </div>
                 <div class="o_grid_item o_cc o_cc1 g-col-lg-2 g-height-7 col-lg-2 col-6" style="grid-area: 1 / 10 / 8 / 12; z-index:5; --grid-item-padding-y: 32px; --grid-item-padding-x: 40px;">
-                    <p class="o_small"><u>Friday</u><br/>8.00am-6.00pm</p>
-                    <p class="o_small"><u>Saturday</u><br/>8.00am-6.00pm</p>
-                    <p class="o_small"><u>Sunday</u><br/>Closed</p>
+                    <p class="o_small-fs"><u>Friday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small-fs"><u>Saturday</u><br/>8.00am-6.00pm</p>
+                    <p class="o_small-fs"><u>Sunday</u><br/>Closed</p>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/s_pricelist_boxed.xml
+++ b/addons/website/views/snippets/s_pricelist_boxed.xml
@@ -70,7 +70,7 @@
             </span>
             <span t-out="price" class="s_pricelist_boxed_item_price ms-auto ps-3"/>
         </p>
-        <p t-if="description" t-out="description" class="s_pricelist_boxed_item_description d-block mt-2 pe-5 text-muted o_small"/>
+        <p t-if="description" t-out="description" class="s_pricelist_boxed_item_description d-block mt-2 pe-5 text-muted o_small-fs"/>
     </li>
 </template>
 

--- a/addons/website/views/snippets/s_pricelist_cafe.xml
+++ b/addons/website/views/snippets/s_pricelist_cafe.xml
@@ -69,7 +69,7 @@
             </span>
             <span t-out="price" class="s_pricelist_cafe_item_price ms-auto ps-3"/>
         </p>
-        <p t-if="description" t-out="description" class="s_pricelist_cafe_item_description d-block mt-2 pe-5 text-muted o_small"/>
+        <p t-if="description" t-out="description" class="s_pricelist_cafe_item_description d-block mt-2 pe-5 text-muted o_small-fs"/>
     </li>
 </template>
 

--- a/addons/website/views/snippets/s_quotes_carousel.xml
+++ b/addons/website/views/snippets/s_quotes_carousel.xml
@@ -18,7 +18,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
                             <img src="/web/image/website.s_quotes_carousel_demo_image_3" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>Jane DOE</strong><br/>
                                     <span class="text-muted">CEO of MyCompany</span>
                                 </span>
@@ -37,7 +37,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
                             <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>John DOE</strong><br/>
                                     <span class="text-muted">CCO of MyCompany</span>
                                 </span>
@@ -56,7 +56,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
                             <img src="/web/image/website.s_quotes_carousel_demo_image_5" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>Iris DOE</strong><br/>
                                     <span class="text-muted">Manager of MyCompany</span>
                                 </span>

--- a/addons/website/views/snippets/s_quotes_carousel_compact.xml
+++ b/addons/website/views/snippets/s_quotes_carousel_compact.xml
@@ -20,7 +20,7 @@
                                 <div class="s_blockquote_infos gap-2 flex-row align-items-start justify-content-start w-100 text-start">
                                     <img src="/web/image/website.s_quotes_carousel_demo_image_3" class="s_blockquote_avatar img rounded-circle" alt=""/>
                                     <div class="s_blockquote_author">
-                                        <span class="o_small">
+                                        <span class="o_small-fs">
                                             <strong>Jane DOE</strong><br/>
                                             <span class="text-muted">CEO of MyCompany</span>
                                         </span>
@@ -43,7 +43,7 @@
                                 <div class="s_blockquote_infos gap-2 flex-row align-items-start justify-content-start w-100 text-start">
                                     <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
                                     <div class="s_blockquote_author">
-                                        <span class="o_small">
+                                        <span class="o_small-fs">
                                             <strong>John DOE</strong><br/>
                                             <span class="text-muted">CCO of MyCompany</span>
                                         </span>
@@ -66,7 +66,7 @@
                                 <div class="s_blockquote_infos gap-2 flex-row align-items-start justify-content-start w-100 text-start">
                                     <img src="/web/image/website.s_quotes_carousel_demo_image_5" class="s_blockquote_avatar img rounded-circle" alt=""/>
                                     <div class="s_blockquote_author">
-                                        <span class="o_small">
+                                        <span class="o_small-fs">
                                             <strong>Iris DOE</strong><br/>
                                             <span class="text-muted">Manager of MyCompany</span>
                                         </span>

--- a/addons/website/views/snippets/s_quotes_carousel_minimal.xml
+++ b/addons/website/views/snippets/s_quotes_carousel_minimal.xml
@@ -18,7 +18,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
                             <img src="/web/image/website.s_quotes_carousel_demo_image_3" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>Jane DOE</strong><br/>
                                     <span class="text-muted">CEO of MyCompany</span>
                                 </span>
@@ -37,7 +37,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
                             <img src="/web/image/website.s_quotes_carousel_demo_image_4" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>John DOE</strong><br/>
                                     <span class="text-muted">CCO of MyCompany</span>
                                 </span>
@@ -56,7 +56,7 @@
                         <div class="s_blockquote_infos d-flex gap-2 flex-column align-items-center w-100 text-center">
                             <img src="/web/image/website.s_quotes_carousel_demo_image_5" class="s_blockquote_avatar img rounded-circle" alt=""/>
                             <div class="s_blockquote_author">
-                                <span class="o_small">
+                                <span class="o_small-fs">
                                     <strong>Iris DOE</strong><br/>
                                     <span class="text-muted">Manager of MyCompany</span>
                                 </span>


### PR DESCRIPTION
This PR fixes an issue where some snippets were using the `.o_small` class instead of `.o_small-fs` to enforce `font-size` on an element.

This may have been an oversight or a workaround, but it causes issues because `.o_small` is not part of the `FONT_SIZE_CLASSES` array.

Although this results in a slight loss of flexibility (as `.o_small` used a `rem` value), the trade-off ensures that users can correctly apply their desired formatting.

task-5431614

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
