### PR TITLE
[FIX] website: close global search modal when entering edit mode

### DIFF
--- a/addons/website/static/src/interactions/search_modal.js
+++ b/addons/website/static/src/interactions/search_modal.js
@@ -8,6 +8,9 @@ export class SearchModal extends Interaction {
             "t-on-shown.bs.modal": () => this.el.querySelector(".search-query").focus(),
         },
     };
+    destroy() {
+        Modal.getInstance(this.el)?.hide();
+    }
 }
 
 registry


### PR DESCRIPTION
Steps to reproduce:
1. Go to the Website.
2. Click the search icon in the header.
3. When the search modal opens, click 'Edit' to enable website editing.
4. Attempt to add a snippet.

Observed behavior:
- Snippets cannot be added while the global search modal remains open.

Expected behavior:
- Snippets should be draggable and added normally in edit mode.

This commit ensures that the global search modal is closed when entering edit mode, preventing it from blocking add snippet.

task-5421051