### PR TITLE
[FIX] account_edi_ubl_cii: remove ensure_one call in api.model

### DIFF
--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -152,7 +152,6 @@ class AccountMoveSend(models.TransientModel):
 
     @api.model
     def _get_ubl_available_attachments(self, mail_attachments_widget, invoice_edi_format):
-        self.ensure_one()
         if not invoice_edi_format or not mail_attachments_widget:
             return self.env['ir.attachment'], self.env['ir.attachment']
         attachment_ids = [values['id'] for values in mail_attachments_widget if values.get('manual')]


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: remove ensure_one call in api.model

This is incorrect to call self.ensure_one() in a function with the @api.model annotation.

introduced by 574a67c73633

no-task
