### PR TITLE
[IMP] mail:  improve video call UI in Picture-in-Picture mode

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -11,7 +11,7 @@ import { ACTION_TAGS } from "@mail/core/common/action";
 
 export class CallActionList extends Component {
     static components = { ActionList };
-    static props = ["channel", "className?", "compact?"];
+    static props = ["channel", "className?", "compact?", "pipExtraActions?"];
     static template = "discuss.CallActionList";
 
     setup() {
@@ -34,16 +34,18 @@ export class CallActionList extends Component {
                     (a) => !a.tags.includes(ACTION_TAGS.CALL_LAYOUT)
                 );
                 const sequenceGroup = filtered[0].sequenceGroup;
-                const maxQuickActions = sequenceGroup === 200 ? 2 : 4;
+                const hasPipActions = sequenceGroup === 200 && this.props.pipExtraActions;
+                const pipActions = hasPipActions ? toRaw(this.props.pipExtraActions) : [];
+                const maxQuickActions = pipActions.length > 0 ? 1 : 4;
                 const quickActions = filtered.slice(0, maxQuickActions);
-                const moreActions = filtered.slice(maxQuickActions);
+                const moreActions = [...pipActions, ...filtered.slice(maxQuickActions)];
                 const newGroup = moreActions?.length
                     ? [
                           ...quickActions,
                           this.callActions.more(
                               {
                                   actions: moreActions,
-                                  dropdownMenuClass: "m-0 mb-1",
+                                  dropdownMenuClass: "m-0 mb-1 overflow-x-hidden",
                                   dropdownPosition: "top-end",
                                   name: this.MORE,
                               },

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -61,7 +61,8 @@ export const muteAction = {
 };
 registerCallAction("mute", muteAction);
 export const quickActionSettings = {
-    condition: ({ owner, channel }) => !owner.env.inCallMenu && channel?.isSelfInCall,
+    condition: ({ owner, channel }) =>
+        !owner.env.inCallMenu && channel?.isSelfInCall && !owner.env.pipWindow,
     dropdown: true,
     dropdownComponent: QuickVoiceSettings,
     dropdownMenuClass: "p-2",
@@ -118,7 +119,8 @@ export const cameraOnAction = {
 };
 registerCallAction("camera-on", cameraOnAction);
 export const quickVideoSettings = {
-    condition: ({ owner, channel }) => !owner.env.inCallMenu && channel?.isSelfInCall,
+    condition: ({ owner, channel }) =>
+        !owner.env.inCallMenu && channel?.isSelfInCall && !owner.env.pipWindow,
     dropdown: true,
     dropdownComponent: QuickVideoSettings,
     dropdownMenuClass: "p-2",
@@ -175,7 +177,7 @@ registerCallAction("fullscreen", {
                 channel.promoteFullscreen === CALL_PROMOTE_FULLSCREEN.ACTIVE
             ),
         }),
-    condition: ({ channel }) => channel?.isSelfInCall,
+    condition: ({ channel, owner }) => channel?.isSelfInCall && !owner.env.pipWindow,
     name: ({ store }) => (store.rtc.isFullscreen ? _t("Exit Fullscreen") : _t("Fullscreen")),
     isActive: ({ store }) => store.rtc.isFullscreen,
     icon: ({ action }) => (action.isActive ? "fa fa-compress" : "fa fa-expand"),
@@ -196,7 +198,8 @@ registerCallAction("picture-in-picture", {
         !owner.env.inCallMenu &&
         channel?.isSelfInCall &&
         store.env.services["discuss.pip_service"] &&
-        !store.env?.isSmall,
+        !store.env?.isSmall &&
+        !owner.env.pipWindow,
     disabledCondition: ({ store }) => store.rtc?.isRemote,
     name: ({ store }) =>
         store.rtc?.isPipMode ? _t("Exit Picture in Picture") : _t("Picture in Picture"),

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -51,6 +51,14 @@
                 <span t-if="showRemoteWarning" class="o-discuss-CallParticipantCard-overlay o-proportional-container z-1 w-50 position-absolute d-flex align-items-center justify-content-center overflow-hidden">
                     <span class="fw-bolder p-1 rounded-3 o-video-text o-proportional-text">Video visible in the call tab</span>
                 </span>
+                <div t-if="!props.inset and !props.minimized" class="o-discuss-CallParticipantCard-overlay position-absolute top-0 end-0 d-flex w-50 flex-row-reverse" t-att-class="{ 'o-proportional-container': isSmall, 'mw-25': props.isSidebarItem or props.inset }">
+                    <span t-if="rtcSession.is_deaf" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="deaf" aria-label="deaf">
+                        <i class="fa fa-deaf"/>
+                    </span>
+                    <span t-if="rtcSession.is_muted and !rtcSession.is_deaf" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="muted" aria-label="muted">
+                        <i class="fa fa-microphone-slash"/>
+                    </span>
+                </div>
                 <CallDropdown t-if="isContextMenuAvailable and ((!isMobileOS and rootHover.isHover) or (isMobileOS and !props.minimized))" class="'position-absolute top-0 end-0'" menuClass="'d-flex o-discuss-CallParticipantCard-contextMenu'">
                     <button class="o-discuss-CallParticipantCard-contextButton btn btn-secondary btn-sm rounded-circle border-0 smaller p-1" title="Participant options">
                         <i class="fa fa-chevron-down fa-fw"/>
@@ -63,10 +71,10 @@
                     <span t-if="hasRaisingHand" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="raising hand" aria-label="raising hand">
                         <i class="fa fa-hand-paper-o"/>
                     </span>
-                    <span t-if="rtcSession.is_muted and !rtcSession.is_deaf" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="muted" aria-label="muted">
+                    <span t-if="rtcSession.is_muted and !rtcSession.is_deaf and (props.inset or props.minimized)" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="muted" aria-label="muted">
                         <i class="fa fa-microphone-slash"/>
                     </span>
-                    <span t-if="rtcSession.is_deaf" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="deaf" aria-label="deaf">
+                    <span t-if="rtcSession.is_deaf and (props.inset or props.minimized)" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="deaf" aria-label="deaf">
                         <i class="fa fa-deaf"/>
                     </span>
                     <span t-if="hasMediaError" class="o-discuss-CallParticipantCard-overlay-replayButton o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="media player Error" t-on-click.stop="onClickReplay">

--- a/addons/mail/static/src/discuss/call/common/meeting.js
+++ b/addons/mail/static/src/discuss/call/common/meeting.js
@@ -16,6 +16,8 @@ import { MeetingSideActions } from "./meeting_side_actions";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { useMessageSearch } from "@mail/core/common/message_search_hook";
 
+const PIP_EXTRA_ACTION_IDS = ["copy-invite-link", "meeting-chat"];
+
 /** @typedef {"chat"|"invite"} MeetingPanel */
 
 /**
@@ -69,5 +71,12 @@ export class Meeting extends Component {
 
     get channel() {
         return this.store.rtc.channel;
+    }
+
+    get pipExtraActions() {
+        if (!this.rtc.isPipMode) {
+            return [];
+        }
+        return this.threadActions.actions.filter((a) => PIP_EXTRA_ACTION_IDS.includes(a.id));
     }
 }

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -11,8 +11,8 @@
                 </div>
             </div>
             <div class="pt-2 d-flex align-items-center justify-content-center overflow-x-auto flex-shrink-0" t-att-class="{'p-2 pb-3': ui.isSmall}">
-                <CallActionList channel="channel" className="'ms-auto'"/>
-                <MeetingSideActions threadActions="threadActions" isSmall="ui.isSmall or rtc.isPipMode"/>
+                <CallActionList channel="channel" className="rtc.isPipMode ? '' : 'ms-auto'" pipExtraActions="pipExtraActions"/>
+                <MeetingSideActions t-if="!rtc.isPipMode" threadActions="threadActions" isSmall="ui.isSmall"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -311,6 +311,8 @@ export class Rtc extends Record {
     fallbackMode = false;
     isPipMode = false;
     isFullscreen = false;
+    /** Whether fullscreen was active before opening PIP. */
+    hadFullscreen = false;
     /** @type {RtcLog} */
     logs = {};
     notifications = reactive(new Map());
@@ -633,7 +635,10 @@ export class Rtc extends Record {
 
     async openPip(options) {
         if (this.isHost) {
-            this.exitFullscreen();
+            this.hadFullscreen = this.isFullscreen;
+            if (this.isFullscreen) {
+                this.exitFullscreen();
+            }
             await this.pipService.openPip(options);
             return;
         }
@@ -2389,6 +2394,10 @@ export const rtcService = {
         onChange(rtc.pipService.state, "active", () => {
             const isPipMode = rtc.pipService.state.active;
             if (!isPipMode) {
+                if (rtc.hadFullscreen && rtc.channel) {
+                    rtc.enterFullscreen();
+                }
+                rtc.hadFullscreen = false;
                 rtc.channel?.openChatWindow();
             }
             rtc.isPipMode = isPipMode;

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -174,21 +174,6 @@ export class ChannelInvitation extends Component {
         ev.target.select();
     }
 
-    async onClickCopy(ev) {
-        let notification = _t("Invitation link copied!");
-        let type = "success";
-        const clipboard = this.env.inDiscussCallView?.isPip
-            ? this.rtc.pipService.pipWindow?.navigator.clipboard
-            : navigator.clipboard;
-        try {
-            await clipboard.writeText(this.props.channel.invitationLink);
-        } catch {
-            notification = _t("Invitation link copy failed (Permission denied?)!");
-            type = "danger";
-        }
-        this.notification.add(notification, { type });
-    }
-
     async onClickInvite() {
         let channelId = this.props.channel.id;
         const invitePromises = [];

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -60,7 +60,7 @@
                 <hr t-if="props.channel?.invitationLink" class="border-dark-subtle"/>
                 <div t-if="props.channel?.invitationLink" class="input-group">
                     <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="props.channel.invitationLink" readonly="" disabled="" t-on-focus="onFocusInvitationLinkInput"/>
-                    <button class="btn btn-primary px-2 o-py-0_5" t-on-click="onClickCopy">
+                    <button class="btn btn-primary px-2 o-py-0_5" t-on-click="() => this.props.channel.copyInvitationLink()">
                         <i class="fa fa-copy"/>
                     </button>
                 </div>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -515,6 +515,18 @@ export class DiscussChannel extends Record {
         super.delete(...arguments);
     }
 
+    async copyInvitationLink({ clipboard = navigator.clipboard } = {}) {
+        const notification = this.store.env.services.notification;
+        try {
+            await clipboard.writeText(this.invitationLink);
+            notification.add(_t("Invitation link copied!"), { type: "success" });
+        } catch {
+            notification.add(_t("Permission denied: invitation link copy failed!"), {
+                type: "danger",
+            });
+        }
+    }
+
     async executeCommand(command, body = "") {
         await command.onExecute?.(this);
         if (command.methodName) {

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -172,6 +172,7 @@ registerThreadAction("invite-people", {
         } bg-100 border border-secondary`,
     condition: ({ channel, owner }) =>
         channel &&
+        !owner.env.pipWindow &&
         (!owner.props.chatWindow || owner.props.chatWindow.isOpen) &&
         !(owner.isDiscussContent && channel?.hasMemberList),
     icon: "oi oi-fw oi-user-plus",
@@ -186,6 +187,17 @@ registerThreadAction("invite-people", {
             });
         }
     },
+});
+registerThreadAction("copy-invite-link", {
+    condition: ({ channel, owner }) => owner.env.pipWindow && channel?.invitationLink,
+    icon: "oi oi-fw oi-user-plus",
+    name: _t("Copy Invite Link"),
+    onSelected: ({ channel, owner }) =>
+        channel.copyInvitationLink({
+            clipboard: owner.env.pipWindow.navigator.clipboard,
+        }),
+    sequence: 20,
+    sequenceGroup: ({ owner }) => (owner.isDiscussContent ? 10 : 20),
 });
 registerThreadAction("member-list", {
     actionPanelClose: ({ action, owner, store, nextActiveAction }) => {


### PR DESCRIPTION
Purpose:
Improve the user experience of calls in Picture-in-Picture (PIP) mode by simplifying the action menu, handling full-screen state more reliably, and improving participant card indicators.

This PR includes:
- Preserve fullscreen state and restore it when exiting PIP
- Fix horizontal scrollbar in the 'More actions' menu in PIP mode
- Move 'Invite people' and 'Chat' actions to the 'More actions' menu in PIP mode
- Add direct invite link copy functionality for 'Invite people' in PIP mode
- Hide microphone and video settings actions in PIP mode for a cleaner UI
- Hide 'Exit PIP' and 'Fullscreen' actions when already in PIP mode
- Move muted microphone indicator to the top-right of the participant card

task-5382649





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
