### PR TITLE
[FIX] web: clickEverywhere: store xmlID of the requested application

### DIFF
--- a/addons/web/static/src/webclient/clickbot/clickbot.js
+++ b/addons/web/static/src/webclient/clickbot/clickbot.js
@@ -494,6 +494,7 @@ async function _clickEverywhere(xmlId, light, currentState) {
     const startTime = performance.now();
     try {
         if (xmlId) {
+            state.xmlId = xmlId;
             state.app = xmlId;
             await testApp();
         } else {


### PR DESCRIPTION
The clickEverywhere function can be executed with one app. To accomplish this, the xmlID should be passed as a parameter to the function.

Before this commit, the xmlID of the requested application was not stored in the status of the current execution saved in localStorage. If a reload occurs while the clickEverywhere function is executing, it will lose this information and continue testing all applications instead of only the requested one.

runbot.build.error: 234747
