### PR TITLE
[FIX] point_of_sale: prevent list_price from being converted twice

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -230,7 +230,7 @@ class ProductTemplate(models.Model):
             products |= products.mapped("pos_optional_product_ids")
 
         fields = self._load_pos_data_fields(config.id)
-        return self.with_context(config_id=config.id)._post_read_pos_data(products.read(fields, load=False))
+        return products.read(fields, load=False)
 
     def _post_read_pos_data(self, data):
         config = self.env['pos.config'].browse(self.env.context.get('config_id'))

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1211,3 +1211,22 @@ registry.category("web_tour.tours").add("test_orderline_merge_with_higher_price_
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_different_currencies_correct_convertion", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            inLeftSide([
+                ...ProductScreen.clickControlButton("Info"),
+                Dialog.is({ title: "Desk Organizer | 2.55" }),
+                Dialog.cancel(),
+                ...Order.hasLine({
+                    productName: "Desk Organizer",
+                    quantity: "1",
+                    price: "2.55",
+                }),
+            ]),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3247,6 +3247,35 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_orderline_merge_with_higher_price_precision', login="pos_user")
 
+    def test_different_currencies_correct_convertion(self):
+        """
+        Tests that if the config and the company's currencies are different, the product_template's list_price
+        is correctly converted.
+        """
+        foreign_currency = self.env['res.currency'].create({
+            'name': "XYZ",
+            'symbol': 'X',
+            'rate_ids': [
+                (0, 0, {'name': '2020-01-01', 'rate': 0.5}),
+            ],
+        })
+        sale_journal = self.env['account.journal'].create({
+            'name': 'POS Sales XYZ',
+            'code': 'POSX',
+            'type': 'sale',
+            'company_id': self.env.company.id,
+            'currency_id': foreign_currency.id,
+        })
+        self.main_pos_config.available_pricelist_ids.write({
+            'currency_id': foreign_currency.id
+        })
+        self.main_pos_config.write({
+            'currency_id': foreign_currency.id,
+            'journal_id': sale_journal.id,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_different_currencies_correct_convertion', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
**Steps to reproduce:**
- Have a company that has USD as currency
- Make a PoS config that has another currency in the sales journal, such as AED
- Open that PoS
- Click on a product, then go the the Info tab
- Some of the displayed prices will be wrong, as they are multiplied by the exchange rate twice

**Why the fix:**
If the config's currency is different from the company's currency, we convert the templates' list_price to match the config's currency. This is done in those lines https://github.com/odoo/odoo/blob/b64bdf67dcf273a7e666928ffa6df37b45566f2b/addons/point_of_sale/models/product_template.py#L277-L278

The current problem with this is that this function is called twice, thus multiplying the list_price twice and making it wrong.

We can prevent this by checking if it has already been converted before multiplying the template's list_price.

opw-5226656