### PR TITLE
[FIX] html_builder: display transformation options when replacing an image

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.js
@@ -14,13 +14,14 @@ export class ImageToolOption extends BaseOptionComponent {
         ImageTransformOption,
     };
     static selector = "img";
-    static exclude = "[data-oe-type='image'] > img";
+    static exclude = "[data-oe-type='image'] > img:not([data-attachment-id])";
     static name = "imageToolOption";
     setup() {
         super.setup();
         this.state = useDomState((editingElement) => ({
             isImageAnimated: editingElement.classList.contains("o_animate"),
             isDynamicSVG: editingElement.matches(dynamicSVGSelector),
+            isImageBinaryField: editingElement.parentElement.matches("[data-oe-type=image]"),
         }));
     }
 }

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -5,14 +5,14 @@
     <t t-if="!state.isDynamicSVG">
         <ImageShapeOption />
     </t>
-    <BuilderRow label.translate="Description"
+    <BuilderRow label.translate="Description" t-if="!state.isImageBinaryField"
         tooltip.translate="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...).">
         <BuilderTextInput
             action="'alt'"
             placeholder.translate="Alt tag"
             />
     </BuilderRow>
-    <BuilderRow label.translate="Tooltip"
+    <BuilderRow label.translate="Tooltip" t-if="!state.isImageBinaryField"
         tooltip.translate="'Title tag' is shown as a tooltip when you hover the picture.">
         <BuilderTextInput
             attributeAction="'title'"
@@ -21,10 +21,10 @@
     <BuilderRow label.translate="Transform" preview="false">
         <BuilderButton title.translate="Crop image" action="'cropImage'" icon="'fa-crop'" id="'cropImage'" />
         <BuilderButton title.translate="Reset crop" action="'resetCrop'" t-if="this.isActiveItem('cropImage')">Reset</BuilderButton>
-        <ImageTransformOption t-if="!state.isImageAnimated" />
+        <ImageTransformOption t-if="!state.isImageAnimated and !state.isImageBinaryField" />
     </BuilderRow>
     <ImageFilterOption />
-    <BuilderRow label.translate="Size">
+    <BuilderRow label.translate="Size" t-if="!state.isImageBinaryField">
         <BuilderButtonGroup styleAction="'width'">
             <BuilderButton styleActionValue="''" title.translate="Resize Default">Default</BuilderButton>
             <BuilderButton styleActionValue="'25%'" title.translate="Resize Quarter">25%</BuilderButton>

--- a/addons/html_builder/static/tests/image_field.test.js
+++ b/addons/html_builder/static/tests/image_field.test.js
@@ -1,6 +1,6 @@
 import { setupHTMLBuilder, dummyBase64Img } from "@html_builder/../tests/helpers";
 import { expect, test, describe } from "@odoo/hoot";
-import { contains } from "@web/../tests/web_test_helpers";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 
@@ -13,4 +13,54 @@ test("image field should not be editable, but the image can be replaced", async 
     expect(":iframe img").toHaveProperty("isContentEditable", false);
     await contains(":iframe img").click();
     expect("span:contains('Double-click to edit')").toHaveCount(1);
+});
+
+test("replacing an image should display the image tool options", async () => {
+    onRpc("/html_editor/get_image_info", () => ({
+        original: {
+            image_src: dummyBase64Img,
+        },
+    }));
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `<div data-oe-model="product.product" data-oe-id="12" data-oe-field="image_1920" data-oe-type="image" data-oe-expression="product_image.image_1920">
+            <img src="${dummyBase64Img}"/>
+        </div>`
+    );
+    await contains(":iframe img").click();
+    await waitSidebarUpdated();
+    expect("button[data-action-id=replaceMedia]").toHaveCount(1);
+
+    // Fields that don't appear before replacing the image
+    expect("div[data-label=Shape] div[role=button]").toHaveCount(0);
+    expect("div[data-label=Transform] button[data-action-id=cropImage]").toHaveCount(0);
+    expect("div[data-label=Transform] button[data-action-id=transformImage]").toHaveCount(0);
+    expect("div[data-label=Size] button").toHaveCount(0);
+
+    await contains("[data-action-id=replaceMedia]").click();
+    await contains("img.o_we_attachment_highlight").click();
+    await waitSidebarUpdated();
+
+    // Fields that are displayed after replacing the image
+    expect("div[data-label=Shape] div[role=button]").toHaveCount(1);
+    expect("div[data-label=Transform] button[data-action-id=cropImage]").toHaveCount(1);
+    expect("div[data-label=Transform] button[data-action-id=transformImage]").toHaveCount(0);
+    expect("div[data-label=Format] button").toHaveCount(1)
+
+    // Fields that should not appear in [data-oe-type='image'] > img for a binary field image
+    expect("div[data-label=Description] input").toHaveCount(0);
+    expect("div[data-label=Tooltip] input").toHaveCount(0);
+    expect("div[data-label=Alignment] button").toHaveCount(0);
+    expect("div[data-label=Style] button").toHaveCount(0);
+    expect("div[data-label=Padding] input").toHaveCount(0);
+    expect("div[data-label=Size] button").toHaveCount(0);
 });

