### PR TITLE
[FIX] html_builder, *: restrict inner edits for image gallery snippet

### DIFF
--- a/addons/html_builder/static/src/core/builder_content_editable_plugin.js
+++ b/addons/html_builder/static/src/core/builder_content_editable_plugin.js
@@ -16,6 +16,7 @@ export class BuilderContentEditablePlugin extends Plugin {
             "section:has(> .o_container_small, > .container, > .container-fluid)",
             ".o_not_editable",
             "[data-oe-field='arch']:empty",
+            ".o_disable_typing",
         ],
         content_editable_selectors: [
             "section > .o_container_small",

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -119,12 +119,18 @@ export class DropZonePlugin extends Plugin {
                 excludeNearParent,
             } = dropzoneSelector;
             if (snippetEl.matches(selector) && !snippetEl.matches(exclude)) {
+                // Allow dropzones when reordering an existing snippet, but
+                // prevents their creation inside the image gallery to avoid
+                // dropping new inner block snippets.
+                const filterTarget = (el) =>
+                    this.editable.contains(snippetEl) ||
+                    !el.closest(".o_disable_snippet_insertion");
                 if (dropNear) {
                     selectorSiblings.push(
                         ...this.getSelectorSiblings(editableAreaEls, rootEl, {
                             selector: dropNear,
                             excludeNearParent,
-                        })
+                        }).filter(filterTarget)
                     );
                 }
                 if (dropIn) {

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -161,6 +161,11 @@ class ImageGalleryOption extends Plugin {
             imageGalleryElement.classList.remove("o_nomode", "o_masonry", "o_grid", "o_slideshow");
             imageGalleryElement.classList.add(`o_${mode}`);
         }
+        if (images.length > 0) {
+            images.forEach((image) => {
+                image.classList.add("o_editable_media");
+            });
+        }
         switch (mode) {
             case "masonry":
                 this.masonry(imageGalleryElement, images);

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -1,6 +1,7 @@
 import {
     confirmAddSnippet,
     dummyBase64Img,
+    getDragMoveHelper,
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
 import { expect, test } from "@odoo/hoot";
@@ -79,6 +80,7 @@ test("Add image in gallery", async () => {
         "data-mimetype-before-conversion",
         "image/png"
     );
+    expect(":iframe .o_masonry_col img[data-index='6']").toHaveClass("o_editable_media");
 });
 
 // TODO Re-enable once interactions run within iframe in hoot tests.
@@ -250,4 +252,36 @@ test("Click the outline option for the image gallery thumbnails", async () => {
         ".o-dropdown--menu [data-action-param='s_image_gallery_indicators_dots']"
     ).click();
     expect(":iframe section.o_slideshow").not.toHaveClass("s_image_gallery_indicators_outline");
+});
+
+test("Disable text input and inner snippet insertion in s_images_wall", async () => {
+    const imageWallSelector = ":iframe .o_masonry";
+    await setupWbsiteBuilderWithImageWall();
+    await contains(imageWallSelector).click();
+    expect(`${imageWallSelector}.o_disable_snippet_insertion`).toHaveCount(1);
+    expect(`${imageWallSelector} .o_disable_typing`).toHaveCount(1);
+    expect(`${imageWallSelector} .o_disable_typing`).toHaveAttribute("contenteditable", "false");
+    expect(`${imageWallSelector} img.o_editable_media`).toHaveCount(6);
+    await contains("[data-label='Mode'] .dropdown-toggle").click();
+    await contains("[data-action-param='grid']").click();
+    await contains(":iframe .o_grid img").click();
+    const { drop } = await contains(".o_overlay_options .o_draggable").drag();
+    expect(":iframe .oe_drop_zone").toHaveCount(7);
+    await drop(getDragMoveHelper());
+    await contains("[data-name='blocks']").click();
+    await contains("[data-snippet='s_button']").drag();
+    expect(":iframe .oe_drop_zone").toHaveCount(0);
+});
+
+test("Disable text input and inner snippet insertion in s_image_gallery", async () => {
+    const imageGallerySelector = ":iframe .s_image_gallery";
+    await setupWebsiteBuilderWithSnippet("s_image_gallery");
+    await contains(imageGallerySelector).click();
+    expect(`${imageGallerySelector}.o_disable_snippet_insertion`).toHaveCount(1);
+    expect(`${imageGallerySelector} .o_disable_typing`).toHaveCount(1);
+    expect(`${imageGallerySelector} .o_disable_typing`).toHaveAttribute("contenteditable", "false");
+    expect(`${imageGallerySelector} img.o_editable_media`).toHaveCount(3);
+    await contains("[data-name='blocks']").click();
+    await contains("[data-snippet='s_button']").drag();
+    expect(":iframe .oe_drop_zone").toHaveCount(0);
 });

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -2,18 +2,18 @@
 <odoo>
 
 <template id="s_image_gallery" name="Image Gallery">
-    <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default o_image_popup" data-vcss="002" data-columns="3">
-        <div class="o_container_small overflow-hidden">
+    <section class="s_image_gallery o_slideshow pt24 pb24 s_image_gallery_controllers_outside s_image_gallery_controllers_outside_arrows_right s_image_gallery_indicators_dots s_image_gallery_arrows_default o_image_popup o_disable_snippet_insertion" data-vcss="002" data-columns="3">
+        <div class="o_container_small overflow-hidden o_disable_typing">
             <div id="slideshow_sample" class="carousel carousel-dark slide" data-bs-ride="carousel" data-bs-interval="0">
                 <div class="carousel-inner">
                     <div class="carousel-item active">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=""/>
+                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover o_editable_media" src="/web/image/website.library_image_08" data-name="Image" data-index="0" alt=""/>
                     </div>
                     <div class="carousel-item">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=""/>
+                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover o_editable_media" src="/web/image/website.library_image_03" data-name="Image" data-index="1" alt=""/>
                     </div>
                     <div class="carousel-item">
-                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=""/>
+                        <img class="img img-fluid d-block mh-100 mw-100 mx-auto rounded object-fit-cover o_editable_media" src="/web/image/website.library_image_02" data-name="Image" data-index="2" alt=""/>
                     </div>
                 </div>
                 <div class="o_carousel_controllers">
@@ -37,20 +37,20 @@
 </template>
 
 <template id="s_images_wall" name="Images Wall">
-    <section class="s_image_gallery o_spc-small o_masonry pt24 pb24 o_image_popup" data-vcss="002" data-columns="3" style="overflow: hidden;">
-        <div class="container">
+    <section class="s_image_gallery o_spc-small o_masonry pt24 pb24 o_image_popup o_disable_snippet_insertion" data-vcss="002" data-columns="3" style="overflow: hidden;">
+        <div class="container o_disable_typing">
             <div class="row s_nb_column_fixed">
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_03" data-index="0" data-name="Image" alt=""/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_10" data-index="3" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded o_editable_media" src="/web/image/website.library_image_03" data-index="0" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded o_editable_media" src="/web/image/website.library_image_10" data-index="3" data-name="Image" alt=""/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_13" data-index="1" data-name="Image" alt=""/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_05" data-index="4" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded o_editable_media" src="/web/image/website.library_image_13" data-index="1" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded o_editable_media" src="/web/image/website.library_image_05" data-index="4" data-name="Image" alt=""/>
                 </div>
                 <div class="o_masonry_col o_snippet_not_selectable col-lg-4">
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_14" data-index="2" data-name="Image" alt=""/>
-                    <img class="img img-fluid d-block rounded" src="/web/image/website.library_image_16" data-index="5" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded o_editable_media" src="/web/image/website.library_image_14" data-index="2" data-name="Image" alt=""/>
+                    <img class="img img-fluid d-block rounded o_editable_media" src="/web/image/website.library_image_16" data-index="5" data-name="Image" alt=""/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
[*]=website

Steps to reproduce:
1. Go to the website and enter edit mode.
2. Drop `s_image_wall` or `s_images_gallery` snippet.
3. Select an image and try to type text.
4. Try to drop an inner content snippet (e.g., a button).

Issue:
Typing while an image is selected replaces the image with text. Additionally, inner content snippets can be inserted inside these snippets, which is not intended.

Reason:
The image gallery and image wall snippets do not explicitly prevent text input or inner snippet insertion.

Fix:
1. Introduce a new class "**o_disable_typing**" to prevent text input. This class is also added as an exclude selector in
`builder_content_editable_plugin.js` file. The existing "**o_not_editable**" class cannot be used, as it also restrict _cloning_ and _deletion_ actions.

2. Introduce a new class "**o_disable_snippet_insertion**" to prevent dropzone creation when inserting new snippets. The "**o_not_editable**" class is not suitable here either, as it would also prevent _dropzone_ creation when dragging existing content of snippet for reordering.

3. Add the "**o_editable_media**" class to all `img` tags to ensure images remain replaceable even when the surrounding content is not editable.

task-5213497