### PR TITLE
[FIX] pos_restaurant: sync empty table assignments across devices

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -916,7 +916,11 @@ patch(PosStore.prototype, {
         return this.floorScrollPositions[floorId];
     },
     shouldCreatePendingOrder(order) {
-        return super.shouldCreatePendingOrder(order) || order.course_ids?.length > 0;
+        return (
+            super.shouldCreatePendingOrder(order) ||
+            order.course_ids?.length > 0 ||
+            Boolean(order.table_id)
+        );
     },
     setOrder(order) {
         order?.ensureCourseSelection();

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -880,8 +880,11 @@ class TestFrontend(TestFrontendCommon):
     def test_delete_line_release_table(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_delete_line_release_table')
-        order = self.pos_config.current_session_id.order_ids[0]
+        order = self.pos_config.current_session_id.order_ids[1]
+        # opening a table at end of tour created a draft order
+        last_order = self.pos_config.current_session_id.order_ids[0]
         self.assertEqual(order.state, "cancel")
+        self.assertEqual(len(last_order.lines), 0)
 
     def test_combo_synchronisation(self):
         """This test checks that when a combo line is set as dirty, the parent combo line is also set as dirty.

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -393,8 +393,16 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         self.start_tour('/pos/ui?config_id=%d' % self.pos_config.id, 'test_pos_self_order_table_transfer', login='pos_user')
 
-        order = self.pos_config.current_session_id.order_ids[0]
-        self.assertEqual(order.self_ordering_table_id, order.table_id)
+        orders = self.pos_config.current_session_id.order_ids
+        self.assertEqual(len(orders), 2, "Expected exactly 2 orders: the transferred self-order and an empty placeholder")
+        orders_with_lines = orders.filtered(lambda o: o.lines)
+        empty_orders = orders.filtered(lambda o: not o.lines)
+        self.assertEqual(len(orders_with_lines), 1, "Expected exactly one order with lines")
+        self.assertEqual(len(empty_orders), 1, "Expected exactly one empty order")
+        self_order = orders_with_lines[0]
+        self.assertEqual(self_order.self_ordering_table_id, self_order.table_id)
+        empty_order = empty_orders[0]
+        self.assertFalse(empty_order.lines, "Empty order should have no lines")
 
     def test_self_order_meal_do_not_change_tracking_number_on_sync(self):
         self.pos_config.write({


### PR DESCRIPTION
When a waiter selects a table without adding any items and returns to the floor screen, the table appears as occupied (green) on their device but not on other devices in the same POS session.

Steps to reproduce:
-------------------
* Open POS session on device A
* Open same POS session on device B
* On device A: click a table, don't add items, go back to floor
* On device B: observe the table does not appear as occupied

> Observation: Empty table assignments were not being synced to the server, so other devices couldn't detect the table occupancy.

Why the fix:
------------
Also treat orders with a table_id as pending so they sync immediately when a table is opened. The backend already supports this: pos.order can be created with just table_id, and pos_restaurant._get_open_order looks orders up by table_id for table-based sync.

opw-5236119