### PR TITLE
[IMP] website: introduce top/bottom movement overlay buttons

### DIFF
--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -49,7 +49,7 @@ test("Use the 'move arrows' overlay buttons", async () => {
     expect(".overlay .o_overlay_options").toHaveCount(1);
     expect(".overlay .fa-angle-right").toHaveCount(1);
     expect(".overlay .fa-angle-left").toHaveCount(0);
-    expect(".overlay .fa-angle-up, .overlay .fa-angle-down").toHaveCount(0);
+    expect(".overlay .fa-angle-up, .overlay .fa-angle-down").toHaveCount(1);
 
     await contains(":iframe .col-lg-3").click();
     expect(".overlay .fa-angle-right").toHaveCount(0);
@@ -99,7 +99,7 @@ test("Use the 'move arrows' overlay buttons within an editable div", async () =>
     expect(".overlay .o_overlay_options").toHaveCount(1);
     expect(".overlay .fa-angle-right").toHaveCount(1);
     expect(".overlay .fa-angle-left").toHaveCount(0);
-    expect(".overlay .fa-angle-up, .overlay .fa-angle-down").toHaveCount(0);
+    expect(".overlay .fa-angle-up, .overlay .fa-angle-down").toHaveCount(1);
 
     await contains(":iframe .col-lg-3").click();
     expect(".overlay .fa-angle-right").toHaveCount(0);
@@ -113,6 +113,13 @@ test("Use the 'move arrows' overlay buttons within an editable div", async () =>
     expect(":iframe .col-lg-4:nth-child(1)").toHaveCount(1);
     expect(".overlay .fa-angle-right").toHaveCount(1);
     expect(".overlay .fa-angle-left").toHaveCount(0);
+
+    // Test moving top and bottom buttons
+    expect(".overlay .fa-angle-up, .overlay .fa-angle-down").toHaveCount(1);
+    await contains(".overlay .fa-angle-down").click();
+    // Now the col will have one sibling above, so both up and down arrows
+    // should be visible
+    expect(".overlay .fa-angle-up, .overlay .fa-angle-down").toHaveCount(2);
 });
 
 test("Use the 'grid' overlay buttons", async () => {


### PR DESCRIPTION
What We Added:
Two new directional buttons (↑ Top, ↓ Bottom) on the element overlay toolbar Smart visual positioning: Moves elements to the closest element in that direction, enabling quick multi-step repositioning Intelligent button visibility: Buttons only appear movement is possible, giving clear visual feedback

Movement Logic:
├─ Adjacent Movement (existing)
│  └─ Moves to next/previous sibling only
│
└─ Visual Direction Movement (NEW)
   ├─ Calculates all element positions on screen
   ├─ Finds closest element above/below current position
   └─ Swaps positions intelligently

Scope Boundaries (What We Did NOT Include):
✅ Movement within columns (team members, etc.)
✅ Movement within editable containers
❌ NOT for sections (to avoid UI clutter with duplicate arrows) 
❌ Does NOT override existing left/right movement