### PR TITLE
[FIX] hr: solve parent_id access error and allow displaying manager image

### DIFF
--- a/addons/hr/models/__init__.py
+++ b/addons/hr/models/__init__.py
@@ -21,3 +21,4 @@ from . import res_company
 from . import res_partner
 from . import resource
 from . import ir_ui_menu
+from . import ir_binary

--- a/addons/hr/models/ir_binary.py
+++ b/addons/hr/models/ir_binary.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class IrBinary(models.AbstractModel):
+    _inherit = "ir.binary"
+
+    def _find_record_check_access(self, record, access_token):
+        if record._name == "hr.employee.public":
+            return record
+        return super()._find_record_check_access(record, access_token)
+
+    def _record_to_stream(self, record, field_name):
+        if record._name == "hr.employee.public" and field_name == 'avatar_128':
+            record = record.sudo()
+        return super()._record_to_stream(record, field_name)

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
@@ -13,10 +13,17 @@ export class Many2OneAvatarEmployeeField extends EmployeeFieldRelationMixin(
     Many2OneAvatarUserField
 ) {
     get many2OneProps() {
-        return {
+        const props = {
             ...super.many2OneProps,
             relation: this.relation,
         };
+        if (
+            (this.props.name === "parent_id" || this.props.name === "coach_id") &&
+            this.props.record.data.has_cross_company_relation
+        ) {
+            props.canOpen = false;
+        }
+        return props;
     }
 }
 

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -75,8 +75,9 @@
                                 <field name="department_id" context="{'open_employees_kanban': 1}"/>
                                 <field name="job_id"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
-                                <field name="parent_id" widget="many2one_avatar_user"/>
-                                <field name="coach_id" widget="many2one_avatar_user"/>
+                                <field name="has_cross_company_relation" invisible="1"/>
+                                <field name="parent_id" widget="many2one_avatar_employee"/>
+                                <field name="coach_id" widget="many2one_avatar_employee"/>
                             </group>
                         </group>
                         <notebook>


### PR DESCRIPTION
Steps to reproduce :
- Log as mitchell admin and make two company (company A and company B)
  with employee (empA and empB).
- Go to employees, set empB as manager of empA.
- Remove company B in allowed companies and HR rights from
  marc demo (public user with company A access).
- Log in as marc demo and open empA profile.
- Click on her manager name
   - Access error will occur and manager image is not displayed.

Cause:
The multi-company record rule 'hr_employee_public_comp_rule' restrict access to
'hr.employee.public' records based on the user allowed companies.
When loading the manager image belonging to another company, access
checks in '_find_record_check_access' and 'from_binary_field' fail,
resulting in an access error.

Fix:
- Override '_find_record_check_access' and '_record_to_stream' to check
  for 'hr.employee.public', allowing the avatar to be fetched with sudo().
   - As in this PR https://tinyurl.com/4c76ac2j, '_find_record_check_access()'
     method is overridden to controlled access checks in stable version, this
     change similarly overrides '_find_record_check_access' to controlled avatar
     access in stable version.
- Add computed field 'has_cross_company_relation' to detect when an employee
  manager or coach belongs to another company.
  - The field is not stored because 'hr.employee.public' is a SQL view. Only
    employees with a cross-company manager or coach are prevented from clicking
    the avatar name, all others can interact normally.
- Use 'has_cross_company_relation' as a flag in Javascript to disable the
  clickability on text.

Task - 5386440