### PR TITLE
[18.0][FIX] point_of_sale: Avoid error

### DIFF
--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -5,7 +5,7 @@ class IrModuleModule(models.Model):
     _inherit = 'ir.module.module'
 
     @api.model
-    def _load_pos_data_fields(self):
+    def _load_pos_data_fields(self, config=None):
         return ['id', 'name', 'state']
 
     @api.model


### PR DESCRIPTION
`IrModuleModule._load_pos_data_fields() takes 1 positional argument but 2 were given`

`File \"/opt/odoo/auto/addons/point_of_sale/models/pos_session.py\", line 185, in load_data\n    'fields': self.env[model]._load_pos_data_fields(response['pos.config']['data'][0]['id']),\nTypeError: IrModuleModule._load_pos_data_fields() takes 1 positional argument but 2 were given\n",`

@Tecnativa TT57146

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
