### PR TITLE
[FIX] iot_drivers: catch value exception

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -43,23 +43,23 @@ class PrinterDriver(PrinterDriverBase):
         self.print_status()
 
     def _init_escpos(self, device):
-        if device.get('usb_product'):
-            def usb_matcher(usb_device):
-                return (
-                    usb_device.manufacturer and usb_device.manufacturer.lower() == device['usb_manufacturer'] and
-                    usb_device.product == device['usb_product'] and
-                    usb_device.serial_number == device['usb_serial_number']
-                )
-
-            self.escpos_device = printer.Usb(usb_args={"custom_match": usb_matcher})
-        elif device.get('ip'):
-            self.escpos_device = printer.Network(device['ip'], timeout=5)
-        else:
-            return
         try:
+            if device.get('usb_product'):
+                def usb_matcher(usb_device):
+                    return (
+                        usb_device.manufacturer and usb_device.manufacturer.lower() == device['usb_manufacturer'] and
+                        usb_device.product == device['usb_product'] and
+                        usb_device.serial_number == device['usb_serial_number']
+                    )
+
+                self.escpos_device = printer.Usb(usb_args={"custom_match": usb_matcher})
+            elif device.get('ip'):
+                self.escpos_device = printer.Network(device['ip'], timeout=5)
+            else:
+                return
             self.escpos_device.open()
             self.escpos_device.close()
-        except escpos.exceptions.Error as e:
+        except (escpos.exceptions.Error, ValueError) as e:
             _logger.info("%s - Could not initialize escpos class: %s", self.device_name, e)
             self.escpos_device = None
 


### PR DESCRIPTION
This PR fixes the exception thrown by the usb devices incompatible with escpos code.
It fixes the following exception:

```
2025-12-22 14:49:59,724 1433 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/home/pi/odoo/addons/iot_drivers/iot_ha
ndlers/drivers/printer_driver_L.py", line 42, in init
    self._init_escpos(device)
2025-12-22 14:49:59,724 1433 ERROR ? odoo.addons.iot_drivers.exception_logger: ValueError: The device has no langid (permission issue, no string descriptors supported or device error)
```