### PR TITLE
[FIX] base: make BIC searchable in bank list view

### DIFF
--- a/doc/cla/individual/muhammadtalha57.md
+++ b/doc/cla/individual/muhammadtalha57.md
@@ -1,0 +1,11 @@
+Pakistan, 2025-12-26
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Muhammad Talha muhammadtalha.mailme@gmail.com https://github.com/MuhammadTalha57

--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -53,6 +53,7 @@
             <field name="arch" type="xml">
                 <search string="Search Bank">
                     <field name="name"/>
+                    <field name="bic"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                 </search>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Fixes #241247

The BIC (Bank Identifier Code) field cannot be found when searching in the bank records list view. Users reported that searching by BIC returns no results, even though the records have BIC values stored in the database.

This creates an inconsistent user experience because:
- BIC is searchable in Many2one dropdowns (via `_rec_names_search = ['name', 'bic']`)
- BIC has custom search logic implemented in `_search_display_name` method
- BIC field is indexed (`index=True`) indicating it's meant to be searchable
- But BIC is not searchable in the main list view search box

**Current behavior before PR:**

When users navigate to the Banks list view and search using a BIC code (e.g., "CHASUS33"), no results are returned. The search only works with the bank name field, making it impossible to find banks by their BIC code from the list view.

**Desired behavior after PR is merged:**

Users can search for banks using their BIC code from the list view search box. Searching for "CHASUS33" will return "Chase Bank - CHASUS33" and any other banks with matching BIC codes. This aligns the list view search behavior with Many2one dropdown searches and makes full use of the indexed BIC field.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
