### PR TITLE
[FIX] mrp_subcontracting: skip consumption warning if writing move qty

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -104,7 +104,7 @@ class StockMove(models.Model):
                 production.qty_producing = 1
                 if not production.lot_producing_id:
                     production.action_generate_serial()
-                production.with_context(cancel_backorder=False).subcontracting_record_component()
+                production.with_context(cancel_backorder=False, skip_consumption=True).subcontracting_record_component()
         else:
             production.qty_producing = qty
             if float_compare(production.qty_producing, production.product_qty, precision_rounding=production.product_uom_id.rounding) > 0:
@@ -115,7 +115,7 @@ class StockMove(models.Model):
             if production.product_tracking == 'lot' and not production.lot_producing_id:
                 production.action_generate_serial()
             production._set_qty_producing()
-            production.with_context(cancel_backorder=False).subcontracting_record_component()
+            production.with_context(cancel_backorder=False, skip_consumption=True).subcontracting_record_component()
 
     def copy(self, default=None):
         self.ensure_one()


### PR DESCRIPTION
**Problem:**
When recording the received quantity of a subcontracted product on the move_ids, if it is higher than the original demand, Odoo will update the consumed quantities. Since the new consumption is not based on the BoM, a consumption warning can happen due to UoM rounding. However, wizards and other actions can't trigger in this context, so instead of blocking the action, it partially completes, putting both the picking and the subcontracting order in an inconsistent state. If the picking is validated, this causes the subcontracting order to only process for the original demand and create a backorder, but the move_ids report the full demand, and its move_line_ids report the original demand.

**Steps to Reproduce:**
- Create a product (default settings)
- Create a BoM for it via smart button, set the quantity to 12
- Add a component (new product w/default settings), 1 Unit
- Set the BoM Type to Subcontracting, set Azure Interior as the subcontractor
- Create a PO for Azure Interior, ordering 5 units of the product, and confirm it
- Go to the delivery, set the received QTY to 6, and validate
 
-> Check "Moves" smart button to see only 5 units of product were produced

**Solution:**
Since the consumption wizard can't be called in the context of _set_quantity(), we skip the consumption warning. The picking and subcontracting order will be processed correctly, but this comes with the limitation that the user will not receive a consumption warning when recording the consumption this way.

opw-5168417