### PR TITLE
[FIX] html_editor: misc RTL fixes

### DIFF
--- a/addons/html_editor/static/src/main/align/align_selector.xml
+++ b/addons/html_editor/static/src/main/align/align_selector.xml
@@ -11,8 +11,8 @@
                     <t t-foreach="items" t-as="item" t-key="item_index">
                         <button
                             t-att-title="item.description"
-                            t-attf-class="btn btn-light fa fa-align-{{item.mode}}"
-                            t-att-class="{ active: item.mode === state.displayName }"
+                            t-attf-class="btn btn-light fa fa-align-{{item.icon}}"
+                            t-att-class="{ active: item.icon === state.displayName }"
                             t-on-click="() => this.onSelected(item)"
                             t-on-pointerdown.prevent="() => {}"
                         />

--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -37,6 +37,17 @@
     }
 }
 
+/* rtl:begin:ignore */
+.o_rtl {
+    .o-we-linkpopover {
+        .o_we_href_input_link {
+            direction: ltr;
+            text-align: right;
+        }
+    }
+}
+/* rtl:end:ignore */
+
 .o_seo_option_child {
     padding-left: 20px;
     position: relative;

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
@@ -6,6 +6,7 @@
     font: 13px / 19.5px SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
     pre, textarea.o_prism_source {
+        direction: ltr #{"/*rtl:ignore*/"};
         margin: 0;
         padding: 8px 16px;
     }
@@ -40,7 +41,7 @@
     .o_code_toolbar {
         position: absolute;
         top: 0;
-        right: 0;
+        right: 0 #{"/*rtl:ignore*/"};
         padding: 3px 4px;
         z-index: 1;
         align-items: center;

--- a/addons/html_editor/static/src/scss/html_editor.common.scss
+++ b/addons/html_editor/static/src/scss/html_editor.common.scss
@@ -190,15 +190,27 @@ ul.o_checklist {
     }
 }
 /*rtl:begin:ignore*/
-ul.o_checklist[dir="rtl"] li:not(.oe-nested)::before {
-    left: auto;
-    right: - $o-checklist-margin-left;
-    text-align: right;
+/* Actual RTL, through user language or switch command */
+.o_rtl ul.o_checklist, ul.o_checklist[dir="rtl"] {
+    li {
+        margin-right: unset;
+        &:not(.oe-nested)::before {
+            left: auto;
+            right: - $o-checklist-margin-left;
+            text-align: right;
+        }
+    }
 }
-ul.o_checklist[dir="ltr"] li:not(.oe-nested)::before {
-    right: auto;
-    left: - $o-checklist-margin-left;
-    text-align: left;
+/* Actual LTR, from RTL language, using switch command */
+ul.o_checklist[dir="ltr"] {
+    li {
+        margin-left: unset;
+        &:not(.oe-nested)::before {
+            right: auto;
+            left: - $o-checklist-margin-left;
+            text-align: left;
+        }
+    }
 }
 /*rtl:end:ignore*/
 ol > li.o_indent, ul > li.o_indent {

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -363,16 +363,16 @@ export function resetSize(editor) {
     editor.shared.table.resetTableSize(findInSelection(selection, "table"));
 }
 /** @param {Editor} editor */
-export function alignLeft(editor) {
-    execCommand(editor, "alignLeft");
+export function alignStart(editor) {
+    execCommand(editor, "alignStart");
 }
 /** @param {Editor} editor */
 export function alignCenter(editor) {
     execCommand(editor, "alignCenter");
 }
 /** @param {Editor} editor */
-export function alignRight(editor) {
-    execCommand(editor, "alignRight");
+export function alignEnd(editor) {
+    execCommand(editor, "alignEnd");
 }
 /** @param {Editor} editor */
 export function justify(editor) {

--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -3,8 +3,8 @@ import { setupEditor, testEditor } from "./_helpers/editor";
 import {
     alignCenter,
     justify,
-    alignLeft,
-    alignRight,
+    alignStart,
+    alignEnd,
     alignTop,
     alignMiddle,
     alignBottom,
@@ -24,22 +24,22 @@ test("should have align tool only if the block is content editable", async () =>
     }
 });
 
-describe("left", () => {
-    test("should align left", async () => {
+describe("start", () => {
+    test("should align start", async () => {
         await testEditor({
             contentBefore: "<p>ab</p><p>c[]d</p>",
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfter: "<p>ab</p><p>c[]d</p>",
         });
     });
 
-    test("should not align left a non-editable node", async () => {
+    test("should not align start a non-editable node", async () => {
         await testEditor({
             contentBefore: '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>',
             contentBeforeEdit:
                 '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>' +
                 '<p data-selection-placeholder=""><br></p>',
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfterEdit:
                 '<p>ab</p><div contenteditable="false"><p>c[]d</p></div>' +
                 '<p data-selection-placeholder=""><br></p>',
@@ -47,67 +47,115 @@ describe("left", () => {
         });
     });
 
-    test("should align several paragraphs left", async () => {
+    test("should align several paragraphs start", async () => {
         await testEditor({
             contentBefore: "<p>a[b</p><p>c]d</p>",
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfter: "<p>a[b</p><p>c]d</p>",
         });
     });
 
-    test("should left align a node within a right-aligned node", async () => {
+    test("should start align a node within a right-aligned node", async () => {
         await testEditor({
             contentBefore: '<div style="text-align: right;"><p>ab</p><p>c[d]e</p></div>',
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfter:
-                '<div style="text-align: right;"><p>ab</p><p style="text-align: left;">c[d]e</p></div>',
+                '<div style="text-align: right;"><p>ab</p><p style="text-align: start;">c[d]e</p></div>',
         });
     });
 
-    test("should left align a node within a right-aligned node and a paragraph", async () => {
+    test("should start align a node within an end-aligned node", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: end;"><p>ab</p><p>c[d]e</p></div>',
+            stepFunction: alignStart,
+            contentAfter:
+                '<div style="text-align: end;"><p>ab</p><p style="text-align: start;">c[d]e</p></div>',
+        });
+    });
+
+    test("should start align a node within a right-aligned node and a paragraph", async () => {
         await testEditor({
             contentBefore: '<div style="text-align: right;"><p>ab</p><p>c[d</p></div><p>e]f</p>',
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfter:
-                '<div style="text-align: right;"><p>ab</p><p style="text-align: left;">c[d</p></div><p>e]f</p>',
+                '<div style="text-align: right;"><p>ab</p><p style="text-align: start;">c[d</p></div><p>e]f</p>',
         });
     });
 
-    test("should left align a node within a right-aligned node and a paragraph, with a center-aligned common ancestor", async () => {
+    test("should start align a node within an end-aligned node and a paragraph", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p>',
+            stepFunction: alignStart,
+            contentAfter:
+                '<div style="text-align: end;"><p>ab</p><p style="text-align: start;">c[d</p></div><p>e]f</p>',
+        });
+    });
+
+    test("should start align a node within a right-aligned node and a paragraph, with a center-aligned common ancestor", async () => {
         await testEditor({
             contentBefore:
                 '<div style="text-align: center;"><div style="text-align: right;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfter:
-                '<div style="text-align: center;"><div style="text-align: right;"><p>ab</p><p style="text-align: left;">c[d</p></div><p style="text-align: left;">e]f</p></div>',
+                '<div style="text-align: center;"><div style="text-align: right;"><p>ab</p><p style="text-align: start;">c[d</p></div><p style="text-align: start;">e]f</p></div>',
         });
     });
 
-    test("should left align a node within a right-aligned node and a paragraph, with a left-aligned common ancestor", async () => {
+    test("should start align a node within an end-aligned node and a paragraph, with a center-aligned common ancestor", async () => {
+        await testEditor({
+            contentBefore:
+                '<div style="text-align: center;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: alignStart,
+            contentAfter:
+                '<div style="text-align: center;"><div style="text-align: end;"><p>ab</p><p style="text-align: start;">c[d</p></div><p style="text-align: start;">e]f</p></div>',
+        });
+    });
+
+    test("should start align a node within a right-aligned node and a paragraph, with a left-aligned common ancestor", async () => {
         await testEditor({
             contentBefore:
                 '<div style="text-align: left;"><div style="text-align: right;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfter:
-                '<div style="text-align: left;"><div style="text-align: right;"><p>ab</p><p style="text-align: left;">c[d</p></div><p>e]f</p></div>',
+                '<div style="text-align: left;"><div style="text-align: right;"><p>ab</p><p style="text-align: start;">c[d</p></div><p style="text-align: start;">e]f</p></div>',
         });
     });
 
-    test("should not left align a node that is already within a left-aligned node", async () => {
+    test("should start align a node within an end-aligned node and a paragraph, with a left-aligned common ancestor", async () => {
         await testEditor({
-            contentBefore: '<div style="text-align: left;"><p>ab</p><p>c[d]e</p></div>',
-            stepFunction: alignLeft,
-            contentAfter: '<div style="text-align: left;"><p>ab</p><p>c[d]e</p></div>',
+            contentBefore:
+                '<div style="text-align: left;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: alignStart,
+            contentAfter:
+                '<div style="text-align: left;"><div style="text-align: end;"><p>ab</p><p style="text-align: start;">c[d</p></div><p style="text-align: start;">e]f</p></div>',
         });
     });
 
-    test("should left align a container within an editable that is center-aligned", async () => {
+    test("should start align a node within an end-aligned node and a paragraph, with a start-aligned common ancestor", async () => {
+        await testEditor({
+            contentBefore:
+                '<div style="text-align: start;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: alignStart,
+            contentAfter:
+                '<div style="text-align: start;"><div style="text-align: end;"><p>ab</p><p style="text-align: start;">c[d</p></div><p>e]f</p></div>',
+        });
+    });
+
+    test("should not start align a node that is already within a start-aligned node", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: start;"><p>ab</p><p>c[d]e</p></div>',
+            stepFunction: alignStart,
+            contentAfter: '<div style="text-align: start;"><p>ab</p><p>c[d]e</p></div>',
+        });
+    });
+
+    test("should start align a container within an editable that is center-aligned", async () => {
         await testEditor({
             contentBefore:
                 '<div contenteditable="true" style="text-align: center;"><h1>a[]b</h1></div>',
-            stepFunction: alignLeft,
+            stepFunction: alignStart,
             contentAfter:
-                '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: left;">a[]b</h1></div>',
+                '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: start;">a[]b</h1></div>',
         });
     });
 });
@@ -139,12 +187,30 @@ describe("center", () => {
         });
     });
 
+    test("should center align a node within an end-aligned node", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: end;"><p>ab</p><p>c[d]e</p></div>',
+            stepFunction: alignCenter,
+            contentAfter:
+                '<div style="text-align: end;"><p>ab</p><p style="text-align: center;">c[d]e</p></div>',
+        });
+    });
+
     test("should center align a node within a right-aligned node and a paragraph", async () => {
         await testEditor({
             contentBefore: '<div style="text-align: right;"><p>ab</p><p>c[d</p></div><p>e]f</p>',
             stepFunction: alignCenter,
             contentAfter:
                 '<div style="text-align: right;"><p>ab</p><p style="text-align: center;">c[d</p></div><p style="text-align: center;">e]f</p>',
+        });
+    });
+
+    test("should center align a node within a end-aligned node and a paragraph", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p>',
+            stepFunction: alignCenter,
+            contentAfter:
+                '<div style="text-align: end;"><p>ab</p><p style="text-align: center;">c[d</p></div><p style="text-align: center;">e]f</p>',
         });
     });
 
@@ -158,6 +224,26 @@ describe("center", () => {
         });
     });
 
+    test("should center align a node within an end-aligned node and a paragraph, with a left-aligned common ancestor", async () => {
+        await testEditor({
+            contentBefore:
+                '<div style="text-align: left;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: alignCenter,
+            contentAfter:
+                '<div style="text-align: left;"><div style="text-align: end;"><p>ab</p><p style="text-align: center;">c[d</p></div><p style="text-align: center;">e]f</p></div>',
+        });
+    });
+
+    test("should center align a node within an end-aligned node and a paragraph, with a start-aligned common ancestor", async () => {
+        await testEditor({
+            contentBefore:
+                '<div style="text-align: start;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: alignCenter,
+            contentAfter:
+                '<div style="text-align: start;"><div style="text-align: end;"><p>ab</p><p style="text-align: center;">c[d</p></div><p style="text-align: center;">e]f</p></div>',
+        });
+    });
+
     test("should center align a node within a right-aligned node and a paragraph, with a center-aligned common ancestor", async () => {
         await testEditor({
             contentBefore:
@@ -165,6 +251,16 @@ describe("center", () => {
             stepFunction: alignCenter,
             contentAfter:
                 '<div style="text-align: center;"><div style="text-align: right;"><p>ab</p><p style="text-align: center;">c[d</p></div><p>e]f</p></div>',
+        });
+    });
+
+    test("should center align a node within an end-aligned node and a paragraph, with a center-aligned common ancestor", async () => {
+        await testEditor({
+            contentBefore:
+                '<div style="text-align: center;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: alignCenter,
+            contentAfter:
+                '<div style="text-align: center;"><div style="text-align: end;"><p>ab</p><p style="text-align: center;">c[d</p></div><p>e]f</p></div>',
         });
     });
 
@@ -185,79 +281,98 @@ describe("center", () => {
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: center;">a[]b</h1></div>',
         });
     });
+
+    test("should center align a start-aligned container within an editable that is center-aligned", async () => {
+        await testEditor({
+            contentBefore:
+                '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: start;">a[]b</h1></div>',
+            stepFunction: alignCenter,
+            contentAfter:
+                '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: center;">a[]b</h1></div>',
+        });
+    });
 });
 
-describe("right", () => {
-    test("should align right", async () => {
+describe("end", () => {
+    test("should align end", async () => {
         await testEditor({
             contentBefore: "<p>ab</p><p>c[]d</p>",
-            stepFunction: alignRight,
-            contentAfter: '<p>ab</p><p style="text-align: right;">c[]d</p>',
+            stepFunction: alignEnd,
+            contentAfter: '<p>ab</p><p style="text-align: end;">c[]d</p>',
         });
     });
 
-    test("should align several paragraphs right", async () => {
+    test("should align several paragraphs end", async () => {
         await testEditor({
             contentBefore: "<p>a[b</p><p>c]d</p>",
-            stepFunction: alignRight,
-            contentAfter:
-                '<p style="text-align: right;">a[b</p><p style="text-align: right;">c]d</p>',
+            stepFunction: alignEnd,
+            contentAfter: '<p style="text-align: end;">a[b</p><p style="text-align: end;">c]d</p>',
         });
     });
 
-    test("should right align a node within a center-aligned node", async () => {
+    test("should end align a node within a center-aligned node", async () => {
         await testEditor({
             contentBefore: '<div style="text-align: center;"><p>ab</p><p>c[d]e</p></div>',
-            stepFunction: alignRight,
+            stepFunction: alignEnd,
             contentAfter:
-                '<div style="text-align: center;"><p>ab</p><p style="text-align: right;">c[d]e</p></div>',
+                '<div style="text-align: center;"><p>ab</p><p style="text-align: end;">c[d]e</p></div>',
         });
     });
 
-    test("should right align a node within a center-aligned node and a paragraph", async () => {
+    test("should end align a node within a center-aligned node and a paragraph", async () => {
         await testEditor({
             contentBefore: '<div style="text-align: center;"><p>ab</p><p>c[d</p></div><p>e]f</p>',
-            stepFunction: alignRight,
+            stepFunction: alignEnd,
             contentAfter:
-                '<div style="text-align: center;"><p>ab</p><p style="text-align: right;">c[d</p></div><p style="text-align: right;">e]f</p>',
+                '<div style="text-align: center;"><p>ab</p><p style="text-align: end;">c[d</p></div><p style="text-align: end;">e]f</p>',
         });
     });
 
-    test("should right align a node within a center-aligned node and a paragraph, with a justify-aligned common ancestor", async () => {
+    test("should end align a node within a center-aligned node and a paragraph, with a justify-aligned common ancestor", async () => {
         await testEditor({
             contentBefore:
                 '<div style="text-align: justify;"><div style="text-align: center;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
-            stepFunction: alignRight,
+            stepFunction: alignEnd,
             contentAfter:
-                '<div style="text-align: justify;"><div style="text-align: center;"><p>ab</p><p style="text-align: right;">c[d</p></div><p style="text-align: right;">e]f</p></div>',
+                '<div style="text-align: justify;"><div style="text-align: center;"><p>ab</p><p style="text-align: end;">c[d</p></div><p style="text-align: end;">e]f</p></div>',
         });
     });
 
-    test("should right align a node within a center-aligned node and a paragraph, with a right-aligned common ancestor", async () => {
+    test("should end align a node within a center-aligned node and a paragraph, with a right-aligned common ancestor", async () => {
         await testEditor({
             contentBefore:
                 '<div style="text-align: right;"><div style="text-align: center;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
-            stepFunction: alignRight,
+            stepFunction: alignEnd,
             contentAfter:
-                '<div style="text-align: right;"><div style="text-align: center;"><p>ab</p><p style="text-align: right;">c[d</p></div><p>e]f</p></div>',
+                '<div style="text-align: right;"><div style="text-align: center;"><p>ab</p><p style="text-align: end;">c[d</p></div><p style="text-align: end;">e]f</p></div>',
         });
     });
 
-    test("should not right align a node that is already within a right-aligned node", async () => {
+    test("should end align a node within a center-aligned node and a paragraph, with an end-aligned common ancestor", async () => {
         await testEditor({
-            contentBefore: '<div style="text-align: right;"><p>ab</p><p>c[d]e</p></div>',
-            stepFunction: alignRight,
-            contentAfter: '<div style="text-align: right;"><p>ab</p><p>c[d]e</p></div>',
+            contentBefore:
+                '<div style="text-align: end;"><div style="text-align: center;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: alignEnd,
+            contentAfter:
+                '<div style="text-align: end;"><div style="text-align: center;"><p>ab</p><p style="text-align: end;">c[d</p></div><p>e]f</p></div>',
         });
     });
 
-    test("should right align a container within an editable that is center-aligned", async () => {
+    test("should not end align a node that is already within an end-aligned node", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: end;"><p>ab</p><p>c[d]e</p></div>',
+            stepFunction: alignEnd,
+            contentAfter: '<div style="text-align: end;"><p>ab</p><p>c[d]e</p></div>',
+        });
+    });
+
+    test("should end align a container within an editable that is center-aligned", async () => {
         await testEditor({
             contentBefore:
                 '<div contenteditable="true" style="text-align: center;"><h1>a[]b</h1></div>',
-            stepFunction: alignRight,
+            stepFunction: alignEnd,
             contentAfter:
-                '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: right;">a[]b</h1></div>',
+                '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: end;">a[]b</h1></div>',
         });
     });
 });
@@ -289,12 +404,30 @@ describe("justify", () => {
         });
     });
 
+    test("should justify align a node within an end-aligned node", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: end;"><p>ab</p><p>c[d]e</p></div>',
+            stepFunction: justify,
+            contentAfter:
+                '<div style="text-align: end;"><p>ab</p><p style="text-align: justify;">c[d]e</p></div>',
+        });
+    });
+
     test("should justify align a node within a right-aligned node and a paragraph", async () => {
         await testEditor({
             contentBefore: '<div style="text-align: right;"><p>ab</p><p>c[d</p></div><p>e]f</p>',
             stepFunction: justify,
             contentAfter:
                 '<div style="text-align: right;"><p>ab</p><p style="text-align: justify;">c[d</p></div><p style="text-align: justify;">e]f</p>',
+        });
+    });
+
+    test("should justify align a node within an end-aligned node and a paragraph", async () => {
+        await testEditor({
+            contentBefore: '<div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p>',
+            stepFunction: justify,
+            contentAfter:
+                '<div style="text-align: end;"><p>ab</p><p style="text-align: justify;">c[d</p></div><p style="text-align: justify;">e]f</p>',
         });
     });
 
@@ -308,6 +441,16 @@ describe("justify", () => {
         });
     });
 
+    test("should justify align a node within an end-aligned node and a paragraph, with a center-aligned common ancestor", async () => {
+        await testEditor({
+            contentBefore:
+                '<div style="text-align: center;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: justify,
+            contentAfter:
+                '<div style="text-align: center;"><div style="text-align: end;"><p>ab</p><p style="text-align: justify;">c[d</p></div><p style="text-align: justify;">e]f</p></div>',
+        });
+    });
+
     test("should justify align a node within a right-aligned node and a paragraph, with a justify-aligned common ancestor", async () => {
         await testEditor({
             contentBefore:
@@ -315,6 +458,16 @@ describe("justify", () => {
             stepFunction: justify,
             contentAfter:
                 '<div style="text-align: justify;"><div style="text-align: right;"><p>ab</p><p style="text-align: justify;">c[d</p></div><p>e]f</p></div>',
+        });
+    });
+
+    test("should justify align a node within an end-aligned node and a paragraph, with a justify-aligned common ancestor", async () => {
+        await testEditor({
+            contentBefore:
+                '<div style="text-align: justify;"><div style="text-align: end;"><p>ab</p><p>c[d</p></div><p>e]f</p></div>',
+            stepFunction: justify,
+            contentAfter:
+                '<div style="text-align: justify;"><div style="text-align: end;"><p>ab</p><p style="text-align: justify;">c[d</p></div><p>e]f</p></div>',
         });
     });
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -492,7 +492,7 @@ test("toolbar works: show the correct text alignment", async () => {
     await click("button[name='text_align']");
     await contains(".o-we-toolbar-dropdown .btn.fa-align-right").click();
     expect(getContent(el)).toBe(
-        `<p style="text-align: right;">[test</p><p style="text-align: right;"><br>]</p>`
+        `<p style="text-align: end;">[test</p><p style="text-align: end;"><br>]</p>`
     );
     expect("button[name='text_align'] span").toHaveInnerHTML(`<i class="fa fa-align-right"> </i>`);
 });


### PR DESCRIPTION
[FIX] html_editor: use start and end in text alignment
Since [1] when text alignment was introduced on the toolbar, `left` and
`right` were used for `text-align` instead of `start` and `end`. This
causes issues in RTL languages, especially given that oriented icons are
already flipped according to the direction.

This commit uses start/end instead of left/right for text alignment.

Steps to reproduce:
- Set the user's language to Arabic
- Go to a "To do" note
- Change the text alingment to left or right

=> The icon in the toolbar showed the opposite

[1]: #191746

task-5155800

[FIX] html_editor: force RTL right alignment of URL in link popover
When using a right-to-left language, the URL field inside the link
popover behaves a bit strangely because some characters are interpreted
as RTL while some other are not.

This commit forces that URL field to be fully LTR but right-aligned,
when used in RTL.

Steps to reproduce:
- Set the user's language to Arabic
- Open the link popup
- Type "http://"

=> "//:http" was displayed

task-5155800

[FIX] html_editor: align checklist items with other list items in RTL
When using a right-to-left language, the checklist items are misaligned
because of a right padding.

This commit removes that padding to realign all types of list items.

Steps to reproduce:
- Set the user's language to Arabic
- Go to a "To do" node
- Insert a numbered list with some elements
- Insert a bulletted list with some elements
- Insert a checklist with some elements

=> The checklist elements were not aligned with the elements of the
other lists

task-5155800

[FIX] html_editor: force syntax highlighting to LTR
When using an LTR language, highlighted source code becomes becomes
scrambled because only letter characters are displayed in LTR.

This commit forces the syntax highlighting to always be displayed in
LTR.

Steps to reproduce:
- Set the user language to Arabic
- Go to a "To do" note
- Add a code block with `/code`
- Paste some actual code from a javascript file
- Select Javascript as language

=> The code characters like parentheses and brackets were not written
sequentially anymore.

task-5155800

[FIX] html_editor: compute tab width also for RTL
In RTL, the order of elements in the DOM compared to the order on screen
can be "surprising" depending on the kinds of characters used inside
text nodes. Because of this, the computation of tab width is incorrect
when using RTL: each tab's width should be calculated after "previous"
tabs have been adjusted.

This commit sorts the tabs before adjusting their widths, as often as
needed - because this might actually impact their sort order. To be
safe, it won't sort more often than the number of tabs to sort.
It also takes into account the correct side of rectangles depending on
whether we are inside an RTL block or not.

Steps to reproduce:
- Set the user language to arabic
- Go to a "To do" note
- Type some text and use the tab key

=> Tab positions were erratic

task-5155800