### PR TITLE
[FIX] point_of_sale: prevent unauthorized access when POS is locked with pos_hr

### DIFF
--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -143,4 +143,13 @@ patch(PosStore.prototype, {
         }
         return await super.allowProductCreation();
     },
+    async handleUrlParams() {
+        if (this.config.module_pos_hr && !this.cashier) {
+            if (this.router.state.current !== "LoginScreen") {
+                this.router.navigate("LoginScreen", {});
+            }
+            return;
+        }
+        return await super.handleUrlParams(...arguments);
+    },
 });


### PR DESCRIPTION
When the POS is locked by an employee (pos_hr module active and no cashier logged in), users could bypass the login screen by using the browser back button.

Steps to reproduce:
-------------------
* Install pos_hr module
* Open a POS session and log in as an employee
* Lock the POS
* Use browser back button to navigate back
> Observation:
The POS reopens without requiring employee login, allowing unauthorized access to protected pages.

Why the fix:
------------
The handleUrlParams method now checks if pos_hr is active and if no cashier is logged in before processing URL parameters. If an unauthenticated user tries to access a protected page (other than LoginScreen), they are automatically redirected to the LoginScreen. This ensures that the POS security is maintained even when using browser navigation.

opw-5400719