### PR TITLE
[FIX] mail: load activity_state in partner kanban view

### DIFF
--- a/addons/mail/views/res_partner_views.xml
+++ b/addons/mail/views/res_partner_views.xml
@@ -26,6 +26,7 @@
             <field name="inherit_id" ref="base.res_partner_kanban_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//aside" position="inside">
+                    <field name="activity_state" invisible="1"/>
                     <div class="ms-auto mt-auto" t-att-class="{ 'o_has_no_activity': !record.activity_state.raw_value }">
                         <field name="activity_ids" widget="kanban_activity"/>
                     </div>


### PR DESCRIPTION
Steps to reproduce:
===================
- Use the POS in mobile view
- Complete a payment
- Click on "Edit Payment"
- Select customer or Edit customer

Issue:
======
- The partner kanban view crashes in the frontend
- `activity_state` is accessed in the template but not loaded

Cause:
======
- The partner kanban view uses activity-related fields
- `activity_state` was not included in the kanban fields

Fix:
====
- Explicitly load `activity_state` in the partner kanban view

Task:5406890