### PR TITLE
[FIX] web, html_editor: preview gradient changes

### DIFF
--- a/addons/html_editor/static/src/main/font/color_picker_gradient_tab.js
+++ b/addons/html_editor/static/src/main/font/color_picker_gradient_tab.js
@@ -31,6 +31,7 @@ export class ColorPickerGradientTab extends Component {
         defaultOpacity: { type: Number, optional: true },
         noTransparency: { type: Boolean, optional: true },
         selectedColor: { type: String, optional: true },
+        currentColorPreview: { type: String, optional: true },
         "*": { optional: true },
     };
     setup() {
@@ -42,6 +43,9 @@ export class ColorPickerGradientTab extends Component {
     }
 
     getCurrentGradientColor() {
+        if (isColorGradient(this.props.currentColorPreview)) {
+            return this.props.currentColorPreview;
+        }
         if (isColorGradient(this.props.selectedColor)) {
             return this.props.selectedColor;
         }

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.js
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.js
@@ -39,8 +39,20 @@ export class GradientPicker extends Component {
             this.setGradientFromString(this.props.selectedGradient);
         } else {
             // initialization of the gradient with default value
-            this.onColorGradientChange();
+            this.onColorGradientPreview();
         }
+
+        // Apply the previewed custom color when the popover is closed.
+        this.props.setOnCloseCallback?.(() => {
+            this.onColorGradientChange();
+        });
+
+        this.props.setOperationCallbacks?.({
+            onApplyCallback: () => {
+                this.props.setOnCloseCallback(() => {});
+            },
+            getPreviewColor: () => this.cssGradients[this.state.type],
+        });
 
         onWillUpdateProps((newProps) => {
             if (newProps.selectedGradient) {
@@ -87,7 +99,7 @@ export class GradientPicker extends Component {
 
     selectType(type) {
         this.state.type = type;
-        this.onColorGradientChange();
+        this.onColorGradientPreview();
     }
 
     onAngleChange(ev) {
@@ -96,7 +108,7 @@ export class GradientPicker extends Component {
             const clampedAngle = Math.min(Math.max(angle, 0), 360);
             ev.target.value = clampedAngle;
             this.state.angle = clampedAngle;
-            this.onColorGradientChange();
+            this.onColorGradientPreview();
         }
     }
 
@@ -106,7 +118,7 @@ export class GradientPicker extends Component {
             const clampedValue = Math.min(Math.max(inputValue, 0), 100);
             ev.target.value = clampedValue;
             this.positions[position] = clampedValue;
-            this.onColorGradientChange();
+            this.onColorGradientPreview();
         }
     }
 
@@ -124,14 +136,14 @@ export class GradientPicker extends Component {
 
     onSizeChange(size) {
         this.state.size = size;
-        this.onColorGradientChange();
+        this.onColorGradientPreview();
     }
 
     onColorPercentageChange(colorIndex, ev) {
         this.state.currentColorIndex = colorIndex;
         this.colors[colorIndex].percentage = ev.target.value;
         this.sortColors();
-        this.onColorGradientChange();
+        this.onColorGradientPreview();
     }
 
     onGradientPreviewClick(ev) {
@@ -178,7 +190,7 @@ export class GradientPicker extends Component {
         this.state.currentColorIndex = this.colors.findIndex(
             (color) => color.percentage === percentage
         );
-        this.onColorGradientChange();
+        this.onColorGradientPreview();
     }
 
     removeColor(colorIndex) {
@@ -187,7 +199,7 @@ export class GradientPicker extends Component {
         }
         this.colors.splice(colorIndex, 1);
         this.state.currentColorIndex = 0;
-        this.onColorGradientChange();
+        this.onColorGradientPreview();
     }
 
     sortColors() {
@@ -249,11 +261,11 @@ export class GradientPicker extends Component {
         };
 
         updateAngle(ev);
-        this.onColorGradientChange();
+        this.onColorGradientPreview();
 
         const onKnobMouseMove = (ev) => {
             updateAngle(ev);
-            this.onColorGradientChange();
+            this.onColorGradientPreview();
         };
         const onKnobMouseUp = () => document.removeEventListener("mousemove", onKnobMouseMove);
 

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
@@ -129,8 +129,6 @@
             <ColorPicker
                 onColorSelect.bind="onColorChange"
                 onColorPreview.bind="onColorPreview"
-                setOnCloseCallback.bind="props.setOnCloseCallback"
-                setOperationCallbacks.bind="props.setOperationCallbacks"
                 defaultColor="this.currentColorHex"
                 selectedColor="this.currentColorHex"
                 noTransparency="props.noTransparency"

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -1331,7 +1331,7 @@ describe("color preview", () => {
         await animationFrame();
         await click(".o-select-color-foreground");
         await contains(".btn:contains('Gradient')").click();
-        await contains(".o_custom_gradient_button").click(); // Click applies the default gradient.
+        await contains(".o_custom_gradient_button").click(); // Click previews the default gradient.
         const initialGradient = queryOne(".o_custom_gradient_button").style.backgroundImage;
         await contains(".o_font_color_selector .o_color_pick_area").click();
         await animationFrame();
@@ -1345,6 +1345,30 @@ describe("color preview", () => {
         expect(".o_custom_gradient_button").not.toHaveStyle({ backgroundImage: gradient1 });
         await press("Escape"); // Close tab and cancel preview.
         await animationFrame();
-        expect("p font").toHaveStyle({ backgroundImage: initialGradient });
+        expect("font").toHaveCount(0); // Gradient was canceled
+    });
+
+    test("should preview when changing different gradient settings", async () => {
+        await setupEditor(`<p>This is a [test].</p>`);
+
+        await expandToolbar();
+        await animationFrame();
+        await click(".o-select-color-foreground");
+        await contains(".btn:contains('Gradient')").click();
+        await contains(".o_custom_gradient_button").click();
+
+        await contains(".o_color_gradient_input>input").edit(250);
+        expect("p font").toHaveStyle({
+            backgroundImage:
+                "linear-gradient(250deg, rgb(223, 124, 196) 0%, rgb(108, 53, 130) 100%)",
+        });
+        await contains("button:contains('Radial')").click();
+        expect("p font").toHaveStyle({
+            backgroundImage:
+                "radial-gradient(circle closest-side at 25% 25%, rgb(223, 124, 196) 0%, rgb(108, 53, 130) 100%)",
+        });
+        await press("Escape"); // Close tab and cancel preview.
+        await animationFrame();
+        expect("font").toHaveCount(0); // Gradient was canceled
     });
 });

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -98,7 +98,6 @@ export class CustomColorPicker extends Component {
         for (const doc of documents) {
             useExternalListener(doc, "pointermove", this.throttleOnPointerMove);
             useExternalListener(doc, "pointerup", this.onPointerUp.bind(this));
-            useExternalListener(doc, "keydown", this.onEscapeKeydown.bind(this), { capture: true });
         }
         // Apply the previewed custom color when the popover is closed.
         this.props.setOnCloseCallback?.(() => {
@@ -391,7 +390,7 @@ export class CustomColorPicker extends Component {
         this._updateCssColor();
     }
     /**
-     * Trigger an event to annonce that the widget value has changed
+     * Trigger an event to announce that the widget value has changed
      *
      * @private
      */
@@ -438,8 +437,6 @@ export class CustomColorPicker extends Component {
         if (this.props.stopClickPropagation) {
             ev.stopPropagation();
         }
-        //TODO: we should remove it with legacy web_editor
-        ev.__isColorpickerClick = true;
 
         if (ev.target.dataset.colorMethod === "hex" && !this.selectedHexValue) {
             ev.target.select();
@@ -460,18 +457,6 @@ export class CustomColorPicker extends Component {
         if (this.lastFocusedSliderEl) {
             this.lastFocusedSliderEl.focus();
             this.lastFocusedSliderEl = undefined;
-        }
-    }
-    /**
-     * Removes the close callback on Escape, so that a preview is cancelled with
-     * escape instead of being applied.
-     *
-     * @param {KeydownEvent} ev
-     */
-    onEscapeKeydown(ev) {
-        const hotkey = getActiveHotkey(ev);
-        if (hotkey === "escape") {
-            this.props.setOnCloseCallback?.(() => {});
         }
     }
     /**

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -396,7 +396,7 @@ class TestUi(HttpCaseWithWebsiteUser):
             'name': 'test.png',
             'mimetype': 'image/png',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_background_edition', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_background_edition', login='admin', watch=True)
 
     def test_12_edit_translated_page_redirect(self):
         lang = self.env['res.lang']._activate_lang('nl_NL')


### PR DESCRIPTION
The gradient color picker was previewing changes all the time, causing reloads
every time we change the gradient color in the theme tab, header, or footer.
Since the Theme tab requires reloading some CSS assets, changes made for the
The theme inside the color picker should only be applied when we exit the color
picker, not for each operation inside it.

Steps to see the issue:
- Open the website builder
- Open the Theme tab
- Unfold on Color Presets
- Unfold one preset
- Open the Background Color picker
- Click on the Gradient tab 
- Click on "Custom" => The editor reloads
- Try adjusting the "Angle" knob => The editor will reload a bunch of times
- Make changes in the color HEX value => The editor reloads

Commit [f905ba132f] already made some changes towards that direction, but not
all sliders and inputs were affected.

[f905ba132f]: https://github.com/odoo/odoo/commit/f905ba132f

task-5407617