### PR TITLE
[REF] product, website_sale: unify pricings

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -16,14 +16,11 @@ class ProductPricelist(models.Model):
     def _default_currency_id(self):
         return self.env.company.currency_id.id
 
-    def _base_domain_item_ids(self):
+    def _domain_item_ids(self):
         return [
             '|', ('product_tmpl_id', '=', None), ('product_tmpl_id.active', '=', True),
             '|', ('product_id', '=', None), ('product_id.active', '=', True),
         ]
-
-    def _domain_item_ids(self):
-        return self._base_domain_item_ids()
 
     name = fields.Char(string="Pricelist Name", required=True, translate=True)
 

--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -185,11 +185,11 @@ class ProductPricelistItem(models.Model):
     def _compute_name(self):
         for item in self:
             if item.categ_id and item.applied_on == '2_product_category':
-                item.name = _("Category: %s", item.categ_id.display_name)
+                item.name = item.categ_id.display_name
             elif item.product_tmpl_id and item.applied_on == '1_product':
                 item.name = item.product_tmpl_id.display_name
             elif item.product_id and item.applied_on == '0_product_variant':
-                item.name = _("Variant: %s", item.product_id.display_name)
+                item.name = item.product_id.display_name
             elif item.display_applied_on == '2_product_category':
                 item.name = _("All Categories")
             else:

--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -9,6 +9,16 @@
                 <filter name="Product Rule" domain="[('applied_on', '=', '1_product')]"/>
                 <filter name="Variant Rule" domain="[('applied_on', '=', '0_product_variant')]" groups="product.group_product_variant"/>
                 <separator/>
+                <filter
+                    name="filter_to_sell"
+                    string="Sales"
+                    domain="[
+                        '|',
+                        ('product_tmpl_id', '=', False),
+                        ('product_tmpl_id.sale_ok', '=', True),
+                    ]"
+                />
+                <separator/>
                 <field name="pricelist_id" groups="product.group_product_pricelist"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="currency_id" groups="base.group_multi_currency"/>
@@ -45,10 +55,15 @@
             <list string="Price Rules">
                 <field name="pricelist_id" groups="product.group_product_pricelist" required="is_pricelist_required"/>
                 <field name="name" string="Applied On"/>
-                <field name="price"/>
                 <field name="min_quantity" colspan="4"/>
-                <field name="date_start" optional="hide"/>
-                <field name="date_end" optional="hide"/>
+                <field
+                    name="date_start"
+                    string="Validity"
+                    widget="daterange"
+                    options="{'end_date_field': 'date_end'}"
+                    optional="show"
+                />
+                <field name="price"/>
                 <field name="company_id" groups="base.group_multi_company" optional="show"/>
             </list>
         </field>
@@ -165,7 +180,7 @@
                         <group name="pricelist_rule_limits">
                             <field name="min_quantity" string="Min Qty"/>
                             <field name="date_start"
-                                string="Validity Period"
+                                string="Validity"
                                 widget="daterange"
                                 options="{'end_date_field': 'date_end'}"/>
                             <field name="date_end" invisible="1"/>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -70,15 +70,20 @@
                         </group>
                     </group>
                     <notebook>
-                        <page name="pricelist_rules" string="Sales Prices">
+                        <page name="pricelist_rules" string="Rules">
                             <field name="item_ids" nolabel="1" context="{'default_base':'list_price'}">
                                 <list string="Pricelist Rules">
                                     <field name="product_tmpl_id" column_invisible="True"/>
                                     <field name="name" string="Apply on"/>
-                                    <field name="price" string="Price"/>
                                     <field name="min_quantity"/>
-                                    <field name="date_start"/>
-                                    <field name="date_end"/>
+                                    <field
+                                        name="date_start"
+                                        string="Validity"
+                                        widget="daterange"
+                                        options="{'end_date_field': 'date_end'}"
+                                        optional="show"
+                                    />
+                                    <field name="price" string="Price"/>
                                     <field name="base" column_invisible="True"/>
                                     <field name="price_discount" column_invisible="True"/>
                                     <field name="applied_on" column_invisible="True"/>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -204,29 +204,50 @@
                         <page
                             string="Prices"
                             name="sales_price"
