### PR TITLE
[IMP] l10n_th: clarify branch code placement and branch name computation

### DIFF
--- a/addons/l10n_th/__manifest__.py
+++ b/addons/l10n_th/__manifest__.py
@@ -22,6 +22,8 @@ Thai accounting chart and localization.
     'data': [
         'data/account_tax_report_data.xml',
         'views/report_invoice.xml',
+        'views/res_partner_view.xml',
+        'views/res_company_view.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_th/models/res_partner.py
+++ b/addons/l10n_th/models/res_partner.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models, fields
+import re
+from odoo import api, models, fields
+from odoo.exceptions import ValidationError
 
 
 class ResPartner(models.Model):
@@ -14,4 +16,10 @@ class ResPartner(models.Model):
                 partner.l10n_th_branch_name = ""
             else:
                 code = partner.company_registry
-                partner.l10n_th_branch_name = f"Branch {code}" if code else "Headquarter"
+                partner.l10n_th_branch_name = f"Branch {code}" if code and code != "00000" else "Headquarter"
+
+    @api.constrains('company_registry')
+    def _check_company_registry_l10n_th(self):
+        for partner in self:
+            if partner.country_code == "TH" and partner.company_registry and not re.fullmatch(r'\d{5}', partner.company_registry):
+                raise ValidationError(partner.env._("The branch Code must be exactly 5 digits."))

--- a/addons/l10n_th/views/res_company_view.xml
+++ b/addons/l10n_th/views/res_company_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <record id="view_company_form_inherit_l10n_th" model="ir.ui.view">
+            <field name="name">res.company.form.inherit.l10n_th</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+                <field name="company_registry" position="attributes">
+                    <attribute name="invisible" add="country_code == 'TH'" separator=" or "/>
+                </field>
+                <field name="company_registry" position="after">
+                    <field name="company_registry"
+                           string="Branch Code"
+                           invisible="country_code != 'TH'"
+                           help="The 5-digit branch code as registered with the Revenue Department."/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_th/views/res_partner_view.xml
+++ b/addons/l10n_th/views/res_partner_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <record id="view_partner_form_inherit_l10n_th" model="ir.ui.view">
+            <field name="name">res.partner.form.inherit.l10n_th</field>
+            <field name="model">res.partner</field>
+            <field name="priority">14</field>
+            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="arch" type="xml">
+                <field name="company_registry" position="attributes">
+                    <attribute name="invisible" add="country_code == 'TH'" separator=" or "/>
+                </field>
+                <field name="vat" position="after">
+                    <field name="company_registry"
+                           string="Branch Code"
+                           placeholder="Empty for Head Office"
+                           invisible="parent_id or not is_company or country_code != 'TH'"
+                           help="The 5-digit branch code as registered with the Revenue Department."/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Thailand uses a single TIN for companies with a separate branch code to identify branches. Only for Thai companies, this commit reuses `company_registry` as the branch code but exposes it by positioning under the Tax ID with a clear 'Branch Code' label and a helpful placeholder, while keeping the original field invisible to avoid confusion.

This commit adds validation so that `company_registry` is strictly 5 numeric digits or empty (for head office), and updates `_compute_l10n_th_branch_name` so the branch name resolves to 'Head Office' when the branch code is empty or set to `00000`.

task-5402592
