### PR TITLE
[FIX] mail: jump to present not working in non-aside chatter

### DIFF
--- a/addons/mail/static/src/chatter/web/form_renderer.scss
+++ b/addons/mail/static/src/chatter/web/form_renderer.scss
@@ -34,6 +34,11 @@
     }
 }
 
+// Disable scroll anchoring when chatter is not in aside mode to prevent unwanted layout shifts
+.o_content:has(.o-mail-Form-chatter:not(.o-aside)) {
+    overflow-anchor: none;
+}
+
 // ------------------------------------------------------------------
 // Style
 // ------------------------------------------------------------------


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------
In non-aside chatter, the **Jump to Present** action did not work reliably. When users clicked it, the view flickered and the scroll position jumped back, preventing users from reaching the latest message.

This happened because the browser’s native scroll anchoring interfered with the scroll-to-bottom behavior when messages were reloaded.

**Current behavior before PR:**
---------------------------------
- In non-aside chatter, clicking **Jump to Present** caused flickering.
- The view jumped back instead of staying on the latest message.
- Users could not reliably reach the most recent messages.

**Desired behavior after PR is merged:**
-----------------------------------------
- Clicking **Jump to Present** in non-aside chatter scrolls directly to the
  latest message without flickering.
- The scroll position remains stable and does not jump back.
- The **Jump to Present** button works consistently.

**Task:** 5264332

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
