### PR TITLE
[ADD] l10n_dk_fik: Add Danish FIK payment reference on customer invoices

### DIFF
--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -3,6 +3,7 @@ from odoo.tests.common import TransactionCase
 
 from odoo.addons.account.tools import (
     is_valid_structured_reference_be,
+    is_valid_structured_reference_dk,
     is_valid_structured_reference_fi,
     is_valid_structured_reference_no_se,
     is_valid_structured_reference_nl,
@@ -44,6 +45,31 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference_be('020343057641'))
         # Validates the entire string
         self.assertFalse(is_valid_structured_reference_be('020343053497-OTHER-RANDOM-STUFF'))
+
+    def test_structured_reference_dk(self):
+        # Accepts FIK 71 references (14-digit payment ID + check digit)
+        self.assertTrue(is_valid_structured_reference_dk('+71<000000001234566+88655702<'))
+        self.assertTrue(is_valid_structured_reference_dk(' 71<000000001234566+88655702< '))
+
+        # Accepts FIK 75 references (15-digit payment ID + check digit)
+        self.assertTrue(is_valid_structured_reference_dk('+75<0000000001234566+88655702<'))
+
+        # Does not validate invalid structured format
+        self.assertFalse(is_valid_structured_reference_dk('71<000000001234566+88655702'))   # missing <
+        self.assertFalse(is_valid_structured_reference_dk('+71<00000000123456688655702<'))  # missing +
+
+        # Does not validate invalid length
+        self.assertFalse(is_valid_structured_reference_dk('+71<12345678901234+88655702<'))  # 14 instead of 15
+        self.assertFalse(is_valid_structured_reference_dk('+75<123456789012345+88655702<'))  # 15 instead of 16
+
+        # Does not validate invalid checksum
+        self.assertFalse(is_valid_structured_reference_dk('+71<000000001234567+88655702<'))  # checksum digit altered
+
+        # Does not validate invalid creditor number
+        self.assertFalse(is_valid_structured_reference_dk('+71<000000001234566+8865570<'))
+
+        # Must validate full string
+        self.assertFalse(is_valid_structured_reference_dk('+71<000000001234566+88655702<-EXTRA'))
 
     def test_structured_reference_fi(self):
         # Accepts references in structured format
@@ -113,12 +139,14 @@ class StructuredReferenceTest(TransactionCase):
         self.assertTrue(is_valid_structured_reference(' RF18 5390 0754 7034 '))  # ISO
         self.assertTrue(is_valid_structured_reference(' +++020/3430/57642+++'))  # BE
         self.assertTrue(is_valid_structured_reference('***020/3430/57642*** '))  # BE
+        self.assertTrue(is_valid_structured_reference('+71<000000001234566+88655702<'))  # DK
         self.assertTrue(is_valid_structured_reference('2023 0000 98'))  # FI
         self.assertTrue(is_valid_structured_reference('1234 5678 97'))  # NO-SE
         self.assertTrue(is_valid_structured_reference('5000056789012345'))  # NL
         # Accept references in unstructured format
         self.assertTrue(is_valid_structured_reference(' RF18539007547034'))  # ISO
         self.assertTrue(is_valid_structured_reference(' 020343057642'))  # BE
+        self.assertTrue(is_valid_structured_reference(' 71<000000001234566+88655702< '))  # DK
         self.assertTrue(is_valid_structured_reference('2023000098'))  # FI
         self.assertTrue(is_valid_structured_reference('1234567897'))  # NO-SE
         self.assertTrue(is_valid_structured_reference('5 000 0567 8901 2345'))  # NL
@@ -130,12 +158,14 @@ class StructuredReferenceTest(TransactionCase):
         # Does not validate invalid structured format
         self.assertFalse(is_valid_structured_reference('18539007547034RF'))  # ISO
         self.assertFalse(is_valid_structured_reference('***02/03430/57642***'))  # BE
+        self.assertFalse(is_valid_structured_reference('71<000000001234566+88655702'))  # DK
         self.assertFalse(is_valid_structured_reference('2023/0000/98'))  # FI
         self.assertFalse(is_valid_structured_reference('1234/5678/97'))  # NO-SE
         self.assertFalse(is_valid_structured_reference('(5)000 0567 8901 2345'))  # NL
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference('RF17539007547034'))  # ISO
         self.assertFalse(is_valid_structured_reference('020343057641'))  # BE
