### PR TITLE
[IMP] web: Inner filter support in search view

### DIFF
--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -53,7 +53,7 @@ export class SearchBarMenu extends Component {
     // Filter Panel
     get filterItems() {
         return this.env.searchModel.getSearchItems((searchItem) =>
-            ["filter", "dateFilter"].includes(searchItem.type)
+            ["filter", "dateFilter", "parentFilter"].includes(searchItem.type)
         );
     }
 
@@ -68,7 +68,7 @@ export class SearchBarMenu extends Component {
      */
     onFilterSelected({ itemId, optionId }) {
         if (optionId) {
-            this.env.searchModel.toggleDateFilter(itemId, optionId);
+            this.env.searchModel.toggleParentFilter(itemId, optionId);
         } else {
             this.env.searchModel.toggleSearchItem(itemId);
         }

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -854,6 +854,7 @@ export class SearchModel extends EventBus {
         switch (searchItem.type) {
             case "dateFilter":
             case "dateGroupBy":
+            case "parentFilter":
             case "field_property":
             case "field": {
                 return;
@@ -877,9 +878,9 @@ export class SearchModel extends EventBus {
      * This can impact the query in various form, e.g. add/remove other query elements
      * in case the filter is of type 'filter'.
      */
-    toggleDateFilter(searchItemId, generatorId) {
+    toggleParentFilter(searchItemId, generatorId) {
         const searchItem = this.searchItems[searchItemId];
-        if (searchItem.type !== "dateFilter") {
+        if (searchItem.type !== "dateFilter" && searchItem.type !== "parentFilter") {
             return;
         }
         const generatorIds = generatorId ? [generatorId] : searchItem.defaultGeneratorIds;
@@ -1168,8 +1169,8 @@ export class SearchModel extends EventBus {
                 .filter((f) => f.isDefault && f.type !== "favorite")
                 .sort((f1, f2) => (f1.defaultRank || 100) - (f2.defaultRank || 100))
                 .forEach((f) => {
-                    if (f.type === "dateFilter") {
-                        this.toggleDateFilter(f.id);
+                    if (f.type === "dateFilter" || f.type === "parentFilter") {
+                        this.toggleParentFilter(f.id);
                     } else if (f.type === "dateGroupBy") {
                         this.toggleDateGroupBy(f.id);
                     } else if (f.type === "field") {
@@ -1376,6 +1377,12 @@ export class SearchModel extends EventBus {
                     queryElements.map((queryElem) => queryElem.intervalId)
                 );
                 break;
+            case "parentFilter":
+                enrichSearchItem.options = _enrichOptions(
+                    searchItem.optionsParams.customOptions,
+                    queryElements.map((queryElem) => queryElem.generatorId)
+                );
+                break;
             case "field":
             case "field_property":
                 enrichSearchItem.autocompleteValues = queryElements.map(
@@ -1559,11 +1566,20 @@ export class SearchModel extends EventBus {
 
     /**
      * Compute the string representation or the description of the current domain associated
-     * with a date filter starting from its corresponding query elements.
+     * with a parent filter (such as a date filter) starting from its corresponding query elements.
      */
-    _getDateFilterDomain(dateFilter, generatorIds, key = "domain") {
-        const dateFilterRange = constructDateDomain(this.referenceMoment, dateFilter, generatorIds);
-        return dateFilterRange[key];
+    _getParentFilterDomain(searchItem, generatorIds, key = "domain") {
+        if (searchItem.type === "dateFilter") {
+            const dateFilterRange = constructDateDomain(
+                this.referenceMoment,
+                searchItem,
+                generatorIds
+            );
+            return dateFilterRange[key];
+        }
+        return searchItem.optionsParams.customOptions
+            .filter((item) => generatorIds.includes(item.id))
+            .map((o) => o[key])[0];
     }
 
     /**
@@ -1667,15 +1683,15 @@ export class SearchModel extends EventBus {
                         }
                         break;
                     }
-                    case "dateFilter": {
+                    case "dateFilter":
+                    case "parentFilter": {
                         type = "filter";
-                        const periodDescription = this._getDateFilterDomain(
+                        const innerFilterDescription = this._getParentFilterDomain(
                             searchItem,
                             activeItem.generatorIds,
                             "description"
                         );
-                        values.push(`${searchItem.description}: ${periodDescription}`);
-
+                        values.push(`${searchItem.description}: ${innerFilterDescription}`);
                         break;
                     }
                     default: {
@@ -2097,8 +2113,9 @@ export class SearchModel extends EventBus {
             case "field": {
                 return this._getFieldDomain(searchItem, activeItem.autocompleteValues);
             }
-            case "dateFilter": {
-                return this._getDateFilterDomain(searchItem, activeItem.generatorIds);
+            case "dateFilter":
+            case "parentFilter": {
+                return this._getParentFilterDomain(searchItem, activeItem.generatorIds);
             }
             case "filter":
             case "favorite": {

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -361,11 +361,9 @@
         <rng:element name="filter">
             <rng:ref name="overload"/>
             <rng:ref name="access_rights"/>
-            <rng:attribute name="name"/>
             <rng:optional><rng:attribute name="icon"/></rng:optional>
             <rng:optional><rng:attribute name="invisible"/></rng:optional>
             <rng:optional><rng:attribute name="separator" /></rng:optional>
-            <rng:optional><rng:attribute name="string" /></rng:optional>
             <rng:optional><rng:attribute name="type" /></rng:optional>
             <rng:optional><rng:attribute name="align" /></rng:optional>
             <rng:optional><rng:attribute name="colspan"/></rng:optional>
@@ -379,17 +377,32 @@
             <rng:optional><rng:attribute name="start_year"/></rng:optional>
             <rng:optional><rng:attribute name="end_year"/></rng:optional>
             <rng:optional><rng:attribute name="default_period"/></rng:optional>
-            <rng:zeroOrMore>
-                <rng:choice>
-                    <rng:ref name="field" />
-                    <rng:ref name="xpath" />
-                    <rng:ref name="separator"/>
-                    <rng:ref name="button"/>
-                    <rng:ref name="filter"/>
-                    <rng:ref name="html"/>
-                    <rng:element name="newline"><rng:empty/></rng:element>
-                </rng:choice>
-            </rng:zeroOrMore>
+            <rng:choice>
+                <!-- Standard Filter with a mandatory 'name' attribute -->
+                <rng:group>
+                    <rng:attribute name="name"/>
+                    <rng:optional><rng:attribute name="string" /></rng:optional>
+                    <rng:zeroOrMore>
+                        <rng:choice>
+                            <rng:ref name="field" />
+                            <rng:ref name="xpath" />
+                            <rng:ref name="separator"/>
+                            <rng:ref name="button"/>
+                            <rng:ref name="filter"/>
+                            <rng:ref name="html"/>
+                            <rng:element name="newline"><rng:empty/></rng:element>
+                        </rng:choice>
+                    </rng:zeroOrMore>
+                </rng:group>
+                <!-- Parent and inner filters with mandatory 'string' attribute -->
+                <!-- Supported in Search View -->
+                <rng:group>
+                    <rng:attribute name="string"/>
+                    <rng:oneOrMore>
+                        <rng:ref name="filter"/>
+                    </rng:oneOrMore>
+                </rng:group>
+            </rng:choice>
 
         </rng:element>
     </rng:define>


### PR DESCRIPTION
In some search views the list of filters can be huge which impairs the
readability.

This commit adds support for inner filters in `<search/>` allowing them
to be collapsed into a parent filter, reducing the number of visible
entries in the search view.

The logic for date filters was partially merged with the one for inner
filters since the syntax is the same.

It can be used inside a search arch as such:
```xml
<search>
    <filter string="Priority">
        <filter string="Urgent" domain="[('priority', '=', 3)]" name="urgent_priority"/>
        <filter string="High" domain="[('priority', '=', 2)]" name="high_priority"/>
        <filter string="Medium " domain="[('priority', '=', 1)]" name="medium_priority"/>
        <filter string="Low" domain="[('priority', '=', 0)]" name="low_priority"/>
    </filter>
</search>
```

task-5232012