### PR TITLE
[FIX] mail: support tracking of HTML fields

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 
 from odoo import api, fields, models, _
+from odoo.addons.mail.tools.text import text_diff_summary
 
 
 class MailTracking(models.Model):
@@ -104,6 +105,15 @@ class MailTracking(models.Model):
                 'old_value_char': ', '.join(initial_value.mapped('display_name')) if initial_value else '',
                 'new_value_char': ', '.join(new_value.mapped('display_name')) if new_value else '',
             })
+        elif col_info['type'] == 'html':
+            initial_text = str(initial_value or '').replace('&nbsp;', ' ')
+            new_text = str(new_value or '').replace('&nbsp;', ' ')
+            if initial_text != new_text:
+                initial_summary, new_summary = text_diff_summary(initial_text, new_text)
+                values.update({
+                    'old_value_char': initial_summary or '',
+                    'new_value_char': new_summary or '',
+                })
         else:
             raise NotImplementedError(f'Unsupported tracking on field {field.name} (type {col_info["type"]}')
 

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -14,6 +14,7 @@ from . import test_res_company
 from . import test_res_partner
 from . import test_res_users
 from . import test_res_users_settings
+from . import test_text_diff
 from . import test_translation_controller
 from . import test_uninstall
 from . import test_update_notification

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1323,7 +1323,10 @@ class MailCase(MockEmail):
                 self.assertEqual(tracking.currency_id, currency)
                 self.assertEqual(tracking.old_value_float, old_value)
                 self.assertEqual(tracking.new_value_float, new_value)
-            if value_type not in suffix_mapping and value_type not in {'many2one', 'monetary'}:
+            elif value_type == 'html':
+                self.assertEqual(tracking.old_value_char, (old_value or ''))
+                self.assertEqual(tracking.new_value_char, (new_value or ''))
+            if value_type not in suffix_mapping and value_type not in {'many2one', 'monetary', 'html'}:
                 self.assertEqual(1, 0, f'Tracking: unsupported tracking test on {value_type}')
 
 

