### PR TITLE
[IMP] account: add payment terms based on delivery date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1382,8 +1382,13 @@ class AccountMove(models.Model):
                         tax_amount = invoice.amount_tax_signed
                         untaxed_amount_currency = invoice.amount_untaxed * sign
                         untaxed_amount = invoice.amount_untaxed_signed
+                    date_ref = invoice.invoice_date or invoice.date or fields.Date.context_today(invoice)
+                    if 'days_after_delivery' in invoice.invoice_payment_term_id.line_ids.mapped('delay_type'):
+                        if not invoice.delivery_date:
+                            raise ValidationError(_("Delivery Date is required for this payment term."))
+                        date_ref = invoice.delivery_date
                     invoice_payment_terms = invoice.invoice_payment_term_id._compute_terms(
-                        date_ref=invoice.invoice_date or invoice.date or fields.Date.context_today(invoice),
+                        date_ref=date_ref,
                         currency=invoice.currency_id,
                         tax_amount_currency=tax_amount_currency,
                         tax_amount=tax_amount,

--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -293,6 +293,7 @@ class AccountPaymentTermLine(models.Model):
             ('days_after_end_of_month', 'Days after end of month'),
             ('days_after_end_of_next_month', 'Days after end of next month'),
             ('days_end_of_month_on_the', 'Days end of month on the'),
+            ('days_after_delivery', 'Days after delivery date'),
         ], required=True, default='days_after')
     display_days_next_month = fields.Boolean(compute='_compute_display_days_next_month')
     days_next_month = fields.Char(


### PR DESCRIPTION
Current behavior before PR:
- Currently, it is only possible to create payment terms based on the invoice date.
- But in some case, companies based their payment on delivery date.

Desired behavior after PR is merged:
- Payment terms can now be calculated based on the delivery date.
- If a payment term line is configured with 'Days after delivery', now uses the delivery date as the reference date when computing due dates.
- If delivery date is missing raises a validation error.

Changes Implemented:
- Added a new delay type option 'Days after delivery'.
- Updated invoice payment term computation to use the delivery date when this option is selected.

task-5249078
