### PR TITLE
[IMP] html_builder: move some containers' computing to the component

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -3,6 +3,7 @@ import { throttleForAnimation } from "@web/core/utils/timing";
 import { getScrollingElement, getScrollingTarget } from "@web/core/utils/scrolling";
 import { BuilderOverlay, sizingY, sizingX, sizingGrid } from "./builder_overlay";
 import { withSequence } from "@html_editor/utils/resource";
+import { checkElement } from "@html_builder/utils/utils";
 
 function isResizable(el) {
     const isResizableY = el.matches(sizingY.selector) && !el.matches(sizingY.exclude);
@@ -106,9 +107,7 @@ export class BuilderOverlayPlugin extends Plugin {
                 iframe: this.iframe,
                 overlayContainer: this.overlayContainer,
                 history: this.dependencies.history,
-                hasOverlayOptions:
-                    this.dependencies.builderOptions.checkElement(option.element, {}) &&
-                    option.hasOverlayOptions,
+                hasOverlayOptions: checkElement(option.element, {}) && option.hasOverlayOptions,
                 next: this.dependencies.operation.next,
                 isMobileView: this.config.isMobileView,
                 mobileBreakpoint: this.config.mobileBreakpoint,

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { reactive } from "@odoo/owl";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { getScrollingElement, getScrollingTarget } from "@web/core/utils/scrolling";
+import { checkElement } from "@html_builder/utils/utils";
 import { OverlayButtons } from "./overlay_buttons";
 import { withSequence } from "@html_editor/utils/resource";
 
@@ -122,7 +123,7 @@ export class OverlayButtonsPlugin extends Plugin {
         }
         const buttons = [];
         for (const { getButtons, editableOnly } of this.getResource("get_overlay_buttons")) {
-            if (this.dependencies.builderOptions.checkElement(this.target, { editableOnly })) {
+            if (checkElement(this.target, { editableOnly })) {
                 buttons.push(...getButtons(this.target));
             }
         }

--- a/addons/html_builder/static/src/sidebar/customize_tab.xml
+++ b/addons/html_builder/static/src/sidebar/customize_tab.xml
@@ -19,15 +19,7 @@
                     <OptionsContainer
                         snippetModel="props.snippetModel"
                         editingElement="optionsContainer.element"
-                        options="optionsContainer.options"
-                        containerTitle="optionsContainer.containerTitle"
-                        optionTitleComponents="optionsContainer.optionTitleComponents"
-                        headerMiddleButtons="optionsContainer.headerMiddleButtons"
-                        isRemovable="optionsContainer.isRemovable"
-                        removeDisabledReason="optionsContainer.removeDisabledReason"
-                        isClonable="optionsContainer.isClonable"
-                        cloneDisabledReason="optionsContainer.cloneDisabledReason"
-                        containerTopButtons="optionsContainer.optionsContainerTopButtons"/>
+                        options="optionsContainer.options"/>
                 </t>
             </div>
         </t>

--- a/addons/html_builder/static/src/sidebar/option_container.xml
+++ b/addons/html_builder/static/src/sidebar/option_container.xml
@@ -16,14 +16,14 @@
                 t-att-role="isActionable ? 'button' : 'heading'"
                 t-on-click="selectElement"
             />
-            <t t-if="props.optionTitleComponents" t-foreach="props.optionTitleComponents" t-as="optionTitleComponent" t-key="optionTitleComponent.id">
+            <t t-if="containerControls.optionTitleComponents" t-foreach="containerControls.optionTitleComponents" t-as="optionTitleComponent" t-key="optionTitleComponent.id">
                 <t t-component="optionTitleComponent.Component" t-props="optionTitleComponent.props || {}"/>
             </t>
             <span class="flex-grow-1" />
 
             <div class="d-flex align-items-center gap-1 p-2">
-                <div t-if="props.headerMiddleButtons">
-                    <t t-foreach="props.headerMiddleButtons" t-as="headerMiddleButton" t-key="headerMiddleButton.id">
+                <div t-if="containerControls.headerMiddleButtons">
+                    <t t-foreach="containerControls.headerMiddleButtons" t-as="headerMiddleButton" t-key="headerMiddleButton.id">
                         <BuilderContext applyTo="headerMiddleButton.applyTo">
                             <t t-if="headerMiddleButton.Component"
                                 t-component="headerMiddleButton.Component"
@@ -32,28 +32,28 @@
                         </BuilderContext>
                     </t>
                 </div>
-                <t t-foreach="props.containerTopButtons" t-as="button" t-key="button_index">
+                <t t-foreach="containerControls.containerTopButtons" t-as="button" t-key="button_index">
                     <button class="o-hb-btn" t-att-class="button.class"
                             t-att-title="button.title" t-att-aria-label="button.title"
                             t-on-click="() => button.handler(props.editingElement)"/>
                 </t>
-                <t t-if="props.isClonable || props.cloneDisabledReason">
+                <t t-if="containerControls.isClonable || containerControls.cloneDisabledReason">
                     <!-- Disabled buttons do not display their title -->
-                    <span t-att-title="props.cloneDisabledReason" t-att-aria-label="props.cloneDisabledReason">
+                    <span t-att-title="containerControls.cloneDisabledReason" t-att-aria-label="containerControls.cloneDisabledReason">
 	                    <button class="fa fa-fw fa-clone oe_snippet_clone o-hb-btn btn btn-success-color-hover"
 	                            title="Duplicate this block"
 	                            aria-label="Duplicate this block"
-                                t-att-disabled="!!props.cloneDisabledReason"
+                                t-att-disabled="!!containerControls.cloneDisabledReason"
 	                            t-on-click="cloneElement"/>
 	                </span>
                 </t>
-                <t t-if="props.isRemovable || props.removeDisabledReason">
+                <t t-if="containerControls.isRemovable || containerControls.removeDisabledReason">
                     <!-- Disabled buttons do not display their title -->
-                    <span t-att-title="props.removeDisabledReason" t-att-aria-label="props.removeDisabledReason">
+                    <span t-att-title="containerControls.removeDisabledReason" t-att-aria-label="containerControls.removeDisabledReason">
 	                    <button class="fa fa-fw fa-trash oe_snippet_remove o-hb-btn btn btn-danger-color-hover"
 	                            title="Remove this block"
 	                            aria-label="Remove this block"
-	                            t-att-disabled="!!props.removeDisabledReason"
+	                            t-att-disabled="!!containerControls.removeDisabledReason"
 	                            t-on-click="removeElement"/>
 	                </span>
                 </t>

--- a/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/design_tab_plugin.js
@@ -78,11 +78,7 @@ class DesignTabPlugin extends Plugin {
             id: id,
             element: this.editable,
             hasOverlayOptions: false,
-            headerMiddleButton: false,
-            isClonable: false,
-            isRemovable: false,
             options: [Option],
-            optionsContainerTopButtons: [],
             snippetModel: {},
         };
     }

--- a/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
+++ b/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
@@ -8,12 +8,7 @@
                 <OptionsContainer
                     snippetModel="optionsContainer.snippetModel"
                     editingElement="optionsContainer.element"
-                    options="optionsContainer.options"
-                    containerTitle="optionsContainer.containerTitle"
-                    headerMiddleButtons="optionsContainer.headerMiddleButtons"
-                    isRemovable="optionsContainer.isRemovable"
-                    isClonable="optionsContainer.isClonable"
-                    containerTopButtons="optionsContainer.optionsContainerTopButtons"/>
+                    options="optionsContainer.options"/>
             </t>
         </div>
     </div>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.xml
@@ -9,12 +9,7 @@
                 <OptionsContainer
                     snippetModel="optionsContainer.snippetModel"
                     editingElement="optionsContainer.element"
-                    options="optionsContainer.options"
-                    containerTitle="optionsContainer.containerTitle"
-                    headerMiddleButtons="optionsContainer.headerMiddleButtons"
-                    isRemovable="optionsContainer.isRemovable"
-                    isClonable="optionsContainer.isClonable"
-                    containerTopButtons="optionsContainer.optionsContainerTopButtons"/>
+                    options="optionsContainer.options"/>
             </t>
         </div>
     </div>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -238,11 +238,7 @@ export class ThemeTabPlugin extends Plugin {
             id: id,
             element: el,
             hasOverlayOptions: false,
-            headerMiddleButton: false,
-            isClonable: false,
-            isRemovable: false,
             options: [options],
-            optionsContainerTopButtons: [],
             snippetModel: {},
         };
     }


### PR DESCRIPTION
After the [refactoring of html_builder], the container's information was computed
directly in the plugin. This change ensures that containers fields (title,
header buttons, isDisabled, etc.) are updated automatically when the editing
element changes, using dom state. This change also fixes an issue addressed in
PR #239235.

[refactoring of html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task 5391316.