### PR TITLE
[web] fix datetime widget show_time option not being respected

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -273,7 +273,10 @@ export const datetimePickerService = {
                  * @returns {[T extends "format" ? string : DateTime, null] | [null, Error]}
                  */
                 const safeConvert = (operation, value) => {
-                    const { type } = pickerProps;
+                    let { type } = pickerProps;
+                    if (type == "datetime" && hookParams.showTime === false) {
+                        type = "date"
+                    }
                     const convertFn = (operation === "format" ? formatters : parsers)[type];
                     const options = { tz: pickerProps.tz, format: hookParams.format };
                     if (operation === "format") {

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -125,6 +125,7 @@ export class DateTimeField extends Component {
         const dateTimePicker = useDateTimePicker({
             target: "root",
             showSeconds: this.props.showSeconds,
+            showTime: this.props.showTime,
             condensed: this.props.condensed,
             get pickerProps() {
                 return getPickerProps();

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -597,8 +597,8 @@ test("datetime field in list with show_time option", async () => {
     });
     await click(dates[0]);
     await animationFrame();
-    expect(".o_field_datetime input:first").toHaveValue("02/08/2017 12:00:00", {
-        message: "for datetime field both date and time should be visible with datetime widget",
+    expect(".o_field_datetime input:first").toHaveValue("02/08/2017", {
+        message: "for datetime field only date should be visible with date widget after click",
     });
 });
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The datetime picker widget does not respect the `"show_time": False` option.

Fixes #207405

Current behavior before PR:

Regardless of the `show_time` option, the time is still shown.

<img width="457" height="448" alt="image" src="https://github.com/user-attachments/assets/8ac36129-ed5f-4bba-a656-2a1bc1ffb559" />

Desired behavior after PR is merged:

With `"show_time": False`, the time is not shown.

<img width="466" height="453" alt="image" src="https://github.com/user-attachments/assets/70a78155-3dd1-49e1-864c-8c61c3fed905" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
