### PR TITLE
[IMP] web: wrap phone field.

### DIFF
--- a/addons/web/static/src/views/fields/phone/phone_field.js
+++ b/addons/web/static/src/views/fields/phone/phone_field.js
@@ -10,6 +10,7 @@ export class PhoneField extends Component {
     static props = {
         ...standardFieldProps,
         placeholder: { type: String, optional: true },
+        wrap: { type: Boolean, optional: true },
     };
 
     setup() {
@@ -30,10 +31,20 @@ export const phoneField = {
             type: "field",
             availableTypes: ["char"],
         },
+        {
+            label: _t("Wrap"),
+            name: "wrap",
+            type: "boolean",
+            default: false,
+            help: _t(
+                "If true, the icons next to the phone number will wrapped when the line is too long."
+            ),
+        },
     ],
     supportedTypes: ["char"],
-    extractProps: ({ placeholder }) => ({
+    extractProps: ({ options, placeholder }) => ({
         placeholder,
+        wrap: options.wrap,
     }),
 };
 

--- a/addons/web/static/src/views/fields/phone/phone_field.xml
+++ b/addons/web/static/src/views/fields/phone/phone_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.PhoneField">
-        <div class="o_phone_content d-inline-flex w-100">
+        <div class="o_phone_content d-inline-flex w-100" t-att-class="props.wrap ? 'flex-wrap' : ''">
             <t t-if="props.readonly">
                 <a t-if="props.record.data[props.name]" class="o_form_uri" target="_blank" t-att-href="phoneHref" t-esc="props.record.data[props.name]"/>
             </t>


### PR DESCRIPTION
[[IMP] web: add wrapping option to phone field.](https://github.com/odoo/odoo/pull/241543/changes/bd7dee1aeeb9f3dbce90328040454a86c077ee89)
This commit adds the option to wrap the icons next to the phone number
when the line is too long. It was first needed in VoIP in the readonly
phone number.

Task-5437330

Enterprise: https://github.com/odoo/enterprise/pull/102876

