### PR TITLE
[IMP] html_builder, *: move button styles option to sidebar

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -189,7 +189,7 @@ export class Builder extends Component {
                     ),
                 snippetModel: this.snippetModel,
                 updateInvisibleElementsPanel: () => this.updateInvisibleEls(),
-                allowCustomStyle: true,
+                hideStylingInLinkPopover: true,
                 allowTargetBlank: true,
                 dropImageAsAttachment: true,
                 getAnimateTextConfig: () => ({ editor: this.editor, editorBus: this.editorBus }),

--- a/addons/html_builder/static/src/core/compatibility_inline_border_removal_plugin.js
+++ b/addons/html_builder/static/src/core/compatibility_inline_border_removal_plugin.js
@@ -24,10 +24,9 @@ export class CompatibilityInlineBorderRemovalPlugin extends Plugin {
     // variables is done at class level using "border" and "rounded" classes, so
     // eventual border-width/radius styles must be removed because they would
     // otherwise take precedence.
-    removeInlineBorderIfNecessary({ editingElement, params }) {
+    removeInlineBorderIfNecessary({ editingElement, styleName }) {
         const newStyleBeingEdited = NEW_STYLES.find(
-            (style) =>
-                params.mainParam === style || CSS_SHORTHANDS[style].includes(params.mainParam)
+            (style) => styleName === style || CSS_SHORTHANDS[style].includes(styleName)
         );
         if (newStyleBeingEdited && OLD_STYLES.some((style) => editingElement.style[style])) {
             // Remove all old inline styles related to border-width/radius as

--- a/addons/html_builder/static/src/core/core_builder_action_plugin.js
+++ b/addons/html_builder/static/src/core/core_builder_action_plugin.js
@@ -302,29 +302,23 @@ export class StyleAction extends BuilderAction {
         return currentValue === value;
     }
     apply({ editingElement, params = {}, value }) {
-        const { mainParam: styleName, ...styleParams } = params;
-        if (
-            !this.delegateTo("apply_custom_css_style", {
-                editingElement,
-                styleName,
-                value,
-                params: styleParams,
-            })
-        ) {
-            this.applyCssStyle({ editingElement, params, value });
-        }
-    }
-    applyCssStyle({ editingElement, params = {}, value }) {
-        params = { ...params };
-        const styleName = params.mainParam;
-        delete params.mainParam;
         // Disable all transitions for the duration of the method as many
         // comparisons will be done on the element to know if applying a
         // property has an effect or not. Also, changing a css property via the
         // editor should not show any transition as previews would not be done
         // immediately, which is not good for the user experience.
         withoutTransition(editingElement, () => {
-            setStyle(editingElement, styleName, value, params);
+            const { mainParam: styleName, ...styleParams } = params;
+            if (
+                !this.delegateTo("apply_custom_css_style", {
+                    editingElement,
+                    styleName,
+                    value,
+                    params: styleParams,
+                })
+            ) {
+                setStyle(editingElement, styleName, value, styleParams);
+            }
         });
     }
     _getValueWithoutTransition(el, styleName) {

--- a/addons/html_builder/static/src/core/core_builder_action_plugin.js
+++ b/addons/html_builder/static/src/core/core_builder_action_plugin.js
@@ -14,8 +14,9 @@ import { getValueFromVar } from "@html_builder/utils/utils";
 /**
  * @typedef {((
  *      editingElement: HTMLElement,
- *      params: ActionParams,
+ *      styleName: string,
  *      value: ActionValue,
+ *      params?: ActionParams,
  * ) => boolean)[]} apply_custom_css_style
  */
 
@@ -301,7 +302,15 @@ export class StyleAction extends BuilderAction {
         return currentValue === value;
     }
     apply({ editingElement, params = {}, value }) {
-        if (!this.delegateTo("apply_custom_css_style", { editingElement, params, value })) {
+        const { mainParam: styleName, ...styleParams } = params;
+        if (
+            !this.delegateTo("apply_custom_css_style", {
+                editingElement,
+                styleName,
+                value,
+                params: styleParams,
+            })
+        ) {
             this.applyCssStyle({ editingElement, params, value });
         }
     }

--- a/addons/html_builder/static/src/core/editor.edit.scss
+++ b/addons/html_builder/static/src/core/editor.edit.scss
@@ -126,3 +126,11 @@ $-editor-messages-margin-x: 2%;
 [data-snippet].o_snippet_previewing_on_drag > *:not(.o_snippet_drag_preview) {
     display: none !important;
 }
+
+.o_we_force_no_transition {
+    // Note: this is forced through a CSS class instead of inline style to avoid
+    // overridding existing inline styles or forgetting to restore them as the
+    // code evolves. We may need to increase the CSS priority of this. It will
+    // also not work to override important inline style... this is a limitation.
+    transition: none !important;
+}

--- a/addons/html_builder/static/src/plugins/button_style_option.js
+++ b/addons/html_builder/static/src/plugins/button_style_option.js
@@ -1,0 +1,127 @@
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { BuilderColorPicker } from "@html_builder/core/building_blocks/builder_colorpicker";
+import { BuilderSelect } from "@html_builder/core/building_blocks/builder_select";
+import { BuilderSelectItem } from "@html_builder/core/building_blocks/builder_select_item";
+import { BuilderNumberInput } from "@html_builder/core/building_blocks/builder_number_input";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { StyleAction, withoutTransition } from "@html_builder/core/core_builder_action_plugin";
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
+import {
+    BUTTON_SHAPES,
+    BUTTON_SIZES,
+    BUTTON_TYPES,
+    computeButtonClasses,
+    getButtonShape,
+    getButtonSize,
+    getButtonType,
+} from "@html_editor/utils/button_style";
+
+class ButtonStyleOptionPlugin extends Plugin {
+    static id = "buttonStyleOption";
+    resources = {
+        builder_options: [ButtonStyleOption],
+        builder_actions: { ButtonStyleAction, ButtonFillColorAction },
+    };
+}
+
+export class ButtonStyleOption extends BaseOptionComponent {
+    static template = "html_builder.ButtonStyleOption";
+    static selector = ".btn";
+    static dependencies = [];
+    static components = {
+        BuilderColorPicker,
+        BuilderSelect,
+        BuilderSelectItem,
+        BuilderNumberInput,
+        BorderConfigurator,
+    };
+
+    buttonSizesData = BUTTON_SIZES;
+    buttonShapesData = BUTTON_SHAPES;
+    buttonTypesData = BUTTON_TYPES;
+
+    setup() {
+        super.setup();
+
+        const editingElement = this.env.getEditingElement();
+        const computedStyle =
+            editingElement.ownerDocument.defaultView.getComputedStyle(editingElement);
+        this.state = useDomState((el) => ({
+            type: getButtonType(el),
+            textColor: computedStyle.color,
+            fillColor: computedStyle.backgroundColor,
+            border: computedStyle.border,
+        }));
+    }
+}
+
+class ButtonStyleAction extends BuilderAction {
+    static id = "buttonStyleAction";
+    static dependencies = [];
+
+    apply({ editingElement, params, value }) {
+        const mode = params.mainParam;
+        if (mode === "type") {
+            this.applyDefaultInlineStyle(editingElement, value);
+        }
+
+        editingElement.className = computeButtonClasses(editingElement, {
+            type: mode === "type" ? value : getButtonType(editingElement),
+            size: mode === "size" ? value : getButtonSize(editingElement),
+            shape: mode === "shape" ? value : getButtonShape(editingElement),
+        });
+    }
+
+    applyDefaultInlineStyle(el, currentType) {
+        const styleProps = ["color", "backgroundColor", "backgroundImage", "border"];
+        if (currentType === "custom") {
+            withoutTransition(el, () => {
+                const computedStyle = el.ownerDocument.defaultView.getComputedStyle(el);
+                for (const prop of styleProps) {
+                    if (computedStyle[prop] !== "none") {
+                        el.style[prop] = computedStyle[prop];
+                    }
+                }
+                if (computedStyle.borderStyle === "none") {
+                    el.style.borderStyle = "solid";
+                }
+            });
+        } else {
+            for (const prop of styleProps) {
+                el.style[prop] = "";
+            }
+        }
+    }
+
+    getValue({ editingElement, params }) {
+        const mode = params.mainParam;
+        switch (mode) {
+            case "type":
+                return getButtonType(editingElement);
+            case "size":
+                return getButtonSize(editingElement);
+            case "shape":
+                return getButtonShape(editingElement);
+        }
+    }
+
+    isApplied({ editingElement, params, value }) {
+        return this.getValue({ editingElement, params }) === value;
+    }
+}
+
+class ButtonFillColorAction extends StyleAction {
+    static id = "buttonFillColorAction";
+    static dependencies = ["color"];
+
+    getValue(context) {
+        // This override is needed because when the button is in outline mode,
+        // the color is not shown unless we hover the button
+        const { editingElement: el } = context;
+        return el.style.backgroundColor || el.style.backgroundImage || super.getValue(context);
+    }
+}
+
+registry.category("builder-plugins").add(ButtonStyleOptionPlugin.id, ButtonStyleOptionPlugin);

--- a/addons/html_builder/static/src/plugins/button_style_option.xml
+++ b/addons/html_builder/static/src/plugins/button_style_option.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.ButtonStyleOption">
+    <BuilderRow label.translate="Type">
+        <BuilderSelect action="'buttonStyleAction'" actionParam="'type'">
+            <t t-foreach="this.buttonTypesData.slice(1)" t-as="opt" t-key="opt.type">
+                <BuilderSelectItem actionValue="opt.type" preview="opt.type !== 'custom'">
+                    <t t-esc="opt.label"/>
+                </BuilderSelectItem>
+            </t>
+        </BuilderSelect>
+    </BuilderRow>
+
+    <t t-if="state.type === 'custom'">
+        <BuilderRow label.translate="Text" level="1">
+            <BuilderColorPicker styleAction="'color'" enabledTabs="['solid', 'custom']" />
+        </BuilderRow>
+        <BuilderRow label.translate="Fill" level="1">
+            <BuilderColorPicker action="'buttonFillColorAction'" actionParam="{ mainParam: 'background-color', allowImportant: false }" enabledTabs="['solid', 'custom', 'gradient']" />
+        </BuilderRow>
+        <BorderConfigurator label.translate="Border" withRoundCorner="false" withBSClass="false" />
+    </t>
+
+    <BuilderRow label.translate="Size">
+        <BuilderSelect action="'buttonStyleAction'" actionParam="'size'">
+            <t t-foreach="this.buttonSizesData" t-as="sizeData" t-key="sizeData.size">
+                <BuilderSelectItem actionValue="sizeData.size">
+                    <t t-esc="sizeData.label"/>
+                </BuilderSelectItem>
+            </t>
+        </BuilderSelect>
+    </BuilderRow>
+    <BuilderRow label.translate="Shape">
+        <BuilderSelect action="'buttonStyleAction'" actionParam="'shape'">
+            <t t-foreach="this.buttonShapesData" t-as="shapeData" t-key="shapeData.shape">
+                <BuilderSelectItem actionValue="shapeData.shape">
+                    <t t-esc="shapeData.label"/>
+                </BuilderSelectItem>
+            </t>
+        </BuilderSelect>
+    </BuilderRow>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -400,31 +400,25 @@ export function applyNeededCss(
         el.style.setProperty(cssProp, cssValue, allowImportant ? "important" : "");
         return true;
     }
-    el.style.removeProperty(cssProp);
-    if (
+
+    const isChangeNeeded = () =>
         !areCssValuesEqual(
             computedStyle.getPropertyValue(cssProp),
             cssValue,
             cssProp,
             computedStyle
-        )
-    ) {
-        el.style.setProperty(cssProp, cssValue);
-        // If change had no effect then make it important.
-        if (
-            allowImportant &&
-            !areCssValuesEqual(
-                computedStyle.getPropertyValue(cssProp),
-                cssValue,
-                cssProp,
-                computedStyle
-            )
-        ) {
-            el.style.setProperty(cssProp, cssValue, "important");
-        }
-        return true;
+        );
+    el.style.removeProperty(cssProp);
+    if (!isChangeNeeded()) {
+        return false;
     }
-    return false;
+
+    el.style.setProperty(cssProp, cssValue);
+    // If change had no effect then make it important.
+    if (allowImportant && isChangeNeeded()) {
+        el.style.setProperty(cssProp, cssValue, "important");
+    }
+    return true;
 }
 
 const builderStylesheet = new CSSStyleSheet();

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -2,6 +2,7 @@ import {
     addBuilderAction,
     addBuilderOption,
     setupHTMLBuilder,
+    waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent } from "@html_builder/core/utils";
@@ -442,4 +443,35 @@ test("the color picker opens on click after it has been remounted", async () => 
     await contains(".o_we_color_preview").click();
     await waitSidebarUpdated();
     expect(".o-hb-colorpicker-popover").toHaveCount(1);
+});
+
+test("should work with force and allowImportant params", async () => {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderColorPicker styleAction="{ mainParam: 'color', force: true, allowImportant: false }" enabledTabs="['custom']"/>`;
+        }
+    );
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderColorPicker styleAction="{ mainParam: 'background-color', force: true, allowImportant: true }" enabledTabs="['custom']"/>`;
+        }
+    );
+    await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+
+    await contains(":iframe .test-options-target").click();
+
+    await contains(".we-bg-options-container .o_we_color_preview:nth-child(1)").click();
+    await contains(".o_colorpicker_widget .o_hex_input").edit("#0000FF");
+    await waitForEndOfOperation();
+    expect(":iframe .test-options-target").toHaveStyle("color: rgb(0, 0, 255)", { inline: true });
+
+    await contains(".we-bg-options-container .o_we_color_preview:nth-child(2)").click();
+    await contains(".o_colorpicker_widget .o_hex_input").edit("#0000FF");
+    await waitForEndOfOperation();
+    expect(":iframe .test-options-target").toHaveStyle(
+        "background-color: rgb(0, 0, 255) !important",
+        { inline: true }
+    );
 });

--- a/addons/html_builder/static/tests/options/button_style_option.test.js
+++ b/addons/html_builder/static/tests/options/button_style_option.test.js
@@ -1,0 +1,189 @@
+import { contains } from "@web/../tests/web_test_helpers";
+import { setupHTMLBuilder } from "@html_builder/../tests/helpers";
+import { expect, test, queryOne, describe } from "@odoo/hoot";
+
+describe.current.tags("desktop");
+
+test("popover should only show the label and url inputs", async () => {
+    const { getEditor } = await setupHTMLBuilder(
+        '<p><a href="https://test.com/" class="btn btn-custom">Link label</a></p>'
+    );
+    getEditor().shared.selection.setSelection({
+        anchorNode: queryOne(":iframe p > a"),
+        anchorOffset: 1,
+    });
+    await contains(".o-we-linkpopover .o_we_edit_link").click();
+    expect(".o-we-linkpopover .input-group").toHaveCount(2, {
+        message: "Only the label and url inputs should be present",
+    });
+    expect(".o-we-linkpopover .o_we_label_link").toHaveValue("Link label");
+    expect(".o-we-linkpopover .o_we_href_input_link").toHaveValue("https://test.com/");
+    expect(".o-we-linkpopover [name='link_type']").toHaveCount(0);
+    expect(".o-we-linkpopover [name='link_style_size']").toHaveCount(0);
+    expect(".o-we-linkpopover [name='link_style_shape']").toHaveCount(0);
+});
+
+test("closing popover should not remove style", async () => {
+    const { getEditor } = await setupHTMLBuilder(
+        '<p><a href="https://test.com/" class="btn btn-custom" style="color: rgb(0, 255, 0);">Link label</a></p>'
+    );
+    getEditor().shared.selection.setSelection({
+        anchorNode: queryOne(":iframe p > a"),
+        anchorOffset: 1,
+    });
+    await contains(".o-we-linkpopover .o_we_edit_link").click();
+    await contains(".o-we-linkpopover [title='Advanced mode']").click();
+    await contains(":iframe").click();
+
+    expect(":iframe p > a").toHaveStyle("color: rgb(0, 255, 0)", { inline: true });
+});
+
+test("should load the current style", async () => {
+    await setupHTMLBuilder(
+        '<p><a href="http://test.com/" class="btn btn-secondary">Link label</a></p>',
+        {
+            styleContent:
+                "p > a.btn { color: #ff0000; background-color: #00ff00; border: 5px dashed #0000ff; }",
+        }
+    );
+    await contains(":iframe p > a").click();
+
+    await contains("[data-label=Type] .o-hb-select-toggle").click();
+    await contains(".o_popover .dropdown-item:contains('Custom')").click();
+
+    expect(":iframe p > a").toHaveStyle(
+        {
+            "background-color": "rgb(0, 255, 0)",
+            border: "5px dashed rgb(0, 0, 255)",
+            color: "rgb(255, 0, 0)",
+        },
+        { inline: true }
+    );
+});
+
+test("should load the current custom style correctly", async () => {
+    await setupHTMLBuilder(
+        '<p><a href="https://test.com/" class="btn btn-custom" style="color: rgb(0, 255, 0); background-color: rgb(0, 0, 255); border-width: 4px; border-color: rgb(255, 0, 0); border-style: dotted;">Link label</a></p>'
+    );
+    await contains(":iframe p > a").click();
+
+    expect("[data-label=Type] .o-hb-select-toggle").toHaveText("Custom");
+    expect("[data-label=Text] .o_we_color_preview").toHaveStyle("background-color: rgb(0, 255, 0)");
+    expect("[data-label=Fill] .o_we_color_preview").toHaveStyle("background-color: rgb(0, 0, 255)");
+    expect("[data-label=Border] .o-hb-input-number").toHaveValue("4");
+    expect("[data-label=Border] .o-hb-select-toggle .o-hb-border-preview").toHaveStyle(
+        "border-style: dotted",
+        { inline: true }
+    );
+    expect("[data-label=Border] .o_we_color_preview").toHaveStyle(
+        "background-color: rgb(255, 0, 0)"
+    );
+});
+
+test("should not have the link option type", async () => {
+    await setupHTMLBuilder('<p><a href="https://test.com/" class="btn">Link label</a></p>');
+
+    await contains(":iframe p > a").click();
+
+    await contains("[data-label=Type] .o-hb-select-toggle").click();
+
+    expect(".o_popover .dropdown-item").toHaveCount(3);
+    expect(".o_popover .dropdown-item:contains('Link')").toHaveCount(0);
+});
+
+test("should correctly set custom style on button", async () => {
+    await setupHTMLBuilder('<p><a href="https://test.com/" class="btn">Link label</a></p>');
+
+    await contains(":iframe p > a").click();
+
+    await contains("[data-label=Type] .o-hb-select-toggle").click();
+    await contains(".o_popover .dropdown-item:contains('Custom')").click();
+
+    await contains("[data-label=Text] .o_we_color_preview").click();
+    await contains(".o_color_button[data-color='#FF0000']").click();
+
+    await contains("[data-label=Fill] .o_we_color_preview").click();
+    await contains(".o_color_button[data-color='#00FF00']").click();
+
+    await contains("[data-label=Border] .o-hb-input-number").edit("6");
+
+    await contains("[data-label=Border] .o_we_color_preview").click();
+    await contains(".o_color_button[data-color='#0000FF']").click();
+
+    await contains("[data-label=Border] .o-hb-select-toggle").click();
+    await contains(".o_popover .dropdown-item[data-action-value=dotted]").click();
+
+    expect(":iframe p > a").toHaveClass("btn btn-custom");
+    expect(":iframe p > a").toHaveStyle(
+        {
+            "background-color": "rgb(0, 255, 0)",
+            border: "6px dotted rgb(0, 0, 255)",
+            color: "rgb(255, 0, 0)",
+        },
+        { inline: true }
+    );
+});
+
+test("fill gradient should be stored as background-image", async () => {
+    await setupHTMLBuilder(
+        '<p><a href="http://test.com/" class="btn btn-custom">Link label</a></p>'
+    );
+
+    await contains(":iframe p > a").click();
+
+    await contains("[data-label=Fill] .o_we_color_preview").click();
+    await contains(".gradient-tab").click();
+    await contains(".o_gradient_color_button").click();
+
+    expect(":iframe p > a").toHaveStyle(
+        {
+            "background-image":
+                "linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%)",
+        },
+        { inline: true }
+    );
+});
+
+test("border works even if current border style is none", async () => {
+    await setupHTMLBuilder('<p><a href="http://test.com/" class="btn">Link label</a></p>', {
+        styleContent: "p > a { border: 0px none rgba(0, 0, 0, 0); }",
+    });
+
+    await contains(":iframe p > a").click();
+
+    await contains("[data-label=Type] .o-hb-select-toggle").click();
+    await contains(".o_popover .dropdown-item:contains('Custom')").click();
+
+    expect("[data-label=Border] .o-hb-input-number").toHaveValue("0");
+
+    await contains("[data-label=Border] .o-hb-input-number").edit("4");
+
+    expect("[data-label=Border] .o-hb-input-number").toHaveValue("4");
+    expect("[data-label=Border] .o-hb-select-toggle .o-hb-border-preview").toHaveStyle(
+        "border-style: solid",
+        { inline: true }
+    );
+    expect("[data-label=Border] .o_we_color_preview").toHaveStyle(
+        "background-color: rgba(0, 0, 0, 0)",
+        { inline: true }
+    );
+    expect(":iframe p > a").toHaveStyle(
+        {
+            border: "4px solid rgba(0, 0, 0, 0)",
+        },
+        { inline: true }
+    );
+
+    await contains("[data-label=Border] .o_we_color_preview").click();
+    await contains(".o_color_button[data-color='#0000FF']").click();
+
+    await contains("[data-label=Border] .o-hb-select-toggle").click();
+    await contains(".o_popover .dropdown-item[data-action-value=dotted]").click();
+
+    expect(":iframe p > a").toHaveStyle(
+        {
+            border: "4px dotted rgb(0, 0, 255)",
+        },
+        { inline: true }
+    );
+});

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -34,7 +34,7 @@ const COLOR_COMBINATION_SELECTOR = COLOR_COMBINATION_CLASSES.map((c) => `.${c}`)
  */
 
 /**
- * @typedef {((element: HTMLElement, cssProp: string, color: string) => boolean)[]} apply_color_style_overrides
+ * @typedef {((element: HTMLElement, cssProp: string, color: string, params: Object) => boolean)[]} apply_color_style_overrides
  * @typedef {((color: string, mode: "color" | "backgroundColor") => void)[]} color_apply_overrides
  * @typedef {((color: string, mode: "color" | "backgroundColor") => string)[]} apply_background_color_processors
  * @typedef {((color: string) => string)[]} get_background_color_processors
@@ -361,8 +361,9 @@ export class ColorPlugin extends Plugin {
      * @param {Element} element
      * @param {string} color hexadecimal or bg-name/text-name class
      * @param {'color'|'backgroundColor'} mode 'color' or 'backgroundColor'
+     * @param {Object} params additional parameters
      */
-    colorElement(element, color, mode) {
+    colorElement(element, color, mode, params = {}) {
         let parts = backgroundImageCssToParts(element.style["background-image"]);
         const oldClassName = element.getAttribute("class") || "";
 
@@ -412,7 +413,12 @@ export class ColorPlugin extends Plugin {
                 element.style["background-color"] = "";
                 element.classList.add("text-gradient");
             }
-            this.applyColorStyle(element, "background-image", backgroundImagePartsToCss(parts));
+            this.applyColorStyle(
+                element,
+                "background-image",
+                backgroundImagePartsToCss(parts),
+                params
+            );
         } else {
             delete parts.gradient;
             if (hasGradientStyle && !backgroundImagePartsToCss(parts)) {
@@ -420,7 +426,7 @@ export class ColorPlugin extends Plugin {
             }
             // Change camelCase to kebab-case.
             mode = mode.replace("backgroundColor", "background-color");
-            this.applyColorStyle(element, mode, color);
+            this.applyColorStyle(element, mode, color, params);
         }
 
         // It was decided that applying a color combination removes any "color"
@@ -481,11 +487,12 @@ export class ColorPlugin extends Plugin {
 
     /**
      * @param {Element} element
-     * @param {string} cssProp
-     * @param {string} cssValue
+     * @param {string} mode
+     * @param {string} color
+     * @param {Object} params additional parameters
      */
-    applyColorStyle(element, mode, color) {
-        if (this.delegateTo("apply_color_style_overrides", element, mode, color)) {
+    applyColorStyle(element, mode, color, params = {}) {
+        if (this.delegateTo("apply_color_style_overrides", element, mode, color, params)) {
             return;
         }
         element.style[mode] = color;

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -512,15 +512,7 @@ export class LinkPlugin extends Plugin {
         const selectionTextContent = selection?.textContent();
         const isImage = !!findInSelection(selection, "img");
 
-        const applyCallback = (
-            url,
-            label,
-            classes,
-            customStyle,
-            linkTarget,
-            attachmentId,
-            relValue
-        ) => {
+        const applyCallback = (url, label, classes, linkTarget, attachmentId, relValue) => {
             if (this.linkInDocument) {
                 if (url) {
                     this.linkInDocument.href = url;
@@ -542,11 +534,6 @@ export class LinkPlugin extends Plugin {
                         this.linkInDocument.className = classes;
                     } else {
                         this.linkInDocument.removeAttribute("class");
-                    }
-                    if (customStyle) {
-                        this.linkInDocument.setAttribute("style", customStyle);
-                    } else {
-                        this.linkInDocument.removeAttribute("style");
                     }
                     if (
                         this.linkInDocument.childElementCount == 0 &&
@@ -601,9 +588,6 @@ export class LinkPlugin extends Plugin {
                     const link = this.createLink(url, label);
                     if (classes) {
                         link.className = classes;
-                    }
-                    if (customStyle) {
-                        link.setAttribute("style", customStyle);
                     }
                     if (linkTarget) {
                         link.setAttribute("target", linkTarget);
@@ -670,7 +654,7 @@ export class LinkPlugin extends Plugin {
             type: this.type || "",
             LinkPopoverState: this.LinkPopoverState,
             showReplaceTitleBanner: this.newlyInsertedLinks.has(linkElement),
-            allowCustomStyle: this.config.allowCustomStyle,
+            includeStyling: !this.config.hideStylingInLinkPopover,
             allowTargetBlank: this.config.allowTargetBlank,
             allowStripDomain: this.config.allowStripDomain,
         };
@@ -709,15 +693,9 @@ export class LinkPlugin extends Plugin {
                     focusNode: link,
                     focusOffset: nodeSize(link),
                 });
-                const saveCustomStyle = link.getAttribute("style");
-                link.removeAttribute("style");
-                this.dependencies.color.removeAllColor();
-                if (
-                    saveCustomStyle &&
-                    this.config.allowCustomStyle &&
-                    link.className.includes("custom")
-                ) {
-                    link.setAttribute("style", saveCustomStyle);
+                if (!this.config.hideStylingInLinkPopover) {
+                    link.removeAttribute("style");
+                    this.dependencies.color.removeAllColor();
                 }
                 // Remove the current link (linkInDocument) if it has no content
                 if (cleanZWChars(link.textContent) === "" && !link.querySelector("img")) {

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -67,10 +67,10 @@
                             </span>
 
                         </div>
-                        <div class="input-group mb-2">
+                        <div t-if="props.includeStyling" class="input-group mb-2">
                             <Dropdown menuClass="'o-we-link-type-dropdown'">
                                 <button name="link_type" class="form-select form-select-sm border-dark-subtle text-start">
-                                    <t t-set="selectedItem" t-value="state.colorsData.find(colorData => colorData.type === state.type)" />
+                                    <t t-set="selectedItem" t-value="this.buttonTypesData.find(typeData => typeData.type === state.type)" />
                                     <span t-att-class="selectedItem.className"
                                         t-att-style="selectedItem.style"
                                         t-out="selectedItem.label"/>
@@ -78,62 +78,32 @@
                                 <t t-set-slot="content">
                                     <div data-prevent-closing-overlay="true">
                                         <DropdownItem
-                                            t-if="props.allowCustomStyle or colorData.type !== 'custom'"
-                                            t-foreach="state.colorsData"
-                                            t-as="colorData"
-                                            t-key="colorData.type"
-                                            onSelected="() => this.onSelectedLinkType(colorData.type)"
+                                            t-if="typeData.type !== 'custom'"
+                                            t-foreach="this.buttonTypesData"
+                                            t-as="typeData"
+                                            t-key="typeData.type"
+                                            onSelected="() => this.onSelectedLinkType(typeData.type)"
                                             t-on-pointerdown.stop.prevent="() => {}"
                                         >
-                                            <span t-att-class="colorData.className"
-                                                t-att-style="colorData.style"
-                                                t-out="colorData.label"/>
+                                            <span t-att-class="typeData.className"
+                                                t-att-style="typeData.style"
+                                                t-out="typeData.label"/>
                                         </DropdownItem>
                                     </div>
                                 </t>
                             </Dropdown>
                         </div>
-                        <div t-if="state.type !== 'link'" class="input-group mb-2">
+                        <div t-if="props.includeStyling and state.type !== 'link'" class="input-group mb-2">
                             <select name="link_style_size" class="form-select form-select-sm border-dark-subtle" t-model="state.buttonSize" t-on-change="onChange" aria-label="Select button size">
                                 <option t-foreach="this.buttonSizesData" t-as="buttonSizesData" t-key="buttonSizesData.size" t-att-value="buttonSizesData.size"
                                     t-att-selected="state.buttonSize === buttonSizesData.size" t-out="buttonSizesData.label"/>
                             </select>
                             <select name="link_style_shape" class="form-select form-select-sm link-style border-dark-subtle" t-model="state.buttonShape" t-on-change="onChange" aria-label="Select button shape">
-                                <option t-foreach="this.buttonShapeData" t-as="buttonShapeData" t-key="buttonShapeData.shape" t-att-value="buttonShapeData.shape"
+                                <option t-foreach="this.buttonShapesData" t-as="buttonShapeData" t-key="buttonShapeData.shape" t-att-value="buttonShapeData.shape"
                                     t-att-selected="state.buttonShape === buttonShapeData.shape" t-out="buttonShapeData.label"/>
                             </select>
                         </div>
 
-                        <t t-if="state.type === 'custom'">
-                            <div class="d-flex mb-1 custom-text-color">
-                                <label>Text Color</label>
-                                <button class="o_we_color_preview custom-text-picker me-3" t-att-data-color="this.customTextColorState.selectedColor" t-ref="customTextColorButton"
-                                        t-attf-style="background-color: {{this.props.formatColor(this.customTextColorState.selectedColor)}}"/>
-                                <label>Fill Color</label>
-                                <button class="o_we_color_preview custom-fill-picker" t-att-data-color="this.customFillColorState.selectedColor" t-ref="customFillColorButton"
-                                        t-attf-style="{{this.customFillColorState.selectedColor?.includes('gradient') ? 'background-image' : 'background-color'}}: {{this.props.formatColor(this.customFillColorState.selectedColor)}}" />
-                            </div>
-                            <div class="d-flex mb-1 custom-border align-items-center">
-                                <label class="flex-shrink-0">Border</label>
-                                <div class="input-group me-1">
-                                    <input type="number" min="0"
-                                        class="form-control form-control-sm custom-border-size flex-grow-0" t-model="state.customBorderSize"
-                                        placeholder="Border Size" t-on-keydown="onKeydownEnter" t-on-input="onInput"/>
-                                    <span class="input-group-text">px</span>
-                                </div>
-                                <div class="d-flex align-items-center" t-if="state.customBorderSize > 0">
-                                    <select name="link_style_border" class="form-select form-select-sm custom-border-style me-1" t-model="state.customBorderStyle" t-on-change="onChange">
-                                        <t t-foreach="this.borderData" t-as="borderData" t-key="borderData.style">
-                                            <option t-att-value="borderData.style" t-att-selected="state.customBorderStyle === borderData.style">
-                                                <span t-esc="borderData.label"/>
-                                            </option>
-                                        </t>
-                                    </select>
-                                    <button class="o_we_color_preview custom-border-picker" t-att-data-color="this.customBorderColorState.selectedColor" t-ref="customBorderColorButton"
-                                        t-attf-style="background-color: {{this.props.formatColor(this.customBorderColorState.selectedColor)}}" />
-                                </div>
-                            </div>
-                        </t>
                         <t t-if="props.allowTargetBlank">
                             <t t-if="state.isDocument">
                                 <CheckBox

--- a/addons/html_editor/static/src/utils/button_style.js
+++ b/addons/html_editor/static/src/utils/button_style.js
@@ -1,0 +1,123 @@
+import { _t } from "@web/core/l10n/translation";
+
+/**
+ * Return the default color options for the editor.
+ *
+ * Each option is an object with:
+ *  - type      : identifier of the role (e.g., "link", "primary").
+ *  - label     : UI label shown in the editor.
+ *  - className : optional CSS classes for preview elements.
+ *  - style     : optional inline style for preview elements.
+ */
+export const BUTTON_TYPES = [
+    {
+        type: "link",
+        label: _t("Link"),
+        style: "color: #008f8c;",
+    },
+    {
+        type: "primary",
+        label: _t("Button Primary"),
+        className: "btn btn-sm btn-primary",
+    },
+    {
+        type: "secondary",
+        label: _t("Button Secondary"),
+        className: "btn btn-sm btn-secondary",
+    },
+    {
+        type: "custom",
+        label: _t("Custom"),
+    },
+    // Note: by compatibility the dialog should be able to remove old
+    // colors that were suggested like the BS status colors or the
+    // alpha -> epsilon classes. This is currently done by removing
+    // all btn-* classes anyway.
+];
+
+export const BUTTON_SHAPES = [
+    { shape: "", label: "Default" },
+    { shape: "rounded-circle", label: "Default + Rounded" },
+    { shape: "outline", label: "Outline" },
+    { shape: "outline rounded-circle", label: "Outline + Rounded" },
+    { shape: "fill", label: "Fill" },
+    { shape: "fill rounded-circle", label: "Fill + Rounded" },
+    { shape: "flat", label: "Flat" },
+];
+
+export const BUTTON_SIZES = [
+    { size: "sm", label: _t("Small") },
+    { size: "", label: _t("Medium") },
+    { size: "lg", label: _t("Large") },
+];
+
+export function computeButtonClasses(el, { type, size, shape }) {
+    const classes = [...el.classList].filter(
+        (value) => !value.match(/^(btn.*|rounded-circle|flat|(text|bg)-(o-color-\d$|\d{3}$))$/)
+    );
+
+    if (!type || type === "link") {
+        return classes.filter(Boolean).join(" ");
+    }
+
+    classes.push("btn");
+    if (size) {
+        classes.push(`btn-${size}`);
+    }
+
+    let shapePrefix = "";
+    if (shape) {
+        const shapeValues = shape.split(" ");
+        if (["outline", "fill"].includes(shapeValues[0])) {
+            shapePrefix = `${shapeValues[0]}-`;
+            classes.push(...shapeValues.slice(1));
+        } else {
+            classes.push(...shapeValues);
+        }
+    }
+
+    classes.push(`btn-${shapePrefix}${type}`);
+
+    return classes.filter(Boolean).join(" ");
+}
+
+export function getButtonType(el) {
+    if (el.classList.contains("btn")) {
+        const match = el.className.match(/btn(-[a-z0-9_-]*)(primary|secondary|custom)/);
+        return match?.pop() || "link";
+    }
+    return "link";
+}
+
+export function getButtonSize(el) {
+    return el.className.match(/btn-(sm|lg)/)?.[1] || "";
+}
+
+export function getButtonShape(el) {
+    const shapeToRegex = (shape) => {
+        const parts = shape.trim().split(/\s+/);
+        const regexParts = parts.map((cls) => {
+            if (["outline", "fill"].includes(cls)) {
+                cls = `btn-${cls}`;
+            }
+            return `(?=.*\\b${cls}\\b)`;
+        });
+        return { regex: new RegExp(regexParts.join("")), nbParts: parts.length };
+    };
+    // If multiple shapes match, prefer the one with more specificity.
+    let shapeMatched = "";
+    let matchScore = 0;
+    for (const { shape } of BUTTON_SHAPES) {
+        if (!shape) {
+            continue;
+        }
+        const { regex, nbParts } = shapeToRegex(shape);
+        if (regex.test(el.className)) {
+            if (matchScore < nbParts) {
+                matchScore = nbParts;
+                shapeMatched = shape;
+            }
+        }
+    }
+    return shapeMatched;
+}

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -972,59 +972,6 @@ describe("Link formatting in the popover", () => {
             '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>'
         );
     });
-    const styleForceColor = `p > a.btn { color: black !important; border-color: gray !important }`;
-    test("custom link format fill with solid color should be stored as background-color", async () => {
-        const { el } = await setupEditor(
-            '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>',
-            {
-                config: {
-                    allowCustomStyle: true,
-                },
-                styleContent: styleForceColor,
-            }
-        );
-        await waitFor(".o-we-linkpopover");
-        await click(".o_we_edit_link");
-        await animationFrame();
-
-        await click("button[name='link_type']");
-        await animationFrame();
-        await click(".o-we-link-type-dropdown .dropdown-item:contains('Custom')");
-        await animationFrame();
-        await click(".o_we_color_preview.custom-fill-picker");
-        await animationFrame();
-        await click('[data-color="#FF9C00"]');
-        expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-custom" style="color: rgb(0, 0, 0); background-color: #FF9C00; border-width: 1px; border-color: rgb(128, 128, 128); border-style: solid; ">link2</a></p>'
-        );
-    });
-    test("custom link format fill with gradient should be stored as background-image", async () => {
-        const { el } = await setupEditor(
-            '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>',
-            {
-                config: {
-                    allowCustomStyle: true,
-                },
-                styleContent: styleForceColor,
-            }
-        );
-        await waitFor(".o-we-linkpopover");
-        await click(".o_we_edit_link");
-        await animationFrame();
-
-        await click("button[name='link_type']");
-        await animationFrame();
-        await click(".o-we-link-type-dropdown .dropdown-item:contains('Custom')");
-        await animationFrame();
-        await click(".o_we_color_preview.custom-fill-picker");
-        await animationFrame();
-        await click(".gradient-tab");
-        await animationFrame();
-        await click(".o_gradient_color_button");
-        expect(cleanLinkArtifacts(getContent(el))).toBe(
-            '<p><a href="http://test.com/" class="btn btn-custom" style="color: rgb(0, 0, 0); background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%); border-width: 1px; border-color: rgb(128, 128, 128); border-style: solid; ">link2</a></p>'
-        );
-    });
     test("clicking the discard button should revert the link format", async () => {
         const { el } = await setupEditor('<p><a href="http://test.com/">link1[]</a></p>');
         await waitFor(".o-we-linkpopover");

--- a/addons/website/static/src/js/editor/html_editor.js
+++ b/addons/website/static/src/js/editor/html_editor.js
@@ -8,7 +8,6 @@ import wUtils from "@website/js/utils";
 import { useEffect } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { session } from "@web/session";
-import { CSS_SHORTHANDS } from "@html_builder/utils/utils_css";
 
 /**
  * The goal of this patch is to handle the URL autocomplete in the LinkPopover
@@ -126,123 +125,6 @@ patch(LinkPopover.prototype, {
             }
         }
         return choices;
-    },
-
-    onChange() {
-        super.onChange();
-        Object.assign(this.state.colorsData, this.computeColorsData());
-    },
-
-    /**
-     * Compute inline styles by applying the given classes to a temporary button
-     * inserted in the container.
-     *
-     * @param {HTMLElement} buttonContainerEl - Container where the temporary
-     *                                          button is placed
-     * @param {string} variantClass - Variant class (e.g., 'btn-primary')
-     * @param {string[]} extraClasses - Extra classes (size, shape)
-     *
-     * @returns {string} Extracted inline style string
-     */
-    computeButtonInlineStyles(buttonContainerEl, variantClass, extraClasses) {
-        const tempButtonEl = document.createElement("a");
-        tempButtonEl.className = `btn ${variantClass} ${extraClasses.join(" ")}`.trim();
-
-        this.props.ignoreDOMMutations(() => buttonContainerEl.appendChild(tempButtonEl));
-
-        const computedStyles = window.getComputedStyle(tempButtonEl);
-        const allowedStyles = [
-            "color",
-            "font-size",
-            "font-weight",
-            "text-transform",
-            "background-color",
-            ...CSS_SHORTHANDS["padding"],
-            ...CSS_SHORTHANDS["border-width"],
-            ...CSS_SHORTHANDS["border-color"],
-            ...CSS_SHORTHANDS["border-style"],
-            ...CSS_SHORTHANDS["border-radius"],
-        ];
-        const inlineStyle = [];
-
-        for (const style of allowedStyles) {
-            const value = computedStyles.getPropertyValue(style);
-            if (value) {
-                inlineStyle.push(`${style}: ${value};`);
-            }
-        }
-
-        this.props.ignoreDOMMutations(() => tempButtonEl.remove());
-        return inlineStyle.join("");
-    },
-
-    /**
-     * Override `computeColorsData` to ensure link style previews (for primary
-     * and secondary buttons) in the popover use the actual button styles based
-     * on the editing element's classes or component state.
-     */
-    computeColorsData() {
-        const colors = super.computeColorsData();
-        if (!this.props.allowCustomStyle) {
-            return colors;
-        }
-
-        let buttonContainerEl = this.props.containerElement;
-        let stylePrefix = "btn";
-        let sizeClasses = [];
-        let shapeClasses = [];
-
-        const stylePrefixRegex = /(outline|fill)/;
-
-        if (buttonContainerEl.classList.contains("btn")) {
-            sizeClasses = [...buttonContainerEl.classList].filter((cls) =>
-                ["btn-lg", "btn-sm"].includes(cls)
-            );
-            shapeClasses = [...buttonContainerEl.classList].filter((cls) =>
-                ["flat", "rounded-circle"].includes(cls)
-            );
-
-            const prefix = buttonContainerEl.className.match(stylePrefixRegex)?.[0];
-            if (prefix) {
-                stylePrefix = `btn-${prefix}`;
-            }
-
-            buttonContainerEl = buttonContainerEl.parentElement;
-        } else if (this.state) {
-            const { buttonShape = "", buttonSize = "" } = this.state;
-
-            const prefix = buttonShape.match(stylePrefixRegex)?.[0];
-            stylePrefix = prefix ? `btn-${prefix}` : "btn";
-
-            if (buttonSize) {
-                sizeClasses.push(`btn-${buttonSize}`);
-            }
-
-            shapeClasses.push(
-                ...buttonShape.split(" ").filter((cls) => ["rounded-circle", "flat"].includes(cls))
-            );
-        }
-
-        const extraClasses = [...sizeClasses, ...shapeClasses];
-
-        const primaryClass = `${stylePrefix}-primary`;
-        const secondaryClass = `${stylePrefix}-secondary`;
-
-        const applyStyle = (btnType, variantClass) => {
-            const index = colors.findIndex((color) => color.type === btnType);
-            if (index !== -1) {
-                colors[index].style = this.computeButtonInlineStyles(
-                    buttonContainerEl,
-                    variantClass,
-                    extraClasses
-                );
-            }
-        };
-
-        applyStyle("primary", primaryClass);
-        applyStyle("secondary", secondaryClass);
-
-        return colors;
     },
 
     onSelect(value) {

--- a/addons/website/static/tests/builder/custom_tab/builder_components/website_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/website_colorpicker.test.js
@@ -7,6 +7,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
+import { waitForEndOfOperation } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
 
@@ -54,4 +55,27 @@ test("should have the theme tab", async () => {
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await contains("button.theme-tab").click();
     expect(".color-combination-button[data-color='o_cc1']").toHaveClass("selected");
+});
+
+test("should work with color transition", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="'color'" enabledTabs="['custom']" />`,
+    });
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`, {
+        // The CSS for the class "o_we_force_no_transition" is needed
+        loadIframeBundles: true,
+        styleContent:
+            ".test-options-target { color: #FF0000; transition: color 0.15s ease-in-out; }",
+        enableIframeTransitions: true,
+    });
+
+    await contains(":iframe .test-options-target").click();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await contains(".o_colorpicker_widget .o_hex_input").edit("#0000FF");
+    await waitForEndOfOperation();
+    expect(":iframe .test-options-target").toHaveStyle("color: rgb(0, 0, 255)");
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await waitForEndOfOperation();
+    expect(":iframe .test-options-target").toHaveStyle("color: rgb(0, 0, 255)");
 });

--- a/addons/website/static/tests/builder/options/button_style_option.test.js
+++ b/addons/website/static/tests/builder/options/button_style_option.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, queryFirst, queryOne, test } from "@odoo/hoot";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+import { contains } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineWebsiteModels();
+
+test("fill color preview shows the hover fill color in outline mode", async () => {
+    await setupWebsiteBuilder(
+        '<p><a href="https://test.com/" class="btn btn-outline-custom" >Link label</a></p>',
+        { loadIframeBundles: true }
+    );
+    await contains(":iframe p > a").click();
+
+    // Set a background color
+    await contains("[data-label=Fill] .o_we_color_preview").click();
+    await contains(".o_color_button[data-color='#0000FF']").click();
+
+    expect(":iframe p > a").toHaveStyle(
+        "background-color: rgba(0, 0, 0, 0); background-image: none",
+        {
+            message:
+                "When not hovering, the button background should be transparent in outline mode",
+        }
+    );
+    expect(":iframe p > a").toHaveStyle("background-color: rgb(0, 0, 255)", { inline: true });
+    expect("[data-label=Fill] .o_we_color_preview").toHaveStyle(
+        "background-color: rgb(0, 0, 255)",
+        { inline: true, message: "The fill color preview should show the hover fill color" }
+    );
+
+    // Set a background gradient
+    await contains("[data-label=Fill] .o_we_color_preview").click();
+    await contains(".gradient-tab").click();
+    const gradientButton = queryFirst(".o_gradient_color_button");
+    const gradient = gradientButton.dataset.color;
+    await contains(gradientButton).click();
+
+    expect(":iframe p > a").toHaveStyle(
+        "background-color: rgba(0, 0, 0, 0); background-image: none",
+        {
+            message:
+                "When not hovering, the button background should be transparent in outline mode",
+        }
+    );
+    expect(":iframe p > a").toHaveStyle({ "background-image": gradient }, { inline: true });
+    expect("[data-label=Fill] .o_we_color_preview").toHaveStyle(
+        { "background-image": gradient },
+        { inline: true, message: "The fill color preview should show the hover fill color" }
+    );
+});
+
+test("keep current style when switching from button", async () => {
+    await setupWebsiteBuilder('<p><a href="#" class="btn btn-secondary">Button Secondary</a></p>', {
+        loadIframeBundles: true,
+    });
+
+    const computedStyle = getComputedStyle(queryOne(":iframe p > a"));
+    const buttonSecondaryStyles = {
+        "background-color": computedStyle.backgroundColor,
+        border: computedStyle.border,
+        color: computedStyle.color,
+    };
+    await contains(":iframe p > a").click();
+
+    expect("[data-label=Type] .o-hb-select-toggle").toHaveText("Button Secondary");
+    await contains("[data-label=Type] .o-hb-select-toggle").click();
+    await contains(".o_popover .dropdown-item:contains('Custom')").click();
+
+    expect(":iframe p > a").toHaveClass("btn btn-custom");
+    expect(":iframe p > a").toHaveStyle(buttonSecondaryStyles, { inline: true });
+});

--- a/addons/website/static/tests/builder/popover.test.js
+++ b/addons/website/static/tests/builder/popover.test.js
@@ -66,12 +66,6 @@ test("Popovers scroll with iframe", async () => {
 
     await contains(".o-we-toolbar button[title='Animate Text']").click();
     await expectScroll(".o_popover:has(> .o_animate_text_popover)");
-
-    await contains(".o-we-toolbar button[name=link]").click();
-    await contains(".o-we-linkpopover button[name=link_type]").click();
-    await contains(".o_popover .o-dropdown-item span:contains(custom)").click();
-    await contains(".o-we-linkpopover button.custom-text-picker").click();
-    await expectScroll(".o_popover:has(> .o_font_color_selector)");
 });
 
 test("Floating toolbar visual consistency and usability", async () => {
@@ -105,62 +99,6 @@ test("Floating toolbar visual consistency and usability", async () => {
     const colorLabel = await waitFor(".o_popover label[for='colorButton']");
     const sublevelRow = colorLabel.closest(".hb-row-sublevel-1");
     expect(sublevelRow).toHaveClass("hb-row-sublevel-1");
-});
-
-test("button preview updates according to button shape, size, and theme colors", async () => {
-    await setupWebsiteBuilder(
-        `<div class="o_cc o_cc1"><a class="btn btn-primary">My Button</a></div>`,
-        {
-            loadIframeBundles: true,
-            styleContent: /*css*/ `
-                .o_cc1 .btn-primary {
-                    --btn-bg: #FF0000;
-                    --btn-border-color: #CE0000;
-                }
-                .o_cc1 .btn-secondary {
-                    --btn-bg: #ff9c00;
-                    --btn-border-color: #BD9400;
-                }
-            `,
-        }
-    );
-    const btnEl = queryOne(":iframe .o_cc1 a");
-    setSelection({
-        anchorNode: btnEl.firstChild.nextSibling,
-        anchorOffset: 0,
-        focusOffset: 1,
-    });
-    await waitFor(".o-we-toolbar");
-    await contains("button[name='link']").click();
-
-    const buttonShapeSelectEl = queryOne("select[name='link_style_shape']");
-    buttonShapeSelectEl.value = "flat";
-    buttonShapeSelectEl.dispatchEvent(new Event("change"));
-    const buttonSizeSelectEl = queryOne("select[name='link_style_size']");
-    buttonSizeSelectEl.value = "lg";
-    buttonSizeSelectEl.dispatchEvent(new Event("change"));
-
-    expect("select[name='link_style_shape']").toHaveValue("flat");
-    expect("select[name='link_style_size']").toHaveValue("lg");
-
-    await contains("button[name='link_type']").click();
-    expect(".dropdown-item span:contains(Button Primary)").toHaveStyle({
-        "background-color": "rgb(255, 0, 0)",
-        "text-transform": "uppercase",
-    });
-    expect(".dropdown-item span:contains(Button Secondary)").toHaveStyle({
-        "background-color": "rgb(255, 156, 0)",
-        "text-transform": "uppercase",
-    });
-    await contains(".dropdown-item span:contains(Button Primary)").click();
-
-    buttonShapeSelectEl.value = "outline";
-    buttonShapeSelectEl.dispatchEvent(new Event("change"));
-    await contains("button[name='link_type']").click();
-    expect(".dropdown-item span:contains(Button Primary)").toHaveStyle({
-        "background-color": "rgba(0, 0, 0, 0)",
-        "text-transform": "none",
-    });
 });
 
 test("closing the link popover should re-open the toolbar", async () => {

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -116,6 +116,7 @@ export async function setupWebsiteBuilder(
         footerContent = "",
         beforeWrapwrapContent = "",
         translateMode = false,
+        enableIframeTransitions = false,
         onIframeLoaded = () => {},
         delayReload = async () => {},
     } = {}
@@ -142,7 +143,9 @@ export async function setupWebsiteBuilder(
         resolveIframeLoaded = async (el) => {
             const iframe = el;
             const styleEl = iframe.contentDocument.createElement("style");
-            styleEl.textContent = /*css*/ `* { transition: none !important; } `;
+            if (!enableIframeTransitions) {
+                styleEl.textContent = /*css*/ `* { transition: none !important; }`;
+            }
             if (styleContent) {
                 styleEl.textContent += styleContent;
             }

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -546,30 +546,29 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "Click on Edit Link in Popover",
-            trigger: ".o-we-linkpopover .o_we_edit_link",
-            run: "click",
-        },
-        {
-            content: "Click on link type dropdown",
-            trigger: ".o-we-linkpopover button[name='link_type']",
+            content: "Click on button type dropdown",
+            trigger: "[data-label=Type] .o-hb-select-toggle",
             run: "click",
         },
         {
             content: "Change button's style",
-            trigger: ".o-we-link-type-dropdown .dropdown-item:contains('Custom')",
+            trigger: ".o_popover .dropdown-item:contains('Custom')",
             run: "click",
         },
         {
-            trigger: ".o-we-linkpopover select[name=link_style_shape]",
-            run: "select rounded-circle",
+            trigger: "[data-label=Shape] .o-hb-select-toggle",
+            run: "click",
         },
         {
-            trigger: ".o-we-linkpopover select[name='link_style_size']",
-            run: "select sm",
+            trigger: ".o_popover [data-action-value='rounded-circle']",
+            run: "click",
         },
         {
-            trigger: ".o-we-linkpopover .o_we_apply_link",
+            trigger: "[data-label=Size] .o-hb-select-toggle",
+            run: "click",
+        },
+        {
+            trigger: ".o_popover [data-action-value='sm']",
             run: "click",
         },
         {


### PR DESCRIPTION
*: html_editor, website

__Before commit:__
`LinkPopover` is used to transform links into buttons and to change
their styles. It is also possible to set custom colors and borders.
These custom style settings and their previews add significant
complexity and are not necessary in the backend.

__Changes:__
- The custom type is removed from the popover, along with the
  corresponding style settings. Only link, button primary, and
  secondary type options remain in the popover for backend use.
- All styling is disabled in the popover when using the website
  builder. These options (including custom type styling) are now moved
  to the sidebar. This allows us to reuse generic builder blocks
  instead of reimplementing functionality in the popover.
- Specific logic is extracted from `LinkPopover` to a utility file to
  allow for shared use in both locations.

task-5443201