### PR TITLE
[FIX] pos{,_discount}: title for discount dialog and width for number popups.

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/number_popup/number_popup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.NumberPopup">
-        <Dialog title="props.title" bodyClass="'d-flex flex-column justify-content-center'" size="'sm'">
+        <Dialog title="props.title" contentClass="'pos-number-popup'" bodyClass="'d-flex flex-column justify-content-center'" size="'sm'">
             <div t-if="props.subtitle" class="subtitle p-1 mx-auto" t-esc="props.subtitle"/>
             <div class="input-symbol mb-3">
                 <div class="popup-input value active form-control form-control-lg text-center position-relative">
@@ -14,8 +14,7 @@
                                 class="number-popup-type col btn btn-lg lh-lg o-default-button rounded-0 py-2"
                                 t-att-class="{
                                     ['number-popup-type-' + type.name]: type.name,
-                                    'btn-primary' : this.state.type.name === type.name,
-                                    'btn-secondary' : this.state.type.name !== type.name,
+                                    'text-primary border border-1 border-primary' : this.state.type.name === type.name,
                                     'rounded-start-2' : type_first,
                                     'rounded-end-2' : type_last}"
                                 t-esc="type.symbol"/>

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -86,6 +86,10 @@ select > option {
     /*rtl:ignore*/
     direction: ltr;
 }
+
+.pos .modal-dialog.modal-sm:has(.pos-number-popup) {
+    --modal-width: 360px;
+}
 .o_mobile_overscroll {
     overscroll-behavior: none;
 }

--- a/addons/point_of_sale/static/tests/generic_helpers/number_popup_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/number_popup_util.js
@@ -26,6 +26,6 @@ export function clickType(name) {
 export function hasTypeSelected(name) {
     return {
         content: `check if --${name}-- type is selected`,
-        trigger: `.modal .number-popup-types .number-popup-type-${name}.btn-primary`,
+        trigger: `.modal .number-popup-types .number-popup-type-${name}.text-primary`,
     };
 }

--- a/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -6,7 +6,7 @@ import { patch } from "@web/core/utils/patch";
 patch(ControlButtons.prototype, {
     async clickDiscount() {
         this.dialog.add(NumberPopup, {
-            title: _t("Discount Percentage"),
+            title: _t("Discount"),
             startingValue: this.pos.config.discount_pc,
             startingType: "percent",
             types: [

--- a/addons/pos_discount/static/tests/tours/discount_numpad.js
+++ b/addons/pos_discount/static/tests/tours/discount_numpad.js
@@ -11,6 +11,16 @@ registry.category("web_tour.tours").add("pos_discount_numpad", {
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Desk Pad", "4", "25"),
             ProductScreen.clickControlButton("Discount"),
+            {
+                content: "Ensure that the dialog title must be Discount",
+                trigger: '.modal-header:contains("Discount")',
+                run: ({ anchor }) => {
+                    const title = anchor.textContent;
+                    if (title != "Discount") {
+                        throw Error(`Title mismatch: expected "Discount", got "${title}".`);
+                    }
+                },
+            },
             NumberPopup.isShown("20 %"),
             NumberPopup.enterValue("10"),
             NumberPopup.clickType("fixed"),


### PR DESCRIPTION
Before this commit:
===================
- The dialog title was `Discount Percentage`, even though the global discount
can be applied either as a fixed amount or as a percentage.
- The NumberPopup has double primary buttons (Type and Confirm buttons),
which leads to an inconsistent UI
- Also, since this commit https://github.com/odoo/odoo/commit/01741aa2619998078bd19aca848146ac75c027fc, the PoS
NumberPopup dialogs have some extra width.

After this commit:
==================
- We renamed the dialog title to `Discount` to make it more generic.
- We updated the NumberPopup type selector styling to make UI consistent.
- Also reduced the width for the number pop-up dialogs, same as the previous
version.

Task: 5424805

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
