### PR TITLE
[IMP] (website_)sale, test_sale_product_configurators, website_sale_stock : refine product configurator for mobile

### DIFF
--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -32,6 +32,10 @@
     max-width: 8rem;
 }
 
+.o_sale_product_configurator_description {
+    --lines-clamp: 3;
+}
+
 @include media-breakpoint-down(lg) {
     .impossible_combination_alert {
         margin-left: -3rem;

--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -28,8 +28,16 @@
     }
 }
 
-.product_name_description {
-    max-width: 8rem;
+@include media-breakpoint-down(sm) {
+    .oe_striked_price {
+        margin-bottom: 0;
+    }
+}
+
+@include media-breakpoint-between(sm, md) {
+    [name="sale_product_configurator_formatted_price"]:only-child {
+        margin-bottom: map-get($spacers, 2) !important;
+    }
 }
 
 .o_sale_product_configurator_description {

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.Product">
-        <td class="o_sale_product_configurator_img py-3 px-0">
+        <td class="o_sale_product_configurator_img pb-3 ps-0 pe-2 pe-lg-0">
             <img
-                class="w-75 w-lg-100 border rounded"
+                class="w-100 border rounded"
                 t-att-src="imageUrl"
                 alt="Product Image"
             />
@@ -11,13 +11,13 @@
         <td class="p-0 p-md-3 product_name_description">
             <div
                 name="o_sale_product_configurator_name"
-                class="mb-1 mb-lg-3 text-break text-truncate"
+                class="mb-1 mb-lg-3"
             >
-                <span class="h5" t-out="this.props.display_name"/>
+                <span class="h5 o_line_clamp" t-out="this.props.display_name"/>
                 <div
                     t-if="this.props.description_sale"
                     t-out="this.props.description_sale"
-                    class="text-muted small text-truncate"
+                    class="o_sale_product_configurator_description o_line_clamp text-muted small"
                 />
                 <div t-if="this.props.selectedComboItems" class="text-muted small">
                     <div
@@ -76,7 +76,7 @@
         <t t-else="">
             <td
                 name="price"
-                class="o_sale_product_configurator_price py-3 px-0 text-end"
+                class="o_sale_product_configurator_price pb-3 px-0 text-end"
             >
                 <div
                     t-if="env.showPrice"

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -8,7 +8,7 @@
                 alt="Product Image"
             />
         </td>
-        <td class="p-0 p-md-3 product_name_description">
+        <td class="d-block p-0 p-md-3 product_name_description">
             <div
                 name="o_sale_product_configurator_name"
                 class="mb-1 mb-lg-3"
@@ -42,11 +42,11 @@
         </td>
         <t t-if="!this.props.optional">
             <td
-                class="o_sale_product_configurator_qty w-25 py-3 px-0 text-end"
+                class="o_sale_product_configurator_qty d-flex d-sm-table-cell align-items-center justify-content-between flex-wrap w-sm-25 py-3 px-0 text-sm-end"
             >
                 <div
                     t-if="env.showPrice"
-                    class="d-md-flex gap-2 align-items-baseline justify-content-end"
+                    class="d-flex flex-sm-column flex-md-row flex-wrap gap-1 align-items-baseline align-items-sm-end align-items-md-baseline justify-content-start justify-content-sm-end"
                 >
                     <t t-call="sale.product_price" name="sale_product_configurator_price"/>
                 </div>
@@ -64,7 +64,7 @@
                     class="h5"
                 />
                 <a
-                    class="d-block mt-2 text-end"
+                    class="d-block mt-2 w-100 text-end"
                     role="button"
                     t-if="!isMainProduct"
                     t-on-click="() => this.env.removeProduct(this.props.product_tmpl_id)"
@@ -76,11 +76,11 @@
         <t t-else="">
             <td
                 name="price"
-                class="o_sale_product_configurator_price pb-3 px-0 text-end"
+                class="o_sale_product_configurator_price d-flex d-sm-table-cell align-items-center justify-content-between p-0 pb-3 text-sm-end"
             >
                 <div
                     t-if="env.showPrice"
-                    class="d-md-flex gap-2 align-items-baseline justify-content-end"
+                    class="d-flex flex-sm-column flex-md-row flex-wrap gap-1 align-items-baseline align-items-sm-end align-items-md-baseline justify-content-start justify-content-sm-end"
                 >
                     <t t-call="sale.product_price" name="sale_product_configurator_optional_price"/>
                 </div>
@@ -100,7 +100,7 @@
     <t t-name="sale.product_price">
         <span
             name="sale_product_configurator_formatted_price"
-            class="h5 text-nowrap fw-bold text-end h6 mb-2 d-block"
+            class="h5 text-nowrap fw-bold text-end h6 mb-0 mb-md-2 d-block"
             t-out="getFormattedPrice()"
         />
         <div t-if="this.props.price_info" t-out="this.props.price_info" class="text-muted"/>

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -24,7 +24,7 @@
                 </button>
                 <h6
                     t-if="env.showPrice"
-                    class="o_configurator_price_total order-1 order-md-2 d-block d-sm-inline-block w-100 w-md-auto text-end ms-md-3 mb-0"
+                    class="o_configurator_price_total order-1 order-md-2 d-block d-sm-inline-block w-100 w-md-auto text-sm-end ms-md-3 mb-0"
                     name="sale_product_configurator_list_total"
                 >
                     <t t-out="totalMessage"/>

--- a/addons/web/static/src/scss/utilities_custom.scss
+++ b/addons/web/static/src/scss/utilities_custom.scss
@@ -206,3 +206,11 @@ $utilities: map-merge(
 .smaller {
     font-size: $o-font-size-base-smaller;
 }
+
+// Multiline text truncation utility : limits visible text to N lines (2 by default)
+.o_line_clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: var(--lines-clamp, 2);
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -681,13 +681,6 @@ p {
     margin-top: $paragraph-margin-top;
 }
 
-.o_line_clamp {
-    display: -webkit-box;
-    -webkit-line-clamp: var(--lines-clamp, 2);
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-
 font[style*='background']:not(.text-gradient),
 font[class*='bg-'] {
     // Not adding any horizontal padding is important as it ensures that several

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -11,12 +11,6 @@
             <attribute name="t-if">this.props.can_be_sold</attribute>
             <attribute name="class" remove="btn-secondary" add="btn-outline-primary" separator=" "/>
         </button>
-        <xpath
-            expr="//button[@name='sale_product_configurator_add_button']/*[hasclass('oi-plus')]"
-            position="attributes"
-        >
-            <attribute name="class" remove="oi oi-plus" add="fa fa-shopping-cart" separator=" "/>
-        </xpath>
         <span name="add_button" position="replace">
             <span name="add_button" class="ms-2 d-none d-md-inline">Add to Cart</span>
         </span>

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -11,7 +11,7 @@
         <h6 name="sale_product_configurator_list_total" position="attributes">
             <attribute
                 name="class"
-                add="order-1 order-md-2 w-100 text-end d-sm-inline-block ms-md-3 mb-0"
+                add="order-1 order-md-2 w-100 text-sm-end d-sm-inline-block ms-md-3 mb-0"
                 remove="d-none mt-0"
             />
         </h6>


### PR DESCRIPTION
This PR refine product configurator for mobile by displaying more characters for the name and description (previously, ... was displayed at the end of the line, but now the name can take up two lines and the description three). 
It also introduces a new mobile layout that optimises space by displaying the price and the ‘Add to cart’ button on one line.

task-5350913

| Before | After |
|--------|--------|
| <img width="390" height="844" alt="product-configurator-before" src="https://github.com/user-attachments/assets/10f74602-3697-4f83-ac29-67276924de97" /> | <img width="390" height="844" alt="B-product-configurator-single-line-price-add" src="https://github.com/user-attachments/assets/b38d5b2d-3745-4d0f-8d67-3241d09fc30f" /> |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
