### PR TITLE
[FIX] mail: prevent unread separator overlap during jump highlight

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -8,6 +8,7 @@
 
     &.o-highlighted {
         transform: translateY(-#{map-get($spacers, 3)});
+        z-index: 2;
     }
 
     &.o-actionMenuMobileOpen {


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
In saas-18.2, the unread message separator can visually overlap with the
message jump/highlight animation when navigating to unread messages.
This issue was not present in 18.0 and results from reduced vertical spacing
between the unread separator and the first unread message.

**Current behavior before PR:**
----------------------------------------------
- Clicking the “X new messages” banner triggers a jump highlight animation
- The highlighted message overlaps the unread red separator line
- The separator becomes partially or fully obscured during the animation

**Desired behavior after PR is merged:**
----------------------------------------------
- The unread separator remains clearly visible during message jump/highlight
- No overlap occurs between the separator and the highlighted message
- Highlight animation behavior remains unchanged
- Visual behavior matches the stable experience observed in 18.0

This PR restores sufficient vertical spacing for the unread separator line,
preventing overlap without altering message animation or interaction logic.

Task-5420965

I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr
