### PR TITLE
[FIX] l10n_fr_fec: reduce FEC export memory footprint

### DIFF
--- a/addons/l10n_fr_fec/__init__.py
+++ b/addons/l10n_fr_fec/__init__.py
@@ -3,4 +3,5 @@
 
 # Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
 
+from . import controllers
 from . import wizard

--- a/addons/l10n_fr_fec/controllers/__init__.py
+++ b/addons/l10n_fr_fec/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/addons/l10n_fr_fec/controllers/main.py
+++ b/addons/l10n_fr_fec/controllers/main.py
@@ -1,0 +1,14 @@
+from odoo import http
+from odoo.http import request
+
+
+class FecDownloadController(http.Controller):
+    @http.route('/download/fec_file/<int:wizard_id>', type='http', auth='user')
+    def download_fec(self, wizard_id):
+        wizard = request.env['account.fr.fec'].browse(wizard_id)
+        content = wizard._get_fec_stream()
+
+        return request.make_response(content, [
+            ('Content-Type', 'text/csv'),
+            ('Content-Disposition', f'attachment; filename={wizard.filename};')
+        ])

--- a/addons/l10n_fr_fec/tests/test_wizard.py
+++ b/addons/l10n_fr_fec/tests/test_wizard.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
 from datetime import timedelta
 from freezegun import freeze_time
 
@@ -67,7 +66,6 @@ class TestAccountFrFec(AccountTestInvoicingCommon):
         cls.invoice_a.action_post()
 
     def test_generate_fec_sanitize_pieceref(self):
-        self.wizard.generate_fec()
         expected_content = (
             "JournalCode|JournalLib|EcritureNum|EcritureDate|CompteNum|CompteLib|CompAuxNum|CompAuxLib|PieceRef|PieceDate|EcritureLib|Debit|Credit|EcritureLet|DateLet|ValidDate|Montantdevise|Idevise\r\n"
             "INV|Customer Invoices|INV/2021/00001|20210502|701000|Ventes de produits finis|||-|20210502|Hello Darkness|0,00| 000000000001437,12|||20210502|-000000000001437,12|EUR\r\n"
@@ -76,5 +74,7 @@ class TestAccountFrFec(AccountTestInvoicingCommon):
             "INV|Customer Invoices|INV/2021/00001|20210502|445710|TVA collectée|||-|20210502|TVA 20,0%|0,00| 000000000001293,41|||20210502|-000000000001293,41|EUR\r\n"
             f"INV|Customer Invoices|INV/2021/00001|20210502|411100|Clients - Ventes de biens ou de prestations de services|{self.partner_a.id}|partner_a|-|20210502|INV/2021/00001| 000000000007760,45|0,00|||20210502| 000000000007760,45|EUR"
         )
-        content = base64.b64decode(self.wizard.fec_data).decode()
+        data_generator = self.wizard.with_context(fec_test_mode=True)._get_fec_stream()
+        content_bytes = b''.join(list(data_generator))
+        content = content_bytes.decode('utf-8')
         self.assertEqual(expected_content, content)

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -3,11 +3,14 @@
 
 # Copyright (C) 2013-2015 Akretion (http://www.akretion.com)
 
-import base64
+import contextlib
+import csv
 import io
 
+from itertools import chain
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, AccessDenied
+from odoo.modules.registry import Registry
 from odoo.tools import float_is_zero, pycompat
 from odoo.tools.misc import get_lang
 from stdnum.fr import siren
@@ -19,7 +22,7 @@ class AccountFrFec(models.TransientModel):
 
     date_from = fields.Date(string='Start Date', required=True)
     date_to = fields.Date(string='End Date', required=True)
