### PR TITLE
[FIX] hr_holidays_attendance: show valid options only and recompute when necessary

### DIFF
--- a/addons/hr_holidays_attendance/models/__init__.py
+++ b/addons/hr_holidays_attendance/models/__init__.py
@@ -8,3 +8,4 @@ from . import hr_leave_type
 from . import hr_leave
 from . import ir_ui_menu
 from . import hr_employee
+from . import resource_calendar_leaves

--- a/addons/hr_holidays_attendance/models/hr_attendance.py
+++ b/addons/hr_holidays_attendance/models/hr_attendance.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class HrAttendance(models.Model):
+    _inherit = "hr.attendance"
+
+    def init(self):
+        super().init()
+        self.env.cr.execute("""
+            CREATE INDEX IF NOT EXISTS hr_attendance_check_in_check_out_employee_id ON hr_attendance (check_in, check_out, employee_id);
+        """)

--- a/addons/hr_holidays_attendance/models/resource_calendar_leaves.py
+++ b/addons/hr_holidays_attendance/models/resource_calendar_leaves.py
@@ -1,0 +1,56 @@
+from odoo import api, models
+from odoo.fields import Domain
+
+
+class ResourceCalendarLeaves(models.Model):
+    _inherit = "resource.calendar.leaves"
+
+    def _get_attendance_domain(self):
+        domain = []
+
+        leaves_time_type_leave = self.filtered(lambda leave: leave.time_type == 'leave')
+
+        resource_leaves = leaves_time_type_leave.filtered(lambda leave: leave.resource_id.employee_id)
+        domain.extend([[
+            ('check_in', '<=', max(leaves.mapped('date_to'))),
+            ('check_out', '>=', min(leaves.mapped('date_from'))),
+            ('employee_id', 'in', resource.employee_id.ids),
+        ] for resource, leaves in resource_leaves.grouped('resource_id').items()])
+
+        for leave in (leaves_time_type_leave - resource_leaves):
+            leave_domain = [
+                ('check_in', '<=', leave.date_to),
+                ('check_out', '>=', leave.date_from),
+            ]
+            if leave.company_id:
+                leave_domain.append(('employee_id.company_id', '=', leave.company_id.id))
+            if leave.calendar_id:
+                leave_domain.append(('employee_id.resource_calendar_id', '=', leave.calendar_id.id))
+            domain.append(leave_domain)
+
+        return Domain.OR(domain)
+
+    def _update_attendances_overtime(self, domain=None):
+        self.env['hr.attendance'].sudo().search(domain or self._get_attendance_domain())._update_overtime()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        res._update_attendances_overtime()
+        return res
+
+    def write(self, vals):
+        affects_attendances = bool({'date_from', 'date_to', 'resource_id', 'calendar_id', 'company_id', 'time_type'} & set(vals.keys()))
+        if affects_attendances:
+            before_domain = self._get_attendance_domain()
+        res = super().write(vals)
+        if affects_attendances:
+            after_domain = self._get_attendance_domain()
+            self._update_attendances_overtime(Domain.OR([before_domain, after_domain]))
+        return res
+
+    def unlink(self):
+        before_domain = self._get_attendance_domain()
+        res = super().unlink()
+        self._update_attendances_overtime(before_domain)
+        return res

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=90, admin=91):
+        with self.assertQueryCount(__system__=91, admin=92):
             leave.action_approve()
         leave.action_refuse()
 


### PR DESCRIPTION
If you don't have time off app, the option Timing - when Employee is off, should not be available. Creating a time off on a day when there is already an attendance record should automatically recompute the overtime if this rule is on the employee.