### PR TITLE
[FIX] l10n_sa: fixing invoice issue time format in qr code

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -43,7 +43,7 @@ class AccountMove(models.Model):
                 seller_name_enc = get_qr_encoding(1, record.company_id.display_name)
                 company_vat_enc = get_qr_encoding(2, record.company_id.vat)
                 time_sa = fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'), record.l10n_sa_confirmation_datetime)
-                timestamp_enc = get_qr_encoding(3, time_sa.isoformat())
+                timestamp_enc = get_qr_encoding(3, time_sa.strftime("%Y-%m-%dT%H:%M:%S"))
                 totals = record._get_l10n_sa_totals()
                 invoice_total_enc = get_qr_encoding(4, float_repr(abs(totals['total_amount']), 2))
                 total_vat_enc = get_qr_encoding(5, float_repr(abs(totals['total_tax']), 2))


### PR DESCRIPTION
In ZATCA phase 1, after converting the time to Asia/Riyadh timezone, the time information is added to the qr code in iso format which concatenates the timezone ("+03:00"). However, ZATCA expects the time to simply be sent as is in Asia/Riyadh timezone.

Task: 5319097

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
