### PR TITLE
[FIX] hr_expense: prevent error on removing company

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -323,14 +323,15 @@ class HrExpense(models.Model):
                 ).ids
             )
         for expense in self:
-            if not expense.company_id:
-                # This would be happening when emptying the required company_id field, triggering the "onchange"s.
-                # This would lead to fields being set as editable, instead of using the env company,
-                # recomputing the interface just to be blocked when trying to save we choose not to recompute anything
-                # and wait for a proper company to be inputted.
-                continue
-            if expense.state not in {'draft', 'submitted', 'approved'} and not self.env.su:
-                # Not editable
+            if (
+                not expense.company_id
+                or (expense.state not in {'draft', 'submitted', 'approved'} and not self.env.su)
+            ):
+                # When emptying the required company_id field, onchanges are triggered.
+                # To avoid recomputing the interface without a company (which could
+                # temporarily make fields editable), we do not recompute anything and wait
+                # for a proper company to be set. The interface is also made not editable
+                # when the state is not draft/submitted/approved and the user is not a superuser.
                 expense.is_editable = False
                 continue
 

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1025,3 +1025,20 @@ class TestExpenses(TestExpenseCommon):
 
         # Check that there is no fourth autobalancing line on the account move
         self.assertEqual(expense.account_move_id.line_ids.mapped('balance'), [86.96, 13.04, -100.0])
+
+    def test_remove_company_id_from_hr_expense(self):
+        expense = self.create_expenses({
+                'name': 'Company PC 1000 + 15%',
+                'employee_id': self.expense_employee.id,
+                'product_id': self.product_c.id,
+                'total_amount_currency': 1000.00,
+                'date': '2021-10-12',
+                'payment_mode': 'company_account',
+                'company_id': self.company_data['company'].id,
+                'tax_ids': [Command.set(self.tax_purchase_a.ids)],
+            })
+        form = Form(expense)
+        form.company_id = self.env['res.company']
+        self.assertEqual(form.is_editable, False)
+        form.company_id = self.env.company
+        self.assertEqual(form.is_editable, True)


### PR DESCRIPTION
Currently an error occurs when user tries to remove company on an expense.

Steps to replicate:
- Install `hr_expense` and create a new company. (make sure you have more than one company).
- Create new expense and remove the value from company field.

Error:
`ValueError: Compute method failed to assign hr.expense(<NewId origin=7>,).is_editable`

Cause:
- Removing the company triggers the [compute] that skips the loop if company is not assigned [1], which causes this error.

Solution:
- Assign `is_editable` as False when company is false.

[compute]: https://github.com/odoo/odoo/blob/43505c919e29065b04d4e9e0a66f38a13f42daed/addons/hr_expense/models/hr_expense.py#L304-L363

[1]: https://github.com/odoo/odoo/blob/43505c919e29065b04d4e9e0a66f38a13f42daed/addons/hr_expense/models/hr_expense.py#L326-L331

No ID

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
