### PR TITLE
[FIX] api_doc: prevent crash on missing model registry lookup

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -150,6 +150,7 @@ class DocController(http.Controller):
                 # sorted(..., key=partial(sort_key_method, modules, type(Model))),
             }
             for ir_model in self.env['ir.model'].sudo().search([])
+            if ir_model.model in self.env
             if (Model := self.env[ir_model.model]).has_access('read')
         ]
         return modules, models

--- a/addons/api_doc/tests/test_doc.py
+++ b/addons/api_doc/tests/test_doc.py
@@ -218,3 +218,20 @@ class TestDoc(HttpCaseWithUserDemo):
                     clean_doc(parse_signature(method).as_dict()),
                     clean_doc(method.expected),
                 )
+
+    def test_ghost_model_robustness(self):
+        """
+        Ensure the documentation generator does not crash when encountering
+        a model in the database (state='base') that is missing from the registry.
+        """
+
+        ghost_model_name = 'ir.min.cron.mixin.test.ghost'
+        self.env['ir.model'].create({
+            'model': ghost_model_name,
+            'name': 'Ghost Model',
+            'state': 'base',
+        })
+
+        self.authenticate('demo', 'demo')
+        res = self.url_open('/doc/index.json')
+        res.raise_for_status()


### PR DESCRIPTION
When accessing the API documentation endpoint (`/doc`), the server could crash with an Internal Server Error if the database contained ir.model records for models that are not loaded in the current registry.

Steps to reproduce:
1. Insert a record into `ir_model` with `model='ghost.model'` and `state='base'`.
2. Open `/doc`.
3. The server raises a `KeyError: 'ghost.model'`.

Root Cause:

The `/doc` endpoint iterates over all records in `ir.model`. For each record, it attempts to resolve the Python class using `self.env[ir_model.model]` to check access rights. If a model exists in the database with `state='base'`, Odoo expects it to be defined in the Python source code and does not generate it dynamically. If the corresponding Python class is missing (e.g., from an old module), it is never added to the registry, causing the lookup to fail with a `KeyError`.

opw-5401782