### PR TITLE
[REF] im_livechat,*: remove livechat_operator_id from discuss channel

### DIFF
--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -39,10 +39,10 @@ class ChatbotScriptStep(models.Model):
 
     def _process_step(self, discuss_channel):
         self.ensure_one()
-        posted_message = super()._process_step(discuss_channel)
+        step_data = super()._process_step(discuss_channel)
         if self.step_type == 'create_lead':
             self._process_step_create_lead(discuss_channel)
-        return posted_message
+        return step_data
 
     def _process_step_create_lead(self, discuss_channel):
         """ When reaching a 'create_lead' step, we extract the relevant information: visitor's

--- a/addons/crm_livechat/static/tests/create_lead.test.js
+++ b/addons/crm_livechat/static/tests/create_lead.test.js
@@ -32,7 +32,6 @@ test("can create a lead from the thread action after the conversation ends", asy
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channel_id);

--- a/addons/crm_livechat/static/tests/message.test.js
+++ b/addons/crm_livechat/static/tests/message.test.js
@@ -22,7 +22,6 @@ test("Can open lead from internal link", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/crm_livechat/tests/test_discuss_channel_access.py
+++ b/addons/crm_livechat/tests/test_discuss_channel_access.py
@@ -25,7 +25,6 @@ class TestDiscussChannelAccess(HttpCase):
             channel = self.env["discuss.channel"].create(
                 {
                     "name": f"channel_{idx}",
-                    "livechat_operator_id": self.env.user.partner_id.id,
                     "channel_type": "livechat",
                     "lead_ids": crm_lead.ids,
                 }
@@ -44,7 +43,6 @@ class TestDiscussChannelAccess(HttpCase):
             .create(
                 {
                     "name": f"Visitor #11",
-                    "livechat_operator_id": self.env.user.partner_id.id,
                     "channel_type": "livechat",
                 }
             )

--- a/addons/im_livechat/data/mail_templates.xml
+++ b/addons/im_livechat/data/mail_templates.xml
@@ -9,8 +9,7 @@
 <div style="font-size: 13px; max-width: 600px; margin: 10px; padding: 24px 32px 0px 32px; background-color: #ffffff; border-radius: 0 0 8px 8px; border: thin solid #dee2e6;">
 <div style="font-size: 13px; padding: 5px 0; white-space:nowrap;">
     Here's a copy of your conversation with
-    <!-- sudo: res.users - visitor can access the name of the operator -->
-    <span t-attf-style="color: {{header_background_color}};" t-out="channel.livechat_operator_id.sudo().user_livechat_username or channel.livechat_operator_id.sudo().name"/> on
+    <span t-attf-style="color: {{header_background_color}};" t-out="correspondent_names"/> on
     <span t-out="channel.create_date.astimezone(tz).strftime('%m/%d/%y')"/> at
     <span t-out="channel.create_date.astimezone(tz).strftime('%I:%M %p')"/>.
 </div>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -4,9 +4,14 @@
         <record id="livechat_channel_chatbot_session_1_demo" model="discuss.channel">
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
-            <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #234, Odoo</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_1_history_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_chatbot_session_1_demo"/>
+            <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_1_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -4,9 +4,14 @@
         <record id="livechat_channel_chatbot_session_2_demo" model="discuss.channel">
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
-            <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #235, Odoo</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_2_history_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_chatbot_session_2_demo"/>
+            <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_2_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -4,9 +4,14 @@
         <record id="livechat_channel_chatbot_session_3_demo" model="discuss.channel">
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
-            <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="livechat_failure">no_agent</field>
             <field name="name">Visitor #236, Odoo</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
+        </record>
+        <record id="livechat_channel_chatbot_session_3_history_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_chatbot_session_3_demo"/>
+            <field name="partner_id" ref="welcome_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5, seconds=25)"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Visitor #234, Mitchell Admin</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -4,7 +4,6 @@
         <record id="livechat_channel_session_10" model="discuss.channel">
             <field name="name">Visiteur, Mitchell Admin</field>
             <field name="livechat_lang_id" ref="base.lang_fr"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -4,7 +4,6 @@
         <record id="livechat_channel_session_11" model="discuss.channel">
             <field name="name">Visitor, Mitchell Admin</field>
             <field name="livechat_lang_id" ref="base.lang_en"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_status">need_help</field>
             <field name="livechat_looking_for_help_since_dt" eval="datetime.now()"/>
             <field name="description">Customer needs more information on the Discuss application</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
@@ -4,7 +4,6 @@
         <record id="livechat_channel_session_12" model="discuss.channel">
             <field name="name">Visitor, Mitchell Admin</field>
             <field name="livechat_lang_id" ref="base.lang_en"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="livechat_failure">no_answer</field>
             <field name="create_date" eval="datetime.now()"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
@@ -4,7 +4,6 @@
         <record id="livechat_channel_session_13" model="discuss.channel">
             <field name="name">Visiteur, Mitchell Admin</field>
             <field name="livechat_lang_id" ref="base.lang_fr"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_14.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_14.xml
@@ -4,7 +4,6 @@
         <record id="livechat_channel_session_14" model="discuss.channel">
             <field name="name">Visiteur, Mitchell Admin</field>
             <field name="livechat_lang_id" ref="base.lang_fr"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=1)"/>
             <field name="livechat_failure">no_failure</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_15.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_15.xml
@@ -5,11 +5,15 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_status">need_help</field>
             <field name="livechat_looking_for_help_since_dt" eval="datetime.now()"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Mitchell Admin</field>
+        </record>
+        <record id="im_livechat.livechat_channel_session_15_history_member_admin" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="livechat_channel_session_15"/>
+            <field name="partner_id" ref="base.partner_admin"/>
+            <field name="livechat_member_type">agent</field>
         </record>
         <record id="im_livechat.livechat_channel_session_15_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=11)"/>
-            <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="name">Visitor #323, Marc Demo</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-1)"/>
         </record>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=15)"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Joel Willis, Mitchell Admin</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=12)"/>
         </record>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=20)"/>
-            <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Marc Demo</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-3)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=10)"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #532, Mitchell Admin</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-4)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=12)"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #649, Mitchell Admin</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-5)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=15)"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Mitchell Admin</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-6)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -6,7 +6,6 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_channel_id" ref="im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=15)"/>
-            <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #722, Marc Demo</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-7)"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -4,7 +4,6 @@
         <record id="livechat_channel_session_9" model="discuss.channel">
             <field name="name">Visitor, Mitchell Admin</field>
             <field name="livechat_lang_id" ref="base.lang_en"/>
-            <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="livechat_end_dt" eval="datetime.now() - timedelta(days=1, seconds=-53)"/>
             <field name="livechat_failure">no_failure</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
@@ -5,8 +5,13 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_lang_id" ref="base.lang_fr"/>
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
-            <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visiteur #301, Support</field>
+            <field name="create_date" eval="datetime.now() - timedelta(minutes=5)"/>
+        </record>
+        <record id="support_bot_session_1_history_member_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_1_demo"/>
+            <field name="partner_id" ref="support_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=5)"/>
         </record>
         <record id="support_bot_session_1_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
@@ -5,8 +5,13 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_lang_id" ref="base.lang_it"/>
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
-            <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitatore #302, Support</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2)"/>
+        </record>
+        <record id="support_bot_session_2_history_member_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_2_demo"/>
+            <field name="partner_id" ref="support_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2)"/>
         </record>
         <record id="support_bot_session_2_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
@@ -5,8 +5,13 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_lang_id" ref="base.lang_it"/>
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
-            <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitatore #303, Support</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-10)"/>
+        </record>
+        <record id="support_bot_session_3_history_member_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_3_demo"/>
+            <field name="partner_id" ref="support_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(days=-10)"/>
         </record>
         <record id="support_bot_session_3_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
@@ -5,10 +5,15 @@
             <field name="channel_type">livechat</field>
             <field name="livechat_lang_id" ref="base.lang_it"/>
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
-            <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="livechat_status">need_help</field>
             <field name="livechat_looking_for_help_since_dt" eval="datetime.now() - timedelta(minutes=3)"/>
             <field name="name">Visitatore #304, Support</field>
+            <field name="create_date" eval="datetime.now() - timedelta(minutes=3)"/>
+        </record>
+        <record id="support_bot_session_4_history_member_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_4_demo"/>
+            <field name="partner_id" ref="support_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=3)"/>
         </record>
         <record id="support_bot_session_4_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
@@ -4,8 +4,13 @@
         <record id="support_bot_session_5_demo" model="discuss.channel">
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
-            <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitor #305, Support</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-5)"/>
+        </record>
+        <record id="support_bot_session_5_history_member_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_5_demo"/>
+            <field name="partner_id" ref="support_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(days=-5)"/>
         </record>
         <record id="support_bot_session_5_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -4,8 +4,13 @@
         <record id="support_bot_session_6_demo" model="discuss.channel">
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
-            <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitor #306, Support</field>
+            <field name="create_date" eval="datetime.now() - timedelta(minutes=6)"/>
+        </record>
+        <record id="support_bot_session_6_history_member_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_6_demo"/>
+            <field name="partner_id" ref="support_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=6)"/>
         </record>
         <record id="support_bot_session_6_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
@@ -4,8 +4,13 @@
         <record id="support_bot_session_7_demo" model="discuss.channel">
             <field name="channel_type">livechat</field>
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
-            <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitor #307, Support</field>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-6)"/>
+        </record>
+        <record id="support_bot_session_7_history_member_bot_demo" model="im_livechat.channel.member.history">
+            <field name="channel_id" ref="support_bot_session_7_demo"/>
+            <field name="partner_id" ref="support_bot_operator_partner_demo"/>
+            <field name="livechat_member_type">bot</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(days=-6)"/>
         </record>
         <record id="support_bot_session_7_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -352,7 +352,9 @@ class ChatbotScriptStep(models.Model):
         self.ensure_one()
         if self.step_type == 'forward_operator':
             return discuss_channel._forward_human_operator(chatbot_script_step=self)
-        return discuss_channel._chatbot_post_message(self.chatbot_script_id, self.message)
+        return {
+            "message": discuss_channel._chatbot_post_message(self.chatbot_script_id, self.message)
+        }
 
     def _store_script_step_fields(self, res: Store.FieldList):
         res.many("answer_ids", "_store_script_answer_fields")

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -15,6 +15,7 @@ class DiscussChannelMember(models.Model):
     livechat_member_type = fields.Selection(
         [("agent", "Agent"), ("visitor", "Visitor"), ("bot", "Chatbot")],
         compute="_compute_livechat_member_type",
+        compute_sql="_compute_sql_livechat_member_type",
         # sudo - reading the history of a member the user has access to is acceptable.
         compute_sudo=True,
         inverse="_inverse_livechat_member_type",
@@ -73,6 +74,10 @@ class DiscussChannelMember(models.Model):
     def _compute_livechat_member_type(self):
         for member in self:
             member.livechat_member_type = member.livechat_member_history_ids.livechat_member_type
+
+    def _compute_sql_livechat_member_type(self, table):
+        history = table._join("livechat_member_history_ids")
+        return history.livechat_member_type
 
     @api.depends("livechat_member_history_ids.chatbot_script_id")
     def _compute_chatbot_script_id(self):

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -127,7 +127,6 @@ class Im_LivechatChannel(models.Model):
         "user_ids.channel_ids.last_interest_dt",
         "user_ids.channel_ids.livechat_end_dt",
         "user_ids.channel_ids.livechat_channel_id",
-        "user_ids.channel_ids.livechat_operator_id",
         "user_ids.channel_member_ids",
         "user_ids.im_status",
         "user_ids.is_in_call",
@@ -337,7 +336,6 @@ class Im_LivechatChannel(models.Model):
         return {
             'channel_member_ids': members_to_add,
             "last_interest_dt": last_interest_dt,
-            'livechat_operator_id': operator_partner.id,
             'livechat_channel_id': self.id,
             "livechat_failure": "no_answer" if is_agent else "no_failure",
             "livechat_status": "in_progress",

--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -197,10 +197,11 @@ class ImLivechatChannelMemberHistory(models.Model):
         res.attr("channel_id")
         res.one("guest_id", ["name"], predicate=lambda r: not r.partner_id)
         res.attr("livechat_member_type")
+        res.attr("member_id")
         # sudo: res.partner - reading partner related to an accessible channel member history is considered acceptable
         res.one(
             "partner_id",
-            "_store_livechat_username_fields",
+            "_store_livechat_member_fields",
             predicate=lambda r: not r.guest_id,
             sudo=True,
         )

--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -49,7 +49,7 @@ class MailMessage(models.Model):
                         res.attr(
                             "operatorFound",
                             step.step_type == "forward_operator" and
-                            channel.livechat_operator_id != chatbot,
+                            bool(channel.livechat_agent_partner_ids),
                         )
                         if answer := chatbot_message.user_script_answer_id:
                             res.attr("selectedAnswer", {"id": answer.id, "label": answer.name})

--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -72,8 +72,8 @@ class ResPartner(models.Model):
         for partner in self:
             partner.livechat_channel_count = livechat_count_by_partner.get(partner, 0)
 
-    def _store_livechat_agent_fields(self, res: Store.FieldList):
-        """Return the standard fields to include for live chat agent."""
+    def _store_livechat_member_fields(self, res: Store.FieldList):
+        """Return the standard fields to include for live chat member."""
         self._store_avatar_fields(res)
         self._store_livechat_username_fields(res)
 

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -65,7 +65,6 @@ declare module "models" {
     export interface Thread {
         composerHidden: Readonly<boolean>;
         livechat_end_dt: import("luxon").DateTime;
-        livechat_operator_id: ResPartner;
         livechatVisitorMember: ChannelMember;
         transcriptUrl: Readonly<string>;
     }

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -40,7 +40,9 @@ const discussChannelPatch = {
         if (this.channel_type !== "livechat" || this.self_member_id?.custom_channel_name) {
             return super.displayName;
         }
-        const selfMemberType = this.self_member_id?.livechat_member_type;
+        const selfMemberType = this.isTransient
+            ? "visitor"
+            : this.self_member_id?.livechat_member_type;
         let memberNames = this.correspondents
             .filter((m) => {
                 if (selfMemberType === "visitor") {

--- a/addons/im_livechat/static/src/core/common/livechat_channel_member_history_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_channel_member_history_model.js
@@ -23,6 +23,7 @@ export class LivechatChannelMemberHistory extends Record {
             return false;
         },
     });
+    member_id = fields.One("discuss.channel.member");
     guest_id = fields.One("mail.guest");
     /** @type {number} */
     id;

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -8,24 +8,14 @@ patch(Thread.prototype, {
     setup() {
         super.setup();
         this.livechat_end_dt = fields.Datetime();
-        this.livechat_operator_id = fields.One("res.partner");
         this.livechatVisitorMember = fields.One("discuss.channel.member", {
             compute() {
                 if (this.channel?.channel_type !== "livechat") {
                     return;
                 }
-                // For live chat conversation, the correspondent is the first
-                // channel member that is not the operator.
-                const orderedChannelMembers = [...this.channel.channel_member_ids].sort(
-                    (a, b) => a.id - b.id
-                );
-                const isFirstMemberOperator = orderedChannelMembers[0]?.partner_id?.eq(
-                    this.livechat_operator_id
-                );
-                const visitor = isFirstMemberOperator
-                    ? orderedChannelMembers[1]
-                    : orderedChannelMembers[0];
-                return visitor;
+                return [...this.channel.channel_member_ids]
+                    .sort((a, b) => a.id - b.id)
+                    .find((member) => member.livechat_member_type === "visitor");
             },
         });
     },

--- a/addons/im_livechat/static/src/embed/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/common/@types/models.d.ts
@@ -17,7 +17,6 @@ declare module "models" {
         chatbotTypingMessage: Message;
         hasWelcomeMessage: Readonly<boolean>;
         isLastMessageFromCustomer: Readonly<boolean>;
-        livechat_operator_id: ResPartner;
         livechatWelcomeMessage: Message;
         readyToSwapDeferred: Deferred;
         requested_by_operator: boolean;

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -125,11 +125,17 @@ export class LivechatService {
         this.store.insert(store_data);
         const channel = this.store["discuss.channel"].get(channel_id);
         const ONE_DAY_TTL = 60 * 60 * 24;
-        expirableStorage.setItem(
-            "im_livechat_previous_operator",
-            channel.livechat_operator_id.id,
-            ONE_DAY_TTL * 7
+        // The channel has just been created and only has one agent member
+        const agent = channel.livechat_channel_member_history_ids.find(
+            (member) => member.livechat_member_type === "agent"
         );
+        if (agent?.partner_id) {
+            expirableStorage.setItem(
+                "im_livechat_previous_operator",
+                agent.partner_id.id,
+                ONE_DAY_TTL * 7
+            );
+        }
         return channel;
     }
 

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -9,14 +9,13 @@ import { Deferred } from "@web/core/utils/concurrency";
 patch(Thread.prototype, {
     setup() {
         super.setup();
-        this.livechat_operator_id = fields.One("res.partner");
         this.chatbotTypingMessage = fields.One("mail.message", {
             compute() {
                 if (this.channel?.chatbot) {
                     return {
                         id: -0.1 - this.id,
                         thread: this,
-                        author_id: this.livechat_operator_id,
+                        author_id: this.channel.chatbot,
                     };
                 }
             },
@@ -29,7 +28,9 @@ patch(Thread.prototype, {
                         id: -0.2 - this.id,
                         body: livechatService.options.default_message,
                         thread: this,
-                        author_id: this.livechat_operator_id,
+                        author_id: this.channel?.livechat_agent_history_ids.sort(
+                            (a, b) => a.id - b.id
+                        )[0]?.partner_id,
                     };
                 }
             },

--- a/addons/im_livechat/static/tests/call.test.js
+++ b/addons/im_livechat/static/tests/call.test.js
@@ -31,7 +31,6 @@ test("should display started a call message with operator livechat username", as
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     setupChatHub({ opened: [channelId] });
     await start();

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -46,7 +46,6 @@ test("Can invite a partner to a livechat channel", async () => {
             }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);
@@ -128,7 +127,6 @@ test("Partners invited most frequently by the current user come first", async ()
                 livechat_member_type: "visitor",
             }),
         ],
-        livechat_operator_id: serverState.partnerId,
     });
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor #2" });
     pyEnv["discuss.channel"].create({
@@ -145,7 +143,6 @@ test("Partners invited most frequently by the current user come first", async ()
                 livechat_member_type: "visitor",
             }),
         ],
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -228,7 +225,6 @@ test("Operator invite shows livechat_username", async () => {
                 livechat_member_type: "visitor",
             }),
         ],
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -45,7 +45,6 @@ test("from the discuss app", async () => {
             ],
             livechat_end_dt: false,
             livechat_channel_id: livechatChannelId,
-            livechat_operator_id: serverState.partnerId,
             create_uid: serverState.publicUserId,
         },
         {
@@ -59,7 +58,6 @@ test("from the discuss app", async () => {
             ],
             livechat_end_dt: serializeDate(today()),
             livechat_channel_id: livechatChannelId,
-            livechat_operator_id: serverState.partnerId,
             create_uid: serverState.publicUserId,
         },
     ]);
@@ -146,7 +144,6 @@ test("visitor leaving ends the livechat conversation", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
     setupChatHub({ opened: [channel_id] });

--- a/addons/im_livechat/static/tests/channel_member_list.test.js
+++ b/addons/im_livechat/static/tests/channel_member_list.test.js
@@ -24,7 +24,6 @@ test("display country in channel member list", async () => {
         ],
         country_id: countryId,
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/chat_hub_compact.test.js
+++ b/addons/im_livechat/static/tests/chat_hub_compact.test.js
@@ -19,7 +19,6 @@ test("Do not open chat windows automatically when chat hub is compact", async ()
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
     await start();

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -32,7 +32,6 @@ test("can fold livechat chat windows in mobile", async () => {
             Command.create({ partner_id: partnerId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -61,7 +60,6 @@ test("closing a chat window with no message from admin side unpins it", async ()
             Command.create({ partner_id: partnerId_1, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     pyEnv["discuss.channel"].create({
         channel_member_ids: [
@@ -74,7 +72,6 @@ test("closing a chat window with no message from admin side unpins it", async ()
         ],
         channel_type: "livechat",
         livechat_end_dt: serializeDate(today()),
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -135,7 +132,6 @@ test("do not ask confirmation if other operators are present", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
             Command.create({ partner_id: otherOperatorId, livechat_member_type: "agent" }),
         ],
-        livechat_operator_id: serverState.partnerId,
         channel_type: "livechat",
     });
     setupChatHub({ opened: [channelId] });
@@ -162,7 +158,6 @@ test("Show livechats with new message in chat hub even when in discuss app)", as
                 Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
         },
         {
             channel_member_ids: [Command.create({ partner_id: serverState.partnerId })],
@@ -206,7 +201,6 @@ test("livechat: non-member can close immediately", async () => {
             Command.create({ partner_id: PartnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
-        livechat_operator_id: PartnerId,
         channel_type: "livechat",
     });
     await start();

--- a/addons/im_livechat/static/tests/composer_patch.test.js
+++ b/addons/im_livechat/static/tests/composer_patch.test.js
@@ -25,7 +25,6 @@ test("Can execute help command on livechat channels", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     onRpc("discuss.channel", "execute_command_help", () => {
         expect.step("execute_command_help");
@@ -47,7 +46,6 @@ test('Receives visitor typing status "is typing"', async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/discuss_app_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_app_patch.test.js
@@ -40,7 +40,6 @@ test("add livechat in the sidebar on visitor sending first message", async () =>
         channel_type: "livechat",
         country_id: countryId,
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -71,7 +70,6 @@ test("invite button should be present on livechat", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);
@@ -96,7 +94,6 @@ test("livechats are sorted by last activity time in the sidebar: most recent at 
                 Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
         },
         {
             channel_member_ids: [
@@ -108,7 +105,6 @@ test("livechats are sorted by last activity time in the sidebar: most recent at 
                 Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
         },
     ]);
     await start();
@@ -137,7 +133,6 @@ test("sidebar search finds livechats", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -155,7 +150,6 @@ test("open visitor's partner profile if visitor has one", async () => {
             Command.create({ partner_id: livechatPartner, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channel);
@@ -173,7 +167,6 @@ test("Conversation description works in livechat", async () => {
         ],
         channel_type: "livechat",
         description: "Yup, that customer again...",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/embed/autopopup.test.js
+++ b/addons/im_livechat/static/tests/embed/autopopup.test.js
@@ -21,7 +21,6 @@ test("persisted session", async () => {
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
     });
     setupChatHub({ opened: [channelId] });
     await start({

--- a/addons/im_livechat/static/tests/embed/chat_bubble.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_bubble.test.js
@@ -26,7 +26,6 @@ test("Do not show bot IM status", async () => {
             Command.create({ partner_id: partnerId2, livechat_member_type: "bot" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: partnerId2,
     });
     setupChatHub({ folded: [channelId1, channelId2] });
     await start({ authenticateAs: false });

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -34,7 +34,6 @@ test("persisted session history", async () => {
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
     });
     expirableStorage.setItem(
         "im_livechat.saved_state",
@@ -147,7 +146,6 @@ test("do not create new thread when operator answers to visitor", async () => {
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
     setupChatHub({ opened: [channelId] });

--- a/addons/im_livechat/static/tests/embed/message_reactions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_reactions.test.js
@@ -32,7 +32,6 @@ test("user custom live chat user name for message reactions", async () => {
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
     });
     pyEnv["mail.message"].create({
         body: "Hello world",

--- a/addons/im_livechat/static/tests/embed/unread_messages.test.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages.test.js
@@ -36,7 +36,6 @@ test("new message from operator displays unread counter", async () => {
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
     });
     expirableStorage.setItem(
         "im_livechat.saved_state",

--- a/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
+++ b/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
@@ -36,7 +36,6 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
                 Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 1",
         },
         {
@@ -50,7 +49,6 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
                 Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 2",
         },
         {
@@ -64,7 +62,6 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
                 Command.create({ guest_id: guestId_3, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 3",
         },
     ]);
@@ -123,7 +120,6 @@ test("Tab livechat picks ended livechats last", async () => {
                 Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
             ],
             livechat_channel_id: livechatChannelId,
-            livechat_operator_id: serverState.partnerId,
             create_uid: serverState.publicUserId,
         }))
     );
@@ -251,7 +247,6 @@ test("switching to folded chat window unfolds it", async () => {
                 Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 1",
         },
         {
@@ -264,7 +259,6 @@ test("switching to folded chat window unfolds it", async () => {
                 Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 2",
         },
     ]);
@@ -304,7 +298,6 @@ test("switching to hidden chat window unhides it", async () => {
                 Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 1",
         },
         {
@@ -317,7 +310,6 @@ test("switching to hidden chat window unhides it", async () => {
                 Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 2",
         },
         { name: "general" },
@@ -359,7 +351,6 @@ test("tab on composer doesn't switch thread if user is typing", async () => {
                 Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 1",
         },
         {
@@ -373,7 +364,6 @@ test("tab on composer doesn't switch thread if user is typing", async () => {
                 Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 2",
         },
     ]);
@@ -398,7 +388,6 @@ test("tab on composer doesn't switch thread if no unread thread", async () => {
                 Command.create({ guest_id: guestId_1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 1",
         },
         {
@@ -410,7 +399,6 @@ test("tab on composer doesn't switch thread if no unread thread", async () => {
                 Command.create({ guest_id: guestId_2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
             name: "Livechat 2",
         },
     ]);

--- a/addons/im_livechat/static/tests/im_livechat_shared_tests.js
+++ b/addons/im_livechat/static/tests/im_livechat_shared_tests.js
@@ -27,7 +27,6 @@ export async function livechatLastAgentLeaveFromChatWindow() {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
     setupChatHub({ opened: [channelId] });

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -33,7 +33,6 @@ test("livechat note is loaded when opening the channel info list", async () => {
         ],
         country_id: countryId,
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         livechat_note: "<p>Initial note<br/>Second line</p>",
     });
     await start();
@@ -62,7 +61,6 @@ test("editing livechat note is synced between tabs", async () => {
         ],
         country_id: countryId,
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         livechat_note: "<p>Initial note</p>",
     });
     const tab1 = await start({ asTab: true });
@@ -102,7 +100,6 @@ test("shows live chat status in discuss sidebar", async () => {
         ],
         country_id: countryId,
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         livechat_status: "waiting",
     });
     await start();
@@ -137,7 +134,6 @@ test("editing livechat status is synced between tabs", async () => {
         ],
         country_id: countryId,
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         livechat_status: "in_progress",
     });
     const tab1 = await start({ asTab: true });
@@ -178,7 +174,6 @@ test("Manage expertises from channel info list", async () => {
         ],
         country_id: countryId,
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         livechat_expertise_ids: expertiseIds,
     });
     await start();
@@ -250,7 +245,6 @@ test("info panel toggle state persists across chats", async () => {
                 Command.create({ guest_id: guestId1, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
         },
         {
             channel_member_ids: [
@@ -261,7 +255,6 @@ test("info panel toggle state persists across chats", async () => {
                 Command.create({ guest_id: guestId2, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
         },
     ]);
     await start();
@@ -293,7 +286,6 @@ test("auto-open of livechat info & members panels should combine", async () => {
                 Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
             ],
             channel_type: "livechat",
-            livechat_operator_id: serverState.partnerId,
         },
         {
             channel_type: "channel",

--- a/addons/im_livechat/static/tests/messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch.test.js
@@ -15,7 +15,6 @@ test('livechats should be in "chat" filter', async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
@@ -36,7 +35,6 @@ test('livechats should be in "livechat" tab in mobile', async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
@@ -33,7 +33,6 @@ test("Livechat button is present when there is at least one livechat thread", as
             }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -55,11 +55,17 @@ async function get_session(request) {
             fetchChannelInfoState: "fetched",
             id: -1,
             isLoaded: true,
-            livechat_operator_id: mailDataHelpers.Store.one(
+            livechat_channel_member_history_ids: [-1],
+            scrollUnread: false,
+        });
+        store.add("im_livechat.channel.member.history", {
+            id: -1,
+            channel_id: -1,
+            livechat_member_type: "agent",
+            partner_id: mailDataHelpers.Store.one(
                 ResPartner.browse(agent.partner_id),
                 makeKwArgs({ fields: ["avatar_128", "user_livechat_username"] })
             ),
-            scrollUnread: false,
         });
         return { store_data: store.get_result(), channel_id: -1 };
     }

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -7,7 +7,7 @@ import { ensureArray } from "@web/core/utils/arrays";
 
 export class DiscussChannel extends mailModels.DiscussChannel {
     livechat_channel_id = fields.Many2one({ relation: "im_livechat.channel", string: "Channel" }); // FIXME: somehow not fetched properly
-    livechat_channel_member_history_ids = fields.Many2many({
+    livechat_channel_member_history_ids = fields.One2many({
         relation: "im_livechat.channel.member.history",
     });
     livechat_note = fields.Html({ sanitize: true });
@@ -82,8 +82,6 @@ export class DiscussChannel extends mailModels.DiscussChannel {
     _to_store(store) {
         /** @type {import("mock_models").ResCountry} */
         const ResCountry = this.env["res.country"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
 
         super._to_store(...arguments);
         for (const channel of this) {
@@ -111,16 +109,6 @@ export class DiscussChannel extends mailModels.DiscussChannel {
             );
             // add the last message date
             if (channel.channel_type === "livechat") {
-                // add the operator id
-                if (channel.livechat_operator_id) {
-                    // livechat_username ignored for simplicity
-                    channelInfo.livechat_operator_id = mailDataHelpers.Store.one(
-                        ResPartner.browse(channel.livechat_operator_id),
-                        makeKwArgs({ fields: ["avatar_128", "user_livechat_username"] })
-                    );
-                } else {
-                    channelInfo.livechat_operator_id = false;
-                }
                 channelInfo["livechat_looking_for_help_since_dt"] =
                     channel.livechat_looking_for_help_since_dt;
                 channelInfo["livechat_end_dt"] = channel.livechat_end_dt;

--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
@@ -84,7 +84,6 @@ export class LivechatChannel extends models.ServerModel {
         return {
             channel_partner_ids: [agent.partner_id],
             channel_member_ids: membersToAdd,
-            livechat_operator_id: agent.partner_id,
             livechat_channel_id: id,
             livechat_status: "in_progress",
             channel_type: "livechat",

--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel_member_history.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel_member_history.js
@@ -16,4 +16,20 @@ export class LivechatChannelMemberHistory extends models.ServerModel {
     });
     member_id = fields.Many2one({ relation: "discuss.channel.member" });
     partner_id = fields.Many2one({ relation: "res.partner" });
+
+    create(values) {
+        const idOrIds = super.create(values);
+        // Update of the livechat_channel_member_history_ids field in discuss.channel
+        // since it is not done automatically for the mock server models.
+        const channel_member_history =
+            this.env["im_livechat.channel.member.history"].browse(idOrIds);
+        channel_member_history.forEach((history) => {
+            const channelId = this.env["discuss.channel"].browse(history.channel_id)[0];
+            channelId.livechat_channel_member_history_ids = [
+                ...(channelId.livechat_channel_member_history_ids || []),
+                history.id,
+            ];
+        });
+        return idOrIds;
+    }
 }

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -23,7 +23,6 @@ test("Unknown visitor", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -51,7 +50,6 @@ test("Do not show channel when visitor is typing", async () => {
         ],
         channel_type: "livechat",
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -89,7 +87,6 @@ test("Smiley face avatar for livechat item linked to a guest", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -112,7 +109,6 @@ test("Partner profile picture for livechat item linked to a partner", async () =
             Command.create({ partner_id: partnerId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);
@@ -139,7 +135,6 @@ test("No counter if the category is unfolded and with unread messages", async ()
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -158,7 +153,6 @@ test("No counter if category is folded and without unread messages", async () =>
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -179,7 +173,6 @@ test("Counter should have count of unread conversations if category is folded an
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     pyEnv["mail.message"].create({
         author_guest_id: guestId,
@@ -203,7 +196,6 @@ test("Close manually by clicking the title", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -233,7 +225,6 @@ test("Open manually by clicking the title, invisible channels when closed", asyn
             }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -267,7 +258,6 @@ test("Active category item should be visible even if the category is closed", as
             }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -288,7 +278,6 @@ test("Clicking on leave button leaves the channel", async () => {
             }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
     pyEnv["mail.message"].create({
@@ -327,7 +316,6 @@ test("Message unread counter", async () => {
             }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();
@@ -356,7 +344,6 @@ test("Local sidebar category state is shared between tabs", async () => {
                 livechat_member_type: "visitor",
             }),
         ],
-        livechat_operator_id: serverState.user,
     });
     const env1 = await start({ asTab: true });
     const env2 = await start({ asTab: true });
@@ -386,7 +373,6 @@ test("live chat is displayed below its category", async () => {
                 livechat_member_type: "visitor",
             }),
         ],
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss();

--- a/addons/im_livechat/static/tests/thread_icon_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_icon_patch.test.js
@@ -18,7 +18,6 @@ test("Public website visitor is typing", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -31,7 +31,6 @@ test("Thread name unchanged when inviting new users", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);
@@ -56,7 +55,6 @@ test("Can set a custom name to livechat conversation", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);
@@ -80,7 +78,6 @@ test("Display livechat custom username if defined", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);
@@ -103,7 +100,6 @@ test("Display livechat custom name in typing status", async () => {
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: partnerId,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/transcript_sender.test.js
+++ b/addons/im_livechat/static/tests/transcript_sender.test.js
@@ -21,7 +21,6 @@ test("agent can send conversation after livechat ends", async () => {
         ],
         channel_type: "livechat",
         livechat_end_dt: serializeDate(today()),
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId);

--- a/addons/im_livechat/static/tests/upgrade_19_1.test.js
+++ b/addons/im_livechat/static/tests/upgrade_19_1.test.js
@@ -25,7 +25,6 @@ test("category 'Livechat' is folded", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     localStorage.setItem("discuss_sidebar_category_folded_im_livechat.category_default", "true");
     await start();
@@ -53,7 +52,6 @@ test("livechat info default open is 'off'", async () => {
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     localStorage.setItem("im_livechat.no_livechat_info_default_open", "true");
     await start();

--- a/addons/im_livechat/static/tests/visitor_disconnection.test.js
+++ b/addons/im_livechat/static/tests/visitor_disconnection.test.js
@@ -41,7 +41,6 @@ test("Visitor going offline shows disconnection banner to operator", async () =>
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
         ],
         livechat_channel_id: livechatChannelId,
-        livechat_operator_id: serverState.partnerId,
         create_uid: serverState.publicUserId,
     });
     setupChatHub({ opened: [channel_id] });

--- a/addons/im_livechat/tests/common.py
+++ b/addons/im_livechat/tests/common.py
@@ -65,7 +65,6 @@ class TestGetOperatorCommon(HttpCase):
                 "name": "Visitor 1",
                 "channel_type": "livechat",
                 "livechat_channel_id": livechat.id,
-                "livechat_operator_id": operator.partner_id.id,
                 "channel_member_ids": [Command.create({"partner_id": operator.partner_id.id})],
                 "last_interest_dt": fields.Datetime.now(),
             }

--- a/addons/im_livechat/tests/test_digest.py
+++ b/addons/im_livechat/tests/test_digest.py
@@ -15,17 +15,16 @@ class TestLiveChatDigest(TestDigestCommon):
 
         cls.channels = cls.env['discuss.channel'].create([{
             'name': 'Channel 1',
-            'livechat_operator_id': cls.env.user.partner_id.id,
             'channel_type': 'livechat',
         }, {
             'name': 'Channel 2',
-            'livechat_operator_id': cls.env.user.partner_id.id,
             'channel_type': 'livechat',
         }, {
             'name': 'Channel 3',
-            'livechat_operator_id': other_partner.id,
             'channel_type': 'livechat',
         }])
+        cls.channels[0:2]._add_members(users=cls.env.user)
+        cls.channels[2]._add_members(partners=other_partner)
 
         cls.env['rating.rating'].search([]).unlink()
 

--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -339,7 +339,6 @@ class TestGetOperator(MailCommon, TestGetOperatorCommon):
             "name": "Visitor 1",
             "channel_type": "livechat",
             "livechat_channel_id": livechat_channel.id,
-            "livechat_operator_id": operator.partner_id.id,
             "channel_member_ids": [Command.create({"partner_id": operator.partner_id.id})],
             "last_interest_dt": fields.Datetime.now() - timedelta(minutes=4),
         }

--- a/addons/im_livechat/tests/test_session_views.py
+++ b/addons/im_livechat/tests/test_session_views.py
@@ -32,7 +32,7 @@ class TestImLivechatSessionViews(TestImLivechatCommon):
 
     @users("admin")
     def test_form_view_embed_thread(self):
-        operator = new_test_user(
+        new_test_user(
             self.env,
             login="operator",
             groups="base.group_user,im_livechat.im_livechat_group_manager",
@@ -44,14 +44,12 @@ class TestImLivechatSessionViews(TestImLivechatCommon):
                     "name": "test 1",
                     "channel_type": "livechat",
                     "livechat_channel_id": self.livechat_channel.id,
-                    "livechat_operator_id": operator.partner_id.id,
                     "channel_member_ids": [Command.create({"partner_id": user_1.id})],
                 },
                 {
                     "name": "test 2",
                     "channel_type": "livechat",
                     "livechat_channel_id": self.livechat_channel.id,
-                    "livechat_operator_id": operator.partner_id.id,
                     "channel_member_ids": [Command.create({"partner_id": user_2.id})],
                 },
             ]

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -69,7 +69,6 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
             {
                 "name": "Livechat session",
                 "channel_type": "livechat",
-                "livechat_operator_id": operator.partner_id.id,
                 "livechat_channel_id": livechat_channel.id,
             }
         )

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -12,7 +12,7 @@
                     <field name="livechat_agent_providing_help_history"/>
                     <field name="country_id" string="Country"/>
                     <field name="livechat_customer_partner_ids" string="Customer"/>
-                    <filter name="filter_my_sessions" domain="[('livechat_operator_id.user_ids', '=', uid)]" string="My Sessions"/>
+                    <filter name="filter_my_sessions" domain="[('livechat_agent_partner_ids.user_ids', 'in', uid)]" string="My Sessions"/>
                     <separator/>
                     <filter name="ongoing" string="Ongoing" domain="[('livechat_end_dt', '=', False)]"/>
                     <separator/>
@@ -123,7 +123,7 @@
             <field name="model">discuss.channel</field>
             <field name="arch" type="xml">
                 <pivot string="Sessions" display_quantity="1" sample="1">
-                    <field name="livechat_operator_id" type="row"/>
+                    <field name="livechat_agent_partner_ids" type="row"/>
                     <field name="create_date" interval="day" type="col"/>
                     <field name="rating_last_value" type="measure" string="Rating (%)" widget="im_livechat.rating_percentage"/>
                 </pivot>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -869,7 +869,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "livechat_visitor_id": False,
                 "livechat_expertise_ids": [],
                 "livechat_looking_for_help_since_dt": False,
-                "livechat_operator_id": self.users[0].partner_id.id,
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
@@ -899,7 +898,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "livechat_visitor_id": False,
                 "livechat_expertise_ids": [],
                 "livechat_looking_for_help_since_dt": False,
-                "livechat_operator_id": self.users[0].partner_id.id,
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
@@ -1267,12 +1265,18 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": histories.filtered(lambda h: h.livechat_member_type == "agent").id,
                     "livechat_member_type": "agent",
                     "partner_id": self.users[0].partner_id.id,
+                    "member_id": channel.channel_member_ids.filtered(
+                        lambda m: m.partner_id == self.users[0].partner_id
+                    ).id,
                 },
                 {
                     "channel_id": channel.id,
                     "id": histories.filtered(lambda h: h.livechat_member_type == "visitor").id,
                     "livechat_member_type": "visitor",
                     "partner_id": self.users[1].partner_id.id,
+                    "member_id": channel.channel_member_ids.filtered(
+                        lambda m: m.partner_id == self.users[1].partner_id
+                    ).id,
                 },
             ]
         if channel == self.channel_livechat_2:
@@ -1282,12 +1286,18 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": histories.filtered(lambda h: h.livechat_member_type == "agent").id,
                     "livechat_member_type": "agent",
                     "partner_id": self.users[0].partner_id.id,
+                    "member_id": channel.channel_member_ids.filtered(
+                        lambda m: m.partner_id == self.users[0].partner_id
+                    ).id,
                 },
                 {
                     "channel_id": channel.id,
                     "guest_id": self.guest.id,
                     "id": histories.filtered(lambda h: h.livechat_member_type == "visitor").id,
                     "livechat_member_type": "visitor",
+                    "member_id": channel.channel_member_ids.filtered(
+                        lambda m: m.guest_id == self.guest
+                    ).id,
                 },
             ]
         return []

--- a/addons/website_livechat/controllers/chatbot.py
+++ b/addons/website_livechat/controllers/chatbot.py
@@ -21,7 +21,7 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
             ["chatbot_current_step_id.chatbot_script_id", "=", chatbot_script.id],
         ])
         for channel in channels:
-            channel._close_livechat_session()
+            channel._close_livechat_session(message=channel._get_visitor_leave_message())
         store.add(channels, {"close_chat_window": True})
 
         discuss_channel_values = {
@@ -43,7 +43,6 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
                     },
                 ),
             ],
-            'livechat_operator_id': chatbot_script.operator_partner_id.id,
             'chatbot_current_step_id': chatbot_script._get_welcome_steps()[-1].id,
             'channel_type': 'livechat',
             'name': chatbot_script.title,

--- a/addons/website_livechat/models/im_livechat_channel.py
+++ b/addons/website_livechat/models/im_livechat_channel.py
@@ -27,9 +27,15 @@ class Im_LivechatChannel(models.Model):
                 ("livechat_end_dt", "=", False),
             ]
             for discuss_channel in self.env["discuss.channel"].sudo().search(pending_chats_domain):
-                operator = discuss_channel.livechat_operator_id
-                operator_name = operator.user_livechat_username or operator.name
-                discuss_channel._close_livechat_session(cancel=True, operator=operator_name)
+                correspondents = (
+                    discuss_channel.livechat_agent_partner_ids
+                    or discuss_channel.livechat_bot_partner_ids
+                )
+                discuss_channel._close_livechat_session(
+                    message=discuss_channel._get_visitor_leave_message(
+                        cancel=True, correspondents=correspondents
+                    )
+                )
                 discuss_channel.is_pending_chat_request = False
 
         return discuss_channel_vals

--- a/addons/website_livechat/static/tests/discuss_content_patch.test.js
+++ b/addons/website_livechat/static/tests/discuss_content_patch.test.js
@@ -21,7 +21,6 @@ test("Discuss header shows visitor avatar", async () => {
             Command.create({ guest_id: guestId }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
         livechat_visitor_id: visitorId,
     });
     await start();

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -76,7 +76,6 @@ test("Show recent conversations in channel info list", async () => {
         },
         {
             channel_member_ids: [],
-            livechat_operator_id: serverState.partnerId,
             channel_type: "livechat",
             livechat_status: "in_progress",
             livechat_visitor_id: visitorId,

--- a/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
+++ b/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
@@ -49,7 +49,6 @@ export class WebsiteVisitor extends websiteModels.WebsiteVisitor {
             const livechatId = DiscussChannel.create({
                 channel_member_ids: membersToAdd,
                 channel_type: "livechat",
-                livechat_operator_id: serverState.partnerId,
                 name: `${visitor_name}, ${
                     operator.livechat_username ? operator.livechat_username : operator.name
                 }`,

--- a/addons/website_livechat/static/tests/thread_patch.test.js
+++ b/addons/website_livechat/static/tests/thread_patch.test.js
@@ -26,7 +26,6 @@ test("Can create a new record as livechat operator with a custom livechat userna
             Command.create({ partner_id: partnerId }),
         ],
         channel_type: "livechat",
-        livechat_operator_id: serverState.partnerId,
     });
     await start();
     await openDiscuss(channelId); // so that it loads custom livechat username

--- a/addons/website_livechat/tests/test_fw_operator.py
+++ b/addons/website_livechat/tests/test_fw_operator.py
@@ -59,7 +59,7 @@ class TestFwOperator(ChatbotCase, HttpCase, TestLivechatCommon):
         channel = self.env["discuss.channel"].search(
             [("livechat_channel_id", "=", self.livechat_channel.id)]
         )
-        self.assertEqual(channel.livechat_operator_id, self.operator.partner_id)
+        self.assertEqual(self.operator.partner_id, channel.livechat_agent_partner_ids)
         self.assertNotIn(
             self.chatbot_fw_script.operator_partner_id, channel.channel_member_ids.partner_id
         )
@@ -72,7 +72,7 @@ class TestFwOperator(ChatbotCase, HttpCase, TestLivechatCommon):
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         self.assertEqual(channel.chatbot_current_step_id.step_type, "question_selection")
         self._post_answer_and_trigger_next_step(channel, self.fw_to_operator_answer.id)
-        self.assertEqual(channel.livechat_operator_id, self.operator.partner_id)
+        self.assertEqual(self.operator.partner_id, channel.livechat_agent_partner_ids)
         self.assertEqual(channel.chatbot_current_step_id.step_type, "forward_operator")
         next_step_data = self.make_jsonrpc_request("/chatbot/step/trigger", {"channel_id": channel.id})
         self.assertFalse(next_step_data)

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -57,7 +57,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
 
         self._send_rating(channel, self.visitor, 5, "This deboulonnage was fine but not topitop.")
 
-        channel._close_livechat_session()
+        channel._close_livechat_session(message=channel._get_visitor_leave_message())
 
         self.assertEqual(len(channel.message_ids), 4)
         self.assertEqual(channel.message_ids[0].author_id, self.env.ref('base.partner_root'), "Odoobot must be the sender of the 'left the conversation' message.")
@@ -68,7 +68,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         channel = self._common_basic_flow()
 
         # left the conversation
-        channel._close_livechat_session()
+        channel._close_livechat_session(message=channel._get_visitor_leave_message())
         self.assertEqual(len(channel.message_ids), 3)
         self.assertEqual(channel.message_ids[0].author_id, self.env.ref('base.partner_root'), "Odoobot must be the author the message.")
         self.assertIn(f"Visitor #{channel.livechat_visitor_id.id}", channel.message_ids[0].body)
@@ -186,7 +186,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "livechat_outcome": "no_failure",
                         "livechat_expertise_ids": [],
                         "livechat_looking_for_help_since_dt": False,
-                        "livechat_operator_id": self.operator.partner_id.id,
                         "livechat_visitor_id": self.visitor.id,
                         "member_count": 2,
                         "message_needaction_counter": 0,
@@ -229,6 +228,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         ).id,
                         "livechat_member_type": "agent",
                         "partner_id": self.operator.partner_id.id,
+                        "member_id": operator_member.id,
                     },
                     {
                         "channel_id": channel.id,
@@ -237,6 +237,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                             lambda h: h.guest_id == guest
                         ).id,
                         "livechat_member_type": "visitor",
+                        "member_id": guest_member.id,
                     },
                 ],
                 "mail.guest": [
@@ -344,7 +345,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     "last_interest_dt": fields.Datetime.to_string(channel.last_interest_dt),
                     "livechat_channel_member_history_ids": channel.livechat_channel_member_history_ids.ids,
                     "livechat_end_dt": fields.Datetime.to_string(agent_left_dt),
-                    "livechat_operator_id": self.operator.partner_id.id,
                     "member_count": 1,
                     "message_needaction_counter": 0,
                     "message_needaction_counter_bus_id": 0,

--- a/addons/website_livechat/tests/test_website_visitor.py
+++ b/addons/website_livechat/tests/test_website_visitor.py
@@ -77,7 +77,7 @@ class WebsiteVisitorTestsLivechat(WebsiteVisitorTestsCommon):
         channel_1 = self.env["discuss.channel"].browse(res_1["channel_id"])
         visitor_1 = self._get_last_visitor()
         self.assertEqual(channel_1.livechat_visitor_id, visitor_1)
-        channel_1._close_livechat_session()
+        channel_1._close_livechat_session(message=channel_1._get_visitor_leave_message())
 
         # After login, the same visitor record is retained
         self._authenticate_via_web(self.user_portal.login, "portal")
@@ -91,7 +91,7 @@ class WebsiteVisitorTestsLivechat(WebsiteVisitorTestsCommon):
         visitor_2 = self._get_last_visitor()
         self.assertEqual(channel_2.livechat_visitor_id, visitor_2)
         self.assertEqual(visitor_2, visitor_1)
-        channel_2._close_livechat_session()
+        channel_2._close_livechat_session(message=channel_2._get_visitor_leave_message())
 
         # After logout, a new visitor is created and reassigned to the original session
         self.url_open(

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -33,8 +33,8 @@
         <field name="inherit_id" ref="website.website_visitor_view_kanban"/>
         <field name="arch" type="xml">
             <field name="country_id" position="after">
-                <field name="livechat_operator_id"/>
                 <field name="session_count"/>
+                <field name="current_livechat_agent_ids"/>
             </field>
             <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="before">
                 <div class="col-lg col-sm-4 col-6 py-0 my-2">
@@ -43,18 +43,17 @@
                     </span>
                     <div t-att-class="record.session_count.raw_value ? '' : 'text-muted'">Chats</div>
                 </div>
-                <div t-if="record.livechat_operator_id.raw_value" class="col-lg col-sm-4 col-6 py-0 my-2">
-                    <field name="livechat_operator_id" widget="image" options="{'preview_image': 'avatar_128', 'size': [19, 19]}" class="rounded-circle" alt="Operator Avatar"/>
-                    <field name="livechat_operator_name" class="fw-bold"/>
+                <div t-if="record.current_livechat_agent_ids.raw_value.length > 0" class="col-lg col-sm-4 col-6 py-0 my-2">
                     <div>Speaking With</div>
+                    <field name="current_livechat_agent_ids" widget="many2many_avatar_user" options="{'no_open': True}" class="rounded-circle" alt="Operator Avatar"/>
                 </div>
                 <div t-else="" class="col-lg d-none d-lg-block"/>
             </xpath>
             <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="inside">
                 <button name="action_send_chat_request" type="object"
                         class="btn btn-secondary"
-                        invisible="livechat_operator_id or not is_connected">
-                        Chat
+                        invisible="current_livechat_agent_ids or not is_connected">
+                    Chat
                 </button>
             </xpath>
         </field>
@@ -67,11 +66,11 @@
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
                 <button name="action_send_chat_request" string="Send chat request" type="object" class="oe_highlight"
-                invisible="livechat_operator_id or not is_connected"/>
+                invisible="current_livechat_agent_ids or not is_connected"/>
             </xpath>
             <xpath expr="//group[@id='general_info']" position="before">
-                <group id="livechat_info" invisible="not livechat_operator_id">
-                    <field name="livechat_operator_id" widget="many2one_avatar"/>
+                <group id="livechat_info" invisible="not current_livechat_agent_ids">
+                    <field name="current_livechat_agent_ids" widget="many2many_avatar_user"/>
                 </group>
             </xpath>
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
@@ -89,9 +88,10 @@
         <field name="inherit_id" ref="website.website_visitor_view_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='last_visited_page_id']" position="after">
-                <field name="livechat_operator_id" optional="hide"/>
+                <field name="current_livechat_agent_ids" optional="hide"
+                       options="{'no_open': True}" widget="many2many_avatar_user"/>
                 <button name="action_send_chat_request" string="Chat" type="object" icon="fa-comments"
-                        invisible="livechat_operator_id or not is_connected"/>
+                        invisible="current_livechat_agent_ids or not is_connected"/>
             </xpath>
         </field>
     </record>
@@ -103,8 +103,8 @@
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='filter_is_connected']" position="after">
                 <separator/>
-                <filter string="Available" name="filter_not_in_conversation" domain="[('livechat_operator_id', '=', False)]"/>
-                <filter string="In Conversation" name="filter_in_conversation" domain="[('livechat_operator_id', '!=', False)]"/>
+                <filter string="Available" name="filter_not_in_conversation" domain="[('discuss_channel_ids', 'not any', [('livechat_end_dt', '=', False)])]"/>
+                <filter string="In Conversation" name="filter_in_conversation" domain="[('discuss_channel_ids.livechat_end_dt', '=', False)]"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
*: crm_livechat, website_livechat

The `livechat_operator_id` field was used while not being completely accurate. Indeed, this field was updated only once when changing from chatbot to a real agent. On top of that, all this information can be reliably derived from the `livechat_channel_member_history`.

This commit tries to remove this field and make use of other ways to find the right information depending on what is needed.

task-4854887
See odoo/enterprise#102570