### PR TITLE
[FIX] payment_stripe: enable stripe connect for french territories

### DIFF
--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -134,7 +134,7 @@ class PaymentProvider(models.Model):
         """
         self.ensure_one()
 
-        if self.env.company.country_id.code not in const.SUPPORTED_COUNTRIES:
+        if self._stripe_get_country(self.env.company.country_id.code) not in const.SUPPORTED_COUNTRIES:
             raise RedirectWarning(
                 _(
                     "Stripe Connect is not available in your country, please use another payment"

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -139,6 +139,25 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
             onboarding_url = self.stripe.action_stripe_connect_account()
         self.assertEqual(onboarding_url['url'], 'https://dummy.url')
 
+    def test_country_mapping_stripe_connect(self):
+        """ Test that La Réunion (and other french territories) is supported by Stripe Connect. """
+        mapped_country_company = self.env['res.company'].create({
+            'name': 'Mapped Company',
+        })
+        with patch.object(
+            self.env.registry['payment.provider'], '_stripe_make_proxy_request',
+            return_value={'url': 'https://dummy.url'},
+        ) as mock, patch.object(
+            self.env.registry['payment.provider'], '_stripe_fetch_or_create_connected_account',
+            return_value={'id': 'dummy'},
+        ):
+            for country_code in const.COUNTRY_MAPPING:
+                country = self.env['res.country'].search([('code', '=', country_code)], limit=1)
+                mapped_country_company.country_id = country
+                self.env.company = mapped_country_company
+                self.stripe.action_stripe_connect_account('dummy')
+            self.assertEqual(mock.call_count, len(const.COUNTRY_MAPPING))
+
     def test_only_create_webhook_if_not_already_done(self):
         """ Test that a webhook is created only if the webhook secret is not already set. """
         self.stripe.stripe_webhook_secret = False


### PR DESCRIPTION
## Versions
17.0+

## Issue
Customers located in French territories (e.g. La Réunion) can't use Stripe Connect.

## Steps to reproduce
*Ensure Stripe payment provider is installed*
- From the Settings' app, access your company's data:
  - Change your company's country for "Réunion".
- Go to Payment Providers and open Stripe:
  - Try to enable Stripe via Stripe Connect;
  - A message tells you your country is not supported by Stripe.

## Cause
Commit 94b37a3f51089621a2f12360c7a13f610b24ba3a introduced territories mapping by adding the method `_stripe_get_country()`, mapping the company country (`self.company_id.country_id.code`) to enable Stripe under the parent country as specified in their documentation (https://support.stripe.com/questions/stripe-availability-for-outlying-territories-of-supported-countries).
This fix was first applied in 16.0 and forwarded but didn't check that commit de782a680de8e5a2d7c89b982c485ca29da34b3a, from saas-16.2, added another condition on (`self.env.company.country_id.code`) on the Stripe Connect flow.

opw-5421185