### PR TITLE
[FIX] html_builder: fix gaps in nested option connectors

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -1,4 +1,4 @@
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { uniqueId } from "@web/core/utils/functions";
 import { useService } from "@web/core/utils/hooks";
 import {
@@ -41,7 +41,10 @@ export class BuilderRow extends Component {
         }
 
         this.labelRef = useRef("label");
+        this.rootRef = useRef("root");
         this.tooltip = useService("tooltip");
+
+        useEffect(() => refreshSublevelLines(this.rootRef.el));
     }
 
     getLevelClass() {
@@ -82,3 +85,76 @@ export class BuilderRow extends Component {
         );
     }
 }
+
+function refreshSublevelLines(rowEl) {
+    const optionsContainerEl = rowEl?.closest(".options-container");
+    if (!optionsContainerEl) {
+        return;
+    }
+    alignSublevelLines(optionsContainerEl);
+}
+
+// Recompute the vertical connector line for nested rows:
+// - Clear any previous offset on all rows.
+// - Skip hidden rows to avoid zero-size measurements.
+// - When a row comes back to a shallower level after deeper rows, stretch its
+//   line up to the last visible sibling of the same level.
+function alignSublevelLines(optionsContainerEl) {
+    const rowEls = [...optionsContainerEl.querySelectorAll(".hb-row")];
+    if (!rowEls.length) {
+        return;
+    }
+    const visibleRowEls = [];
+    for (const rowEl of rowEls) {
+        const labelEl = rowEl.querySelector(":scope > .hb-row-label");
+        if (labelEl) {
+            labelEl.style.removeProperty("--o-hb-row-sublevel-top");
+        }
+        if (getComputedStyle(rowEl).display !== "none") {
+            visibleRowEls.push(rowEl);
+        }
+    }
+    for (let index = 0; index < visibleRowEls.length; index++) {
+        const rowEl = visibleRowEls[index];
+        const level = getRowLevel(rowEl);
+        if (!level) {
+            continue;
+        }
+        const previousRowEl = visibleRowEls[index - 1];
+        if (!previousRowEl || getRowLevel(previousRowEl) <= level) {
+            continue;
+        }
+        for (let previousIndex = index - 1; previousIndex >= 0; previousIndex--) {
+            if (getRowLevel(visibleRowEls[previousIndex]) === level) {
+                // Stretch the line up to the previous sibling of the same level.
+                applyLineOffset(rowEl, visibleRowEls[previousIndex]);
+                break;
+            }
+        }
+    }
+}
+
+function applyLineOffset(rowEl, previousRowEl) {
+    const labelEl = rowEl.querySelector(":scope > .hb-row-label");
+    const previousLabelEl = previousRowEl.querySelector(":scope > .hb-row-label");
+    if (!labelEl || !previousLabelEl) {
+        return;
+    }
+    const offset =
+        previousLabelEl.getBoundingClientRect().bottom - labelEl.getBoundingClientRect().top;
+    if (offset < 0) {
+        labelEl.style.setProperty("--o-hb-row-sublevel-top", `${offset}px`);
+    }
+}
+
+function getRowLevel(rowEl) {
+    const sublevelClass = [...rowEl.classList].find((className) =>
+        className.startsWith("hb-row-sublevel-")
+    );
+    if (!sublevelClass) {
+        return 0;
+    }
+    return parseInt(sublevelClass.replace("hb-row-sublevel-", ""), 10) || 0;
+}
+
+export { refreshSublevelLines };

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -1,6 +1,6 @@
 @mixin sublevel-line($_level-left: 0) {
     position: absolute;
-    top: 0;
+    top: var(--o-hb-row-sublevel-top, 0);
     bottom: 0;
     left: $_level-left - $o-we-border-width;
     border: $o-we-border-width solid var(--o-hb-row-sublevel-color, #{mix($o-we-bg-lighter, $o-we-fg-light)});

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_row.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_row.test.js
@@ -1,10 +1,12 @@
 import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
+import { refreshSublevelLines } from "@html_builder/core/building_blocks/builder_row";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { describe, expect, test } from "@odoo/hoot";
 import {
     advanceTime,
     animationFrame,
     hover,
+    queryAll,
     queryAllTexts,
     queryOne,
     waitFor,
@@ -78,6 +80,60 @@ test("hide empty row and display row with content", async () => {
 
     await contains("[data-class-action='my-custom-class']").click();
     expect(queryAllTexts(selectorRowLabel)).toEqual(["Row 1", "Row 3"]);
+});
+
+test("reconnects lines across mixed levels", async () => {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`
+                <div class="options-container">
+                    <BuilderRow label="'root-1'">root-1</BuilderRow>
+                    <BuilderRow label="'level-1'" level="1">A</BuilderRow>
+                    <BuilderRow label="'level-2'" level="2">B</BuilderRow>
+                    <BuilderRow label="'level-1'" level="1">C</BuilderRow>
+                    <BuilderRow label="'root-2'">root-2</BuilderRow>
+                    <BuilderRow label="'level-1'" level="1">D</BuilderRow>
+                    <BuilderRow label="'level-2'" level="2">E</BuilderRow>
+                    <BuilderRow label="'level-2'" level="2">F</BuilderRow>
+                    <BuilderRow label="'level-3'" level="3">G</BuilderRow>
+                    <BuilderRow label="'level-3'" level="3">H</BuilderRow>
+                    <BuilderRow label="'level-2'" level="2">I</BuilderRow>
+                    <BuilderRow label="'level-1'" level="1">J</BuilderRow>
+                </div>`;
+        }
+    );
+
+    await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+    await contains(":iframe .test-options-target").click();
+    await waitFor(".options-container .hb-row-label");
+
+    const labelEls = queryAll(".options-container .hb-row-label");
+    const rowEls = queryAll(".options-container .hb-row");
+    const rects = [
+        { top: 0, bottom: 40 },
+        { top: 40, bottom: 80 },
+        { top: 80, bottom: 120 },
+        { top: 120, bottom: 160 },
+        { top: 160, bottom: 200 },
+        { top: 200, bottom: 240 },
+        { top: 240, bottom: 280 },
+        { top: 280, bottom: 320 },
+        { top: 320, bottom: 360 },
+        { top: 360, bottom: 400 },
+        { top: 400, bottom: 440 },
+        { top: 440, bottom: 480 },
+    ];
+    labelEls.forEach((labelEl, index) => {
+        labelEl.getBoundingClientRect = () => rects[index];
+    });
+    refreshSublevelLines(rowEls[10]);
+    await animationFrame();
+
+    const offsets = labelEls.map((labelEl) =>
+        labelEl.style.getPropertyValue("--o-hb-row-sublevel-top")
+    );
+    expect(offsets).toEqual(["", "", "", "-40px", "", "", "", "", "", "", "-80px", "-200px"]);
 });
 
 /* ================= Collapse template ================= */


### PR DESCRIPTION
Steps to reproduce:

- Open the website builder and drop a "Cover" snippet on the page.
- In "Background > Image", choose "Position: Repeat pattern" to reveal
the "Width/Height" sub-options.
- Issue: the vertical connector line between the "Filter" and "Position"
options is broken.

After this commit, the gap is removed. Options at the same level are now
properly connected, even when one of them contains sub-options.

task-5155955

| Before  | After |
| ------------- | ------------- |
| <img width="286" height="424" alt="image" src="https://github.com/user-attachments/assets/db035598-5094-4ec3-a42b-dc86bd871b9b" />  | <img width="285" height="422" alt="image" src="https://github.com/user-attachments/assets/d0229c5b-d3ea-41a2-9ed7-6155fc34d280" />  |