### PR TITLE
[IMP] account, *: backport embed multiple files peppol

### DIFF
--- a/addons/account/wizard/account_invoice_send_views.xml
+++ b/addons/account/wizard/account_invoice_send_views.xml
@@ -18,6 +18,8 @@
                     <field name="invoice_ids" invisible="1"/>
                     <field name="email_from" invisible="1" />
                     <field name="mail_server_id" invisible="1"/>
+                    <field name="display_attachment_fields" invisible="1"/>
+                    <field name="attachments_not_supported" invisible="1"/>
                     <div name="option_print">
                         <field name="is_print" />
                         <b><label for="is_print"/></b>
@@ -53,15 +55,22 @@
                             <field name="body" class="oe-bordered-editor" options="{'style-inline': true}"/>
                         </div>
                         <group>
-                            <group attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}">
-                                <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1" colspan="2" attrs="{'invisible': [('composition_mode', '=', 'mass_mail')]}"/>
-                            </group>
                             <group>
                                 <field name="template_id" options="{'no_create': True, 'no_edit': True}"
                                     context="{'default_model': 'account.move'}"/>
                             </group>
                         </group>
                     </div>
+
+                    <group attrs="{'invisible': [('display_attachment_fields', '=', False)]}">
+                        <field name="attachment_ids"
+                               widget="many2many_binary"
+                               string="Attach a file"
+                               nolabel="1"
+                               colspan="2"
+                               attrs="{'invisible': [('display_attachment_fields', '=', False)]}"
+                               options="{'attachments_not_supported_field': 'attachments_not_supported' }"/>
+                    </group>
 
                     <footer>
                         <button string="Send &amp; Print"

--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.js
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.js
@@ -16,7 +16,18 @@ export class Many2ManyBinaryField extends Component {
     }
 
     get files() {
-        return this.props.value.records.map((record) => record.data);
+        const attachments = this.props.value.records.map((record) => record.data);
+        const attachmentsNotSupported = this.props.record.data[this.props.attachmentsNotSupportedField]
+
+        if (this.props.record.resModel == 'account.invoice.send' && attachmentsNotSupported) {
+            for (const attachment of attachments) {
+                if (attachment.id && attachment.id in attachmentsNotSupported) {
+                    attachment.tooltip = attachmentsNotSupported[attachment.id];
+                }
+            }
+        }
+
+        return attachments;
     }
 
     getUrl(id) {
@@ -52,6 +63,7 @@ Many2ManyBinaryField.components = {
 Many2ManyBinaryField.props = {
     ...standardFieldProps,
     acceptedFileExtensions: { type: String, optional: true },
+    attachmentsNotSupportedField: { type: String, optional: true },
     className: { type: String, optional: true },
     uploadText: { type: String, optional: true },
 };
@@ -65,6 +77,7 @@ Many2ManyBinaryField.isEmpty = () => false;
 Many2ManyBinaryField.extractProps = ({ attrs, field }) => {
     return {
         acceptedFileExtensions: attrs.options.accepted_file_extensions,
+        attachmentsNotSupportedField: attrs.options.attachments_not_supported_field,
         className: attrs.class,
         uploadText: field.string,
     };

--- a/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
+++ b/addons/web/static/src/views/fields/many2many_binary/many2many_binary_field.xml
@@ -26,7 +26,7 @@
 
 <t t-name="Many2ManyBinaryField.attachment_preview" owl="1">
     <t t-set="editable" t-value="!props.readonly"/>
-    <div t-attf-class="o_attachment o_attachment_many2many #{ editable ? 'o_attachment_editable' : '' } #{upload ? 'o_attachment_uploading' : ''}" t-att-title="file.name">
+    <div t-attf-class="o_attachment o_attachment_many2many d-flex flex-row align-items-center gap-1 #{ editable ? 'o_attachment_editable' : '' } #{upload ? 'o_attachment_uploading' : ''}" t-att-title="file.name">
         <div class="o_attachment_wrap">
             <t t-set="ext" t-value="getExtension(file)"/>
             <div class="o_image_box float-start" t-att-data-tooltip="'Download ' + file.name">
@@ -48,6 +48,7 @@
             <div class="o_attachment_uploaded"><i class="text-success fa fa-check" role="img" aria-label="Uploaded" title="Uploaded"/></div>
             <div t-if="editable" class="o_attachment_delete" t-on-click.stop="() => this.onFileRemove(file.id)"><span class="text-white" role="img" aria-label="Delete" title="Delete">×</span></div>
         </div>
+        <i class="fa fa-fw o_button_icon fa-warning" t-if="file.tooltip" t-att-data-tooltip="file.tooltip"></i>
     </div>
 </t>
 


### PR DESCRIPTION
[IMP] account, *: backport embed multiple files peppol

modules: account, account_peppol, web

This commit is a backport of 574a67c73633755438d0aff7ff85f380fec9ef0d

This commit allows user to send multiple attachments through peppol. The attachments will be embedded into the xml under the <AdditionalDocumentReference> tag

task-5103539
