### PR TITLE
[FIX] product: prevent infinite loop in `_cartesian_product`

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1242,6 +1242,11 @@ class ProductTemplate(models.Model):
         if not product_template_attribute_values_per_line:
             return
 
+        product_template_attribute_values_per_line = [ptav for ptav in product_template_attribute_values_per_line if len(ptav)]
+        if not product_template_attribute_values_per_line:
+            yield self.env['product.template.attribute.value']
+            return
+
         all_exclusions = {self.env['product.template.attribute.value'].browse(k):
                           self.env['product.template.attribute.value'].browse(v) for k, v in
                           self._get_own_attribute_exclusions().items()}

--- a/addons/product/tests/test_product_attribute_value_config.py
+++ b/addons/product/tests/test_product_attribute_value_config.py
@@ -32,6 +32,7 @@ class TestProductAttributeValueCommon(TransactionCase):
             cls.hdd_attribute,
             cls.size_attribute,
             cls.extras_attribute,
+            cls.operating_system_attribute,
         ) = cls.env['product.attribute'].create([{
             'name': 'Memory',
             'sequence': 1,
@@ -111,6 +112,21 @@ class TestProductAttributeValueCommon(TransactionCase):
                     'sequence': 2,
                 }),
             ],
+        }, {
+            'name': "Operating System",
+            'sequence': 6,
+            'display_type': 'multi',
+            'create_variant': 'no_variant',
+            'value_ids': [
+                Command.create({
+                    'name': "Linux",
+                    'sequence': 1,
+                }),
+                Command.create({
+                    'name': "Windows",
+                    'sequence': 2,
+                }),
+            ],
         }])
 
         cls.ssd_256, cls.ssd_512 = cls.ssd_attribute.value_ids
@@ -118,6 +134,7 @@ class TestProductAttributeValueCommon(TransactionCase):
         cls.hdd_1, cls.hdd_2, cls.hdd_4 = cls.hdd_attribute.value_ids
         cls.size_m, cls.size_l, cls.size_xl = cls.size_attribute.value_ids
         cls.extra_cpu, cls.extra_ram = cls.extras_attribute.value_ids
+        cls.linux_operating_system, cls.windows_operating_system = cls.operating_system_attribute.value_ids
 
         cls.COMPUTER_SSD_PTAL_VALUES = {
             'product_tmpl_id': cls.computer.id,
@@ -138,6 +155,11 @@ class TestProductAttributeValueCommon(TransactionCase):
             'product_tmpl_id': cls.computer.id,
             'attribute_id': cls.extras_attribute.id,
             'value_ids': [Command.set([cls.extra_cpu.id, cls.extra_ram.id])],
+        }
+        cls.COMPUTER_OPERATING_SYSTEM_VALUES = {
+            'product_tmpl_id': cls.computer.id,
+            'attribute_id': cls.operating_system_attribute.id,
+            'value_ids': [Command.set([cls.windows_operating_system.id, cls.linux_operating_system.id])],
         }
 
         cls._add_computer_attribute_lines()
@@ -160,11 +182,13 @@ class TestProductAttributeValueCommon(TransactionCase):
             cls.computer_ram_attribute_lines,
             cls.computer_hdd_attribute_lines,
             cls.computer_extras_attribute_lines,
+            cls.computer_operating_system_lines,
         ) = cls.env['product.template.attribute.line'].create([
             cls.COMPUTER_SSD_PTAL_VALUES,
             cls.COMPUTER_RAM_PTAL_VALUES,
             cls.COMPUTER_HDD_PTAL_VALUES,
             cls.COMPUTER_EXTRAS_PTAL_VALUES,
+            cls.COMPUTER_OPERATING_SYSTEM_VALUES,
         ])
 
         # Setup extra prices


### PR DESCRIPTION
Before this commit, having a `product.template.attribute.line` with zero `product.template.attribute.value` records might cause an infinite loop if this **multi-checkbox** attribute wasn't in the end of the list.

Suppose the order was arbitrary and we are generating combinations for two lines (the order here is important):
    - Line (A) -> [] (multi checkbox type)
    - Line (B) -> [attr_1, attr_2] 
    - The possible combinations are {(attr_1), (attr_2)}.
  
  After generating the second combination the following 2 procedures happen.
    - The value_index_per_line[1] will be resetted to -1,
    - The line_index will decrement from 1 to 0. 


Now, since the first line doesn't have any values, it will be skipped and the line_index will be incremented to 1.
This results in the redundant generation of the same combination, triggering an infinite loop.

Since this method yields a recordset of `product.template.attribute.value` model and the **multi-checkbox** attribute doesn't have a value being passed to the method anyways, we can exclude the lines that doesn't have values for the algorthim not to be stuck in an infinite loop.


opw-5267179
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
