### PR TITLE
[FIX] resource: use resource timezone for leaves default dates

### DIFF
--- a/addons/resource/models/resource_calendar_leaves.py
+++ b/addons/resource/models/resource_calendar_leaves.py
@@ -18,14 +18,12 @@ class ResourceCalendarLeaves(models.Model):
         if 'date_from' in fields_list and 'date_to' in fields_list and not res.get('date_from') and not res.get('date_to'):
             # Then we give the current day and we search the begin and end hours for this day in resource.calendar of the current company
             today = fields.Datetime.now()
-            user_tz = timezone(self.env.user.tz or self._context.get('tz') or self.company_id.resource_calendar_id.tz or 'UTC')
-            date_from = user_tz.localize(datetime.combine(today, time.min))
-            date_to = user_tz.localize(datetime.combine(today, time.max))
-            intervals = self.env.company.resource_calendar_id._work_intervals_batch(date_from.replace(tzinfo=utc), date_to.replace(tzinfo=utc))[False]
-            if intervals:  # Then we stop and return the dates given in parameter
-                list_intervals = [(start, stop) for start, stop, records in intervals]  # Convert intervals in interval list
-                date_from = list_intervals[0][0]  # We take the first date in the interval list
-                date_to = list_intervals[-1][1]  # We take the last date in the interval list
+            calendar = self.env.company.resource_calendar_id
+            if 'calendar_id' in res:
+                calendar = self.env['resource.calendar'].browse(res['calendar_id'])
+            tz = timezone(calendar.tz or 'UTC')
+            date_from = tz.localize(datetime.combine(today, time.min))
+            date_to = tz.localize(datetime.combine(today, time.max))
             res.update(
                 date_from=date_from.astimezone(utc).replace(tzinfo=None),
                 date_to=date_to.astimezone(utc).replace(tzinfo=None)


### PR DESCRIPTION
Steps to reproduce:
1. Create an appointment with resources.
2. Set the resource to have a resource leave on a specific day for the whole day.
3. When trying to book with that resource for that day we still can.

Before this commit, when creating a time off entry (resource.calendar.leaves), the default start and end dates were calculated based on the Company's timezone or the current User's timezone.

This behavior caused issues when the Resource (e.g., an employee or facility) was located in a different timezone than the Company. The calculated default dates would "snap" to the wrong midnight (e.g., midnight in New York instead of midnight in London), resulting in time off entries that shifted by several hours when viewed in the correct timezone. This shift could leave unexpected availability slots open in the appointments system.

This commit backports the logic from Odoo 19 to fix this behavior. The default_get method now checks if a specific calendar_id is provided in the context, if found, it uses that calendar's timezone to calculate the start and end of the day, ensuring the time off entry correctly covers the full day in the resource's local time.\

ref 8e9ad7c

opw-5404984



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
