### PR TITLE
[IMP] l10n_in: create branch journals based on GST difference

### DIFF
--- a/addons/l10n_in/tests/__init__.py
+++ b/addons/l10n_in/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_check_status
 from . import test_tds_tcs_alert
 from . import test_gstr_section
 from . import test_invoice_label
+from . import test_l10n_in_company

--- a/addons/l10n_in/tests/test_l10n_in_company.py
+++ b/addons/l10n_in/tests/test_l10n_in_company.py
@@ -1,0 +1,44 @@
+from odoo import Command
+from odoo.addons.l10n_in.tests.common import L10nInTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestL10nInCompany(L10nInTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Create a branch company under the default company
+        cls.company_data['company'].write({
+            'child_ids': [Command.create({
+                'name': 'IN Branch',
+                'country_id': cls.country_in.id,
+                'vat': '24FANCY1234AAZA',
+            })],
+        })
+        cls.in_branch = cls.company_data['company'].child_ids
+
+    def test_l10n_in_journal_priority(self):
+        """
+        Ensure that when a branch company has its own journals,
+        it is selected instead of falling back to the parent company's journal.
+        """
+
+        # Check: branch has no journal initially
+        branch_sale_journal = self.env['account.journal'].search([
+            ('company_id', '=', self.in_branch.id),
+            ('type', '=', 'sale'),
+        ], limit=1)
+        self.assertFalse(branch_sale_journal)
+
+        # Load the chart template for the branch (creates branch journals)
+        self._use_chart_template(self.in_branch)
+
+        # After branch journal, Ensure branch and parent
+        # companies select their respective journals.
+        branch_invoice = self._create_invoice(company_id=self.in_branch.id)
+        parent_company_invoice = self._create_invoice(company_id=self.default_company.id)
+        self.assertEqual(self.in_branch.id, branch_invoice.journal_id.company_id.id)
+        self.assertEqual(self.default_company.id, parent_company_invoice.journal_id.company_id.id)


### PR DESCRIPTION
Currently, when a branch is created, no separate accounting journals are created by default. As per `Section 25(4) of the CGST Act`, a person having more than one GST registration—whether in the same State/UT or in different States/UTs—is treated as a distinct person under GST law.

With this change, the GST number of the branch is compared with that of the parent company at the time of branch creation. If the GST numbers differ, separate accounting journals for `sale` and `purchase` are created for the branch to ensure that independent books of accounts are maintained.

task-5417349




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
