### PR TITLE
[FIX] project_purchase : Check for account_id in distribution when multiple

### DIFF
--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -160,7 +160,16 @@ class ProjectProject(models.Model):
                         if str(self.account_id.id) in ids.split(',')
                     ) / 100.
                     purchase_line_amount_to_invoice = price_subtotal * analytic_contribution
-                    invoice_lines = purchase_line.invoice_lines.filtered(lambda l: l.parent_state != 'cancel' and l.analytic_distribution and str(self.account_id.id) in l.analytic_distribution)
+                    invoice_lines = purchase_line.invoice_lines.filtered(
+                        lambda l:
+                        l.parent_state != 'cancel'
+                        and l.analytic_distribution
+                        and any(
+                            key == str(self.account_id.id)
+                            or key.startswith(str(self.account_id.id) + ",")
+                            for key in l.analytic_distribution
+                        )
+                    )
                     if invoice_lines:
                         invoiced_qty = sum(invoice_lines.filtered(lambda l: not l.is_refund).mapped('quantity'))
                         if invoiced_qty < purchase_line.product_qty:


### PR DESCRIPTION
### Steps to reproduce:
	- Create a billable Project
	- Create a Purchase order and set the created project and a department in analytic distribution
	- Create a Vendor Bill with the same analytic distribution and match with the PO
	- Confirm the Vendor Bill
	- Check the project dashboard
	- Notice the amount is under To Bill not Billed

### Cause:
When checking the invoice lines we check if the AA in the distribution is the same as the one in the project. The problem comes when we have a Project and a Department set in the distribution as the keys in the JSON dict will be 'account_id,department_id' so the comma will trigger an incosistency so the invoice_line will be filtered out so we will consider this line as still waiting to be invoiced

### Fix:
Make sure we cover the case of the comma presence in one of the JSON keys.

opw-5350246