### PR TITLE
[FIX] website_sale_stock: change d-flex to d-inline-flex for badge

### DIFF
--- a/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
+++ b/addons/website_sale_stock/static/src/xml/website_sale_stock_product_availability.xml
@@ -10,7 +10,7 @@
             <div t-if="free_qty lte 0 and !cart_qty" t-attf-class="availability_message_#{product_template} mb-1">
                 <div id="out_of_stock_message" class="mb-3">
                     <t t-if="has_out_of_stock_message">
-                        <div class="d-flex align-items-center badge text-start text-bg-danger text-wrap">
+                        <div class="d-inline-flex align-items-center badge text-start text-bg-danger text-wrap">
                             <i class="fa fa-circle text-danger me-2"/>
                             <span>
                                 <t t-out="out_of_stock_message"/>


### PR DESCRIPTION
- As per the suggestion on this [PR](https://github.com/odoo/odoo/pull/240235#issuecomment-3670221013),
I missed applying some of the suggested changes in my previous [PR](https://github.com/odoo/odoo/pull/240235).
This PR fixes that oversight and corrects the typo.

opw-5274850

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
