### PR TITLE
[FIX] web: hadle empty data when exporting pivot xlsx

### DIFF
--- a/addons/web/controllers/pivot.py
+++ b/addons/web/controllers/pivot.py
@@ -6,6 +6,7 @@ import io
 import json
 
 from werkzeug.datastructures import FileStorage
+from werkzeug.exceptions import UnprocessableEntity
 
 from odoo import http, _
 from odoo.http import content_disposition, request
@@ -18,6 +19,8 @@ class TableExporter(http.Controller):
     @http.route('/web/pivot/export_xlsx', type='http', auth="user", readonly=True)
     def export_xlsx(self, data, **kw):
         jdata = json.load(data) if isinstance(data, FileStorage) else json.loads(data)
+        if not jdata:
+            raise UnprocessableEntity(_('No data to export'))
         output = io.BytesIO()
         workbook = xlsxwriter.Workbook(output, {'in_memory': True})
         worksheet = workbook.add_worksheet(jdata['title'])

--- a/addons/web/tests/test_pivot_export.py
+++ b/addons/web/tests/test_pivot_export.py
@@ -1,5 +1,6 @@
 import io
 import json
+from http import HTTPStatus
 from lxml import etree
 from zipfile import ZipFile
 
@@ -48,3 +49,17 @@ class TestPivotExport(HttpCase):
         self.assertEqual(xml_data['B1'], '500')
         self.assertEqual(xml_data['A2'], '0')
         self.assertEqual(xml_data['B2'], '42')
+
+    def test_export_xlsx_with_empty_data(self):
+        """ Test the export_xlsx method of the pivot controller without jdata """
+        self.authenticate('admin', 'admin')
+
+        response = self.url_open(
+            '/web/pivot/export_xlsx',
+            data={
+                'data': json.dumps({}),
+                'csrf_token': http.Request.csrf_token(self),
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
+        self.assertIn('No data to export', response.text)


### PR DESCRIPTION
Currently an exception is generated when controlled `/web/pivot/export_xlsx'
tries to export xlsx with empty data.

`KeyError: 'title'`

This PR resolves the issue by raising an `UnprocessableEntity` exception
when empty data is provided. The resulting 422 response indicates that
the server understood the request and its syntax, but cannot process it
because the data is invalid.


sentry-6321555617






