### PR TITLE
[FIX] web: load inactive records for x2many filters

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -870,7 +870,8 @@ export class CalendarModel extends Model {
                 const records = await this.orm.searchRead(
                     field.relation,
                     [["id", "in", relatedIds]],
-                    fieldsToFetch
+                    fieldsToFetch,
+                    {context: {active_test: false}}
                 );
                 if (isX2Many) {
                     const nameById = Object.fromEntries(records.map((r) => [r.id, r.display_name]));


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In fa56409da23727c62c3de128a180d25e72b481d2 support was added for many2many filters in the calendar arch. Since X2many fields use the many2one formatter (see makeFilterDynamic) filters need to be passed in the following format [id, display_name]. Since x2many records are not automatically fetched in this format fa56409da23727c62c3de128a180d25e72b481d2 added an additional step wherein colors and display names are fetched (by calling searchRead) and filters are properly formatted. An issue arises though if a record is archived and therefore not found by searchRead. In this case the filter will not be properly formatted and formatMany2one will raise an exception.

Current behavior before PR:
Using a x2many filter with an archived record raises an exception.

Desired behavior after PR is merged:
Using a x2many filter with an archived record will not raise an exception.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
