### PR TITLE
[FIX] mrp: prevent duplicate work orders when setting BoM and quantity

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -591,7 +591,9 @@ class MrpProduction(models.Model):
             if not production.bom_id and not production._origin.product_id:
                 production.workorder_ids = workorders_list
             # if the product has changed or if in a second onchange with bom resets the relations
-            if production.product_id != production._origin.product_id or (production._origin.bom_id != production.bom_id and production._origin.bom_id.operation_ids and not production.workorder_ids.filtered(lambda wo: wo.ids and wo.operation_id)):
+            if production.product_id != production._origin.product_id \
+                or (not production._origin.bom_id and production.bom_id) \
+                or (production._origin.bom_id != production.bom_id and production._origin.bom_id.operation_ids and not production.workorder_ids.filtered(lambda wo: wo.ids and wo.operation_id)):
                 production.workorder_ids = [Command.clear()]
             if production.bom_id and production.product_id and production.product_qty > 0:
                 # keep manual entries

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5255,6 +5255,21 @@ class TestMrpOrder(TestMrpCommon):
             with mo_form.workorder_ids.edit(1) as second_wo_line:
                 second_wo_line.duration = 12.0  # Edit the duration of the second workorder
 
+    def test_change_bom_and_quantity_together(self):
+        """Ensure that changing the BoM and the production quantity together before saving
+        does not create duplicate work orders for the same operation.
+        """
+        mo = self.env['mrp.production'].create({
+            'product_id': self.bom_2.product_id.id
+        })
+        self.assertFalse(mo.workorder_ids)
+        self.assertEqual(len(self.bom_2.operation_ids), 1)
+        mo_form = Form(mo)
+        mo_form.bom_id = self.bom_2
+        mo_form.product_qty = 10
+        mo = mo_form.save()
+        self.assertEqual(len(mo.workorder_ids), 1)
+
 
 @tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product "P1"
    - Create a BoM with one operation
- Create a manufacturing order for product "P1"
    - Do not set any BoM
    - Save
- In draft state:
    - Set the BoM
    - Without saving, update the quantity to produce

Problem:
The same operation is added twice, resulting in duplicate work orders.

Cause:
Work orders are recomputed multiple times when BoM and quantity are changed before saving, and existing (not yet saved) work orders linked to the same BoM are not properly filtered out.

Fix:
Ensure that work orders linked to the current BoM are only created once during recomputation.

opw-5404686