### PR TITLE
[IMP] mail: redirect to discuss from public page

### DIFF
--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -108,6 +108,8 @@ class PublicPageController(http.Controller):
         if guest and not guest_already_known:
             store.add_global_values(is_welcome_page_displayed=True)
             channel = channel.with_context(guest=guest)
+        if self.env.user._is_internal():
+            return request.redirect(f"/odoo/action-mail.action_discuss?active_id={channel.id}")
         return self._response_discuss_public_template(store, channel)
 
     def _response_discuss_public_template(self, store: Store, channel):

--- a/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
@@ -28,11 +28,11 @@ function getMeetingViewTourSteps({ inWelcomePage = false } = {}) {
         },
         {
             trigger:
-                ".o-mail-Meeting .o-mail-ActionPanel .o-mail-Thread:contains('john (base.group_user) and bob (base.group_user)')",
+                ".o-mail-Meeting .o-mail-ActionPanel .o-mail-Thread:contains('john (base.group_user), bob (base.group_user), and Guest')",
         },
         {
             trigger: ".o-mail-Message[data-persistent]:contains('Hello everyone!')",
-            run: "hover && click .o-mail-Message-actions button[title='Expand']",
+            run: "hover && click .o-mail-Meeting .o-mail-Message-actions button[title='Expand']",
         },
         {
             trigger: ".o-dropdown-item:contains('Mark as Unread')",
@@ -67,7 +67,10 @@ function getMeetingViewTourSteps({ inWelcomePage = false } = {}) {
         { trigger: "body:not(:has(.o-mail-Meeting))" },
     ];
     if (inWelcomePage) {
-        steps.unshift({ trigger: "[title='Join Channel']", run: "click" });
+        steps.unshift(
+            { trigger: "input[name='guest_name']", run: "edit Guest" },
+            { trigger: "[title='Join Channel']", run: "click" }
+        );
     }
     return steps;
 }


### PR DESCRIPTION
When sharing an invitation link, user is always redirected to the discuss guest page.
However, it's better to redirect internal users to discuss.
This commit redirects internal users to the discuss app from the invitation link.

part of task-4873812