### PR TITLE
[FIX] base_import_module: show full list of industry modules

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -408,10 +408,10 @@ class IrModuleModule(models.Model):
     def web_search_read(self, domain, specification, offset=0, limit=None, order=None, count_limit=None):
         if _domain_asks_for_industries(domain):
             fields_name = list(specification.keys())
-            modules_list = self._get_modules_from_apps(fields_name, 'industries', False, domain, offset=offset, limit=limit)
+            modules_list = self._get_modules_from_apps(fields_name, 'industries', False, domain, offset=offset)
             return {
-                'length': len(modules_list),
-                'records': modules_list,
+                'length': len(modules_list) + offset,
+                'records': modules_list[:(limit or 80)],
             }
         else:
             return super().web_search_read(domain, specification, offset=offset, limit=limit, order=order, count_limit=count_limit)


### PR DESCRIPTION
Before this commit, when displaying the list of industry modules (from Apps > Industries), it is not possible to display more than 80 modules. This is because the override of web_search_read is not handling the full count of modules, as it was relying on the number of modules returned from the appstore, ignoring there is a limit (80 by default).

This commit removes the limit on the query to appstore so that all modules are retrieved, allowing the users to navigate through all modules. This solution is acceptable since the number of industry modules is rather limited  for now (around 100).