### PR TITLE
[FIX] website_forum: fix forum post form validation

### DIFF
--- a/addons/website_forum/static/src/interactions/website_forum.js
+++ b/addons/website_forum/static/src/interactions/website_forum.js
@@ -196,7 +196,7 @@ export class WebsiteForum extends Interaction {
         const textareaEl = currentTargetEl.querySelector("textarea[name=content]");
 
         if (titleEl?.required) {
-            titleEl.classList.toggle("is-invalid", !!titleEl.value);
+            titleEl.classList.toggle("is-invalid", !titleEl.value);
             validForm = !!titleEl.value;
         }
 
@@ -206,7 +206,7 @@ export class WebsiteForum extends Interaction {
             const textareaContainerEl = currentTargetEl.querySelector(".o_wysiwyg_textarea_wrapper");
             const hasContent = !!textareaContainerEl.innerText.trim() || !!textareaContainerEl.querySelector("img");
             ["border", "border-danger", "rounded-top"].forEach((cls) => {
-                textareaContainerEl.classList.toggle(cls, hasContent);
+                textareaContainerEl.classList.toggle(cls, !hasContent);
             });
             validForm = hasContent;
         }


### PR DESCRIPTION
Steps to reproduce
===================
1. Go to Forum.
2. Select any forum and Click on New Post.
3. Add a title and keep description empty.
4. Post Your Question.
=> The title is marked as invalid.
6. Now add a description.
7. Post Your Question.
=> Both the title and description are marked as invalid, yet form is submitted successfully.

After commit [1], refactoring public widgets to Interactions, the `is-invalid` class toggle for forum post title and description used an incorrect condition, leading to improper highlighting of these fields.

[1] https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba

Task-5400394

