### PR TITLE
[IMP] website_sale: SSR dynamic product snippet

### DIFF
--- a/addons/website_sale/models/ir_http.py
+++ b/addons/website_sale/models/ir_http.py
@@ -1,5 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+from lxml import html
+
 from odoo import api, models
 from odoo.http import request
 from odoo.tools import lazy
@@ -32,3 +35,168 @@ class IrHttp(models.AbstractModel):
         request.cart = lazy(request.website._get_and_cache_current_cart)
         request.fiscal_position = lazy(request.website._get_and_cache_current_fiscal_position)
         request.pricelist = lazy(request.website._get_and_cache_current_pricelist)
+
+    @classmethod
+    def _post_dispatch(cls, response):
+        super()._post_dispatch(response)
+        cls._inject_dynamic_snippet_products(response)
+
+    @classmethod
+    def _inject_dynamic_snippet_products(cls, response):
+        """Server-side rendering of dynamic product snippets for SEO."""
+
+        if not 'text/html' in response.headers.get('Content-Type'):
+            return
+
+        content = response.data
+        if not content:
+            return
+
+        tree = html.fromstring(content)
+
+        snippets = tree.xpath('//*[@data-snippet="s_dynamic_snippet_products"]')
+        if not snippets:
+            return
+
+        filter_ids = set()
+        for snippet in snippets:
+            filter_id = snippet.get('data-filter-id')
+            if filter_id:
+                filter_ids.add(int(filter_id))
+
+        filters = request.env['website.snippet.filter'].sudo().browse(list(filter_ids)).exists()
+        filter_map = {f.id: f for f in filters}
+
+        modified = False
+        for snippet in snippets:
+            if cls._render_snippet_products(snippet, filter_map, response, tree):
+                modified = True
+
+        if modified:
+            response.data = html.tostring(tree, encoding='utf-8')
+
+    @classmethod
+    def _render_snippet_products(cls, snippet, filter_map, response, tree):
+        """Render dynamic product snippet.
+
+        :param snippet: lxml element representing the snippet
+        :param filter_map: dict mapping filter IDs to filter records
+        :param response: the response object
+        :param tree: lxml parsed HTML tree
+        :return: True if snippet was modified, False otherwise
+        """
+
+        # Extract snippet configuration
+        filter_id = snippet.get('data-filter-id')
+        snippet_filter = filter_map.get(int(filter_id))
+        rendered_content = snippet_filter._render(
+            template_key=snippet.get('data-template-key'),
+            limit=int(snippet.get('data-number-of-records', 16)),
+            search_domain=cls._build_product_search_domain(snippet, tree),
+            with_sample=False,
+        )
+
+        template_area = snippet.xpath('.//*[contains(@class, "dynamic_snippet_template")]')[0]
+        template_area.classes.add('d-none')  # hidden until client-side hydration
+
+        wrapped_products = [
+            html.fromstring(f'<div class="d-flex">{chunk}</div>')
+            for chunk in rendered_content
+        ]
+        template_area.extend(wrapped_products)
+
+        # Mark as server-side rendered to prevent client-side fetching
+        snippet.set('data-ssr-rendered', 'true')
+
+        return True
+
+    @classmethod
+    def _build_product_search_domain(cls, snippet, tree):
+        """Build search domain from snippet attributes, mirroring client-side logic.
+
+        :param snippet: lxml element with data attributes
+        :param tree: lxml parsed HTML tree
+        :return: search domain list
+        """
+
+        search_domain = []
+
+        # Category filter
+        product_category_id = snippet.get('data-product-category-id')
+        if product_category_id and product_category_id not in ('all', None):
+            if product_category_id == 'current':
+                category_id = cls._get_current_category_id()
+                if category_id:
+                    search_domain.append(('public_categ_ids', 'child_of', category_id))
+                else:
+                    product_template_id = cls._get_current_product_template_id(tree)
+                    if product_template_id:
+                        search_domain.append(('public_categ_ids.product_tmpl_ids', '=', product_template_id))
+            else:
+                # Specific category ID provided
+                category_id = int(product_category_id)
+                search_domain.append(('public_categ_ids', 'child_of', category_id))
+
+        # Tag filter
+        product_tag_ids = snippet.get('data-product-tag-ids')
+        if product_tag_ids:
+            tag_ids = json.loads(product_tag_ids)
+            tag_id_list = []
+            for tag in tag_ids:
+                tag_id_list.append(tag["id"])
+            search_domain.append(('all_product_tag_ids', 'in', tag_id_list))
+
+        # Product name filter (searches name, default_code and barcode)
+        product_names = snippet.get('data-product-names')
+        if product_names:
+            name_domain = []
+            for product_name in product_names.split(','):
+                if not product_name:
+                    continue
+                if name_domain:
+                    name_domain.insert(0, '|')
+                name_domain.extend([
+                    '|', '|',
+                    ('name', 'ilike', product_name),
+                    ('default_code', '=', product_name),
+                    ('barcode', '=', product_name),
+                ])
+            if name_domain:
+                search_domain.extend(name_domain)
+
+        # Variant visibility filter
+        if not snippet.get('data-show-variants'):
+            search_domain.append('hide_variants')
+
+        return search_domain
+
+    @classmethod
+    def _get_current_category_id(cls):
+        """ Extract current product category ID
+
+        :return: Category ID (int) if found, else None
+        """
+        path = request.httprequest.path
+        if '/category/' not in path:
+            return None
+
+        category_segment = path.split('/category/')[-1].split('/')[0]
+        if '-' in category_segment:
+            category_id = int(category_segment.rsplit('-', 1)[-1])
+            if request.env['product.public.category'].sudo().browse(category_id).exists():
+                return category_id
+        return None
+
+    @classmethod
+    def _get_current_product_template_id(cls, tree):
+        """ Extract current product template ID from DOM.
+        :param tree: lxml parsed HTML tree
+        :return: Product template ID (int) if found, else None
+        """
+
+        product_elements = tree.xpath('//*[contains(@class, "js_product")]//*[@data-product-template-id]')
+        if product_elements:
+            template_id = product_elements[0].get('data-product-template-id')
+            if template_id and int(template_id) > 0:
+                return int(template_id)
+        return None

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
@@ -1,8 +1,25 @@
 import { DynamicSnippetCarousel } from "@website/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel";
 import { registry } from "@web/core/registry";
