### PR TITLE
[FIX] hr_expense: Fix wrong partner for bank

### DIFF
--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from freezegun import freeze_time
 
 from odoo import Command, fields
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.mail.tests.common import mail_new_test_user
 
@@ -53,7 +54,15 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             'user_id': cls.expense_user_employee.id,
             'expense_manager_id': cls.expense_user_manager.id,
             'work_contact_id': cls.expense_user_employee.partner_id.id,
+            'bank_account_ids': [
+                Command.create({
+                    'acc_number': 'BE68539007547034',
+                    'allow_out_payment': True,
+                    'partner_id': cls.expense_user_employee.partner_id.id,
+            })]
         }).sudo(False)
+
+        cls.expense_employee.user_partner_id.parent_id = cls.env.company.partner_id
 
         # Allow the current accounting user to access the expenses.
         cls.env.user.group_ids |= group_expense_manager
@@ -138,4 +147,5 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
                 'journal_id': self.company_data['default_journal_bank'].id,
                 'payment_method_line_id': self.inbound_payment_method_line.id,
             })
+            self.assertEqual(payment_register.partner_bank_id.partner_id, expenses.employee_id.work_contact_id)
             return payment_register._create_payments()

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -5,9 +5,10 @@ from datetime import date
 from freezegun import freeze_time
 
 from odoo import Command, fields
-from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import tagged, Form
+from odoo.tests import Form, tagged
+
+from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 
 
 @tagged('-at_install', 'post_install')
@@ -149,6 +150,18 @@ class TestExpenses(TestExpenseCommon):
             {'balance':   18.46, 'account_id': tax_account_id,              'name': '15% (copy)',                                'date': date(2021, 10, 11), 'invoice_date': False},
             {'balance': -160.00, 'account_id': company_payment_account_id,  'name': 'expense_employee: Company PB 160 + 2*15%',  'date': date(2021, 10, 11), 'invoice_date': False},
 
+        ])
+
+        # Check lines partners:
+        self.assertRecordValues(expenses_by_employee.account_move_id.line_ids, [
+            # If the test fails, it is probably because the partner is the company's partner instead of the employee's one
+            {'partner_id': employee_partner_id},
+            {'partner_id': employee_partner_id},
+            {'partner_id': employee_partner_id},
+            {'partner_id': employee_partner_id},
+            {'partner_id': employee_partner_id},
+            {'partner_id': employee_partner_id},
+            {'partner_id': employee_partner_id},
         ])
 
         in_payment_state = expenses_by_employee.account_move_id._get_invoice_in_payment_state()


### PR DESCRIPTION
The aim of this commit is to fix the commercial partner id of the move lines to default to the move's partner commercial partner

Steps to reproduce:
- Have a bank account setup for the current company
- Create an employee for a user, sets its `parent_id` to be the current company and set a bank account on the employee
- Create an expense for said employee in `own_account`
- Submit -> Pay flow
- Bank account on the wizard is the company one, not the employee one

After this commit:
- Bank account on the wizard is the employee one, we stop pretending to reimburse them and actually give them money

task-id: 5420587

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
