### PR TITLE
[IMP] sale_stock, purchase_stock: Create pickings on stock install

### DIFF
--- a/addons/purchase_stock/__init__.py
+++ b/addons/purchase_stock/__init__.py
@@ -5,6 +5,13 @@ from . import models
 from . import report
 from . import wizard
 
+from odoo.fields import Domain
+
+
+def post_init_hook(env):
+    _create_buy_rules(env)
+    _create_pickings_for_open_purchase_orders(env)
+
 
 def _create_buy_rules(env):
     """ This hook is used to add a default buy_pull_id on every warehouse. It is
@@ -13,3 +20,32 @@ def _create_buy_rules(env):
     """
     warehouse_ids = env['stock.warehouse'].search([('buy_pull_id', '=', False)])
     warehouse_ids.write({'buy_to_resupply': True})
+
+
+def _create_pickings_for_open_purchase_orders(env):
+    """ Upon installing stock create pickings for all open (confirmed but not delivered/received)
+        SO/PO. If any lines are partially done, split them.
+    """
+    to_adjust = Domain.AND([
+        Domain('state', '=', 'purchase'),
+        Domain('receipt_status', '!=', "full")
+    ])
+    open_purchase_orders = env["purchase.order"].search([to_adjust])
+    lines_to_create = []
+    for po in open_purchase_orders:
+        for line in po.order_line:
+            partial_procurement = 0 < line.qty_received < line.product_uom_qty
+            if line.qty_received != line.product_uom_qty and not partial_procurement:
+                line._create_or_update_picking()
+            elif partial_procurement:
+                lines_to_create.append(
+                    {
+                        "order_id": line.order_id.id,
+                        "product_id": line.product_id.id,
+                        "product_uom_qty": line.product_uom_qty - line.qty_received,
+                        "product_uom_id": line.product_uom_id,
+                    }
+                )
+                line.product_qty = line.qty_received
+    if lines_to_create:
+        env["purchase.order.line"].create(lines_to_create)  # Also triggers _create_or_update_picking

--- a/addons/purchase_stock/__manifest__.py
+++ b/addons/purchase_stock/__manifest__.py
@@ -32,7 +32,7 @@
         'data/purchase_stock_demo.xml',
     ],
     'auto_install': True,
-    'post_init_hook': '_create_buy_rules',
+    'post_init_hook': 'post_init_hook',
     'assets': {
         'web.assets_backend': [
             'purchase_stock/static/src/**/*',

--- a/addons/sale_stock/__init__.py
+++ b/addons/sale_stock/__init__.py
@@ -5,3 +5,33 @@ from . import controllers
 from . import models
 from . import report
 from . import wizard
+
+from odoo.fields import Domain
+
+
+def _create_pickings_for_open_sale_orders(env):
+    """ Upon installing stock create pickings for all open (confirmed but not delivered/received)
+        SO/PO. If any lines are partially done, split them.
+    """
+    to_adjust = Domain.AND([
+        Domain('state', '=', 'sale'),
+        Domain('delivery_status', '!=', "full")
+    ])
+    open_sale_orders = env["sale.order"].search([to_adjust])
+    lines_to_create = []
+    for so in open_sale_orders:
+        for line in so.order_line:
+            partial_procurement = 0 < line.qty_delivered < line.product_uom_qty
+            if line.qty_delivered != line.product_uom_qty and not partial_procurement:
+                line._action_launch_stock_rule()
+            elif partial_procurement:
+                lines_to_create.append(
+                    {
+                        "order_id": line.order_id.id,
+                        "product_id": line.product_id.id,
+                        "product_uom_qty": line.product_uom_qty - line.qty_delivered,
+                    }
+                )
+                line.product_uom_qty = line.qty_delivered
+    if lines_to_create:
+        env["sale.order.line"].create(lines_to_create)  # Also triggers _action_launch_stock_rule

--- a/addons/sale_stock/__manifest__.py
+++ b/addons/sale_stock/__manifest__.py
@@ -49,6 +49,7 @@ Preferences
             'sale_stock/static/tests/tours/*.js',
         ]
     },
+    'post_init_hook': '_create_pickings_for_open_sale_orders',
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Creates Deliveries and receipts for orderlines that were not fully received/delivered when installing stock.

WHY: Otherwise if the user was to edit partially filled order lines, the qty on hand would not update.

NOTE: that the old SO lines for which we didn't create pickings will still be editable as its currently the case in master ( recomputing the qty_delivered_method triggeres a qty_delivered recompute and is a bit of a headache to bypass)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
