### PR TITLE
[IMP] {test_}mail, calendar, crm: improve default values in activity

### DIFF
--- a/addons/calendar/tests/test_calendar_activity.py
+++ b/addons/calendar/tests/test_calendar_activity.py
@@ -186,7 +186,7 @@ class TestCalendarActivity(ActivityScheduleCase):
                 'res_id': self.env['res.partner'].create({'name': 'A Partner'}).id,
                 'summary': 'Meeting with partner',
             })
-        self.assertEqual(activity.date_deadline, date(2025, 6, 19))
+        self.assertEqual(activity.date_deadline, date(2025, 6, 19) + timedelta(days=4))
 
         with freeze_time(datetime(2025, 6, 19, 12, 44, 00)):
             calendar_event = self.env['calendar.event'].create({
@@ -224,7 +224,7 @@ class TestCalendarActivity(ActivityScheduleCase):
                 'res_model_id': self.env['ir.model']._get_id('res.partner'),
                 'summary': 'Meeting with partner',
             })
-        self.assertEqual(activity.date_deadline, date(2025, 6, 19))
+        self.assertEqual(activity.date_deadline, date(2025, 6, 19) + timedelta(days=4))
 
         with freeze_time(datetime(2025, 6, 19, 12, 44, 00)):
             calendar_event = self.env['calendar.event'].create({

--- a/addons/crm/tests/test_crm_activity.py
+++ b/addons/crm/tests/test_crm_activity.py
@@ -132,7 +132,6 @@ class TestCrmMailActivity(TestCrmCommon):
             'res_id': self.lead_1.id,
             'res_model_id': self.env.ref('crm.model_crm_lead').id,
         })
-        activity._onchange_activity_type_id()
         self.assertEqual(self.lead_1.activity_type_id, self.activity_type_1)
         self.assertEqual(self.lead_1.activity_summary, self.activity_type_1.summary)
         # self.assertEqual(self.lead.activity_date_deadline, self.activity_type_1.summary)
@@ -157,23 +156,18 @@ class TestCrmMailActivity(TestCrmCommon):
             'res_id': test_lead.id,
             'res_model_id': lead_model_id,
         })
-        activity._onchange_activity_type_id()
 
         # Check the next activity is correct
         self.assertEqual(test_lead.activity_summary, activity.summary)
         self.assertEqual(test_lead.activity_type_id, activity.activity_type_id)
-        # self.assertEqual(fields.Datetime.from_string(self.lead.activity_date_deadline), datetime.now() + timedelta(days=activity.activity_type_id.days))
 
         activity.write({
             'activity_type_id': self.activity_type_2.id,
-            'summary': '',
             'note': 'Content of the activity to log',
         })
-        activity._onchange_activity_type_id()
 
         self.assertEqual(test_lead.activity_summary, activity.activity_type_id.summary)
         self.assertEqual(test_lead.activity_type_id, activity.activity_type_id)
-        # self.assertEqual(fields.Datetime.from_string(self.lead.activity_date_deadline), datetime.now() + timedelta(days=activity.activity_type_id.days))
 
         self.assertEqual(test_lead.activity_ids, activity)
         activity.action_done()

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date, datetime, timedelta, UTC
+from markupsafe import Markup
 from unittest.mock import patch
 from unittest.mock import DEFAULT
 from zoneinfo import ZoneInfo
@@ -320,38 +321,62 @@ class TestActivityFlow(TestActivityCommon):
             activity.with_user(self.user_admin).write({'user_id': self.user_employee.id})
         self.assertEqual(activity.user_id, self.user_employee)
 
