### PR TITLE
[FIX] html_editor: preserve image responsiveness when resizing

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -187,9 +187,8 @@ export class ImageTransformation extends Component {
                 }
             }
             this.image.style.width = newWidth + "px";
-            this.image.style.height = newHeight + "px";
+            this.image.style.height = "auto";
             settings.width = newWidth;
-            settings.height = newHeight;
         }
 
         settings.angle = Math.round(settings.angle);
@@ -208,9 +207,16 @@ export class ImageTransformation extends Component {
         this.positionTransfoContainer();
     }
 
+    convertPixelWidthToPercentage() {
+        const currentPixelWidth = this.image.offsetWidth;
+        const widthPercent = (currentPixelWidth / this.image.parentElement.offsetWidth) * 100;
+        this.image.style.width = widthPercent.toFixed(2) + "%";
+    }
+
     mouseUp() {
         this.isCurrentlyTransforming = false;
         this.transfo.active = null;
+        this.convertPixelWidthToPercentage();
         this.props.onApply?.();
         this.props.onChange();
     }


### PR DESCRIPTION
Problem:
On website pages, resizing an image using the transform option breaks responsiveness across display sizes. After resizing on desktop, the image may overflow its container on smaller screens.

Cause:
The resize logic currently sets both width and height in `px`. Once fixed in pixels on a large screen, the image no longer adapts when the responsive container becomes smaller on mobile.

Solution:
Use a percentage value for `width` and set `height` to `auto`. This preserves responsiveness while keeping the aspect ratio correct. Using `height: auto` is required because setting both width and height in percentages would still ignore height in practice.

Steps to reproduce:
- Add a card snippet to a website page.
- Resize the image.
- Switch the display mode to mobile.
- Observe that the image is no longer responsive.

opw-5368040


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
