### PR TITLE
[IMP] website_sale: add main shop and category micro-datas

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -200,13 +200,6 @@ class ProductProduct(models.Model):
         }
         if self.website_meta_description or self.description_sale:
             markup_data['description'] = self.website_meta_description or self.description_sale
-        if website.is_view_active('website_sale.product_comment') and self.rating_count:
-            markup_data['aggregateRating'] = {
-                '@type': 'AggregateRating',
-                # sudo: product.product - visitor can access product average rating
-                'ratingValue': self.sudo().rating_avg,
-                'reviewCount': self.rating_count,
-            }
         return markup_data
 
     def _get_image_1920_url(self):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1039,26 +1039,37 @@ class ProductTemplate(models.Model):
         self.ensure_one()
 
         if self.product_variant_count == 1:
-            return self.product_variant_id._to_markup_data(website)
-
-        # perf: temporal solution to avoid slowness when product have many variants and pricelist rules
-        limit = self.env['ir.config_parameter'].sudo().get_int('website_sale.markup_data_limit_variants') or None
-        if limit:
-            product_variant_ids = self.product_variant_ids[:limit]
+            markup_data = self.product_variant_id._to_markup_data(website)
         else:
-            product_variant_ids = self.product_variant_ids
+            # perf: temporal solution to avoid slowness when product have many variants and
+            # pricelist rules
+            limit = self.env['ir.config_parameter'].sudo().get_int(
+                'website_sale.markup_data_limit_variants'
+            ) or None
+            if limit:
+                product_variant_ids = self.product_variant_ids[:limit]
+            else:
+                product_variant_ids = self.product_variant_ids
 
-        base_url = website.get_base_url()
-        markup_data = {
-            '@context': 'https://schema.org/',
-            '@type': 'ProductGroup',
-            'name': self.name,
-            'image': f'{base_url}{website.image_url(self, "image_1920")}',
-            'url': f'{base_url}{self.website_url}',
-            'hasVariant': [product._to_markup_data(website) for product in product_variant_ids]
-        }
-        if self.description_ecommerce:
-            markup_data['description'] = text_from_html(self.description_ecommerce)
+            base_url = website.get_base_url()
+            markup_data = {
+                '@context': 'https://schema.org',
+                '@type': 'ProductGroup',
+                'name': self.name,
+                'image': f'{base_url}{website.image_url(self, "image_1920")}',
+                'url': f'{base_url}{self.website_url}',
+                'hasVariant': [product._to_markup_data(website) for product in product_variant_ids]
+            }
+            if self.description_ecommerce:
+                markup_data['description'] = text_from_html(self.description_ecommerce)
+
+        if website.is_view_active('website_sale.product_comment') and self.rating_count:
+            markup_data['aggregateRating'] = {
+                '@type': 'AggregateRating',
+                # sudo: product.product - visitor can access product average rating
+                'ratingValue': self.sudo().rating_avg,
+                'reviewCount': self.rating_count,
+            }
         return markup_data
 
     def _get_ribbon(self, price_vals=None, auto_assign_ribbons=None, variant=None):

--- a/addons/website_sale/templates/website_templates.xml
+++ b/addons/website_sale/templates/website_templates.xml
@@ -53,7 +53,6 @@
         </xpath>
     </template>
 
-    <!-- Insert JSON-LD markup data for SEO. -->
     <template id="website_sale.website_sale_layout" inherit_id="website.layout" priority="1">
         <body position="before">
             <t
@@ -67,21 +66,10 @@
             />
         </body>
         <head position="inside">
-            <!-- Company markup data, in all pages. -->
-            <t t-set="base_url" t-value="website.get_base_url()"/>
-            <script t-if="res_company and website" type="application/ld+json" >
-{
-    "@context": "http://schema.org",
-    "@type": "Organization",
-    "name": "<t t-out="res_company.name"/>",
-    "logo": "<t t-out="'%s/logo.png?company=%s' % (base_url, res_company.id)"/>",
-    "url": "<t t-out="base_url"/>"
-}
-            </script>
-
-             <!-- Product markup data, on product pages. -->
+            <!-- Insert JSON-LD markup data for SEO. -->
             <script
-                t-if="product_markup_data" type="application/ld+json" t-out="product_markup_data"
+                type="application/ld+json"
+                t-out="markup_data_json or website and website._get_ecommerce_store_markup_json()"
             />
         </head>
     </template>


### PR DESCRIPTION
Add the following micro-datas to the main /shop page and the Category pages, improving their SEO:
- Company information (name, URL, logo, social media)
- Shop information (website name, url)
- Breadcrumbs (if applicable)

Merged new methods with the existing ones to improve company information in homepage and breadcrumbs in product pages.


task-4771459
