### PR TITLE
[FIX] web: Calendar's event dispatch when attached to shadow tree only

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -151,12 +151,12 @@ export class CalendarCommonRenderer extends Component {
         return `[data-event-id="${event.id}"]`;
     }
     highlightEvent(event, className) {
-        for (const el of this.fc.el.querySelectorAll(this.computeEventSelector(event))) {
+        for (const el of this.fc.api.el.querySelectorAll(this.computeEventSelector(event))) {
             el.classList.add(className);
         }
     }
     unhighlightEvent(event, className) {
-        for (const el of this.fc.el.querySelectorAll(this.computeEventSelector(event))) {
+        for (const el of this.fc.api.el.querySelectorAll(this.computeEventSelector(event))) {
             el.classList.remove(className);
         }
     }


### PR DESCRIPTION
Tour "knowledge_calendar_command_tour" fails since Chrome 143 with an error "Cannot read properties of null (reading 'querySelectorAll')".

This is due to the fix in Chromium "Fix target/relatedTarget clearing logic during dispatch" [^1] introduced in Chrome 143, to actually match the spec [^2].

To quote the Chromium commit message:
> According to the spec, only if the top node is in a shadow tree, both
> the target and relatedTarget should be cleared.
> However, if the top node is not in a shadow tree and not a document,
> the target and relatedTarget are always cleared. Because the current
> implementation only checks whether the top node is not a document.
> So, this patch fixes the bug by checking whether the top node is in a
> shadow tree.

In practice, this means that events are now properly dispatched when the FullCalendar container's element is not connected to the document but still to the shadow tree. As a result, the OWL reference to this container can not exist anymore when the event handler is called but FullCalendar's API still has the right reference to this element.

Note: Firefox and Safari already implemented the spec properly (aka. it was already broken for them...)

[^1]: https://chromium.googlesource.com/chromium/src/+/63178146cd776eae2b466983f0835e86c314d051%5E%21/
[^2]: https://dom.spec.whatwg.org/#concept-event-dispatch

