### PR TITLE
[FIX] im_livechat,mail: do not show IM status in livechat for visitor

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_bubble_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_bubble_patch.js
@@ -4,9 +4,9 @@ import { patch } from "@web/core/utils/patch";
 
 patch(ChatBubble.prototype, {
     get showImStatus() {
-        return (
-            super.showImStatus &&
-            !(this.thread?.correspondent?.livechat_member_type === "bot" && this.env.embedLivechat)
-        );
+        if (this.thread?.self_member_id?.livechat_member_type === "visitor") {
+            return false;
+        }
+        return super.showImStatus;
     },
 });

--- a/addons/im_livechat/static/tests/embed/chat_bubble.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_bubble.test.js
@@ -4,7 +4,7 @@ import {
 } from "@im_livechat/../tests/livechat_test_helpers";
 import { contains, setupChatHub, start, startServer } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import { Command, makeMockEnv } from "@web/../tests/web_test_helpers";
+import { Command, makeMockEnv, serverState } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineLivechatModels();
@@ -16,12 +16,15 @@ test("Do not show bot IM status", async () => {
     const partnerId1 = pyEnv["res.partner"].create({ name: "Mitchell", im_status: "online" });
     pyEnv["res.users"].create({ partner_id: partnerId1 });
     const channelId1 = pyEnv["discuss.channel"].create({
-        channel_member_ids: [Command.create({ partner_id: partnerId1 })],
+        channel_member_ids: [
+            Command.create({ partner_id: partnerId1, livechat_member_type: "visitor" }),
+        ],
         channel_type: "chat",
     });
     const partnerId2 = pyEnv["res.partner"].create({ name: "Dummy" });
     const channelId2 = pyEnv["discuss.channel"].create({
         channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "visitor" }),
             Command.create({ partner_id: partnerId2, livechat_member_type: "bot" }),
         ],
         channel_type: "livechat",

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -23,7 +23,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { CHAT_HUB_KEY } from "@mail/core/common/chat_hub_model";
-import { contains } from "./mail_test_helpers_contains";
+import { click, contains } from "./mail_test_helpers_contains";
 
 import { closeStream, mailGlobal } from "@mail/utils/common/misc";
 import { Component, onMounted, onPatched, onWillDestroy, status } from "@odoo/owl";
@@ -978,4 +978,26 @@ export function patchVoiceMessageAudio() {
         });
     });
     return res;
+}
+
+/**
+ * Assert IM status on chat bubble and chat window of given `conversationName` with `count`.
+ * The conversation should be present as a bubble initially, becomes open and folded again
+ * after calling function.
+ *
+ * This is made as a function so that negative assertion on ImStatus can use this function and
+ * ensure using correct selector and await properly like the positive assertions.
+ *
+ * @param {string} conversationName
+ * @param {Number} count
+ */
+export async function assertChatBubbleAndWindowImStatus(conversationName, count) {
+    await contains(`.o-mail-ChatBubble[name=${conversationName}]`);
+    expect(`.o-mail-ChatBubble[name=${conversationName}] .o-mail-ImStatus`).toHaveCount(count);
+    await click(`.o-mail-ChatBubble[name=${conversationName}]`);
+    await contains(`.o-mail-ChatWindow-header:has(:text(${conversationName}))`);
+    expect(
+        `.o-mail-ChatWindow-header:has(:text(${conversationName})) .o-mail-ImStatus`
+    ).toHaveCount(count);
+    await click(`.o-mail-ChatWindow-header:has(:text(${conversationName}))`);
 }


### PR DESCRIPTION
Before this commit, IM status was visible by livechat visitor in chat bubble, i.e. when folding chat window.

This commit hides the showing of IM status for livechat visitors.

Task-5435992

Before / After
<img width="85" height="83" alt="Screenshot 2025-12-22 at 14 40 22" src="https://github.com/user-attachments/assets/8f5a0935-1d08-456e-baad-16651a2ecf00" /> <img width="78" height="71" alt="Screenshot 2025-12-22 at 14 40 35" src="https://github.com/user-attachments/assets/b9e40587-0864-40d3-b321-758368bd5122" />
