### PR TITLE
[IMP] im_livechat, mail: change store.records from Object to Map

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
@@ -10,9 +10,9 @@ const messagingMenuPatch = {
      */
     get _tabs() {
         const items = super._tabs;
-        const hasLivechats = Object.values(this.store["discuss.channel"].records).some(
-            (channel) => channel.channel_type === "livechat"
-        );
+        const hasLivechats = this.store["discuss.channel"]
+            .all()
+            .some((channel) => channel.channel_type === "livechat");
         if (hasLivechats) {
             items.push({
                 counter: this.store.discuss.livechats.reduce(

--- a/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
@@ -23,12 +23,14 @@ registry.category("command_provider").add("im_livechat.channel_join_leave", {
         }
         await store.livechatChannels.fetch();
         const activeChannels = new Set(
-            Object.values(store["im_livechat.channel"].records)
+            store["im_livechat.channel"]
+                .all()
                 .filter((c) => c.channel_ids.length > 0)
                 .map((c) => c.id)
         );
         // Show live chat channels with ongoing conversations first
-        return Object.values(store["im_livechat.channel"].records)
+        return store["im_livechat.channel"]
+            .all()
             .sort((c) => (activeChannels.has(c.id) ? -1 : 1))
             .map((c) => ({
                 action: c.are_you_inside ? c.leave.bind(c) : c.join.bind(c),

--- a/addons/im_livechat/static/tests/embed/feedback_panel.test.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel.test.js
@@ -66,7 +66,7 @@ test("Last operator leaving ends the livechat", async () => {
     // simulate operator leaving
     await withUser(operatorUserId, () =>
         getService("orm").call("discuss.channel", "action_unfollow", [
-            [Object.values(getService("mail.store")["mail.thread"].records).at(-1).id],
+            [getService("mail.store")["mail.thread"].all().at(-1).id],
         ])
     );
     await contains("span", { text: "This livechat conversation has ended" });

--- a/addons/im_livechat/static/tests/embed/history_command.test.js
+++ b/addons/im_livechat/static/tests/embed/history_command.test.js
@@ -22,7 +22,7 @@ test("Handle livechat history command", async () => {
     await contains(".o-mail-Composer-input").edit("Hello World!", { confirm: false });
     await press("Enter");
     await waitFor(".o-mail-Message:contains(Hello World!)");
-    const thread = Object.values(getService("mail.store")["mail.thread"].records).at(-1);
+    const thread = getService("mail.store")["mail.thread"].all().at(-1);
     const guestId = pyEnv.cookie.get("dgid");
     const [guest] = pyEnv["mail.guest"].read(guestId);
     pyEnv["bus.bus"]._sendone(guest, "im_livechat.history_command", {

--- a/addons/im_livechat/static/tests/embed/livechat_session.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_session.test.js
@@ -75,9 +75,8 @@ test("Seen message is saved on the server", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-Message", { text: "Hello, I need help!" });
     await waitUntilSubscribe();
-    const initialSeenMessageId = Object.values(getService("mail.store")["mail.thread"].records).at(
-        -1
-    ).self_member_id.seen_message_id?.id;
+    const initialSeenMessageId = getService("mail.store")["mail.thread"].all().at(-1).self_member_id
+        .seen_message_id?.id;
     queryFirst(".o-mail-Composer-input").blur();
     await withUser(userId, () =>
         rpc("/mail/message/post", {
@@ -86,7 +85,7 @@ test("Seen message is saved on the server", async () => {
                 message_type: "comment",
                 subtype_xmlid: "mail.mt_comment",
             },
-            thread_id: Object.values(getService("mail.store")["mail.thread"].records).at(-1).id,
+            thread_id: getService("mail.store")["mail.thread"].all().at(-1).id,
             thread_model: "discuss.channel",
         })
     );
@@ -97,15 +96,10 @@ test("Seen message is saved on the server", async () => {
     const guestId = pyEnv.cookie.get("dgid");
     const [member] = pyEnv["discuss.channel.member"].search_read([
         ["guest_id", "=", guestId],
-        [
-            "channel_id",
-            "=",
-            Object.values(getService("mail.store")["mail.thread"].records).at(-1).id,
-        ],
+        ["channel_id", "=", getService("mail.store")["mail.thread"].all().at(-1).id],
     ]);
     expect(initialSeenMessageId).not.toBe(member.seen_message_id[0]);
     expect(
-        Object.values(getService("mail.store")["mail.thread"].records).at(-1).self_member_id
-            .seen_message_id.id
+        getService("mail.store")["mail.thread"].all().at(-1).self_member_id.seen_message_id.id
     ).toBe(member.seen_message_id[0]);
 });

--- a/addons/mail/static/src/chatter/web/scheduled_message_model.js
+++ b/addons/mail/static/src/chatter/web/scheduled_message_model.js
@@ -5,8 +5,6 @@ import { _t } from "@web/core/l10n/translation";
 export class ScheduledMessage extends Record {
     static _name = "mail.scheduled.message";
     static id = "id";
-    /** @type {Object.<number, import("models").ScheduledMessage>} */
-    static records = {};
     /** @returns {import("models").ScheduledMessage} */
     static get(data) {
         return super.get(data);

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -68,9 +68,10 @@ declare module "models" {
     export interface Volume extends VolumeClass {}
 
     type StaticMailRecord<ClassInterface, JSClassType> = Omit<JSClassType, "get" | "insert" | "records"> & {
+        all: (data: any) => ClassInterface[];
         get: (data: any) => ClassInterface;
         insert: <D extends object | object[]>(data: D, options?: object) => D extends object[] ? ClassInterface[] : ClassInterface;
-        records: { [localId: string]: ClassInterface };
+        records: Map<string, ClassInterface>;
     };
 
     export interface Store {

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -26,7 +26,7 @@ export class Notification extends Record {
             if (!this.mail_message_id?.isSelfAuthored) {
                 return;
             }
-            const failure = Object.values(this.store.Failure.records).find(
+            const failure = this.store.Failure.all().find(
                 (f) =>
                     f.resModel === thread?.model &&
                     f.type === this.notification_type &&

--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -124,10 +124,12 @@ export class ResPartner extends Record {
     }
 
     searchChat() {
-        return Object.values(this.store["discuss.channel"].records).find(
-            (channel) =>
-                channel.channel_type === "chat" && channel.correspondent?.partner_id?.eq(this)
-        );
+        return this.store["discuss.channel"]
+            .all()
+            .find(
+                (channel) =>
+                    channel.channel_type === "chat" && channel.correspondent?.partner_id?.eq(this)
+            );
     }
 
     updateImStatus(newStatus) {

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -450,10 +450,9 @@ export class Store extends BaseStore {
 
     /** @returns {number} */
     getLastMessageId() {
-        return Object.values(this["mail.message"].records).reduce(
-            (lastMessageId, message) => Math.max(lastMessageId, message.id),
-            0
-        );
+        return this["mail.message"]
+            .all()
+            .reduce((lastMessageId, message) => Math.max(lastMessageId, message.id), 0);
     }
 
     handleValidChannelMention(channelLinks) {

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -117,9 +117,11 @@ export class SuggestionService {
     }
 
     searchCannedResponseSuggestions(cleanedSearchTerm) {
-        const cannedResponses = Object.values(this.store["mail.canned.response"].records).filter(
-            (cannedResponse) => cleanTerm(cannedResponse.source).includes(cleanedSearchTerm)
-        );
+        const cannedResponses = this.store["mail.canned.response"]
+            .all()
+            .filter((cannedResponse) =>
+                cleanTerm(cannedResponse.source).includes(cleanedSearchTerm)
+            );
         const sortFunc = (c1, c2) => {
             const cleanedName1 = cleanTerm(c1.source);
             const cleanedName2 = cleanTerm(c2.source);
@@ -197,9 +199,9 @@ export class SuggestionService {
     }
 
     searchRoleSuggestions(cleanedSearchTerm) {
-        const roles = Object.values(this.store["res.role"].records).filter((role) =>
-            cleanTerm(role.name).includes(cleanedSearchTerm)
-        );
+        const roles = this.store["res.role"]
+            .all()
+            .filter((role) => cleanTerm(role.name).includes(cleanedSearchTerm));
         const sortFunc = (r1, r2) => {
             const cleanedName1 = cleanTerm(r1.name);
             const cleanedName2 = cleanTerm(r2.name);
@@ -236,9 +238,9 @@ export class SuggestionService {
     }
 
     getPartnerSuggestions(thread) {
-        return Object.values(this.store["res.partner"].records).filter((partner) =>
-            this.isSuggestionValid(partner, thread)
-        );
+        return this.store["res.partner"]
+            .all()
+            .filter((partner) => this.isSuggestionValid(partner, thread));
     }
 
     searchPartnerSuggestions(cleanedSearchTerm, thread) {
@@ -306,12 +308,14 @@ export class SuggestionService {
     }
 
     searchChannelSuggestions(cleanedSearchTerm) {
-        const suggestionList = Object.values(this.store["discuss.channel"].records).filter(
-            (channel) =>
-                channel.channel_type === "channel" &&
-                channel.displayName &&
-                cleanTerm(channel.displayName).includes(cleanedSearchTerm)
-        );
+        const suggestionList = this.store["discuss.channel"]
+            .all()
+            .filter(
+                (channel) =>
+                    channel.channel_type === "channel" &&
+                    channel.displayName &&
+                    cleanTerm(channel.displayName).includes(cleanedSearchTerm)
+            );
         const sortFunc = (c1, c2) => {
             const isPublicChannel1 = c1.channel_type === "channel" && !c2.group_public_id;
             const isPublicChannel2 = c2.channel_type === "channel" && !c2.group_public_id;

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -683,9 +683,9 @@ export class Thread extends Component {
 
     get startMessageSubtitle() {
         if (this.props.thread.channel?.parent_channel_id) {
-            const authorName = Object.values(this.store["res.partner"].records).find((partner) =>
-                partner.main_user_id?.eq(this.props.thread.create_uid)
-            )?.name;
+            const authorName = this.store["res.partner"]
+                .all()
+                .find((partner) => partner.main_user_id?.eq(this.props.thread.create_uid))?.name;
             if (authorName) {
                 return _t("Started by %(authorName)s", { authorName });
             }

--- a/addons/mail/static/src/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/core/public_web/store_service_patch.js
@@ -16,13 +16,15 @@ patch(Store.prototype, {
             compute() {
                 /** @type {import("models").Thread[]} */
                 const searchTerm = cleanTerm(this.discuss.searchTerm);
-                let threads = Object.values(this["mail.thread"].records).filter(
-                    (thread) =>
-                        (thread.channel?.self_member_id?.is_pinned ||
-                            (thread.needactionMessages.length > 0 &&
-                                thread.model !== "mail.box")) &&
-                        cleanTerm(thread.displayName).includes(searchTerm)
-                );
+                let threads = this["mail.thread"]
+                    .all()
+                    .filter(
+                        (thread) =>
+                            (thread.channel?.self_member_id?.is_pinned ||
+                                (thread.needactionMessages.length > 0 &&
+                                    thread.model !== "mail.box")) &&
+                            cleanTerm(thread.displayName).includes(searchTerm)
+                    );
                 const tab = this.discuss.activeTab;
                 if (tab === "inbox") {
                     threads = threads.filter((thread) =>

--- a/addons/mail/static/src/core/web/activity_list_popover.js
+++ b/addons/mail/static/src/core/web/activity_list_popover.js
@@ -39,7 +39,7 @@ export class ActivityListPopover extends Component {
 
     get activities() {
         /** @type {import("models").Activity[]} */
-        const allActivities = Object.values(this.store["mail.activity"].records);
+        const allActivities = this.store["mail.activity"].all();
         return allActivities
             .filter((activity) => this.props.activityIds.includes(activity.id))
             .sort((a, b) => compareDatetime(a.date_deadline, b.date_deadline) || a.id - b.id);

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -251,11 +251,13 @@ export class ChannelInvitation extends Component {
                     return _t("Invite");
                 }
                 if (this.selectedPartners.length === 1) {
-                    const alreadyChat = Object.values(this.store["discuss.channel"].records).some(
-                        (channel) =>
-                            channel.channel_type === "chat" &&
-                            channel.correspondent?.partner_id?.eq(this.selectedPartners[0])
-                    );
+                    const alreadyChat = this.store["discuss.channel"]
+                        .all()
+                        .some(
+                            (channel) =>
+                                channel.channel_type === "chat" &&
+                                channel.correspondent?.partner_id?.eq(this.selectedPartners[0])
+                        );
                     if (alreadyChat) {
                         return _t("Go to conversation");
                     }

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -60,7 +60,8 @@ const storeServicePatch = {
      * @returns {number[]}
      */
     getRecentChatPartnerIds() {
-        return Object.values(this["discuss.channel"].records)
+        return this["discuss.channel"]
+            .all()
             .filter(
                 (channel) => channel?.channel_type === "chat" && channel.correspondent?.partner_id
             )

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -160,12 +160,14 @@ export class DiscussCommandPalette {
         const remaining = TOTAL_LIMIT - (filtered ? filtered.size : 0);
         let partners = [];
         if (this.store.self_user) {
-            partners = Object.values(this.store["res.partner"].records).filter(
-                (partner) =>
-                    partner.main_user_id?.share === false &&
-                    cleanTerm(partner.displayName).includes(this.cleanedTerm) &&
-                    (!filtered || !filtered.has(partner))
-            );
+            partners = this.store["res.partner"]
+                .all()
+                .filter(
+                    (partner) =>
+                        partner.main_user_id?.share === false &&
+                        cleanTerm(partner.displayName).includes(this.cleanedTerm) &&
+                        (!filtered || !filtered.has(partner))
+                );
             partners = this.suggestion
                 .sortPartnerSuggestions(partners, this.cleanedTerm)
                 .slice(0, TOTAL_LIMIT);
@@ -177,7 +179,8 @@ export class DiscussCommandPalette {
             // selfPersona filtered here to put at the bottom as lowest priority
             partners = partners.filter((p) => p.notEq(selfPartner));
         }
-        const channels = Object.values(this.store["discuss.channel"].records)
+        const channels = this.store["discuss.channel"]
+            .all()
             .filter(
                 (channel) =>
                     channel.channel_type &&

--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -17,17 +17,19 @@ const StorePatch = {
         const channelsContribution =
             this.channels.status !== "fetched"
                 ? this.initChannelsUnreadCounter
-                : Object.values(this.store["discuss.channel"].records).filter(
-                      (channel) =>
-                          channel.self_member_id?.is_pinned &&
-                          !channel.self_member_id?.mute_until_dt &&
-                          (channel.self_member_id?.message_unread_counter ||
-                              channel.message_needaction_counter)
-                  ).length;
+                : this.store["discuss.channel"]
+                      .all()
+                      .filter(
+                          (channel) =>
+                              channel.self_member_id?.is_pinned &&
+                              !channel.self_member_id?.mute_until_dt &&
+                              (channel.self_member_id?.message_unread_counter ||
+                                  channel.message_needaction_counter)
+                      ).length;
         // Needactions are already counted in the super call, but we want to discard them for channel so that there is only +1 per channel.
-        const channelsNeedactionCounter = Object.values(
-            this.store["discuss.channel"].records
-        ).reduce((acc, channel) => acc + channel.message_needaction_counter, 0);
+        const channelsNeedactionCounter = this.store["discuss.channel"]
+            .all()
+            .reduce((acc, channel) => acc + channel.message_needaction_counter, 0);
         return super.computeGlobalCounter() + channelsContribution + channelsNeedactionCounter;
     },
     /** @returns {import("models").DiscussChannel[]} */
@@ -36,7 +38,8 @@ const StorePatch = {
     },
     /** @returns {import("models").DiscussChannel[]} */
     getSelfRecentChannels() {
-        return Object.values(this["discuss.channel"].records)
+        return this["discuss.channel"]
+            .all()
             .filter((channel) => channel.self_member_id)
             .sort((a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id);
     },

--- a/addons/mail/static/src/model/make_store.js
+++ b/addons/mail/static/src/model/make_store.js
@@ -173,7 +173,7 @@ export function makeStore(env, { localRegistry } = {}) {
         Model._ = markRaw(new ModelInternal());
         Object.assign(Model, {
             Class,
-            records: reactive({}),
+            records: reactive(new Map()),
         });
         Models[Model.getName()] = Model;
         store[Model.getName()] = Model;

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -34,20 +34,21 @@ export class Record {
     static env;
     /** @type {import("@web/env").OdooEnv} */
     env;
-    /** @type {Object<string, Record>} */
-    static records;
     /** @type {import("models").Store} */
     static store;
     /** @param {() => any} fn */
     static MAKE_UPDATE(fn) {
         return this.store.MAKE_UPDATE(...arguments);
     }
+    static all() {
+        return [...this.records.values()];
+    }
     static onChange(record, name, cb) {
         return this.store.onChange(...arguments);
     }
     static get(data) {
         const Model = toRaw(this);
-        return this.records[Model.localId(data)];
+        return this.records.get(Model.localId(data));
     }
     static getName() {
         return this._name || this.name;
@@ -196,7 +197,7 @@ export class Record {
                 record._.prepareField(record, name, recordProxy);
             }
             Object.assign(recordProxy, { ...ids });
-            Model.records[record.localId] = recordProxy;
+            Model.records.set(record.localId, recordProxy);
             if (record.Model.getName() === "Store") {
                 Object.assign(record, {
                     env: Model._rawStore.env,

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -158,7 +158,7 @@ export class StoreInternal extends RecordInternal {
                 /** @type {import("./record").Record} */
                 const [record] = params;
                 record._proxy[IS_DELETED_SYM] = true;
-                delete record.Model.records[record.localId];
+                record.Model.records.delete(record.localId);
                 if (!this.RHD_QUEUE.has(record)) {
                     this.RHD_QUEUE.set(record, true);
                 }

--- a/addons/mail/static/tests/core/common/store_service.test.js
+++ b/addons/mail/static/tests/core/common/store_service.test.js
@@ -69,11 +69,11 @@ test("store.insert different PY model having same JS model", async () => {
     };
 
     store.insert(data);
-    expect(store["mail.thread"].records).toHaveLength(6); // 3 mailboxes + 3 channels
+    expect(store["mail.thread"].records.size).toBe(6); // 3 mailboxes + 3 channels
     expect(Boolean(store["mail.thread"].get({ id: 1, model: "discuss.channel" }))).toBe(true);
     expect(Boolean(store["mail.thread"].get({ id: 2, model: "discuss.channel" }))).toBe(true);
     expect(Boolean(store["mail.thread"].get({ id: 3, model: "discuss.channel" }))).toBe(true);
-    expect(store["discuss.channel"].records).toHaveLength(3); // 3 channels
+    expect(store["discuss.channel"].records.size).toBe(3); // 3 channels
     expect(Boolean(store["discuss.channel"].get(1))).toBe(true);
     expect(Boolean(store["discuss.channel"].get(2))).toBe(true);
     expect(Boolean(store["discuss.channel"].get(3))).toBe(true);

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -949,7 +949,7 @@ test("record.toData() is JSON stringified and can be reinserted as record", asyn
     expect(p.team.name).toBe("Discuss");
     expect(p.signature.toString()).toBe("<p>-- John</p>");
     expect(p.signature).toBeInstanceOf(Markup);
-    expect(toRaw(store.Person.records[p.localId])).toBe(toRaw(p));
+    expect(toRaw(store.Person.records.get(p.localId))).toBe(toRaw(p));
     expect(serializeDateTime(p.due_datetime)).toBe("2024-08-28 10:19:44");
     // export data, delete, then insert back
     const data = JSON.parse(JSON.stringify(p.toData()));
@@ -957,14 +957,14 @@ test("record.toData() is JSON stringified and can be reinserted as record", asyn
     store.Message.get("1").delete();
     store.Message.get("2").delete();
     store.Team.get("Discuss").delete();
-    expect(toRaw(store.Person.records[p.localId])).toBe(undefined);
+    expect(toRaw(store.Person.records.get(p.localId))).toBe(undefined);
     store.insert(data);
     const p2 = store.Person.get(1);
     // Same assertions as before
     expect(p2.names).toEqual(["John", "Marc"]);
     expect(p2.messages.map((msg) => msg.body)).toEqual(["1", "2"]);
     expect(p2.team.name).toBe("Discuss");
-    expect(toRaw(store.Person.records[p2.localId])).toBe(toRaw(p2));
+    expect(toRaw(store.Person.records.get(p2.localId))).toBe(toRaw(p2));
     expect(serializeDateTime(p2.due_datetime)).toBe("2024-08-28 10:19:44");
     expect(p2.signature.toString()).toBe("<p>-- John</p>");
     expect(p.signature).toBeInstanceOf(Markup);
@@ -1250,7 +1250,7 @@ test("Deleted records are not returned by 'Model.records' nor 'Model.get()'", as
         if (msg) {
             expect(toRaw(msg).exists()).toBe(true);
         }
-        for (const msg of Object.values(store.Message.records)) {
+        for (const msg of store.Message.records.values()) {
             expect(toRaw(msg).exists()).toBe(true);
         }
     }
@@ -1278,11 +1278,9 @@ test("Deleted records are not returned by 'Model.records' nor 'Model.get()'", as
                     expect.step("allMessagesInStore:compute");
                     expect(this._lastAllMessagesInStore.some((m) => m.exists())).toBe(false);
                 }
-                expect(this.thread.hasMessages).toBe(
-                    Boolean(Object.values(store.Message.records).length > 0)
-                );
+                expect(this.thread.hasMessages).toBe(Boolean(store.Message.records.size > 0));
                 assertExists(this.store);
-                const allMessagesInStore = Object.values(store.Message.records);
+                const allMessagesInStore = store.Message.all();
                 toRaw(this)._raw._lastAllMessagesInStore = allMessagesInStore;
                 return allMessagesInStore;
             },
@@ -1296,7 +1294,7 @@ test("Deleted records are not returned by 'Model.records' nor 'Model.get()'", as
     const message = store.Message.insert({ content: "msg-1", thread });
     expectRecord(thread.messages[0]).toEqual(message);
     expectRecord(store.Message.get("msg-1")).toEqual(message);
-    expectRecord(store.Message.records[message.localId]).toEqual(message);
+    expectRecord(store.Message.records.get(message.localId)).toEqual(message);
     deleting = true;
     message.delete();
     deleting = false;


### PR DESCRIPTION
`Store.MyModel.records` is an object whose key is record local id and value is the record.

While format of object is nice, this object has its shape changing quite often as this is based on creation and deletion of records. Objects in javascript are expected to have their shape changed rarely, which is not the case of `records`. In theory, creation of JS models can lead to noticeable stuttering from major and minor GC.

This commit changes the shape of `records` to become a Map instead, which doesn't have these problems.

As this becomes a Map, and quite some business code was using `Object.values()` around records, this commit also add a new feature on Model object: `.all()`, which returns list of all records of the given model:

```js
// previously
Object.values(store.MyModel.records);
// now
store.MyModel.all();
```

Task-5437248