### PR TITLE
[FIX] website: do not try to schedule if field not loaded

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -253,7 +253,7 @@ class WebsitePublishedMixin(models.AbstractModel):
             if model_name in seen or model_name not in self.env:
                 continue
             model = self.env[model_name]
-            if {'id', 'is_published'} <= set(model._fields):
+            if {'id', 'is_published', 'publish_on'} <= set(model._fields):
                 seen.add(model_name)
                 yield model
 


### PR DESCRIPTION
If `publish_on` field isn't loaded for the model we attempt to schedule get an error.

Steps to reproduce:
1. Install `website_appointment`
2. Update `website` (via `-u`)

We get the error:
```
Traceback (most recent call last):
  File "/data/build/odoo/odoo/orm/domains.py", line 936, in __get_field
    field = model._fields[field_name]
            ~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'publish_on'
...
ValueError: Invalid field appointment.type.publish_on in condition ('publish_on', '!=', False)
```

Reason:
The field `publish_on` is added to the model `appointment_type` by the module `website_appointment` but when we are loading `website` the former is still not loaded.
https://github.com/odoo/enterprise/blob/42c817197fee14ec83d907d2be1893d1fd85cc85/website_appointment/models/appointment_type.py#L13

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