-    fec_data = fields.Binary('FEC File', readonly=True)
+    fec_data = fields.Binary('FEC File', readonly=True)  # This field is not used anymore.
     filename = fields.Char(string='Filename', size=256, readonly=True)
     test_file = fields.Boolean()
     export_type = fields.Selection([
@@ -102,26 +105,8 @@ class AccountFrFec(models.TransientModel):
         else:
             return company.vat
 
-    def generate_fec(self):
-        self.ensure_one()
-        if not (self.env.is_admin() or self.env.user.has_group('account.group_account_user')):
-            raise AccessDenied()
-        # We choose to implement the flat file instead of the XML
-        # file for 2 reasons :
-        # 1) the XSD file impose to have the label on the account.move
-        # but Odoo has the label on the account.move.line, so that's a
-        # problem !
-        # 2) CSV files are easier to read/use for a regular accountant.
-        # So it will be easier for the accountant to check the file before
-        # sending it to the fiscal administration
-        today = fields.Date.today()
-        if self.date_from > today or self.date_to > today:
-            raise UserError(_('You could not set the start date or the end date in the future.'))
-        if self.date_from >= self.date_to:
-            raise UserError(_('The start date must be inferior to the end date.'))
-
-        company = self.env.company
-        company_legal_data = self._get_company_legal_data(company)
+    def _get_fec_stream(self):
+        company_id = self.env.company.id
 
         header = [
             u'JournalCode',    # 0
@@ -144,269 +129,317 @@ class AccountFrFec(models.TransientModel):
             u'Idevise',        # 17
             ]
 
-        rows_to_write = [header]
-        # INITIAL BALANCE
-        unaffected_earnings_account = self.env['account.account'].search([
-            ('account_type', '=', 'equity_unaffected'),
-            ('company_id', '=', company.id)
-        ], limit=1)
-        unaffected_earnings_line = True  # used to make sure that we add the unaffected earning initial balance only once
-        if unaffected_earnings_account:
-            #compute the benefit/loss of last year to add in the initial balance of the current year earnings account
-            unaffected_earnings_results = self._do_query_unaffected_earnings()
-            unaffected_earnings_line = False
-
         if self.pool['account.account'].name.translate:
             lang = self.env.user.lang or get_lang(self.env).code
             aa_name = f"COALESCE(aa.name->>'{lang}', aa.name->>'en_US')"
         else:
             aa_name = "aa.name"
-        sql_query = f'''
-        SELECT
-            'OUV' AS JournalCode,
-            'Balance initiale' AS JournalLib,
-            'OUVERTURE/' || %s AS EcritureNum,
-            %s AS EcritureDate,
-            MIN(aa.code) AS CompteNum,
-            replace(replace(MIN({aa_name}), '|', '/'), '\t', '') AS CompteLib,
-            '' AS CompAuxNum,
-            '' AS CompAuxLib,
-            '-' AS PieceRef,
-            %s AS PieceDate,
-            '/' AS EcritureLib,
-            replace(CASE WHEN sum(aml.balance) <= 0 THEN '0,00' ELSE to_char(SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Debit,
-            replace(CASE WHEN sum(aml.balance) >= 0 THEN '0,00' ELSE to_char(-SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Credit,
-            '' AS EcritureLet,
-            '' AS DateLet,
-            %s AS ValidDate,
-            '' AS Montantdevise,
-            '' AS Idevise,
-            MIN(aa.id) AS CompteID
-        FROM
-            account_move_line aml
-            LEFT JOIN account_move am ON am.id=aml.move_id
-            JOIN account_account aa ON aa.id = aml.account_id
-        WHERE
-            am.date < %s
-            AND am.company_id = %s
-            AND aa.include_initial_balance = 't'
-        '''
 
-        # For official report: only use posted entries
-        if self.export_type == "official":
-            sql_query += '''
-            AND am.state = 'posted'
-            '''
+        def format_row(row):
+            with io.StringIO() as buf:
+                writer = csv.writer(buf, delimiter='|', lineterminator='\r\n')
+                writer.writerow(row)
+                return buf.getvalue().encode()
 
-        sql_query += '''
-        GROUP BY aml.account_id, aa.account_type
-        HAVING aa.account_type not in ('asset_receivable', 'liability_payable') AND round(sum(aml.balance), %s) != 0
-        '''
-        formatted_date_from = fields.Date.to_string(self.date_from).replace('-', '')
-        date_from = self.date_from
-        formatted_date_year = date_from.year
-        currency_digits = 2
+        @contextlib.contextmanager
+        def get_cursor():
+            if self.env.context.get('fec_test_mode'):
+                yield self.env.cr
+            else:
+                with Registry(self.env.cr.dbname).cursor() as cr:
+                    yield cr
 
-        self._cr.execute(
-            sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, self.date_from, company.id,
-                        currency_digits))
+        def stream_header():
+            yield format_row(header)
 
-        for row in self._cr.fetchall():
-            listrow = list(row)
-            account_id = listrow.pop()
-            if not unaffected_earnings_line:
-                account = self.env['account.account'].browse(account_id)
-                if account.account_type == 'equity_unaffected':
-                    #add the benefit/loss of previous fiscal year to the first unaffected earnings account found.
-                    unaffected_earnings_line = True
-                    current_amount = float(listrow[11].replace(',', '.')) - float(listrow[12].replace(',', '.'))
-                    unaffected_earnings_amount = float(unaffected_earnings_results[11].replace(',', '.')) - float(unaffected_earnings_results[12].replace(',', '.'))
-                    listrow_amount = current_amount + unaffected_earnings_amount
-                    if float_is_zero(listrow_amount, precision_digits=currency_digits):
-                        continue
-                    if listrow_amount > 0:
-                        listrow[11] = str(listrow_amount).replace('.', ',')
-                        listrow[12] = '0,00'
-                    else:
-                        listrow[11] = '0,00'
-                        listrow[12] = str(-listrow_amount).replace('.', ',')
-            rows_to_write.append(listrow)
+        def stream_initial_balance():
+            with get_cursor() as cr:
+                fec = self.with_env(self.env(cr=cr))
+                unaffected_earnings_account = fec.env['account.account'].search([
+                    ('account_type', '=', 'equity_unaffected'),
+                    ('company_id', '=', company_id)
+                ], limit=1)
+                unaffected_earnings_line = True  # used to make sure that we add the unaffected earning initial balance only once
+                if unaffected_earnings_account:
+                    # compute the benefit/loss of last year to add in the initial balance of the current year earnings account
+                    unaffected_earnings_results = fec._do_query_unaffected_earnings()
+                    unaffected_earnings_line = False
 
-        #if the unaffected earnings account wasn't in the selection yet: add it manually
-        if (not unaffected_earnings_line
-            and unaffected_earnings_results
-            and (unaffected_earnings_results[11] != '0,00'
-                 or unaffected_earnings_results[12] != '0,00')):
-            #search an unaffected earnings account
-            unaffected_earnings_account = self.env['account.account'].search([('account_type', '=', 'equity_unaffected'),
-                                                                              ('company_id', '=', company.id)], limit=1)
-            if unaffected_earnings_account:
-                unaffected_earnings_results[4] = unaffected_earnings_account.code
-                unaffected_earnings_results[5] = unaffected_earnings_account.name
-            rows_to_write.append(unaffected_earnings_results)
+                sql_query = f'''
+                SELECT
+                    'OUV' AS JournalCode,
+                    'Balance initiale' AS JournalLib,
+                    'OUVERTURE/' || %s AS EcritureNum,
+                    %s AS EcritureDate,
+                    MIN(aa.code) AS CompteNum,
+                    replace(replace(MIN({aa_name}), '|', '/'), '\t', '') AS CompteLib,
+                    '' AS CompAuxNum,
+                    '' AS CompAuxLib,
+                    '-' AS PieceRef,
+                    %s AS PieceDate,
+                    '/' AS EcritureLib,
+                    replace(CASE WHEN sum(aml.balance) <= 0 THEN '0,00' ELSE to_char(SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Debit,
+                    replace(CASE WHEN sum(aml.balance) >= 0 THEN '0,00' ELSE to_char(-SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Credit,
+                    '' AS EcritureLet,
+                    '' AS DateLet,
+                    %s AS ValidDate,
+                    '' AS Montantdevise,
+                    '' AS Idevise,
+                    MIN(aa.id) AS CompteID
+                FROM
+                    account_move_line aml
+                    LEFT JOIN account_move am ON am.id=aml.move_id
+                    JOIN account_account aa ON aa.id = aml.account_id
+                WHERE
+                    am.date < %s
+                    AND am.company_id = %s
+                    AND aa.include_initial_balance = 't'
+                '''
 
-        # INITIAL BALANCE - receivable/payable
-        sql_query = f'''
-        SELECT
-            'OUV' AS JournalCode,
-            'Balance initiale' AS JournalLib,
-            'OUVERTURE/' || %s AS EcritureNum,
-            %s AS EcritureDate,
-            MIN(aa.code) AS CompteNum,
-            replace(MIN({aa_name}), '|', '/') AS CompteLib,
-            CASE WHEN MIN(aa.account_type) IN ('asset_receivable', 'liability_payable')
-            THEN
-                CASE WHEN rp.ref IS null OR rp.ref = ''
-                THEN rp.id::text
-                ELSE replace(rp.ref, '|', '/')
-                END
-            ELSE ''
-            END
-            AS CompAuxNum,
-            CASE WHEN aa.account_type IN ('asset_receivable', 'liability_payable')
-            THEN COALESCE(replace(rp.name, '|', '/'), '')
-            ELSE ''
-            END AS CompAuxLib,
-            '-' AS PieceRef,
-            %s AS PieceDate,
-            '/' AS EcritureLib,
-            replace(CASE WHEN sum(aml.balance) <= 0 THEN '0,00' ELSE to_char(SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Debit,
-            replace(CASE WHEN sum(aml.balance) >= 0 THEN '0,00' ELSE to_char(-SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Credit,
-            '' AS EcritureLet,
-            '' AS DateLet,
-            %s AS ValidDate,
-            '' AS Montantdevise,
-            '' AS Idevise,
-            MIN(aa.id) AS CompteID
-        FROM
-            account_move_line aml
-            LEFT JOIN account_move am ON am.id=aml.move_id
-            LEFT JOIN res_partner rp ON rp.id=aml.partner_id
-            JOIN account_account aa ON aa.id = aml.account_id
-        WHERE
-            am.date < %s
-            AND am.company_id = %s
-            AND aa.include_initial_balance = 't'
-        '''
+                # For official report: only use posted entries
+                if fec.export_type == "official":
+                    sql_query += '''
+                    AND am.state = 'posted'
+                    '''
 
-        # For official report: only use posted entries
-        if self.export_type == "official":
-            sql_query += '''
-            AND am.state = 'posted'
-            '''
+                sql_query += '''
+                GROUP BY aml.account_id, aa.account_type
+                HAVING aa.account_type not in ('asset_receivable', 'liability_payable') AND round(sum(aml.balance), %s) != 0
+                '''
+                formatted_date_from = fields.Date.to_string(fec.date_from).replace('-', '')
+                date_from = fec.date_from
+                formatted_date_year = date_from.year
+                currency_digits = 2
 
-        sql_query += '''
-        GROUP BY aml.account_id, aa.account_type, rp.ref, rp.id
-        HAVING aa.account_type in ('asset_receivable', 'liability_payable') AND round(sum(aml.balance), %s) != 0
-        '''
-        self._cr.execute(
-            sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, self.date_from, company.id,
-                        currency_digits))
+                fec._cr.execute(
+                    sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, fec.date_from, company_id,
+                                currency_digits))
 
