### PR TITLE
[FIX] account_edi_ubl_cii: prevent crash when invoice line has no lable

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -768,7 +768,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         line_nodes = vals['document_node'][line_tag]
 
         for line_node in line_nodes:
-            if not line_node['cac:Item']['cbc:Name']['_text']:
+            if not (line_node['cac:Item']['cbc:Name'] or {}).get('_text'):
                 # [BR-25]-Each Invoice line (BG-25) shall contain the Item name (BT-153).
                 constraints.update({'cen_en16931_item_name': _("Each invoice line should have a product or a label.")})
                 break


### PR DESCRIPTION
Before this commit:
When sending an invoice via Peppol with an invoice line that has no product name, the system crashes with a TypeError instead of showing a  error message.

Steps to reproduce:

1. Go to Accounting
2. Navigate to Customers > Invoices
3. Create a new invoice
4. Add an invoice line without entering a product name
5. Click 'Send'
6. Select 'by Peppol (Demo)'
7. Click 'Send'

-> TypeError: 'NoneType' object is not subscriptable

After this commit:
System validates that the product name exists before accessing its text content. Users see a clear, error message: `Each invoice line should have a product or a label.`

task-5432061

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
