### PR TITLE
[FIX] sale_timesheet : hide remaining hours on subscription tasks

### DIFF
--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -19,7 +19,7 @@ class SaleOrderLine(models.Model):
     @api.depends_context('with_remaining_hours', 'company')
     def _compute_display_name(self):
         super()._compute_display_name()
-        with_remaining_hours = self.env.context.get('with_remaining_hours')
+        with_remaining_hours = self.env.context.get('with_remaining_hours') and not self.env.context.get('skip_remaining_hours', False)
         if with_remaining_hours and any(line.remaining_hours_available for line in self):
             company = self.env.company
             encoding_uom = company.timesheet_encode_uom_id


### PR DESCRIPTION
This change hides the remaining_hours_so field when the sales order line is linked to a subscription. Unlike standard service or time-based sales orders, where this field reflects the difference between the quantity ordered and the quantity delivered, the concept does not translate well to subscription logic.

In the context of a subscription, the service is delivered on a recurring period (monthly, yearly, etc.). Delivery quantities continuously accumulate over time, and because the subscription renews indefinitely until cancellation, the “remaining hours” calculation quickly becomes misleading. In many cases it can drift into negative values, giving the impression of an error or over-consumption when, in reality, the subscription is simply following its recurring delivery cycle.

To avoid confusing end-users and to maintain a clean, intuitive interface, we hide this field whenever the line is part of a subscription.

opw-5246238
