### PR TITLE
[FIX] hr_holidays, hr_work_entry_holidays: leave with changing calendar

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -452,10 +452,14 @@ class HrEmployeeBase(models.AbstractModel):
         # 'no_leave_resource_calendar_update'
         if 'resource_calendar_id' in values and not self.env.context.get('no_leave_resource_calendar_update'):
             try:
-                self.env['hr.leave'].search([
+                leaves = self.env['hr.leave'].search([
                     ('employee_id', 'in', self.ids),
                     ('resource_calendar_id', '!=', int(values['resource_calendar_id'])),
-                    ('date_from', '>', fields.Datetime.now())]).write({'resource_calendar_id': values['resource_calendar_id']})
+                    ('date_from', '>', fields.Datetime.now())])
+                leaves.write({'resource_calendar_id': values['resource_calendar_id']})
+                non_hourly_leaves = leaves.filtered(lambda l: not l.request_unit_hours)
+                non_hourly_leaves.with_context(leave_skip_date_check=True, leave_skip_state_check=True)._compute_date_from_to()
+                non_hourly_leaves.filtered(lambda l: l.state == 'validate')._validate_leave_request()
             except ValidationError:
                 raise ValidationError(_("Changing this working schedule results in the affected employee(s) not having enough "
                                         "leaves allocated to accomodate for their leaves already taken in the future. Please "

--- a/addons/hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/hr_work_entry_holidays/models/hr_contract.py
@@ -85,7 +85,7 @@ class HrContract(models.Model):
         # _check_contracts raises an issue.
         # If there are existing leaves that are spanned by this new
         # contract, update their resource calendar to the current one.
-        if not (vals.get("state") == 'open' or vals.get('kanban_state') == 'done'):
+        if not (vals.get("state") == 'open' or vals.get('kanban_state') == 'done' or vals.get('resource_calendar_id', False)):
             return super().write(vals)
 
         specific_contracts = self.env['hr.contract']
@@ -96,7 +96,7 @@ class HrContract(models.Model):
         # increase their duration), we catch this error to display a more meaningful error message.
         try:
             for contract in self:
-                if vals.get('state') != 'open' and contract.state != 'draft':
+                if vals.get('state') != 'open' and contract.state not in ('draft', 'open'):
                     # In case the current contract is not in the draft state, the kanban_state transition does not
                     # cause any leave changes.
                     continue
@@ -111,8 +111,13 @@ class HrContract(models.Model):
                              ('kanban_state', '=', 'done'),
                     ]).sorted(key=lambda c: {'open': 1, 'close': 2, 'draft': 3, 'cancel': 4}[c.state])
                     if len(overlapping_contracts.resource_calendar_id) <= 1:
+                        super(HrContract, contract).write(vals)
                         if overlapping_contracts and leave.resource_calendar_id != overlapping_contracts[0].resource_calendar_id:
                             leave.resource_calendar_id = overlapping_contracts[0].resource_calendar_id
+                            if not leave.request_unit_hours:
+                                leave.with_context(leave_skip_date_check=True, leave_skip_state_check=True)._compute_date_from_to()
+                                if leave.state == 'validate':
+                                    leave._validate_leave_request()
                         continue
                     if leave.id not in leaves_state:
                         leaves_state[leave.id] = leave.state

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -248,3 +248,48 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         self.assertEqual(len(entries), 4, 'Leaves should have 1 entry per type')
         self.assertEqual((paid_leave_entry.date_stop - paid_leave_entry.date_start).seconds, 3600)
         self.assertEqual((unpaid_leave_entry.date_stop - unpaid_leave_entry.date_start).seconds, 3600)
+
+    def test_leave_change_working_schedule(self):
+        calendar_20h = self.env['resource.calendar'].create({
+            'name': '20h calendar',
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+            ]
+        })
+        self.contract_cdi.resource_calendar_id = calendar_20h
+        self.contract_cdi.generate_work_entries(date(2019, 10, 1), date(2019, 10, 30))
+        leave = self.env['hr.leave'].create({
+            'name': 'Holiday!!',
+            'employee_id': self.jules_emp.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': date(2019, 10, 10),
+            'request_date_to': date(2019, 10, 10),
+        })
+        leave.action_validate()
+        work_entries = self.env['hr.work.entry'].search([
+            ('employee_id', '=', self.jules_emp.id),
+            ('date_start', '>=', date(2019, 10, 10)),
+            ('date_stop', '<=', date(2019, 10, 10))
+        ])
+        self.assertEqual(len(work_entries), 1)
+        self.assertEqual(work_entries.leave_id, leave)
+        self.assertEqual(work_entries.work_entry_type_id, self.leave_type.work_entry_type_id)
+        self.assertEqual(work_entries.duration, 4.0)
+        self.assertEqual(work_entries.date_start, datetime(2019, 10, 10, 6, 0))
+        self.assertEqual(work_entries.date_stop, datetime(2019, 10, 10, 10, 0))
+        self.contract_cdi.resource_calendar_id = self.calendar_40h
+        work_entries = self.env['hr.work.entry'].search([
+            ('employee_id', '=', self.jules_emp.id),
+            ('date_start', '>=', date(2019, 10, 10)),
+            ('date_stop', '<=', date(2019, 10, 10))
+        ])
+        self.assertEqual(len(work_entries), 2)
+        self.assertEqual(work_entries.leave_id, leave)
+        self.assertEqual(work_entries.work_entry_type_id, self.leave_type.work_entry_type_id)
+        self.assertEqual(work_entries.mapped('duration'), [4.0, 4.0])
+        self.assertEqual(work_entries.mapped('date_start'), [datetime(2019, 10, 10, 6, 0), datetime(2019, 10, 10, 11, 0)])
+        self.assertEqual(work_entries.mapped('date_stop'), [datetime(2019, 10, 10, 10, 0), datetime(2019, 10, 10, 15, 0)])


### PR DESCRIPTION
purpose: Accepted leaves should be recomputed upon working schedule change.

- made the `resource_calendar_id` change on the leave when it's changed on the corresponding employee/contract, then forced recomputation of its dates from the new resource calendar

task-id: 5424312

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
