### PR TITLE
[FIX] hw_drivers: allow upgrades to >= 19.1

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -123,6 +123,37 @@ def check_certificate():
         return {"status": CertificateStatus.OK, "message": message}
 
 
+def check_version_upgrades(local_branch, db_branch):
+    """
+    Check if the iot is < 19.1 and upgrading to >= saas-19.1
+    If so and current python version is less than 3.12, run the scripts
+    located in upgrade_scripts/ to upgrade the python version
+    :param local_branch: The local git branch (Ex: "19.0" / "17.0-hw-drivers-compatibility-with-trixie-yaso")
+    :param db_branch: The git branch of the connected Odoo database (Ex: "saas-19.1" / "master" etc.)
+    """
+    if platform.system() != 'Linux':
+        _logger.debug("Ignoring version upgrade check on non-Linux system")
+        return
+
+    try:
+        # 1. Check if the upgrade script needs to be ran
+        # Needed if local branch is < 19.1 and db branch is >= 19.1 + python version < 3.12
+        _logger.info("Checking for version upgrades for local branch %s / db_branch %s", local_branch, db_branch)
+        version_db = db_branch[-4:] if db_branch != 'master' else db_branch  # master is currently always >= 19.1
+        version_local = local_branch[-4:] if local_branch != 'master' else local_branch
+        local_python_version = tuple(int(x) for x in platform.python_version_tuple()[:2])
+        if version_local >= '19.1' or version_db < '19.1' or local_python_version >= (3, 12):
+            _logger.info("Ignoring unnecessary upgrade for local branch %s / db_branch %s with python version %s", local_branch, db_branch, local_python_version)
+            return
+        with writable():
+            _logger.warning("Updating to Debian Trixie for >= 19.1")
+            subprocess.run(
+                ['/home/pi/odoo/addons/hw_drivers/tools/upgrade_scripts/upgrade_trixie/upgrade_trixie.sh'], check=True,
+            )
+    except subprocess.CalledProcessError:
+        _logger.exception("Failed to upgrade to debian Trixie. Check /home/pi/upgrade.log file for more details")
+
+
 def check_git_branch():
     """
     Check if the local branch is the same than the connected Odoo DB and
@@ -148,7 +179,6 @@ def check_git_branch():
             db_branch = json.loads(response.data)['result']['server_serie'].replace('~', '-')
             if not subprocess.check_output(git + ['ls-remote', 'origin', db_branch]):
                 db_branch = 'master'
-
             local_branch = (
                 subprocess.check_output(git + ['symbolic-ref', '-q', '--short', 'HEAD']).decode('utf-8').rstrip()
             )
@@ -160,6 +190,8 @@ def check_git_branch():
 
             if db_branch != local_branch:
                 try:
+                    check_version_upgrades(local_branch, db_branch)
+
                     with writable():
                         subprocess.run(git + ['branch', '-m', db_branch], check=True)
                         subprocess.run(git + ['remote', 'set-branches', 'origin', db_branch], check=True)

--- a/addons/hw_drivers/tools/upgrade_scripts/upgrade_trixie/upgrade_trixie.sh
+++ b/addons/hw_drivers/tools/upgrade_scripts/upgrade_trixie/upgrade_trixie.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+sudo mount -o remount,rw / && sudo mount -o remount,rw /root_bypass_ramdisks
+
+logfile=/home/pi/upgrade.log
+sudo touch "$logfile"
+exec 3>&1 4>&2
+trap 'exec 2>&4 1>&3' 0 1 2 3
+exec > >(sudo tee -a "$logfile") 2>&1  # Print to stdout and logfile
+set -x                            # display commands before execution
+
+# Commands to upgrade IoT 25.07 to Raspbian 13 Trixie
+
+# Setup chroot
+cd /root_bypass_ramdisks/
+sudo mount -t proc /proc proc/
+sudo mount -t sysfs /sys sys/
+sudo mount --rbind /dev dev/
+
+# Use hw_drivers if present, otherwise fall back to iot_drivers
+if [ -d /home/pi/odoo/addons/hw_drivers ]; then
+    SCRIPT_PATH=/home/pi/odoo/addons/hw_drivers/tools/upgrade_scripts/upgrade_trixie/upgrade_trixie_chroot.sh
+else
+    SCRIPT_PATH=/home/pi/odoo/addons/iot_drivers/tools/upgrade_scripts/upgrade_trixie/upgrade_trixie_chroot.sh
+fi
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+    echo "Upgrade script not found at $SCRIPT_PATH" >&2
+    exit 1
+fi
+
+sudo chroot /root_bypass_ramdisks/ "$SCRIPT_PATH"
+
+# Checkout saas-19.1 (if >= 19.1 is needed the iot box will checkout again to the required version on start)
+cd /home/pi/odoo
+sudo -u odoo git remote set-url origin https://github.com/odoo/odoo.git
+sudo -u odoo git fetch origin saas-19.1 --depth=1 --prune
+sudo -u odoo git reset --hard FETCH_HEAD
+sudo -u odoo git branch -m saas-19.1
+
+# Copy service scripts to /etc
+sudo cp /home/pi/odoo/setup/iot_box_builder/overwrite_after_init/etc/setup_ramdisks.sh /root_bypass_ramdisks/etc/setup_ramdisks.sh
+sudo cp /home/pi/odoo/setup/iot_box_builder/overwrite_after_init/etc/led_manager.sh /root_bypass_ramdisks/etc/led_manager.sh
+
+# Reinstall PIP packages
+sudo mount -o remount,rw / && sudo mount -o remount,rw /root_bypass_ramdisks
+sudo -u odoo pip install --break-system-packages -r /home/pi/odoo/setup/iot_box_builder/configuration/requirements.txt
+
+# Ensure iot drivers are used in odoo.conf
+sudo sed -i 's|^server_wide_modules *=.*|server_wide_modules = iot_drivers,web|' /home/pi/odoo.conf
+
+set +x
+
+# Reboot
+sudo reboot
+
+

--- a/addons/hw_drivers/tools/upgrade_scripts/upgrade_trixie/upgrade_trixie_chroot.sh
+++ b/addons/hw_drivers/tools/upgrade_scripts/upgrade_trixie/upgrade_trixie_chroot.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+set -x  # display commands before execution
+
+# Full upgrade
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew"
+
+# Switch to Trixie packages
+sed -i 's|bookworm|trixie|g' /etc/apt/sources.list
+sed -i 's|bookworm|trixie|g' /etc/apt/sources.list.d/raspi.list
+apt-get update
+apt-get autoremove -y
+
+# Upgrade all packages to Trixie versions
+DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" --purge --auto-remove
+
+# Reinstall packages that got removed in the upgrade
+apt-get install -y chromium python3-lxml-html-clean
+
+# Disable read-only on boot
+sed -i 's|,ro|   |g' /etc/fstab
+
+# Fix sparse-checkout
+echo setup/iot_box_builder/configuration | tee -a /home/pi/odoo/.git/info/sparse-checkout
+echo setup/iot_box_builder/overwrite_after_init/etc | tee -a /home/pi/odoo/.git/info/sparse-checkout
+
+# Fix services
+sed -i 's|After=.*|After=network-online.target time-sync.target cups.socket NetworkManager.service rc-local.service|g' /etc/systemd/system/odoo.service
+sed -i 's|Wants=.*|Wants=network-online.target time-sync.target|g' /etc/systemd/system/odoo.service
+sed -i '/Environment="LIBCAMERA_LOG_LEVELS=3"/a Environment="ODOO_PY_COLORS=True"' /etc/systemd/system/odoo.service
+sed -i 's|ExecStart=.*|ExecStart=/etc/setup_ramdisks.sh|g' /etc/systemd/system/ramdisks.service
+sed -i 's|ExecStart=.*|ExecStart=/etc/led_manager.sh|g' /etc/systemd/system/odoo-led-manager.service
+
+# Fix LNA popup in Chromium
+mkdir -p /etc/chromium/policies/managed
+echo '{"LocalNetworkAccessAllowedForUrls":["*"]}' | tee /etc/chromium/policies/managed/local_access.json


### PR DESCRIPTION
This PR adds 2 migration scripts which allow older iot box images (<= 25_07) to work with databases in saas-19.1 and later.

It updates os to debian trixie and installs all of the necessary packages to allow working after upgrades or with new databases. The update takes approximately 30 minutes. A warning about the necessity to update is added in this
upgrade script: https://github.com/odoo/upgrade/pull/9153

1) Our IoT Boxes which the clients are currently using are running under "Bookworm" os with Python 3.11 with Odoo on it.
2) We have a mecanism which aligns the iot box code to the connected database version using `git checkout`
3) In saas-19.1 Odoo bumped the Python minimal version requirement to 3.12
4) As a result when our iot boxes will do 'git checkout saas-19.1' Odoo will never be able to start anymore
5) When this happens the only way to fix it is either remotely connect to the iot box and run a script like in this PR (remote debug must be activated before upgrading) or flash the iot box with a new image based on Trixie
6) This PR avoids this by updating the current OS to Trixie and the Python version accordingly so that the clients can keep using their iot boxes in saas-19.1
