### PR TITLE
[FIX] l10n_sa_edi: ensure consistent line amounts in ZATCA invoice XML

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -441,7 +441,12 @@ class AccountEdiXmlUbl_21Zatca(models.AbstractModel):
             for grouping_key, values in aggregated_tax_details.items()
             if grouping_key
         )
-        total_amount = base_line['tax_details']['total_excluded_currency'] + total_tax_amount
+        total_base_amount = sum(
+            values['base_amount_currency']
+            for grouping_key, values in aggregated_tax_details.items()
+            if grouping_key
+        )
+        total_amount = total_base_amount + total_tax_amount
 
         line_node['cac:TaxTotal'] = {
             'cbc:TaxAmount': {


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **l10n_sa_edi** and **accounting** modules.
* Create a **15% tax** (tax-included).
* Create a customer invoice with two lines with amounts 18 and 14 and apply
  the tax on an invoice line.
* Post the invoice and **send it to ZATCA**.
* Review the generated XML or submit it for ZATCA validation.

**Observed behavior:**
* The XML nodes **LineExtensionAmount**, **TaxAmount**, and
  **RoundingAmount** contain inconsistent values.
* ZATCA validation raises warnings due to rounding mismatches.
* Example:
  * in xml data look like this
  * `15.66(LineExtensionAmount) + 2.34(TaxAmount) != 17.99(RoundingAmount)`(v19)
* The required relation
  **LineExtensionAmount + TaxAmount = RoundingAmount**
  is violated.

**Cause:**

* In v19.0, `_round_base_lines_tax_details()` distributes rounding deltas so
  that the **sum of rounded line taxes** matches the **rounded global tax**.
* When taxes are **included in price** and there are **multiple invoice lines**,
  this distribution adjusts the per-line tax and base amounts.

  Example pattern:
  * Raw line taxes sum to something like **4.1739…**
  * Rounded global tax = **4.17**
  * Sum of individually-rounded line taxes = **4.18**
  * A **-0.01 delta** is distributed across the lines
  * Result:
    * Line 1 base becomes **15.66**, tax **2.34**
    * Line 2 base becomes **12.17**, tax **1.83**

  So the XML correctly reports:
  * **LineExtensionAmount = 15.66**
  * **TaxAmount = 2.34**

* However, **RoundingAmount** is computed differently:
https://github.com/odoo/odoo/blob/e8a41b5b50ac71974d98c18fa9d47e37e0f7763f/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py#L439-L444

* Here, `base_line['tax_details']['total_excluded_currency']` **does not include the distributed delta**. It still reflects the *pre-distribution* base (e.g. **17.99 total excluded**), while **LineExtensionAmount** uses `vals['total_excluded_currency']`, which *does* include the delta.

* Result: the required identity
`LineExtensionAmount + TaxAmount = RoundingAmount`
is broken — producing inconsistencies such as:
`15.66 + 2.34 ≠ 17.99`

**Fix:**
* Use the same **vals[total_excluded_currency]** as it has a tax-excluded price with the delta included.

opw-5402750
