### PR TITLE
[FIX] mail: don't bump channel on notification message

### DIFF
--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -329,7 +329,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         member = channel.with_user(operator).self_member_id
         self.assertEqual(member.partner_id, operator.partner_id, "operator should be member of channel")
         self.assertFalse(member.is_pinned, "channel should not be pinned for operator initially")
-        channel.message_post(body="cc")
+        channel.message_post(body="cc", message_type="comment")
         self.assertTrue(member.is_pinned, "channel should be pinned for operator after visitor sent a message")
         self.authenticate(operator.login, self.password)
         data = self.make_jsonrpc_request("/mail/data", {"fetch_params": ["channels_as_member"]})
@@ -346,7 +346,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 ("partner_id", "in", self.operators.partner_id.ids),
             ]
         )
-        message = self.env["discuss.channel"].browse(data["channel_id"]).message_post(body="cc")
+        message = self.env["discuss.channel"].browse(data["channel_id"]).message_post(body="cc", message_type="comment")
         member_of_operator._mark_as_read(message.id)
         with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=1))):
             member_of_operator._gc_unpin_livechat_sessions()
@@ -363,7 +363,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 ("partner_id", "in", self.operators.partner_id.ids),
             ]
         )
-        self.env["discuss.channel"].browse(data["channel_id"]).message_post(body="cc")
+        self.env["discuss.channel"].browse(data["channel_id"]).message_post(body="cc", message_type="comment")
         with freeze_time(fields.Datetime.to_string(fields.Datetime.now() + timedelta(days=1))):
             member_of_operator._gc_unpin_livechat_sessions()
         self.assertTrue(member_of_operator.is_pinned, "unread channel should not be unpinned after autovacuum")

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -248,8 +248,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             rating = self.env["rating.rating"].sudo().search([], order="id desc", limit=1)
             return (
                 [
-                    # channel last interest (not asserted below)
-                    (self.env.cr.dbname, "discuss.channel", channel.id),
                     # unread counter/new message separator (not asserted below)
                     (self.env.cr.dbname, "res.partner", self.env.user.partner_id.id),
                     # new_message

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1003,8 +1003,9 @@ class DiscussChannel(models.Model):
         return partners.ids
 
     def message_post(self, *, message_type="notification", partner_ids=None, **kwargs):
-        # sudo: discuss.channel - write to discuss.channel is not accessible for most users
-        self.sudo().last_interest_dt = fields.Datetime.now()
+        if message_type not in ["notification", "user_notification"]:
+            # sudo: discuss.channel - write to discuss.channel is not accessible for most users
+            self.sudo().last_interest_dt = fields.Datetime.now()
         if "everyone" in kwargs.pop("special_mentions", []):
             partner_ids = list(OrderedSet((partner_ids or []) + self.channel_member_ids.partner_id.ids))
         if partner_ids:

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -67,20 +67,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                 [
                     (self.cr.dbname, "discuss.channel", test_group.id),
                     (self.cr.dbname, "res.partner", self.test_partner.id),
-                    (self.cr.dbname, "discuss.channel", test_group.id),
                     (self.cr.dbname, "res.partner", self.partner_employee.id),
                     (self.cr.dbname, "discuss.channel", test_group.id),
                     (self.cr.dbname, "discuss.channel", test_group.id),
                 ],
                 [
-                    {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [
-                                {"id": test_group.id, "last_interest_dt": "2020-03-22 10:42:06"},
-                            ],
-                        },
-                    },
                     {
                         "type": "discuss.channel/new_message",
                         "payload": {

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -178,11 +178,9 @@ class TestChannelRTC(MailCommon, HttpCase):
             [
                 # update new session
                 (self.cr.dbname, "discuss.channel", channel.id),
-                # message_post "started a live conference" (not asserted below)
-                (self.cr.dbname, "discuss.channel", channel.id),
                 # update new message separator
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update of last interest (not asserted below)
+                # message_post "started a live conference" (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # update call history (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
@@ -291,11 +289,9 @@ class TestChannelRTC(MailCommon, HttpCase):
             [
                 # update new session
                 (self.cr.dbname, "discuss.channel", channel.id),
-                # message_post "started a live conference" (not asserted below)
-                (self.cr.dbname, "discuss.channel", channel.id),
                 # update new message separator
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update of last interest (not asserted below)
+                # message_post "started a live conference" (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # update call history (not asserted below)
                 (self.cr.dbname, "discuss.channel", channel.id),
@@ -955,8 +951,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                 (self.cr.dbname, "discuss.channel", channel.id),
                 # discuss.channel/joined
                 (self.cr.dbname, "res.partner", test_user.partner_id.id),
-                # mail.record/insert - discuss.channel (last_interest_dt)
-                (self.cr.dbname, "discuss.channel", channel.id),
                 # mail.record/insert - discuss.channel.member (message_unread_counter, new_message_separator, …)
                 (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
                 # discuss.channel/new_message

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -249,7 +249,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 },
             )["channel_id"]
         )
-        self.channel_livechat_1.with_user(self.users[1]).message_post(body="test")
+        self.channel_livechat_1.with_user(self.users[1]).message_post(body="test", message_type="comment")
         # add conversation tags into livechat channels
         self.conversation_tag = self.env["im_livechat.conversation.tag"].create({"name": "Support", "color": 1})
         self.channel_livechat_1.livechat_conversation_tag_ids = [Command.link(self.conversation_tag.id)]
@@ -511,7 +511,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": "starred",
                     "model": "mail.box",
                 },
-                "initChannelsUnreadCounter": 2,
+                "initChannelsUnreadCounter": 3,
             },
         }
 
@@ -1198,7 +1198,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": member_0.id,
                 "livechat_member_type": "agent",
                 "last_interest_dt": member_0_last_interest_dt,
-                "message_unread_counter": 0,
+                "message_unread_counter": 1,
                 "message_unread_counter_bus_id": bus_last_id,
                 "mute_until_dt": False,
                 "last_seen_dt": member_0_last_seen_dt,
@@ -1464,7 +1464,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
                 "message_link_preview_ids": [],
-                "message_type": "notification",
+                "message_type": "comment",
                 "model": "discuss.channel",
                 "needaction": False,
                 "notification_ids": [],


### PR DESCRIPTION
Before this commit, a notification message would bump a channel on top of the channel list.
This happens because the update of `last_interest_dt` is done on the `message_post` method, which is called when posting notification messages.

This behaviour is unwanted as those messages are not considered important enough to bump the channel, and is inconsistent with other features such as push notifications and undread badge.

This commit fixes the issue by updating `last_interest_dt` on the actual "human" flow of posting a message.

task-5138777