### PR TITLE
[FIX] point_of_sale: some fixes for printers

### DIFF
--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -78,9 +78,6 @@
                                     </div>
                                 </div>
                             </div>
-                            <div role="alert" class="alert alert-warning" invisible="not other_devices or default_receipt_printer_id in [False, '']">
-                                The Epson receipt printer will be used instead of the receipt printer connected to the IoT Box.
-                            </div>
                         </setting>
                         <setting id="preparation_devices" string="Preparation Printers" help="Connect preparation printers to your PoS">
                             <field name="preparation_devices"/>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -406,7 +406,7 @@
                                         </div>
                                         <div class="mt16 mb-1">
                                             <label string="Default" for="pos_default_receipt_printer_id" class="o_light_label me-2"/>
-                                            <field name="pos_default_receipt_printer_id"/>
+                                            <field name="pos_default_receipt_printer_id" domain="[('id', 'in', pos_receipt_printer_ids)]"/>
                                         </div>
                                         <div class="mt16 mb-1">
                                             <label string="Link Cashdrawer" for="pos_iface_cashdrawer" class="o_light_label me-2"/>


### PR DESCRIPTION
Previously, when an Epos IP and for IoT devices were configured both in one pos config , the Epson printer was prioritized over IoT devices, and a warning message was displayed to notify the user.

This behavior has been removed. Printers are no longer managed this way, and the default receipt printer is now always the one selected for printing.

Also, the filter for the default receipt printer in the res settings has been adjusted to display only receipt printers in the available field.

enterprise pr: https://github.com/odoo/enterprise/pull/102673

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
