### PR TITLE
[FIX] {l10n_din5008_,}sale: restore decimal precision of unit price in report

### DIFF
--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -117,5 +117,9 @@
                 <t t-set="line_number" t-value="line_number+1"/>
             </t>
         </xpath>
+        <!--adding currency to unit price-->
+        <xpath expr="//td[@name='td_product_priceunit']/span" position="attributes">
+            <attribute name="t-options"  >{"widget": "monetary", "display_currency": line.currency_id}</attribute>
+        </xpath>
     </template>
 </odoo>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -220,7 +220,6 @@
                                     <span
                                         t-if="not collapse_prices"
                                         t-field="line.price_unit"
-                                        t-options="{'widget': 'monetary', 'display_currency': line.currency_id}"
                                     >
                                         25.00
                                     </span>


### PR DESCRIPTION
Steps to reproduce:
1. Install the Sale app.
2. Enable developer mode and go to Decimal Accuracy.
3. Set the "Product Price" precision to 3 digits.
4. Create a quotation and print the report.

Issue:
The decimal precision of the unit price is not respected in the report.

Cause:
The unit price field in the report uses the `monetary` widget, which ignores the Decimal Accuracy configuration and enforces currency precision instead.

Solution:
Remove the `monetary` widget from the unit price field in the report so that Decimal Accuracy is applied correctly.

Before:
<img width="570" height="97" alt="image" src="https://github.com/user-attachments/assets/dda22b25-0ade-40ae-b585-c6251ba89c89" />


After :
<img width="584" height="87" alt="image" src="https://github.com/user-attachments/assets/b51d3040-e7b5-41d6-bdd9-7ec799b8005d" />

opw-5418665

Revert [PR #224219](https://github.com/odoo/odoo/pull/224219/files#diff-92dda03d204cc6ea8b7aacd0c07939843c83b1841f4a3049903844777d83c07bR201) to the original implementation so that the configured Decimal Accuracy is correctly applied in reports as other apps i.e. Purchase or Account 