### PR TITLE
[FIX] hr_holidays: Incorrect Display of allocated days

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -378,10 +378,9 @@ class HrLeaveType(models.Model):
         if not self.requested_display_name():
             # leave counts is based on employee_id, would be inaccurate if not based on correct employee
             return super()._compute_display_name()
-        # use sudo() to get the correct remaining leaves
-        for record in self.sudo():
+        for record in self:
             name = record.name
-            if record.requires_allocation:
+            if record.requires_allocation and self.env.context.get('default_date_from'):
                 remaining_time = float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0
                 maximum = float_round(record.max_leaves, precision_digits=2) or 0.0
 

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -322,8 +322,12 @@ class TestAllocations(TestHrHolidaysCommon):
         shown correctly in the dropdown menu or not
         :return:
         """
+        self.env.user.write({
+            'company_ids': [(4, self.employee.company_id.id)]
+        })
+
         leave_type = self.env.ref('hr_holidays.leave_type_compensatory_days')
-        allocation = self.env['hr.leave.allocation'].sudo().create({
+        allocation = self.env['hr.leave.allocation'].create({
             'name': 'Alloc',
             'employee_id': self.employee.id,
             'holiday_status_id': leave_type.id,
@@ -334,7 +338,7 @@ class TestAllocations(TestHrHolidaysCommon):
         })
         allocation.action_approve()
 
-        second_allocation = self.env['hr.leave.allocation'].sudo().create({
+        second_allocation = self.env['hr.leave.allocation'].create({
             'name': 'Alloc2',
             'employee_id': self.employee.id,
             'holiday_status_id': leave_type.id,
@@ -347,7 +351,7 @@ class TestAllocations(TestHrHolidaysCommon):
 
         # _compute_leaves depends on the context that is getting cleared
         self.env['hr.leave.type'].invalidate_model(['max_leaves', 'leaves_taken', 'virtual_remaining_leaves'])
-        result = self.env['hr.leave.type'].with_context(
+        result = self.env['hr.leave.type'].with_company(self.employee.company_id).with_context(
             employee_id=self.employee.id,
             leave_date_from='2024-08-18 06:00:00',  # for _compute_leaves
             default_date_from='2024-08-18 06:00:00',


### PR DESCRIPTION
Bug:

      - Create a new employee (also reproducible with existing employees)

      - Create a Paid Time Off allocation that becomes available in the future

      - Create a Time Off request for this employee at a future date

      - When selecting the Time Off type, it shows “0 remaining out of 0 days” even though leave has been allocated

Reason:
In `_compute_display_name`, the record is accessed using `self.sudo().` Switching to superuser triggers `_compute_leaves`, but the context is lost and therefore the `target_date` is lost as well.
In `get_allocation_data`, because target_date is False, it is replaced with today’s date. This causes `max_leaves` and `virtual_remaining_leaves` to be computed as of today instead of the intended future date.

Fix:
Remove the `sudo() `and use the current user context instead.

-------------------------------------------------------------------------------
Test fix: `test_allocation_dropdown_after_period`

Bug:
After removing `sudo() `from `_compute_display_name`, the test fails and shows “0 remaining out of 0” instead of “9 remaining out of 9”.

Reason:
The test user (Admin) did not have the employee’s company in their allowed companies.
The `name_search` method triggers `_compute_display_name`, which triggers the computation of virtual_remaining_leaves.

Before the fix, `_compute_display_name` used `sudo()`, which propagated superuser privileges down to `_compute_leaves` and `get_allocation_data`. This masked the fact that the test user did not have access to the employee’s company (multi-company rule).

After removing `sudo(),` the user no longer had access to the allocation when running `name_search`, causing the test to fail.

Fix:
Add the employee’s company to the user’s company_ids. This allows allocations and `name_search` to work correctly without using `sudo().`

-----------------------------------------------------------------------
Known limitation:
When booking time off from the employee calendar view, the default value of `holiday_status_id` in the Time Off request widget still calculates remaining days based on today’s date instead of date_from.

To avoid confusion, the display name does not include “(x days remaining out of y days)” in this context.
However, when opening the selection dropdown, the display name is correct and uses the proper date-based calculation.