### PR TITLE
[FIX] hr_holidays_attendance: correct extra hours deduction for validated alloc.

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -62,7 +62,7 @@ class HrLeave(models.Model):
             domain=[
                 ('holiday_status_id.overtime_deductible', '=', True),
                 ('employee_id', 'in', employees.ids),
-                ('state', '=', 'confirm'),
+                ('state', 'in', ['confirm', 'validate']),
             ],
             groupby=['employee_id'],
             aggregates=['number_of_hours_display:sum'],


### PR DESCRIPTION
Currently, when a time off allocation that deducts from extra hours is validated (approved), it ceases to be deducted from the employee's available overtime balance. The system only correctly deducts allocations that are in the 'confirm' (To Approve) state.

**Steps to Reproduce:**
1) Install `hr_holidays_attendance` module with demo. 
2) Enable `Display Extra Hours` in Attendance settings. 
3) Create a new `time off type` with `Duration type - Hours` and
   enable `Deduct Extra Hours` from configuration section.
4) In the employees profile make sure `Overtime Ruleset` is set and
   `Working Hours` is set as `Standard 40 hours/week` for easy calculation.
5) create attendance of that employee with check-in time 5 AM and check-out time
   11PM. (9 hrs OT). open form view of that attendance by clicking on expand button
   and make sure to enable `compensable as Time off` is checked.
6) Open employees profile and click on monthly hours.
   (you'll see Remaining Extra Hours: 09:00). click on `Deduct Extra Hours` and
   create allocation for 8hrs.  (you'll see Remaining Extra Hours: 01:00).
7) Navigate to `Time off > Management > Allocations` validate the recently
   generated allocation and again check the monthly hours of employee.
   (you'll see Remaining Extra Hours: 09:00)

Ref video for steps: https://drive.google.com/file/d/1hDlqUNOxVdDn5UPMgRZxlN-gVqkU-5eD/view?usp=sharing

**Observed behaviour:**
After validation, the remaining extra hours revert to the original amount (9 hours), as if the deduction never happened.

**Expected behaviour:**
After validation, the remaining extra hours should be 1 hours.

**Root cause:**
The method `_get_deductible_employee_overtime`(see [1]) uses a domain for `hr.leave.allocation` that explicitly checks for `('state', '=', 'confirm')`. This filters out any allocations that have moved to the 'validate' state.

**Fix:**
Update the domain to check for `('state', 'in', ['confirm', 'validate'])` instead of only 'confirm'. This ensures that validated allocations continue to be deducted from the available overtime balance.

**opw-5426826**
