### PR TITLE
[IMP] mail: match discuss search icon opacity with text

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_search.xml
+++ b/addons/mail/static/src/core/public_web/discuss_search.xml
@@ -28,7 +28,7 @@
 <t t-name="mail.DiscussSearch.inputContainer">
     <div class="o-mail-DiscussSearch-inputContainer border border-secondary position-relative d-flex align-items-center justify-content-center gap-1 flex-grow-1 rounded-2" t-on-click="onClickSearchConversations">
         <div class="d-flex w-100 align-items-center gap-2" t-att-class="{ 'p-2': store.discuss.isSidebarCompact and !ui.isSmall, 'ps-2 gap-2': !store.discuss.isSidebarCompact or ui.isSmall }">
-            <i class="oi oi-search smaller"/>
+            <i class="oi oi-search smaller opacity-50"/>
             <input t-if="ui.isSmall or !store.discuss.isSidebarCompact" class="form-control rounded-2 border-0 bg-inherit ps-0" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Search conversations" tabindex="0"/>
         </div>
         <div class="o-mail-DiscussSearch-inputClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>


### PR DESCRIPTION
This commit reduces the opacity of discuss search bar icon to match with text.

Before / After
<img width="297" height="343" alt="Screenshot 2025-12-19 at 15 47 26" src="https://github.com/user-attachments/assets/b958710e-fb35-4ca9-84e1-b27b30187025" /> <img width="300" height="342" alt="Screenshot 2025-12-19 at 15 47 10" src="https://github.com/user-attachments/assets/c26f8229-e53f-4907-97da-3aa2ba8d4c4a" />

Before / After
<img width="300" height="348" alt="Screenshot 2025-12-19 at 15 47 39" src="https://github.com/user-attachments/assets/ac31393d-632f-4ae1-9022-3f00e40d2f88" /> <img width="301" height="346" alt="Screenshot 2025-12-19 at 15 46 53" src="https://github.com/user-attachments/assets/673369a1-16a1-4057-9707-77e0650a95f3" />
