### PR TITLE
[IMP] barcodes_gs1_nomenclature: missing hex support

### DIFF
--- a/addons/barcodes_gs1_nomenclature/__manifest__.py
+++ b/addons/barcodes_gs1_nomenclature/__manifest__.py
@@ -13,6 +13,8 @@
         'web.assets_backend': [
             'barcodes_gs1_nomenclature/static/src/js/barcode_parser.js',
             'barcodes_gs1_nomenclature/static/src/js/barcode_service.js',
+            'barcodes_gs1_nomenclature/static/src/js/epc_model.js',
+            'barcodes_gs1_nomenclature/static/src/js/epc_utils.js',
         ],
         'web.assets_unit_tests': [
             'barcodes_gs1_nomenclature/static/src/js/tests/**/*',

--- a/addons/barcodes_gs1_nomenclature/static/src/js/epc_model.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/epc_model.js
@@ -1,0 +1,279 @@
+export const SCHEME_TEMPLATE = {
+    0x30: {
+        name: "SGTIN-96",
+        length: 24, // Scheme length in Hexa characters, 0 if variable
+        uri_pattern_tag: "urn:epc:tag:sgtin-96:F.C.I.S",
+        uri_pure_tag: "urn:epc:id:sgtin:C.I.S",
+        partition: "sgtin",
+        fields_template: [
+            "header",
+            "filter",
+            "partition",
+            "company_prefix",
+            "item_reference",
+            "serial_integer",
+        ],
+        fields_bit_count: [8, 3, 3, 0, 0, 38], // 0 is for dynamically sized fields
+        ai_list: {
+            1: null, // To 'compute'
+            21: "serial_integer", // Simply copy field value
+        },
+    },
+    0x36: {
+        name: "SGTIN-198",
+        length: 52, // (198 + Math.ceil((198%16)/15)*(16 - 198%16))/ 4 = 52
+        uri_pattern_tag: "urn:epc:tag:sgtin-198:F.C.I.S",
+        uri_pure_tag: "urn:epc:id:sgtin:C.I.S",
+        partition: "sgtin",
+        fields_template: [
+            "header",
+            "filter",
+            "partition",
+            "company_prefix",
+            "item_reference",
+            "serial_string",
+        ],
+        fields_bit_count: [8, 3, 3, 0, 0, 140],
+        ai_list: {
+            1: null,
+            21: "serial_string",
+        },
+    },
+    0x31: {
+        name: "SSCC-96",
+        length: 24,
+        uri_pattern_tag: "urn:epc:tag:sscc-96:F.C.S",
+        uri_pure_tag: "urn:epc:id:sscc:C.S",
+        partition: "sscc",
+        fields_template: [
+            "header",
+            "filter",
+            "partition",
+            "company_prefix",
+            "serial_integer",
+            "blank",
+        ],
+        fields_bit_count: [8, 3, 3, 0, 0, 24],
+        ai_list: {
+            0: null,
+        },
+    },
+    0x32: {
+        name: "SGLN-96",
+        length: 24,
+        uri_pattern_tag: "urn:epc:tag:sgln-96:F.C.L.E",
+        uri_pure_tag: "urn:epc:id:sgln:C.L.E",
+        partition: "sgln",
+        fields_template: [
+            "header",
+            "filter",
+            "partition",
+            "company_prefix",
+            "location_reference",
+            "extension_integer",
+        ],
+        fields_bit_count: [8, 3, 3, 0, 0, 41],
+        ai_list: {
+            414: null,
+            254: "extension_integer",
+        },
+    },
+    0x39: {
+        name: "SGLN-195",
+        length: 52,
+        uri_pattern_tag: "urn:epc:tag:sgln-195:F.C.L.E",
+        uri_pure_tag: "urn:epc:id:sgln:C.L.E",
+        partition: "sgln",
+        fields_template: [
+            "header",
+            "filter",
+            "partition",
+            "company_prefix",
+            "location_reference",
+            "extension_string",
+        ],
+        fields_bit_count: [8, 3, 3, 0, 0, 140],
+        ai_list: {
+            414: null,
+            254: "extension_string",
+        },
+    },
+};
+
+export const FIELD_TEMPLATE = {
+    header: {
+        name: "EPC Header",
+        encoding: "integer",
+    },
+    filter: {
+        name: "Filter",
+        encoding: "integer",
+        uri_portion: "F",
+    },
+    partition: {
+        name: "Partition",
+        encoding: "partition_table",
+    },
+    company_prefix: {
+        name: "Company Prefix",
+        encoding: "integer",
+        uri_portion: "C",
+    },
+    item_reference: {
+        name: "Item Reference",
+        encoding: "integer",
+        uri_portion: "I",
+    },
+    serial_integer: {
+        name: "Serial (Integer)",
+        encoding: "integer",
+        uri_portion: "S",
+    },
+    serial_string: {
+        name: "Serial (Alphanumeric)",
+        encoding: "string",
+        uri_portion: "S",
+    },
+    blank: {
+        name: "Blank Filler",
+        encoding: "blank",
+    },
+    location_reference: {
+        name: "Location Reference",
+        encoding: "integer",
+        uri_portion: "L",
+    },
+    extension_integer: {
+        name: "Extension (Integer)",
+        encoding: "integer",
+        uri_portion: "E",
+    },
+    extension_string: {
+        name: "Extension (Alphanumeric)",
+        encoding: "string",
+        uri_portion: "E",
+    },
+};
+
+export const PARTITION = {
+    sgtin: [
+        { left_bit: 40, left_digit: 12, right_bit: 4, right_digit: 1 },
+        { left_bit: 37, left_digit: 11, right_bit: 7, right_digit: 2 },
+        { left_bit: 34, left_digit: 10, right_bit: 10, right_digit: 3 },
+        { left_bit: 30, left_digit: 9, right_bit: 14, right_digit: 4 },
+        { left_bit: 27, left_digit: 8, right_bit: 17, right_digit: 5 },
+        { left_bit: 24, left_digit: 7, right_bit: 20, right_digit: 6 },
+        { left_bit: 20, left_digit: 6, right_bit: 24, right_digit: 7 },
+    ],
+    sscc: [
+        { left_bit: 40, left_digit: 12, right_bit: 18, right_digit: 5 },
+        { left_bit: 37, left_digit: 11, right_bit: 21, right_digit: 6 },
+        { left_bit: 34, left_digit: 10, right_bit: 24, right_digit: 7 },
+        { left_bit: 30, left_digit: 9, right_bit: 28, right_digit: 8 },
+        { left_bit: 27, left_digit: 8, right_bit: 31, right_digit: 9 },
+        { left_bit: 24, left_digit: 7, right_bit: 34, right_digit: 10 },
+        { left_bit: 20, left_digit: 6, right_bit: 38, right_digit: 11 },
+    ],
+    sgln: [
+        { left_bit: 40, left_digit: 12, right_bit: 1, right_digit: 0 },
+        { left_bit: 37, left_digit: 11, right_bit: 4, right_digit: 1 },
+        { left_bit: 34, left_digit: 10, right_bit: 7, right_digit: 2 },
+        { left_bit: 30, left_digit: 9, right_bit: 11, right_digit: 3 },
+        { left_bit: 27, left_digit: 8, right_bit: 14, right_digit: 4 },
+        { left_bit: 24, left_digit: 7, right_bit: 17, right_digit: 5 },
+        { left_bit: 20, left_digit: 6, right_bit: 21, right_digit: 6 },
+    ],
+    grai: [
+        { left_bit: 40, left_digit: 12, right_bit: 4, right_digit: 0 },
+        { left_bit: 37, left_digit: 11, right_bit: 7, right_digit: 1 },
+        { left_bit: 34, left_digit: 10, right_bit: 10, right_digit: 2 },
+        { left_bit: 30, left_digit: 9, right_bit: 14, right_digit: 3 },
+        { left_bit: 27, left_digit: 8, right_bit: 17, right_digit: 4 },
+        { left_bit: 24, left_digit: 7, right_bit: 20, right_digit: 5 },
+        { left_bit: 20, left_digit: 6, right_bit: 24, right_digit: 6 },
+    ],
+    giai96: [
+        { left_bit: 40, left_digit: 12, right_bit: 42, right_digit: 13 },
+        { left_bit: 37, left_digit: 11, right_bit: 45, right_digit: 14 },
+        { left_bit: 34, left_digit: 10, right_bit: 48, right_digit: 15 },
+        { left_bit: 30, left_digit: 9, right_bit: 52, right_digit: 16 },
+        { left_bit: 27, left_digit: 8, right_bit: 55, right_digit: 17 },
+        { left_bit: 24, left_digit: 7, right_bit: 58, right_digit: 18 },
+        { left_bit: 20, left_digit: 6, right_bit: 62, right_digit: 19 },
+    ],
+    giai202: [
+        { left_bit: 40, left_digit: 12, right_bit: 148, right_digit: 18 },
+        { left_bit: 37, left_digit: 11, right_bit: 151, right_digit: 19 },
+        { left_bit: 34, left_digit: 10, right_bit: 154, right_digit: 20 },
+        { left_bit: 30, left_digit: 9, right_bit: 158, right_digit: 21 },
+        { left_bit: 27, left_digit: 8, right_bit: 161, right_digit: 22 },
+        { left_bit: 24, left_digit: 7, right_bit: 164, right_digit: 23 },
+        { left_bit: 20, left_digit: 6, right_bit: 168, right_digit: 24 },
+    ],
+    gsrn: [
+        { left_bit: 40, left_digit: 12, right_bit: 18, right_digit: 5 },
+        { left_bit: 37, left_digit: 11, right_bit: 21, right_digit: 6 },
+        { left_bit: 34, left_digit: 10, right_bit: 24, right_digit: 7 },
+        { left_bit: 30, left_digit: 9, right_bit: 28, right_digit: 8 },
+        { left_bit: 27, left_digit: 8, right_bit: 31, right_digit: 9 },
+        { left_bit: 24, left_digit: 7, right_bit: 34, right_digit: 10 },
+        { left_bit: 20, left_digit: 6, right_bit: 38, right_digit: 11 },
+    ],
+    gsrnp: [
+        { left_bit: 40, left_digit: 12, right_bit: 18, right_digit: 5 },
+        { left_bit: 37, left_digit: 11, right_bit: 21, right_digit: 6 },
+        { left_bit: 34, left_digit: 10, right_bit: 24, right_digit: 7 },
+        { left_bit: 30, left_digit: 9, right_bit: 28, right_digit: 8 },
+        { left_bit: 27, left_digit: 8, right_bit: 31, right_digit: 9 },
+        { left_bit: 24, left_digit: 7, right_bit: 34, right_digit: 10 },
+        { left_bit: 20, left_digit: 6, right_bit: 38, right_digit: 11 },
+    ],
+    gdti: [
+        { left_bit: 40, left_digit: 12, right_bit: 1, right_digit: 0 },
+        { left_bit: 37, left_digit: 11, right_bit: 4, right_digit: 1 },
+        { left_bit: 34, left_digit: 10, right_bit: 7, right_digit: 2 },
+        { left_bit: 30, left_digit: 9, right_bit: 11, right_digit: 3 },
+        { left_bit: 27, left_digit: 8, right_bit: 14, right_digit: 4 },
+        { left_bit: 24, left_digit: 7, right_bit: 17, right_digit: 5 },
+        { left_bit: 20, left_digit: 6, right_bit: 21, right_digit: 6 },
+    ],
+    cpi_96: [
+        { left_bit: 40, left_digit: 12, right_bit: 11, right_digit: 3 },
+        { left_bit: 37, left_digit: 11, right_bit: 14, right_digit: 4 },
+        { left_bit: 34, left_digit: 10, right_bit: 17, right_digit: 5 },
+        { left_bit: 30, left_digit: 9, right_bit: 21, right_digit: 6 },
+        { left_bit: 27, left_digit: 8, right_bit: 24, right_digit: 7 },
+        { left_bit: 24, left_digit: 7, right_bit: 27, right_digit: 8 },
+        { left_bit: 20, left_digit: 6, right_bit: 31, right_digit: 9 },
+    ],
+    // cpi_var special case : here, right bit is not absolute and rather define the maximum bits.
+    // This is due to '6-bit Variable String Partition Table' encoding of the field.
+    // That's why we should rely on right_digit instead of right_bit in the decode process for this case.
+    cpi_var: [
+        { left_bit: 40, left_digit: 12, right_bit: 114, right_digit: 18 },
+        { left_bit: 37, left_digit: 11, right_bit: 120, right_digit: 19 },
+        { left_bit: 34, left_digit: 10, right_bit: 126, right_digit: 20 },
+        { left_bit: 30, left_digit: 9, right_bit: 132, right_digit: 21 },
+        { left_bit: 27, left_digit: 8, right_bit: 138, right_digit: 22 },
+        { left_bit: 24, left_digit: 7, right_bit: 144, right_digit: 23 },
+        { left_bit: 20, left_digit: 6, right_bit: 150, right_digit: 24 },
+    ],
+    sgcn: [
+        { left_bit: 40, left_digit: 12, right_bit: 1, right_digit: 0 },
+        { left_bit: 37, left_digit: 11, right_bit: 4, right_digit: 1 },
+        { left_bit: 34, left_digit: 10, right_bit: 7, right_digit: 2 },
+        { left_bit: 30, left_digit: 9, right_bit: 11, right_digit: 3 },
+        { left_bit: 27, left_digit: 8, right_bit: 14, right_digit: 4 },
+        { left_bit: 24, left_digit: 7, right_bit: 17, right_digit: 5 },
+        { left_bit: 20, left_digit: 6, right_bit: 21, right_digit: 6 },
+    ],
+    itip: [
+        { left_bit: 40, left_digit: 12, right_bit: 4, right_digit: 1 },
+        { left_bit: 37, left_digit: 11, right_bit: 7, right_digit: 2 },
+        { left_bit: 34, left_digit: 10, right_bit: 10, right_digit: 3 },
+        { left_bit: 30, left_digit: 9, right_bit: 14, right_digit: 4 },
+        { left_bit: 27, left_digit: 8, right_bit: 17, right_digit: 5 },
+        { left_bit: 24, left_digit: 7, right_bit: 20, right_digit: 6 },
+        { left_bit: 20, left_digit: 6, right_bit: 24, right_digit: 7 },
+    ],
+};

--- a/addons/barcodes_gs1_nomenclature/static/src/js/epc_utils.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/epc_utils.js
@@ -1,0 +1,285 @@
+import { SCHEME_TEMPLATE, FIELD_TEMPLATE, PARTITION } from "@barcodes_gs1_nomenclature/js/epc_model";
+import { FNC1_CHAR } from "@barcodes_gs1_nomenclature/js/barcode_parser";
+
+const REGEX_IS_HEXA = /^[0-9a-f]+$/i;
+
+//  Technical Utilities
+function getBitLength(num) {
+    if (num === 0n) {
+        return 1;
+    } // Special case for 0
+    let bitLength = 0;
+    while (num > 0n) {
+        num >>= 1n;
+        bitLength++;
+    }
+    return bitLength;
+}
+
+function readBits(value, index, length, bitLength = null) {
+    if (index < 0 || length < 0) {
+        throw new Error("Index and length must be non-negative");
+    }
+    if (bitLength === null) {
+        bitLength = getBitLength(value);
+    }
+    const indexEnd = index + length;
+    if (indexEnd > bitLength) {
+        throw new Error("Index range exceeds bit length of the value");
+    }
+    let read = value >> BigInt(bitLength - indexEnd); // Remove the rightmost unwanted part
+    const mask = (1n << BigInt(length)) - 1n; // And Mask to extract the wanted part
+    read &= mask;
+    return read;
+}
+
+// EPC encoding must have a multiple of 16 bits.
+// c.f. [TDS  2.1], §15.1.1
+function missingBits(bitLength, standardSize = 16) {
+    const remainder = bitLength % standardSize;
+    return remainder === 0 ? 0 : standardSize - remainder;
+}
+
+// Decode Methods
+function decodeField(encoding, model, fieldName) {
+    switch (encoding) {
+        case "blank":
+            return null;
+        case "integer":
+            return decodeInteger(model, fieldName);
+        case "partition_table":
+            return decodePartition(model, fieldName);
+        case "string":
+            return decodeString(model, fieldName);
+        default:
+            throw new Error(`No decode function found for encoding: ${encoding}`);
+    }
+}
+
+function decodeInteger(model, fieldName) {
+    const field = model.fields[fieldName];
+    const value = readBits(model.hexValue, field.offset, field.bitSize, model.bitLength);
+    let res = value.toString();
+    //Improve later
+    if (field.digits) {
+        res = res.padStart(field.digits, "0");
+    }
+    return res;
+}
+
+function decodePartition(model, fieldName) {
+    const field = model.fields[fieldName];
+    const partition = PARTITION[model.partition];
+    if (partition === undefined) {
+        throw new Error(`No partition found for value: ${model.partition}`);
+    }
+    const value = readBits(model.hexValue, field.offset, field.bitSize, model.bitLength);
+    const fieldEntries = Object.entries(model.fields);
+    const fieldIndex = fieldEntries.findIndex(([name]) => name === fieldName);
+    if (fieldIndex === -1 || fieldIndex + 2 >= fieldEntries.length) {
+        throw new Error(`Field ${fieldName} or subsequent fields are not defined.`);
+    }
+    // Update the bitSize of the next two fields based on partition information
+    const [nextFieldName1] = fieldEntries[fieldIndex + 1];
+    const [nextFieldName2] = fieldEntries[fieldIndex + 2];
+    model.fields[nextFieldName1].bitSize = partition[value].left_bit;
+    model.fields[nextFieldName1].digits = partition[value].left_digit;
+    model.fields[nextFieldName2].bitSize = partition[value].right_bit;
+    model.fields[nextFieldName2].digits = partition[value].right_digit;
+
+    return null;
+}
+
+function decodeString(model, fieldName) {
+    const field = model.fields[fieldName];
+    const value = readBits(model.hexValue, field.offset, field.bitSize, model.bitLength);
+    const charLength = field.bitSize / 7;
+    const charCodes = [];
+    // loop read 7 bits at a time
+    for (let i = 0; i < charLength; i++) {
+        const res = Number(readBits(value, i * 7, 7, field.bitSize));
+        if (res === 0) {
+            break;
+        }
+        charCodes[i] = res;
+    }
+    // parse to UTF string
+    return String.fromCharCode(...charCodes);
+}
+
+// 'Business' Utilities
+function toPureUri(model) {
+    const fieldEntries = Object.entries(model.fields);
+    const [uriHeader, uriBody] = getSplitUri(model.template.uri_pure_tag);
+    for (let i = 0; i < fieldEntries.length; i++) {
+        const index = uriBody.indexOf(fieldEntries[i][1].uriPortion);
+        if (index !== -1) {
+            uriBody[index] = fieldEntries[i][1].value;
+            if (fieldEntries[i][1].encoding == "string") {
+                uriBody[index] = encodeURIComponent(uriBody[index]); // For an URI, characters must be escaped
+            }
+        }
+    }
+    return uriHeader + ":" + uriBody.join(".");
+}
+
+function getSplitUri(uri) {
+    const uriHeader = uri.split(":");
+    const uriBody = uriHeader.pop();
+    return [uriHeader.join(":"), uriBody.split(".")];
+}
+
+function toElementString(model) {
+    const aiDict = model.template.ai_list;
+    let elementString = "";
+    let value;
+    for (const [key, field] of Object.entries(aiDict)) {
+        if (field === null) {
+            value = getAi(key, model);
+        } else {
+            value = model.fields[field].value;
+        }
+        elementString += `${FNC1_CHAR}${key.padStart(2, "0")}${value}`;
+    }
+    return elementString;
+}
+
+function getAi(identifier, model) {
+    switch (identifier) {
+        case "0":
+            return getAi00(model);
+        case "1":
+            return getAi01(model);
+        case "414":
+            return getAi414(model);
+        default:
+            throw new Error(
+                `No extrapolation function found for the GS1 Application Identifier (${identifier.padStart(2, "0")})`
+            );
+    }
+}
+
+function getAi00(model) {
+    const companyPrefix = model.fields["company_prefix"];
+    const serialInteger = model.fields["serial_integer"];
+
+    const extensionDigit = serialInteger.value.substr(0, 1);
+    const serialRefRemainder = serialInteger.value.substr(1);
+    const ssccToCheck = extensionDigit + companyPrefix.value + serialRefRemainder;
+    const checkdigit = getGs1Checksum(ssccToCheck);
+    return ssccToCheck + checkdigit;
+}
+
+function getAi01(model) {
+    // input length : sum of companyPrefix.digits and itemReference.digits is always 13 digits (preserving leading zeroes)
+    // output: 14 digits
+    const companyPrefix = model.fields["company_prefix"];
+    const itemReference = model.fields["item_reference"];
+
+    const indicator = itemReference.value.substr(0, 1);
+    const itemRefRemainder = itemReference.value.substr(1);
+    const gtinToCheck = indicator + companyPrefix.value + itemRefRemainder;
+    const checkdigit = getGs1Checksum(gtinToCheck);
+    return gtinToCheck + checkdigit;
+}
+
+function getAi414(model) {
+    const companyPrefix = model.fields["company_prefix"];
+    const locationReference = model.fields["location_reference"];
+
+    // company_prefix + location_ref
+    const glnToCheck = companyPrefix.value + locationReference.value;
+    const checkdigit = getGs1Checksum(glnToCheck);
+    return glnToCheck + checkdigit;
+}
+
+function getGs1Checksum(data) {
+    // The GS1 specification defines the check digit calculation as follows (cf. [TDS 2.1] §7.3):
+    // d14 = (10 - ((3(d1 + d3 + d5 + d7 + d9 + d11 + d13) + (d2 + d4 + d6 + d8 + d10 + d12)) mod 10) mod 10
+    // However, it should be noted that here the index starts at 0 and not 1.
+    // It is therefore necessary to multiply even numbers instead of odd numbers.
+
+    // Note : same method is used for multiple data structures up to 17 digits (excluding check digits).
+    // Cf. https://ref.gs1.org/standards/genspecs/ §7.9.1
+    // data = data.padStart(17, '0'); is not optimal so we cheat on i value of incoming for loop instead
+    const offset = 17 - data.length;
+    let sum = 0;
+    for (let i = 0; i < data.length; i++) {
+        const value = parseInt(data.charAt(i));
+        if ((i + offset) % 2 == 0) {
+            sum += value * 3;
+        } else {
+            sum += value;
+        }
+    }
+    return ((10 - (sum % 10)) % 10).toString();
+}
+
+//public
+export function isValidEpcFormat(hexString) {
+    if (hexString.length < 2) {
+        return false;
+    }
+    const headerString = hexString.substring(0,2);
+    if (!REGEX_IS_HEXA.test(headerString)) {
+        return false;
+    }
+    const header = parseInt(headerString, 16);
+    return SCHEME_TEMPLATE[header]?.length === hexString.length //TODO: allow length in range for variable length schemes
+        && REGEX_IS_HEXA.test(hexString);
+}
+
+export function decode(hexString, asURI = false) {
+    // Prepare values
+    let hexValue;
+    try{
+        hexValue = BigInt("0x" + hexString);
+    }catch{
+        return hexString; // return original value if unable to decode
+    }
+    const bitLength = getBitLength(hexValue);
+    const headerRealBitCount = 8 - missingBits(bitLength, 8); // compensate for leftmost missing 0
+    const header = Number(readBits(hexValue, 0, headerRealBitCount, bitLength));
+
+    //Find template
+    if (SCHEME_TEMPLATE[header] === undefined) {
+        return hexString; // return original value if unable to decode
+    }
+    const template = SCHEME_TEMPLATE[header];
+    // Create & initialize base scheme structure
+    const model = {
+        hexValue: hexValue,
+        bitLength: bitLength,
+        partition: template.partition,
+        fields: {},
+        template: template,
+    };
+    for (let i = 0; i < template.fields_template.length; i++) {
+        const fieldName = template.fields_template[i];
+        const fieldTemplate = FIELD_TEMPLATE[fieldName];
+        const fieldBitCount = template.fields_bit_count[i];
+
+        model.fields[fieldName] = {
+            encoding: fieldTemplate.encoding,
+            bitSize: i === 0 ? headerRealBitCount : fieldBitCount,
+            uriPortion: fieldTemplate.uri_portion,
+            offset: i === 0 ? 0 : null,
+            value: i === 0 ? header.toString() : null,
+        };
+    }
+
+    // Effectively process fields
+    const fieldEntries = Object.entries(model.fields);
+    for (let i = 1; i < fieldEntries.length; i++) {
+        const [fieldName, fieldInfo] = fieldEntries[i];
+        const previousField = fieldEntries[i - 1][1];
+        fieldInfo.offset = previousField.offset + previousField.bitSize;
+        fieldInfo.value = decodeField(fieldInfo.encoding, model, fieldName);
+    }
+
+    // return GS1 AI(s) as String
+    if (asURI) {
+        return toPureUri(model); // TODO : Should be the only available option for GID-96, USDOD-96 and ADI-var. Cf. [TDT 2.0] Figure 1-1
+    }
+    return toElementString(model);
+}

--- a/addons/barcodes_gs1_nomenclature/static/src/js/tests/epc_utils.test.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/tests/epc_utils.test.js
@@ -1,0 +1,64 @@
+import { expect, test } from "@odoo/hoot";
+import { decode } from "@barcodes_gs1_nomenclature/js/epc_utils";
+
+test.tags("RFID");
+
+test("Decode SGTIN-96 URI", () => {
+    const test = decode("3066C4409047E140075BCD15", true);
+    expect(test).toEqual("urn:epc:id:sgtin:95060001343.05.123456789");
+});
+
+test("Decode SGTIN-96 Barcode Format", () => {
+    const test = decode("3066C4409047E140075BCD15");
+    expect(test).toEqual("\x1D0109506000134352\x1D21123456789");
+});
+
+test("Decode SGTIN-198 URI", () => {
+    const test = decode("3666C4409047E159B2C2BF100000000000000000000000000000", true);
+    expect(test).toEqual("urn:epc:id:sgtin:95060001343.05.32a%2Fb");
+});
+
+test("Decode SGTIN-198 Barcode Format", () => {
+    const test = decode("3666C4409047E159B2C2BF100000000000000000000000000000");
+    expect(test).toEqual("\x1D0109506000134352\x1D2132a/b");
+});
+
+test("Decode SSCC-96 URI", () => {
+    const test = decode("311BA1B300CE0A6A83000000", true);
+    expect(test).toEqual("urn:epc:id:sscc:952012.03456789123");
+});
+
+test("Decode SSCC-96 Barcode Format", () => {
+    const test = decode("311BA1B300CE0A6A83000000");
+    expect(test).toEqual("\x1D00095201234567891235");
+});
+
+test("Decode SGLN-96 URI", () => {
+    const test = decode("3276451FD46072000000162E", true);
+    expect(test).toEqual("urn:epc:id:sgln:9521141.12345.5678");
+});
+
+test("Decode SGLN-96 Barcode Format", () => {
+    const test = decode("3276451FD46072000000162E");
+    expect(test).toEqual("\x1D2545678\x1D4149521141123454");
+});
+
+test("Decode SGLN-195 URI", () => {
+    const test = decode("3976451FD46072CD9615F8800000000000000000000000000000", true);
+    expect(test).toEqual("urn:epc:id:sgln:9521141.12345.32a%2Fb");
+});
+
+test("Decode SGLN-195 Barcode Format", () => {
+    const test = decode("3976451FD46072CD9615F8800000000000000000000000000000");
+    expect(test).toEqual("\x1D25432a/b\x1D4149521141123454");
+});
+
+test("Decode unrecognized EPC", () => {
+    const test = decode("006604409047014007500015");
+    expect(test).toEqual("006604409047014007500015");
+});
+
+test("Decode non hex value", () => {
+    const test = decode("300123456789ABCDEFGHIJ");
+    expect(test).toEqual("300123456789ABCDEFGHIJ");
+});

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -175,6 +175,8 @@
             'barcodes/static/src/js/barcode_parser.js',
             'barcodes_gs1_nomenclature/static/src/js/barcode_parser.js',
             'barcodes_gs1_nomenclature/static/src/js/barcode_service.js',
+            'barcodes_gs1_nomenclature/static/src/js/epc_model.js',
+            'barcodes_gs1_nomenclature/static/src/js/epc_utils.js',
             # report download utils
             'web/static/src/webclient/actions/reports/utils.js',
             # PoS files


### PR DESCRIPTION
Add an EPC decoder as a front-end service.
The decoder takes an EPC as a hexadecimal input and return the resulting URI or Element String. On incorrect input or unsupported decoding, the returned value is null.
Currently support SGTIN-96, SGTIN-198, SSCC-96, SGLN-96, SGLN-195.

This commit also adds support for reading values from an RFID device without requiring a specific mobile app.
To achieve this, we use the same entry point as the one used for barcode scanning.
As a result, a refactoring of the naming is planned on the master branch.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
