### PR TITLE
[FIX] mail: prevent crash when rtc.selfSession is undefined

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -7,7 +7,7 @@ export const callActionsRegistry = registry.category("discuss.call/actions");
 
 callActionsRegistry
     .add("mute", {
-        condition: (component) => component.rtc,
+        condition: (component) => component.rtc.channel?.isSelfInCall,
         name: (component) => (component.rtc.selfSession.isMute ? _t("Unmute") : _t("Mute")),
         isActive: (component) => component.rtc.selfSession?.isMute,
         inactiveIcon: "fa-microphone",
@@ -28,7 +28,7 @@ callActionsRegistry
         sequence: 10,
     })
     .add("deafen", {
-        condition: (component) => component.rtc,
+        condition: (component) => component.rtc.channel?.isSelfInCall,
         name: (component) => (component.rtc.selfSession.is_deaf ? _t("Undeafen") : _t("Deafen")),
         isActive: (component) => component.rtc.selfSession?.is_deaf,
         inactiveIcon: "fa-headphones",
@@ -39,7 +39,7 @@ callActionsRegistry
         sequence: 20,
     })
     .add("camera-on", {
-        condition: (component) => component.rtc,
+        condition: (component) => component.rtc.channel?.isSelfInCall,
         available: (component) => !component.rtc?.isRemote,
         name: (component) => {
             if (component.rtc?.isRemote) {
@@ -56,7 +56,7 @@ callActionsRegistry
         sequence: 30,
     })
     .add("raise-hand", {
-        condition: (component) => component.rtc,
+        condition: (component) => component.rtc.channel?.isSelfInCall,
         name: (component) =>
             component.rtc.selfSession.raisingHand ? _t("Lower Hand") : _t("Raise Hand"),
         isActive: (component) => component.rtc.selfSession?.raisingHand,
@@ -65,7 +65,7 @@ callActionsRegistry
         sequence: 50,
     })
     .add("share-screen", {
-        condition: (component) => component.rtc && !isMobileOS(),
+        condition: (component) => component.rtc.channel?.isSelfInCall && !isMobileOS(),
         available: (component) => !component.rtc?.isRemote,
         name: (component) => {
             if (component.rtc?.isRemote) {
@@ -84,7 +84,7 @@ callActionsRegistry
     .add("blur-background", {
         condition: (component) =>
             !isBrowserSafari() &&
-            component.rtc &&
+            component.rtc.channel?.isSelfInCall &&
             component.rtc.selfSession?.is_camera_on &&
             component.rtc?.isHost,
         name: (component) =>
@@ -97,7 +97,8 @@ callActionsRegistry
         sequence: 60,
     })
     .add("fullscreen", {
-        condition: (component) => component.props && component.props.fullscreen,
+        condition: (component) =>
+            component.rtc.channel?.isSelfInCall && component.props && component.props.fullscreen,
         name: (component) =>
             component.props.fullscreen.isActive ? _t("Exit Fullscreen") : _t("Enter Full Screen"),
         isActive: (component) => component.props.fullscreen.isActive,

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -65,6 +65,9 @@ const ThreadPatch = {
             },
         });
     },
+    get isSelfInCall() {
+        return this.store.rtc.selfSession && this.eq(this.store.rtc.channel);
+    },
     get videoCount() {
         return Object.values(this.store["discuss.channel.rtc.session"].records).filter(
             (session) => session.hasVideo


### PR DESCRIPTION
**Steps to reproduce:**
- Start a meeting with user A
- Share the invitation link with user B
- Login with user B and join the call
- Open another browser tab/window with the same user B
- Join the same call in that tab using the invitation link
- The call ends for that user as the RTC session is terminated
- **_TAB1_**: join the call again
- **_TAB2_**: error

**Current behavior before PR:**

When the same user joined the same call from another tab or 
during RTC renegotiation, selfSession could temporarily be undefined.

**Desired behavior after PR is merged:**


This PR ensures that  no crash happens when dealing with the 
RTC Session in a `multi-tab` scenario.

task-[5263097](https://www.odoo.com/odoo/project/1519/tasks/5263097)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
