### PR TITLE
[FIX] website_event_sale: remove pricelist warning on event products

### DIFF
--- a/addons/website_event_sale/models/product_pricelist.py
+++ b/addons/website_event_sale/models/product_pricelist.py
@@ -10,9 +10,7 @@ class ProductPricelistItem(models.Model):
     def _onchange_event_sale_warning(self):
         if self.min_quantity > 0:
             msg = ''
-            if self.applied_on == '3_global' or self.applied_on == '2_product_category':
-                msg = _("A pricelist item with a positive min. quantity will not be applied to the event tickets products.")
-            elif ((self.applied_on == '1_product' and self.product_tmpl_id.service_tracking == 'event') or
+            if ((self.applied_on == '1_product' and self.product_tmpl_id.service_tracking == 'event') or
                     (self.applied_on == '0_product_variant' and self.product_id.service_tracking == 'event')):
                 msg = _("A pricelist item with a positive min. quantity cannot be applied to this event tickets product.")
             if msg:


### PR DESCRIPTION
* Remove the warning shown when creating pricelist rules for event products.
* The warning is noisy, not well localized, and appears for every rule, resulting in a poor user experience with little practical value for most users

opw-5441138



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
