### PR TITLE
[FIX] point_of_sale: raise alert for invalid journal company

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -35,6 +35,7 @@ class PosPaymentMethod(models.Model):
         domain=['|', '&', ('type', '=', 'cash'), ('pos_payment_method_ids', '=', False), ('type', '=', 'bank')],
         ondelete='restrict',
         index='btree_not_null',
+        check_company=True,
         help='Leave empty to use the receivable account of customer.\n'
              'Defines the journal where to book the accumulated payments (or individual payment if Identify Customer is true) after closing the session.\n'
              'For cash journal, we directly write to the default account in the journal via statement lines.\n'


### PR DESCRIPTION
Before this commit:
===========
- Selecting a journal for a payment method belonging to a company that was neither a parent nor a child of the current company caused payment methods to fail loading for the POS session, resulting in no payment methods being available for the configuration.

After this commit:
===========
- Users are now prevented from selecting journals belonging to companies that are neither parent nor child of the current company.

task-5158448
