### PR TITLE
[WIP][FIX] resource, hr_holidays: correct leave duration for flexible calendars

### DIFF
--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1698,3 +1698,32 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         })
 
         self.assertEqual(leave.number_of_hours, 13.0)
+
+    def test_duration_display_with_flexible_calendar_and_public_holidays(self):
+        """
+        Ensure correct leave duration for flexible calendars with public holidays.
+        This test verifies that leave duration is correctly computed when using a
+        flexible working calendar and part of the requested leave period overlaps
+        with public holidays.
+        """
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Test flexi calendar',
+            'hours_per_day': 8,
+            'full_time_required_hours': 40,
+            'flexible_hours': True
+        })
+        self.employee_emp.resource_calendar_id = calendar
+        self.env['resource.calendar.leaves'].create({
+            'date_from': '2025-12-24 00:00:00',
+            'date_to': '2025-12-28 23:59:59',
+            'calendar_id': calendar.id,
+        })
+
+        leave = self.env['hr.leave'].with_user(self.user_employee_id).create({
+            'name': 'Test leave',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.holidays_type_1.id,
+            'request_date_from': '2025-12-24',
+            'request_date_to': '2025-12-30',
+        })
+        self.assertEqual(leave.number_of_days, 0)


### PR DESCRIPTION


Steps to reproduce:
-------------------
1. Install hr_holidays
2. Create a public holiday on 9th jan
3. Set an employee's working schedule to a flexible 40h/week calendar
4. Create a time off request from Jan 4th → Jan 10th
5. Observe the displayed duration

Issue:
------
The leave duration is displayed as 5 days instead of 4. 
This happens because public holidays are not correctly accounted for
within the work intervals.

Cause:
------
Work intervals for flexible calendars are allocated on a weekly basis.
Currently, the required weekly hours (40h) are distributed across the
first five days of the week without verifying if any of those days are
public holidays. Consequently, if a holiday falls on the 6th or 7th day
of the week, it is ignored by the allocation logic, leading to an incorrect
duration calculation.


reference: [attendance_intervals_batch](https://github.com/odoo/odoo/blob/403866e4b426107d2e869c052cd1a7f16f9a3173/addons/resource/models/resource_calendar.py#L393-L447)


Solution:
---------
Modify the allocation logic to identify public holidays within the week before
distributing hours. Prioritize generating attendance intervals for these
holidays to ensure they are subtracted correctly from the leave duration,
regardless of their position in the week.


opw-5387651
