### PR TITLE
[FIX] html_editor: detect first/last line of a single text node in table

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1,17 +1,12 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isBlock } from "@html_editor/utils/blocks";
-import {
-    fillEmpty,
-    fillShrunkPhrasingParent,
-    removeClass,
-} from "@html_editor/utils/dom";
+import { fillEmpty, fillShrunkPhrasingParent, removeClass } from "@html_editor/utils/dom";
 import {
     getDeepestPosition,
     isProtected,
     isProtecting,
     isEmptyBlock,
-    isTextNode,
     nextLeaf,
     previousLeaf,
     isTableCell,
@@ -875,19 +870,26 @@ export class TablePlugin extends Plugin {
         }
         // Handle selection for the single cell.
         if (startTd === endTd && !startTd.classList.contains("o_selected_td")) {
-            const { focusNode, focusOffset } = selection;
+            const { focusNode } = selection;
             // Do not prevent default when there is a text in cell.
-            if (focusNode.nodeType === Node.TEXT_NODE) {
-                const textNodes = descendants(startTd).filter(isTextNode);
-                const lastTextChild = textNodes[textNodes.length - 1];
-                const firstTextChild = textNodes[0];
-                const isAtTextBoundary = {
-                    ArrowRight: nodeSize(focusNode) === focusOffset && focusNode === lastTextChild,
-                    ArrowLeft: focusOffset === 0 && focusNode === firstTextChild,
-                    ArrowUp: focusNode === firstTextChild,
-                    ArrowDown: focusNode === lastTextChild,
+            if (
+                !(ev.ctrlKey && ["ArrowUp", "ArrowDown"].includes(ev.key)) &&
+                (focusNode.nodeType === Node.TEXT_NODE ||
+                    focusNode.matches("br, p, div.o-paragraph"))
+            ) {
+                const isAtTextBoundary = (key) => {
+                    const actualSelection = this.document.getSelection();
+                    const preserveSelection = this.dependencies.selection.preserveSelection();
+                    actualSelection.modify(
+                        "extend",
+                        ["ArrowDown", "ArrowRight"].includes(ev.key) ? "forward" : "backward",
+                        ["ArrowUp", "ArrowDown"].includes(key) ? "line" : "character"
+                    );
+                    const reachedTd = closestElement(actualSelection.focusNode, "td");
+                    preserveSelection.restore();
+                    return startTd !== reachedTd;
                 };
-                if (isAtTextBoundary[ev.key]) {
+                if (isAtTextBoundary(ev.key)) {
                     ev.preventDefault();
                     this.selectTableCells(this.dependencies.selection.getEditableSelection());
                 }
@@ -1140,13 +1142,33 @@ export class TablePlugin extends Plugin {
 
     navigateCell(ev) {
         const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
-        const anchorNode = selection.anchorNode;
-        const currentCell = closestElement(anchorNode, isTableCell);
-        const currentTable = closestElement(anchorNode, "table");
-        if (!selection.isCollapsed || !currentCell) {
+        // Using focusNode because we might be leaving a multi-cell selection.
+        const focusNode = selection.focusNode;
+        const currentCell = closestElement(focusNode, isTableCell);
+        if (!currentCell) {
             return;
         }
+        const currentTable = closestElement(currentCell, "table");
+        const areCellsSelected = currentCell.classList.contains("o_selected_td");
         const isArrowUp = ev.key === "ArrowUp";
+        // Should navigate within multi-line text node itself ?
+        if (!areCellsSelected) {
+            if (ev.ctrlKey) {
+                ev.preventDefault();
+                this.dependencies.selection.setSelection({
+                    anchorNode: currentCell,
+                    anchorOffset: isArrowUp ? 0 : currentCell.childNodes.length,
+                });
+                return;
+            }
+            const actualSelection = this.document.getSelection();
+            actualSelection.modify("move", isArrowUp ? "backward" : "forward", "line");
+            const reachedCell = closestElement(actualSelection.focusNode, "td");
+            ev.preventDefault();
+            if (currentCell === reachedCell) {
+                return;
+            }
+        }
         const cellPosition = {
             row: getRowIndex(currentCell),
             col: getColumnIndex(currentCell),
@@ -1178,7 +1200,7 @@ export class TablePlugin extends Plugin {
             // If no target cell is available, navigate to sibling element
             targetNode = siblingElement;
         }
-        if (shouldNavigateCell(anchorNode)) {
+        if (shouldNavigateCell(focusNode)) {
             ev.preventDefault();
             if (targetNode) {
                 targetNode = isArrowUp ? lastLeaf(targetNode) : firstLeaf(targetNode);

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1,9 +1,22 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
-import { bold, resetSize, setColor, insertText } from "../_helpers/user_actions";
+import {
+    bold,
+    insertText,
+    resetSize,
+    setColor,
+    simulateArrowKeyPress,
+} from "../_helpers/user_actions";
 import { getContent, setSelection } from "../_helpers/selection";
-import { press, queryAll, manuallyDispatchProgrammaticEvent, click } from "@odoo/hoot-dom";
+import {
+    click,
+    keyDown,
+    keyUp,
+    press,
+    queryAll,
+    manuallyDispatchProgrammaticEvent,
+} from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { nodeSize } from "@html_editor/utils/position";
 
@@ -2230,5 +2243,528 @@ describe("deselecting table", () => {
             </table>
             <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
+    });
+});
+
+describe("keyboard navigation with multiline", () => {
+    describe("move", () => {
+        test("should reach above cell when pressing up from text's first line", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1[]L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            const events = await press("ArrowUp");
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2[]</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should allow default text navigation when pressing up from text's second line", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1[]L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, "ArrowUp");
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1[]L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should reach cell below when pressing down from text's last line", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2[]L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            const events = await press("ArrowDown");
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>[]C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should allow default text navigation when pressing down from text's non-last line", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, "ArrowDown");
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2[]L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should reach begin of cell when pressing Ctrl+ArrowUp", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Control", "ArrowUp"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        []<div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should reach end of cell when pressing Ctrl+ArrowDown", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Control", "ArrowDown"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>[]
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+    });
+    describe("select", () => {
+        test("should select current cell when pressing shift+up from text's first line", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1[]L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Shift", "ArrowUp"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1[]L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should allow default text selection when pressing shift+up from text's second line", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1[]L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Shift", "ArrowUp"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1]L1<br>P1[L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should select current cell when pressing shift+down from text's last line", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2[]L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Shift", "ArrowDown"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2[]L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should allow default text selection when pressing shift+down from text's non-last line", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Shift", "ArrowDown"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[L1<br>P2]L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should select whole cell when pressing Ctrl+Shift+ArrowUp", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Control", "Shift", "ArrowUp"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should select whole cell when pressing Ctrl+Shift+ArrowDown", async () => {
+            const { el, editor } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await simulateArrowKeyPress(editor, ["Control", "Shift", "ArrowDown"]);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2[]L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+    });
+    describe("select then move", () => {
+        test("should move from reached selection (upwards)", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1[]L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await keyDown("Shift");
+            let events = await press("ArrowUp");
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1[]L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+            events = await press("ArrowUp");
+            await keyUp("Shift");
+            await tick();
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td class="o_selected_td">]C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1[L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+            events = await press("ArrowUp");
+            await tick();
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1[]</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
+        test("should move from reached selection (downwards)", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2[]L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                `)
+            );
+            await keyDown("Shift");
+            let events = await press("ArrowDown");
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2[]L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+            events = await press("ArrowDown");
+            await keyUp("Shift");
+            await tick();
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table class="o_selected_table"><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td class="o_selected_td">
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2[L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td class="o_selected_td">]C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+            events = await press("ArrowDown");
+            await tick();
+            expect(events[0].defaultPrevented).toBe(true);
+            expect(getContent(el)).toBe(
+                unformat(`
+                    <p data-selection-placeholder=""><br></p>
+                    <table><tbody>
+                    <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
+                    <tr><td>A2</td><td>B2</td><td>C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A3</td><td>B3</td><td>
+                        <div class="o-paragraph">P1L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
+                    </td><td>D3</td><td>E3</td></tr>
+                    <tr><td>A4</td><td>B4</td><td>C4</td><td>D4</td><td>E4</td></tr>
+                    <tr><td>A5</td><td>B5</td><td>[]C5</td><td>D5</td><td>E5</td></tr>
+                    </tbody></table>
+                    <p data-selection-placeholder=""><br></p>
+                `)
+            );
+        });
     });
 });


### PR DESCRIPTION
When navigating inside a table cell, if a single text node is rendered over several lines, the cursor up and down key go directly to the next cell instead of navigating to the (visually) previous or next line of text.

This commit determines if the cursor position is within such positions inside a multi-line text node and prevents the table navigation if needed.

Steps to reproduce:
- Add a table with `/table`
- Put a very long text (without paragraph splits) in the center cell, so that the text spans over several lines
- Navigate with the up and down arrows

=> The cursor could not reach distinct lines within the text

task-5417834
