### PR TITLE
[IMP] web: apply left alignment to progressbar columns

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -44,8 +44,8 @@
                     <field name="ab_testing_enabled" string="A/B Test" groups="mass_mailing.group_mass_mailing_campaign"/>
                     <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
                     <field name="sent" sum="Total" />
-                    <field name="received_ratio" class="d-flex align-items-center ps-0 ps-lg-5" widget="progressbar" string="Delivered (%)" avg="Average"/>
-                    <field name="opened_ratio" class="d-flex align-items-center ps-0 ps-lg-5" widget="progressbar" string="Opened (%)" avg="Average"/>
+                    <field name="received_ratio" class="d-flex align-items-center ps-0" widget="progressbar" string="Delivered (%)" avg="Average"/>
+                    <field name="opened_ratio" class="d-flex align-items-center ps-0" widget="progressbar" string="Opened (%)" avg="Average"/>
                     <field name="bounced_ratio" string="Bounced (%)" optional="hide" avg="Average"/>
                     <field name="clicks_ratio" string="Clicked (%)" avg="Average"/>
                     <field name="replied_ratio" string="Replied (%)" avg="Average"/>

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.scss
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.scss
@@ -24,21 +24,28 @@
     }
 }
 
-.o_list_view .o_data_cell {
-    .o_progressbar {
-        // Force progress bars to respect table's layout
-        display: table-row;
-        justify-content: end;
-        .o_rtl & {
-            justify-content: flex-start;
-            text-align: right;
-        }
-        .o_progressbar_value {
-            span {
-                min-width: 1.5rem;
+.o_list_view {
+    .o_progressbar_cell .o_list_number_th {
+        text-align: left !important;
+    }
+
+    .o_data_cell {
+        .o_progressbar {
+            // Force progress bars to respect table's layout
+            display: table-row;
+            justify-content: start;
+            .o_rtl & {
+                justify-content: flex-end;
+                text-align: right;
             }
-            span:last-child{
-                text-align: left;
+            .o_progressbar_value {
+                span {
+                    min-width: 1.5rem;
+                    text-align: end;
+                }
+                span:last-child{
+                    text-align: start;
+                }
             }
         }
     }

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -18334,13 +18334,13 @@ test(`monetary field display for rtl languages`, async () => {
     expect(`thead th:not(.o_list_record_selector):eq(1)`).toHaveStyle(
         { "text-align": "right" },
         {
-            message: "header cells of monetary fields should be right alined",
+            message: "header cells of monetary fields should be right aligned",
         }
     );
     expect(`tbody tr:eq(0) td:not(.o_list_record_selector):eq(1)`).toHaveStyle(
         { "text-align": "right" },
         {
-            message: "Monetary cells should be right alined",
+            message: "Monetary cells should be right aligned",
         }
     );
     expect(`tbody tr:eq(0) td:not(.o_list_record_selector):eq(1)`).toHaveStyle(


### PR DESCRIPTION
**Progressbar** columns currently have **right-aligned headers**, which results in
visual inconsistency. This change enforces **left alignment** for both the
**progressbar headers** and their **column content** to ensure a clearer and more
consistent layout. When rendered in an **RTL (right-to-left)** format, the headers
and content are aligned to the **right** accordingly, consistent with the alignment
of other fields in that format.

Enterprise: https://github.com/odoo/enterprise/pull/102871

task-5248253

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
