### PR TITLE
[FIX] account,point_of_sale: fix refund invoice

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -72,6 +72,18 @@ class AccountMove(models.Model):
                             'pos_payment_name': pos_payment.payment_method_id.name,
                         })
 
+    def _reconciliation_vals_has_payment_or_st_line(self, reconciliation_vals):
+        return super()._reconciliation_vals_has_payment_or_st_line(reconciliation_vals) or any(x['has_pos_payment'] for x in reconciliation_vals)
+
+    def _from_payment(self, source_field, counterpart_field):
+        pos_from = """LEFT JOIN pos_payment pp ON pp.account_move_id = counterpart_move.id"""
+        return super()._from_payment(source_field, counterpart_field) + pos_from
+
+    def _select_payment(self):
+        pos_select = """,
+            BOOL_OR(COALESCE(BOOL(pp.id), FALSE)) as has_pos_payment"""
+        return super()._select_payment() + pos_select
+
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1795,6 +1795,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         credit_notes = self.env['account.move'].search([('move_type', '=', 'out_refund')], order='id desc', limit=1)
         self.assertEqual(credit_notes.ref, "Reversal of: "+invoices.name)
         self.assertEqual(credit_notes.reversed_entry_id.id, invoices.id)
+        self.assertEqual(credit_notes.payment_state, 'paid')
 
     def test_order_total_subtotal_account_line_values(self):
         self.tax1 = self.env['account.tax'].create({


### PR DESCRIPTION
When invoicing a refund in the PoS the payment status would be 'reversed' when it should be 'paid'

Steps to reproduce:
-------------------
* Open PoS and make a sale
* Refund the order and invoice it when processing the payment
* Go to the backend and check the invoice status
> Observation: The payment status is 'Reversed'

Why the fix:
------------
When computing the payment status of an invoice we check if there are any payment linked to it. In the normal flow of an invoice we look for 'account.payment' records linked to the invoice. However in the PoS we create 'pos.payment' records linked to the invoice instead.

opw-5080947