### PR TITLE
[IMP] point_of_sale, product: customize barcode validation for product form

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -74,3 +74,18 @@ class ProductProduct(models.Model):
         self.product_tmpl_id._ensure_unused_in_pos()
         self.product_tmpl_id._check_is_special_product()
         return super().action_archive()
+
+    def _build_duplicate_barcode_error_string(self, barcode, duplicate_products):
+        if not self.env.context.get("is_pos_product_action"):
+            return super()._build_duplicate_barcode_error_string(barcode, duplicate_products)
+
+        return _(
+            "Barcode \"%(barcode)s\" already assigned to \"%(product_list)s\"",
+            barcode=barcode,
+            product_list=(duplicate_products - self).mapped('display_name'),
+        )
+
+    def _build_duplicate_barcode_error_note(self):
+        if not self.env.context.get("is_pos_product_action"):
+            return super()._build_duplicate_barcode_error_note()
+        return ""

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1933,6 +1933,7 @@ export class PosStore extends WithLazyGetterTrap {
                 additionalContext: {
                     taxes_readonly: orderContainsProduct,
                     pos_session_id: this.session.id,
+                    is_pos_product_action: true,
                 },
             }
         );

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -294,6 +294,18 @@ class ProductProduct(models.Model):
             domain.append(('company_id', 'in', (False, company_id)))
         return domain
 
+    def _build_duplicate_barcode_error_string(self, barcode, duplicate_products):
+        """Returns a single line for one duplicated barcode. Override to customise the message."""
+        return _(
+            "- Barcode \"%(barcode)s\" already assigned to product(s): %(product_list)s",
+            barcode=barcode,
+            product_list=duplicate_products.mapped('display_name'),
+        )
+
+    def _build_duplicate_barcode_error_note(self):
+        """Returns a note appended once at the end of the error. Override to customise or remove it."""
+        return _("Note: Some products may be hidden due to access restrictions.")
+
     def _check_duplicated_product_barcodes(self, barcodes_within_company, company_id):
         domain = self._get_barcode_search_domain(barcodes_within_company, company_id)
         products_by_barcode = self.sudo()._read_group(
@@ -301,16 +313,12 @@ class ProductProduct(models.Model):
         )
 
         duplicates_as_str = "\n".join(
-            self.env._(
-                "- Barcode \"%(barcode)s\" already assigned to product(s): %(product_list)s",
-                barcode=barcode, product_list=duplicate_products._filtered_access('read').mapped('display_name'),
-            )
+            self._build_duplicate_barcode_error_string(barcode, duplicate_products._filtered_access('read'))
             for barcode, duplicate_products in products_by_barcode
         )
+
         if duplicates_as_str:
-            duplicates_as_str += _(
-                "\n\nNote: products that you don't have access to will not be shown above."
-            )
+            duplicates_as_str += "\n\n" + self._build_duplicate_barcode_error_note()
             raise ValidationError(_("Barcode(s) already assigned:\n\n%s", duplicates_as_str))
 
     def _check_duplicated_packaging_barcodes(self, barcodes_within_company, company_id):


### PR DESCRIPTION
### Before this commit:
- When creating a product quickly from the POS, the duplicate barcode
error coming from the product module was too much and hard to read.

### After this commit:
- A new barcode validation method is added in the product module to return
only duplicated barcode data, making it easier to reuse in the POS.
- The POS now shows a clear and easy-to-read message when a barcode
is already used by another product.

Task-5406847