### PR TITLE
[FIX] l10n_vn_edi_viettel: wrong exchange rate when issue foreign currency invoice

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -13,6 +13,7 @@ from requests import RequestException
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import float_round, float_repr
 
 SINVOICE_API_URL = 'https://api-vinvoice.viettel.vn/services/einvoiceapplication/api/'
 SINVOICE_TIMEOUT = 60  # They recommend between 60 and 90 seconds, but 60s is already quite long.
@@ -582,12 +583,14 @@ class AccountMove(models.Model):
 
         # When invoicing in a foreign currency, we need to provide the rate, or it will default to 1.
         if self.currency_id.name != 'VND':
-            invoice_data['exchangeRate'] = self.env['res.currency']._get_conversion_rate(
+            # Sinvoice only allow upto 2 decimal place for exchange rate
+            exchange_rate = self.env['res.currency']._get_conversion_rate(
                 from_currency=self.currency_id,
                 to_currency=self.env.ref('base.VND'),
                 company=self.company_id,
                 date=self.invoice_date or self.date,
             )
+            invoice_data['exchangeRate'] = float_repr(float_round(exchange_rate, 2), 2)
 
         adjustment_origin_invoice = None
         if self.move_type == 'out_refund':  # Credit note are used to adjust an existing invoice

--- a/addons/l10n_vn_edi_viettel/tests/test_edi.py
+++ b/addons/l10n_vn_edi_viettel/tests/test_edi.py
@@ -266,7 +266,7 @@ class TestVNEDI(AccountTestInvoicingCommon):
             currency=self.currency_data['currency'],
         )
         json_data = invoice._l10n_vn_edi_generate_invoice_json()
-        self.assertEqual(json_data['generalInvoiceInfo']['exchangeRate'], 0.5)
+        self.assertEqual(json_data['generalInvoiceInfo']['exchangeRate'], "0.50")
 
     @freeze_time('2024-01-01')
     def test_send_and_print(self):


### PR DESCRIPTION
* STEP TO REPRODUCE: create USD invoice to issue sinvoice, have currency
rate like 26337.9186666777 , when issue we will get error because too
many decimal

* SOLUTION: round exchange rate up to 2 decimal because documentation
said that is maximum

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
