### PR TITLE
[FIX] account_edi_ubl_cii: add invoice date to test invoices

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -576,6 +576,7 @@ class TestAccountEdiUblCii(TestUblCiiCommon):
             'partner_id': self.partner_a.id,
             'move_type': 'out_invoice',
             'fiscal_position_id': fiscal_position.id,
+            'invoice_date': fields.Date.from_string('2025-12-22'),
             'invoice_line_ids': [Command.create({
                 'product_id': self.product_a.id,
                 'tax_ids': [Command.set(tax.ids)],
@@ -584,6 +585,7 @@ class TestAccountEdiUblCii(TestUblCiiCommon):
         local_invoice = self.env['account.move'].create({
             'partner_id': self.partner_b.id,
             'move_type': 'out_invoice',
+            'invoice_date': fields.Date.from_string('2025-12-22'),
             'invoice_line_ids': [Command.create({
                 'product_id': self.product_a.id,
             })],


### PR DESCRIPTION
When merging odoo/odoo#236692, the invoice date was missing on the test invoices. This could lead to issues when there's no qualifying fiscal position. Adding it removes the need to recompute the fiscal position ensuring the correct taxes are applied for the relevant test case.

No task ID