### PR TITLE
[FIX] l10n_tw_edi_ecpay: exclude company name in EDI address

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -575,7 +575,7 @@ class AccountMove(models.Model):
             "MerchantID": self.company_id.sudo().l10n_tw_edi_ecpay_merchant_id,
             "RelateNumber": self.l10n_tw_edi_related_number,
             "CustomerIdentifier": self.partner_id.vat if self.l10n_tw_edi_is_b2b and self.partner_id.vat else "",
-            "CustomerAddr": self.partner_id.contact_address,
+            "CustomerAddr": self.partner_id._l10n_tw_edi_formatted_address(),
             "CustomerEmail": self.partner_id.email or "",
             "CustomerPhone": formatted_phone,
             "InvType": self.l10n_tw_edi_invoice_type,
@@ -672,8 +672,8 @@ class AccountMove(models.Model):
             "EmailAddress": self.partner_id.commercial_partner_id.email,
         }
 
-        if self.partner_id.commercial_partner_id.contact_address_inline:
-            buyer_json_data["Address"] = self.partner_id.commercial_partner_id.contact_address_inline
+        if partner := self.partner_id.commercial_partner_id:
+            buyer_json_data["Address"] = partner._l10n_tw_edi_formatted_address()
         if self.partner_id.commercial_partner_id.phone or self.partner_id.commercial_partner_id.mobile:
             number = self.partner_id.commercial_partner_id.phone or self.partner_id.commercial_partner_id.mobile
             buyer_json_data["TelephoneNumber"] = self._reformat_phone_number(number)

--- a/addons/l10n_tw_edi_ecpay/models/res_partner.py
+++ b/addons/l10n_tw_edi_ecpay/models/res_partner.py
@@ -7,3 +7,7 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     invoice_edi_format = fields.Selection(selection_add=[('tw_ecpay', "ECPay")])
+
+    def _l10n_tw_edi_formatted_address(self):
+        address = self._display_address(without_company=True)
+        return ", ".join(filter(None, map(str.strip, address.splitlines())))

--- a/addons/l10n_tw_edi_ecpay/tests/test_edi.py
+++ b/addons/l10n_tw_edi_ecpay/tests/test_edi.py
@@ -31,13 +31,19 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
         })
         cls.partner_a.write({
             'phone': '+886 123 456 789',
-            'contact_address': 'test address',
+            'street': 'street七美',
+            'city': '中正區',
+            'state_id': cls.env.ref('l10n_tw.state_tw_tpc').id,
+            'country_id': cls.env.ref('base.tw').id,
             'company_type': 'person',
         })
         cls.partner_b.write({
             'phone': '+886 123 456 789',
-            'contact_address': 'test address',
-            'vat': '12345678',
+            'street': 'street七美',
+            'city': '信義區',
+            'state_id': cls.env.ref('l10n_tw.state_tw_klc').id,
+            'country_id': cls.env.ref('base.tw').id,
+            'vat': '24153791',
             'company_type': 'company',
         })
         # We can reuse this invoice for the flow tests.
@@ -64,6 +70,7 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
         self.assertEqual(json_data.get("CustomerEmail"), "partner_a@tsointsoin")
         self.assertEqual(json_data.get("CustomerPhone"), "0123456789")
         self.assertEqual(json_data.get("SalesAmount"), 1050.0)
+        self.assertEqual(json_data.get("CustomerAddr"), "street七美, 中正區 TPC, Taiwan")
 
     @freeze_time("2025-01-06 15:00:00")
     def test_02_basic_submission(self):
@@ -204,7 +211,9 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
         test_partner = self.env['res.partner'].create({
             'name': 'Test Partner',
             'phone': '+886 123 456 789',
-            'contact_address': 'test address',
+            'street': 'street七美',
+            'city': '中正區',
+            'state_id': self.env.ref('l10n_tw.state_tw_tpc').id,
             'company_type': 'company',
         })
         invoice_a = self.init_invoice(


### PR DESCRIPTION
In this commit:
---
Update EDI address formatting to remove the company name and send a comma-separated single-line address.


task-5410619
