### PR TITLE
[FIX] base_import: clear nextrow on import completion

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -430,6 +430,7 @@ export class BaseImportModel {
             importRes.nextrow = nextrow;
         } else {
             // Falsy `nextrow` signals there's nothing left to import
+            importRes.nextrow = 0;
             this.stopImport();
         }
         return false;


### PR DESCRIPTION
When importing a large file in multiple batches , Odoo incorrectly displays a "Resume" prompt at the end of the process, even though all records have been successfully imported.

Steps to reproduce:

1. Create a CSV file with enough records to trigger at least 2 batches
2. Go to any list view and select "Import records".
3. Upload the file and click "Import".
4. Wait for the import to complete.
5. Observe that despite an "X records successfully imported" notification, a warning "Click 'Resume' to proceed..." appears.

The issue occurs because the `importRes.nextrow` state variable is updated during intermediate batches but is not cleared when the final batch completes.

* In `_executeImportStep`, if `nextrow` is returned (intermediate batch), `importRes.nextrow` is updated.
* If `nextrow` is falsy (final batch), the loop is stopped, but `importRes.nextrow` retains the value from the previous batch.
* `executeImport` checks `importRes.nextrow` to decide whether to show the `"Resume"` message, leading to a false positive caused by the stale value.

This commit fixes the issue by explicitly setting `importRes.nextrow` to `0` in `_executeImportStep` when the server indicates completion (returns a falsy `nextrow`).

opw-5343837