--- a/addons/website/static/src/builder/plugins/image/image_tool_option.xml
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option.xml
@@ -2,7 +2,7 @@
     <t t-inherit="html_builder.ImageToolOption" t-inherit-mode="extension">
         <!-- Hide the image "Size" option when card cover width control is available -->
         <xpath expr="//BuilderRow[@label.translate='Size']" position="attributes">
-            <attribute name="t-if">!this.env.getEditingElement().closest('.o_card_img_wrapper')</attribute>
+            <attribute name="t-if" add="!this.env.getEditingElement().closest('.o_card_img_wrapper')" separator=" and "/>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
## Context
On the website page of a product, users can transform a picture in various ways (shape, size, cropping, etc.) when uploading it.

## Issue
When uploading a new picture, users can only replace the image or reorder it, but they cannot reshape it, crop it, or edit its size.

## Steps to reproduce
1. Install the *eCommerce* (`website_sale`) app.
2. Create a product and set a picture for it.
3. Go to that product's page in the Website app and open the website editor.
4. Click on the picture and replace it.
5. **The options to transform the picture are not displayed.**

## Cause
The transformation options are disabled due to the following static `exclude` variable in `ImageToolOption`:

https://github.com/odoo/odoo/blob/2b6b937c1c6d92e4e8b4657ae62127f0f8a7eb56/addons/html_builder/static/src/plugins/image/image_tool_option.js#L16

## Solution
We should prevent the transformation options from being displayed **only** when the image is external. In such cases, certain options from the `ImageToolOption` (such as the `ImageTransformOption` or the `ImageShapeOption`) cannot be applied. This is confirmed by the message displayed when trying to crop an external image:

https://github.com/odoo/odoo/blob/2b6b937c1c6d92e4e8b4657ae62127f0f8a7eb56/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js#L164-L173

We can determine whether an image is external by looking at its `data-attachment-id` property. If it is present, the image was recently uploaded to Odoo.

On top of updating the `exclude` variable, we need to filter out the options that cannot be used on images from the eCommerce. These options are:
- Description
- Tooltip
- Transform (*"Transform the picture"*)
- Size

## Tests
The test checks that the behavior matches the one from previous versions: the options to edit an image are not displayed before replacing the image, but are displayed after. Both the test `image field should not be editable, but the image can be replaced` (shown below) and the new test from this PR fail if the modified `exclude` variable allow to edit the image before replacing it.

https://github.com/odoo/odoo/blob/dea5a1d28a1935c2b4d87c3c6e8c07cd874c7d6b/addons/html_builder/static/tests/image_field.test.js#L7-L16

## Options displayed
|   | Before this commit  | After this commit  | Previous versions |
|---|---|---|---|
|  **Before replacing the image**  | Media, Re-order | Media, Re-order  | Media, Re-order
|  **After replacing the image**  | Media, Re-order | Media, Re-order, Shape, Transform (crop), Filter, Format, Quality | Media, Re-order, Shape, Transform (crop), Filter, Format, Quality


opw-5251864