### PR TITLE
[IMP] website: allow inserting snippets between form fields

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -82,6 +82,19 @@
     </button>
 </t>
 
+<t t-name="website.s_website_form_form_option_add_snippet_dropdown">
+    <Dropdown menuClass="'o-hb-select-dropdown'">
+        <button class="btn btn-success pe-2" t-att-title="props.tooltip">+ New</button>
+        <t t-set-slot="content">
+            <t t-foreach="this.snippets" t-as="snippet" t-key="snippet.name">
+                <DropdownItem onSelected="() => this.addField(snippet)">
+                    <t t-esc="snippet.name"/>
+                </DropdownItem>
+            </t>
+        </t>
+    </Dropdown>
+</t>
+
 <t t-name="website.s_website_form_field_option_redraw">
     <FormFieldOption redrawSequence="this.domState.redrawSequence" t-props="this.props"/>
 </t>

--- a/addons/website/static/src/builder/plugins/form/form_option_add_field_button.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_add_field_button.js
@@ -1,5 +1,33 @@
 import { useOperation } from "@html_builder/core/operation_plugin";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+
+const FORM_INNER_SNIPPETS = [
+    {
+        name: "Title",
+        id: "s_inline_text",
+        build: (el) => {
+            const span = document.createElement("span");
+            span.textContent = "Add a Section Title";
+            span.className = "h2-fs";
+            el.style.textAlign = "center";
+            el.replaceChildren(span);
+            return el;
+        },
+    },
+    {
+        name: "Text",
+        id: "s_inline_text",
+        build: (el) => {
+            el.style.textAlign = "center";
+            el.textContent =
+                "Add or adjust these fields to collect the information relevant to your needs.";
+            return el;
+        },
+    },
+    { name: "Separator", id: "s_hr" },
+];
 
 export class FormOptionAddFieldButton extends BaseOptionComponent {
     static template = "website.s_website_form_form_option_add_field_button";
@@ -15,6 +43,28 @@ export class FormOptionAddFieldButton extends BaseOptionComponent {
     addField() {
         this.callOperation(() => {
             this.props.addField(this.env.getEditingElement());
+        });
+    }
+}
+
+export class FormOptionAddContentDropdown extends BaseOptionComponent {
+    static template = "website.s_website_form_form_option_add_snippet_dropdown";
+    static components = {
+        DropdownItem,
+        Dropdown,
+    };
+    static props = {
+        addField: Function,
+        tooltip: String,
+    };
+
+    setup() {
+        this.callOperation = useOperation();
+        this.snippets = [{ name: "Field", id: "field" }, ...FORM_INNER_SNIPPETS];
+    }
+    addField(config) {
+        this.callOperation(() => {
+            this.props.addField(this.env.getEditingElement(), config);
         });
     }
 }

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -4,7 +4,10 @@ import { Cache } from "@web/core/utils/cache";
 import { Plugin } from "@html_editor/plugin";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { redirect } from "@web/core/utils/urls";
-import { FormOptionAddFieldButton } from "./form_option_add_field_button";
+import {
+    FormOptionAddFieldButton,
+    FormOptionAddContentDropdown,
+} from "./form_option_add_field_button";
 import {
     deleteConditionalVisibility,
     findCircular,
@@ -95,12 +98,12 @@ export class FormOptionPlugin extends Plugin {
                 },
             },
             {
-                Component: FormOptionAddFieldButton,
+                Component: FormOptionAddContentDropdown,
                 selector: ".s_website_form_field",
                 exclude: ".s_website_form_dnone",
                 props: {
-                    addField: (fieldEl) => this.addFieldAfterField(fieldEl),
-                    tooltip: _t("Add a new field after this one"),
+                    addField: (fieldEl, config) => this.addSnippetAfterField(fieldEl, config),
+                    tooltip: _t("Add some content after this field"),
                 },
             },
         ],
@@ -458,16 +461,33 @@ export class FormOptionPlugin extends Plugin {
         }
         this.dependencies.builderOptions.setNextTarget(fieldEl);
     }
-    addFieldAfterField(fieldEl) {
+    addSnippetAfterField(fieldEl, snippet) {
+        let newSnippetEl = null;
         const formEl = fieldEl.closest("form");
-        const field = getCustomField("char", _t("Custom Text"));
-        field.formatInfo = getFieldFormat(fieldEl);
-        field.formatInfo.requiredMark = isRequiredMark(formEl);
-        field.formatInfo.optionalMark = isOptionalMark(formEl);
-        field.formatInfo.mark = getMark(formEl);
-        const newFieldEl = renderField(field);
-        fieldEl.insertAdjacentElement("afterend", newFieldEl);
-        this.dependencies.builderOptions.setNextTarget(newFieldEl);
+        if (snippet.id === "field") {
+            const field = getCustomField("char", _t("Custom Text"));
+            field.formatInfo = getFieldFormat(fieldEl);
+            field.formatInfo.requiredMark = isRequiredMark(formEl);
+            field.formatInfo.optionalMark = isOptionalMark(formEl);
+            field.formatInfo.mark = getMark(formEl);
+            newSnippetEl = renderField(field);
+        } else {
+            newSnippetEl = document.createElement("div");
+            newSnippetEl.className = "col-lg-12";
+            const snippetConfig = this.config.snippetModel.getSnippetByName(
+                "snippet_content",
+                snippet.id
+            );
+            const defaultSnippetEl = snippetConfig.content.cloneNode(true);
+            newSnippetEl.appendChild(snippet.build?.(defaultSnippetEl) || defaultSnippetEl);
+        }
+        // WARNING: For now, inner snippets allowed between form fields
+        // do not need to be built. If additional blocks that require building
+        // are introduced in the future, make sure to handle them here as well,
+        // either via "on_snippet_dropped_handlers" or through a dedicated
+        // resource.
+        fieldEl.insertAdjacentElement("afterend", newSnippetEl);
+        this.dependencies.builderOptions.setNextTarget(newSnippetEl);
     }
     /**
      * To be used in load for any action that uses getActiveField or

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -149,7 +149,8 @@ test("undo redo add form field", async () => {
     expect(":iframe span.s_website_form_label_content").toHaveCount(1);
 
     await contains(":iframe span.s_website_form_label_content").click();
-    await contains("button[title='Add a new field after this one']").click();
+    await contains("button[title='Add some content after this field']").click();
+    await contains("span.o-dropdown-item:contains('Field')").click();
 
     expect(":iframe span.s_website_form_label_content").toHaveCount(2);
     undo(editor);

--- a/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
+++ b/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
@@ -13,6 +13,11 @@ function addNewField() {
             run: "click",
         },
         {
+            content: "Select the 'Field' option",
+            trigger: "span.o-dropdown-item:contains('Field')",
+            run: "click",
+        },
+        {
             content: "Wait until the new field type options are displayed",
             trigger: "[data-label='Type'] button:contains('text')",
         },


### PR DESCRIPTION
Currently, the "+ Field" button only supports adding a field after
the selected one, making it difficult to insert snippets in between.

This commit extends the feature to also allow inserting "Title", "Text",
and "Separator" snippets after a selected field.

task-5436870