### PR TITLE
[FIX] web utils

### DIFF
--- a/addons/web/static/src/core/l10n/translation.js
+++ b/addons/web/static/src/core/l10n/translation.js
@@ -1,25 +1,68 @@
-import { markup } from "@odoo/owl";
-
 import { formatList } from "@web/core/l10n/utils";
 import { isIterable } from "@web/core/utils/arrays";
 import { Deferred } from "@web/core/utils/concurrency";
-import { htmlSprintf } from "@web/core/utils/html";
-import { isObject } from "@web/core/utils/objects";
-import { sprintf } from "@web/core/utils/strings";
+import { htmlSprintf, isMarkup } from "@web/core/utils/html";
+import { mapSubstitutions, sprintf } from "@web/core/utils/strings";
 
-export const translationLoaded = Symbol("translationLoaded");
-export const translatedTerms = {
-    [translationLoaded]: false,
-};
 /**
- * Contains all the translated terms. Unlike "translatedTerms", there is no
- * "namespacing" by module. It is used as a fallback when no translation is
- * found within the module's context, or when the context is not known.
+ * @typedef {ReturnType<markup>} Markup
  */
-export const translatedTermsGlobal = {};
-export const translationIsReady = new Deferred();
 
-const Markup = markup().constructor;
+/**
+ * Returns true if the given value is a non-empty string, i.e. it contains other
+ * characters than white spaces and zero-width spaces.
+ *
+ * @param {unknown} value
+ */
+function isNotBlank(value) {
+    return typeof value === "string" && !R_BLANK.test(value);
+}
+
+/**
+ * Same behavior as sprintf, but doing two additional things:
+ * - If any of the provided values is an iterable, it will format its items
+ *   as a language-specific formatted string representing the elements of the
+ *   list.
+ * - If any of the provided values is a markup, it will escape all non-markup
+ *   content before performing the interpolation, then wraps the result in a
+ *   markup.
+ *
+ * @param {string} str
+ * @param {Substitutions} substitutions
+ * @returns {string | Markup | TranslatedString}
+ */
+function translationSprintf(str, substitutions) {
+    let hasMarkup = false;
+
+    /**
+     * @param {string | Markup} value
+     * @returns {string | Markup}
+     */
+    function formatSubstitution(value) {
+        hasMarkup ||= isMarkup(value);
+        // The `!(value instanceof String)` check is to prevent interpreting `Markup` and `TranslatedString`
+        // objects as iterables, since they are both subclasses of `String`.
+        if (isIterable(value) && !(value instanceof String)) {
+            return formatList(value);
+        } else {
+            return value;
+        }
+    }
+    const formattedSubstitutions = mapSubstitutions(substitutions, formatSubstitution);
+    if (hasMarkup) {
+        return htmlSprintf(str, ...formattedSubstitutions);
+    } else {
+        return sprintf(str, ...formattedSubstitutions);
+    }
+}
+
+/**
+ * @template [T=unknown]
+ * @typedef {import("@web/core/utils/strings").Substitutions<T>} Substitutions
+ */
+
+const DEFAULT_MODULE = "base";
+const R_BLANK = /^[\s\u200B]*$/;
 
 /**
  * Translates a term, or returns the term as it is if no translation can be
@@ -45,93 +88,12 @@ const Markup = markup().constructor;
  * _t("I love %s", markup`<blink>Minecraft</blink>`); // Markup {"J'adore <blink>Minecraft</blink>"}
  * _t("Good morning %s!", ["Mitchell", "Marc", "Louis"]); // Bonjour Mitchell, Marc et Louis !
  *
- * @param {string} term
- * @returns {string|Markup|LazyTranslatedString}
+ * @param {string} source
+ * @param {Substitutions} substitutions
+ * @returns {string | Markup | TranslatedString}
  */
