### PR TITLE
[IMP] sale_project: consistent top bar display for sales orders

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -211,7 +211,7 @@ class ProjectProject(models.Model):
         action_window = {
             'type': 'ir.actions.act_window',
             'res_model': 'sale.order.line',
-            'name': _("%(name)s's Sales Order Items", name=self.name),
+            'name': self.env._("Sales Order Items"),
             'context': {
                 'show_sale': True,
                 'link_to_project': self.id,
@@ -240,7 +240,6 @@ class ProjectProject(models.Model):
         all_sale_orders = self._fetch_sale_order_items({'project.task': [('is_closed', '=', False)]}).sudo().order_id
         embedded_action_context = self.env.context.get('from_embedded_action', False)
         action_window = self._get_view_action()
-        action_window["display_name"] = self.env._("%(name)s's %(action_name)s", name=self.name, action_name=action_window.get('name'))
         action_window["domain"] = self._get_sale_orders_domain(all_sale_orders)
         action_window['context'] = {
             **ast.literal_eval(action_window['context']),


### PR DESCRIPTION
- Currently, the top bar displays the project name for Sales Orders (e.g., "Project's Sales Orders"), while other menus like Invoices and Bills only display the menu name.

- This commit modifies the actions to display only the menu name (e.g., "Sales Orders" and "Sales Order Items") to ensure consistency across all menus

task-5257695
