### PR TITLE
[FIX] {google_,microsoft_,}calendar: keep SMS reminders for mail-synced events

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -152,7 +152,8 @@ class AlarmManager(models.AbstractModel):
         already.
         """
         lastcall = self.env.context.get('lastcall', False) or fields.date.today() - relativedelta(weeks=1)
-        extra_conditions = self._get_notify_alert_extra_conditions()
+        # TODO MASTER: remove context and add a proper parameter
+        extra_conditions = self.with_context(alarm_type=alarm_type)._get_notify_alert_extra_conditions()
         now = fields.Datetime.now()
         self.env.cr.execute(SQL("""
             SELECT alarm.id, event.id

--- a/addons/google_calendar/models/calendar_alarm_manager.py
+++ b/addons/google_calendar/models/calendar_alarm_manager.py
@@ -10,4 +10,6 @@ class AlarmManager(models.AbstractModel):
     @api.model
     def _get_notify_alert_extra_conditions(self):
         base = super()._get_notify_alert_extra_conditions()
-        return SQL("%s AND event.google_id IS NULL", base)
+        if self.env.context.get('alarm_type') == 'email':
+            return SQL("%s AND event.google_id IS NULL", base)
+        return base

--- a/addons/microsoft_calendar/models/calendar_alarm_manager.py
+++ b/addons/microsoft_calendar/models/calendar_alarm_manager.py
@@ -10,4 +10,6 @@ class AlarmManager(models.AbstractModel):
     @api.model
     def _get_notify_alert_extra_conditions(self):
         base = super()._get_notify_alert_extra_conditions()
-        return SQL("%s AND event.microsoft_id IS NULL", base)
+        if self.env.context.get('alarm_type') == 'email':
+            return SQL("%s AND event.microsoft_id IS NULL", base)
+        return base


### PR DESCRIPTION
SMS reminders are not sent for calendar events synced with Google, even though only email reminders should be delegated to Google.

Reproduction steps:

* Create a calendar event in Odoo with an SMS reminder.
* Sync the calendar with Google.
* Wait for the reminder to trigger.
* Observe that no SMS is sent by Odoo.

Cause:

The event reminder scheduled action groups events by alarm type and calls `_get_events_by_alarm_to_notify`. For Google-synced events, `_get_notify_alert_extra_conditions` blindly excludes any event with a `google_id`, assuming Google will manage all reminders. This exclusion is incorrect for non-email alarms (e.g. SMS), which must still be handled by Odoo.

Fix:

The alarm type is propagated through the context so Google-specific exclusions only apply to email reminders. This restores SMS notifications while preserving the existing behavior for emails. A context key is used for stability; a proper method argument will be introduced in master.

opw-5172958