-        for row in self._cr.fetchall():
-            listrow = list(row)
-            account_id = listrow.pop()
-            rows_to_write.append(listrow)
+                for row in fec._cr.fetchall():
+                    listrow = list(row)
+                    account_id = listrow.pop()
+                    if not unaffected_earnings_line:
+                        account = fec.env['account.account'].browse(account_id)
+                        if account.account_type == 'equity_unaffected':
+                            # add the benefit/loss of previous fiscal year to the first unaffected earnings account found.
+                            unaffected_earnings_line = True
+                            current_amount = float(listrow[11].replace(',', '.')) - float(listrow[12].replace(',', '.'))
+                            unaffected_earnings_amount = float(unaffected_earnings_results[11].replace(',', '.')) - float(unaffected_earnings_results[12].replace(',', '.'))
+                            listrow_amount = current_amount + unaffected_earnings_amount
+                            if float_is_zero(listrow_amount, precision_digits=currency_digits):
+                                continue
+                            if listrow_amount > 0:
+                                listrow[11] = str(listrow_amount).replace('.', ',')
+                                listrow[12] = '0,00'
+                            else:
+                                listrow[11] = '0,00'
+                                listrow[12] = str(-listrow_amount).replace('.', ',')
+                    yield format_row(listrow)
 
-        # LINES
-        if self.pool['account.journal'].name.translate:
-            lang = self.env.user.lang or get_lang(self.env).code
-            aj_name = f"COALESCE(aj.name->>'{lang}', aj.name->>'en_US')"
-        else:
-            aj_name = "aj.name"
+                # if the unaffected earnings account wasn't in the selection yet: add it manually
+                if (not unaffected_earnings_line
+                    and unaffected_earnings_results
+                    and (unaffected_earnings_results[11] != '0,00'
+                        or unaffected_earnings_results[12] != '0,00')):
+                    # search an unaffected earnings account
+                    unaffected_earnings_account = fec.env['account.account'].search([('account_type', '=', 'equity_unaffected'),
+                                                                                    ('company_id', '=', company_id)], limit=1)
+                    if unaffected_earnings_account:
+                        unaffected_earnings_results[4] = unaffected_earnings_account.code
+                        unaffected_earnings_results[5] = unaffected_earnings_account.name
+                    yield format_row(unaffected_earnings_results)
 
