### PR TITLE
[PERF] point_of_sale: optimize category info loading in product screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -145,7 +145,9 @@ export class ProductScreen extends Component {
                     ? `/web/image?model=pos.category&field=image_128&id=${category.id}`
                     : undefined,
             isSelected: this.getAncestorsAndCurrent().includes(category),
-            isChildren: this.getChildCategories(this.pos.selectedCategory).includes(category),
+            isChildren: this.pos.selectedCategory
+                ? this.pos.selectedCategory.child_ids.includes(category)
+                : !category.parent_id,
         };
     }
 


### PR DESCRIPTION
Before this commit, the product category info loading was done in O(n^2) time complexity due to nested loops. It caused performance issues when loading a large number of product categories.

opw-5442894

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
