### PR TITLE
[FIX] html_editor: scope LocalOverlayPlugin containers cleanup

### DIFF
--- a/addons/html_editor/static/src/main/local_overlay_plugin.js
+++ b/addons/html_editor/static/src/main/local_overlay_plugin.js
@@ -15,6 +15,7 @@ export class LocalOverlayPlugin extends Plugin {
 
     setup() {
         this.localOverlayContainer = this.config.localOverlayContainers?.ref.el;
+        this.localOverlays = new Set();
     }
 
     /**
@@ -31,12 +32,16 @@ export class LocalOverlayPlugin extends Plugin {
         container.setAttribute("data-oe-local-overlay-id", containerId);
         if (this.localOverlayContainer) {
             this.localOverlayContainer.append(container);
+            this.localOverlays.add(container);
         }
         return container;
     }
 
     destroy() {
-        this.localOverlayContainer?.replaceChildren();
+        for (const container of this.localOverlays) {
+            container.remove();
+        }
+        this.localOverlays.clear();
         super.destroy();
     }
 }


### PR DESCRIPTION
The bug is only observable after 18.4, after the website refactoring, but the root cause has been present since 18.0, so we fix it there in case there are other use cases.

Since [1], overlays are no longer visible after an operation that executes `reloadEditor`.

Steps to reproduce (observable after 18.4):
- On website, go into edit mode
- Change header template
- After reload, overlays are missing

Reason:
`WebsiteBuilderClientAction.reloadEditor` sets up the new `Editor` before the old one is destroyed.
Consequently, `LocalOverlayPlugin.destroy` removes the newest overlays as well. This commit ensures the plugin only cleans up its specific DOM elements.

The order of operations bug will be fixed in a later PR.

task-5438306

[1]: https://github.com/odoo/odoo/commit/3cd29fbac2b06566bfff40b5e7ed310cb0ce12c1