### PR TITLE
[FIX] test_mimetypes: xlsx 2025 mimetype detection test without libmagic

### DIFF
--- a/odoo/addons/test_mimetypes/tests/test_guess_mimetypes.py
+++ b/odoo/addons/test_mimetypes/tests/test_guess_mimetypes.py
@@ -37,10 +37,9 @@ class TestMimeGuessing(BaseCase):
         )
 
     def test_xlsx_2025(self):
-        # only work when python-magic is not installed otherwise seen as a zip
         self.assertEqual(
             guess_mimetype(contents('2025.xlsx')),
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' if magic is None else 'application/zip',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         )
 
     def test_odt(self):


### PR DESCRIPTION
Following commit [^1] increasing bytes passed to mimetype guesser, the differentiation made in test between whether python-magic bindings are present or not isn't relevant anymore, as both use case now returns the same mimetype.

Note: while the regular runbot builds doesn't have the python-magic bindings installed, the ones for nightlies' DistroBuilds does (and obviously broke in this case).

runbot-234738

[^1]: https://github.com/odoo/odoo/commit/72e8a29dd0edb0ca3d464142ce869f38f96c730a