+import { markup } from "@odoo/owl";
 
 export class DynamicSnippetProducts extends DynamicSnippetCarousel {
     static selector = ".s_dynamic_snippet_products";
+
+    /**
+     * @override
+     */
+    async fetchData() {
+        if (this.el.dataset.ssrRendered === "true") {
+            const templateArea = this.el.querySelector(".dynamic_snippet_template");
+            if (templateArea && templateArea.children.length > 0) {
+                this.data = [...templateArea.children].map((el) => el.innerHTML).map(markup);
+                templateArea.classList.remove("d-none");
+                delete this.el.dataset.ssrRendered;
+                return;
+            }
+        }
+        return super.fetchData();
+    }
 
     /**
      * Gets the category search domain

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -41,4 +41,5 @@ from . import (
     test_website_sale_checkout_steps,
     test_website_sequence,
     test_website_visitor,
+    test_dynamic_snippet_ssr,
 )

--- a/addons/website_sale/tests/test_dynamic_snippet_ssr.py
+++ b/addons/website_sale/tests/test_dynamic_snippet_ssr.py
@@ -1,0 +1,64 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('post_install', '-at_install', 'ssr_test')
+class TestDynamicSnippetSSR(HttpCase):
+
+    def test_dynamic_snippet_products_ssr(self):
+        website = self.env['website'].get_current_website()
+        self.env['product.template'].create({
+            'name': 'Product 1',
+            'website_published': True,
+            'website_id': website.id,
+            'list_price': 10.0,
+        })
+        self.env['product.template'].create({
+            'name': 'Product 2',
+            'website_published': True,
+            'website_id': website.id,
+            'list_price': 20.0,
+        })
+
+        filter_newest = self.env.ref('website_sale.dynamic_filter_newest_products')
+        view = self.env['ir.ui.view'].create({
+            'name': 'QWeb View',
+            'type': 'qweb',
+            'key': 'website_sale.ssr_view_test',
+            'arch': f"""
+                <t t-name="website_sale.ssr_view_test">
+                    <t t-call="website.layout">
+                        <div id="wrap">
+                            <section class="s_dynamic_snippet_products"
+                                     data-snippet="s_dynamic_snippet_products"
+                                     data-filter-id="{filter_newest.id}"
+                                     data-template-key="website_sale.dynamic_filter_template_product_product_products_item"
+                                     data-number-of-records="2">
+                                <div class="container">
+                                    <div class="dynamic_snippet_template row"/>
+                                </div>
+                            </section>
+                        </div>
+                    </t>
+                </t>
+            """,
+        })
+
+        self.env['website.page'].create({
+            'view_id': view.id,
+            'url': '/test',
+            'is_published': True,
+        })
+
+        response = self.url_open('/test')
+        self.assertEqual(response.status_code, 200)
+
+        content = response.content.decode()
+        self.assertIn(
+            'data-ssr-rendered="true"',
+            content,
+            "Dynamic snippet should be SSR rendered")
+
+        self.assertIn('Product 1', content, "Product 1 should be present in the rendered content")
+        self.assertIn('Product 2', content, "Product 2 should be present in the rendered content")


### PR DESCRIPTION
Render dynamic product snippets server-side to improve SEO by making
product content indexable without JavaScript execution.

The dynamic behavior is preserved on the client side through hydration,
reusing server-rendered DOM content and preventing duplicate RPC calls.

Key points:
- Inject rendered product items during HTTP post-dispatch.
- Mirror client-side domain computation on the server.
- Mark snippets as SSR-rendered to skip initial client fetch.

task-[5245362](https://www.odoo.com/odoo/project/974/tasks/5245362)