### PR TITLE
[FIX] l10n_vn_edi_viettel: fix items name & unit

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -692,9 +692,9 @@ class AccountMove(models.Model):
             # For credit notes amount, we send negative values (reduces the amount of the original invoice)
             sign = 1 if self.move_type == 'out_invoice' else -1
             item_information = {
-                'itemCode': line.product_id.code,
-                'itemName': line.product_id.name,
-                'unitName': line.product_uom_id.name,
+                'itemCode': line.product_id.code or '',
+                'itemName': line.name,
+                'unitName': line.product_uom_id.name or 'Units',
                 'unitPrice': line.price_unit * sign,
                 'quantity': line.quantity,
                 # This amount should be without discount applied.

--- a/addons/l10n_vn_edi_viettel/tests/test_edi.py
+++ b/addons/l10n_vn_edi_viettel/tests/test_edi.py
@@ -133,7 +133,7 @@ class TestVNEDI(AccountTestInvoicingCommon):
                 'payments': [{'paymentMethodName': 'TM/CK'}],
                 'itemInfo': [{
                     'itemCode': 'BN/1035',
-                    'itemName': 'product_a',
+                    'itemName': '[BN/1035] product_a',
                     'unitName': 'Units',
                     'unitPrice': 1000.0,
                     'quantity': 1.0,
@@ -149,6 +149,76 @@ class TestVNEDI(AccountTestInvoicingCommon):
                     'taxPercentage': 10.0,
                     'taxableAmount': 1000.0,
                     'taxAmount': 100.0,
+                    'taxableAmountPos': True,
+                    'taxAmountPos': True
+                }]
+            }
+        )
+
+    @freeze_time('2024-01-01')
+    def test_json_data_generation_no_product(self):
+        """ Test the data dict generated to ensure consistency with the data we set in the system. """
+        invoice = self.init_invoice(
+            move_type='out_invoice',
+            amounts=[250],
+            taxes=self.tax_sale_a,
+            post=True,
+        )
+        self.assertDictEqual(
+            invoice._l10n_vn_edi_generate_invoice_json(),
+            {
+                'generalInvoiceInfo': {
+                    'transactionUuid': mock.ANY,  # Random, not important.
+                    'invoiceType': '1',
+                    'templateCode': '1/001',
+                    'invoiceSeries': 'K24TUT',
+                    'invoiceIssuedDate': 1704067200000,
+                    'currencyCode': 'VND',
+                    'adjustmentType': '1',
+                    'paymentStatus': False,
+                    'cusGetInvoiceRight': True,
+                    'validation': 1,
+                },
+                'buyerInfo': {
+                    'buyerName': 'partner_a',
+                    'buyerLegalName': 'partner_a',
+                    'buyerTaxCode': '0100109106-505',
+                    'buyerAddressLine': '121 Hang Bac Street',
+                    'buyerPhoneNumber': '38257670',
+                    'buyerEmail': 'partner_a@gmail.com',
+                    'buyerCityName': 'Hà Nội',
+                    'buyerCountryCode': 'VN',
+                    'buyerNotGetInvoice': 0,
+                },
+                'sellerInfo': {
+                    'sellerLegalName': 'company_1_data',
+                    'sellerTaxCode': '0100109106-506',
+                    'sellerAddressLine': '3 Alley 45 Phan Dinh Phung, Quan Thanh Ward',
+                    'sellerPhoneNumber': '62661275',
+                    'sellerEmail': 'test_company@gmail.com',
+                    'sellerDistrictName': 'Hà Nội',
+                    'sellerCountryCode': 'VN',
+                    'sellerWebsite': 'http://test_company.com',
+                },
+                'payments': [{'paymentMethodName': 'TM/CK'}],
+                'itemInfo': [{
+                    'itemCode': '',
+                    'itemName': 'test line',
+                    'unitName': 'Units',
+                    'unitPrice': 250.0,
+                    'quantity': 1.0,
+                    'itemTotalAmountWithoutTax': 250.0,
+                    'taxPercentage': 10.0,
+                    'taxAmount': 25.0,
+                    'discount': 0.0,
+                    'itemTotalAmountAfterDiscount': 250.0,
+                    'itemTotalAmountWithTax': 275.0,
+                    'selection': 1,
+                }],
+                'taxBreakdowns': [{
+                    'taxPercentage': 10.0,
+                    'taxableAmount': 250.0,
+                    'taxAmount': 25.0,
                     'taxableAmountPos': True,
                     'taxAmountPos': True
                 }]


### PR DESCRIPTION
Currently, the item name in the data sent to the SInvoice system is comprised only of the product name on the line. This brings a few issues that should be corrected:
- Any description set on the line on top of the product won't be sent
- If there is no product, the required item name will be set to False
- If there is no product, the required unit name will be set to False too

To fix these issues, we will:
- Use the line name directly and not the product name and;
- Default to 'Units' for the unit name in all cases where it wouldn't be set.

task-5438691

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
