### PR TITLE
[FIX] base: constrains wrongly triggered on fiscal last day

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -385,8 +385,12 @@ class Company(models.Model):
                     ('id', 'child_of', company.id),
                     ('id', '!=', company.id),
                 ])
-                for fname in sorted(changed):
-                    branches[fname] = company[fname]
+
+                changed_vals = {
+                    fname: self._fields[fname].convert_to_write(company[fname], branches)
+                    for fname in sorted(changed)
+                }
+                branches.write(changed_vals)
 
         if companies_needs_l10n:
             companies_needs_l10n.install_l10n_modules()

--- a/odoo/addons/base/tests/test_res_company.py
+++ b/odoo/addons/base/tests/test_res_company.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from unittest.mock import patch
+
 from odoo.exceptions import ValidationError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Command, TransactionCase
 
 
 class TestCompany(TransactionCase):
@@ -54,3 +56,13 @@ class TestCompany(TransactionCase):
     def test_create_branch_with_default_parent_id(self):
         branch = self.env['res.company'].with_context(default_parent_id=self.env.company.id).create({'name': 'Branch Company'})
         self.assertFalse(branch.partner_id.parent_id)
+
+    def test_write_company_root_delegated_field_names(self):
+        self.env['res.company'].with_context(default_parent_id=self.env.company.id).create({'name': 'foo'})
+        new_currency = self.env['res.currency'].create({
+            'name': 'AAA',
+            'symbol': 'AAA',
+            'rate_ids': [Command.create({'name': '2009-09-09', 'rate': 1})]
+        })
+        with patch('odoo.addons.base.models.res_company.Company._get_company_root_delegated_field_names', return_value=["currency_id", "zip"]):
+            self.env.company.write({'currency_id': new_currency.id, 'zip': '12345'})


### PR DESCRIPTION
Having a parent company and a chid company selected, and changing both
the last day and the last month of the fiscal year as the same time
raises a ValidationError.

This is because in this case, in the write we successively modify each changed
delegated fields from root company to the branches. Then, when
checking the constrains we loop through all delegated fields and check
if the value of the branches are the same as the root company. This
check triggers the error as all values are not set yet.

By using a write on branches for all changed delegated fields instead of
a simple assignation, the constrains check occurs once all the value
have been updated.

Steps:

- Have a root company and a branch
- Select both in company selector
- Go to Accounting configuration
- Change fiscalyear last month AND ast day at the same time
- Save
-> ValidationError in `_check_root_delegated_fields`

opw-5431145