-export function _t(term, ...values) {
-    if (translatedTerms[translationLoaded]) {
-        const translation = _getTranslation(term, odoo.translationContext);
-        if (values.length === 0) {
-            return translation;
-        }
-        return _safeFormatAndSprintf(translation, ...values);
-    } else {
-        return new LazyTranslatedString(term, values);
-    }
-}
-
-class LazyTranslatedString extends String {
-    constructor(term, values) {
-        super(term);
-        this.translationContext = odoo.translationContext;
-        this.values = values;
-    }
-    valueOf() {
-        const term = super.valueOf();
-        if (translatedTerms[translationLoaded]) {
-            const translation = _getTranslation(term, this.translationContext);
-            if (this.values.length === 0) {
-                return translation;
-            }
-            return _safeFormatAndSprintf(translation, ...this.values);
-        } else {
-            throw new Error(`translation error`);
-        }
-    }
-    toString() {
-        return this.valueOf();
-    }
-}
-
-/**
- * Load the installed languages long names and code
- *
- * The result of the call is put in cache.
- * If any new language is installed, a full page refresh will happen,
- * so there is no need invalidate it.
- */
-export async function loadLanguages(orm) {
-    if (!loadLanguages.installedLanguages) {
-        loadLanguages.installedLanguages = await orm.call("res.lang", "get_installed");
-    }
-    return loadLanguages.installedLanguages;
-}
-
-function _getTranslation(sourceTerm, ctx) {
-    return translatedTerms[ctx]?.[sourceTerm] ?? translatedTermsGlobal[sourceTerm] ?? sourceTerm;
-}
-
-/**
- * Same behavior as sprintf, but doing two additional things:
- * - If any of the provided values is an iterable, it will format its items
- *   as a language-specific formatted string representing the elements of the
- *   list.
- * - If any of the provided values is a markup, it will escape all non-markup
- *   content before performing the interpolation, then wraps the result in a
- *   markup.
- *
- * @param {string} str The string with placeholders (%s) to insert values into.
- * @param  {...any} values Primitive values to insert in place of placeholders.
- * @returns {string|Markup}
- */
-function _safeFormatAndSprintf(str, ...values) {
-    let hasMarkup = false;
-    let valuesObject = values;
-    if (values.length === 1 && isObject(values[0])) {
-        valuesObject = values[0];
-    }
-    for (const [key, value] of Object.entries(valuesObject)) {
-        // The `!(value instanceof String)` check is to prevent interpreting `Markup` and `LazyTranslatedString`
-        // objects as iterables, since they are both subclasses of `String`.
-        if (isIterable(value) && !(value instanceof String)) {
-            valuesObject[key] = formatList(value);
-        }
-        hasMarkup ||= value instanceof Markup;
-    }
-    if (hasMarkup) {
-        return htmlSprintf(str, ...values);
-    }
-    return sprintf(str, ...values);
+export function _t(source, ...substitutions) {
+    return appTranslateFn(source, odoo.translationContext, ...substitutions);
 }
 
 /**
@@ -142,14 +104,88 @@ function _safeFormatAndSprintf(str, ...values) {
  * translations, e.g. "table" has a different meaning depending on the module:
  * the table of a restaurant (POS module) vs. a spreadsheet table.
  *
- * @param {string} str The term to translate
+ * @param {string} source The term to translate
  * @param {string} moduleName The name of the module, used as a context key to
  * retrieve the translation.
- * @param  {...any} args The other arguments passed to _t.
+ * @param  {Substitutions} substitutions The other arguments passed to _t.
+ * @returns {string | Markup | TranslatedString}
  */
-export function appTranslateFn(str, moduleName, ...args) {
-    odoo.translationContext = moduleName;
-    const translatedTerm = _t(str, ...args);
-    odoo.translationContext = null;
-    return translatedTerm;
+export function appTranslateFn(source, moduleName, ...substitutions) {
+    const string = new TranslatedString(source, substitutions, moduleName);
+    return string.lazy ? string : string.valueOf();
 }
+
+/**
+ * Load the installed languages long names and code
+ *
+ * The result of the call is put in cache.
+ * If any new language is installed, a full page refresh will happen,
+ * so there is no need invalidate it.
+ *
+ * @param {import("services").ServiceFactories["orm"]} orm
+ */
+export async function loadLanguages(orm) {
+    if (!loadLanguages.installedLanguages) {
+        loadLanguages.installedLanguages = await orm.call("res.lang", "get_installed");
+    }
+    return loadLanguages.installedLanguages;
+}
+
+export class TranslatedString extends String {
+    /** @type {string} */
+    context;
+    lazy = false;
+    /** @type {Substitutions} */
+    substitutions;
+
+    /**
+     *
+     * @param {string} value
+     * @param {Substitutions} substitutions
+     * @param {string | null} [context]
+     */
+    constructor(value, substitutions, context) {
+        super(value);
+
+        if (!isNotBlank(value)) {
+            return new String(value);
+        }
+
+        this.lazy = !translatedTerms[translationLoaded];
+        this.substitutions = substitutions;
+        this.context = context || DEFAULT_MODULE;
+    }
+
+    toString() {
+        return this.valueOf();
+    }
+
+    valueOf() {
+        const source = super.valueOf();
+        if (this.lazy && !translatedTerms[translationLoaded]) {
+            // Evaluate lazy translated string while translations are not loaded
+            // -> error
+            throw new Error(`Cannot translate string: translations have not been loaded`);
+        }
+        const translation =
+            translatedTerms[this.context]?.[source] ?? translatedTermsGlobal[source] ?? source;
+        if (this.substitutions.length) {
+            return translationSprintf(translation, this.substitutions);
+        } else {
+            return translation;
+        }
+    }
+}
+
+export const translationLoaded = Symbol("translationLoaded");
+/** @type {Record<string, string>} */
+export const translatedTerms = {
+    [translationLoaded]: false,
+};
+/**
+ * Contains all the translated terms. Unlike "translatedTerms", there is no
+ * "namespacing" by module. It is used as a fallback when no translation is
+ * found within the module's context, or when the context is not known.
+ */
+export const translatedTermsGlobal = Object.create(null);
+export const translationIsReady = new Deferred();

--- a/addons/web/static/src/core/l10n/utils/format_list.js
+++ b/addons/web/static/src/core/l10n/utils/format_list.js
@@ -1,6 +1,10 @@
 import { user } from "@web/core/user";
 
 /**
+ * @typedef {keyof typeof LIST_STYLES} FormatListStyle
+ */
+
+/**
  * Convert Unicode TR35-49 list pattern types to ES Intl.ListFormat options
  */
 const LIST_STYLES = {
@@ -35,7 +39,8 @@ const LIST_STYLES = {
 };
 
 /**
- * Format the items in `list` as a list in a locale-dependent manner with the chosen style.
+ * Format the items in `values` as a list in a locale-dependent manner with the
+ * chosen style.
  *
  * The available styles are defined in the Unicode TR35-49 spec:
  * * standard:
@@ -60,16 +65,17 @@ const LIST_STYLES = {
  *   A list suitable for narrow units, where space on the screen is very limited.
  *   e.g. "3′ 7″"
  *
- * See https://www.unicode.org/reports/tr35/tr35-49/tr35-general.html#ListPatterns for more details.
+ * @see https://www.unicode.org/reports/tr35/tr35-general.html#ListPatterns for more details.
  *
- * @param {string[]} list The array of values to format into a list.
- * @param {Object} [param0]
- * @param {string} [param0.localeCode] The locale to use (e.g. en-US).
- * @param {"standard"|"standard-short"|"or"|"or-short"|"unit"|"unit-short"|"unit-narrow"} [param0.style="standard"] The style to format the list with.
- * @returns {string} The formatted list.
+ * @param {Iterable<string>} values values to format into a list.
+ * @param {{
+ *  localeCode?: string;
+ *  style?: FormatListStyle;
+ * }} [options]
+ * @returns {string} formatted list.
  */
-export function formatList(list, { localeCode = "", style = "standard" } = {}) {
+export function formatList(values, { localeCode, style } = {}) {
     const locale = localeCode || user.lang || "en-US";
-    const formatter = new Intl.ListFormat(locale, LIST_STYLES[style]);
-    return formatter.format(Array.from(list, String));
+    const formatter = new Intl.ListFormat(locale, LIST_STYLES[style || "standard"]);
+    return formatter.format(Array.from(values, String));
 }

--- a/addons/web/static/src/core/l10n/utils/normalize.js
+++ b/addons/web/static/src/core/l10n/utils/normalize.js
@@ -1,4 +1,12 @@
 /**
+ * @typedef {{
+ *  match: string;
+ *  start: number;
+ *  end: number;
+ * }} NormalizedMatchResult
+ */
+
+/**
  * Normalizes a string for use in comparison.
  *
  * @example
@@ -20,7 +28,7 @@ export function normalize(str) {
  *
  * @param {string} src
  * @param {string} substr
- * @returns {{match: string, start: number, end: number}}
+ * @returns {NormalizedMatchResult}
  */
 export function normalizedMatch(src, substr) {
     if (!substr) {
@@ -84,7 +92,7 @@ export function normalizedMatch(src, substr) {
  *
  * @param {string} src
  * @param {string} substr
- * @returns {Array<{match: string, start: number, end: number}>}
+ * @returns {NormalizedMatchResult[]}
  */
 export function normalizedMatches(src, substr) {
     const matches = [];

--- a/addons/web/static/src/core/template_inheritance.js
+++ b/addons/web/static/src/core/template_inheritance.js
@@ -3,6 +3,10 @@ const RSTRIP_REGEXP = /(?=\n[ \t]*$)/;
 let translationContext = null;
 
 const TCTX = "t-translation-context";
+
+/**
+ * @param {Node} node
+ */
 function getTranslationContext(node) {
     if (node.hasAttribute(TCTX)) {
         return node.getAttribute(TCTX);
@@ -11,6 +15,10 @@ function getTranslationContext(node) {
 }
 
 const contextByTextNode = new Map();
+
+/**
+ * @param {Node} node
+ */
 function setTranslationContext(node) {
     switch (node.nodeType) {
         case Node.TEXT_NODE:
@@ -34,6 +42,9 @@ export function applyContextToTextNode() {
     contextByTextNode.clear();
 }
 
+/**
+ * @param {Node} node
+ */
 export function deepClone(node) {
     const clone = node.cloneNode();
     if (node.nodeType === Node.TEXT_NODE) {

--- a/addons/web/static/src/core/utils/html.js
+++ b/addons/web/static/src/core/utils/html.js
@@ -1,8 +1,11 @@
 import { htmlEscape, markup } from "@odoo/owl";
-
 import { formatList, normalizedMatches } from "@web/core/l10n/utils";
 import { unique } from "@web/core/utils/arrays";
-import { escapeRegExp, sprintf } from "@web/core/utils/strings";
+import { escapeRegExp, mapSubstitutions, sprintf } from "@web/core/utils/strings";
+
+/**
+ * @typedef {ReturnType<markup>} Markup
+ */
 
 const Markup = markup().constructor;
 
@@ -10,7 +13,7 @@ const Markup = markup().constructor;
  * Safely creates a Document fragment from content. If content was flagged as safe HTML using
  * `markup` it is parsed as HTML. Otherwise it is escaped and parsed as text.
  *
- * @param {string|ReturnType<markup>} content
+ * @param {string | Markup} content
  */
 export function createDocumentFragmentFromContent(content) {
     return new document.defaultView.DOMParser().parseFromString(htmlEscape(content), "text/html");
@@ -21,7 +24,7 @@ export function createDocumentFragmentFromContent(content) {
  * `markup` it is set as innerHTML. Otherwise it is set as text.
  *
  * @param {string} elementName
- * @param {string|ReturnType<markup>} content
+ * @param {string | Markup} content
  * @returns {Element}
  */
 export function createElementWithContent(elementName, content) {
@@ -36,23 +39,24 @@ export function createElementWithContent(elementName, content) {
  * if it is part of the text. Will normalize the query
  * for advanced symbols matching
  *
- * @param {string | ReturnType<markup>} query
- * @param {string | ReturnType<markup>} text
- * @param {string | ReturnType<markup>} classes
- * @returns {string | ReturnType<markup>}
+ * @param {string | Markup} query
+ * @param {string | Markup} text
+ * @param {string | Markup} classes
+ * @returns {string | Markup}
  */
 export function highlightText(query, text, classes) {
-    if (!query) {
+    if (!query || !text) {
         return text;
     }
+    let result = text;
+    const isQueryMarkup = isMarkup(query);
     const matches = unique(
-        normalizedMatches(text, query).map((m) =>
+        normalizedMatches(result, query).map((m) =>
             // normalizedMatch will remove Markup and return string matches
             // so it is necessary to restore the removed Markup when needed
-            query instanceof Markup ? markup(m.match.toLowerCase()) : m.match.toLowerCase()
+            isQueryMarkup ? markup(m.match.toLowerCase()) : m.match.toLowerCase()
         )
     );
-    let result = text;
     for (const match of matches) {
         const regex = new RegExp(
             `(?<!&[^;]{0,5})(${escapeRegExp(htmlEscape(match))})(?=(?:[^>]*<[^<]*>)*[^<>]*$)`,
@@ -72,81 +76,78 @@ export function highlightText(query, text, classes) {
 }
 
 /**
- * Same behavior as formatList, but produces safe HTML. If the values are flagged as safe HTML using
- * `markup()` they are set as it is. Otherwise they are escaped.
+ * Same behavior as {@link formatList}, but producing safe HTML. If the values are
+ * flagged as safe HTML using `markup()` they are set as it is. Otherwise they are
+ * escaped.
  *
- * @param {Array<string|ReturnType<markup>>} list The array of values to format into a list.
- * @param {Object} [param0]
- * @param {string} [param0.localeCode] The locale to use (e.g. en-US).
- * @param {"standard"|"standard-short"|"or"|"or-short"|"unit"|"unit-short"|"unit-narrow"} [param0.style="standard"] The style to format the list with.
- * @returns {ReturnType<markup>} The formatted list.
+ * @param {Parameters<formatList>[0]} values
+ * @param {Parameters<formatList>[1]} [options]
+ * @returns {Markup}
  */
-export function htmlFormatList(list, ...args) {
-    return markup(
-        formatList(
-            Array.from(list, (val) => htmlEscape(val).toString()),
-            ...args
-        )
-    );
+export function htmlFormatList(values, options) {
+    // markup: args are escaped (or markup), and list separators are limited to
+    // `Intl.ListFormat` strings.
+    return markup(formatList(Array.from(values, htmlEscape), options));
+}
+
+/**
+ * Applies list join on content and returns a markup result built for HTML.
+ *
+ * @param {Iterable<string | Markup>} list
+ * @param {string | Markup} [separator]
+ * @returns {Markup}
+ */
+export function htmlJoin(list, separator = "") {
+    // markup: args and separator are escaped (or markup), join is considered safe
+    return markup(Array.from(list, htmlEscape).join(htmlEscape(separator)));
 }
 
 /**
  * Applies string replace on content and returns a markup result built for HTML.
  *
- * @param {string|ReturnType<markup>} content
+ * @param {string | Markup} content
  * @param {string | RegExp} search
- * @param {string} replacement
- * @returns {ReturnType<markup>}
+ * @param {string | (substring: string, ...args: any[]) => string | Markup} replacer
+ * @returns {Markup}
  */
-export function htmlReplace(content, search, replacement) {
-    if (search instanceof RegExp && !(replacement instanceof Function)) {
-        throw new Error("htmlReplace: replacement must be a function when search is a RegExp.");
+export function htmlReplace(content, search, replacer) {
+    const isReplacerFn = typeof replacer === "function";
+    if (search instanceof RegExp && !isReplacerFn) {
+        throw new TypeError("htmlReplace: replacer must be a function when search is a RegExp.");
     }
     content = htmlEscape(content);
     if (typeof search === "string" || search instanceof String) {
         search = htmlEscape(search);
     }
-    const safeReplacement =
-        replacement instanceof Function
-            ? (...args) => htmlEscape(replacement(...args))
-            : htmlEscape(replacement);
-    // markup: content and replacement are escaped (or markup), replace is considered safe
+    const safeReplacement = isReplacerFn
+        ? (...args) => htmlEscape(replacer(...args))
+        : htmlEscape(replacer);
+    // markup: content and replacer are escaped (or markup), replace is considered safe
     return markup(content.replace(search, safeReplacement));
 }
 
 /**
  * Applies string replaceAll on content and returns a markup result built for HTML.
  *
- * @param {string|ReturnType<markup>} content
+ * @param {string | Markup} content
  * @param {string | RegExp} search
- * @param {string|(match: string) => string|ReturnType<markup>} replacement
- * @returns {ReturnType<markup>}
+ * @param {string | (substring: string, ...args: any[]) => string | Markup} replacer
+ * @returns {Markup}
  */
-export function htmlReplaceAll(content, search, replacement) {
-    if (search instanceof RegExp && !(replacement instanceof Function)) {
-        throw new Error("htmlReplaceAll: replacement must be a function when search is a RegExp.");
+export function htmlReplaceAll(content, search, replacer) {
+    const isReplacerFn = typeof replacer === "function";
+    if (search instanceof RegExp && !isReplacerFn) {
+        throw new TypeError("htmlReplaceAll: replacer must be a function when search is a RegExp.");
     }
     content = htmlEscape(content);
     if (typeof search === "string" || search instanceof String) {
         search = htmlEscape(search);
     }
-    const safeReplacement =
-        replacement instanceof Function
-            ? (...args) => htmlEscape(replacement(...args))
-            : htmlEscape(replacement);
-    // markup: content and replacement are escaped (or markup), replaceAll is considered safe
+    const safeReplacement = isReplacerFn
+        ? (...args) => htmlEscape(replacer(...args))
+        : htmlEscape(replacer);
+    // markup: content and replacer are escaped (or markup), replaceAll is considered safe
     return markup(content.replaceAll(search, safeReplacement));
-}
-
-/**
- * Applies list join on content and returns a markup result built for HTML.
- *
- * @param {Array<string|ReturnType<markup>>} args
- * @returns {ReturnType<markup>}
- */
-export function htmlJoin(list, separator = "") {
-    // markup: args and separator are escaped (or markup), join is considered safe
-    return markup(list.map((arg) => htmlEscape(arg)).join(htmlEscape(separator)));
 }
 
 /**
@@ -154,43 +155,19 @@ export function htmlJoin(list, separator = "") {
  * using `markup()` they are set as it is. Otherwise they are escaped.
  *
  * @param {string} str The string with placeholders (%s) to insert values into.
- * @param  {...any} values Primitive values to insert in place of placeholders.
- * @returns {string|Markup}
+ * @param  {...unknown[]} substitutions Primitive values to insert in place of placeholders.
+ * @returns {string | Markup}
  */
-export function htmlSprintf(str, ...values) {
-    const valuesDict = values[0];
-    if (
-        valuesDict &&
-        Object.prototype.toString.call(valuesDict) === "[object Object]" &&
-        !(valuesDict instanceof Markup)
-    ) {
-        // markup: escaped base string and values (assuming sprintf itself is safe)
-        return markup(
-            sprintf(
-                htmlEscape(str).toString(),
-                Object.fromEntries(
-                    Object.entries(valuesDict).map(([key, value]) => [
-                        key,
-                        htmlEscape(value).toString(),
-                    ])
-                )
-            )
-        );
-    }
-    // markup: escaped base string and values (assuming sprintf itself is safe)
-    return markup(
-        sprintf(
-            htmlEscape(str).toString(),
-            values.map((value) => htmlEscape(value).toString())
-        )
-    );
+export function htmlSprintf(str, ...substitutions) {
+    const replaced = sprintf(htmlEscape(str), ...mapSubstitutions(substitutions, htmlEscape));
+    return markup(replaced);
 }
 
 /**
  * Applies string trim on content and returns a markup result built for HTML.
  *
- * @param {string|ReturnType<markup>} content
- * @returns {string|ReturnType<markup>}
+ * @param {string | Markup} content
+ * @returns {string | Markup}
  */
 export function htmlTrim(content) {
     content = htmlEscape(content);
@@ -206,7 +183,7 @@ export function htmlTrim(content) {
  * like there's one <img> tag in the content. In such case, even if it's the
  * actual content, we consider it empty.
  *
- * @param {string|ReturnType<markup>} content
+ * @param {string | Markup} [content]
  * @returns {boolean} true if no content found or if containing only formatting tags
  */
 export function isHtmlEmpty(content = "") {
@@ -214,59 +191,54 @@ export function isHtmlEmpty(content = "") {
 }
 
 /**
- * Format the text as follow:
- *      \*\*text\*\* => Put the text in bold.
- *      --text-- => Put the text in muted.
- *      \`text\` => Put the text in a rounded badge (bg-primary).
- *      \n => Insert a breakline.
- *      \t => Insert 4 spaces.
+ * @param {unknown} content
+ */
+export function isMarkup(content) {
+    return content instanceof Markup;
+}
+
+/**
+ * Formats the given `text` as follow:
+ *  - \*\*text\*\* => puts `text` in bold.
+ *  - --text-- => puts `text` in "muted" (i.e. grayed out).
+ *  - \`text\` => puts `text` in a rounded badge (bg-primary).
+ *  - \n => inserts a line break.
+ *  - \t => inserts the equivalent of 4 spaces.
  *
- * @param {string|ReturnType<markup>} text
- * @returns {string|ReturnType<markup>} the formatted text
+ * @param {string | Markup} text
+ * @returns {string | Markup} the formatted text
  */
 export function odoomark(text) {
-    const replacements = [
-        [/\n/g, () => markup`<br/>`],
-        [/\t/g, () => markup`<span style="margin-left: 2em"></span>`],
-        [
-            /\*\*(.+?)\*\*/g,
-            (_, bold) => {
-                /**
-                 * markup: text is a Markup object (either escaped inside htmlReplace or
-                 * flagged safe), `bold` is directly coming from this value,
-                 * and the regex doesn't do anything crazy to unescape it.
-                 */
-                markup(bold);
-                return markup`<b>${bold}</b>`;
-            },
-        ],
-        [
-            /--(.+?)--/g,
-            (_, muted) => {
-                /**
-                 * markup: text is a Markup object (either escaped inside htmlReplace or
-                 * flagged safe), `muted` is directly coming from this value,
-                 * and the regex doesn't do anything crazy to unescape it.
-                 */
-                muted = markup(muted);
-                return markup`<span class='text-muted'>${muted}</span>`;
-            },
-        ],
+    /**
+     * Mapping of patterns - replacer functions to apply to odoomarked strings.
+     *
+     * For the content passed directly to `markup` (e.g. **bold** or ``tagged``):
+     * the content is considered safe, as it directly comes from {@link htmlReplaceAll}
+     * which uses {@link htmlEscape}.
+     *
+     * Note: this list is declared inline in the `odoomark` function to avoid other
+     * functions using the marked-up replacers for injection.
+     */
+    const replacers = [
+        // Line break
+        ["\n", markup`<br>`],
+        // Larger spacing
+        ["\t", markup`<span style="margin-left: 2em"></span>`],
+        // Bold
+        [/\*\*(.+?)\*\*/g, (_, content) => markup(`<b>${content}</b>`)],
+        // Muted
+        [/--(.+?)--/g, (_, content) => markup(`<span class="text-muted">${content}</span>`)],
+        // Badge
         [
             /&#x60;(.+?)&#x60;/g,
-            (_, tag) => {
-                /**
-                 * markup: text is a Markup object (either escaped inside htmlReplace or
-                 * flagged safe), `tag` is directly coming from this value,
-                 * and the regex doesn't do anything crazy to unescape it.
-                 */
-                tag = markup(tag);
-                return markup`<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">${tag}</span>`;
-            },
+            (_, content) =>
+                markup(
+                    `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">${content}</span>`
+                ),
         ],
     ];
-    for (const replacement of replacements) {
-        text = htmlReplaceAll(text, replacement[0], replacement[1]);
+    for (const [pattern, replacer] of replacers) {
+        text = htmlReplaceAll(text, pattern, replacer);
     }
     return text;
 }
@@ -276,17 +248,13 @@ export function odoomark(text) {
  * innerHTML. Otherwise it is set as text.
  *
  * @param {Element} element
- * @param {string|ReturnType<markup>} content
+ * @param {string | Markup} content
  */
 export function setElementContent(element, content) {
-    if (content instanceof Markup) {
+    if (isMarkup(content)) {
         // innerHTML: content is markup
         element.innerHTML = content;
     } else {
         element.textContent = content;
     }
-}
-
-export function isMarkup(content) {
-    return content instanceof Markup;
 }

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -1,143 +1,75 @@
 import { isObject } from "./objects";
 
+/**
+ * @template [T=unknown]
+ * @typedef {[Record<string, T>] | T[]} Substitutions
+ */
+
+/**
+ * @param {Substitutions} substitutions
+ */
+function hasSubstitutionDict(substitutions) {
+    return substitutions.length === 1 && isObject(substitutions[0]);
+}
+
+const HTML_ESCAPED_CHARACTERS = [
+    ["&", "&amp;"],
+    ["<", "&lt;"],
+    [">", "&gt;"],
+    ["'", "&#x27;"],
+    ['"', "&quot;"],
+    ["`", "&#x60;"],
+];
+
+/**
+ * Based on:
+ * {@link http://stackoverflow.com/questions/46155/validate-email-address-in-javascript}
+ */
+const R_EMAIL =
+    /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
+const R_FALSY = /^false|0$/i;
+const R_KEYED_SUBSTITUTION = /%\((?<key>[^)]+)\)s/g;
+const R_NUMERIC = /^\d+$/;
+const R_REGEX_SPECIAL_CHARS = /[.*+?^${}()|[\]\\]/g;
+
 export const nbsp = "\u00a0";
-
-/**
- * Escapes a string for HTML.
- *
- * @param {string | number} [str] the string to escape
- * @returns {string} an escaped string
- */
-export function escape(str) {
-    if (str === undefined) {
-        return "";
-    }
-    if (typeof str === "number") {
-        return String(str);
-    }
-    [
-        ["&", "&amp;"],
-        ["<", "&lt;"],
-        [">", "&gt;"],
-        ["'", "&#x27;"],
-        ['"', "&quot;"],
-        ["`", "&#x60;"],
-    ].forEach((pairs) => {
-        str = String(str).replaceAll(pairs[0], pairs[1]);
-    });
-    return str;
-}
-
-/**
- * Escapes a string to use as a RegExp.
- * @url https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
- *
- * @param {string} str
- * @returns {string} escaped string to use as a RegExp
- */
-export function escapeRegExp(str) {
-    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * Intersperses ``separator`` in ``str`` at the positions indicated by
- * ``indices``.
- *
- * ``indices`` is an array of relative offsets (from the previous insertion
- * position, starting from the end of the string) at which to insert
- * ``separator``.
- *
- * There are two special values:
- *
- * ``-1``
- *   indicates the insertion should end now
- * ``0``
- *   indicates that the previous section pattern should be repeated (until all
- *   of ``str`` is consumed)
- *
- * @param {string} str
- * @param {number[]} indices
- * @param {string} separator
- * @returns {string}
- */
-export function intersperse(str, indices, separator = "") {
-    separator = separator || "";
-    const result = [];
-    let last = str.length;
-    for (let i = 0; i < indices.length; ++i) {
-        let section = indices[i];
-        if (section === -1 || last <= 0) {
-            // Done with string, or -1 (stops formatting string)
-            break;
-        } else if (section === 0 && i === 0) {
-            // repeats previous section, which there is none => stop
-            break;
-        } else if (section === 0) {
-            // repeat previous section forever
-            //noinspection AssignmentToForLoopParameterJS
-            section = indices[--i];
-        }
-        result.push(str.substring(last - section, last));
-        last -= section;
-    }
-    const s = str.substring(0, last);
-    if (s) {
-        result.push(s);
-    }
-    return result.reverse().join(separator);
-}
-
-/**
- * Returns a string formatted using given values.
- * If the value is an object, its keys will replace `%(key)s` expressions.
- * If the values are a set of strings, they will replace `%s` expressions.
- * If no value is given, the string will not be formatted.
- *
- * @param {string} s
- * @param {any[]} values
- * @returns {string}
- */
-export function sprintf(s, ...values) {
-    if (values.length === 1 && isObject(values[0])) {
-        const valuesDict = values[0];
-        s = s.replace(/%\(([^)]+)\)s/g, (match, value) => valuesDict[value]);
-    } else if (values.length > 0) {
-        s = s.replace(/%s/g, () => values.shift());
-    }
-    return s;
-}
 
 /**
  * Capitalizes a string: "abc def" => "Abc def"
  *
- * @param {string} s the input string
+ * @param {string} str the input string
  * @returns {string}
  */
-export function capitalize(s) {
-    return s ? s[0].toUpperCase() + s.slice(1) : "";
+export function capitalize(str) {
+    return str ? str[0].toUpperCase() + str.slice(1) : "";
 }
 
 /**
- * @param {string} value
- * @returns boolean
- */
-export function isEmail(value) {
-    // http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
-    const re =
-        // eslint-disable-next-line no-useless-escape
-        /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
-    return re.test(value);
-}
-
-/**
- * Return true if the string is composed of only digits
+ * Escapes HTML special characters in a given value.
  *
- * @param {string} value
- * @returns boolean
+ * @param {unknown} [value]
+ * @returns {string}
  */
+export function escape(value) {
+    if (typeof value !== "string") {
+        return String(value ?? "");
+    }
+    for (const [char, replacer] of HTML_ESCAPED_CHARACTERS) {
+        value = value.replaceAll(char, replacer);
+    }
+    return value;
+}
 
-export function isNumeric(value) {
-    return Boolean(value?.match(/^\d+$/));
+/**
+ * Escapes a pattern to use as a RegExp.
+ *
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping}
+ *
+ * @param {string} pattern
+ * @returns {string} escaped string to use as a RegExp
+ */
+export function escapeRegExp(pattern) {
+    return pattern.replaceAll(R_REGEX_SPECIAL_CHARS, "\\$&");
 }
 
 /**
@@ -150,19 +82,7 @@ export function isNumeric(value) {
  * @returns {boolean}
  */
 export function exprToBoolean(str, trueIfEmpty = false) {
-    return str ? !/^false|0$/i.test(str) : trueIfEmpty;
-}
-
-/**
- * Generate a unique identifier (64 bits) in hexadecimal.
- *
- * @returns {string}
- */
-export function uuid() {
-    const array = new Uint8Array(8);
-    window.crypto.getRandomValues(array);
-    // Uint8Array to hex
-    return [...array].map((b) => b.toString(16).padStart(2, "0")).join("");
+    return str ? !R_FALSY.test(str) : trueIfEmpty;
 }
 
 /**
@@ -190,4 +110,159 @@ export function hashCode(...strings) {
     // Convert the possibly negative number hash code into an 8 character
     // hexadecimal string
     return (hash + 16 ** 8).toString(16).slice(-8);
+}
+
+/**
+ * Intersperses ``separator`` in ``str`` at the positions indicated by
+ * ``indices``.
+ *
+ * ``indices`` is an array of relative offsets (from the previous insertion
+ * position, starting from the end of the string) at which to insert
+ * ``separator``.
+ *
+ * There are two special values:
+ *
+ * ``-1``
+ *   indicates the insertion should end now
+ * ``0``
+ *   indicates that the previous section pattern should be repeated (until all
+ *   of ``str`` is consumed)
+ *
+ * @param {string} str
+ * @param {number[]} indices
+ * @param {string} [separator=""]
+ * @returns {string}
+ */
+export function intersperse(str, indices, separator) {
+    /** @type {string[]} */
+    const result = [];
+    let last = str.length;
+    for (let i = 0; i < indices.length; ++i) {
+        let section = indices[i];
+        if (section === -1 || last <= 0) {
+            // Done with string, or -1 (stops formatting string)
+            break;
+        } else if (section === 0 && i === 0) {
+            // repeats previous section, which there is none => stop
+            break;
+        } else if (section === 0) {
+            // repeat previous section forever
+            //noinspection AssignmentToForLoopParameterJS
+            section = indices[--i];
+        }
+        result.unshift(str.substring(last - section, last));
+        last -= section;
+    }
+    const substr = str.substring(0, last);
+    if (substr) {
+        result.unshift(substr);
+    }
+    return result.join(separator || "");
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isEmail(value) {
+    return R_EMAIL.test(value);
+}
+
+/**
+ * Return true if the string is composed of only digits
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isNumeric(value) {
+    return R_NUMERIC.test(value);
+}
+
+/**
+ * @template T, M
+ * @param {Substitutions<T>} substitutions
+ * @param {(value: T) => M} mapFn
+ * @returns {Substitutions<M>}
+ */
+export function mapSubstitutions(substitutions, mapFn) {
+    if (hasSubstitutionDict(substitutions)) {
+        const substitutionDict = {};
+        for (const [key, value] of Object.entries(substitutions[0])) {
+            substitutionDict[key] = mapFn(value);
+        }
+        return [substitutionDict];
+    } else {
+        return substitutions.map(mapFn);
+    }
+}
+
+/**
+ * Returns a string formatted using given values.
+ *
+ * If the value is an object:
+ *  - its keys will replace `%(key)s` expressions;
+ *  - these expressions CANNOT be escaped (e.g. '%%(key)s');
+ *  - missing keys will yield empty strings.
+ *
+ * If the value(s) is a list of string(s):
+ *  - they will replace `%s` expressions;
+ *  - these expressions CAN be escaped by adding another '%';
+ *  - surplus of "%s" expressions will be replaced by empty strings.
+ *
+ * If no value is given, the string will not be formatted at all.
+ *
+ * @template T
+ * @param {string} str
+ * @param {Substitutions<T>} substitutions
+ * @returns {string}
+ * @example
+ *  // Generic substitutions
+ *  sprintf("Hello %s!", "world"); // "Hello world!"
+ *  sprintf("Hello %%s!", "world"); // "Hello %s!"
+ *  // Keyed substitutions
+ *  sprintf("Hello %(place)s!", { place: "world" }); // "Hello world!"
+ *  sprintf("Hello %(missing)s!", { place: "world" }); // "Hello !"
+ *  sprintf("Hello %%(place)s!", { place: "world" }); // "Hello %world!"
+ *  // Unchanged because no substitutions
+ *  sprintf("Hello %s!"); // "Hello %s!"
+ */
+export function sprintf(str, ...substitutions) {
+    if (!substitutions.length) {
+        // No substitutions => leave the string as is
+        return str;
+    }
+    if (hasSubstitutionDict(substitutions)) {
+        // Keyed (%(key)s) substitutions
+        const dict = substitutions[0];
+        return str.replaceAll(R_KEYED_SUBSTITUTION, (_match, key) => dict[key] ?? "");
+    } else {
+        // Generic (%s) substitutions
+        const raw = [""];
+        for (let i = 0; i < str.length; i++) {
+            if (str[i] === "%") {
+                if (str[i + 1] === "%") {
+                    // Escaped "%" character: => single "%"
+                    raw[raw.length - 1] += str[++i];
+                    continue;
+                }
+                if (str[i + 1] === "s") {
+                    // Substitution (ignore "%s" in final string)
+                    i++;
+                    raw.push("");
+                    continue;
+                }
+            }
+            raw[raw.length - 1] += str[i];
+        }
+        return String.raw({ raw }, ...substitutions);
+    }
+}
+
+/**
+ * Generate a unique identifier (64 bits) in hexadecimal.
+ *
+ * @returns {string}
+ */
+export function uuid() {
+    return crypto.randomUUID().split("-").slice(0, 3).join("");
 }

--- a/addons/web/static/src/env.js
+++ b/addons/web/static/src/env.js
@@ -11,11 +11,12 @@ import { isMacOS } from "@web/core/browser/feature_detection";
 // -----------------------------------------------------------------------------
 
 /**
- * @typedef {Object} OdooEnv
- * @property {import("services").Services} services
- * @property {EventBus} bus
- * @property {string} debug
- * @property {boolean} [isSmall]
+ * @typedef {{
+ *  bus: EventBus;
+ *  debug: string;
+ *  services: import("services").Services;
+ *  readonly isSmall: boolean;
+ * }} OdooEnv
  */
 
 // -----------------------------------------------------------------------------

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -10,9 +10,9 @@ import {
     registerDebugInfo,
 } from "@odoo/hoot";
 import { makeErrorFromResponse, rpc, RPCError } from "@web/core/network/rpc";
+import { RPCCache } from "@web/core/network/rpc_cache";
 import { ensureArray, isIterable } from "@web/core/utils/arrays";
 import { isObject } from "@web/core/utils/objects";
-import { RPCCache } from "@web/core/network/rpc_cache";
 import { hashCode } from "@web/core/utils/strings";
 import { serverState } from "../mock_server_state.hoot";
 import { fetchModelDefinitions, globalCachedFetch, registerModelToFetch } from "../module_set.hoot";

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -51,6 +51,7 @@ async function mockLang(lang) {
     await makeMockEnv();
 }
 
+test.tags("headless");
 test("lang is given by the user context", async () => {
     onRpc("/web/webclient/translations", (request) => {
         const urlParams = new URLSearchParams(new URL(request.url).search);
@@ -60,6 +61,7 @@ test("lang is given by the user context", async () => {
     expect.verifySteps(["fr_FR"]);
 });
 
+test.tags("headless");
 test("lang is given by an attribute on the DOM root node", async () => {
     serverState.lang = null;
     onRpc("/web/webclient/translations", (request) => {
@@ -74,6 +76,7 @@ test("lang is given by an attribute on the DOM root node", async () => {
     expect.verifySteps(["fr_FR"]);
 });
 
+test.tags("headless");
 test("url is given by the session", async () => {
     patchWithCleanup(session, {
         translationURL: "/get_translations",
@@ -336,56 +339,67 @@ test("can lazy translate", async () => {
     expect("#main").toHaveText("Bonjour");
 });
 
+test.tags("headless");
 test("luxon is configured in the correct lang", async () => {
     await mockLang("fr_BE");
     expect(DateTime.utc(2021, 12, 10).toFormat("MMMM")).toBe("décembre");
 });
 
+test.tags("headless");
 test("arabic has the correct numbering system (generic)", async () => {
     await mockLang("ar_001");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("١٠/١٢/٢٠٢١ ١٢:٠٠:٠٠");
 });
 
+test.tags("headless");
 test("arabic has the correct numbering system (Algeria)", async () => {
     await mockLang("ar_DZ");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("10/12/2021 12:00:00");
 });
 
+test.tags("headless");
 test("arabic has the correct numbering system (Lybia)", async () => {
     await mockLang("ar_LY");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("10/12/2021 12:00:00");
 });
 
+test.tags("headless");
 test("arabic has the correct numbering system (Morocco)", async () => {
     await mockLang("ar_MA");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("10/12/2021 12:00:00");
 });
 
+test.tags("headless");
 test("arabic has the correct numbering system (Saudi Arabia)", async () => {
     await mockLang("ar_SA");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("١٠/١٢/٢٠٢١ ١٢:٠٠:٠٠");
 });
 
+test.tags("headless");
 test("arabic has the correct numbering system (Tunisia)", async () => {
     await mockLang("ar_TN");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("10/12/2021 12:00:00");
 });
 
+test.tags("headless");
 test("bengalese has the correct numbering system", async () => {
     await mockLang("bn");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("১০/১২/২০২১ ১২:০০:০০");
 });
 
+test.tags("headless");
 test("punjabi (gurmukhi) has the correct numbering system", async () => {
     await mockLang("pa_IN");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("੧੦/੧੨/੨੦੨੧ ੧੨:੦੦:੦੦");
 });
 
+test.tags("headless");
 test("tamil has the correct numbering system", async () => {
     await mockLang("ta");
     expect(DateTime.utc(2021, 12, 10).toFormat("dd/MM/yyyy hh:mm:ss")).toBe("௧௦/௧௨/௨௦௨௧ ௧௨:௦௦:௦௦");
 });
 
+test.tags("headless");
 test("_t fills the format specifiers in translated terms with its extra arguments", async () => {
     patchTranslations({
         web: {
@@ -396,6 +410,7 @@ test("_t fills the format specifiers in translated terms with its extra argument
     expect(translatedStr).toBe("Échéance dans 513 jours");
 });
 
+test.tags("headless");
 test("_t fills the format specifiers in translated terms with formatted lists", async () => {
     await mockLang("fr_FR");
     patchTranslations({
@@ -414,6 +429,7 @@ test("_t fills the format specifiers in translated terms with formatted lists", 
     expect(translatedStr2).toBe("Échéance dans 30, 60 et 90 jours pour Mitchell");
 });
 
+test.tags("headless");
 test("_t fills the format specifiers in lazy translated terms with its extra arguments", async () => {
     translatedTerms[translationLoaded] = false;
     const translatedStr = _t("Due in %s days", 513);
@@ -425,6 +441,7 @@ test("_t fills the format specifiers in lazy translated terms with its extra arg
     expect(translatedStr.toString()).toBe("Échéance dans 513 jours");
 });
 
+describe.tags("headless");
 describe("_t with markups", () => {
     test("non-markup values are escaped", () => {
         translatedTerms[translationLoaded] = true;

--- a/addons/web/static/tests/core/utils/html.test.js
+++ b/addons/web/static/tests/core/utils/html.test.js
@@ -1,8 +1,6 @@
+import { describe, expect, test } from "@odoo/hoot";
 import { htmlEscape, markup } from "@odoo/owl";
 
-const Markup = markup().constructor;
-
-import { describe, expect, test } from "@odoo/hoot";
 import {
     createDocumentFragmentFromContent,
     createElementWithContent,
@@ -17,6 +15,8 @@ import {
     odoomark,
     setElementContent,
 } from "@web/core/utils/html";
+
+const Markup = markup().constructor;
 
 describe.current.tags("headless");
 
@@ -114,9 +114,7 @@ test("htmlSprintf escapes list params", () => {
         markup`<span>test 1</span>`,
         `<span>test 2</span>`
     );
-    expect(res.toString()).toBe(
-        "<p><span>test 1</span>,&lt;span&gt;test 2&lt;/span&gt;</p>undefined"
-    );
+    expect(res.toString()).toBe("<p><span>test 1</span></p>&lt;span&gt;test 2&lt;/span&gt;");
     expect(res).toBeInstanceOf(Markup);
 });
 
@@ -302,10 +300,10 @@ test("htmlReplaceAll with html/text does not find, keeps all", () => {
 
 test("htmlReplace/htmlReplaceAll only accept functions replacement when search is a RegExp", () => {
     expect(() => htmlReplace("test", /test/, "$1")).toThrow(
-        "htmlReplace: replacement must be a function when search is a RegExp."
+        "htmlReplace: replacer must be a function when search is a RegExp."
     );
     expect(() => htmlReplaceAll("test", /test/, "$1")).toThrow(
-        "htmlReplaceAll: replacement must be a function when search is a RegExp."
+        "htmlReplaceAll: replacer must be a function when search is a RegExp."
     );
 });
 
@@ -327,9 +325,9 @@ test("odoomark", () => {
     expect(odoomark("**test** something else **test**").toString()).toBe(
         "<b>test</b> something else <b>test</b>"
     );
-    expect(odoomark("--test--").toString()).toBe("<span class='text-muted'>test</span>");
+    expect(odoomark("--test--").toString()).toBe(`<span class="text-muted">test</span>`);
     expect(odoomark("--test-- something else --test--").toString()).toBe(
-        "<span class='text-muted'>test</span> something else <span class='text-muted'>test</span>"
+        `<span class="text-muted">test</span> something else <span class="text-muted">test</span>`
     );
     expect(odoomark("`test`").toString()).toBe(
         `<span class="o_tag position-relative d-inline-flex align-items-center mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">test</span>`
@@ -340,7 +338,7 @@ test("odoomark", () => {
     expect(odoomark("test\ttest2").toString()).toBe(
         `test<span style="margin-left: 2em"></span>test2`
     );
-    expect(odoomark("test\ntest2").toString()).toBe("test<br/>test2");
+    expect(odoomark("test\ntest2").toString()).toBe("test<br>test2");
     expect(odoomark("<p>**test**</p>").toString()).toBe("&lt;p&gt;<b>test</b>&lt;/p&gt;");
     expect(odoomark(markup`<p>**test**</p>`).toString()).toBe("<p><b>test</b></p>");
 });

--- a/addons/web/static/tests/core/utils/strings.test.js
+++ b/addons/web/static/tests/core/utils/strings.test.js
@@ -84,6 +84,7 @@ describe("sprintf", () => {
         expect(sprintf("Hello!")).toBe("Hello!");
         expect(sprintf("Hello %s!")).toBe("Hello %s!");
         expect(sprintf("Hello %(value)s!")).toBe("Hello %(value)s!");
+        expect(sprintf("Hello %(value)s!", {})).toBe("Hello !");
     });
 
     test("properly formats numbers", () => {
@@ -107,6 +108,16 @@ describe("sprintf", () => {
 
         const vals = { one: _t("one"), two: _t("two") };
         expect(sprintf("Hello %(two)s %(one)s", vals)).toBe("Hello två en");
+    });
+
+    test("supports escaped '%' signs", () => {
+        expect(sprintf("Escape %s", "%s")).toBe("Escape %s");
+        expect(sprintf("Escape %%s", "this!")).toBe("Escape %s");
+        expect(sprintf("Escape %%%s", "this!")).toBe("Escape %this!");
+        expect(sprintf("Escape %%%%s!", "this")).toBe("Escape %%s!");
+        expect(sprintf("Escape %s%s", "this!")).toBe("Escape this!");
+        expect(sprintf("Escape %%s%s", "this!")).toBe("Escape %sthis!");
+        expect(sprintf("Escape %foo!", "this")).toBe("Escape %foo!");
     });
 });
 


### PR DESCRIPTION
### [[FIX] web: cleanup string-related utils](https://github.com/odoo/odoo/pull/241068/changes)

This commit cleans up several utility files relating to string-parsing
and translations. Main changes are:

- fixed `sprintf` and related functions: before this commmit, string
substitutions were incorrectly inserted in the template string, and it
was actually reflected in a test (template : `"<p>%s</p>%s"` => test
incorrectly asserted that both strings were inserted in the first "%s"
and "undefined" was inserted in the second);

- to replicate the Python homonymous behaviour: "%s" characters can now
be escaped in "sprintf-ed" strings by adding an additional "%" sign
before the expression;

- unification of translations via a TranslatedString class (which will
also simplify external overrides);

- unified API for some utility functions sharing the same purpose
(typically: accepting an iterable instead of a list, etc.);

- filling missing docstring, re-ordering functions and constants for
clarity;

- added "headless" tag to some utility functions' tests, when UI is not
needed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr