### PR TITLE
[IMP] calendar: ensure partner calendar filters are created and loaded

### DIFF
--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -96,9 +96,11 @@ class ResPartner(models.Model):
         self.ensure_one()
         partner_ids = self.ids
         partner_ids.append(self.env.user.partner_id.id)
+        self.env['calendar.filters'].create_partner_calendar_filters(self.ids)
         action = self.env["ir.actions.actions"]._for_xml_id("calendar.action_calendar_event")
         action['context'] = {
             'default_partner_ids': partner_ids,
+            'calendar_filter_partner_ids': self.ids,
         }
         action['domain'] = ['|', ('id', 'in', self._compute_meeting()[self.id]), ('partner_ids', 'in', self.ids)]
         return action

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -72,6 +72,27 @@ export class AttendeeCalendarModel extends CalendarModel {
     }
 
     /**
+     * Load calendar filters using partner IDs from context.
+     * @override
+     */
+    fetchFilters(resModel, fieldNames) {
+        const partnerIds = this.meta.context.calendar_filter_partner_ids;
+        if (resModel !== "calendar.filters" || !partnerIds?.length) {
+            return super.fetchFilters(resModel, fieldNames);
+        }
+
+        const domain = [
+            ["user_id", "=", user.userId],
+            "|",
+            ["active", "=", true],
+            "&",
+            ["active", "=", false],
+            ["partner_id", "in", partnerIds],
+        ];
+        return this.orm.searchRead(resModel, domain, fieldNames);
+    }
+
+    /**
      * Load the filter section and add both 'user' and 'everybody' filters to the context.
      * @override
      */


### PR DESCRIPTION
Ensure that when opening the calendar view from a partner, all related meetings are visible.

Add a helper method to create the required `calendar.filters` and mark the relevant partners as checked.
Pass `calendar_filter_partner_ids` in the context to load only the partner-related filters and meetings,
without polluting the user's existing calendar filters.

Task-5249028

Related PR: https://github.com/odoo/enterprise/pull/99639