### PR TITLE
[FIX] html_editor: avoid highlighting link on initial load

### DIFF
--- a/addons/html_editor/static/src/main/link/link_selection_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_selection_plugin.js
@@ -116,7 +116,8 @@ export class LinkSelectionPlugin extends Plugin {
 
         if (
             singleLinkInSelection &&
-            this.isLinkEligibleForVisualIndication(singleLinkInSelection)
+            this.isLinkEligibleForVisualIndication(singleLinkInSelection) &&
+            this.document.activeElement === this.editable
         ) {
             singleLinkInSelection.classList.add("o_link_in_selection");
         }

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -102,7 +102,7 @@ describe("should position the cursor outside the link", () => {
         expect(getContent(el)).toBe(
             // The editable selection is in the link (first leaf of the editable
             // upon initialization).
-            '<p><strong>\ufeff<a href="#/" class="o_link_in_selection">\ufefftest\ufeff</a>\ufeff</strong></p>'
+            '<p><strong>\ufeff<a href="#/">\ufefftest\ufeff</a>\ufeff</strong></p>'
         );
 
         const aElement = queryOne("p a");
@@ -110,7 +110,7 @@ describe("should position the cursor outside the link", () => {
         // Simulate the selection with mousedown
         setSelection({ anchorNode: aElement.childNodes[0], anchorOffset: 0 });
         expect(getContent(el)).toBe(
-            '<p><strong>\ufeff<a href="#/" class="o_link_in_selection">[]\ufefftest\ufeff</a>\ufeff</strong></p>'
+            '<p><strong>\ufeff<a href="#/">[]\ufefftest\ufeff</a>\ufeff</strong></p>'
         );
         await animationFrame(); // selection change
         await pointerUp(el);
@@ -348,7 +348,7 @@ test("should remove zwnbsp from middle of the link", async () => {
         contentBeforeEdit:
             // The editable selection is in the link (first leaf of the editable
             // upon initialization).
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffcontent\ufeff</a>\ufeff</p>',
+            '<p>\ufeff<a href="#/">\ufeffcontent\ufeff</a>\ufeff</p>',
         stepFunction: async (editor) => {
             // Cursor before the FEFF text node
             setSelection({ anchorNode: editor.editable.querySelector("a"), anchorOffset: 0 });
@@ -366,7 +366,7 @@ test("should remove zwnbsp from middle of the link (2)", async () => {
         contentBeforeEdit:
             // The editable selection is in the link (first leaf of the editable
             // upon initialization).
-            '<p>\ufeff<a href="#/" class="o_link_in_selection">\ufeffcontent\ufeff</a>\ufeff</p>',
+            '<p>\ufeff<a href="#/">\ufeffcontent\ufeff</a>\ufeff</p>',
         stepFunction: async (editor) => {
             // Cursor inside the FEFF text node
             setSelection({
@@ -394,4 +394,21 @@ test("should not add visual indication to a button", async () => {
         contentBeforeEdit:
             '<p>\ufeff<a href="http://test.test/" class="btn">\ufeff[]content\ufeff</a>\ufeff</p>',
     });
+});
+
+test("Should not highlight link if editable not focused", async () => {
+    const { el } = await setupEditor('<p><a href="http://test.test/">abc</a></p>');
+    expect(getContent(el)).toBe(
+        '<p>\ufeff<a href="http://test.test/">\ufeffabc\ufeff</a>\ufeff</p>'
+    );
+});
+
+test("Should highlight link if editable focused", async () => {
+    const { el } = await setupEditor('<p><a href="http://test.test/">abc</a></p>');
+    el.focus();
+    setSelection({ anchorNode: el.querySelector("a"), anchorOffset: 0 });
+    await animationFrame();
+    expect(getContent(el)).toBe(
+        '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">[]\ufeffabc\ufeff</a>\ufeff</p>'
+    );
 });


### PR DESCRIPTION
Problem:
Add a link as the first line in a todo and refresh the page. The link is highlighted as soon as the page loads, even though no selection was made by the user.

Cause:
After 880734ee1f1f4d20d92c44e3cedcf2c61c0da908, when the editor is loaded without an active selection, the selection is set to the first element in the editable. If that element is a link, the class `o_link_in_selection` is added automatically.

Solution:
Only add `o_link_in_selection` when the selection is on a link and the editable is focused.

Steps to reproduce:
- Open a Todo.
- Add a link as the first text.
- Refresh the page.
- Observe the link is highlighted.

task-5436106

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
