### PR TITLE
[FIX] website: prevent entering text inside grid image items

### DIFF
--- a/addons/web_editor/static/src/js/common/grid_layout_utils.js
+++ b/addons/web_editor/static/src/js/common/grid_layout_utils.js
@@ -321,6 +321,7 @@ export function _convertToNormalColumn(columnEl) {
     columnEl.style.removeProperty("--grid-item-padding-x");
     columnEl.style.removeProperty("--grid-item-padding-y");
     columnEl.style.removeProperty("grid-area");
+    columnEl.removeAttribute("contenteditable");
 }
 /**
  * Checks whether the column only contains an image or not. An image is


### PR DESCRIPTION
Grid image-only items are actually `contenteditable`. This makes it possible to replace the image with text.

This commit makes the item non-editable, while keeping the media inside it replaceable.

Steps to reproduce:
- Drop a Banner block
- Select an image
- Type something

=> Image was replaced with text

task-5436148
