### PR TITLE
[IMP] mail: better UI size in messaging menu

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
@@ -35,7 +35,9 @@
         <span t-if="livechatThread.channel?.channel_type === 'livechat' and (['waiting', 'need_help'].includes(livechatThread.channel.livechat_status) or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel" t-att-title="livechatThread.channel.livechatStatusLabel" t-att-class="{
             'position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble or env.inNotificationItem,
             'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': env.inDiscussSidebar,
-            'mx-n1 d-flex z-1 bg-opacity-100': env.inChatBubble or env.inNotificationItem,
+            'd-flex z-1 bg-opacity-100': env.inChatBubble or env.inNotificationItem,
+            'mx-n1': env.inChatBubble,
+            'mx-n2 my-n1': env.inNotificationItem,
             'text-warning': livechatThread.channel.livechat_status === 'waiting',
             'o-help': livechatThread.channel.livechat_status === 'need_help',
             'bg-warning': livechatThread.channel.livechat_status === 'waiting' and env.inDiscussSidebar,

--- a/addons/im_livechat/static/src/core/web/notification_item_patch.xml
+++ b/addons/im_livechat/static/src/core/web/notification_item_patch.xml
@@ -3,7 +3,7 @@
     <t t-inherit="mail.NotificationItem" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-NotificationItem-avatarContainer')]" position="inside">
             <t t-if="props.thread?.channel?.channel_type === 'livechat'" t-call="im_livechat.LivechatStatusLabelOfThread">
-                <t t-set="templateParams" t-value="{ livechatThread: props.thread }"/>
+                <t t-set="templateParams" t-value="{ livechatThread: props.thread, small: true }"/>
             </t>
         </xpath>
     </t>

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -15,7 +15,7 @@
 }
 
 .o-mail-NotificationItem-avatarContainer {
-    height: 42px;
+    height: 32px;
     aspect-ratio: 1;
     margin-top: map-get($spacers, 1) / 2;
     margin-bottom: map-get($spacers, 1) / 2;
@@ -43,7 +43,7 @@
 }
 
 .o-mail-NotificationItem-country {
-    width: 16px;
+    width: 14px;
     bottom: -2px;
     left: -4px;
 }

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -20,11 +20,11 @@
                 <t t-if="!ui.isSmall">
                     <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
                     <t t-else="">
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'notification' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'notification'">Notifications</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
-                        <button t-if="(threads.length + visibleStandaloneMessages.length) >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
-                        <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-sm btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'notification' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'notification'">Notifications</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-sm btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-sm btn-link o-px-1_5 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                        <button t-if="(threads.length + visibleStandaloneMessages.length) >= 20 and store.channels.status !== 'fetching'" class="btn btn-sm btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
+                        <button t-if="store.channels.status === 'fetching'" class="btn btn-sm btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>
                 </t>
             </div>

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.xml
@@ -1,6 +1,6 @@
 <t t-name="mail.MessagingMenuQuickSearch">
-    <div class="position-relative w-50 m-1" t-ref="search" t-on-keydown="onKeydownInput">
-        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control px-1 py-0" placeholder="Quick search…" type="text" />
-        <button class="btn btn-link text-muted p-1 position-absolute top-50 end-0 translate-middle-y" title="Close search" t-on-click="props.onClose"><i class="oi oi-close"/></button>
+    <div class="position-relative w-50 m-1 d-flex" t-ref="search" t-on-keydown="onKeydownInput">
+        <input t-model="store.discuss.searchTerm" t-ref="autofocus" class="form-control rounded-pill px-2 o-py-0_5 smaller" placeholder="Quick search…" type="text" />
+        <button class="btn btn-sm btn-link text-muted p-1 o-me-0_5 position-absolute top-50 end-0 translate-middle-y" title="Close search" t-on-click="props.onClose"><i class="fa fa-times-circle"/></button>
     </div>
 </t>

--- a/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/messaging_menu_patch.xml
@@ -7,7 +7,7 @@
             </t>
             <t t-else="">
                 <div class="flex-grow-1"/>
-                <button t-if="!ui.isSmall" t-att-class="ui.isSmall ? 'w-50 p-2 btn btn-secondary m-1' : 'btn btn-link px-2 py-1'" t-on-click.stop="onClickNewMessage">
+                <button t-if="!ui.isSmall" t-att-class="ui.isSmall ? 'w-50 p-2 btn btn-secondary m-1' : 'btn btn-sm btn-link px-2 py-1'" t-on-click.stop="onClickNewMessage">
                     New Message
                 </button>
             </t>


### PR DESCRIPTION
- smaller avatar and icons in desktop
- smaller filter button
- prettier quick search visual
- more visible separator between items

Task-5461742

Before / After
<img width="475" height="631" alt="Screenshot 2026-01-02 at 14 16 49" src="https://github.com/user-attachments/assets/0c71634f-fbfe-46c4-854d-c55e26656f0b" />
<img width="476" height="634" alt="Screenshot 2026-01-02 at 14 19 22" src="https://github.com/user-attachments/assets/f72feebf-e2d5-4054-8862-44586f7b0cd6" />


Before / After
<img width="479" height="90" alt="Screenshot 2025-12-24 at 14 03 23" src="https://github.com/user-attachments/assets/2d355a5c-879c-474d-bd4c-e7a9005d98f7" />
<img width="479" height="87" alt="Screenshot 2025-12-24 at 14 03 29" src="https://github.com/user-attachments/assets/fc93e1ed-6555-402a-a6dd-0960957ded9e" />
