### PR TITLE
[FIX] website: remove data-name attribute in form cover snippet

### DIFF
--- a/addons/website/views/snippets/s_website_form_cover.xml
+++ b/addons/website/views/snippets/s_website_form_cover.xml
@@ -5,7 +5,7 @@
     <section class="s_website_form_cover" data-snippet="s_website_form_cover">
         <div class="container-fluid">
             <div class="row s_nb_column_fixed">
-                <div class="col-lg-6 oe_img_bg o_bg_img_center o_not_editable pt128 pb128" data-name="Image" style="background-image: url('/web/image/website.s_website_form_cover_default_image');"/>
+                <div class="col-lg-6 oe_img_bg o_bg_img_center o_not_editable pt128 pb128" style="background-image: url('/web/image/website.s_website_form_cover_default_image');"/>
                 <div class="col-lg-6 pt48 pb48 px-4">
                     <h2>Send us a message</h2>
                     <p class="lead">Get in touch with your customers to provide them with better service. You can modify the form fields to gather more precise information.</p>


### PR DESCRIPTION
Steps to reproduce:
1. Go to the website and enter edit mode.
2. Drop `s_website_form_cover` snippet.
3. Click on the image on the left side.

Issue:
The option container displays “**Image**” as the title instead of “**Column**”.

Reason:
The `s_website_form_cover.xml` file contains a `data-name` attribute set to "**Image**".

Fix:
The `data-name` attribute has been removed from the snippet. As a result, the option container now correctly uses “**Column**” as the default title.

Before:
<img width="1578" height="683" alt="image" src="https://github.com/user-attachments/assets/38cd8126-2c59-46fe-acb3-f9dd710c370b" />

After:
<img width="1920" height="861" alt="image" src="https://github.com/user-attachments/assets/414cd4b8-9e7f-4b8f-a62f-b2c89fffe878" />


task-5441732