### PR TITLE
[IMP] account: make include_initial_balance False for equity_unaffected

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -664,12 +664,12 @@ class AccountAccount(models.Model):
     @api.depends('account_type')
     def _compute_include_initial_balance(self):
         for account in self:
-            account.include_initial_balance = account.internal_group not in ['income', 'expense']
+            account.include_initial_balance = account.internal_group not in ['income', 'expense'] and account.account_type != 'equity_unaffected'
 
     def _search_include_initial_balance(self, operator, value):
         if operator != 'in':
             return NotImplemented
-        return [('internal_group', 'not in', ['income', 'expense'])]
+        return [('internal_group', 'not in', ['income', 'expense']), ('account_type', '!=', 'equity_unaffected')]
 
     def _get_internal_group(self, account_type):
         return account_type.split('_', maxsplit=1)[0]


### PR DESCRIPTION
This commit changes the computation and search of the field include_initial_balance so equity_unaffected accounts do not include the previous fiscal year's balance.

With this change, equity_unaffected accounts behave like income and expense accounts in the reports.

no-task
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