-        query_limit = int(self.env['ir.config_parameter'].sudo().get_param('l10n_fr_fec.batch_size', 500000)) # To prevent memory errors when fetching the results
+                # INITIAL BALANCE - receivable/payable
+                sql_query = f'''
+                SELECT
+                    'OUV' AS JournalCode,
+                    'Balance initiale' AS JournalLib,
+                    'OUVERTURE/' || %s AS EcritureNum,
+                    %s AS EcritureDate,
+                    MIN(aa.code) AS CompteNum,
+                    replace(MIN({aa_name}), '|', '/') AS CompteLib,
+                    CASE WHEN MIN(aa.account_type) IN ('asset_receivable', 'liability_payable')
+                    THEN
+                        CASE WHEN rp.ref IS null OR rp.ref = ''
+                        THEN rp.id::text
+                        ELSE replace(rp.ref, '|', '/')
+                        END
+                    ELSE ''
+                    END
+                    AS CompAuxNum,
+                    CASE WHEN aa.account_type IN ('asset_receivable', 'liability_payable')
+                    THEN COALESCE(replace(rp.name, '|', '/'), '')
+                    ELSE ''
+                    END AS CompAuxLib,
+                    '-' AS PieceRef,
+                    %s AS PieceDate,
+                    '/' AS EcritureLib,
+                    replace(CASE WHEN sum(aml.balance) <= 0 THEN '0,00' ELSE to_char(SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Debit,
+                    replace(CASE WHEN sum(aml.balance) >= 0 THEN '0,00' ELSE to_char(-SUM(aml.balance), '000000000000000D99') END, '.', ',') AS Credit,
+                    '' AS EcritureLet,
+                    '' AS DateLet,
+                    %s AS ValidDate,
+                    '' AS Montantdevise,
+                    '' AS Idevise,
+                    MIN(aa.id) AS CompteID
+                FROM
+                    account_move_line aml
+                    LEFT JOIN account_move am ON am.id=aml.move_id
+                    LEFT JOIN res_partner rp ON rp.id=aml.partner_id
+                    JOIN account_account aa ON aa.id = aml.account_id
+                WHERE
+                    am.date < %s
+                    AND am.company_id = %s
+                    AND aa.include_initial_balance = 't'
+                '''
 
