### PR TITLE
[FIX] point_of_sale: ensure related data are removed when order is deleted

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -880,9 +880,9 @@ export class PosData extends Reactive {
         const relationsToDelete = Object.values(this.relations[recordModel])
             .filter((rel) => this.opts.cascadeDeleteModels.includes(rel.relation))
             .map((rel) => rel.name);
-        const recordsToDelete = Object.entries(record)
-            .filter(([idx, values]) => relationsToDelete.includes(idx) && values)
-            .map(([idx, values]) => values)
+        const recordsToDelete = relationsToDelete
+            .map((key) => record[key])
+            .filter(Boolean)
             .flat();
 
         // Delete all children records before main record

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -256,9 +256,11 @@ describe("pos_store.js", () => {
     test("deleteOrders", async () => {
         const store = await setupPosEnv();
         const order1 = await getFilledOrder(store);
+        const line1 = order1.lines[0];
         await store.syncAllOrders();
         await store.deleteOrders([order1]);
         expect(store.models["pos.order"].getBy("uuid", order1.uuid)).toBeEmpty();
+        expect(store.models["pos.order.line"].getBy("uuid", line1.uuid)).toBeEmpty();
     });
 
     test("deleteOrders multiple orders", async () => {

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -268,7 +268,7 @@ describe("restaurant pos_store.js", () => {
                 await createOrderForTable();
                 expect(table.getOrders()).toHaveLength(1);
                 expect(table.getOrder().id).toBeOfType("number");
-                expect(table.getOrder().lines).toHaveLength(4 + i * 2);
+                expect(table.getOrder().lines).toHaveLength(2);
             }
 
             expect(store.models["pos.order"].length).toEqual(1);


### PR DESCRIPTION
Step to reproduce: (try this in 19.0)
- open pos and settle a order
- refund the same order, from payment screen, go back to product screen
- cancel this order
- again try to refund the same order

Observation:
- Blank screen with traceback in console
```
Caused by: TypeError: Cannot read properties of undefined (reading 'state')
at Proxy.reduce (<anonymous>)
at get refundedQty
```

Cause:
- refundedQty() reads refund_orderline_ids.order_id.
- On the first refund cancellation, the refund was deleted but its related order_line was not.
- Order deletion relies on localDeleteCascade, which uses Object.entries() to find related records to delete.
- With lazy getters, this fails because Object.entries() does not expose or execute getter-based properties.

Fix:
- as we already have keys `relationsToDelete`, we pull the value, which execute the getter and we will have the needed data.
- Fixed the test, as for new order, we expect the newer orderline, older ones
    should be deleted.

opw-5379747


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
