### PR TITLE
[FIX] mail: correct message_type for email invitations in Discuss

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -740,6 +740,7 @@ class DiscussChannel(models.Model):
                     "body_html": body,
                     "email_from": self.env.user.partner_id.email_formatted,
                     "email_to": addr,
+                    "message_type": "user_notification",
                     "model": "discuss.channel",
                     "res_id": self.id,
                     "subject": self.env._("%(author_name)s has invited you to a channel")

--- a/addons/mail/tests/discuss/test_discuss_channel_invite.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_invite.py
@@ -4,7 +4,7 @@ from itertools import product
 
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import UserError
-from odoo.tests import HttpCase, new_test_user, tagged
+from odoo.tests import HttpCase, new_test_user, tagged, users
 from odoo.tools.misc import hash_sign
 
 
@@ -189,3 +189,11 @@ class TestDiscussChannelInvite(HttpCase, MailCommon):
                     self.assertEqual(result["selectable_email"], search_term)
                     continue
                 self.assertFalse(result["selectable_email"])
+
+    @users("employee")
+    def test_06_invite_by_email_posts_user_notification(self):
+        group_chat = self.env["discuss.channel"]._create_group(partners_to=self.user_employee.partner_id.ids)
+        with self.mock_mail_gateway():
+            group_chat.invite_by_email(["alfred@test.com"])
+        last_message = group_chat._get_last_messages()
+        self.assertEqual(last_message.message_type, "user_notification")


### PR DESCRIPTION
Steps to reproduce:

* Open a public Discuss channel.
* Invite an external user by email.
* Refresh the page.

An email-related message is fetched and displayed as
`this message has been removed`. This happens because the message is created
with `message_type = 'email_outgoing'`, even though it is conceptually a user
notification and not meant to be rendered as an email in Discuss channels.

This commit fixes the issue by setting the correct `message_type`
(`user_notification`) instead of `email_outgoing`, ensuring the message
is not displayed in Discuss, avoiding a misleading removed message.


Task-5438936



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