-        sql_query = f'''
-        SELECT
-            REGEXP_REPLACE(replace(aj.code, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS JournalCode,
-            REGEXP_REPLACE(replace({aj_name}, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS JournalLib,
-            REGEXP_REPLACE(replace(am.name, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS EcritureNum,
-            TO_CHAR(am.date, 'YYYYMMDD') AS EcritureDate,
-            aa.code AS CompteNum,
-            REGEXP_REPLACE(replace({aa_name}, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS CompteLib,
-            CASE WHEN aa.account_type IN ('asset_receivable', 'liability_payable')
-            THEN
-                CASE WHEN rp.ref IS null OR rp.ref = ''
-                THEN rp.id::text
-                ELSE replace(rp.ref, '|', '/')
-                END
-            ELSE ''
-            END
-            AS CompAuxNum,
-            CASE WHEN aa.account_type IN ('asset_receivable', 'liability_payable')
-            THEN COALESCE(REGEXP_REPLACE(replace(rp.name, '|', '/'), '[\\t\\r\\n]', ' ', 'g'), '')
-            ELSE ''
-            END AS CompAuxLib,
-            CASE WHEN am.ref IS null OR am.ref = ''
-            THEN '-'
-            ELSE REGEXP_REPLACE(replace(am.ref, '|', '/'), '[\\t\\r\\n]', ' ', 'g')
-            END
-            AS PieceRef,
-            TO_CHAR(COALESCE(am.invoice_date, am.date), 'YYYYMMDD') AS PieceDate,
-            CASE WHEN aml.name IS NULL OR aml.name = '' THEN '/'
-                WHEN aml.name SIMILAR TO '[\\t|\\s|\\n]*' THEN '/'
-                ELSE REGEXP_REPLACE(replace(aml.name, '|', '/'), '[\\t\\n\\r]', ' ', 'g') END AS EcritureLib,
-            replace(CASE WHEN aml.debit = 0 THEN '0,00' ELSE to_char(aml.debit, '000000000000000D99') END, '.', ',') AS Debit,
-            replace(CASE WHEN aml.credit = 0 THEN '0,00' ELSE to_char(aml.credit, '000000000000000D99') END, '.', ',') AS Credit,
-            CASE WHEN rec.name IS NULL THEN '' ELSE rec.name END AS EcritureLet,
-            CASE WHEN aml.full_reconcile_id IS NULL THEN '' ELSE TO_CHAR(rec.create_date, 'YYYYMMDD') END AS DateLet,
-            TO_CHAR(am.date, 'YYYYMMDD') AS ValidDate,
-            CASE
-                WHEN aml.amount_currency IS NULL OR aml.amount_currency = 0 THEN ''
-                ELSE replace(to_char(aml.amount_currency, '000000000000000D99'), '.', ',')
-            END AS Montantdevise,
-            CASE WHEN aml.currency_id IS NULL THEN '' ELSE rc.name END AS Idevise
-        FROM
-            account_move_line aml
-            LEFT JOIN account_move am ON am.id=aml.move_id
-            LEFT JOIN res_partner rp ON rp.id=aml.partner_id
-            JOIN account_journal aj ON aj.id = am.journal_id
-            JOIN account_account aa ON aa.id = aml.account_id
-            LEFT JOIN res_currency rc ON rc.id = aml.currency_id
-            LEFT JOIN account_full_reconcile rec ON rec.id = aml.full_reconcile_id
-        WHERE
-            am.date >= %s
-            AND am.date <= %s
-            AND am.company_id = %s
-            {"AND am.state = 'posted'" if self.export_type == 'official' else ""}
-        ORDER BY
-            am.date,
-            am.name,
-            aml.id
-        LIMIT %s
-        OFFSET %s
-        '''
+                # For official report: only use posted entries
+                if fec.export_type == "official":
+                    sql_query += '''
+                    AND am.state = 'posted'
+                    '''
 
