### PR TITLE
[FIX] mail: close invite dialog after creating group chat

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -210,6 +210,7 @@ export class ChannelInvitation extends Component {
                 partnerIds.unshift(this.props.thread.correspondent.partner_id.id);
             }
             await this.store.startChat(partnerIds);
+            this.props.close?.();
             return;
         }
         const invitePromises = [];

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -137,9 +137,11 @@ test("should be able to create a new group chat from an existing chat", async ()
     await start();
     await openDiscuss(channelId);
     await click(".o-mail-DiscussContent-header button[title='Invite People']");
+    await contains(".o-discuss-ChannelInvitation");
     await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
     await click(".o-discuss-ChannelInvitation-selectable", { text: "TestPartner2" });
     await click("button[title='Create Group Chat']:enabled");
+    await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", {
         text: "Mitchell Admin, TestPartner, and TestPartner2",
     });


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

When creating a group chat from a Direct Message via the invite dialog, the invite dialog remained open after the group chat was created. This resulted in a confusing user experience.

**Current behavior before PR:**
---------------------------------

- The invite dialog stays open after creating a group chat

**Desired behavior after PR is merged:**
-----------------------------------------

- The invite dialog closes after creating the group chat
- No extra dialogs remain open

**Task:** 5440535

---
I confirm I have signed the CLA and read the PR guidelines at
https://www.odoo.com/submit-pr
