### PR TITLE
[i18n][17.0] stock: fix i18n

### DIFF
--- a/addons/stock/i18n/vi.po
+++ b/addons/stock/i18n/vi.po
@@ -1431,13 +1431,13 @@ msgstr "Số lượng có sẵn phải được đặt là 0 trước khi thay �
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__backorder_id
 msgid "Back Order of"
-msgstr "Đơn hàng trậm trễ của"
+msgstr "Đơn hàng chậm trễ của"
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__backorder_ids
 #: model_terms:ir.ui.view,arch_db:stock.stock_picking_type_kanban
 msgid "Back Orders"
-msgstr "Đơn hàng trậm trễ"
+msgstr "Đơn hàng chậm trễ"
 
 #. module: stock
 #: model:ir.model,name:stock.model_stock_backorder_confirmation


### PR DESCRIPTION
correct Vietnamese translation typo for "Back Order of"

This issue is also present in Odoo 18



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
