### PR TITLE
[IMP] mail: better UI sizes in discuss app sidebar and chat bubble

### DIFF
--- a/addons/im_livechat/static/src/core/web/chat_bubble_patch.xml
+++ b/addons/im_livechat/static/src/core/web/chat_bubble_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.ChatBubble" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='root']" position="inside">
             <t t-if="channel" t-call="im_livechat.LivechatStatusLabelOfThread">
-                <t t-set="templateParams" t-value="{ livechatThread: channel.thread }"/>
+                <t t-set="templateParams" t-value="{ livechatThread: channel.thread, small: true }"/>
             </t>
         </xpath>
     </t>

--- a/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
@@ -8,7 +8,7 @@
                title="Relevant to your expertise"
             />
             <t t-else="" t-call="im_livechat.LivechatStatusLabelOfThread">
-                <t t-set="templateParams" t-value="{ livechatThread: props.channel.thread }"/>
+                <t t-set="templateParams" t-value="{ livechatThread: props.channel.thread, small: true }"/>
             </t>
         </xpath>
     </t>
@@ -31,18 +31,20 @@
 
     <t t-name="im_livechat.LivechatStatusLabelOfThread">
         <t t-set="livechatThread" t-value="templateParams.livechatThread"/>
+        <t t-set="small" t-value="templateParams.small"/>
         <span t-if="livechatThread.channel?.channel_type === 'livechat' and (['waiting', 'need_help'].includes(livechatThread.channel.livechat_status) or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel" t-att-title="livechatThread.channel.livechatStatusLabel" t-att-class="{
             'position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble or env.inNotificationItem,
             'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': env.inDiscussSidebar,
-            'm-n2 z-1 bg-opacity-100': env.inChatBubble or env.inNotificationItem,
+            'mx-n1 d-flex z-1 bg-opacity-100': env.inChatBubble or env.inNotificationItem,
             'text-warning': livechatThread.channel.livechat_status === 'waiting',
             'o-help': livechatThread.channel.livechat_status === 'need_help',
             'bg-warning': livechatThread.channel.livechat_status === 'waiting' and env.inDiscussSidebar,
             'bg-info': livechatThread.channel.livechat_status === 'need_help' and env.inDiscussSidebar,
         }">
-            <i class="o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ livechatThread.livechat_end_dt ? 'fa fa-flag-checkered' : store.livechatStatusButtons.find(btn => btn.status === livechatThread.channel.livechat_status)?.icon }}" t-att-class="{
+            <t t-set="livechatStatusButton" t-value="store.livechatStatusButtons.find(btn => btn.status === livechatThread.channel.livechat_status)"/>
+            <i class="o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ livechatThread.livechat_end_dt ? ('fa fa-flag-checkered' + (small ? ' o-xsmaller' : '')) : small ? livechatStatusButton?.iconSmall : livechatStatusButton?.icon }}" t-att-class="{
                 'o-white': livechatThread.livechat_end_dt,
-                'position-absolute start-0 top-0 z-1 o-inDiscussSidebar rounded-circle o-px-0_5 m-n1': env.inDiscussSidebar,
+                'position-absolute start-0 top-0 z-1 o-inDiscussSidebar rounded-circle o-px-0_5': env.inDiscussSidebar,
                 'fa-fw': !env.inDiscussSidebar,
             }"/>
         </span>

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -50,16 +50,19 @@ const storePatch = {
                 label: _t("In progress"),
                 status: "in_progress",
                 icon: "fa fa-comments",
+                iconSmall: "fa fa-comments o-xsmaller",
             },
             {
                 label: _t("Waiting for customer"),
                 status: "waiting",
                 icon: "fa fa-hourglass-start",
+                iconSmall: "fa fa-hourglass-start o-xsmaller",
             },
             {
                 label: _t("Looking for help"),
                 status: "need_help",
                 icon: "fa fa-lg fa-exclamation-circle",
+                iconSmall: "fa fa-exclamation-circle",
             },
         ];
     },

--- a/addons/im_livechat/static/src/embed/common/chat_hub_patch.xml
+++ b/addons/im_livechat/static/src/embed/common/chat_hub_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//*[hasclass('o-mail-ChatHub')]" position="attributes">
             <attribute name="part">ChatHub</attribute>
         </xpath>
-        <xpath expr="//*[hasclass('o-mail-ChatHub-extraActions')]" position="inside">
+        <xpath expr="//t[@name='extra-actions']" position="inside">
             <LivechatButton/>
         </xpath>
     </t>

