### PR TITLE
[19.0] mail: display file attachments in activities after save

### DIFF
--- a/addons/mail/static/src/core/web/activity.js
+++ b/addons/mail/static/src/core/web/activity.js
@@ -1,3 +1,6 @@
+import { HtmlViewer } from "@html_editor/components/html_viewer/html_viewer";
+import { READONLY_MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
+
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { ActivityMailTemplate } from "@mail/core/web/activity_mail_template";
 import { ActivityMarkAsDone } from "@mail/core/web/activity_markasdone_popover";
@@ -20,7 +23,7 @@ import { FileUploader } from "@web/views/fields/file_handler";
  * @extends {Component<Props, Env>}
  */
 export class Activity extends Component {
-    static components = { ActivityMailTemplate, FileUploader };
+    static components = { ActivityMailTemplate, FileUploader, HtmlViewer };
     static props = ["activity", "onActivityChanged", "reloadParentView"];
     static template = "mail.Activity";
 
@@ -42,6 +45,13 @@ export class Activity extends Component {
             return _t("“%s”", this.props.activity.summary);
         }
         return this.props.activity.display_name;
+    }
+
+    get htmlViewerConfig() {
+        return {
+            value: this.props.activity.note,
+            embeddedComponents: READONLY_MAIN_EMBEDDINGS,
+        };
     }
 
     updateDelayAtNight() {

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -44,7 +44,6 @@
                 </table>
             </div>
             <HtmlViewer t-if="props.activity.note" config="htmlViewerConfig"/>
-            <div t-if="props.activity.note" class="o-mail-Activity-note text-break" t-out="props.activity.note"/>
             <div t-if="props.activity.mail_template_ids?.length > 0" class="o-mail-Activity-mailTemplates">
                 <ActivityMailTemplate activity="props.activity" onActivityChanged="props.onActivityChanged"/>
             </div>

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -43,6 +43,7 @@
                     </tbody>
                 </table>
             </div>
+            <HtmlViewer t-if="props.activity.note" config="htmlViewerConfig"/>
             <div t-if="props.activity.note" class="o-mail-Activity-note text-break" t-out="props.activity.note"/>
             <div t-if="props.activity.mail_template_ids?.length > 0" class="o-mail-Activity-mailTemplates">
                 <ActivityMailTemplate activity="props.activity" onActivityChanged="props.onActivityChanged"/>

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -43,7 +43,9 @@
                     </tbody>
                 </table>
             </div>
-            <HtmlViewer t-if="props.activity.note" config="htmlViewerConfig"/>
+            <div t-if="props.activity.note" class="o-mail-Activity-note text-break">
+                <HtmlViewer config="htmlViewerConfig"/>
+            </div>
             <div t-if="props.activity.mail_template_ids?.length > 0" class="o-mail-Activity-mailTemplates">
                 <ActivityMailTemplate activity="props.activity" onActivityChanged="props.onActivityChanged"/>
             </div>

--- a/doc/cla/individual/GautamKantesariya.md
+++ b/doc/cla/individual/GautamKantesariya.md
@@ -1,0 +1,9 @@
+India, 2025-12-25
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Gautam gautamkantesariya@yahoo.com https://github.com/GautamKantesariya


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In Odoo 19, file attachments added to activities (for example, on Project Tasks) were not visible after saving the activity.
Although the attachment was correctly stored, it was not rendered in the activity chatter.

The root cause was that the activity note containing the embedded attachment placeholder
`(<span data-embedded="file">) `was rendered as raw HTML, bypassing the HtmlViewer logic that mounts embedded file components.

As a result, the attachment card and download link were missing from the UI.

**Current behavior before PR:**
Attachments can be added to an activity and are saved correctly.
After saving the activity:
  - The attachment card is not displayed.
  - No download link appears in the activity chatter.
  - The activity note is rendered as raw HTML, so embedded file components are never mounted.

**Desired behavior after PR is merged:**
  - Attachments added to activities are correctly displayed after saving.
  - The attachment card and download link appear in the activity chatter.
  - Activity notes are rendered using the HtmlViewer component, ensuring embedded files are properly mounted and displayed.

**Related issue**
Closes #238967


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
