### PR TITLE
[FIX] im_livechat:  prevent leave livechat dialog box in non-livechat channels

### DIFF
--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -42,7 +42,12 @@ const discussChannelPatch = {
         return super.isHideUntilNewMessageSupported;
     },
     get livechatShouldAskLeaveConfirmation() {
-        if (this.isTransient || this.livechat_end_dt || !this.self_member_id) {
+        if (
+            this.isTransient ||
+            this.livechat_end_dt ||
+            !this.self_member_id ||
+            this.channel_type !== "livechat"
+        ) {
             return false;
         }
         return (

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -500,3 +500,21 @@ test("show looking for help duration in the sidebar", async () => {
         ".o-mail-DiscussSidebarChannel-container:has(:text(Visitor #1)) .o-livechat-LookingForHelp-timer:text(2d)"
     );
 });
+
+test("sidebar: leave non-livechat channel removes it from sidebar", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({
+        name: "General",
+        channel_type: "group",
+    });
+    await start();
+    await openDiscuss();
+    await click(".o-mail-DiscussSidebarChannel-itemName:text('General')");
+    await click(".o-mail-DiscussSidebarChannel:text('General') .oi-ellipsis-h");
+    await click(".o-dropdown-item:contains('Leave Channel')");
+    await contains(
+        ".modal-body:text('You are about to leave this group conversation and will no longer have access to it unless you are invited again. Are you sure you want to continue?')"
+    );
+    await click("button:text('Leave Conversation')");
+    await contains(".o-mail-DiscussSidebarChannel-itemName:text('General')", { count: 0 });
+});


### PR DESCRIPTION
Current behavior before PR:
The leave livechat confirmation dialog was incorrectly displayed for non-livechat channels, such as group chats with one or two members.

Desired behavior after PR is merged:
The confirmation dialog is now restricted to livechat channels only, preventing incorrect prompts in group or private conversations.

task-5446834

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr