### PR TITLE
[FIX] pos_sale: COGS issue with repair

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -270,7 +270,7 @@ class PosOrder(models.Model):
 
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
         moves = self.filtered(lambda o: o.partner_id.id == partner_id)\
-            .mapped('picking_ids.move_ids')\
+            ._get_stock_moves()\
             ._filter_anglo_saxon_moves(product)\
             .sorted(lambda x: x.date)
         price_unit = product.with_company(self.company_id)._compute_average_price(0, quantity, moves)
@@ -659,6 +659,9 @@ class PosOrder(models.Model):
             'type': 'ir.actions.act_window',
             'domain': [('id', 'in', self.mapped('lines.refund_orderline_ids.order_id').ids)],
         }
+
+    def _get_stock_moves(self):
+        return self.picking_ids.move_ids
 
     def _is_pos_order_paid(self):
         amount_total = self.amount_total

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -166,6 +166,10 @@ class PosOrder(models.Model):
             }
         return order_line
 
+    def _get_stock_moves(self):
+        res = super()._get_stock_moves()
+        return res | self.lines.sale_order_line_id.move_ids
+
     def _get_invoice_lines_values(self, line_values, pos_line):
         inv_line_vals = super()._get_invoice_lines_values(line_values, pos_line)
 


### PR DESCRIPTION
1) Create a product with FIFO - automated costing method
2) Initial quantities updated 2 with the unit value 7. (2*7) =14
3) Create purchase order with 1 unit and price 10
4) Add this product into the repair order (as a line) > Validate the repair
5) Create a sale order from the repair order
6) Settle this sale order from the POS > Invoice the order

Expected behavior:
A cogs for 7$

Current behavior:
A cogs with 8$( std price )
 

It happens because the stock.move are linked to the repair order and not
generated from the PoS. So the cogs value can't be retrieve in the usual
way. In order to fix it, we check the move linked to the sale.order if
there is no move generated by the pos.
