### PR TITLE
[FIX] stock_picking_batch: remove extra slash in batch/wave names

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -417,7 +417,7 @@ class StockPickingBatch(models.Model):
     @api.model
     def _prepare_name(self, picking_type, sequence_code, company_id):
         sequence_prefix, sequence_number = (self.env['ir.sequence'].with_company(company_id).next_by_code(sequence_code) or '/').split('/')
-        return f"{sequence_prefix}/{picking_type.sequence_code}/{sequence_number}"
+        return f"{sequence_prefix}/{picking_type.sequence_code}{sequence_number}"
 
     def _sanity_check(self):
         for batch in self:


### PR DESCRIPTION
Issue before this commit:
=========================
The batch and wave names were generated with an extra '/' before the sequence number. Example: `BATCH/WH/OUT//00001`.

Steps to Reproduce:
=========================
- Install the stock_picking_batch module.
- Go to Operations → Batch Transfers.
- Observe existing batch names containing an extra /.

Cause of the issue:
=========================
In this [PR](https://github.com/odoo/odoo/pull/190305), the 'sequence_code' field was changed to be 'related' to 'sequence_id.prefix', which already includes the warehouse and operation parts defaults(e.g., WH/OUT/).

However, in the _prepare_name method, an additional / was still appended after picking_type.sequence_code, leading to the duplicate slash in the name.

With This Commit:
=========================
The redundant '/' insertion in _prepare_name has been removed.
Since picking_type.sequence_code already defines the separator, this
change ensures that batch and wave names are generated correctly and remain clean.

