### PR TITLE
[FIX] point_of_sale: convert standard price

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -153,6 +153,7 @@ class ProductProduct(models.Model):
         for product in products:
             if different_currency:
                 product['lst_price'] = self.env.company.currency_id._convert(product['lst_price'], config_id.currency_id, self.env.company, fields.Date.today())
+                product['standard_price'] = self.env.company.currency_id._convert(product['standard_price'], config_id.currency_id, self.env.company, fields.Date.today())
             product['image_128'] = bool(product['image_128'])
 
             if len(taxes_by_company) > 1 and len(product['taxes_id']) > 1:

--- a/addons/point_of_sale/tests/test_pos_other_currency_config.py
+++ b/addons/point_of_sale/tests/test_pos_other_currency_config.py
@@ -362,3 +362,9 @@ class TestPoSOtherCurrencyConfig(TestPoSCommon):
                 debit += line.debit
                 credit += line.credit
             self.assertEqual(tools.float_compare(debit, credit, precision_rounding=self.other_currency_config.currency_id.rounding), 0)  # debit and credit should be equal
+
+    def test_pos_data_standard_price_converted(self):
+        self.other_currency_config.open_ui()
+        res = self.other_currency_config.current_session_id.load_data({})
+        product1_data = next(filter(lambda product: product['display_name'] == "Product 1", res['product.product']['data']))
+        self.assertEqual(product1_data['standard_price'], 2.5)  # standard price should be converted


### PR DESCRIPTION
The standard price of the products were not converted to the currency of the PoS journal, which could lead to issues when creating pricelist items based on the standard price.

Steps to reproduce:
-------------------
* Change the currency of any PoS journal to a different currency than the company currency.
* Create a product with a standard price > 0.
* Create a pricelist that uses the standard price as a base price. (e.g. price = standard price * 2)
* Add this product to a PoS order
> Observation: The price is not correctly computed according to the
  pricelist, because the standard price was not converted to the PoS currency.

Why the fix:
------------
We just make sure to convert the standard price of the products when loading the products in the PoS session the same way as we do it for the list price.

opw-5124388