### PR TITLE
[FIX] l10n_{be,nl}: fix translation of accounts

### DIFF
--- a/addons/l10n_be/data/template/account.account-be.csv
+++ b/addons/l10n_be/data/template/account.account-be.csv
@@ -6,7 +6,7 @@
 "a132","Untaxed Reserves","132","equity","","False","","Réserves immunisées","Belastingvrije reserves","Steuerfreie Rücklagen","","","","","",""
 "a140","Profit Brought Forward","140","equity","","False","","Bénéfice reporté","Overgedragen winst","Gewinnvortrag","","","","","",""
 "a141","Loss Brought Forward (-)","141","equity","","False","","Perte reportée (-)","Overgedragen verlies (-)","Verlustvortrag (-)","","","","","",""
-"a149","Profit/Loss Allocations","149","equity_unaffected","","False","","Bénéfices de l'année en cours","Winst van het lopende jaar","Gewinn des laufenden Jahres","","","","","",""
+"a149","Profit/Loss Allocations","149","equity_unaffected","","False","","Répartition des profits et des pertes","Winst-/verliesverdeling","Gewinn-/Verlustverteilung","","","","","",""
 "a160","Provisions for Pensions and Similar Obligations","160","liability_non_current","","False","","Provisions pour pensions et obligations similaires","Voorzieningen voor pensioenen en soortgelijke verplichtingen","Rückstellungen für Pensionen und ähnliche Verpflichtungen","","","","","",""
 "a161","Provisions for Taxation","161","liability_non_current","","False","","Provisions pour charges fiscales","Voorzieningen voor belastingen","Rückstellungen für Steuern","","","","","",""
 "a162","Provisions for Major Repairs and Maintenance","162","liability_non_current","","False","","Provisions pour grosses réparations et gros entretien","Voorzieningen voor grote herstellings- en onderhoudswerken","Rückstellungen für große Reparaturen und Instandhaltungsarbeiten","","","","","",""

--- a/addons/l10n_nl/data/template/account.account-nl.csv
+++ b/addons/l10n_nl/data/template/account.account-nl.csv
@@ -347,4 +347,4 @@
 "9200","Error account","9200","expense","l10n_nl.account_tag_prev_years_earnings,l10n_nl.account_tag_29","False","","Foutenrekening","Fehler Konto"
 "9900","Corporate tax","9900","expense","l10n_nl.account_tag_prev_years_earnings,l10n_nl.account_tag_33","False","","Vennootschapsbelasting","Körperschaftssteuer"
 "9950","Corporation tax previous years","9950","expense","l10n_nl.account_tag_prev_years_earnings,l10n_nl.account_tag_33","False","","Vennootschapsbelasting voorgaande jaren","Corporation tax previous years"
-"9999","Undistributed Profits/Losses","99999","equity_unaffected","l10n_nl.account_tag_undist_profit","False","","Uitgekeerde winsten/verliezen","Unverteilte Gewinne/Verluste"
+"9999","Undistributed Profits/Losses","99999","equity_unaffected","l10n_nl.account_tag_undist_profit","False","","Niet-uitgekeerde winsten/verliezen","Unverteilte Gewinne/Verluste"


### PR DESCRIPTION
Following odoo#227754, a couple of translations for changed accounts need to be updated to correctly reflect their english name.

no-task


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
