### PR TITLE
[FIX] base: align flag icons in app icons

### DIFF
--- a/odoo/addons/base/static/src/css/modules.css
+++ b/odoo/addons/base/static/src/css/modules.css
@@ -1,9 +1,13 @@
 .oe_module_flag {
     position: absolute;
-    left: 12px;
-    top: calc(50% - 35px);
+    left: calc(var(--KanbanRecord-padding-h) * -0.5);
+    top: calc(var(--KanbanRecord-padding-v) * -1);
     font: 27px icon;
     text-shadow: 0px 0px 5px rgba(0, 0, 0, 0.5);
+}
+
+.o_modules_kanban .o_kanban_record > aside {
+    position: relative;
 }
 
 .o_kanban_view.o_modules_kanban .o_kanban_renderer .o_kanban_record .o_dropdown_kanban,


### PR DESCRIPTION
In commit[1] the apps icons were aligned on top of the kanbancard. In the cases of apps that display a flag, the flag is misaligned (eg. l10 modules).

When pressing alt, a filter is applied which changes the stacking context to the `<aside>` which offsets the flag icon.

This change realigns the flag on top of the kanbancard to match the new position of the app icon. Set `<aside>` to position relative to avoid the filter offseting the flag.


task-5437786

[1]: odoo/odoo@abaa06a8b3e639be03a1ba0a95629f5b6f73a08a

| 19.0 | saas-19.1 | This PR |
|--------|--------|--------|
| <img width="439" height="110" alt="image" src="https://github.com/user-attachments/assets/06eda607-121c-4089-9341-90564e99788b" /> | <img width="439" height="110" alt="image" src="https://github.com/user-attachments/assets/d6a529ef-5153-4eea-8602-42d09475ce26" /> | <img width="439" height="110" alt="image" src="https://github.com/user-attachments/assets/5e8944a7-361f-4692-a0f9-8fde830007d4" /> | 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
