### PR TITLE
[FIX] website_forum: fix void description on post submission

### DIFF
--- a/addons/website_forum/static/src/components/website_forum_wysiwyg/website_forum_wysiwyg.js
+++ b/addons/website_forum/static/src/components/website_forum_wysiwyg/website_forum_wysiwyg.js
@@ -91,6 +91,7 @@ export class WebsiteForumWysiwyg extends Wysiwyg {
 
     onSubmitButtonClick(ev) {
         if (this.readyToSubmit) {
+            this.readyToSubmit = false;
             return;
         }
         ev.preventDefault();


### PR DESCRIPTION
Steps to reproduce
===================
1. Go to Forum.
2. Select any forum and Click on New Post.
3. Add a title and keep description empty.
4. Post Your Question.
=> The title is marked as invalid.
5. Now add a description.
6. Post Your Question.
=> Error page: Bad Request
7. Go back or open any forum page
=> Will receive error on each page until you clear sessionStorage

Technical
============
The commit [1] updates the website forum interaction to use
the html_editor `Wysiwyg` instead of `loadWysiwygFromTextarea`.
The textarea is hidden and populated through `WebsiteForumWysiwyg`.

When the description is left empty and the form is submitted,
`WebsiteForumWysiwyg.onSubmitButtonClick` populates empty content
into the textarea, sets the `readyToSubmit` property to true, and
resubmits the form to trigger the interaction logic. The editor
container is then validated as empty, marked invalid, and the
submission is prevented.

After the description is refilled and the form is submitted again,
the `readyToSubmit` is already true, causing an early return from
`onSubmitButtonClick`. This skips populating the textarea from the
editor container. Since validation is performed against the editor
container, the form is submitted successfully.

As we use form action that relies on named inputs, including the hidden
textarea, the submitted payload contains an empty textarea value.
As a result, the request fails with a bad request error due to empty content.

[1] https://github.com/odoo/odoo/commit/6bd3d1b557f82475f0a78ef8ff0529528e5f2b29

After this commit
======================

This commit fix the issue by resetting `readyToSubmit` property to false.

Task-5400394