### PR TITLE
[IMP] html_editor, *: default link attributes

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/html_mail_field.js
@@ -32,6 +32,7 @@ export class HtmlMailField extends HtmlField {
     getConfig() {
         const config = super.getConfig();
         config.dropImageAsAttachment = false;
+        config.defaultLinkAttributes = { target: "_blank", rel: "noreferrer noopener" };
         config.Plugins = config.Plugins.filter((plugin) => plugin !== ColumnPlugin);
         return config;
     }

--- a/addons/website_forum/static/src/components/website_forum_wysiwyg/website_forum_wysiwyg.js
+++ b/addons/website_forum/static/src/components/website_forum_wysiwyg/website_forum_wysiwyg.js
@@ -64,7 +64,7 @@ export class WebsiteForumWysiwyg extends Wysiwyg {
                 start_edition_handlers: () => this.cleanImageClasses(this.editor.editable),
                 clean_for_save_handlers: ({ root }) => this.cleanImageClasses(root),
             },
-            defaultLinkAttributes: { rel: "ugc" },
+            defaultLinkAttributes: { rel: "ugc noreferrer noopener", target: "_blank" },
             dropImageAsAttachment: true,
             allowImageTransform: false,
             height: this.props.height,


### PR DESCRIPTION
*: `mail`, `website_forum`

Currently when a link is created from the full composer or while scheduling activity in chatter, we don't apply the right attributes and it can lead to troubles. This PR aims to add default following attributes while creating a link in chatter or creating a post in website_forum.

`target: '_blank'`
`rel: 'noreferrer noopener'`

task-5417475





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