--- a/addons/mail/tests/test_text_diff.py
+++ b/addons/mail/tests/test_text_diff.py
@@ -1,0 +1,68 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+from odoo.tests.common import BaseCase, tagged
+from odoo.addons.mail.tools.text import text_diff_summary
+
+
+@tagged('at_install')
+class TestTextDiff(BaseCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.base_text = re.sub(r'\s+', ' ', '''
+            ’Twas brillig, and the slithy toves
+            Did gyre and gimble in the wabe;
+            All mimsy were the borogoves,
+            And the mome raths outgrabe.
+        ''').strip()
+
+    def test_unchanged(self):
+        """Summaries should be '...' when there is no change"""
+        diff_1, diff_2 = text_diff_summary(self.base_text, self.base_text, 5)
+        rev_diff_1, rev_diff_2 = text_diff_summary(self.base_text, self.base_text, 5)
+        self.assertEqual(diff_1, rev_diff_2, "Direction should not matter")
+        self.assertEqual(diff_2, rev_diff_1, "Direction should not matter")
+        self.assertEqual(diff_1, '...')
+        self.assertEqual(diff_2, '...')
+
+    def test_middle(self):
+        """Summaries should have ellipsis around a change in the middle"""
+        alt_text = self.base_text.replace('slithy', 'slictuous')
+        diff_1, diff_2 = text_diff_summary(self.base_text, alt_text, 5)
+        rev_diff_1, rev_diff_2 = text_diff_summary(alt_text, self.base_text, 5)
+        self.assertEqual(diff_1, rev_diff_2, "Direction should not matter")
+        self.assertEqual(diff_2, rev_diff_1, "Direction should not matter")
+        self.assertEqual(diff_1, '...e slithy tove...')
+        self.assertEqual(diff_2, '...e slictuous tove...')
+
+    def test_near_border(self):
+        """Summaries should not have ellipsis before start nor after end"""
+        alt_text = self.base_text.replace('’Twas', '’Twere').replace('outgrabe', 'outgave')
+        diff_1, diff_2 = text_diff_summary(self.base_text, alt_text, 5)
+        rev_diff_1, rev_diff_2 = text_diff_summary(alt_text, self.base_text, 5)
+        self.assertEqual(diff_1, rev_diff_2, "Direction should not matter")
+        self.assertEqual(diff_2, rev_diff_1, "Direction should not matter")
+        self.assertEqual(diff_1, '’Twas bril... outgrabe.')
+        self.assertEqual(diff_2, '’Twere bril... outgave.')
+
+    def test_first_last(self):
+        """Summaries should show difference on first and last character"""
+        alt_text = self.base_text.replace('’Twas', 'It was').replace('outgrabe.', 'outgrabe!')
+        diff_1, diff_2 = text_diff_summary(self.base_text, alt_text, 5)
+        rev_diff_1, rev_diff_2 = text_diff_summary(alt_text, self.base_text, 5)
+        self.assertEqual(diff_1, rev_diff_2, "Direction should not matter")
+        self.assertEqual(diff_2, rev_diff_1, "Direction should not matter")
+        self.assertEqual(diff_1, '’Twas b...grabe.')
+        self.assertEqual(diff_2, 'It was b...grabe!')
+
+    def test_symmetry(self):
+        """Summaries should not be asymmetrical even when the change paths in both directions are different"""
+        alt_text = self.base_text.replace('mome raths', 'verchons')
+        diff_1, diff_2 = text_diff_summary(self.base_text, alt_text, 5)
+        rev_diff_1, rev_diff_2 = text_diff_summary(alt_text, self.base_text, 5)
+        self.assertEqual(diff_1, rev_diff_2, "Direction should not matter")
+        self.assertEqual(diff_2, rev_diff_1, "Direction should not matter")
+        self.assertEqual(diff_1, '... the mome raths out...')
+        self.assertEqual(diff_2, '... the verchons out...')

--- a/addons/mail/tools/__init__.py
+++ b/addons/mail/tools/__init__.py
@@ -6,3 +6,4 @@ from . import discuss
 from . import link_preview
 from . import mail_validation
 from . import parser
+from . import text

--- a/addons/mail/tools/text.py
+++ b/addons/mail/tools/text.py
@@ -1,0 +1,44 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from difflib import SequenceMatcher
+
+
+def text_diff_summary(text1, text2, kept_chars=25):
+    """ Returns the differences between two text, keeping some context
+    characters around the differences.
+
+    :param str text1: first text to compare
+    :param str text2: second text to compare
+    :param int kept_chars: number of characters to include in result on each
+        side of each difference
+
+    :return: tuple (first text difference summary, second text difference summary)
+    """
+    if text1 == text2:
+        return '...', '...'
+    matcher = SequenceMatcher(None, text1, text2)
+    result1, result2 = [], []
+    first = True
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == 'equal':
+            chunk = text1[i1:i2]
+            if first:
+                if len(chunk) > kept_chars:
+                    chunk = f'...{chunk[-kept_chars:]}'
+            elif i2 == len(text1) and j2 == len(text2):  # end
+                if len(chunk) > kept_chars:
+                    chunk = f'{chunk[:kept_chars]}...'
+            elif len(chunk) > kept_chars * 2:
+                chunk = f'{chunk[:kept_chars]}...{chunk[-kept_chars:]}'
+            result1.append(chunk)
+            result2.append(chunk)
+        elif tag == 'replace':
+            result1.append(text1[i1:i2])
+            result2.append(text2[j1:j2])
+        elif tag == 'delete':
+            result1.append(text1[i1:i2])
+        elif tag == 'insert':
+            result2.append(text2[j1:j2])
+        first = False
+    diff1, diff2 = ''.join(result1), ''.join(result2)
+    return diff1, diff2

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -122,7 +122,7 @@ class MailTestTrackAll(models.Model):
     datetime_field = fields.Datetime('Datetime', tracking=4)
     float_field = fields.Float('Float', tracking=5)
     float_field_with_digits = fields.Float('Precise Float', digits=(10, 8), tracking=5)
-    html_field = fields.Html('Html', tracking=False)
+    html_field = fields.Html('Html', tracking=6)
     integer_field = fields.Integer('Integer', tracking=7)
     many2many_field = fields.Many2many(
         'mail.test.track.all.m2m', string='Many2Many',

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -555,6 +555,7 @@ class TestTrackingInternals(MailCommon):
             ('datetime_field', 'datetime', False, now),
             ('float_field', 'float', 0, 3.22),
             ('float_field_with_digits', 'float', 0, 3.00001),
+            ('html_field', 'html', False, '<p>Html Value</p>'),
             ('integer_field', 'integer', 0, 42),
             ('many2one_field_id', 'many2one', self.env['res.partner'], self.test_partner),
             ('monetary_field', 'monetary', False, (42.42, self.env.ref('base.USD'))),
@@ -748,14 +749,6 @@ class TestTrackingInternals(MailCommon):
             self.env['mail.tracking.value']._create_tracking_values(
                 '', 'Test',
                 'not_existing_field', {'string': 'Test', 'type': 'char'},
-                test_record,
-            )
-
-        # raise on unsupported field type
-        with self.assertRaises(NotImplementedError):
-            self.env['mail.tracking.value']._create_tracking_values(
-                '', '<p>Html</p>',
-                'html_field', {'string': 'HTML', 'type': 'html'},
                 test_record,
             )
 


### PR DESCRIPTION
Nothing prevent tracking from being enabled on HTML fields, but if it is enabled, updates of the field systematically fail.

This commit avoids this error by tracking the differences in the HTML field.

Steps to reproduce:
- Install `sale` and `web_studio`
- Activate debug mode
- Add a custom HTML field inside the invoice form view
- Open the "More..." of the field (or go to Settings/Technical/Field) and go to the new field
- Set "Enable Ordered Tracking" to 1
- Save
- Go to an invoice and modify the new field
- Save

=> An error was displayed

task-5236436
