### PR TITLE
[FIX] html_editor: ensure link preview works in template view

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -403,7 +403,7 @@ export class LinkPopover extends Component {
      */
     async updateDocumentState() {
         const url = this.state.url;
-        const urlObject = URL.parse(url, this.props.document.URL);
+        const urlObject = URL.parse(url, document.URL);
         if (
             url &&
             (url.startsWith("/web/content/") ||
@@ -504,7 +504,7 @@ export class LinkPopover extends Component {
             return;
         }
         try {
-            url = new URL(this.state.url, this.props.document.URL); // relative to absolute
+            url = new URL(this.state.url, document.URL); // relative to absolute
         } catch {
             // Invalid URL, might happen with editor unsuported protocol. eg type
             // `geo:37.786971,-122.399677`, become `http://geo:37.786971,-122.399677`


### PR DESCRIPTION
**Steps to reproduce:**
- Install `mass_mailing` and `website_sale`.
- Go to Email Marketing > Create new record.
- In the template editor, insert a /button.
- Set the URL to `/shop` and select it from the app URLs.
- Click on Apply, then click on the newly created button.

**Issue:**
- Clicking on the button raises a UI error: `This URL is invalid. Preview couldn't be updated.`

**Root cause:**
- In [1], `this.props.document.url` is used.
- This works in the website editor, but in template view `this.props.document` points to the iframe document, not the document.

**Solution:**
- Replace `this.props.document.url` with `document.URL`.
- This ensures the preview works correctly in both website and template views.

[1]https://github.com/odoo/odoo/blob/12d63b536dddc40428fb5edb6f6b3302605dc72d/addons/html_editor/static/src/main/link/link_popover.js#L506-L507

**Before:**
<img width="381" height="123" alt="image" src="https://github.com/user-attachments/assets/1370b04d-8bc6-40b9-b7b0-77413a36bd51" />

**After:**
<img width="419" height="119" alt="image" src="https://github.com/user-attachments/assets/d5d47a47-1805-4b1f-b852-88ea725beaba" />


opw-5428680
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
