### PR TITLE
[FIX] html_builder: remove empty structures after element removal

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -22,6 +22,7 @@ export class SetupEditorPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         closest_savable_providers: withSequence(10, (el) => el.closest(".o_editable")),
         unremovable_node_predicates: (node) => node.classList?.contains("o_editable"),
+        on_removed_handlers: this.cleanupEmptyStructures.bind(this),
     };
 
     setup() {
@@ -97,5 +98,22 @@ export class SetupEditorPlugin extends Plugin {
             editablesAreaEls.unshift(editableEl);
         }
         return editablesAreaEls;
+    }
+
+    /**
+     * Cleans up whitespace-only text nodes in empty structures.
+     * Ensures `.oe_empty` elements are truly empty after snippet removal.
+     */
+    cleanupEmptyStructures() {
+        if (!this.editable) {
+            return;
+        }
+
+        const emptyStructureEls = this.editable.querySelectorAll(".oe_empty");
+        for (const emptyEl of emptyStructureEls) {
+            if (emptyEl.children.length === 0) {
+                emptyEl.replaceChildren();
+            }
+        }
     }
 }

--- a/addons/html_builder/static/tests/editor.test.js
+++ b/addons/html_builder/static/tests/editor.test.js
@@ -224,4 +224,19 @@ describe("toolbar dropdowns", () => {
         await expandToolbar();
         expect(".o-we-toolbar .btn[name='font']").toHaveCount(0);
     });
+
+    test("should cleanup whitespace after last element removal", async () => {
+        const { getEditor } = await setupHTMLBuilder(`
+            <section class="test_snippet" data-snippet="s_test" data-name="Test">
+                <p>Content to remove</p>
+            </section>
+        `);
+        const editor = getEditor();
+        const emptyStructureEl = editor.editable.querySelector(".oe_empty");
+        // The snippet is surrounded by new line text nodes.
+        expect(emptyStructureEl.childNodes.length).toBe(3);
+        await contains(":iframe .test_snippet").click();
+        await contains(".overlay .oe_snippet_remove").click();
+        expect(emptyStructureEl.childNodes.length).toBe(0);
+    });
 });


### PR DESCRIPTION
Steps to reproduce:
===================
1- Go to Website > eCommerce > Products
2- Open any product and click "Edit website"
3- Add a lot of content blocks (contact form etc..) & save
4- In the product description, delete all content blocks and keep
the last one
5- Click Save

->"Document is empty" validation error appears

Cause:
======
When saving an HTML field after deleting all content, whitespace text
nodes (like newlines) may remain in the DOM element. The
_copy_custom_snippet_translations lang_value might have this
whitespace as the content, which will cause "Document is empty" error
when the content is parsed by fromstring().

This didn't occur before the migration because the previous
implementation called _onSnippetRemoved after a content block was
deleted, and that handler removed any empty elements.
https://github.com/odoo/odoo/blob/8d66c79ecf74900af1c5b003723363be3d52cbc8/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js#L1370

Solution:
=========
After removing the content block, we should also do a cleanup.

opw-5263743