### PR TITLE
[FIX] sale_project: unlink SO when no SO item is linked to a task

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -916,7 +916,7 @@ class ProjectTask(models.Model):
     @api.depends('sale_line_id', 'project_id', 'partner_id.commercial_partner_id', 'allow_billable')
     def _compute_sale_order_id(self):
         for task in self:
-            if not task.allow_billable:
+            if not (task.allow_billable and task.sale_line_id):
                 task.sale_order_id = False
                 continue
             sale_order = (


### PR DESCRIPTION
Currently, a task remains linked to its original sales order even when it has no sales order item. This prevents users to not bill a task and temporarily detach it from a sales order until it can be linked to a new one.

**Steps to produce:**
* Install Sales, Project
* Products > Virtual Home Staging > Create On Order > Project and Task
* Create and confirm quotation with that product.
* Tasks > Empty the Sale Order Item Field

**Observed Behavior:**
* Sale Order is still linked to the task despite sale order line has been unlinked from that task.

**Root cause:**
* Compute method [1] only detaches the sale order if the customer has been changed.

**Solution:**
* Only detach the sale order when there are no sale order items and the record
  is not a field service task.
* Field service tasks should always keep the sale order linked so materials can
  still be added to the existing sale order, even when the task is non-billable
  (i.e., no sale order line is linked). This logic is handled by the compute
  override at [2], which reassigns the sale order when needed.

[1]:
https://github.com/odoo/odoo/blob/3f4e45ecaca46a98c904536658728a1f1571bdbd/addons/sale_project/models/project.py#L916-L935
[2]:
https://github.com/odoo/enterprise/blob/6658581828dcdc43ffc5823814a05cb936cd0500/industry_fsm_sale/models/project_task.py#L178-L194

Related Enterprise PR: https://github.com/odoo/enterprise/pull/103487

opw-5215989