### PR TITLE
[IMP] project: preserve task state when moving to shared stage project

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -395,7 +395,7 @@ class ProjectTask(models.Model):
                 if task.state not in CLOSED_STATES:
                     task.state = '04_waiting_normal'
             # if the task as no blocking dependencies and is in waiting_normal, the task goes back to in progress
-            elif task.state not in CLOSED_STATES:
+            elif task.state == '04_waiting_normal':
                 task.state = '01_in_progress'
 
     @api.depends('state')
@@ -425,7 +425,7 @@ class ProjectTask(models.Model):
 
     @api.onchange('project_id')
     def _onchange_project_id(self):
-        if self.state != '04_waiting_normal':
+        if self.state != '04_waiting_normal' and self.stage_id != self._origin.stage_id:
             self.state = '01_in_progress'
 
     def is_blocked_by_dependences(self):
@@ -1300,6 +1300,10 @@ class ProjectTask(models.Model):
             additional_vals['description'] = vals.pop('description')
 
             # write changes
+        if 'project_id' in vals:
+            tasks_to_check = self | self._get_all_subtasks()
+            previous_stage_ids = {task.id: task.stage_id.id for task in tasks_to_check}
+
         if self.env.su or not self.env.user._is_portal():
             vals.update(additional_vals)
         elif additional_vals:
@@ -1328,8 +1332,17 @@ class ProjectTask(models.Model):
                     if task.is_blocked_by_dependences() and vals['state'] not in CLOSED_STATES and vals['state'] != '04_waiting_normal':
                         task.state = '04_waiting_normal'
                 task.date_last_stage_update = now
-        elif 'project_id' in vals:
-            self.filtered(lambda t: t.state != '04_waiting_normal').state = '01_in_progress'
+
+        if 'project_id' in vals:
+            tasks_to_check.filtered(
+                lambda t: (
+                    t.state != '04_waiting_normal'
+                    and previous_stage_ids.get(t.id) != t.stage_id.id
+                    and not (t.id in self.ids and 'state' in vals)
+                )
+            ).state = '01_in_progress'
+        elif 'stage_id' in vals and 'state' not in vals:
+            self.filtered(lambda t: t.state != '04_waiting_normal' and t.state not in CLOSED_STATES).state = '01_in_progress'
 
         # Do not recompute the state when changing the parent (to avoid resetting the state)
         if 'parent_id' in vals:

--- a/addons/project/tests/test_task_state.py
+++ b/addons/project/tests/test_task_state.py
@@ -225,3 +225,35 @@ class TestTaskState(TestProjectCommon):
         self.assertEqual(self.task_1.state, '03_approved')
         self.project_goats.allow_task_dependencies = True
         self.assertEqual(self.task_1.state, '03_approved')
+
+    def test_project_move_state_preservation(self):
+        """ Test that state is preserved when moving to a project sharing the stage """
+        project_goats_copy = self.project_goats.copy()
+        self.task_1.write({
+            'state': '03_approved',
+        })
+        # Test state preservation when moving to shared stage
+        original_stage = self.task_1.stage_id
+        self.task_1.write({
+            'project_id': project_goats_copy.id,
+        })
+        self.assertEqual(self.task_1.stage_id, original_stage, "Stage should remain the same")
+        self.assertEqual(
+            self.task_1.state,
+            '03_approved',
+            "State should be preserved when moving to project with shared stages"
+        )
+        # Test state reset when moving to non-shared stage
+        self.task_1.write({
+            'project_id': self.project_pigs.id,
+        })
+        self.assertNotEqual(
+            self.task_1.stage_id,
+            original_stage,
+            "Stage should change when moving to a project with different stages"
+        )
+        self.assertEqual(
+            self.task_1.state,
+            '01_in_progress',
+            "Task state should change when moving to a project with non-shared stage."
+        )


### PR DESCRIPTION
Before this commit, moving a task to another project always reset its state to "In Progress", even if the new project shared the same stage.

This commit ensures:
- The task state (e.g., "Approved") is preserved when moving to a project with a shared stage.

task-4210148
