### PR TITLE
[IMP] im_livechat: better thread name

### DIFF
--- a/addons/im_livechat/static/tests/join_livechat_needing_help.test.js
+++ b/addons/im_livechat/static/tests/join_livechat_needing_help.test.js
@@ -37,7 +37,11 @@ test("Show looking for help in the sidebar while active or still seeking help", 
         channel_member_ids: [],
         livechat_status: "need_help",
     });
-    pyEnv["discuss.channel.member"].create({ channel_id: bobChannelId, partner_id: bobPartnerId });
+    pyEnv["discuss.channel.member"].create({
+        channel_id: bobChannelId,
+        partner_id: bobPartnerId,
+        livechat_member_type: "visitor",
+    });
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarCategory-livechatNeedHelp .oi-chevron-down");


### PR DESCRIPTION
Live chat display name changes according to who sees the chat:
- For visitor, it's the names of the agents.
- For agents, it's the names of the visitors.
- For everyone else, it's all the member names.

However, when an internal user sees the live chat, the agent name doesn't matter. Only the visitor is relevant. This commit changes the way display name is computed to display the agent names to visitors and the visitor names otherwise.

task-5408945

enterprise: https://github.com/odoo/enterprise/pull/102681
