### PR TITLE
[FIX] html_builder: avoid Firefox scroll jump on undo

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -446,7 +446,8 @@ export class BuilderOptionsPlugin extends Plugin {
                 this.updateContainers(targetEl, { forceUpdate: true });
                 // Scroll to the target if not visible.
                 if (!isElementInViewport(targetEl)) {
-                    targetEl.scrollIntoView({ behavior: "smooth", block: "center" });
+                    // Firefox mis-scrolls with block "center" on tall snippets; keep "start".
+                    targetEl.scrollIntoView({ behavior: "smooth", block: "start" });
                 }
             } else {
                 this.deactivateContainers();

--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -94,7 +94,8 @@ export class ClonePlugin extends Plugin {
 
         // Scroll to the clone if required and if it is not visible.
         if (scrollToClone && !isElementInViewport(cloneEl)) {
-            cloneEl.scrollIntoView({ behavior: "smooth", block: "center" });
+            // Firefox mis-scrolls with block "center" on tall snippets; keep "start".
+            cloneEl.scrollIntoView({ behavior: "smooth", block: "start" });
         }
 
         for (const onCloned of this.getResource("on_cloned_handlers")) {

--- a/addons/html_builder/static/src/sidebar/invisible_elements_panel.js
+++ b/addons/html_builder/static/src/sidebar/invisible_elements_panel.js
@@ -98,7 +98,8 @@ export class InvisibleElementsPanel extends Component {
             this.shared.builderOptions.updateContainers(snippetEl);
             // Scroll to the target if not visible.
             if (!isElementInViewport(snippetEl) && !snippetEl.matches(".s_popup")) {
-                snippetEl.scrollIntoView({ behavior: "smooth", block: "center" });
+                // Firefox mis-scrolls with block "center" on tall snippets; keep "start".
+                snippetEl.scrollIntoView({ behavior: "smooth", block: "start" });
             }
         }
         this.shared.disableSnippets.disableUndroppableSnippets();


### PR DESCRIPTION
Steps to reproduce:
 - On Firefox, drop a snippet taller than the page height.
 - Remove it.
 - Undo. => The page shows a white gap until you scroll again. Same issue when showing a hidden tall snippet.

After investigation, no real explanation was found for this bug in Firefox. We only observed that changing the "center" parameter to "start" in the "scrollIntoView" function fixes the issue.

In the end, this is not a bad idea, since scrolling a snippet to its beginning arguably makes more sense than centering it, especially when the snippet’s height is larger than the viewport.

task-5194559