### PR TITLE
[IMP] website: support property field for customer in form snippet

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -79,11 +79,12 @@ class IrModel(models.Model):
             elif fields_get[field]['type'] == 'properties':
                 property_field = fields_get[field]
                 del fields_get[field]
-                if property_origins:
+                if property_origins is not None:
                     # Add property pseudo-fields
                     # The properties of a property field are defined in a
                     # definition record (e.g. properties inside a project.task
                     # are defined inside its related project.project)
+                    properties_definitions = []
                     definition_record = property_field['definition_record']
                     if definition_record in property_origins:
                         definition_record_field = property_field['definition_record_field']
@@ -94,31 +95,38 @@ class IrModel(models.Model):
                             continue
                         definition_record = definition_model.browse(int(property_origins[definition_record]))
                         properties_definitions = definition_record[definition_record_field]
-                        for property_definition in properties_definitions:
-                            if ((
-                                property_definition['type'] in ['many2one', 'many2many']
-                                and 'comodel' not in property_definition
-                            ) or (
-                                property_definition['type'] == 'selection'
-                                and not property_definition['selection']
-                            ) or (
-                                property_definition['type'] == 'tags'
-                                and not property_definition['tags']
-                            ) or (property_definition['type'] == 'separator')):
-                                # Ignore non-fully defined properties
+                    else:
+                        # If the properties field does not depend on a parent record
+                        # (e.g. res.partner and mailing.contact), In that case
+                        # property definitions must be taken from properties.base.definition,
+                        # which stores property definitions for models without a parent.
+                        properties_definitions = self.env['properties.base.definition'] \
+                            ._get_definition_for_property_field(model_name, field) \
+                            .properties_definition
+                    for property_definition in properties_definitions:
+                        if ((
+                            property_definition['type'] in ['many2one', 'many2many']
+                            and 'comodel' not in property_definition
+                        ) or (
+                            property_definition['type'] == 'selection'
+                            and not property_definition['selection']
+                        ) or (
+                            property_definition['type'] == 'tags'
+                            and not property_definition['tags']
+                        ) or (property_definition['type'] == 'separator')):
+                            # Ignore non-fully defined properties
+                            continue
+                        property_definition['_property'] = {
+                            'field': field,
+                        }
+                        property_definition['required'] = False
+                        if 'domain' in property_definition and isinstance(property_definition['domain'], str):
+                            property_definition['domain'] = literal_eval(property_definition['domain'])
+                            try:
+                                property_definition['domain'] = list(Domain(property_definition['domain']))
+                            except ValueError:
                                 continue
-                            property_definition['_property'] = {
-                                'field': field,
-                            }
-                            property_definition['required'] = False
-                            if 'domain' in property_definition and isinstance(property_definition['domain'], str):
-                                property_definition['domain'] = literal_eval(property_definition['domain'])
-                                try:
-                                    property_definition['domain'] = list(Domain(property_definition['domain']))
-                                except Exception:
-                                    # Ignore non-fully defined properties
-                                    continue
-                            fields_get[property_definition.get('name')] = property_definition
+                        fields_get[property_definition.get('name')] = property_definition
 
         return fields_get
 

--- a/addons/website_mass_mailing/data/ir_model_data.xml
+++ b/addons/website_mass_mailing/data/ir_model_data.xml
@@ -17,6 +17,7 @@
                 'list_ids',
                 'country_id',
                 'tag_ids',
+                'properties',
             ]"/>
         </function>
     </data>

--- a/addons/website_mass_mailing/tests/__init__.py
+++ b/addons/website_mass_mailing/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_controllers
+from . import test_property_field_mailing_contact
 from . import test_snippets

--- a/addons/website_mass_mailing/tests/test_property_field_mailing_contact.py
+++ b/addons/website_mass_mailing/tests/test_property_field_mailing_contact.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestMailingPropertyField(TransactionCase):
+
+    def test_mailing_contact_property_field_shown_in_website_form(self):
+        """Test that a property field defined on mailing.contact is correctly shown in the website form."""
+        definition = self.env['properties.base.definition'] \
+            ._get_definition_for_property_field('mailing.contact', 'properties')
+        definition.write({
+            'properties_definition': [{
+                'name': 'contact_color',
+                'type': 'char',
+            }]
+        })
+        self.assertEqual(
+            definition.properties_definition,
+            [{'name': 'contact_color', 'type': 'char'}]
+        )
+        fields = self.env['ir.model'].get_authorized_fields('mailing.contact', {})
+        self.assertIn(
+            'contact_color',
+            fields,
+            "Property field 'contact_color' is not exposed to website form"
+        )
+        property_field = fields['contact_color']
+        self.assertEqual(property_field['type'], 'char')
+        self.assertFalse(property_field.get('required'))
+        self.assertIn('_property', property_field)
+        self.assertEqual(property_field['_property']['field'], 'properties')

--- a/addons/website_sale/data/data.xml
+++ b/addons/website_sale/data/data.xml
@@ -51,7 +51,7 @@
         <value eval="[
             'name', 'phone', 'email',
             'city', 'zip', 'street', 'street2', 'state_id', 'country_id',
-            'vat', 'parent_name'
+            'vat', 'parent_name', 'properties'
         ]"/>
     </function>
 

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -21,6 +21,7 @@ from . import (
     test_mail,
     test_main_controller,
     test_pricelist,
+    test_property_field_res_partner,
     test_product_attribute_value_config,
     test_product_configurator,
     test_product_filters,

--- a/addons/website_sale/tests/test_property_field_res_partner.py
+++ b/addons/website_sale/tests/test_property_field_res_partner.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSalePropertyField(TransactionCase):
+
+    def test_res_partner_propety_field_shown_in_website_form(self):
+        """Test that a property field defined on res.partner is correctly shown in the website form."""
+        definition = self.env['properties.base.definition'] \
+            ._get_definition_for_property_field('res.partner', 'properties')
+        definition.write({
+            'properties_definition': [{
+                'name': 'website_color',
+                'type': 'char',
+            }]
+        })
+        self.assertEqual(
+            definition.properties_definition,
+            [{'name': 'website_color', 'type': 'char'}]
+        )
+        fields = self.env['ir.model'].get_authorized_fields('res.partner', {})
+        self.assertIn(
+            'website_color',
+            fields,
+            "Property field 'website_color' is not shown in the website form"
+        )
+        property_field = fields['website_color']
+        self.assertEqual(property_field['type'], 'char')
+        self.assertFalse(property_field.get('required'))
+        self.assertIn('_property', property_field)
+        self.assertEqual(property_field['_property']['field'], 'properties')


### PR DESCRIPTION
[IMP] website, *: support property field for customer in form snippet

*: website_sale, website_mass_mailing

Steps to reproduce
1.Add a property field on the res.partner (Contacts) and mailing.contact
 (Mass Mailing) models.
2.Go to Website and add any Form Snippet.
3.Select an action:
Create a Customer (for res.partner)
Subscribe to Newsletter (for mailing.contact)
4.Select any field and change its Type section.
5.Observe that no property fields are shown for these two models.

This commit ensures that any property field added to models without a
parent record (such as res.partner and mailing.contact) is also
available in the Website Form Snippet field type.

Technical Stuff:
property_origins is only populated for models whose property fields depend on a 
parent record (e.g. project.task, helpdesk.ticket). Since res.partner has no
parent model, its property fields correctly have a null property_origins value.
More Info : https://github.com/odoo/odoo/pull/241429#issuecomment-3758437816

task-5436162
