### PR TITLE
[IMP] web: make header in day/week calendar clickable

### DIFF
--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -67,7 +67,7 @@ registry.category("web_tour.tours").add("calendar_appointments_hour_tour", {
         {
             trigger: ".fc-col-header-cell.fc-day.fc-day-mon",
             content: "Check the day is properly displayed",
-            run: "click",
+            run: "hover",
         },
         {
             trigger: '.fc-time:contains("10:00")',

--- a/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_homeworking_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -32,8 +32,6 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
                 }
             },
             dayCellDidMount: this.onDayCellDidMount,
-            dayHeaderDidMount: this.onDayHeaderDidMount,
-            dayHeaderWillUnmount: this.onDayHeaderWillUnmount,
         };
     },
     handleWorkLocationClick(target, date) {
@@ -53,31 +51,6 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
             }
         }
         return this.props.openWorkLocationWizard(date);
-    },
-    onDayHeaderDidMount(info) {
-        if (this.props.model.scale === 'week' || this.props.model.scale === 'day') {
-            const date = DateTime.fromJSDate(info.date);
-            const handler = (event) => {
-                if (event.target.closest(".o_worklocation_btn")) {
-                    this.handleWorkLocationClick(event.target, date);
-                }
-            };
-            this.customListeners = {
-                ...this.customListeners,
-                [date]: handler,
-            };
-            info.el.addEventListener("click", handler);
-        }
-    },
-    onDayHeaderWillUnmount(info) {
-        if (this.props.model.scale === 'week' || this.props.model.scale === 'day') {
-            const date = DateTime.fromJSDate(info.date);
-            const customListener = {...this.customListeners}[date];
-            if (customListener) {
-                info.el.removeEventListener("click", customListener);
-                delete this.customListeners[date];
-            }
-        }
     },
     onDayCellDidMount(info){
         if (this.props.model.scale === 'month'){
@@ -142,6 +115,5 @@ AttendeeCalendarCommonRenderer.props = {
     openWorkLocationWizard: { type: Function, optional: true }
 };
 
-AttendeeCalendarCommonRenderer.WorklocationTemplate = "hr_homeworking_calendar.CalendarCommonRenderer.worklocation";
 AttendeeCalendarCommonRenderer.ButtonWorklocationTemplate = "hr_homeworking_calendar.CalendarCommonRenderer.buttonWorklocation";
 AttendeeCalendarCommonRenderer.headerTemplate = "hr_homeworking_calendar.CalendarCommonRendererHeader";

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -272,6 +272,10 @@
                     align-items: center;
                 }
 
+                .o_cw_day_number:hover {
+                    cursor: default;
+                }
+
                 &.fc-day-today .o_cw_day_number {
                     color: var(--o-cw-color);
                     background-color: var(--o-cw-bg);
@@ -288,6 +292,7 @@
             // Align labels and timelines
             .fc-timegrid-slot {
                 font-size: .6rem;
+                height: 2em;
 
                 @include media-breakpoint-up(md) {
                     font-size: .75rem;

--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -1,5 +1,5 @@
 import { click, drag, edit, hover, queryFirst, queryRect } from "@odoo/hoot-dom";
-import { advanceFrame, advanceTime, animationFrame } from "@odoo/hoot-mock";
+import { advanceFrame, advanceTime, animationFrame } from "@odoo/hoot";
 import { EventBus } from "@odoo/owl";
 import { contains, getMockEnv, swipeLeft, swipeRight } from "@web/../tests/web_test_helpers";
 
@@ -516,7 +516,7 @@ export async function moveEventToTime(eventId, dateTime) {
 
     await moveTo(row, {
         position: {
-            y: rowRect.y + 1,
+            y: rowRect.y + 0.5,
             x: columnRect.x + columnRect.width / 2,
         },
     });

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -5432,12 +5432,12 @@ test(`scroll to current hour when clicking on today`, async () => {
         arch: `<calendar event_open_popup="1" date_start="start" date_stop="stop" all_day="is_all_day" mode="week"/>`,
     });
     // Default scroll time should be 6am no matter the current hour
-    expect(queryOne(".fc-scroller:last").scrollTop).toBeWithin(210, 230);
+    expect(queryOne(".fc-scroller:last").scrollTop).toBeWithin(280, 300);
     await contains(".o_calendar_button_today").click();
     expect(queryOne(".fc-scroller:last").scrollTop).toBe(0);
     mockDate("2016-12-12T20:00:00", 1);
     await contains(".o_calendar_button_today").click();
-    expect(queryOne(".fc-scroller:last").scrollTop).toBeWithin(360, 380);
+    expect(queryOne(".fc-scroller:last").scrollTop).toBeWithin(620, 640);
 });
 
 test("save selected date during view switching", async () => {


### PR DESCRIPTION
Add the option to create all day events by clicking the date header, similar to google calendar. This was previously doable by clicking the unlabeled 'all day' row below the header.

Task-5421331