### PR TITLE
[FIX] product,sale: ensure cart quantity updates correctly

### DIFF
--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -30,7 +30,7 @@
                 <input class="o_input form-control border text-center text-bg-light"
                         type="number"
                         t-att-value="quantity"
-                        t-on-change="this.env.setQuantity"
+                        t-on-input="this.env.setQuantity"
                         t-on-focus="_onFocus"
                 />
                 <button class="btn btn-primary border"

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -15,7 +15,7 @@
                 name="sale_quantity"
                 type="number"
                 t-att-value="props.quantity"
-                t-on-change="setQuantity"/>
+                t-on-input="setQuantity"/>
             <button
                 t-attf-class="btn btn-secondary {{ props.btnClasses or 'd-none d-md-inline-block' }}"
                 name="sale_quantity_button_plus"


### PR DESCRIPTION
**Steps to produce:**
- Install `website_sale` with demo data.
- Go to the shop page.
- Select product `Customizable Desk` > click `Add to cart`.
- In the wizard, change the quantity to 100 and directly click `Checkout`.

**Issue:**
- The cart shows the product with quantity = 1 instead of the edited value.

**Root Cause:**
- The template uses `t-on-change`, which only triggers when the input
  loses focus or is explicitly modified.
- When the user clicks `Checkout`, both `setQuantity` and `onConfirm`
  are executed in parallel.
- If `onConfirm` runs first, it reads the previously stored quantity
  (`1` from `this.state.products` initialized in `onWillStart`) before
  `setQuantity` has updated the value.
- Consequently, the checkout process proceeds with the stale quantity
  instead of the newly entered one.

**Solution:**
- Replace `t-on-change` with `t-on-input` so that the quantity is updated immediately when the user edits the field.
- This ensures the correct quantity is reflected in the cart even if the user proceeds directly to checkout.

opw-5435672
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
