### PR TITLE
[IMP] l10n_in: invoice label as per section 31 of CGST Act

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -732,3 +732,22 @@ class AccountMove(models.Model):
         tax_tags_dict = self.env['account.move.line']._get_l10n_in_tax_tag_ids()
         # we set the section on the invoice lines
         moves.line_ids._set_l10n_in_gstr_section(tax_tags_dict)
+
+    def _get_l10n_in_invoice_label(self):
+        self.ensure_one()
+        exempt_types = {'exempt', 'nil_rated', 'non_gst'}
+        if self.country_code != 'IN' or not self.is_sale_document(include_receipts=False):
+            return
+        gst_treatment = self.l10n_in_gst_treatment
+        company = self.company_id
+        tax_types = set(self.invoice_line_ids.tax_ids.mapped('l10n_in_tax_type'))
+        if company.l10n_in_is_gst_registered and tax_types:
+            if gst_treatment in ['overseas', 'special_economic_zone']:
+                return 'Tax Invoice'
+            elif tax_types.issubset(exempt_types):
+                return 'Bill of Supply'
+            elif tax_types.isdisjoint(exempt_types):
+                return 'Tax Invoice'
+            elif gst_treatment in ['unregistered', 'consumer']:
+                return 'Invoice-cum-Bill of Supply'
+        return 'Invoice'

--- a/addons/l10n_in/tests/__init__.py
+++ b/addons/l10n_in/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_l10n_in_fiscal_position
 from . import test_check_status
 from . import test_tds_tcs_alert
 from . import test_gstr_section
+from . import test_invoice_label

--- a/addons/l10n_in/tests/common.py
+++ b/addons/l10n_in/tests/common.py
@@ -109,6 +109,7 @@ class L10nInTestInvoicingCommon(AccountTestInvoicingCommon):
             AccountChartTemplate.ref("sgst_sale_12")
             + AccountChartTemplate.ref("cess_5_plus_1591_sale")
         )
+        cls.exempt = AccountChartTemplate.ref('exempt_sale')
 
         # === Products === #
         cls.product_a.write({

--- a/addons/l10n_in/tests/test_invoice_label.py
+++ b/addons/l10n_in/tests/test_invoice_label.py
@@ -1,0 +1,72 @@
+from odoo import Command
+from odoo.addons.l10n_in.tests.common import L10nInTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestInvoiceLabel(L10nInTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.partner_b.l10n_in_gst_treatment = "regular"
+        cls.unregistered_partner = cls.partner_a.copy({"state_id": cls.state_in_mh.id, "vat": None, "l10n_in_gst_treatment": "unregistered"})
+
+    def test_invoice_label(self):
+        # Regular with taxable items
+        regular_taxable_invoice = self._init_inv(
+            partner=self.partner_b,
+            taxes=self.igst_sale_18,
+            line_vals={'price_unit': 1000, 'quantity': 1},
+        )
+        invoice_label = regular_taxable_invoice._get_l10n_in_invoice_label()
+        self.assertEqual(invoice_label, 'Tax Invoice')
+
+        # Regular with exempt items
+        regular_exempt_invoice = self._init_inv(
+            partner=self.partner_b,
+            taxes=self.exempt,
+            line_vals={'price_unit': 1000, 'quantity': 1},
+        )
+        invoice_label = regular_exempt_invoice._get_l10n_in_invoice_label()
+        self.assertEqual(invoice_label, 'Bill of Supply')
+
+        # Regular with taxable and exempt items
+        regular_mix_invoice = self._init_inv(
+            partner=self.partner_b,
+            taxes=self.igst_sale_18,
+            line_vals={'price_unit': 1000, 'quantity': 1},
+            post=False,
+        )
+        regular_mix_invoice.write({
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_b.id,
+                'account_id': regular_mix_invoice.invoice_line_ids[0].account_id.id,
+                'price_unit': 500,
+                'quantity': 1,
+                'tax_ids': [(6, 0, [self.exempt.id])],
+            })],
+        })
+        regular_mix_invoice.action_post()
+        invoice_label = regular_mix_invoice._get_l10n_in_invoice_label()
+        self.assertEqual(invoice_label, 'Invoice')
+
+        # unregistered with taxable and exempt items
+        unregistered_invoice = self._init_inv(
+            partner=self.unregistered_partner,
+            taxes=self.igst_sale_18,
+            line_vals={'price_unit': 220000, 'quantity': 1},
+            post=False,
+        )
+        unregistered_invoice.write({
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_b.id,
+                'account_id': unregistered_invoice.invoice_line_ids[0].account_id.id,
+                'price_unit': 500,
+                'quantity': 1,
+                'tax_ids': [(6, 0, [self.exempt.id])],
+            })],
+        })
+        unregistered_invoice.action_post()
+        invoice_label = unregistered_invoice._get_l10n_in_invoice_label()
+        self.assertEqual(invoice_label, 'Invoice-cum-Bill of Supply')

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -61,21 +61,13 @@
 
         <t name="invoice_title" position="replace">
             <t name="invoice_title">
-                <span t-if="o.invoice_line_ids.tax_ids">
-                    Tax Invoice
-                </span>
-                <span t-else="">
-                    Invoice
-                </span>
+                <span t-out="o._get_l10n_in_invoice_label()"/>
             </t>
         </t>
         <t name="proforma_invoice_title" position="replace">
-                <span t-if="o.invoice_line_ids.tax_ids">
-                   Proforma Tax Invoice
-                </span>
-                <span t-else="">
-                    Proforma Invoice
-                </span>
+            <t name="proforma_invoice_title">
+                Proforma <span t-out="o._get_l10n_in_invoice_label()"/>
+            </t>
         </t>
 
         <xpath expr="//div[@id='payment_term']" position="after">


### PR DESCRIPTION
Previously, the invoice label was always displayed as “Tax Invoice” or “Invoice”. However, as per Section 31 of the CGST Act, the document label must depend on the nature of supplies and the customer type:
 - If the document contains only taxable supplies => “Tax Invoice”
 - If the document contains only exempt supplies => “Bill of Supply”
 - If the customer is unregistered and the document contains both taxable and exempt supplies => “Invoice-cum-Bill of Supply”
 - If the customer is registered and the document contains both taxable and exempt supplies, separate documents must be issued as per the law.

With this commit, the invoice label is generated strictly in accordance with Section 31 of the CGST Act.
In the case of a registered customer where both taxable and exempt supplies exist in a single document, the label will be printed as “Invoice”.

task-5468323