### PR TITLE
[FIX] point_of_sale: load activity_state in partner kanban view

### DIFF
--- a/addons/point_of_sale/views/res_partner_view.xml
+++ b/addons/point_of_sale/views/res_partner_view.xml
@@ -23,6 +23,17 @@
             </field>
         </record>
 
+        <record id="res_partner_kanban_view_inherit" model="ir.ui.view">
+            <field name="name">res.partner.view.kanban.inherit</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.res_partner_kanban_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//aside" position="inside">
+                    <field name="activity_state" invisible="1"/>
+                </xpath>
+            </field>
+        </record>
+
         <record id="res_partner_action_edit_pos" model="ir.actions.act_window">
             <field name="name">Edit Partner</field>
             <field name="res_model">res.partner</field>


### PR DESCRIPTION
Steps to reproduce:
===================
- Use the POS in mobile view
- Complete a payment
- Click on "Edit Payment"
- Select customer or Edit customer

Issue:
======
- POS crashes when rendering the partner kanban view
- Frontend error occurs because `activity_state` is missing in the record

Cause:
======
- The partner kanban view references activity-related fields
- `activity_state` was not loaded when the view is rendered in POS

Fix:
====
- Explicitly load `activity_state` in the kanban view (invisible)

Task:5406890
