### PR TITLE
[FIX] website_event_booth: guide existing partners to sign in or sign up

### DIFF
--- a/addons/website_event_booth/static/src/js/booth_register.js
+++ b/addons/website_event_booth/static/src/js/booth_register.js
@@ -134,7 +134,7 @@ publicWidget.registry.boothRegistration = publicWidget.Widget.extend({
         }
 
         if (errors.includes('existingPartnerError')) {
-            errorMessages.push(_t("It looks like your email is linked to an existing account."));
+            errorMessages.push(_t("It looks like your email is already in our system."));
             if (errorSigninEl) {
                 errorSigninEl.classList.remove('d-none');
             }

--- a/addons/website_event_booth/views/event_booth_registration_templates.xml
+++ b/addons/website_event_booth/views/event_booth_registration_templates.xml
@@ -57,7 +57,7 @@
                     <span class="o_wbooth_registration_error_message"/>
                     <a class="o_wbooth_registration_error_signin d-none"
                         t-attf-href="/web/login?redirect={{redirect_url}}">
-                        Please Sign In.
+                        Please Sign In or Create an Account.
                     </a>
                 </div>
                 <div class="row pt24 pb48">


### PR DESCRIPTION
When booking with an email that belongs to an existing partner, a 'Sign in' link is shown to the booker. If the partner has no portal access, then it is not relevant as they could also need to create an account. Therefore, change the wording by adding 'or create an account'. This way, the use of the login page redirection is more complete.

opw-5419532