### PR TITLE
[FIX] mail: prevent rare traceback when opening a parent channel

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -22,7 +22,7 @@
                 </t>
                 <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-1">
                     <div t-if="thread.parent_channel_id" class="d-flex align-items-center gap-1 ms-1">
-                        <span class="fw-bolder cursor-pointer opacity-75 opacity-100-hover o-hover-text-underline" t-esc="thread.parent_channel_id.displayName" t-on-click="() => this.thread.parent_channel_id.open({ focus: true })"/>
+                        <span class="fw-bolder cursor-pointer opacity-75 opacity-100-hover o-hover-text-underline" t-esc="thread.parent_channel_id.displayName" t-on-click="() => this.thread?.parent_channel_id?.open({ focus: true })"/>
                         <i class="oi oi-chevron-right o-xsmaller mx-1"/>
                     </div>
                     <AutoresizeInput


### PR DESCRIPTION
This commit fixes a rare traceback that could occur when opening a parent channel from a thread that has been deleted.

task-5355205