### PR TITLE
[FIX] account: correct reverse charge tax with non-deductible part

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1537,6 +1537,17 @@ class AccountTax(models.Model):
             manual_tax_amounts=base_line['manual_tax_amounts'],
             filter_tax_function=base_line['filter_tax_function'],
         )
+
+        # Only python side for professional with reverse charge
+        if base_line['special_type'] == 'non_deductible':
+            taxes_data = taxes_computation['taxes_data']
+            taxes_computation['taxes_data'] = []
+            for tax_data in taxes_data:
+                if not tax_data.get('is_reverse_charge'):
+                    taxes_computation['taxes_data'].append(tax_data)
+                else:
+                    taxes_computation['total_included'] -= tax_data['tax_amount']
+
         rate = base_line['rate']
         tax_details = base_line['tax_details'] = {
             'raw_total_excluded_currency': taxes_computation['total_excluded'],


### PR DESCRIPTION
When combining a Reverse Charge tax (e.g., Intra-Community Acquisition) with a Non-Deductible tax configuration (e.g., 60% Professional Use), the resulting accounting entry for the VAT Payable (Output Tax) was incorrect.

Steps to reproduce:
1. Create a Vendor Bill.
2. Use a Tax configured as both Reverse Charge (e.g., 21%) and partially Non-Deductible (e.g., 40% non-deductible).
3. Set the price to 100.00.

Observed behavior:
- VAT Deductible (Input): 12.60 (Correct: 60% of 21).
- Non-Deductible Expense: 8.40 (Correct: 40% of 21).
- VAT Payable (Output): 12.60 (Incorrect: it was reduced by the non-deductible part).

Expected behavior:
- VAT Payable (Output) should be 21.00. In a Reverse Charge mechanism, the full tax amount must be declared as due, regardless of the deductibility on the input side.

Solution:
Post process the taxes_data in case of professional with reverse-charge so wie will have the Payable part with the hole amount 21 in the previous example


task-5418096

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
