### PR TITLE
[IMP] web: make header in day/week calendar clickable

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -278,6 +278,14 @@
                     border-radius: 50%;
                     aspect-ratio: 1;
                 }
+
+                .o_cw_day_number:hover {
+                      color: color-contrast($o-gray-300);
+                      background-color: $o-gray-300;
+                      border-radius: 50%;
+                      aspect-ratio: 1;
+                      cursor: pointer;
+                  }
             }
 
             // Remove dotted borders (half-hours)


### PR DESCRIPTION
Add the option to create all day events by clicking the date header, similar to google calendar. This was previously doable by clicking the unlabeled 'all day' row below the header.

Task-5421331