### PR TITLE
[FIX] sale{,_purchase}: ensure SOL description computed before saving

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -535,7 +535,9 @@ class ProductProduct(models.Model):
                 # not be a performance issue.
                 if company_id:
                     sellers = [x for x in sellers if x.company_id.id in [company_id, False]]
-            if sellers:
+            # Avoid overriding the product name with vendor descriptions when the customer
+            # and vendor are the same
+            if sellers and sellers[0].partner_id.id != partner_id:
                 temp = []
                 for s in sellers:
                     seller_variant = s.product_name and (

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -402,8 +402,10 @@ class SaleOrderLine(models.Model):
           the product is not sufficient because we also need to know the event_id and the event_ticket_id (both which belong to the sale order line).
         """
         self.ensure_one()
+        seller = self.product_id._select_seller(quantity=self.product_uom_qty, partner_id=self.order_id.partner_id, params={'order_id': self.order_id})
+        product_ctx = {'seller_id': seller.id, 'lang': self.order_id._get_lang()}
         description = (
-            self.product_id.get_product_multiline_description_sale()
+            self.product_id.with_context(product_ctx).get_product_multiline_description_sale()
             + self._get_sale_order_line_multiline_description_variants()
         )
         if self.linked_line_id and not self.combo_item_id:
@@ -487,7 +489,7 @@ class SaleOrderLine(models.Model):
     def _compute_translated_product_name(self):
         for line in self:
             line.translated_product_name = line.product_id.with_context(
-                lang=line.order_id._get_lang(),
+                lang=line.order_id._get_lang(), partner_id=None
             ).display_name
 
     @api.depends('display_type', 'product_id', 'product_packaging_qty')

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -402,8 +402,10 @@ class SaleOrderLine(models.Model):
           the product is not sufficient because we also need to know the event_id and the event_ticket_id (both which belong to the sale order line).
         """
         self.ensure_one()
+        seller = self.product_id._select_seller(quantity=self.product_uom_qty, partner_id=self.order_id.partner_id, params={'order_id': self.order_id})
+        product_ctx = {'seller_id': seller.id, 'lang': self.order_id._get_lang()}
         description = (
-            self.product_id.get_product_multiline_description_sale()
+            self.product_id.with_context(product_ctx).get_product_multiline_description_sale()
             + self._get_sale_order_line_multiline_description_variants()
         )
         if self.linked_line_id and not self.combo_item_id:

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -189,9 +189,6 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
             'product.template',
             'get_single_product_variant',
             [this.props.record.data.product_template_id[0]],
-            {
-                context: this.context,
-            }
         );
         if(result && result.product_id) {
             if (this.props.record.data.product_id != result.product_id.id) {

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -2,7 +2,7 @@
 
 from odoo import Command
 from odoo.exceptions import UserError, AccessError
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 from odoo.addons.sale_purchase.tests.common import TestCommonSalePurchaseNoChart
 
 
@@ -437,3 +437,30 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         so.order_line.product_uom_qty = 2
         po_2 = so._get_purchase_orders() - po_1
         self.assertEqual(po_2.order_line.product_qty, 12, "The quantity on the SO line should be converted to the purchase UoM.")
+
+    def test_sol_description_with_same_vendor_customer(self):
+        """
+        Ensure SOL description is computed before saving and that vendor
+        information does not override the product name when the partner
+        is both customer and vendor.
+        """
+        test_product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'seller_ids': [Command.create({
+                'partner_id': self.partner_vendor_service.id,
+                'product_code': 'P123',
+                'product_name': 'Name1',
+            })]
+        })
+        with Form(self.env['sale.order']) as order:
+            order.partner_id = self.partner_vendor_service
+            with order.order_line.new() as line:
+                line.product_id = test_product
+                # Product display_name should NOT be overridden
+                product_name = line.product_id.with_context(
+                    partner_id=self.partner_vendor_service.id
+                ).display_name
+                self.assertEqual(product_name, "Test Product")
+                self.assertEqual(line.name, "[P123] Name1")
+        order = order.save()
+        self.assertEqual(order.order_line.name, "[P123] Name1")


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install Sales and Purchase modules.
2. Create a product; in the Purchase tab, add a vendor with
a vendor "Product Name" and "Product Code".
3. Create a Sale Order using this same vendor as the Customer.
4. Add the product to the Sale Order Line (SOL).

Reference [video](https://drive.google.com/file/d/1wqsOoE00kOowm9puGXgDTGdV9Xkkwton/view?usp=sharing)

Observation and issue:
------------------------
1. Before clicking outside the SOL, the description remains
unfilled despite the availability of a vendor product name and code.

2. Upon clicking outside the SOL, the description displays
only the vendor product name and code incorrectly overriding
the standard product name.

Cause:
---------
* The SOL description([_compute_name](https://github.com/odoo/odoo/blob/cbcfb93067f6a3ec6f87dfa5b05497777bead425/addons/sale/models/sale_order_line.py#L406)) depends on product's `display_name`, 
but missing dependencies prevent `_compute_display_name` from being
triggered before saving.

For reference, POL description:
https://github.com/odoo/odoo/blob/a877beaeeb45a2ca3d68bf423f9948f58f6c64aa/addons/purchase/models/purchase_order_line.py#L369-L370

* When the customer and vendor are the same, the `display_name` is
computed using vendor context (`partner_id`), causing vendor-specific
values to override the product name.
https://github.com/odoo/odoo/blob/cbcfb93067f6a3ec6f87dfa5b05497777bead425/addons/product/models/product_product.py#L538-L548

Solution:
-----------
* Add the required dependencies to ensure the SOL description is
computed correctly .
* Skip vendor-based naming when the seller and customer are the same,
and fallback to the default product name.



opw-5262670

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
