### PR TITLE
[FIX] hr_expense: include all attachments in generated journal entries

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -865,7 +865,7 @@ class HrExpense(models.Model):
             'line_ids': [Command.create(line) for line in move_lines],
             'attachment_ids': [
                 Command.create(attachment.copy_data({'res_model': 'account.move', 'res_id': False, 'raw': attachment.raw})[0])
-                for attachment in self.message_main_attachment_id]
+                for attachment in self.attachment_ids]
         }
 
     def _prepare_move_lines_vals(self):

--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -739,7 +739,7 @@ class HrExpenseSheet(models.Model):
             'line_ids': [Command.create(expense._prepare_move_lines_vals()) for expense in self.expense_line_ids],
             'attachment_ids': [
                 Command.create(attachment.copy_data({'res_model': 'account.move', 'res_id': False, 'raw': attachment.raw})[0])
-                for attachment in self.expense_line_ids.message_main_attachment_id
+                for attachment in self.expense_line_ids.attachment_ids
             ],
         }
 

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -742,6 +742,33 @@ class TestExpenses(TestExpenseCommon):
             'res_id': expense_sheet.account_move_ids[1].id
         }])
 
+    def test_multiple_attachments_in_move_from_company_expense(self):
+        """ Checks that all attachments from expense are copied to their journal entries. """
+
+        attachments = self.env['ir.attachment'].create([{
+            'raw': b"R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=",
+            'name': f'expense1_file{i}.png',
+            'res_model': 'hr.expense',
+        } for i in range(1, 3)])
+
+        expense_sheet = self.env['hr.expense.sheet'].create({
+            'name': 'Expenses paid by company',
+            'employee_id': self.expense_employee.id,
+            'expense_line_ids': [Command.create({
+                'name': 'Company expense 1',
+                'date': '2022-11-16',
+                'payment_mode': 'company_account',
+                'total_amount_currency': 1000.00,
+                'employee_id': self.expense_employee.id,
+                'attachment_ids': [Command.set(attachments.ids)],
+            })]
+        })
+        expense_sheet.action_submit_sheet()
+        expense_sheet.action_approve_expense_sheets()
+        expense_sheet.action_sheet_move_create()
+
+        self.assertEqual(len(expense_sheet.account_move_ids.attachment_ids), 2)
+
     def test_expense_payment_method(self):
         default_payment_method_line = self.company_data['default_journal_bank'].outbound_payment_method_line_ids[0]
         check_method = self.env['account.payment.method'].sudo().create({


### PR DESCRIPTION
**Steps to reproduce:**
* Install **hr_expense** and **accounting** modules.
* Create two or more expenses, each with **multiple attachments**.
* Submit and approve the expenses.
* Create the **journal entry** of all approved expenses.
* Open the generated journal entry and review its attachments.

**Observed behavior:**
* Only the **first attachment** from each expense is present on the journal entry.
* Additional attachments are missing.

**Cause:**
* while creating journal entry, the logic of expense iterate on `message_main_attachment_id`.
* `message_main_attachment_id` stores only a **single attachment**, so only one file per expense is copied.

**Fix:**
* Iterate on `attachment_ids` instead of `message_main_attachment_id`.
* Ensures **all attachments** from each expense are included in the generated journal entry.

opw-5414834