+        self.assertFalse(is_valid_structured_reference('+71<000000001234567+88655702<'))  # DK
         self.assertFalse(is_valid_structured_reference('2023000095'))  # FI
         self.assertFalse(is_valid_structured_reference('1234567898'))  # NO-SE
         self.assertFalse(is_valid_structured_reference('6000056789012345'))  # NL

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -46,6 +46,21 @@ def is_valid_structured_reference_be(reference):
     be_ref = re.fullmatch(r'(\d{10})(\d{2})', ref)
     return be_ref and int(be_ref.group(1)) % 97 == int(be_ref.group(2)) % 97
 
+
+def is_valid_structured_reference_dk(reference):
+    """Check whether the provided reference is a valid structured reference for Denmark.
+    Example: +71<022646321691221+88655702<
+
+    :param reference: the reference to check
+    """
+    ref = sanitize_structured_reference(reference)
+    match = re.fullmatch(r'\+?(?:71<(\d{15})|75<(\d{16}))\+\d{8}<', ref)
+    if not match:
+        return False
+
+    payment_ref = match.group(1) or match.group(2)
+    return luhn.is_valid(payment_ref)
+
 def is_valid_structured_reference_fi(reference):
     """Check whether the provided reference is a valid structured reference for Finland.
 
@@ -117,6 +132,7 @@ def is_valid_structured_reference(reference):
 
     return (
         is_valid_structured_reference_be(reference) or
+        is_valid_structured_reference_dk(reference) or
         is_valid_structured_reference_fi(reference) or
         is_valid_structured_reference_no_se(reference) or
         is_valid_structured_reference_nl(reference) or

--- a/addons/l10n_be/models/account_journal.py
+++ b/addons/l10n_be/models/account_journal.py
@@ -6,6 +6,7 @@ from odoo import fields, models
 class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
-    invoice_reference_model = fields.Selection(selection_add=[
-        ('be', 'Belgium')
-        ], ondelete={'be': lambda recs: recs.write({'invoice_reference_model': 'odoo'})})
+    invoice_reference_model = fields.Selection(
+        selection_add=[('be', 'Belgium')],
+        ondelete={'be': lambda recs: recs.write({'invoice_reference_model': 'odoo'})}
+    )

--- a/addons/l10n_dk_fik/__init__.py
+++ b/addons/l10n_dk_fik/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_dk_fik/__manifest__.py
+++ b/addons/l10n_dk_fik/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    "name": "Denmark - FIK Number",
+    "version": "1.0",
+    "category": "Accounting/Localizations",
+    "description": """
+Support Danish FIK number as payment references on customer invoices.
+""",
+    "summary": "Use FIK Number as Payment reference",
+    "depends": [
+        "l10n_dk",
+    ],
+    "data": [
+        "views/account_journal_view.xml",
+    ],
+    "auto_install": True,
+    "license": "LGPL-3",
+}

--- a/addons/l10n_dk_fik/models/__init__.py
+++ b/addons/l10n_dk_fik/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_journal
+from . import account_move

--- a/addons/l10n_dk_fik/models/account_journal.py
+++ b/addons/l10n_dk_fik/models/account_journal.py
@@ -1,0 +1,53 @@
+import re
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+L10N_DK_FIK_MODELS = ('dk_fik_71', 'dk_fik_75')
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    invoice_reference_model = fields.Selection(
+        selection_add=[
+            ('dk_fik_71', "Denmark FIK Number (+71)"),
+            ('dk_fik_75', "Denmark FIK Number (+75)"),
+        ],
+        ondelete={
+            'dk_fik_71': lambda recs: recs.write({'invoice_reference_model': 'odoo'}),
+            'dk_fik_75': lambda recs: recs.write({'invoice_reference_model': 'odoo'}),
+        },
+    )
+
+    l10n_dk_fik_creditor_number = fields.Char(
+        string="FIK Creditor Number",
+        compute='_compute_l10n_dk_fik_creditor_number',
+        store=True,
+        readonly=False,
+    )
+
+    @api.depends('invoice_reference_model', 'company_id.bank_ids.acc_number')
+    def _compute_l10n_dk_fik_creditor_number(self):
+        for journal in self:
+            if journal.invoice_reference_model not in L10N_DK_FIK_MODELS:
+                journal.l10n_dk_fik_creditor_number = False
+                continue
+
+            bank = journal.company_id.bank_ids[:1]
+            creditor_number = '00000000'
+            if bank and bank.acc_number:
+                digits = re.sub(r'\D', '', bank.acc_number or '')
+                creditor_number = digits[-8:].zfill(8)
+
+            journal.l10n_dk_fik_creditor_number = creditor_number
+
+    @api.constrains('l10n_dk_fik_creditor_number', 'invoice_reference_model')
+    def _check_fik_creditor_number(self):
+        for record in self:
+            if record.invoice_reference_model not in L10N_DK_FIK_MODELS:
+                continue
+
+            creditor = record.l10n_dk_fik_creditor_number
+            if not creditor or not (creditor.isdigit() and len(creditor) == 8):
+                raise ValidationError(_("FIK Creditor Number must be exactly 8 digits."))

--- a/addons/l10n_dk_fik/models/account_move.py
+++ b/addons/l10n_dk_fik/models/account_move.py
@@ -1,0 +1,30 @@
+import re
+from stdnum import luhn
+
+from odoo import models
+from odoo.exceptions import ValidationError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _get_invoice_reference_dk_fik(self, prefix, max_digits):
+        self.ensure_one()
+        invoice_digits = re.sub(r"\D", "", self.name or "") or str(self.id)
+        if len(invoice_digits) > max_digits:
+            raise ValidationError(
+                self.env._(
+                    "FIK %s reference cannot be generated: invoice number '%s' has more than %s digits."
+                ) % (prefix, self.name, max_digits)
+            )
+        payment_id = invoice_digits.zfill(max_digits)
+        check_digit = luhn.calc_check_digit(payment_id)
+        creditor_number = self.journal_id.l10n_dk_fik_creditor_number
+
+        return f"+{prefix}<{payment_id}{check_digit}+{creditor_number}<"
+
+    def _get_invoice_reference_dk_fik_71_invoice(self):
+        return self._get_invoice_reference_dk_fik("71", 14)
+
+    def _get_invoice_reference_dk_fik_75_invoice(self):
+        return self._get_invoice_reference_dk_fik("75", 15)

--- a/addons/l10n_dk_fik/views/account_journal_view.xml
+++ b/addons/l10n_dk_fik/views/account_journal_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_journal_form_l10n_dk_fik" model="ir.ui.view">
+        <field name="name">account.journal.form.l10n.dk.fik</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_reference_model']" position="after">
+                <field name="l10n_dk_fik_creditor_number"
+                       invisible="type != 'sale' or invoice_reference_model not in ['dk_fik_71', 'dk_fik_75']"
+                       required="invoice_reference_model in ['dk_fik_71', 'dk_fik_75']"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
@@ -157,7 +157,7 @@
 	<cac:PaymentMeans>
 		<cbc:PaymentMeansCode name="credit transfer">1</cbc:PaymentMeansCode>
 		<cbc:PaymentDueDate>2017-02-28</cbc:PaymentDueDate>
-		<cbc:InstructionID>INV/2017/00001</cbc:InstructionID>
+		<cbc:InstructionID>+71&lt;000002017000015+40116243&lt;</cbc:InstructionID>
 		<cbc:PaymentID>___ignore___</cbc:PaymentID>
 		<cac:PayeeFinancialAccount>
 			<cbc:ID>DK5000400440116243</cbc:ID>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
@@ -156,7 +156,7 @@
 	<cac:PaymentMeans>
 		<cbc:PaymentMeansCode name="credit transfer">1</cbc:PaymentMeansCode>
 		<cbc:PaymentDueDate>2017-02-28</cbc:PaymentDueDate>
-		<cbc:InstructionID>INV/2017/00001</cbc:InstructionID>
+		<cbc:InstructionID>+71&lt;000002017000015+40116243&lt;</cbc:InstructionID>
 		<cbc:PaymentID>___ignore___</cbc:PaymentID>
 		<cac:PayeeFinancialAccount>
 			<cbc:ID>DK5000400440116243</cbc:ID>

--- a/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
+++ b/addons/l10n_dk_oioubl/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
@@ -157,7 +157,7 @@
 	<cac:PaymentMeans>
 		<cbc:PaymentMeansCode name="unknown">1</cbc:PaymentMeansCode>
 		<cbc:PaymentDueDate>2017-02-28</cbc:PaymentDueDate>
-		<cbc:InstructionID>INV/2017/00001</cbc:InstructionID>
+		<cbc:InstructionID>+71&lt;000002017000015+40116243&lt;</cbc:InstructionID>
 		<cbc:PaymentID>___ignore___</cbc:PaymentID>
 		<cac:PayeeFinancialAccount>
 			<cbc:ID>DK5000400440116243</cbc:ID>


### PR DESCRIPTION
Before:
- Danish companies had to rely on manual or non-standard payment communication on invoices.
- They could not generate official FIK payment references.

After:
- Sales journals can now generate Danish FIK payment references automatically.
- Users configure an 8-digit bank-issued FIK creditor number on sales journal.

Impact:
- Enables compliant Danish FIK payments without changing user workflows.

Related PR: https://github.com/odoo/enterprise/pull/102612
taskID-5401553
