### PR TITLE
[FIX] website: allow long SEO keywords

### DIFF
--- a/addons/website/static/src/components/dialog/seo.xml
+++ b/addons/website/static/src/components/dialog/seo.xml
@@ -176,7 +176,7 @@
         <div role="form" class="input-group w-50">
             <t t-set="placeholderRemove">Remove a keyword first</t>
             <t t-set="placeholderAdd">Add your keyword</t>
-            <input t-model="state.keyword" type="text" class="form-control" t-att-placeholder="isFull ? placeholderRemove : placeholderAdd" t-att-readonly="isFull" maxlength="30" t-on-keyup="onKeyup"/>
+            <input t-model="state.keyword" type="text" class="form-control" t-att-placeholder="isFull ? placeholderRemove : placeholderAdd" t-att-readonly="isFull" t-on-keyup="onKeyup"/>
             <select t-if="languages.length > 1" title="The language of the keyword and related keywords."
                     t-model="state.language" class="btn btn-outline-primary pe-5 form-select">
                 <t t-foreach="languages" t-as="lang" t-key="lang[0]">


### PR DESCRIPTION
Steps to reproduce:
- Open the SEO dialog on a website page.
- Try to enter a keyword longer than 30 characters.
- Observe the input stops at 30 characters.

Before this commit, the keyword field had a 30 character maxlength and blocked longer keywords.

After this commit, the SEO keyword input accepts longer values with no maxlength restriction.

task-5423796