### PR TITLE
[FIX] pos_hr: enable opening employee form form backend

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1930,6 +1930,9 @@ export class PosStore extends Reactive {
         return {
             resModel: "pos.order",
             resId: order.id,
+            context: {
+                from_frontend: true,
+            },
             onRecordSaved: async (record) => {
                 await this.data.read("pos.order", [record.evalContext.id]);
                 await this.data.read(

--- a/addons/pos_hr/views/pos_order_view.xml
+++ b/addons/pos_hr/views/pos_order_view.xml
@@ -6,7 +6,8 @@
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='user_id']" position='replace'>
-                <field name="employee_id" readonly="1" invisible="not employee_id" options="{'no_open': True}"/>
+                <field name="employee_id" readonly="1" invisible="not employee_id or context.get('from_frontend')"/>
+                <field name="employee_id" readonly="1" invisible="not employee_id or not context.get('from_frontend')" options="{'no_open': True}"/>
                 <field name="user_id" readonly="1" invisible="employee_id"/>
             </xpath>
         </field>


### PR DESCRIPTION
Opening employee form in the frontend was throwing an error, since not all thre required assets were available on the PoS frontend. So in this commit 57aba149b6e6927f9055124e58bed03f842329d5, we disabled openening the employee form by making the employee_id field unclikcable, both in forntend and backend!!
It was enough however to only macking it unclikcable on the frontend, since it was working fine on the backend where all the required assets were loaded anyway.

This commit restores the functionality on the backend, but overriding the `Many2OneField` used by the `employee_id`, and making it unclickable only on the frontned.

opw-5252486