### PR TITLE
[FIX] l10n_hu_edi: e-invoice currency rate date

### DIFF
--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -285,7 +285,7 @@ class AccountMove(models.Model):
             from_currency=self.currency_id,
             to_currency=self.env.ref('base.HUF'),
             company=self.company_id,
-            date=self.invoice_date,
+            date=self._get_invoice_currency_rate_date(),
         )
 
     def _l10n_hu_edi_set_chain_index(self):

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -13,6 +13,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
         super().setUpClass()
 
         cls.today = datetime.date.today()
+        cls.yesterday = cls.today - datetime.timedelta(days=1)
 
         # Company
         company = cls.company_data['company']
@@ -87,7 +88,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
         )
         cls.env['res.currency.rate'].create(
             {
-                'name': cls.today - datetime.timedelta(days=1),
+                'name': cls.yesterday,
                 'currency_id': currency_eur.id,
                 'company_id': company.id,
                 'inverse_company_rate': '377.66',
@@ -316,7 +317,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             'journal_id': self.company_data['default_journal_sale'].id,
             'currency_id': self.env.ref('base.EUR').id,
             'partner_id': self.partner_company.id,
-            'invoice_date': self.today,
+            'invoice_date': self.yesterday,
             'delivery_date': self.today,
             'l10n_hu_payment_mode': 'TRANSFER',
             'invoice_line_ids': [

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
@@ -5,7 +5,7 @@
     xmlns="http://schemas.nav.gov.hu/OSA/3.0/data"
     xsi:schemaLocation="http://schemas.nav.gov.hu/OSA/3.0/data invoiceData.xsd">
     <invoiceNumber>INV/2024/00001</invoiceNumber>
-    <invoiceIssueDate>2024-02-01</invoiceIssueDate>
+    <invoiceIssueDate>2024-01-31</invoiceIssueDate>
     <completenessIndicator>false</completenessIndicator>
     <invoiceMain>
         <invoice>


### PR DESCRIPTION
In the Hungarian localization, the currency exchange rate for invoices
is based on the delivery date.

Steps to reproduce:
- With HU localization setup
- Create an invoice

Issue:
Currently, when issuing the e-invoice, the system would compute the
currency exchange rate using the invoice date.

opw-5126816