-                            groups="product.group_product_pricelist"
-                            invisible="not sale_ok"
+                            invisible="not show_sales_price_page"
                         >
                             <field
-                                name="pricelist_rule_ids"
+                                name="fixed_pricelist_rule_ids"
                                 context="{
+                                    'default_compute_price': 'fixed',
+                                    'default_applied_on': '1_product',
                                     'form_view_ref': 'product.product_pricelist_item_product_template_form_view',
                                 }"
                             >
-                                <list>
+                                <list editable="bottom">
                                     <control>
                                         <create name="add_product_price" string="Add a price"/>
                                     </control>
-                                    <field name="pricelist_id" required="is_pricelist_required"/>
-                                    <field name="name" string="Applied On" column_invisible="parent.product_variant_count &lt; 2"/>
-                                    <field name="price"/>
-                                    <field name="min_quantity"/>
-                                    <field name="date_start" optional="hide"/>
-                                    <field name="date_end" optional="hide"/>
+                                    <field
+                                        name="product_id"
+                                        string="Variant"
+                                        column_invisible="parent.product_variant_count &lt; 2"
+                                        optional="hide"
+                                    />
+                                    <field
+                                        name="pricelist_id"
+                                        required="is_pricelist_required"
+                                        options="{'no_create': True}"
+                                    />
+                                    <field name="min_quantity" optional="show"/>
+                                    <field
+                                        name="date_start"
+                                        string="Validity"
+                                        widget="daterange"
+                                        options="{'end_date_field': 'date_end'}"
+                                        optional="hide"
+                                    />
+                                    <field
+                                        name="fixed_price"
+                                        string="Price"
+                                        widget="monetary"
+                                        options="{'currency_field': 'currency_id'}"
+                                    />
                                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
 
                                     <!-- Needed for rule edition & creation on product.product form -->
                                     <field name="product_tmpl_id" column_invisible="True"/>
+                                    <field name="currency_id" column_invisible="True"/>
                                 </list>
                             </field>
                         </page>
@@ -536,11 +557,13 @@
             <field eval="7" name="priority"/>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="//page[@name='sales_price']/field[@name='pricelist_rule_ids']" position="attributes">
+                <xpath expr="//field[@name='fixed_pricelist_rule_ids']" position="attributes">
                     <attribute name="context">
                         {
                             'default_product_id': id,
-                            'form_view_ref': 'product.product_pricelist_item_product_product_form_view'
+                            'default_compute_price': 'fixed',
+                            'default_applied_on': '1_product',
+                            'form_view_ref': 'product.product_pricelist_item_product_product_form_view',
                         }
                     </attribute>
                 </xpath>

--- a/addons/sale/views/product_pricelist_item_views.xml
+++ b/addons/sale/views/product_pricelist_item_views.xml
@@ -12,7 +12,7 @@
                         <field name="min_quantity" string="Min Qty"/>
                         <field
                             name="date_start"
-                            string="Validity Period"
+                            string="Validity"
                             widget="daterange"
                             options="{'end_date_field': 'date_end'}"
                         />

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -563,9 +563,7 @@ class ProductTemplate(models.Model):
                 in product_or_template.sudo().combo_ids.combo_item_ids.product_id.taxes_id
             )
         ):
-            combination_info['tax_disclaimer'] = _(
-                "Final price may vary based on selection. Tax will be calculated at checkout."
-            )
+            combination_info["tax_disclaimer"] = _("Taxes calculated at checkout.")
 
         return combination_info
 

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -382,7 +382,7 @@ class ProductTemplate(models.Model):
         if not self:
             return {}
 
-        pricelist = request.pricelist
+        pricelist = request.pricelist.with_context(self.env.context)
         currency = website.currency_id
         fiscal_position_sudo = request.fiscal_position
         date = fields.Date.context_today(self)

