### PR TITLE
[FIX] mass_mailing: restore CRUD on ir.views for group_system

### DIFF
--- a/addons/mass_mailing/security/security.xml
+++ b/addons/mass_mailing/security/security.xml
@@ -25,5 +25,12 @@
             <field name="domain_force">[('technical_usage', '=', 'mass_mailing')]</field>
             <field name="perm_read" eval="False"/>
         </record>
+
+        <record id="ir_ui_view_rule_system" model="ir.rule">
+            <field name="name">ir.ui.view: system CRUD all</field>
+            <field name="model_id" ref="base.model_ir_ui_view"/>
+            <field name="domain_force">[(1,'=',1)]</field>
+            <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
There was an issue where, if someone was to install `mass_mailing` without
`website`, a user with `group_system` could not read `ir.ui.view` records.

Steps to reproduce:
- install mass_mailing, web_studio
- connect as an admin user
- try to edit a view (not a snippet) with studio

Issue:
- access error

In a previous [commit], new rules were introduced in `mass_mailing` to allow
`group_mass_mailing_user` to handle custom snippet (views). However, a
superseding rule for `group_system` was missing in `mass_mailing`, to allow an
admin to continue to manage other types of views.

[commit]: https://github.com/odoo/odoo/commit/6d39d72453842cf0d22880e14b1fa182c23538e6

task-5436780