### PR TITLE
[FIX] html_editor: fix non-deterministic link test

### DIFF
--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -223,6 +223,7 @@ describe("Custom button style", () => {
         await contains(".o-we-linkpopover input.o_we_href_input_link").edit("http://test.test/", {
             confirm: false,
         });
+        await animationFrame();
         await click("button[name='link_type']");
         await animationFrame();
         await click(".o-we-link-type-dropdown .dropdown-item:contains('Custom')");


### PR DESCRIPTION


Description of the issue this PR addresses:

This test was not awaiting a step properly which somehow moved the selection to the overlay container which made the link popover to close resulting in further steps not working properly.

runbot-234926

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
