### PR TITLE
[FIX] website_forum: comment with portal user on forum best answer

### DIFF
--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -768,7 +768,7 @@ class ForumPost(models.Model):
                 raise AccessError(_('%d karma required to comment.', self.karma_comment))
             if not kwargs.get('force_record_name') and self.parent_id.name:
                 kwargs['force_record_name'] = self.parent_id.name
-        return super().message_post(message_type=message_type, **kwargs)
+        return super(ForumPost, self.sudo()).message_post(message_type=message_type, **kwargs)
 
     def _notify_thread_by_inbox(self, message, recipients_data, msg_vals=False, **kwargs):
         # Override to avoid keeping all notified recipients of a comment.


### PR DESCRIPTION
Steps to reproduce:
===================
1- On a forum add a comment
2- Portal user answer that comment & selected as best answer 
3- Protal user2 comment that answer
-> access error
(See ticket video easier to describe)

cause:
======
When commenting on a forum answer, the message post method adds followers of the parent question as `partner_ids`. (See [1])
In 19.0, a new ORM security check requires read access on comodel records when writing to Many2many fields.
(See [2])

This caused an AccessError when the user couldn't read all followers (partners).

Filter `partner_ids` using `search()` to include only partners accessible to the current user.

[1]: https://github.com/odoo/odoo/blob/411c14210668ac6290ef6dc8535770179879b9bc/addons/website_forum/models/forum_post.py#L758
[2]: https://github.com/odoo/odoo/commit/aae732957c3c

opw-5357483

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
