### PR TITLE
[FIX] mail: call permission dialog layout on small screens

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_permission_dialog.js
+++ b/addons/mail/static/src/discuss/call/common/call_permission_dialog.js
@@ -19,6 +19,7 @@ export class CallPermissionDialog extends Component {
 
     setup() {
         this.rtc = useService("discuss.rtc");
+        this.ui = useService("ui");
     }
 
     async onClickUseMicrophone() {

--- a/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
+++ b/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.CallPermissionDialog">
         <Dialog title="''" size="'md'">
-            <div class="d-flex flex-fill align-items-center gap-3">
+            <div class="d-flex flex-fill align-items-center gap-3" t-att-class="{ 'flex-column-reverse': ui.isSmall }">
                 <div>
                     <h2 t-out="permissionPrompt"/>
                     <p class="text-muted" t-out="permissionNote"/>
@@ -18,7 +18,7 @@
     </t>
 
     <t t-name="discuss.CallPermissionDialogImg">
-        <svg role="img" aria-label="Permissions Lady - Lady pushing a giant toggle button" width="431" height="294" viewBox="0 0 431 294" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg role="img" aria-label="Permissions Lady - Lady pushing a giant toggle button" width="auto" height="auto" viewBox="0 0 431 294" fill="none" xmlns="http://www.w3.org/2000/svg">
             <title>Permissions Lady</title>
             <description>Illustration showing a lady pushing a giant toggle button representing microphone and camera permissions</description>
             <g>


### PR DESCRIPTION
**Current behavior before PR:**
On small screens, the call permission dialog uses a horizontal layout, causing cramped content and poor readability.

**Desired behavior after PR is merged:**
On small screens, the call permission dialog stacks elements vertically, improving spacing and readability.

Before
<img width="365" height="462" alt="image" src="https://github.com/user-attachments/assets/31431f11-5a69-418e-9d6b-7b30294a548c" />

After
<img width="369" height="494" alt="image" src="https://github.com/user-attachments/assets/d7942381-57f5-4c5c-a7bc-79b621f48b4e" />


task-[5435662](https://www.odoo.com/odoo/project/1519/tasks/5435662)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
