### PR TITLE
[FIX] account: tooltip props validation error

### DIFF
--- a/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
+++ b/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
@@ -11,7 +11,7 @@ import { Component, onMounted } from "@odoo/owl";
 class BankTag extends Component {
     static template = "account.BankTag";
     static components = { BadgeTag };
-    static props = ["allowOutPayment?", "color", "onClick", "onDelete", "onClick", "text"];
+    static props = ["allowOutPayment?", "color", "onClick", "onDelete", "onClick", "text", "tooltip"];
 }
 
 export class FieldMany2ManyTagsBanks extends Many2ManyTagsField {


### PR DESCRIPTION
Steps to reproduce:
- Install the Accounting and Contacts modules
- Open a contact that has a value in the Bank Accounts field (e.g., Deco Addict)
- Click on the Invoicing / Accounting notebook
- A traceback occurs

Reason:
In this commit https://github.com/odoo/odoo/commit/58e9fbf651473dc39214d7faabdfb06606ce92d0, A new tooltip prop was added but it was not included in the props definition here: https://github.com/odoo/odoo/blob/saas-19.1/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js#L14 Since the `FieldMany2ManyTagsBanks` component calls `super.getTagProps(record)`, all expected props must be defined. The missing tooltip prop causes the validation error and results in the traceback.

Fix:
Added a tooltip to the static props list of the component. With this change, the issue is resolved.

task-5438012