### PR TITLE
[IMP] mass_mailing(_sms): restore UI changes overwritten by another task

### DIFF
--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -133,15 +133,6 @@
                     action="action_view_contacts" type="object">
                 <field name="active"/>
                 <templates>
-                    <t t-name="menu" t-if="!selection_mode">
-                        <a role="menuitem" name="action_send_mailing" type="object" class="dropdown-item">Send Mailing</a>
-                        <div role="separator" class="dropdown-divider"></div>
-                        <a role="menuitem" name="action_archive" type="object" class="dropdown-item" t-if="record.active.raw_value">Archive</a>
-                        <a role="menuitem" name="action_unarchive" type="object" class="dropdown-item" t-if="!record.active.raw_value">Unarchive</a>
-                        <a t-if="widget.deletable" role="menuitem" type="delete" class="dropdown-item text-danger">Delete</a>
-                        <div role="separator" class="dropdown-divider"></div>
-                        <field name="color" widget="kanban_color_picker"/>
-                    </t>
                     <t t-name="card">
                         <div class="d-flex gap-1 flex-row justify-content-between align-items-center flex-wrap">
                             <div class="col-lg-3 col-sm-6 col-12 py-0 my-auto">
@@ -216,7 +207,8 @@
                             <hr class="my-1"/>
                             <a role="menuitem" class="dropdown-item oe_kanban_action" name="action_send_mailing" type="object">New Mailing</a>
                             <hr class="my-1"/>
-                            <a role="menuitem" class="dropdown-item oe_kanban_action" name="action_archive" href="#" type="object">Archive</a>
+                            <a role="menuitem" class="dropdown-item oe_kanban_action" name="action_archive" href="#" type="object" t-if="record.active.raw_value">Archive</a>
+                            <a role="menuitem" class="dropdown-item oe_kanban_action" name="action_unarchive" type="object" t-if="!record.active.raw_value">Unarchive</a>
                             <a role="menuitem" class="dropdown-item oe_kanban_action" name="unlink" type="object" href="#">Delete</a>
                             <hr class="my-1 mb-2"/>
                             <div t-if="widget.editable" role="menuitem" aria-haspopup="true">

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -73,13 +73,12 @@
                             data-hotkey="d" invisible="state != 'done'"/>
                         <button name="action_test" type="object" class="btn-secondary" string="Test" data-hotkey="k"/>
                         <button name="action_cancel" type="object" invisible="state != 'in_queue'" class="btn-secondary" string="Cancel" data-hotkey="x"/>
-                        <button name="action_retry_failed" type="object" invisible="state != 'done' or failed == 0" class="oe_highlight" string="Retry" data-hotkey="y"/>
                         <field name="state" readonly="1" widget="statusbar" statusbar_visible="draft,in_queue,sending,done"/>
                     </header>
                     <div class="alert alert-info o_mass_mailing_alert_message" role="alert"
                             invisible="state not in ['in_queue', 'done'] and sent == 0 and canceled == 0 and scheduled == 0 and failed == 0 and not warning_message">
                         <div class="o_mails_canceled" invisible="canceled == 0">
-                            <button class="btn btn-link py-0"
+                            <button class="btn btn-link p-0"
                                     name="action_view_traces_canceled"
                                     type="object">
                                 <strong>
@@ -89,7 +88,7 @@
                             </button>
                         </div>
                         <div class="o_mails_scheduled" invisible="scheduled == 0">
-                            <button class="btn btn-link py-0"
+                            <button class="btn btn-link p-0"
                                     name="action_view_traces_scheduled"
                                     type="object">
                                 <strong>
@@ -99,7 +98,7 @@
                             </button>
                         </div>
                         <div class="o_mails_process" invisible="process == 0">
-                            <button class="btn btn-link py-0"
+                            <button class="btn btn-link p-0"
                                     name="action_view_traces_process"
                                     type="object">
                                 <strong>
@@ -109,7 +108,7 @@
                             </button>
                         </div>
                         <div class="o_mails_sent" invisible="sent == 0 and state in ('draft', 'test', 'in_queue')">
-                            <button class="btn btn-link py-0"
+                            <button class="btn btn-link p-0"
                                     name="action_view_traces_sent"
                                     type="object">
                                 <strong>
@@ -122,7 +121,7 @@
                             </strong>
                         </div>
                         <div class="o_mails_failed" invisible="state != 'done' or failed == 0">
-                            <button class="btn btn-link py-0"
+                            <button class="btn btn-link p-0"
                                     name="action_view_traces_failed"
                                     type="object">
                                 <strong>

--- a/addons/mass_mailing_sms/views/mailing_list_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_list_views.xml
@@ -5,9 +5,6 @@
         <field name="model">mailing.list</field>
         <field name="inherit_id" ref="mass_mailing.mailing_list_view_kanban"/>
         <field name="arch" type="xml">
-            <xpath expr="//a[@name='action_send_mailing']" position="after">
-                <a name="action_send_mailing_sms" class="dropdown-item" role="menuitem" type="object">Send SMS</a>
-            </xpath>
             <xpath expr="//div[hasclass('o_mailing_list_kanban_stats')]//a" position="after">
                 <a class="me-sm-0 me-3 fs-4 fw-light lh-1" tabindex="-1"
                     name="action_view_contacts_sms" type="object">


### PR DESCRIPTION
This commit reintroduces a few UI changes that were lost after being overwritten by another task.

Originally introduced in: https://github.com/odoo/odoo/commit/807477e78850671b9561c36f185482ee612c0c5d
Later overwritten by: https://github.com/odoo/odoo/commit/0f7ee1764e8b59029003c6ad7269e185b30c6b43

Fixes:
- Removed duplicate 'Retry' buttons (keeps only one)
- Removed duplicate code of t-menu in mailing list kanban
- Removed duplicate xpath of 'sms' option in mailing list kanban
- Restored the 'Unarchive' option in the Kanban record dropdown to recover
  archived mailing lists
- fixed left-alignment of mailing informations in header to keep styling
  consistent.

task-5435584
