### PR TITLE
[IMP] *: improve consistency section subsection combo

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
@@ -4,7 +4,6 @@
 
 table.o_section_and_note_list_view {
     --o-SectionAndNote-border-color: #{$gray-500};
-    $_SectionAndNote-transition: 0.1s ease-in-out;
 
     tr {
         &.o_is_line_note {
@@ -24,8 +23,8 @@ table.o_section_and_note_list_view {
         }
 
         &.o_is_line_section {
-            --table-hover-bg: #{rgba($body-emphasis-color, .08)};
-            --table-bg-type: #{rgba($body-emphasis-color, .06)};
+            --table-hover-bg: #{rgba($body-emphasis-color, .1)};
+            --table-bg-type: #{rgba($body-emphasis-color, .08)};
             --ListRenderer-data-row-focused-striped-bg: var(--table-bg-type);
 
             font-weight: $font-weight-bolder;
@@ -46,20 +45,6 @@ table.o_section_and_note_list_view {
             --table-bg-type: #{rgba($body-emphasis-color, .03)};
 
             font-weight: $font-weight-bold;
-
-            &.o_dragged {
-                // We rely on td borders, when dragged we need to remove
-                // the borders on .o_data_row to avoid double borders
-                --ListRenderer-data-row-border-bottom-width: 0;
-            }
-
-            td {
-                border-bottom-width: $border-width;
-
-                &:not(.o_handle_cell) {
-                    border-color: var(--o-SectionAndNote-border-color);
-                }
-            }
         }
 
         // Check if next sibling is a section to apply a border-color.

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -262,7 +262,7 @@
                                                         <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
                                                     </td>
                                                     <td colspan="1" class="text-end o_price_total">
-                                                        <span t-out="section_subtotal" class="o_price_subtotal_section text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                                        <span t-out="section_subtotal" class="text-nowrap" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                                     </td>
                                                 </t>
                                                 <t t-elif="is_note">

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -172,7 +172,7 @@
                                 <td t-if="show_section_total" name="td_section_price" class="text-end o_price_total">
                                     <span
                                         t-out="line._get_section_totals(price_field)"
-                                        class="o_price_subtotal_section text-nowrap"
+                                        class="text-nowrap"
                                         t-options="{'widget': 'monetary', 'display_currency': doc.currency_id}"
                                     >
                                         27.00
@@ -188,17 +188,22 @@
                                     <span t-field="line.name">A note, whose content usually applies to the section or product above.</span>
                                 </td>
                             </tr>
-                            <tr t-elif="is_combo" name="tr_combo" class="fw-bold o_line_subsection">
+                            <tr t-elif="is_combo" name="tr_combo" class="o_line_combo fw-bold">
                                 <td
                                     name="td_combo_name"
-                                    t-att-colspan="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
-                                    class="border-end-0"
                                     t-att-style="padding_style"
                                 >
                                     <span t-field="line.name">Combo Product</span>
-                                    x <span t-field="line.product_uom_qty" t-options="{'widget': 'integer'}"/>
                                 </td>
-                                <td name="td_combo_price" class="text-end o_price_total">
+                                <td name="td_combo_quantity" class="text-end">
+                                    <span t-field="line.product_uom_qty"/>
+                                    <span t-field="line.product_uom_id"/>
+                                </td>
+                                <td
+                                    name="td_combo_price"
+                                    t-att-colspan="2 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                    class="text-end o_price_total"
+                                >
                                     <span
                                         t-if="not collapse_prices"
                                         name="price_subtotal_combo"
@@ -266,7 +271,6 @@
                                 t-foreach="line._get_grouped_section_summary(display_taxes)"
                                 t-as="section_line"
                                 name="tr_section_group"
-                                class="o_line_section"
                             >
                                 <td name="td_section_group_name" t-att-style="padding_style">
                                     <span t-field="line.name">

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -111,7 +111,7 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
         if (this.isCombo(record) || this.isComboItem(record)) {
             classNames = classNames.replace('o_row_draggable', '');
         }
-        return `${classNames} ${this.isCombo(record) ? 'o_is_line_section o_is_line_section_no_indent' : ''}`;
+        return `${classNames} ${this.isCombo(record) ? 'fw-bold' : ''}`;
     }
 
     isCellReadonly(column, record) {

--- a/addons/sale/static/src/scss/sale_portal.scss
+++ b/addons/sale/static/src/scss/sale_portal.scss
@@ -1,5 +1,9 @@
 /* ---- My Orders page ---- */
 
+#sales_order_table {
+    font-size: MAX($font-size-sm, 14px);
+}
+
 .orders_vertical_align {
     display: flex;
     align-items: center;
@@ -26,8 +30,9 @@
     width: 100% !important;
 }
 
-.sale_tbody tr:has(+ .o_line_section) {
-    border-bottom: $border-width solid $dark;
+.sale_tbody tr:has(+ .o_line_section),
+thead:has(+ .sale_tbody > .o_line_section:first-child) {
+    border-bottom: $border-width solid $gray-600;
 }
 
 .o_portal .sale_tbody .js_quantity_container {

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -570,7 +570,7 @@
                         <h5 class="mb-1">Sale Information</h5>
                         <hr class="mt-1 mb-2"/>
                     </span>
-                    <table class="table table-borderless table-sm">
+                    <table class="table table-borderless">
                         <tbody style="white-space:nowrap" id="sale_info_table">
                             <tr>
                                 <th t-if="sale_order.state in ['sale', 'cancel']" class="ps-0 pb-0">Order Date:</th>
@@ -697,12 +697,12 @@
                 <t t-set="display_taxes" t-value="not hide_taxes_details and any(line._has_taxes() for line in lines_to_report)"/>
 
                 <div name="sol_table" class="table-responsive">
-                    <table t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="table table-sm" id="sales_order_table">
+                    <table t-att-data-order-id="sale_order.id" t-att-data-token="sale_order.access_token" class="table" id="sales_order_table">
                         <thead>
                             <tr>
                                 <th class="text-start" id="product_name_header">Description</th>
                                 <th class="text-end" id="product_qty_header">Quantity</th>
-                                <th t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}" id="product_unit_price_header">
+                                <th t-attf-class="text-end text-nowrap {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}" id="product_unit_price_header">
                                     Unit Price
                                 </th>
                                 <th t-if="display_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}" id="product_discount_header">
@@ -757,7 +757,7 @@
                                     <tr
                                         t-if="is_section or is_subsection"
                                         name="tr_section"
-                                        t-attf-class="{{'fw-bold o_line_section bg-200' if is_section else 'fw-medium o_line_subsection border-dark bg-100'}}"
+                                        t-attf-class="{{'o_line_section bg-200' if is_section else 'o_line_subsection bg-100'}} fw-bold"
                                     >
                                         <t t-set="show_section_total" t-value="is_section or not line.parent_id.collapse_prices"/>
                                         <t
@@ -796,7 +796,7 @@
                                             <span t-field="line.name"/>
                                         </td>
                                     </tr>
-                                    <tr t-elif="is_combo" name="tr_combo" class="fw-bold o_line_subsection bg-100 border-dark">
+                                    <tr t-elif="is_combo" name="tr_combo" class="fw-bold">
                                         <td
                                             name="td_combo_name"
                                             t-att-class="padding_class"
@@ -813,20 +813,10 @@
                                             </div>
                                         </td>
                                         <td
-                                            name="td_combo_priceunit"
-                                            t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
-                                        />
-                                        <td
-                                            t-if="display_discount"
-                                            name="td_combo_discount"
-                                            t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
-                                        />
-                                        <td
-                                            t-if="display_taxes"
-                                            name="td_combo_taxes"
-                                            t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
-                                        />
-                                        <td name="td_combo_subtotal" class="text-end">
+                                            name="td_combo_subtotal"
+                                            class="text-end"
+                                            t-att-colspan="2 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
+                                        >
                                             <span
                                                 t-if="not collapse_prices"
                                                 name="price_subtotal_combo"
@@ -899,7 +889,6 @@
                                         t-foreach="line._get_grouped_section_summary(display_taxes)"
                                         t-as="section_line"
                                         name="tr_section_group"
-                                        class="o_line_section"
                                     >
                                         <td name="td_section_group_name" t-att-class="padding_class">
                                             <span t-field="line.name">
@@ -973,7 +962,7 @@
     </template>
 
     <template id="sale_order_portal_content_totals_table">
-        <table class="table table-sm" name="sale_order_totals_table">
+        <table class="table" name="sale_order_totals_table">
             <t t-call="#{sale_order._get_name_tax_totals_view()}">
                 <t t-set="tax_totals" t-value="sale_order.tax_totals"/>
                 <t t-set="currency" t-value="sale_order.currency_id"/>

--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -15,10 +15,6 @@ table.table {
         border-top: $border-width solid $o-gray-400;
     }
 
-    .o_line_subsection {
-        border-bottom: $border-width solid $o-gray-400;
-    }
-
     .o_line_section {
         td, td.o_price_total {
             background-color: $gray-200;
@@ -47,14 +43,10 @@ div#total {
         }
 
         th:first-child, td:first-child {
-            padding-left: 0;
+            padding-left: map-get($spacers, 1);
         }
 
         th:last-child, td:last-child {
-            padding-right: 0;
-        }
-
-        .o_price_subtotal_section {
             padding-right: map-get($spacers, 1);
         }
     }
@@ -69,11 +61,11 @@ div#total {
     table:not(.o_ignore_layout_styling) {
 
         td:first-child, th:first-child {
-            padding-left: 0;
+            padding-left: map-get($spacers, 1);
         }
 
         td:last-child, th:last-child {
-            padding-right: 0;
+            padding-right: map-get($spacers, 1);
         }
 
         &:not(.o_total_table) {
@@ -98,10 +90,6 @@ div#total {
 
         .o_line_section, .o_line_subsection {
             border-top: $border-width solid;
-
-            .o_price_subtotal_section {
-                padding-right: map-get($spacers, 1);
-            }
         }
     }
 }
@@ -109,7 +97,7 @@ div#total {
 .o_table_striped {
     table:not(.o_ignore_layout_styling) {
         tbody tr {
-            &.o_line_section, &.o_line_subsection {
+            &.o_line_section {
                 border: none;
             }
 
@@ -177,7 +165,7 @@ div#total {
                 border-bottom: $border-width solid $gray-700;
             }
 
-            tr:not(.o_line_section):not(.o_line_subsection) td.o_price_total,
+            tr:not(.o_line_section):not(.o_line_subsection):not(.o_line_combo) td.o_price_total,
             .o_taxes td {
                 background-color: rgba($gray-200, .5);
             }
@@ -245,11 +233,11 @@ div#total {
     table:not(.o_ignore_layout_styling) {
 
         td:first-child, th:first-child {
-            padding-left: 0;
+            padding-left: map-get($spacers, 1);
         }
 
         td:last-child, th:last-child {
-            padding-right: 0;
+            padding-right: map-get($spacers, 1);
         }
 
         &:not(.o_total_table) {
@@ -268,13 +256,9 @@ div#total {
 
         border-bottom: $border-width solid $o-gray-400;
 
-        .o_line_section, .o_line_subsection {
+        .o_line_section, .o_line_subsection, .o_line_combo {
             border-bottom: $border-width solid $o-gray-400;
             border-top: $border-width solid $o-gray-400;
-
-            .o_price_subtotal_section {
-                padding-right: map-get($spacers, 1);
-            }
         }
     }
 }


### PR DESCRIPTION
Improve consistency of the section, subsection and combo lines on portal, reports and SO.

Note: website has a different font-size-base than portal, thus using small on the table in portal will render 12.25px without website but 14px when website is installed. 12.25px is barely accessible, which is why `max()` is used, ensuring the font-size of portal SO preview doesn't get too small.

[task-5439762](https://www.odoo.com/web#id=5439762&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
