### PR TITLE
[FIX] pos_restaurant: correct course timer in preparation display

### DIFF
--- a/addons/pos_restaurant/models/restaurant_order_course.py
+++ b/addons/pos_restaurant/models/restaurant_order_course.py
@@ -16,6 +16,13 @@ class RestaurantOrderCourse(models.Model):
     order_id = fields.Many2one('pos.order', string='Order Ref', required=True, index=True, ondelete='cascade')
     line_ids = fields.One2many('pos.order.line', 'course_id', string="Order Lines", readonly=True)
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get('fired') and not vals.get('fired_date'):
+                vals['fired_date'] = fields.Datetime.now()
+        return super().create(vals_list)
+
     def write(self, vals):
         if vals.get('fired') and not self.fired_date:
             vals['fired_date'] = fields.Datetime.now()

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -238,6 +238,11 @@ registry.category("web_tour.tours").add("test_pos_restaurant_course", {
             // Check empty course gets remove after fire course.
             ProductScreen.clickCourseButton(),
             ProductScreen.selectCourseLine("Course 2"),
+            {
+                content: "Wait atleast 1 sec so that courses have different fired_date timestamps",
+                trigger: "body",
+                run: async () => await delay(1000),
+            },
             ProductScreen.fireCourseButton(),
             FloorScreen.clickTable("5"),
             {

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -342,6 +342,10 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.write({'printer_ids': False})
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_pos_restaurant_course')
+        order = self.pos_config.current_session_id.order_ids
+        self.assertEqual(len(order), 1)
+        # Verify whether the two courses have different timestamps
+        self.assertNotEqual(order.course_ids[0].fired_date, order.course_ids[1].fired_date)
 
     def test_preparation_printer_content(self):
             self.env['pos.printer'].create({


### PR DESCRIPTION
Before this commit:
--
- In the preparation display (PDIS), the first course shows a preparation time of 0 untill the second course is fired.
- After course 2 fired, course 1 and course 2 have same preparation time value.

After this commit:
--
- Each course shows its correct preparation time when fired.

task-5421616

