### PR TITLE
[FIX] pos_hr: prevent error with barcode scanning when module disabled

### DIFF
--- a/addons/pos_hr/static/src/overrides/components/cashier_name/cashier_name.js
+++ b/addons/pos_hr/static/src/overrides/components/cashier_name/cashier_name.js
@@ -5,7 +5,9 @@ import { useCashierSelector } from "@pos_hr/app/select_cashier_mixin";
 patch(CashierName.prototype, {
     setup() {
         super.setup(...arguments);
-        this.cashierSelector = useCashierSelector();
+        if (this.pos.config.module_pos_hr) {
+            this.cashierSelector = useCashierSelector();
+        }
     },
     //@Override
     get avatar() {

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -8,7 +8,7 @@ import * as NumberPopup from "@point_of_sale/../tests/tours/utils/number_popup_u
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as SelectionPopup from "@point_of_sale/../tests/tours/utils/selection_popup_util";
 import { registry } from "@web/core/registry";
-import { negate } from "@point_of_sale/../tests/tours/utils/common";
+import { negate, scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("PosHrTour", {
     steps: () =>
@@ -306,5 +306,15 @@ registry.category("web_tour.tours").add("test_maximum_closing_difference", {
             Chrome.hasBtn("Proceed anyway"),
             Chrome.clickBtn("Proceed anyway"),
             PosHr.loginScreenIsShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_scan_employee_barcode_with_pos_hr_disabled", {
+    steps: () =>
+        [
+            // scan a barcode with 041 as prefix for cashiers
+            scan_barcode("041123"),
+            Chrome.clickBtn("Open Register"),
+            ProductScreen.isShown(),
         ].flat(),
 });

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -191,3 +191,17 @@ class TestUi(TestPosHrHttpCommon):
             "test_maximum_closing_difference",
             login="pos_admin"
         )
+
+    def test_scan_employee_barcode_with_pos_hr_disabled(self):
+        """
+        Ensure that scanning an employee barcode when module_pos_hr is disabled does not
+        trigger any traceback.
+        """
+        self.main_pos_config.module_pos_hr = False
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_scan_employee_barcode_with_pos_hr_disabled",
+            login="pos_admin"
+        )


### PR DESCRIPTION
Before this commit, if logging with employee was disabled, scanning a cashier barcode would raise an error.

opw-5437310

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
