### PR TITLE
[FIX] web: fix range to behave as expected

### DIFF
--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -16,16 +16,23 @@ export function clamp(num, min, max) {
 
 /**
  * A function to create flexibly-numbered lists of integers, handy for each and map loops.
- * step defaults to 1.
  * Returns a list of integers from start (inclusive) to stop (exclusive), incremented (or decremented) by step.
- * @param {number} start default 0
- * @param {number} stop
- * @param {number} step default 1
+ *
+ * @param {number} start
+ * @param {number} [stop] if not provided, start is used as stop and start is set to 0.
+ * @param {number} [step] default to 1 if start < stop, -1 otherwise.
  * @returns {number[]}
  */
-export function range(start, stop, step = 1) {
+export function range(start, stop, step) {
     const array = [];
-    const nsteps = Math.floor((stop - start) / step);
+    if (stop === undefined) {
+        stop = start;
+        start = 0;
+    }
+    if (step === undefined) {
+        step = start < stop ? 1 : -1;
+    }
+    const nsteps = Math.ceil((stop - start) / step);
     for (let i = 0; i < nsteps; i++) {
         array.push(start + step * i);
     }

--- a/addons/web/static/tests/core/utils/numbers.test.js
+++ b/addons/web/static/tests/core/utils/numbers.test.js
@@ -26,11 +26,24 @@ test("clamp", () => {
 test("range", () => {
     expect(range(0, 10)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     expect(range(0, 35, 5)).toEqual([0, 5, 10, 15, 20, 25, 30]);
+    expect(range(0, 34, 5)).toEqual([0, 5, 10, 15, 20, 25, 30]);
+    expect(range(0, 36, 5)).toEqual([0, 5, 10, 15, 20, 25, 30, 35]);
     expect(range(-10, 6, 2)).toEqual([-10, -8, -6, -4, -2, 0, 2, 4]);
     expect(range(0, -10, -1)).toEqual([0, -1, -2, -3, -4, -5, -6, -7, -8, -9]);
     expect(range(4, -4, -1)).toEqual([4, 3, 2, 1, 0, -1, -2, -3]);
     expect(range(1, 4, -1)).toEqual([]);
     expect(range(1, -4, 1)).toEqual([]);
+    expect(range(3)).toEqual([0, 1, 2]);
+    expect(range(0, 3)).toEqual([0, 1, 2]);
+    expect(range(0, 3, 1)).toEqual([0, 1, 2]);
+    expect(range(3, 0)).toEqual([3, 2, 1]);
+    expect(range(3, 0, -1)).toEqual([3, 2, 1]);
+    expect(range(-3)).toEqual([0, -1, -2]);
+    expect(range(0, -3)).toEqual([0, -1, -2]);
+    expect(range(0, -3, -1)).toEqual([0, -1, -2]);
+    expect(range(2, -2)).toEqual([2, 1, 0, -1]);
+    expect(range(2, -2, -3)).toEqual([2, -1]);
+    expect(range(-2, 2)).toEqual([-2, -1, 0, 1]);
 });
 
 describe("roundPrecision", () => {


### PR DESCRIPTION
None of the optional parameters were working as expected.

- `floor` was wrong, should be `ceil`: see test
  `expect(range(0, 34, 5)).toEqual([0, 5, 10, 15, 20, 25, 30]);`
  -> last 30 was not present
- step = 1 was not the right default when start > stop
- when stop was undefined -> stop - start = NaN

part of task-4822140