### PR TITLE
[FIX] website_slides: Add padding to the pager

### DIFF
--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -349,7 +349,7 @@
                 </t>
             </div>
         </t>
-        <div class="d-flex justify-content-center" t-if="pager">
+        <div class="d-flex justify-content-center py-4" t-if="pager">
             <t t-call="website.pager"/>
         </div>
     </div>


### PR DESCRIPTION
Issue:
------
If there are more than 10 courses in the `courses` page of website. Then the pager is getting attached/sticked to one of the courses. This is because no padding applied to the pager.

Solution:
---------
Add padding of `py-4` to the newly added pager in the template `courses_search_results`.

Steps to reproduce:
-------------------
1. Create a db with `website_slides`` installed in version 19.0.
2. Add courses more than 10.
3. Then we get the pager attached with the course box.

Ref PR:
https://github.com/odoo/odoo/commit/662f3eff044737391653951ae6e554aa29d15e1d#diff-3bcf684c25eefc24786dc62ada3438f5fbaf455f2c5933444f229ad813e0fce9R278

Ref Images:
---------------
Before Fix:
<img width="1371" height="378" alt="image" src="https://github.com/user-attachments/assets/b57b7e95-9a9b-4593-90d9-4742323c30d8" />

After Fix:
<img width="1293" height="390" alt="image" src="https://github.com/user-attachments/assets/f8b164f1-77ba-48c2-8408-8f7c48a70d6e" />


- OPW - [5391252](https://www.odoo.com/odoo/project/70/tasks/5391252)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
