### PR TITLE
[FIX] website_slides: support Google Shared Drive links

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1140,6 +1140,7 @@ class Slide(models.Model):
 
         params = {}
         params['projection'] = 'BASIC'
+        params['supportsAllDrives'] = 'true'  # Allow Shared Drive links
         if 'google.drive.config' in self.env:
             access_token = False
             try:


### PR DESCRIPTION
Step to reproduce:
1. Install `website_slides`
2. Go to eLearning > Courses > select a course > Add Content
3. Paste a public link that belongs to a file located in a Google `Shared Drive`

Issue:
- The system shows a warning
  `Your file could not be found on Google Drive, please check the link and/or privacy settings` even if the link is accessible via a   browser in incognito mode.

Cause:
- The Google Drive API restricts the search scope to the user's personal `My Drive` by default It filters out items located in Shared Drives unless the client explicitly signals

Solution:
- Add `params['supportsAllDrives'] = 'true'` to the API request

opw-5424413