--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -58,8 +58,8 @@
 }
 
 .o-mail-ChatBubble-country {
-    width: 16px;
-    left: 3px;
+    width: 14px;
+    left: 0px;
 }
 
 .o-mail-ChatBubble-counter {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -9,7 +9,7 @@
             <ChatWindow chatWindow="cw" t-if="cw.canShow" right="chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2)"/>
         </t>
         <div class="o-mail-ChatHub-bubbles position-fixed d-flex flex-column align-content-start justify-content-end align-items-center" t-attf-style="top: {{position.top}}; left: {{position.left}}; right: {{position.right}}; --mail-ChatHub-bubbles-bottom: {{position.bottom}}" t-att-class="{ 'o-liftUp': busMonitoring.hasConnectionIssues, 'o-mobile': isMobileOS }" t-ref="bubbles">
-            <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
+            <div class="d-flex flex-column align-content-start justify-content-end align-items-center o-gap-1_5">
                 <Dropdown t-if="(chatHub.showConversations and !chatHub.compact) or position.dragged" state="options" position="'top-end'" menuClass="'m-0 mb-1 ' + store.discussDropdownMenuClass(this)">
                     <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn bg-100 mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !position.dragged and !options.isOpen and !isMobileOS, 'o-bubblesHover': (bubblesHover.isHover or position.dragged) and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"><i class="oi oi-ellipsis-h"/></button>
                     <t t-set-slot="content">
@@ -21,7 +21,7 @@
                     <t t-foreach="chatHub.folded.slice(0, chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                         <ChatBubble t-if="cw.canShow" chatWindow="cw"/>
                     </t>
-                    <div class="o-mail-ChatHub-extraActions"/>
+                    <t name="extra-actions"/>
                     <t t-if="chatHub.showConversations and chatHub.folded.length > chatHub.maxFolded" t-call="mail.ChatHub.hiddenButton"/>
                 </t>
             </div>

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -4,7 +4,7 @@ $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
 $o-mail-ChatHub-bubblesMargin: 10px !default; // same value as BUBBLE_OUTER
 $o-mail-ChatHub-bubblesStart: 15px !default; // same value as BUBBLE_START
-$o-mail-ChatBubble-size: 45px !default;
+$o-mail-ChatBubble-size: 42px !default;
 $o-mail-ChatBubble-sizeBig: 50px !default;
 $o-mail-ChatBubble-zindex: 1001 !default;
 // Needed because $border-radius variations are all set to 0 in enterprise.

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -3,9 +3,9 @@
 
     <t t-name="mail.ThreadIcon">
         <div class="o-mail-ThreadIcon d-flex justify-content-center flex-shrink-0" t-att-class="props.className">
-            <t t-set="largeClass" t-value="props.size === 'large' ? 'fa-lg' : ''"/>
+            <t t-set="sizeClass" t-value="props.size === 'large' ? 'fa-lg' : props.size === 'small' ? 'o-xsmaller' : ''"/>
             <t t-if="props.thread.channel?.channel_type === 'channel'">
-                <div t-if="!props.thread.group_public_id" class="fa fa-fw fa-globe" t-att-class="largeClass" title="Public Channel"/>
+                <div t-if="!props.thread.group_public_id" class="fa fa-fw fa-globe" t-att-class="sizeClass" title="Public Channel"/>
             </t>
             <t t-elif="props.thread.channel?.channel_type === 'group'">
                 <t name="group"/>
@@ -13,17 +13,17 @@
             <t t-elif="props.thread.channel?.channel_type?.includes('chat') and correspondent">
                 <t name="chat">
                     <t name="chat_static">
-                        <ImStatus t-if="correspondent.im_status" member="correspondent" size="'md'"/>
+                        <ImStatus t-if="correspondent.im_status" member="correspondent" size="props.size"/>
                         <div t-else="" class="d-flex rounded-circle bg-inherit">
-                            <i class="fa-fw" t-att-class="largeClass" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/>
+                            <i class="fa-fw" t-att-class="sizeClass" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/>
                         </div>
                     </t>
                 </t>
             </t>
             <t t-elif="props.thread.model === 'mail.box'">
-                <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="largeClass"/>
-                <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="largeClass"/>
-                <div t-elif="props.thread.id === 'history'" class="fa fa-fw fa-history" t-att-class="largeClass"/>
+                <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="sizeClass"/>
+                <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="sizeClass"/>
+                <div t-elif="props.thread.id === 'history'" class="fa fa-fw fa-history" t-att-class="sizeClass"/>
             </t>
         </div>
     </t>


### PR DESCRIPTION
- reduce size of livechat status icon, thread icons, and im status in discuss app sidebar
- reduce size of livechat status icon, thread icons, im status, and country flag in chat bubble
- reduce slightly size of chat bubble and compensate with slightly increased gap between bubbles
- fix spacing issue between hidden chat bubbles and visible chat bubbles

Before / After
<img width="593" height="890" alt="Screenshot 2025-12-24 at 13 36 01" src="https://github.com/user-attachments/assets/3ce8fec0-f842-49d9-9691-fe6d1666cd07" />

Before / After
<img width="165" height="418" alt="Screenshot 2025-12-24 at 13 36 14" src="https://github.com/user-attachments/assets/bac55e93-bade-4d09-be51-21a768896675" />
