### PR TITLE
[FIX] web: correct autoresizeInput width calculation

### DIFF
--- a/addons/web/static/src/core/utils/autoresize.js
+++ b/addons/web/static/src/core/utils/autoresize.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { useEffect } from "@odoo/owl";
-import { browser } from "../browser/browser";
+import { memoize } from "@web/core/utils/functions";
 
 /**
  * This is used on text inputs or textareas to automatically resize it based on its
@@ -39,23 +39,47 @@ export function useAutoresize(ref, options = {}) {
     });
 }
 
+const doesScrollWidthExcludePadding = memoize(() => {
+    const input = document.createElement("input");
+    input.style.cssText = `
+        position: absolute;
+        visibility: hidden;
+        padding: 0;
+        border: 0;
+        width: auto;
+    `;
+    document.body.appendChild(input);
+    const widthWithoutPadding = input.scrollWidth;
+    input.style.padding = "10px";
+    const widthWithPadding = input.scrollWidth;
+    input.remove();
+    return widthWithPadding === widthWithoutPadding;
+});
+
 function resizeInput(input) {
+    const style = window.getComputedStyle(input);
     // This mesures the maximum width of the input which can get from the flex layout.
     input.style.width = "100%";
     const maxWidth = input.clientWidth;
-    // Somehow Safari 16 computes input sizes incorrectly. This is fixed in Safari 17
-    const isSafari16 = /Version\/16.+Safari/i.test(browser.navigator.userAgent);
     // Minimum width of the input
     input.style.width = "10px";
     if (input.value === "" && input.placeholder !== "") {
         input.style.width = "auto";
         return;
     }
-    if (input.scrollWidth + 5 + (isSafari16 ? 8 : 0) > maxWidth) {
+    // scrollWidth measures the content box only; borders are added separately
+    let boxExtraWidth = parseFloat(style.borderLeftWidth) + parseFloat(style.borderRightWidth);
+    // Some browsers (Safari ≤16, Firefox ≥145) exclude padding from input scrollWidth
+    if (doesScrollWidthExcludePadding()) {
+        const padding = parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+        boxExtraWidth += padding;
+    }
+    const desiredWidth = input.scrollWidth + boxExtraWidth + 1;
+    if (desiredWidth > maxWidth) {
         input.style.width = "100%";
         return;
     }
-    input.style.width = input.scrollWidth + 5 + (isSafari16 ? 8 : 0) + "px";
+    input.style.width = `${desiredWidth}px`;
 }
 
 export function resizeTextArea(textarea, options = {}) {


### PR DESCRIPTION
Before this PR,
`autoresizeInput` used a fixed buffer of `5px` to compensate for input borders. This caused incorrect sizing when inputs had thicker borders, leading to overflow issues.

Safari 16 and earlier versions did not include padding and border in `scrollWidth`. To work around this, browser detection via regex was used to add a hardcoded extra value.
A similar issue appeared in Firefox 145, where scrollWidth also excluded padding and border, causing inputs to overflow again.

After this PR,
The buffer is no longer hardcoded. The border width is now calculated dynamically and applied correctly to the final width. 
Browser sniffing has been removed entirely. Instead, the logic detects at runtime whether scrollWidth includes padding; if not, the missing padding is added to the computed width. This makes the behavior consistent across browsers and prevents overflow without relying on user agent checks.

task-[5412025](https://www.odoo.com/odoo/project/1519/tasks/5412025)