### PR TITLE
[IMP] hr_expense: use payment_reference for payment term line name

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -70,7 +70,7 @@ class AccountMove(models.Model):
                     ): {
                         "balance": -sum(term_lines.mapped("balance")),
                         "amount_currency": -sum(term_lines.mapped("amount_currency")),
-                        "name": "",
+                        "name": move.payment_reference or "",
                         "account_id": move.expense_sheet_id._get_expense_account_destination(),
                     }
                 }


### PR DESCRIPTION
Currently, when creating a bill from an expense with payment_mode='company_account',
the payment term line's name is set to an empty string because expenses are immediate payment expenses. However, users may enter notes in the payment_reference field.

The account.move.line's `_compute_name` ([1](https://github.com/odoo/odoo/blob/3f4e45ecaca46a98c904536658728a1f1571bdbd/addons/account/models/account_move_line.py#L520)) method uses payment_reference to compute the name for payment term lines. By setting the name in needed_terms from payment_reference, the payment term line will display the user's notes, providing better context and traceability in the accounting entries.

This change ensures consistency with the standard invoice behavior where payment_reference is used to populate the payment term line name.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
