### PR TITLE
[IMP] website_sale: customize dynamic snippet via t-call variables

### DIFF
--- a/addons/website_sale/templates/snippets/s_dynamic_snippet_categories.xml
+++ b/addons/website_sale/templates/snippets/s_dynamic_snippet_categories.xml
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <template
-        id="website_sale.s_dynamic_snippet_category_template"
-        inherit_id="website.s_dynamic_snippet_template"
-        primary="True"
-    >
-        <xpath expr="//section[contains(@t-attf-class, 's_dynamic_snippet_title')]/*" position="replace">
-            <div>
-                <h2 class="h3">Crafting Beautiful Spaces</h2>
-                <p class="lead">Designing elegant, inviting environments that inspire and delight.</p>
-            </div>
-        </xpath>
-    </template>
 
     <template id="website_sale.s_dynamic_snippet_category_list" name="Category List">
-        <t t-call="website_sale.s_dynamic_snippet_category_template"
+        <t t-call="website.s_dynamic_snippet_template"
             snippet_name.f="s_dynamic_snippet_category_list"
             snippet_classes.f="oe_website_sale s_dynamic_category_clickable_items
                           s_dynamic_snippet_category s_dynamic_category_no_arrows"
-            main_page_url.f="/shop">
+            main_page_url.f="/shop"
+            snippet_title.f="Crafting Beautiful Spaces"
+            snippet_description.f="Designing elegant, inviting environments that inspire and delight.">
             <t t-call="website_sale.s_dynamic_snippet_category_preview_data"/>
         </t>
     </template>

--- a/addons/website_sale/templates/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/templates/snippets/s_dynamic_snippet_products.xml
@@ -19,7 +19,7 @@
                 o_wsale_products_opt_wishlist_fixed o_wsale_products_opt_actions_theme
                 o_wsale_products_opt_has_cta'"
         />
-        <t t-set="snippet_title" t-valuef="Featured products"/>
+        <t t-set="snippet_title" t-valuef="Our latest products"/>
         <t t-set="snippet_description" t-valuef="Explore our curated selection and find the products that perfectly match your needs."/>
         <t t-set="snippet_button_text" t-valuef="Shop all"/>
         <t t-set="snippet_heading_extra_classes" t-valuef="flex-column"/>


### PR DESCRIPTION
Implement the dynamic category snippet to customize its title and
description using `t-call` variables instead of q-web inheritance.

The base `website.s_dynamic_snippet_template` already supports
variable-based configuration, so inheritance was unnecessary and made
the snippet non-callable.

This change:
- Removes the inherited template used only for text overrides
- Calls the website.s_dynamic_snippet_template directly
- Passes `snippet_title` and `snippet_description` via `t-set`

This makes the snippet easier to reuse, safer to extend, and more
consistent with other dynamic snippets in the website module.

upgrade PR: https://github.com/odoo/upgrade/pull/9126

task-5177451
