### PR TITLE
[FIX] stock_account: compute cogs with multiple products in pos

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -276,7 +276,7 @@ class PosOrder(models.Model):
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
         moves = self.filtered(lambda o: o.partner_id.id == partner_id)\
             .mapped('picking_ids.move_ids')\
-            .filtered(lambda m: m.is_valued and m.product_id.valuation == 'real_time')\
+            .filtered(lambda m: m.is_valued and m.product_id.valuation == 'real_time' and m.product_id.id == product.id)\
             .sorted(lambda x: x.date)
         return moves._get_price_unit()
 

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -66,7 +66,6 @@ class TestAngloSaxonCommon(AccountTestInvoicingCommon):
 
 
 @tagged('post_install', '-at_install')
-@skip('Temporary to fast merge new valuation')
 class TestAngloSaxonFlow(TestAngloSaxonCommon):
 
     def test_create_account_move_line(self):
@@ -151,8 +150,8 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
             'inventory_quantity': 10.0,
             'location_id': self.warehouse.lot_stock_id.id,
         }).action_apply_inventory()
-        self.assertEqual(self.product.value_svl, 30, "Value should be (5*5 + 5*1) = 30")
-        self.assertEqual(self.product.quantity_svl, 10)
+        self.assertEqual(self.product.total_value, 30, "Value should be (5*5 + 5*1) = 30")
+        self.assertEqual(self.product.virtual_available, 10)
 
 
         self.pos_config.open_ui()
@@ -231,6 +230,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         self.assertEqual(pos_order_pos0.account_move.journal_id, self.pos_config.invoice_journal_id)
         self.assertEqual(line.debit, 27, 'As it is a fifo product, the move\'s value should be 5*5 + 2*1')
 
+    @skip('Temporary to fast merge new valuation')
     def test_cogs_with_ship_later_no_invoicing(self):
         # This test will check that the correct journal entries are created when a product in real time valuation
         # is sold using the ship later option and no invoice is created in a company using anglo-saxon
@@ -310,6 +310,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         self.assertEqual(aml_output[0].debit, 100.0, "Cost of Good Sold entry missing or mismatching")
         self.assertEqual(aml_output[0].credit, 0.0, "Cost of Good Sold entry missing or mismatching")
 
+    @skip('Temporary to fast merge new valuation')
     def test_action_pos_order_invoice(self):
         self.company.point_of_sale_update_stock_quantities = 'closing'
 
@@ -404,6 +405,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         self.assertEqual(product_line.price_subtotal, 90.25)  # Discount applies on price_unit
         self.assertEqual(product_line.price_total, 103.79)  # Taxes applied with price_total
 
+    @skip('Temporary to fast merge new valuation')
     def test_cogs_with_ship_later_with_backorder(self):
         # This test will check that the correct journal entries are created when 2 products are sold
         # using the ship later option and one of them is processed in a backorder
@@ -513,3 +515,72 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         self.assertEqual(len(aml_output), 1, "There should be 1 output account move lines")
         self.assertEqual(aml_output.debit, 0)
         self.assertEqual(aml_output.credit, 20)
+
+    def test_cogs_multi_products_perpetual(self):
+        """ Tests that an order with mutliple products that is invoice
+        in anglo saxon perpetual posts stock valuation entries"""
+        self.env.company.inventory_valuation = 'real_time'
+        self.category.property_valuation = 'real_time'
+        self.product.write({
+            'name': "P1",
+            'categ_id': self.category,
+            'standard_price': 20,
+            'list_price': 100
+        })
+
+        product2 = self.env['product.product'].create({
+            'name': 'P2',
+            'standard_price': 100,
+            'list_price': 200,
+            'available_in_pos': True,
+            'is_storable': True,
+        })
+        product2.categ_id = self.category
+
+        self.pos_config.open_ui()
+        pos_session = self.pos_config.current_session_id
+        pos_session.set_opening_control(0, None)
+
+        # create order
+        pos_order_values = {
+            'company_id': self.company.id,
+            'partner_id': self.partner.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': [(0, 0, {
+                'product_id': self.product.id,
+                'price_unit': 100,
+                'discount': 0.0,
+                'qty': 1.0,
+                'price_subtotal': 100,
+                'price_subtotal_incl': 100,
+            }), (0, 0, {
+                'product_id': product2.id,
+                'price_unit': 200,
+                'discount': 0.0,
+                'qty': 1.0,
+                'price_subtotal': 200,
+                'price_subtotal_incl': 200,
+            })],
+            'amount_total': 300,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'last_order_preparation_change': '{}',
+            'to_invoice': True,
+        }
+        pos_order = self.PosOrder.create(pos_order_values)
+
+        # register payment
+        context_make_payment = {"active_ids": [pos_order.id], "active_id": pos_order.id}
+        pos_payment = self.PosMakePayment.with_context(context_make_payment).create({
+            'amount': 300.0,
+            'payment_method_id': self.cash_payment_method.id,
+        })
+        context_payment = {'active_id': pos_order.id}
+        pos_payment.with_context(context_payment).check()
+
+        valuation_account = self.category.property_stock_valuation_account_id
+        valuation_lines = pos_order.account_move.line_ids.filtered(lambda line: line.account_id == valuation_account)
+
+        self.assertEqual(len(valuation_lines), 2)
+        self.assertEqual(sum(valuation_lines.mapped('credit')), 120.0)


### PR DESCRIPTION
Currently, when a pos order contains more than 1 product, inventory valuation lines are not generated when invoicing the order.

Steps to reproduce:
-------------------
* Using anglo-saxon accounting
* In the settings search for inventory valuation
  * Set inventory valuation to Perpetual
  * Choose standard cost method
  * Set up valuation account and journal
* Create two different products
  * Type -> Goods
  * Track inventory by quantity
  * Set a purchase cost
  * Put some quantity on hand
  * Add category
* In the settings of the category
  * Set up Stock account
  * Set up costing methog, standard
  * Set inventory valuation to perpetual
* Open pos session
* Make 3 orders, invoice them
  * Order 1, only product 1
  * Order 2, only product 2
  * Order 3, both products
> Observation: The invoces for orders 1 & 2 have entries regarding
inventory valuation while the invoice for order 3 does not have any.

Why the fix:
------------
Stock valuation entries are not created for order 3 because the price unit computed is 0.
https://github.com/odoo/odoo/blob/008e69e8215fecc1f3fe45a36189592577cdc593/addons/stock_account/models/account_move.py#L122-L126

The reason why the price unit is 0 is because in
`_get_pos_anglo_saxon_price_unit` we have multiple records in `moves` related to multiple products.
https://github.com/odoo/odoo/blob/008e69e8215fecc1f3fe45a36189592577cdc593/addons/point_of_sale/models/pos_order.py#L276-L281

`_get_price_unit` was not designed to treat moves with different products https://github.com/odoo/odoo/blob/008e69e8215fecc1f3fe45a36189592577cdc593/addons/stock_account/models/stock_move.py#L225-L228

This leads to think we should filter moves in `_get_pos_anglo_saxon_price_unit` regarding the product.

The end result is now the same as when we make a SO with the two products in the Sales app and invoice it. This results in 2 valorisation lines (1 per product) but this does not change the valorisation when the pos order is not invoice and we close the session (still 1 valorisation line).

Tests:
------
We remove the skip on the whole test class and only skip the tests that are currently failing. Only 3 out of the now 8 need to be worked on, we re-introduce the rest.

opw-5328152