--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -72,14 +72,14 @@ export class CartLine extends Interaction {
             input.value = data.quantity
         );
 
-        const websiteSale = document.querySelector('.oe_website_sale');
-        // `updateCartNavBar` regenerates the cart lines and `updateQuickReorderSidebar`
-        // regenerates the quick reorder products, so we need to stop and start interactions
-        // to make sure the regenerated cart lines and reorder products are properly handled.
-        this.services['public.interactions'].stopInteractions(websiteSale);
+        const cart = this.el.closest('#shop_cart');
+        // `updateCartNavBar` regenerates the cart lines and `updateQuickReorderSidebar` regenerates
+        // the quick reorder products, so we need to stop and start interactions to make sure the
+        // regenerated cart lines and reorder products are properly handled.
+        this.services['public.interactions'].stopInteractions(cart);
         wSaleUtils.updateCartNavBar(data);
         wSaleUtils.updateQuickReorderSidebar(data);
-        this.services['public.interactions'].startInteractions(websiteSale);
+        this.services['public.interactions'].startInteractions(cart);
         wSaleUtils.showWarning(data.warning);
         // Propagate the change to the express checkout forms.
         this.env.bus.trigger('cart_amount_changed', [data.amount, data.minor_amount]);

--- a/addons/website_sale/static/src/interactions/quick_reorder.js
+++ b/addons/website_sale/static/src/interactions/quick_reorder.js
@@ -141,14 +141,17 @@ export class QuickReorder extends Interaction {
         }));
 
         // Add the product to the cart and update the DOM.
-        const websiteSale = document.querySelector('.oe_website_sale');
-        // `updateCartNavBar` regenerates the cart lines and `updateQuickReorderSidebar`
-        // regenerates the quick reorder products, so we need to stop and start interactions to
-        // make sure the regenerated reorder products and cart lines are properly handled.
-        this.services['public.interactions'].stopInteractions(websiteSale);
+        const cart = this.el.closest('#shop_cart');
+        const cartSummary = document.querySelector('.o_wsale_shorter_cart_summary');
+        // `updateCartNavBar` regenerates the cart lines and `updateQuickReorderSidebar` regenerates
+        // the quick reorder products, so we need to stop and start interactions to make sure the
+        // regenerated cart lines and reorder products are properly handled.
+        this.services['public.interactions'].stopInteractions(cart);
+        this.services['public.interactions'].stopInteractions(cartSummary);
         wSaleUtils.updateCartNavBar(data);
         wSaleUtils.updateQuickReorderSidebar(data);
-        this.services['public.interactions'].startInteractions(websiteSale);
+        this.services['public.interactions'].startInteractions(cart);
+        this.services['public.interactions'].startInteractions(cartSummary);
 
         // Move the focus to the next quantity input.
         this._focusNextQuantityInput(currentButtonIndex);

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -478,8 +478,16 @@ export class CartService {
             product_custom_attribute_values: productCustomAttributeValues,
             no_variant_attribute_value_ids: noVariantAttributeValues,
             ...rest
+        }).catch(error => {
+            this._showCartNotification({
+                type: 'warning',
+                data: { warning_message: error.data.message },
+            });
+            return null;
         });
