### PR TITLE
[FIX] base: prevent key error when accessing leaf_id from self.__leaves

### DIFF
--- a/odoo/tools/set_expression.py
+++ b/odoo/tools/set_expression.py
@@ -120,7 +120,7 @@ class SetDefinitions:
         if keep_subsets:
             ids = set(ids)
             ids = [leaf_id for leaf_id in ids if not any((self.__leaves[leaf_id].subsets - {leaf_id}) & ids)]
-        return Union(Inter([self.__leaves[leaf_id]]) for leaf_id in ids)
+        return Union(Inter([self.__leaves[leaf_id]]) for leaf_id in ids if leaf_id in self.__leaves)
 
     def from_key(self, key: str) -> SetExpression:
         """ Return the set expression corresponding to the given key. """


### PR DESCRIPTION
An error occurs when the code attempts to access `leaf_id` in `self.__leaves`,
but `leaf_id` does not exist in the dictionary .

Error: `KeyError: 35`

This might happen during installation when the `leaf_id` is not available in `self.__leaves`.

This commit fixes the issue by accessing `leaf_id` from `self.__leaves` only when it is present.

sentry-6925358461

