### PR TITLE
[FIX] point_of_sale: fix runbot error

### DIFF
--- a/addons/point_of_sale/static/tests/tours/synchronization_tour.js
+++ b/addons/point_of_sale/static/tests/tours/synchronization_tour.js
@@ -17,7 +17,9 @@ registry.category("web_tour.tours").add("test_sync_from_ui_one_by_one", {
                 run: async () => {
                     // Create 5 orders that will be synced one by one
                     for (let i = 0; i < 5; i++) {
-                        const product = posmodel.models["product.product"].getFirst();
+                        const product = posmodel.models["product.product"].find(
+                            (el) => el.attribute_line_ids.length == 0
+                        );
                         const order = posmodel.createNewOrder();
                         await posmodel.addLineToOrder({ product_id: product }, order);
                         posmodel.addPendingOrder([order.id]);


### PR DESCRIPTION
In certain cases, the product selected in the tour would be a product that require a configuration (having attribute lines), which would lead opening a popup that is not handled in the tour, leading to a failure.

When selecting the product we now make sure that we select a product that does not require any configuration.

runbot-234734