### PR TITLE
[FIX] account_edi_ubl_cii: use the right VAT when exporting invoices

### DIFF
--- a/addons/account_edi_ubl_cii/data/cii_22_templates.xml
+++ b/addons/account_edi_ubl_cii/data/cii_22_templates.xml
@@ -198,7 +198,11 @@
                             </t>
 
                             <!-- VAT. -->
-                            <ram:SpecifiedTaxRegistration t-if="record.company_id.vat">
+                            <ram:SpecifiedTaxRegistration t-if="record.fiscal_position_id.foreign_vat">
+                                <ram:ID schemeID="VA" t-out="record.fiscal_position_id.foreign_vat"/>
+                            </ram:SpecifiedTaxRegistration>
+
+                            <ram:SpecifiedTaxRegistration t-elif="record.company_id.vat">
                                 <ram:ID schemeID="VA" t-out="record.company_id.vat"/>
                             </ram:SpecifiedTaxRegistration>
                         </ram:SellerTradeParty>


### PR DESCRIPTION
When exporting invoices, the VAT number of the company could be wrong if the fiscal position of the invoice defines a foreign VAT number. In that case we need to use it.

Steps to reproduce:
1. Install a European localization (e.g. l10n_at)
2. Enable EU Intra-community Distance Selling. You should now have new OSS fiscal positions. Update the one you want to use with a foreign VAT.
3. Create a valid foreign customer. (within the EU)
4. Create and send an invoice for this customer.
5. In the PDF, there is an embedded factur-x file. Notice how the VAT number under the SellerTradeParty corresponds to the company's VAT, not the foreign VAT number defined on the fiscal position.

This is more apparent because we use the correct VAT number in the PDF file but not in the corresponding XML.

This commit fixes this issue by first checking if we have a foreign VAT number defined on the fiscal position of the invoice. If so, we use it.

This is a backport of odoo/odoo#236692. Since this is a general fix, it is needed by customers using 17.0 and therefore necessary to add.

opw-5401880
opw-5182837