### PR TITLE
[FIX] website,*: restrict submit button options in form builder

### DIFF
--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -18,7 +18,8 @@ import { BuilderAction } from "@html_builder/core/builder_action";
  * Called on the original element before clone.
  */
 
-const clonableSelector = "a.btn:not(.oe_unremovable)";
+const clonableSelector =
+    "a.btn:not(.oe_unremovable, .js_subscribe_btn, .s_website_form_send, .s_website_form_submit)";
 
 export function isClonable(el) {
     // TODO and isDraggable

--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -6,7 +6,8 @@ import { _t } from "@web/core/l10n/translation";
 
 const savableSelector = "[data-snippet], a.btn";
 // TODO `so_submit_button_selector` ?
-const savableExclude = ".o_no_save, .s_donation_donate_btn, .s_website_form_send";
+const savableExclude =
+    ".o_no_save, .s_donation_donate_btn, .s_website_form_send, .js_subscribe_btn";
 
 // Checks if the element can be saved as a custom snippet.
 function isSavable(el) {

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -118,9 +118,6 @@ export class FormOptionPlugin extends Plugin {
             ) {
                 reasons.push(_t("You cannot duplicate this field."));
             }
-            if (el.classList.contains("s_website_form_submit")) {
-                reasons.push(_t("You can't duplicate the submit button of the form."));
-            }
         },
         remove_disabled_reason_providers: ({ el, reasons }) => {
             if (el.classList.contains("s_website_form_model_required")) {
@@ -129,9 +126,6 @@ export class FormOptionPlugin extends Plugin {
                         "This field is mandatory for this action. You cannot remove it. Try hiding it with the 'Visibility' option instead and add it a default value."
                     )
                 );
-            }
-            if (el.classList.contains("s_website_form_submit")) {
-                reasons.push(_t("You can't remove the submit button of the form"));
             }
         },
         builder_options: [FormOption, FormFieldOptionRedraw, WebsiteFormSubmitOption],
@@ -193,6 +187,7 @@ export class FormOptionPlugin extends Plugin {
         so_content_addition_selector: [".s_website_form"],
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         on_cloned_handlers: this.onCloned.bind(this),
+        is_unremovable_selector: ".s_website_form_send, .s_website_form_submit",
     };
     setup() {
         this.modelsCache = new SyncCache(this._fetchModels.bind(this));

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -10,7 +10,7 @@ export class AnimateOption extends BaseOptionComponent {
     static dependencies = ["animateOption"];
     static selector = ".o_animable, section .row > div, img, .fa, .btn";
     static exclude =
-        "[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize";
+        "[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, .s_website_form_submit";
     static props = {
         dropdownClass: { type: String, optional: true, default: "o-hb-select-dropdown" },
         requireAnimation: { type: Boolean, optional: true },

--- a/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
@@ -21,7 +21,8 @@ export class DeviceVisibilityOption extends BaseOptionComponent {
     static template = "website.DeviceVisibilityOption";
     static dependencies = ["visibility"];
     static selector = DEVICE_VISIBILITY_OPTION_SELECTOR;
-    static exclude = ".s_col_no_resize.row > div, .s_masonry_block .s_col_no_resize";
+    static exclude =
+        ".s_col_no_resize.row > div, .s_masonry_block .s_col_no_resize, .s_website_form_submit";
 }
 
 class VisibilityOptionPlugin extends Plugin {

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -545,6 +545,11 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
+            content: "Verify that the button options do not have clone/remove/save buttons.",
+            trigger:
+                "div[data-container-title='Button'] .options-container-header:not(:has(.oe_snippet_remove, .oe_snippet_clone, .oe_snippet_save))",
+        },
+        {
             content: "Click on Edit Link in Popover",
             trigger: ".o-we-linkpopover .o_we_edit_link",
             run: "click",

--- a/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
@@ -28,6 +28,7 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {
                 dropIn: ".row.o_grid_mode",
             },
         ],
+        is_unremovable_selector: ".js_subscribe_btn",
     };
 }
 

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -19,6 +19,15 @@ registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
         content: 'Wait for the list id to be set.',
         trigger: ':iframe .s_newsletter_block[data-list-id]:not([data-list-id="0"]) .s_newsletter_subscribe_form',
     },
+    {
+        content: "Click on the Subscribe button to open its options.",
+        trigger: ":iframe .s_newsletter_block .js_subscribe_btn",
+        run: "click",
+    },
+    {
+        content: "Verify that the button options do not have clone/remove/save buttons.",
+        trigger: "div[data-container-title='Button'] .options-container-header:not(:has(.oe_snippet_remove, .oe_snippet_clone, .oe_snippet_save))",
+    },
     ...clickOnSave(),
     // Subscribe to the newsletter.
     {


### PR DESCRIPTION
*: html_builder, website_mass_mailing

Prevent unsupported actions and options on form submit buttons to avoid cloning/deletion issues and UI inconsistencies.

- Remove Duplicate and Remove actions from the sidebar for submit buttons (newsletter popup, forms, etc.) instead of disabling them.
- Hide the animation option for submit buttons, since it is already handled in the "Button" section.
- Remove the Visibility option for submit buttons.

Prevent unsupported actions and options on form submit buttons to avoid cloning/deletion issues and UI inconsistencies.

task-4702429