### PR TITLE
[FIX] l10n_dk_nemhandel: document support traceback

### DIFF
--- a/addons/l10n_dk_nemhandel/models/res_partner.py
+++ b/addons/l10n_dk_nemhandel/models/res_partner.py
@@ -179,16 +179,6 @@ class ResPartner(models.Model):
 
         return edi_identification == participant_identifier and service_href.startswith(smp_nemhandel_url)
 
-    def _check_document_type_support(self, participant_info, ubl_cii_format):
-        if self._deduce_country_code() != 'DK':
-            return super()._check_document_type_support(participant_info, ubl_cii_format)
-
-        service_references = participant_info.findall(
-            '{*}ServiceMetadataReferenceCollection/{*}ServiceMetadataReference'
-        )
-        document_type = self.env['account.edi.xml.ubl_21']._get_customization_ids()[ubl_cii_format]
-        return any(document_type in parse.unquote_plus(service.attrib.get('href', '')) for service in service_references)
-
     def _update_nemhandel_state_per_company(self, vals=None):
         partners = self.env['res.partner']
         if vals is None:


### PR DESCRIPTION
The function `_check_document_type_support` is extended in `l10n_dk_nemhandel` (from `account_peppol`).

The function causes an issue since it contains the old CNAME logic while peppol does not use it anymore;
but the newer NAPTR.

This commit removes the function
- It does not do anything different than the version in `account_peppol` (and it would cause issues if it did)
- The function is only called in `account_peppol`
- The module does not depend on `account_peppol`

Reproduce:
- Install `l10n_dk_nemhandel`; check that `account_peppol` is installed
- Select `DK Company`
- Activate Peppol in test mode
- Go to the `DK Company` contact (customers)
- Select "By Peppol" and "EU Standard (Peppol Bis 3.0)"
- Traceback should appear


opw-5232123