### PR TITLE
[ADD] al10n_it_edi: add CodiceCommessaConvenzione to electronic invoices

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -249,6 +249,7 @@
 <template id="account_invoice_FatturaPA_origin_document">
                 <IdDocumento t-if="origin_document_name" t-out="format_alphanumeric(origin_document_name, 20)"/>
                 <Data t-if="origin_document_date" t-out="format_date(origin_document_date)"/>
+                <CodiceCommessaConvenzione t-if="convention_code" t-out="format_alphanumeric(convention_code, 100)"/>
                 <CodiceCUP t-if="cup" t-out="format_alphanumeric(cup, 15)"/>
                 <CodiceCIG t-if="cig" t-out="format_alphanumeric(cig, 15)"/>
 </template>

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -124,6 +124,12 @@ class AccountMove(models.Model):
         copy=False,
     )
 
+    l10n_it_convention_code = fields.Char(
+        string="Order/Convention Code",
+        size=100,
+        help=" Used to connect an individual invoice to a broader framework agreement, a specific project, or a long-term convention."
+    )
+
     def _auto_init(self):
         # Create compute stored field l10n_it_document_type and l10n_it_payment_method
         # here to avoid timeout error on large databases.
@@ -865,6 +871,7 @@ class AccountMove(models.Model):
             'origin_document_date': self.l10n_it_origin_document_date,
             'cig': self.l10n_it_cig,
             'cup': self.l10n_it_cup,
+            'convention_code': self.l10n_it_convention_code,
             'currency': self.currency_id or self.company_currency_id if not convert_to_euros else self.env.ref('base.EUR'),
             'regime_fiscale': company.l10n_it_tax_system if not is_self_invoice else 'RF18',
             'is_self_invoice': is_self_invoice,

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -159,6 +159,7 @@
                                 <field name="l10n_it_origin_document_type" readonly="state != 'draft'"/>
                                 <field name="l10n_it_origin_document_name" readonly="state != 'draft'"/>
                                 <field name="l10n_it_origin_document_date" readonly="state != 'draft'"/>
+                                <field name="l10n_it_convention_code" readonly="state != 'draft'"/>
                                 <field name="l10n_it_cig" readonly="state != 'draft'"/>
                                 <field name="l10n_it_cup" readonly="state != 'draft'"/>
                             </group>


### PR DESCRIPTION
This commit adds the "Order/Convention Code" (CodiceCommessaConvenzione) field to the account.move model and the Italian EDI XML export.

This field is used in the SDI ecosystem to link transactions to framework agreements, projects, or conventions
It helps automate accounting by allowing recipient ERP systems to assign invoices to specific budget lines without manual intervention.

task-5433265

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
