### PR TITLE
[FIX] l10n_it_edi: use sudo() for proxy user search

### DIFF
--- a/addons/l10n_it_edi/models/res_config_settings.py
+++ b/addons/l10n_it_edi/models/res_config_settings.py
@@ -41,7 +41,7 @@ class ResConfigSettings(models.TransientModel):
         for config in self:
             company = config.company_id._l10n_it_get_edi_company()
             company.l10n_it_edi_register = config.l10n_it_edi_register
-            proxy_user = self.env['account_edi_proxy_client.user'].search([
+            proxy_user = self.env['account_edi_proxy_client.user'].sudo().search([
                 ('company_id', '=', company.id),
                 ('proxy_type', '=', 'l10n_it_edi'),
                 ('edi_mode', '!=', 'demo'),  # make sure it's a "real" proxy_user (edi_mode is 'test' or 'prod')
@@ -57,12 +57,12 @@ class ResConfigSettings(models.TransientModel):
 
             if proxy_user:
                 # Delete any previously created demo proxy user
-                self.env['account_edi_proxy_client.user'].search([
+                self.env['account_edi_proxy_client.user'].sudo().search([
                     ('company_id', '=', company.id),
                     ('proxy_type', '=', 'l10n_it_edi'),
                     ('edi_mode', '=', 'demo'),
                     ('id', '!=', proxy_user.id),
-                ]).sudo().unlink()
+                ]).unlink()
 
     @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
     def _compute_use_root_proxy_user(self):


### PR DESCRIPTION
Fix issue when saving a branch company sharing the same VAT and Codice Fiscale as its parent. The proxy user search fails because `account_edi_proxy_client.user` is looked up in the branch company instead of the parent one. The same applies when searching the demo user to remove.

Steps to reproduce:
- Install `account` and `l10n_it_edi`
- Set up the company's VAT and Codice Fiscale
- Create a branch company with the same VAT and Codice Fiscale
- Enable the Electronic Invoicing processing through the SDI in the settings
- Select only the branch company and try to save the settings
- Observe error since we will try to create a proxy user on the IAP server for an already existing company (the parent one).

Ticket [link](https://www.odoo.com/odoo/project.task/5391668)
opw-5391668