### PR TITLE
[IMP] mail, im_livechat: disable fold toggle for empty sidebar categories

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.js
@@ -29,6 +29,11 @@ const DiscussSidebarCategoryPatch = {
         }
         return actions;
     },
+    get isToggleFoldDisabled() {
+        return this.category.eq(this.store.discuss.livechatLookingForHelpCategory)
+            ? false
+            : super.isToggleFoldDisabled;
+    },
 };
 
 /** @type {DiscussSidebarChannel} */

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.js
@@ -44,6 +44,10 @@ export class DiscussSidebarCategory extends Component {
         return [];
     }
 
+    get isToggleFoldDisabled() {
+        return !this.category.channels.some((channel) => channel.isDisplayInSidebar);
+    }
+
     toggle() {
         this.category.is_open = !this.category.is_open;
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/category.xml
@@ -22,11 +22,11 @@
 
     <t t-name="mail.DiscussSidebarCategory.main">
         <div class="o-mail-DiscussSidebarCategory position-relative d-flex align-items-center rounded opacity-trigger-hover" t-att-class="{ 'mx-2 my-1 ps-1 position-relative': store.discuss.isSidebarCompact, 'mt-1 mx-2 o-ps-1_5 pe-1': !store.discuss.isSidebarCompact }" t-attf-class="#{category.extraClass}" name="header" t-ref="root">
-            <button class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start" t-att-class="{ 'align-items-baseline o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
+            <button t-att-disabled="isToggleFoldDisabled" class="o-mail-DiscussSidebarCategory-toggler btn btn-link text-reset flex-grow-1 d-flex p-0 text-start" t-att-class="{ 'align-items-baseline o-gap-0_5': !store.discuss.isSidebarCompact, 'align-items-center justify-content-center border-0 o-compact gap-1': store.discuss.isSidebarCompact }" t-on-click="() => this.toggle()" name="toggler">
                 <t t-if="store.discuss.isSidebarCompact">
                     <i class="o-mail-DiscussSidebarCategory-chevronCompact position-absolute fa-fw o-xxsmaller o-mt-0_5" t-att-class="{
-                        'oi oi-chevron-down': category.is_open,
-                        'oi oi-chevron-right': !category.is_open,
+                        'oi oi-chevron-down': !isToggleFoldDisabled and category.is_open,
+                        'oi oi-chevron-right': isToggleFoldDisabled or !category.is_open,
                     }"/>
                     <span class="rounded p-1"><i t-if="store.channels.status === 'fetching'" class="fa fa-fw fa-circle-o-notch fa-spin"/><i t-else="" class="fa-fw fa-lg" t-att-class="category.icon ?? 'fa fa-user'"/></span>
                 </t>
@@ -35,7 +35,7 @@
                         <t name="titleText" t-esc="category.name"/>
                     </span>
                     <span t-if="store.channels.status === 'fetching'" class="o-visible-short-delay"><i class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa fa-fw fa-circle-o-notch fa-spin opacity-50 ps-1"/></span>
-                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa-fw align-self-center ps-1" t-att-class="category.is_open ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
+                    <i t-else="" class="o-mail-DiscussSidebarCategory-icon o-xxsmaller fa-fw align-self-center ps-1" t-att-class="(!isToggleFoldDisabled and category.is_open) ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                 </t>
             </button>
             <t t-if="actions.length and !store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarCategory.actions"/>

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -181,7 +181,8 @@ test("Auto-open OdooBot chat when opening discuss for the first time", async () 
 });
 
 test("no conversation selected when opening non-existing channel in discuss", async () => {
-    await startServer();
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(200); // non-existing id
     await contains("h4:text('No conversation selected.')");

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -159,6 +159,18 @@ test("channel - command: should have view command when category is unfolded", as
 });
 
 test("Category fold is locally persistent (saved in local storage)", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
+    pyEnv["discuss.channel"].create([
+        { name: "Main Channel" },
+        {
+            channel_member_ids: [
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ partner_id: partnerId }),
+            ],
+            channel_type: "chat",
+        },
+    ]);
     setDiscussSidebarCategoryFoldState("channels", true);
     setDiscussSidebarCategoryFoldState("chats", true);
     await start();
@@ -187,6 +199,8 @@ test("Category fold is locally persistent (saved in local storage)", async () =>
 });
 
 test("Category fold is crosstab synced", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "General" });
     setDiscussSidebarCategoryFoldState("channels", true);
     const env1 = await start({ asTab: true });
     const env2 = await start({ asTab: true });
@@ -1210,4 +1224,23 @@ test("add and remove channel from favorites updates sidebar", async () => {
     await click(`${favoriteContainerSelector} ${generalChannelSelector} button .oi-ellipsis-h`);
     await click(".o-dropdown-item:contains('Remove from Favorites')");
     await contains(`${channelContainerSelector} ${generalChannelSelector}`);
+});
+
+test("sidebar category toggle is visually disabled when no visible channels", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({ name: "General" });
+    setDiscussSidebarCategoryFoldState("channels", true);
+    await start();
+    await openDiscuss();
+    await click(
+        ".o-mail-DiscussSidebarCategory-toggler:enabled:contains('Channels') i.oi-chevron-right"
+    );
+    await contains(
+        ".o-mail-DiscussSidebarCategory-toggler:enabled:contains('Channels') i.oi-chevron-down"
+    );
+    await click("[title='Channel Actions']");
+    await click(".o-dropdown-item:text('Hide Until New Message')");
+    await contains(
+        ".o-mail-DiscussSidebarCategory-toggler:disabled:contains('Channels') i.oi-chevron-right"
+    );
 });


### PR DESCRIPTION
**Current behavior before PR:**
The fold/unfold toggle remained enabled even when a sidebar category contained no visible channels.

**Desired behavior after PR is merged:**
The fold/unfold toggle is disabled when a sidebar category has no visible channels, except for the Live Chat `Looking for Help` category as it is dynamic and should remain enabled when empty.

task-[4783313](https://www.odoo.com/odoo/project/1519/tasks/4783313)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
