### PR TITLE
[FIX] web:  exclude nested card-body from background_color override

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_frontend.scss
@@ -42,7 +42,7 @@
     // case, which is not what we want.
     --body-color: var(--card-color);
 }
-:where(.card:not([data-vxml])) .card-body {
+:where(.card:not([data-vxml])) .card-body:not(.card[data-vxml] .card-body) {
     // BS4 colored cards do not have a very popular design. This will reset them
     // to a BS3-like one: only the header and footer are colored and the body
     // will use the color of a default card background with a light opacity.


### PR DESCRIPTION
Steps to reproduce:
===================
1- Drop the block tab snippet
2- Inside one of the tab panes, drop a Columns snippet.
3- Select background_color for one of the columns
4- Change tab style to tab

-> The background color of the inner column is overridden.

Cause:
======
When the "Tabs" snippet style is set, a `.card` class is added to its container (See [1])
A generic CSS rule, intended to style these tabs, was targeting any `.card` element with a `.card-body` child. (See [2])

However, the Columns snippet also uses a `.card > .card-body` structure (distinguished by a `data-vxml` attribute). This caused the overly broad tab-styling rule to incorrectly cascade and override the background color of the nested column.

Solution
========
The SCSS selector has been made more specific so that works if `card-body` class doesn't have any parent class with class `card` and has attribute `data-vxml`

[1]: https://github.com/odoo/odoo/blob/4cb3ffc09507fdfdb1aeabb70b2c93105f992700/addons/website/static/src/snippets/s_tabs/options.js#L149
[2]: https://github.com/odoo/odoo/blob/4cb3ffc09507fdfdb1aeabb70b2c93105f992700/addons/web/static/src/scss/bootstrap_review_frontend.scss#L55

opw-5394480

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
