### PR TITLE
[IMP] hw_drivers: normalise logs around actions

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -43,9 +43,10 @@ class DriverController(http.Controller):
 
         iot_device.data['owner'] = session_id
         data = json.loads(data)
-
-        _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
+        start_operation_time = time.perf_counter()
+        _logger.info("Longpolling: calling action %s for device %s", data.get('action', ''), device_identifier)
         iot_device.action(data)
+        _logger.info("device '%s' action finished - %.*f", device_identifier, 3, time.perf_counter() - start_operation_time)
         return True
 
     @route.iot_route('/hw_drivers/check_certificate', type='http', cors='*', csrf=False)

--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -72,7 +72,7 @@ def on_message(ws, messages):
                     device_identifier = device['identifier']
                     if device_identifier in main.iot_devices:
                         start_operation_time = time.perf_counter()
-                        _logger.info("device '%s' action started", device_identifier)
+                        _logger.info("websocket: device '%s' action started", device_identifier)
                         main.iot_devices[device_identifier].action(payload)
                         _logger.info("device '%s' action finished - %.*f", device_identifier, 3, time.perf_counter() - start_operation_time)
             else:


### PR DESCRIPTION
Currently we only log actions done through the websocket connection in info level. This PR adds the same for longpolling controller and adds the performance time check around the actions

Added in sas-18.3 as only longpolling for pos is possible before that