-    def test_activity_summary_sync(self):
-        """ Test summary from type is copied on activities if set (currently only in form-based onchange) """
-        ActivityType = self.env['mail.activity.type']
-        call_activity_type = ActivityType.create({'name': 'call', 'sequence': 1})
-        email_activity_type = ActivityType.create({
-            'name': 'email',
-            'summary': 'Email Summary',
-            'sequence': '30'
+    @freeze_time('2026-01-22')
+    def test_activity_edition(self):
+        """ Test summary, user_id, date_deadline, note computed based on activity_type """
+        todo_activity_type = self.env.ref('mail.mail_activity_data_todo')
+        todo_activity_type.write({'default_note': 'Test note', 'default_user_id': self.user_employee.id})
+        call_activity_type = self.env['mail.activity.type'].create({
+            'name': 'call',
+            'summary': False,
         })
-        call_activity_type = ActivityType.create({'name': 'call', 'summary': False})
-        with Form(
-            self.env['mail.activity'].with_context(
-                default_res_model_id=self.env['ir.model']._get_id('mail.test.activity'),
-                default_res_id=self.test_record.id,
-            )
-        ) as ActivityForm:
-            # coming from default activity type, which is to do
-            self.assertEqual(ActivityForm.activity_type_id, self.env.ref("mail.mail_activity_data_todo"))
-            self.assertEqual(ActivityForm.summary, "TodoSummary")
-            # `res_model_id` and `res_id` are invisible, see view `mail.mail_activity_view_form_popup`
-            # they must be set using defaults, see `action_feedback_schedule_next`
-            ActivityForm.activity_type_id = call_activity_type
-            # activity summary should be empty
-            self.assertEqual(ActivityForm.summary, "TodoSummary", "Did not erase if void on type")
 
-            ActivityForm.activity_type_id = email_activity_type
-            # activity summary should be replaced with email's default summary
-            self.assertEqual(ActivityForm.summary, email_activity_type.summary)
+        test_activity = self.env['mail.activity'].create({
+            'res_model_id': self.env['ir.model']._get_id('mail.test.activity'),
+            'res_id': self.test_record.id,
+            'activity_type_id': call_activity_type.id,
+        })
+        self.assertEqual(
+            test_activity.summary,
+            'call',
+            'summary should fallback to name when first loaded activity_type does not contain the default summary.'
+        )
+        self.assertEqual(
+            test_activity.user_id.id,
+            self.env.user.id,
+            'user_id should fallback to current user when first loaded activity_type does not contain the default user_id.'
+        )
+        self.assertEqual(
+            test_activity.date_deadline,
+            date(2026, 1, 22),
+            'date_deadline should fallback to today when first loaded activity_type does not have the delay_count.'
+        )
+        self.assertFalse(test_activity.note, 'note should be computed based on activity_type.')
 
-            ActivityForm.activity_type_id = call_activity_type
-            # activity summary remains unchanged from change of activity type as call activity doesn't have default summary
-            self.assertEqual(ActivityForm.summary, email_activity_type.summary)
+        test_activity.activity_type_id = todo_activity_type
+        self.assertEqual(
+            test_activity.summary,
+            'TodoSummary',
+            'summary should be computed based on the default_summary provided on activity_type'
+        )
+        self.assertEqual(
+            test_activity.user_id.id,
+            self.user_employee.id,
+            'user_id should be computed based on the default_user_id provided on activity_type.'
+        )
+        self.assertEqual(
+            test_activity.date_deadline,
+            date(2026, 1, 22) + relativedelta(days=4),
+            'date_deadline should be computed based on delay_count provided on activity_type.'
+        )
+        self.assertEqual(test_activity.note, Markup('<p>Test note</p>'), 'note should be computed based on activity_type.')
+
+        test_activity.activity_type_id = call_activity_type
+        # Values should not change as call_activity_type doesn't contains the default values.
+        self.assertEqual(test_activity.summary, 'TodoSummary')
+        self.assertEqual(test_activity.user_id.id, self.user_employee.id)
+        self.assertEqual(test_activity.date_deadline, date(2026, 1, 22) + relativedelta(days=4))
+        self.assertEqual(test_activity.note, Markup('<p>Test note</p>'))
 
     def test_activity_type_unlink(self):
         """ Removing type should allocate activities to Todo """

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -344,7 +344,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             # voip module read activity_type during create leading to one less query in enterprise on action_feedback
             _category = activity.activity_type_id.category
 
-        with self.assertQueryCount(admin=10, employee=9):  # tm: 7 / 7
+        with self.assertQueryCount(admin=11, employee=10):  # tm: 8 / 8
             activity.action_feedback(feedback='Zizisse Done !')
 
     @warmup


### PR DESCRIPTION
This PR made the following changes with the default values when switching the activity type while scheduling the activity.

- If the new activity type has a default user, summary, or note, replace the existing values with the default ones. If not, keep the previous values unchanged.
- If the new activity type has a schedule day different than 0, then recompute the date based on the scheduled days; otherwise, keep the existing date.
- Edge case for summary when the first activity_type in sequence doesn't have the default summary, use it's name as a summary. 
- Removed the `_onchange_activity_type_id` method for changing the values.
  Instead of that used the compute method for every field as it is much more
  reliable compared to onchanges.
- Adpated `test_activity_summary_sync` to test multiple fields based on the new flow.
- Increased query count as the field is stored computed, which will add an extra
  query to get field value when not present in cache for the first time when
  accessing them. Here, note field seems missing from cache, so it is
  being fetched from the database when `message_activity_done` template tries
  access it.
Task-5269655