-        with io.BytesIO() as fecfile:
-            csv_writer = pycompat.csv_writer(fecfile, delimiter='|', lineterminator='')
+                sql_query += '''
+                GROUP BY aml.account_id, aa.account_type, rp.ref, rp.id
+                HAVING aa.account_type in ('asset_receivable', 'liability_payable') AND round(sum(aml.balance), %s) != 0
+                '''
+                fec._cr.execute(
+                    sql_query, (formatted_date_year, formatted_date_from, formatted_date_from, formatted_date_from, fec.date_from, company_id,
+                                currency_digits))
 
-            # Write header and initial balances
-            for initial_row in rows_to_write:
-                initial_row = list(initial_row)
-                # We don't skip \n at then end of the file if there are only initial balances, for simplicity. An empty period export shouldn't happen IRL.
-                initial_row[-1] += u'\r\n'
-                csv_writer.writerow(initial_row)
+                for row in fec._cr.fetchall():
+                    listrow = list(row)
+                    account_id = listrow.pop()
+                    yield format_row(listrow)
 
-            # Write current period's data
-            query_offset = 0
-            has_more_results = True
-            while has_more_results:
-                self._cr.execute(
-                    sql_query,
-                    (self.date_from, self.date_to, company.id, query_limit + 1, query_offset)
-                )
-                query_offset += query_limit
-                has_more_results = self._cr.rowcount > query_limit # we load one more result than the limit to check if there is more
-                query_results = self._cr.fetchall()
-                for i, row in enumerate(query_results[:query_limit]):
-                    if i < len(query_results) - 1:
-                        # The file is not allowed to end with an empty line, so we can't use lineterminator on the writer
+        def stream_lines():
+            with get_cursor() as cr:
+                fec = self.with_env(self.env(cr=cr))
+                if fec.pool['account.journal'].name.translate:
+                    lang = fec.env.user.lang or get_lang(fec.env).code
+                    aj_name = f"COALESCE(aj.name->>'{lang}', aj.name->>'en_US')"
+                else:
+                    aj_name = "aj.name"
+
+                query_limit = int(fec.env['ir.config_parameter'].sudo().get_param('l10n_fr_fec.batch_size', 500000))  # To prevent memory errors when fetching the results
+
+                sql_query = f'''
+                SELECT
+                    REGEXP_REPLACE(replace(aj.code, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS JournalCode,
+                    REGEXP_REPLACE(replace({aj_name}, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS JournalLib,
+                    REGEXP_REPLACE(replace(am.name, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS EcritureNum,
+                    TO_CHAR(am.date, 'YYYYMMDD') AS EcritureDate,
+                    aa.code AS CompteNum,
+                    REGEXP_REPLACE(replace({aa_name}, '|', '/'), '[\\t\\r\\n]', ' ', 'g') AS CompteLib,
+                    CASE WHEN aa.account_type IN ('asset_receivable', 'liability_payable')
+                    THEN
+                        CASE WHEN rp.ref IS null OR rp.ref = ''
+                        THEN rp.id::text
+                        ELSE replace(rp.ref, '|', '/')
+                        END
+                    ELSE ''
+                    END
+                    AS CompAuxNum,
+                    CASE WHEN aa.account_type IN ('asset_receivable', 'liability_payable')
+                    THEN COALESCE(REGEXP_REPLACE(replace(rp.name, '|', '/'), '[\\t\\r\\n]', ' ', 'g'), '')
+                    ELSE ''
+                    END AS CompAuxLib,
+                    CASE WHEN am.ref IS null OR am.ref = ''
+                    THEN '-'
+                    ELSE REGEXP_REPLACE(replace(am.ref, '|', '/'), '[\\t\\r\\n]', ' ', 'g')
+                    END
+                    AS PieceRef,
+                    TO_CHAR(COALESCE(am.invoice_date, am.date), 'YYYYMMDD') AS PieceDate,
+                    CASE WHEN aml.name IS NULL OR aml.name = '' THEN '/'
+                        WHEN aml.name SIMILAR TO '[\\t|\\s|\\n]*' THEN '/'
+                        ELSE REGEXP_REPLACE(replace(aml.name, '|', '/'), '[\\t\\n\\r]', ' ', 'g') END AS EcritureLib,
+                    replace(CASE WHEN aml.debit = 0 THEN '0,00' ELSE to_char(aml.debit, '000000000000000D99') END, '.', ',') AS Debit,
+                    replace(CASE WHEN aml.credit = 0 THEN '0,00' ELSE to_char(aml.credit, '000000000000000D99') END, '.', ',') AS Credit,
+                    CASE WHEN rec.name IS NULL THEN '' ELSE rec.name END AS EcritureLet,
+                    CASE WHEN aml.full_reconcile_id IS NULL THEN '' ELSE TO_CHAR(rec.create_date, 'YYYYMMDD') END AS DateLet,
+                    TO_CHAR(am.date, 'YYYYMMDD') AS ValidDate,
+                    CASE
+                        WHEN aml.amount_currency IS NULL OR aml.amount_currency = 0 THEN ''
+                        ELSE replace(to_char(aml.amount_currency, '000000000000000D99'), '.', ',')
+                    END AS Montantdevise,
+                    CASE WHEN aml.currency_id IS NULL THEN '' ELSE rc.name END AS Idevise
+                FROM
+                    account_move_line aml
+                    LEFT JOIN account_move am ON am.id=aml.move_id
+                    LEFT JOIN res_partner rp ON rp.id=aml.partner_id
+                    JOIN account_journal aj ON aj.id = am.journal_id
+                    JOIN account_account aa ON aa.id = aml.account_id
+                    LEFT JOIN res_currency rc ON rc.id = aml.currency_id
+                    LEFT JOIN account_full_reconcile rec ON rec.id = aml.full_reconcile_id
+                WHERE
+                    am.date >= %s
+                    AND am.date <= %s
+                    AND am.company_id = %s
+                    {"AND am.state = 'posted'" if fec.export_type == 'official' else ""}
+                ORDER BY
+                    am.date,
+                    am.name,
+                    aml.id
+                LIMIT %s
+                OFFSET %s
+                '''
+
+                query_offset = 0
+                has_more_results = True
+                while has_more_results:
+                    fec._cr.execute(
+                        sql_query,
+                        (fec.date_from, fec.date_to, company_id, query_limit + 1, query_offset)
+                    )
+                    query_offset += query_limit
+                    has_more_results = fec._cr.rowcount > query_limit  # we load one more result than the limit to check if there is more
+                    query_results = fec._cr.fetchall()
+                    for row in query_results[:query_limit]:
                         row = list(row)
