### PR TITLE
[FIX] resource: fix average hours per day computation with attendance dates

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -165,7 +165,6 @@ class ResourceCalendar(models.Model):
     def _get_global_attendances(self):
         return self.attendance_ids.filtered(lambda attendance:
             attendance.day_period != 'lunch'
-            and not attendance.date_from and not attendance.date_to
             and not attendance.resource_id and not attendance.display_type)
 
     def _get_hours_per_day(self, attendances):

--- a/addons/resource/tests/test_utils.py
+++ b/addons/resource/tests/test_utils.py
@@ -82,3 +82,18 @@ class TestExpression(TransactionCase):
             self.assertTrue(res.id, 'The resource was successfully created')
             self.assertEqual(res.date_from, Datetime.to_string(date_from))
             self.assertEqual(res.date_to, Datetime.to_string(date_to))
+
+    def test_avg_hours_per_day_with_attendance_dates(self):
+        """
+        Ensure that setting a start or end date on an attendance line does not
+        affect the average hours per day computation.
+        """
+        calendar = self.env.ref('resource.resource_calendar_std')
+        self.assertEqual(calendar.hours_per_day, 8.0)
+
+        with Form(calendar) as calendar_form:
+            with calendar_form.attendance_ids.edit(0) as line_form:
+                line_form.date_from = Datetime.now()
+
+        # Average hours per day must remain unchanged
+        self.assertEqual(calendar.hours_per_day, 8.0)


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install hr_employee
2. Open Working Schedules and select any record
3. Enable the Start Date or End Date optional column
4. Set a start or end date on one of the working hours

Issue:
------
The "Average hours per day" value changes unexpectedly after setting a start or end date on an attendance line.

Cause:
------
The `_compute_hours_per_day` method relies on `_get_global_attendances`,
which excludes attendances having `date_from` or `date_to`.
https://github.com/odoo/odoo/blob/67e4cd087de179a7b06c23321cfc4e6d5aa2a9dd/addons/resource/models/resource_calendar.py#L165-L169

Solution:
---------
Compute the `hours_per_day` independently of attendance `date_from` or `date_to`
by including all attendances in the computation, ensuring a consistent and correct value.

**NOTE:**
The `date_from` and `date_to` fields are removed from version 19.0.
related commit: 77f860f

opw-5417724




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
