### PR TITLE
[FIX] html_editor, website: focus cropper keyboard actions

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -44,6 +44,8 @@ export class ImageCrop extends Component {
         this.elRef = useRef("el");
         this.cropperWrapper = useRef("cropperWrapper");
         this.imageRef = useRef("imageRef");
+        this.applyButtonRef = useRef("applyButton");
+        this.discardButtonRef = useRef("discardButton");
         this.isCropperActive = false;
 
         // We use capture so that the handler is called before other editor handlers
@@ -53,6 +55,9 @@ export class ImageCrop extends Component {
             capture: true,
         });
         useExternalListener(this.document, "keydown", this.onDocumentKeydown, {
+            capture: true,
+        });
+        useExternalListener(document, "keydown", this.onDocumentKeydown, {
             capture: true,
         });
         useExternalListener(
@@ -209,6 +214,7 @@ export class ImageCrop extends Component {
             }
         });
         this.isCropperActive = true;
+        this.applyButtonRef.el?.focus({ preventScroll: true });
     }
     /**
      * Updates the DOM image with cropped data and associates required
@@ -309,9 +315,18 @@ export class ImageCrop extends Component {
      * @param {KeyboardEvent} ev
      */
     onDocumentKeydown(ev) {
+        if (!this.isCropperActive) {
+            return;
+        }
         if (ev.key === "Enter") {
+            ev.preventDefault();
+            ev.stopImmediatePropagation();
+            if (ev.target === this.discardButtonRef.el) {
+                return this.closeCropper();
+            }
             return this.save();
-        } else if (ev.key === "Escape") {
+        } else if (["Backspace", "Escape"].includes(ev.key)) {
+            ev.preventDefault();
             ev.stopImmediatePropagation();
             return this.closeCropper();
         }

--- a/addons/html_editor/static/src/main/media/image_crop.scss
+++ b/addons/html_editor/static/src/main/media/image_crop.scss
@@ -21,7 +21,11 @@
         bottom: 1rem;
 
         input[type=radio] {
-            display: none;
+            // Hide radios visually but keep them focusable for keyboard
+            // navigation.
+            position: absolute;
+            opacity: 0;
+            pointer-events: none;
         }
 
         .btn-group {
@@ -43,7 +47,7 @@
             }
         }
 
-        button:not(.btn), label {
+        button:not(.btn), label, label:active {
             margin: 0;
             border: none;
             border-right: 1px solid $o-we-bg;
@@ -60,6 +64,12 @@
                 border-bottom-right-radius: 0.25rem;
                 border-right: none;
             }
+        }
+
+        button:focus-visible, label:focus-within {
+            box-shadow: unset;
+            outline: 1px solid $o-we-color;
+            z-index: 1;
         }
     }
 }

--- a/addons/html_editor/static/src/main/media/image_crop.xml
+++ b/addons/html_editor/static/src/main/media/image_crop.xml
@@ -2,6 +2,7 @@
     <t t-name="html_editor.ImageCrop">
         <div t-name="html_editor.ImageCrop"
              class="o_we_crop_widget"
+             tabindex="-1"
              contenteditable="false"
              t-ref="el"
              t-on-zoom="this.onCropZoom"
@@ -33,8 +34,8 @@
                         <button type="button" title="Reset Image" t-on-click="this.onReset"><i class="fa fa-refresh"/> Reset Image</button>
                     </div>
                     <div class="btn-group" role="group">
-                        <button type="button" title="Apply" t-on-click="this.save" class="btn btn-primary"><i class="fa fa-check"/> Apply</button>
-                        <button type="button" title="Discard" t-on-click="this.closeCropper" class="btn btn-danger"><i class="fa fa-times"/> Discard</button>
+                        <button type="button" title="Apply" t-ref="applyButton" t-on-click="this.save" class="btn btn-primary"><i class="fa fa-check"/> Apply</button>
+                        <button type="button" title="Discard" t-ref="discardButton" t-on-click="this.closeCropper" class="btn btn-danger"><i class="fa fa-times"/> Discard</button>
                     </div>
                 </div>
             </div>

--- a/addons/website/static/tests/builder/image_crop.test.js
+++ b/addons/website/static/tests/builder/image_crop.test.js
@@ -1,0 +1,45 @@
+import { test } from "@odoo/hoot";
+import { press, waitFor, waitForNone } from "@odoo/hoot-dom";
+import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { ImageCrop } from "@html_editor/main/media/image_crop";
+import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import { testImg } from "./image_test_helpers";
+
+defineWebsiteModels();
+
+test("Image cropper Enter saves and Escape closes in website builder", async () => {
+    const superShow = ImageCrop.prototype.show;
+    let resolveCropperReady;
+    const waitCropperReady = () =>
+        new Promise((resolve) => {
+            resolveCropperReady = resolve;
+        });
+    patchWithCleanup(ImageCrop.prototype, {
+        async show(...args) {
+            const res = await superShow.apply(this, args);
+            resolveCropperReady?.();
+            return res;
+        },
+    });
+
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `<div class="test-options-target">${testImg}</div>`
+    );
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+
+    const openCropper = async () => {
+        const ready = waitCropperReady();
+        await contains("[data-label='Transform'] [data-action-id='cropImage']").click();
+        await waitFor(".o_we_crop_widget", { timeout: 1000 });
+        await ready;
+    };
+
+    await openCropper();
+    await press("Enter");
+    await waitForNone(".o_we_crop_widget", { timeout: 1000 });
+
+    await openCropper();
+    await press("Escape");
+    await waitForNone(".o_we_crop_widget", { timeout: 1000 });
+});


### PR DESCRIPTION
Steps to reproduce:
- Select an image in the website builder.
- Open the cropping tools.
- Press Enter.
- Try to discard the cropper.

Before this commit, focus stayed on the toolbar crop button so `Enter` opened another cropper, `Escape` closed the sidebar, and the cropper buttons were not reachable via keyboard.

After this commit, the cropper grabs focus and handles `Enter/Escape` itself so keyboard interactions validate or dismiss the cropper.

task-5432043