-                        row[-1] += u'\r\n'
-                    csv_writer.writerow(row)
+                        yield format_row(row)
 
-            base64_result = base64.encodebytes(fecfile.getvalue())
+        def remove_trailing_newline(rows_iterator):
+            """
+            Remove the trailing newline characters (\r\n) from the last row.
+
+            Each row in the iterator ends with '\r\n', but the FEC file format
+            requires no trailing newline after the final row. This function
+            yields all rows unchanged except the last one, which has its
+            trailing 2 characters (the \r\n) stripped.
+            """
+            try:
+                current_row = next(rows_iterator)
+            except StopIteration:
+                return
+
+            for next_row in rows_iterator:
+                yield current_row
+                current_row = next_row
+
+            yield current_row[:-2]
+
+        return remove_trailing_newline(chain(stream_header(), stream_initial_balance(), stream_lines()))
+
+    def generate_fec(self):
+        self.ensure_one()
+        if not (self.env.is_admin() or self.env.user.has_group('account.group_account_user')):
+            raise AccessDenied()
+        # We choose to implement the flat file instead of the XML
+        # file for 2 reasons :
+        # 1) the XSD file impose to have the label on the account.move
+        # but Odoo has the label on the account.move.line, so that's a
+        # problem !
+        # 2) CSV files are easier to read/use for a regular accountant.
+        # So it will be easier for the accountant to check the file before
+        # sending it to the fiscal administration
+        today = fields.Date.today()
+        if self.date_from > today or self.date_to > today:
+            raise UserError(_('You could not set the start date or the end date in the future.'))
+        if self.date_from >= self.date_to:
+            raise UserError(_('The start date must be inferior to the end date.'))
+
+        company = self.env.company
+        company_legal_data = self._get_company_legal_data(company)
 
         end_date = fields.Date.to_string(self.date_to).replace('-', '')
         suffix = ''
@@ -414,7 +447,6 @@ class AccountFrFec(models.TransientModel):
             suffix = '-NONOFFICIAL'
 
         self.write({
-            'fec_data': base64_result,
             # Filename = <siren>FECYYYYMMDD where YYYMMDD is the closing date
             'filename': '%sFEC%s%s.csv' % (company_legal_data, end_date, suffix),
             })
@@ -426,7 +458,7 @@ class AccountFrFec(models.TransientModel):
         return {
             'name': 'FEC',
             'type': 'ir.actions.act_url',
-            'url': "web/content/?model=account.fr.fec&id=" + str(self.id) + "&filename_field=filename&field=fec_data&download=true&filename=" + self.filename,
+            'url': f'/download/fec_file/{self.id}',
             'target': 'self',
         }
 


### PR DESCRIPTION
On large databases (millions of account moves), The FEC exported file can be huge.
This resulted in memory error since at some point we have the entire file in memory.

This commit aims to overcome this issue by streaming the content of the file to the user.

task-5404142