### PR TITLE
[FIX] hr_holidays: show correct return date for worked-time leaves on employee

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -139,22 +139,23 @@ class HrEmployee(models.Model):
             ('employee_id', 'in', self.ids),
             ('date_from', '<=', fields.Datetime.now()),
             ('date_to', '>=', fields.Datetime.now()),
-            ('holiday_status_id.time_type', '=', 'leave'),
             ('state', '=', 'validate'),
         ])
         leave_data = {}
         for holiday in holidays:
-            leave_data[holiday.employee_id.id] = {}
+            leave_data.setdefault(holiday.employee_id.id, {})
             leave_data[holiday.employee_id.id]['leave_date_from'] = holiday.date_from.date()
             back_on = holiday.employee_id._get_first_working_interval(holiday.date_to)
             leave_data[holiday.employee_id.id]['leave_date_to'] = back_on.date() if back_on else None
             leave_data[holiday.employee_id.id]['current_leave_state'] = holiday.state
+            leave_data[holiday.employee_id.id]['is_absent'] = leave_data[holiday.employee_id.id].get('is_absent') or holiday.holiday_status_id.time_type == 'leave'
 
         for employee in self:
-            employee.leave_date_from = leave_data.get(employee.id, {}).get('leave_date_from')
-            employee.leave_date_to = leave_data.get(employee.id, {}).get('leave_date_to')
-            employee.current_leave_state = leave_data.get(employee.id, {}).get('current_leave_state')
-            employee.is_absent = leave_data.get(employee.id) and leave_data.get(employee.id).get('current_leave_state') == 'validate'
+            employee_leave_data = leave_data.get(employee.id, {})
+            employee.leave_date_from = employee_leave_data.get('leave_date_from')
+            employee.leave_date_to = employee_leave_data.get('leave_date_to')
+            employee.current_leave_state = employee_leave_data.get('current_leave_state')
+            employee.is_absent = employee_leave_data and employee_leave_data.get('is_absent') and employee_leave_data.get('current_leave_state') == 'validate'
 
     @api.depends('parent_id')
     def _compute_leave_manager(self):

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -45,6 +45,8 @@ class TestHrLeaveType(TestHrHolidaysCommon):
         with freeze_time('2025-09-03 13:00:00'):
             employee._compute_leave_status()
             self.assertFalse(employee.is_absent)
+            self.assertEqual(employee.leave_date_from, leave_0.request_date_from)
+            self.assertEqual(employee.leave_date_to, leave_0.employee_id._get_first_working_interval(leave_0.date_to).date())
 
         with self.assertRaises(ValidationError):
             leave_1 = self.env['hr.leave'].create({


### PR DESCRIPTION
Issue:
- When a time off type was configured as , adding a leave for today caused the employee form to display instead of a real date.

Fix:
- Compute leave dates for all validated leaves, including worked-time leaves.
- Ensure the  date is always computed using the first working interval after the leave end date.

Impact:
- Employee profiles now display a correct return date for worked-time leaves.

task-5421688

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