-        // TODO should not redirect if errors in data.
+        if (!data) {
+            return 0;
+        }
         if (shouldRedirectToCart || session.add_to_cart_action === 'go_to_cart') {
             redirect('/shop/cart');
             return data.quantity;

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -149,7 +149,6 @@ export function assertCartContains({
         steps.push({
             content: `Checking if the cart line holds the expected quantity.`,
             trigger: `${backend ? ":iframe" : ""} ${quantityTrigger}`,
-            break: true,
         })
     }
 

--- a/addons/website_sale/static/tests/tours/combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/combo_configurator.js
@@ -20,7 +20,7 @@ registry
             comboConfiguratorTourUtils.assertFooterButtonsEnabled(),
             {
                 content: "Check that the tax disclaimer gets displayed",
-                trigger: '.js_product small:contains(Final price may vary based on selection)',
+                trigger: '.js_product small:contains(Taxes calculated at checkout.)',
             },
             // Assert that the cart's content is correct.
             {

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -945,15 +945,13 @@
     </template>
 
     <template id="website_sale.tax_indication" active="False">
-        <span
+        <small
             t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
-            class="fs-6 fw-normal text-muted text-nowrap"
+            class="text-muted text-nowrap"
         >
             (Tax excluded)
-        </span>
-        <span t-else="" class="fs-6 fw-normal text-muted text-nowrap">
-            (Tax included)
-        </span>
+        </small>
+        <small t-else="" class="text-muted text-nowrap">(Tax included)</small>
     </template>
 
     <template id="website_sale.product_price">
@@ -963,7 +961,7 @@
         >
             <div
                 name="product_price_container"
-                class="css_editable_mode_hidden d-flex align-items-baseline justify-content-end gap-2 flex-wrap h5 mb-0 text-wrap"
+                t-attf-class="css_editable_mode_hidden d-flex align-items-baseline {{is_view_active('website_sale.cta_wrapper_boxed') and 'justify-content-end'}} gap-2 flex-wrap h5 mb-0 text-wrap"
             >
                 <span class="oe_price"
                       style="white-space: nowrap;"
@@ -975,7 +973,6 @@
                       t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
                       name="product_list_price"
                 />
-                <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
                 <del
                     name="product_price_strikethrough"
                     t-if="combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])"
@@ -995,13 +992,20 @@
             >
                 <span t-field="product.list_price"
                       t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
-                <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
                 <del t-if="combination_info.get('compare_list_price') and (combination_info['compare_list_price'] &gt; combination_info['price'])">
                     <bdi dir="inherit">
                     <span t-field="product.compare_list_price"
                           t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
                     </bdi>
                 </del>
+
+            </div>
+            <div
+                name="tax_indicator"
+                t-if="not combination_info.get('tax_disclaimer') and is_view_active('website_sale.tax_indication')"
+                t-attf-class="d-flex {{is_view_active('website_sale.cta_wrapper_boxed') and 'justify-content-end'}}"
+            >
+                <t t-call="website_sale.tax_indication"/>
             </div>
             <small t-if="combination_info.get('tax_disclaimer')" class="text-muted">
                 <t t-out="combination_info['tax_disclaimer']"/>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -181,53 +181,62 @@
             <field name="description_sale" position="attributes">
                 <attribute name="placeholder">This note is added to sales orders, invoices, eCommerce listing and SEO descriptions.</attribute>
             </field>
-            <group name="expense_info" position="before">
-                <group string="Long Description" name="ecom_description">
-                   <field
-                        colspan="2"
-                        name="description_ecommerce"
-                        nolabel="1"
-                        placeholder="A detailed, formatted description to promote your product on this page."
-                    />
-                </group>
-                <group name="product_template_images" string="Media" invisible="not sale_ok">
-                    <field
-                        name="product_template_image_ids"
-                        class="o_website_sale_image_list"
-                        context="{'default_name': name}"
-                        mode="kanban"
-                        add-label="Add Media"
-                        nolabel="1"
-                        colspan="2"
-                        widget="x2_many_media_viewer"
-                        options="{'convert_to_webp': True}"
-                    />
-                </group>
-            </group>
-            <field name="product_tag_ids" position="before">
-                <field name="publish_on" invisible="1"/> <!-- Needed for next fields and elements -->
-                <field string="Published" name="website_published" widget="boolean_toggle" readonly="publish_on"/>
-                <label invisible="website_published" for="publish_on" string="Publish on"/>
-                <div invisible="website_published" class="o_row">
-                    <field name="publish_on" widget="datetime"/>
-                    <button name="action_unschedule" type="object" invisible="not publish_on">Unschedule</button>
-                </div>
-                <field name="website_sequence" groups="base.group_no_one"/>
-                <field
-                    name="website_id"
-                    options="{'no_create': True}"
-                    groups="website.group_multi_website"
-                    placeholder="All"
-                />
-                <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
-                <field
-                    name="website_ribbon_id"
-                    options="{'no_quick_create': True}"
-                />
-            </field>
+            <!-- Move all extra info fields into "eCommerce" page -->
             <group name="extra_info" position="attributes">
-                <attribute name="string">Ecommerce Shop</attribute>
+                <attribute name="invisible" add="True" separator="or"/>
             </group>
+            <notebook position="inside">
+                <page name="website_sale" string="eCommerce" invisible="not sale_ok">
+                    <group>
+                        <group name="shop" string="Shop">
+                            <field name="publish_on" invisible="1"/> <!-- Needed for next fields and elements -->
+                            <field string="Published" name="website_published" widget="boolean_toggle" readonly="publish_on"/>
+                            <label invisible="website_published" for="publish_on" string="Publish on"/>
+                            <div invisible="website_published" class="o_row">
+                                <field name="publish_on" widget="datetime"/>
+                                <button name="action_unschedule" type="object" invisible="not publish_on">Unschedule</button>
+                            </div>
+                            <field name="website_sequence" groups="base.group_no_one"/>
+                            <field
+                                name="website_id"
+                                options="{'no_create': True}"
+                                groups="website.group_multi_website"
+                                placeholder="All"
+                            />
+                            <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
+                            <field
+                                name="website_ribbon_id"
+                                options="{'no_quick_create': True}"
+                            />
+                            <!-- From hidden "Extra Info" group -->
+                            <field name="product_tag_ids" widget="many2many_tags" context="{'product_template_id': id}"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group string="Long Description" name="ecom_description">
+                            <field
+                                colspan="2"
+                                name="description_ecommerce"
+                                nolabel="1"
+                                placeholder="A detailed, formatted description to promote your product on your eCommerce."
+                            />
+                        </group>
+                        <group name="product_template_images" string="Media" invisible="not sale_ok">
+                            <field
+                                name="product_template_image_ids"
+                                class="o_website_sale_image_list"
+                                context="{'default_name': name}"
+                                mode="kanban"
+                                add-label="Add Media"
+                                nolabel="1"
+                                colspan="2"
+                                widget="x2_many_media_viewer"
+                                options="{'convert_to_webp': True}"
+                            />
+                        </group>
+                    </group>
+                </page>
+            </notebook>
         </field>
     </record>
 

--- a/addons/website_sale_stock/views/product_template_views.xml
+++ b/addons/website_sale_stock/views/product_template_views.xml
@@ -5,10 +5,10 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="website_sale.product_template_form_view" />
         <field name="arch" type="xml">
-            <group name="description" position="after">
+            <group name="shop" position="after">
                 <group
                     name="ecommerce_inventory"
-                    string="Ecommerce Inventory"
+                    string="Inventory"
                     invisible="not is_storable"
                 >
                     <field name="allow_out_of_stock_order"/>


### PR DESCRIPTION
The primary goal of this PR is to unify product pricing management across the Odoo ecosystem by centralizing configurations for Sales, Rental, and Subscription applications within the core pricelist engine. 

This consolidation introduces a single "Prices" tab on the product template form, effectively replacing fragmented, app-specific views with a unified interface. To improve daily efficiency, the PR enables users to quickly manage fixed-price rules through an inline editable interface directly on the product form, while still providing access to the full pricelist engine for more complex configurations. 

On a technical level, the pricelist engine has been evolved to support the temporal and contextual needs of dependent applications; this includes dissociating the date used for rule application from the date used for currency conversion, as well as propagating request contexts during eCommerce price computations.

task-5375343

See also:
- https://github.com/odoo/enterprise/pull/102625
- https://github.com/odoo/upgrade/pull/9172

---

To accelerate this PR, it was decided to rebase the work on an ongoing PR [^1][^2] refactoring and greatly facilitating the interactions backend-frontend of the eCommerce/Rental applications.

Thx Louis 😉 (and Victor for thinking about it)

[^1]: https://github.com/odoo/odoo/pull/234405
[^2]: https://github.com/odoo/enterprise/pull/98161