### PR TITLE
[FIX] website_slides: prevent traceback on content sharing

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -701,7 +701,10 @@
             const slide = this._slideValue;
             this.call("dialog", "add", SlideShareDialog, {
                 category: slide.category,
-                documentMaxPage: slide.category == 'document' && this.getDocumentMaxPage(),
+                documentMaxPage:
+                    slide.category == "document" &&
+                    new URL(slide.embedUrl, window.location.href).origin === window.location.origin &&
+                    this.getDocumentMaxPage(),
                 emailSharing: slide.emailSharing === 'True',
                 embedCode: slide.embedCode || '',
                 id: slide.id,

--- a/addons/website_slides/static/src/js/slides_share.js
+++ b/addons/website_slides/static/src/js/slides_share.js
@@ -27,7 +27,11 @@ publicWidget.registry.websiteSlidesShare = publicWidget.Widget.extend({
         const data = ev.currentTarget.dataset;
         this.call("dialog", "add", SlideShareDialog, {
             category: data.category,
-            documentMaxPage: data.category == 'document' && this.getDocumentMaxPage(),
+            documentMaxPage:
+                data.category == "document" &&
+                new URL($(data.embedCode).attr("src"), window.location.href).origin ===
+                    window.location.origin &&
+                this.getDocumentMaxPage(),
             emailSharing: data.emailSharing === 'True',
             embedCode: data.embedCode,
             id: parseInt(data.id),


### PR DESCRIPTION
Step to reproduce:
1. Install `website_slides`
2. Open any course and add content
3. Select the `Document` type and upload a Google Drive link
4. Save and publish the content
5. Click the "Share" button for this specific content in full screen

Issue:
- A traceback occurs: `Uncaught Javascript Error > Failed to read a named property 'document' from 'Window': Blocked a frame with origin "http://localhost:3000" from accessing a cross-origin frame.`

Cause:
- The `_onClickShareSlide` method attempts to calculate the `documentMaxPage` by accessing the internal DOM of the slide's iframe (`iframe.contentWindow.document`). When the content is hosted externally the iframe source is cross-origin. Browsers enforce the Same-Origin Policy.

Solution:
- Check the origin of the iframe's source URL before attempting to get max page.

opw-5422655