### PR TITLE
[FIX] point_of_sale: don't depend on translations in test

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -258,7 +258,7 @@ registry.category("web_tour.tours").add("test_add_money_button_with_different_de
     steps: () =>
         [
             Chrome.startPoS(),
-            Dialog.confirm("Ouvrir la caisse"),
+            Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Whiteboard Pen", "1"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3063,8 +3063,8 @@ class TestUi(TestPointOfSaleHttpCommon):
         Tests that the buttons such as +10 or +50 work even in languages such as
         french that have ',' as a decimal separator.
         """
-        self.env['res.lang']._activate_lang('fr_BE')
-        self.pos_user.write({'lang': 'fr_BE'})
+        lang = self.env['res.lang'].search([('code', '=', self.pos_user.lang)])
+        lang.write({'thousands_sep': '.', 'decimal_point': ','})
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_add_money_button_with_different_decimal_separator', login="pos_user")
 
     def test_consistent_order_receipt_number_offline(self):


### PR DESCRIPTION
In the tour added in this commit[^1], they switched the language to French to test `,` as a decimal separator. The test depends on a button label to click that was translated to French.

This is pretty brittle since translations can change, and also not necessary for what we need to test.

We just change the decimal separator on the current language in the test so the label can keep the source language. This is also done in other places in the tours.

(Issue found when translating saas-19.1)

[^1]: https://github.com/odoo/odoo/commit/c712835cf7fc364a50ad9797f933df148720e829