### PR TITLE
[FIX] bus: close cursor as soon as possible

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -763,31 +763,31 @@ class Websocket:
             notifications = fetch_bus_notifications(
                 cr, self._channels, self._last_notif_sent_id, [n[0] for n in self._notif_history]
             )
-            if not notifications:
-                return
-            for notif in notifications:
-                bisect.insort(self._notif_history, (notif['id'], time.time()), key=lambda x: x[0])
-            # Discard all the smallest notification ids that have expired and
-            # increment the last id accordingly. History can only be trimmed of ids
-            # that are below the new last id otherwise some notifications might be
-            # dispatched again.
-            # For example, if the theshold is 10s, and the state is:
-            # last id 2, history [(3, 8s), (6, 10s), (7, 7s)]
-            # If 6 is removed because it is above the threshold, the next query will
-            # be (id > 2 AND id NOT IN (3, 7)) which will fetch 6 again.
-            # 6 can only be removed after 3 reaches the threshold and is removed as
-            # well, and if 4 appears in the meantime, 3 can be removed but 6 will
-            # have to wait for 4 to reach the threshold as well.
-            last_index = -1
-            for i, notif in enumerate(self._notif_history):
-                if time.time() - notif[1] > self.MAX_NOTIFICATION_HISTORY_SEC:
-                    last_index = i
-                else:
-                    break
-            if last_index != -1:
-                self._last_notif_sent_id = self._notif_history[last_index][0]
-                self._notif_history = self._notif_history[last_index + 1 :]
-            self._send(notifications)
+        if not notifications:
+            return
+        for notif in notifications:
+            bisect.insort(self._notif_history, (notif['id'], time.time()), key=lambda x: x[0])
+        # Discard all the smallest notification ids that have expired and
+        # increment the last id accordingly. History can only be trimmed of ids
+        # that are below the new last id otherwise some notifications might be
+        # dispatched again.
+        # For example, if the theshold is 10s, and the state is:
+        # last id 2, history [(3, 8s), (6, 10s), (7, 7s)]
+        # If 6 is removed because it is above the threshold, the next query will
+        # be (id > 2 AND id NOT IN (3, 7)) which will fetch 6 again.
+        # 6 can only be removed after 3 reaches the threshold and is removed as
+        # well, and if 4 appears in the meantime, 3 can be removed but 6 will
+        # have to wait for 4 to reach the threshold as well.
+        last_index = -1
+        for i, notif in enumerate(self._notif_history):
+            if time.time() - notif[1] > self.MAX_NOTIFICATION_HISTORY_SEC:
+                last_index = i
+            else:
+                break
+        if last_index != -1:
+            self._last_notif_sent_id = self._notif_history[last_index][0]
+            self._notif_history = self._notif_history[last_index + 1 :]
+        self._send(notifications)
 
 
 class TimeoutManager:


### PR DESCRIPTION
In [1], the block following the fetch of notifications was wrongly indented. Cursor should be held for as little time as possible. This commit fixes the issue.

[1]: https://github.com/odoo/odoo/pull/235746

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
