### PR TITLE
[FIX] website: fix dynamic snippet options

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_hook.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_hook.js
@@ -82,5 +82,6 @@ export function useDynamicSnippetOption(modelNameFilter, contextualFilterDomain 
         getFilteredTemplates,
         showFilterOption,
         ...dynamicSnippetUtils,
+        modelNameFilter,
     };
 }

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -8,8 +8,9 @@
     <t t-set="filteredTemplates" t-value="dynamicOptionParams.getFilteredTemplates()"/>
     <t t-set="isSingleMode" t-value="dynamicOptionParams.domState.isSingleMode"/>
     <t t-set="numberOfRecords" t-value="dynamicOptionParams.domState.numberOfRecords"/>
+    <t t-set="modelNameFilter" t-value="dynamicOptionParams.modelNameFilter"/>
     <!-- Single record filter options -->
-    <BuilderRow label.translate="Model" t-if="!props.modelNameFilter and isSingleMode">
+    <BuilderRow label.translate="Model" t-if="!modelNameFilter and isSingleMode">
         <BuilderSelect action="'dynamicModel'" preview="false" id="'model_opt'"></BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Record" t-if="isSingleMode">
@@ -30,7 +31,7 @@
             </t>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow id="template_opt_row" label.translate="Template" t-if="!props.modelNameFilter and filteredTemplates.length > 1">
+    <BuilderRow id="template_opt_row" label.translate="Template" t-if="!modelNameFilter and filteredTemplates.length > 1">
         <BuilderSelect action="'dynamicSnippetTemplate'" preview="false" id="'template_opt'">
             <t t-foreach="filteredTemplates" t-as="template" t-key="template.key">
                 <t t-if="template.thumb">

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
@@ -1,0 +1,55 @@
+import {
+    changeOptionInPopover,
+    clickOnSnippet,
+    insertSnippet,
+    registerWebsitePreviewTour,
+    goBackToBlocks,
+} from "@website/js/tours/tour_utils";
+
+const dynamicSnippet = {
+    id: "s_dynamic_snippet",
+    name: "Dynamic Snippet",
+    groupName: "Debug",
+};
+const blogPostsSnippet = {
+    id: "s_blog_posts_single_aside",
+    name: "Blog Post",
+    groupName: "Blogs",
+};
+
+registerWebsitePreviewTour(
+    "blog_posts_dynamic_snippet_options",
+    {
+        url: "/?debug=1",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet(blogPostsSnippet),
+        ...clickOnSnippet({ ...blogPostsSnippet, id: "s_blog_posts" }),
+        {
+            content: "Check That the `Model` option is hidden",
+            trigger: `.options-container:not(:has([data-label="Model"]))`,
+        },
+        {
+            content: "Check That the `Template` option is hidden",
+            trigger: `.options-container:not(:has([data-label="Template"]))`,
+        },
+        goBackToBlocks(),
+        ...insertSnippet(dynamicSnippet),
+        ...clickOnSnippet(dynamicSnippet),
+        ...changeOptionInPopover("Dynamic Snippet", "Filter", "Latest Blog Posts"),
+        ...changeOptionInPopover(
+            "Dynamic Snippet",
+            "Fetched Elements",
+            `div[data-action-param*='1']`
+        ),
+        {
+            content: "Check That the `Model` option is visible",
+            trigger: `.options-container [data-label="Model"]`,
+        },
+        {
+            content: "Check That the `Template` option is visible",
+            trigger: `.options-container [data-label="Template"]`,
+        },
+    ]
+);

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -120,3 +120,6 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         blog_post_2.write({'tag_ids': [(4, blog_tag.id)]})
 
         self.start_tour("/blog", "blog_tags_with_date", login="admin")
+
+    def test_blog_posts_dynamic_snippet_options(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_options', login='admin')


### PR DESCRIPTION
Steps to reproduce (19.0+):

1. Add a "Blog" mono-record snippet to a website page.

2. Select the snippet → the "Model" and "Template" options are visible.

The code from [1], which introduced mono-record dynamic snippets,
restricted the visibility of these options as follows:

- The "Model" option should only be visible for generic mono-record
snippets (in `Debug` mode).

- The "Template" option should be available for generic snippets
and, exceptionally, for the "Products" snippet (which had no default
layouts in the snippets dialog).

Starting from [2], these conditions are no longer applied, as the
change simply removed the `props.modelNameFilter` used in the XML to
enforce them.

[1]: https://github.com/odoo/odoo/commit/e3b062e5d3820ddfcee2eb669f21edc0c53c3330
[2]: https://github.com/odoo/odoo/commit/36f741745b927d7cbac9b32042bd53b47711da6f

related-task-4280375