### PR TITLE
[FIX] hr_timesheet:  stop notifications appearing everywhere timesheet is created

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -336,20 +336,21 @@ class AccountAnalyticLine(models.Model):
             if line.project_id:  # applied only for timesheet
                 line._timesheet_postprocess(values)
 
-        if skipped_vals:
-            type = "danger"
-            if valid_vals:
-                message = self.env._("Some timesheets were not created: employees aren’t working on the selected days")
+        if self.env.context.get('timesheet_calendar'):
+            if skipped_vals:
+                type = "danger"
+                if valid_vals:
+                    message = self.env._("Some timesheets were not created: employees aren’t working on the selected days")
+                else:
+                    message = self.env._("No timesheets created: employees aren’t working on the selected days")
             else:
-                message = self.env._("No timesheets created: employees aren’t working on the selected days")
-        else:
-            type = "success"
-            message = self.env._("Timesheets successfully created")
+                type = "success"
+                message = self.env._("Timesheets successfully created")
 
-        self.env.user._bus_send('simple_notification', {
-            "type": type,
-            "message": message,
-        })
+            self.env.user._bus_send('simple_notification', {
+                "type": type,
+                "message": message,
+            })
 
         return lines
 


### PR DESCRIPTION
This occurs due to the reason we have not limited the notification using bus to shown only when records are created in calendar. Due to this when ever timesheet is created notification occurs.

Fix:

Use context to limit notifications to be visible.
Problem from : https://github.com/odoo/odoo/pull/240049

opw-5431729
