### PR TITLE
[FIX] website_sale: align carousel arrow direction in RTL

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -1,4 +1,9 @@
 .s_dynamic_snippet_products {
+    // RTL chevron rotation
+    .o_rtl & {
+        --o-chevron-rtl-rotate: 180deg;
+    }
+
     // Adjusts carousel arrows' aligments
     @mixin o-aligns-controlers {
 
@@ -12,7 +17,7 @@
             padding-top: 1rem;
 
             .oi {
-                transform: scaleX(5);
+                transform: scaleX(5) rotate(var(--o-chevron-rtl-rotate, 0deg));
             }
         }
 


### PR DESCRIPTION
Steps to reproduce:
===================
- Install an RTL language (e.g., Arabic) on the website.
- Go to website & Edit mode
- Drop product snippet `s_dynamic_snippet_products`.

->When the website is viewed in an RTL language, the navigation arrows
in the snippet are displayed in the wrong direction.

Cause:
======
A previous commit [1] applied a specific `transform` to arrows to adjust their visual style,
By defining a new transformation for the snippet, the default generic transform for RTL language was overwritten.
https://github.com/odoo/odoo/blob/e0a5e68e861363378ecd184711bc9356fe0376ff/addons/web/static/lib/odoo_ui_icons/style.css#L105 Consequently, the arrows lost their RTL-specific orientation.

Solution:
=========
The CSS has been updated to explicitly handle the RTL context.

[1]: https://github.com/odoo/odoo/commit/d9ea6d1ebabf64dac434e0d2a7c2535bbfff5c71

opw-5440273

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
