### PR TITLE
[FIX] website_links: unused "copy" step in tour

### DIFF
--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -1,7 +1,6 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { browser } from "@web/core/browser/browser";
 
 function fillSelectMenu(inputID, search) {
     return [
@@ -72,18 +71,6 @@ registry.category("web_tour.tours").add('website_links_tour', {
         ...fillSelectMenu("campaign-select-wrapper", campaignValue),
         ...fillSelectMenu("channel-select-wrapper", mediumValue),
         ...fillSelectMenu("source-select-wrapper", sourceValue),
-        {
-            content: "Copy tracker link",
-            trigger: '#btn_shorten_url',
-            run: function () {
-                // Patch and ignore write on clipboard in tour as we don't have permissions
-                const oldWriteText = browser.navigator.clipboard.writeText;
-                browser.navigator.clipboard.writeText = () => {
-                    console.info("Copy in clipboard ignored!");
-                };
-                browser.navigator.clipboard.writeText = oldWriteText;
-            },
-        },
         {
             content: "Generate Link Tracker",
             trigger: "#btn_shorten_url",


### PR DESCRIPTION
Following PR [^1], the step about copying the tracker link doesn't do anything as the only actual "action" made in the custom "run()" function has been removed (sic), leaving only the mocking of the Clipboard API (which isn't called anymore, anyway).

This commit removes this unused step to avoid confusion.

[^1]: https://github.com/odoo/odoo/pull/170548