### PR TITLE
[IMP] web: do not generate main in kanban articles

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -31,7 +31,8 @@ export class KanbanCompiler extends ViewCompiler {
     setup() {
         this.compilers.push(
             { selector: "t[t-call]", fn: this.compileTCall },
-            { selector: "img", fn: this.compileImage }
+            { selector: "img", fn: this.compileImage },
+            { selector: "main", fn: this.compileMain }
         );
     }
 
@@ -92,6 +93,19 @@ export class KanbanCompiler extends ViewCompiler {
         const element = el.cloneNode(true);
         element.setAttribute("loading", "lazy");
         return element;
+    }
+
+    /**
+     * @returns {Element}
+     */
+    compileMain(el, params) {
+        const compiled = createElement("div");
+
+        compiled.setAttribute("class", `o_record_main`);
+        for (const child of el.childNodes) {
+            append(compiled, this.compileNode(child, params));
+        }
+        return compiled;
     }
 
     /**

--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -53,7 +53,7 @@
     &:where(:not(.row)) {
         flex-flow: column;
 
-        main {
+        .o_record_main {
             flex-grow: 1;
         }
 
@@ -62,7 +62,7 @@
         }
     }
 
-    > main {
+    > .o_record_main {
         display: flex;
         flex-flow: column;
         min-width: 0;
@@ -73,7 +73,7 @@
         }
     }
 
-    > footer, > main > footer {
+    > footer, > .o_record_main > footer {
         display: flex;
         align-items: center;
         column-gap: var(--Card-Footer-gap, #{map-get($spacers, 2)});


### PR DESCRIPTION
For accessibility reasons, there should never be more than one `<main>` element in the document [1].
In kanban, we use the main tag in archs, and the kanban compiler leaves it as is in the compiled template. As a consequence, there's one `main` element inside each kanban card (see the Contact kanban view for instance).

This commit converts the `main` node in the kanban compiler into a `<div class="o_record_main"/>` and adapts the css and selectors accordingly.

[1]
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main

task-5423577