### PR TITLE
[FIX] purchase_stock: SM price using validation date currency rate

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -255,8 +255,9 @@ class PurchaseOrderLine(models.Model):
             price_unit /= self.product_uom_id.factor
             price_unit *= self.product_id.uom_id.factor
         if order.currency_id != order.company_id.currency_id:
+            conversion_date = self.env.context.get('conversion_date', self.date_order) or fields.Date.today()
             price_unit = order.currency_id._convert(
-                price_unit, order.company_id.currency_id, self.company_id, self.date_order or fields.Date.today(), round=False)
+                price_unit, order.company_id.currency_id, self.company_id, conversion_date, round=False)
         return float_round(price_unit, precision_digits=price_unit_prec)
 
     def _get_qty_procurement(self):

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -209,7 +209,7 @@ class StockMove(models.Model):
         # TODO: Start from global value
         if not self.purchase_line_id:
             return super()._get_value_from_quotation(quantity, at_date)
-        price_unit = self.purchase_line_id._get_stock_move_price_unit()
+        price_unit = self.purchase_line_id.with_context(conversion_date=self.date)._get_stock_move_price_unit()
         uom_quantity = self.product_uom._compute_quantity(quantity, self.product_id.uom_id)
         quantity = min(quantity, uom_quantity)
         value = price_unit * quantity


### PR DESCRIPTION
Steps to reproduce:
- Go to Accounting / Configuration / Accounting / Currencies
    - Enable EUR
    - Add two rates:
        - Date: December 15 → 1 EUR = 1 USD
        - Date: December 23 → 1 EUR = 2 USD

- Create a storable product "P1"
    - Costing method: AVCO

- Create a Purchase Order:
    - Vendor: any
    - Currency: EUR
    - Product: 1 unit of P1 at 10 EUR
    - Order Deadline / Expected Arrival: December 15
    - Confirm the PO

- Validate the receipt on December 23

Problem:
The product standard price is computed as 10 USD instead of 20 USD.

The stock move value is computed using the purchase order date instead of the stock move validation date, causing the currency conversion to use an outdated exchange rate.

Solution:
Use the stock move validation date when converting the purchase price to the company currency.

opw-5402545

