### PR TITLE
[IMP] sale_project: confirming a vendor bill reinvoices cost on most recent sales order

### DIFF
--- a/addons/sale_project/models/account_move_line.py
+++ b/addons/sale_project/models/account_move_line.py
@@ -59,7 +59,7 @@ class AccountMoveLine(models.Model):
             orders = orders_per_project.get(project)
             if not orders:
                 continue
-            orders = orders.sorted('create_date')
+            orders = orders.sorted('create_date', reverse=True)
             in_sale_state_orders = orders.filtered(lambda s: s.state == 'sale')
 
             mapping[move_line.id] = in_sale_state_orders[0] if in_sale_state_orders else orders[0]


### PR DESCRIPTION
When confirming a vendor bill, it will automatically reinvoice the costs on the most recent sales order instead of the oldest one.

In the case one has multiple sales orders, it makes more sense to invoice on the latest sales order, as older ones may already be closed

task-4850329