### PR TITLE
[FIX] Fix mentions of CPF/CNPJ in Portuguese translation

### DIFF
--- a/addons/portal/i18n/pt.po
+++ b/addons/portal/i18n/pt.po
@@ -149,7 +149,7 @@ msgid ""
 msgstr ""
 "<small class=\"form-text text-muted\">\n"
 "                            Não é permitido alterar o nome da empresa ou "
-"CNPJ quando há documentos relacionados à sua conta. Entre em contato conosco "
+"NIF quando há documentos relacionados à sua conta. Entre em contato connosco "
 "diretamente para esta operação..\n"
 "                        </small>"
 
@@ -162,7 +162,7 @@ msgid ""
 "                        </small>"
 msgstr ""
 "<small class=\"form-text text-muted\">\n"
-"                            O número de CNPJ só pode ser atualizado na conta "
+"                            O NIF só pode ser atualizado na conta "
 "da empresa.\n"
 "                        </small>"
 
@@ -1156,7 +1156,7 @@ msgstr "O anexo não existe ou você não tem direitos para acessá-lo."
 msgid ""
 "The company name and VAT number can only be updated on your main account."
 msgstr ""
-"O nome da empresa e o número de CNPJ só podem ser atualizados em sua conta "
+"O nome da empresa e o NIF só podem ser atualizados na sua conta "
 "principal."
 
 #. module: portal
@@ -1276,7 +1276,7 @@ msgstr "Utilizadores"
 #. odoo-python
 #: code:addons/portal/controllers/portal.py:0
 msgid "VAT"
-msgstr "CPF/CNPJ"
+msgstr "NIF"
 
 #. module: portal
 #: model:ir.model.fields.selection,name:portal.selection__portal_wizard_user__email_state__ok


### PR DESCRIPTION
CPF/CNPJ does not exist in the Portuguese Fiscal system, they are all NIF.