### PR TITLE
[FIX] l10n_dk_nemhandel: document support traceback

### DIFF
--- a/addons/l10n_dk_nemhandel/models/res_partner.py
+++ b/addons/l10n_dk_nemhandel/models/res_partner.py
@@ -179,15 +179,11 @@ class ResPartner(models.Model):
 
         return edi_identification == participant_identifier and service_href.startswith(smp_nemhandel_url)
 
+    # DEPRECATED
     def _check_document_type_support(self, participant_info, ubl_cii_format):
-        if self._deduce_country_code() != 'DK':
+        if self.env['ir.module.module']._get('account_peppol').state == 'installed':
             return super()._check_document_type_support(participant_info, ubl_cii_format)
-
-        service_references = participant_info.findall(
-            '{*}ServiceMetadataReferenceCollection/{*}ServiceMetadataReference'
-        )
-        document_type = self.env['account.edi.xml.ubl_21']._get_customization_ids()[ubl_cii_format]
-        return any(document_type in parse.unquote_plus(service.attrib.get('href', '')) for service in service_references)
+        return False
 
     def _update_nemhandel_state_per_company(self, vals=None):
         partners = self.env['res.partner']


### PR DESCRIPTION
The function `_check_document_type_support` is extended in `l10n_dk_nemhandel` (from `account_peppol`).

The function causes a traceback when called from
`_get_peppol_verification_state` in `account_peppol` since it contains the old CNAME logic while peppol does not use it anymore; but the newer NAPTR.

Note that the module does not depend on `account_peppol` strictly speaking but it is auto-installed due to the dependenciies.

This commit updates the code to just call the `super()` function (so `account_peppol`) in case peppol is installed. The function is not removed for stable compliance.

Reproduce:
- Install `l10n_dk_nemhandel`; check that `account_peppol` is installed
- Select `DK Company`
- Activate Peppol in test mode
- Go to the `DK Company` contact (customers)
- Select "By Peppol" and "EU Standard (Peppol Bis 3.0)"
- Traceback should appear

opw-5232123
