### PR TITLE
[FIX] mrp: make runbot green on weekend

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -345,6 +345,8 @@ class MrpWorkcenter(models.Model):
         :rtype: tuple
         """
         self.ensure_one()
+        ICP = self.env['ir.config_parameter'].sudo()
+        max_planning_iterations = max(int(ICP.get_param('mrp.workcenter_max_planning_iterations', '50')), 1)
         resource = self.resource_id
         start_datetime, revert = make_aware(start_datetime)
         get_available_intervals = partial(self.resource_calendar_id._work_intervals_batch, resources=resource, tz=timezone(self.resource_calendar_id.tz))
@@ -358,7 +360,7 @@ class MrpWorkcenter(models.Model):
         now = make_aware(datetime.now())[0]
         delta = timedelta(days=14)
         start_interval, stop_interval = None, None
-        for n in range(50):  # 50 * 14 = 700 days in advance (hardcoded)
+        for n in range(max_planning_iterations):  # 50 * 14 = 700 days in advance
             if forward:
                 date_start = start_datetime + delta * n
                 date_stop = date_start + delta

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -265,3 +265,17 @@ class TestMrpCommon(TestStockCommon):
                 ],
             }
         )
+
+    def full_availability(self):
+        """set full availability for all calendars"""
+        calendar = self.env['resource.calendar'].search([])
+        calendar.write({'attendance_ids': [(5, 0, 0)]})
+        calendar.write({'attendance_ids': [
+            (0, 0, {'name': 'Monday', 'dayofweek': '0', 'hour_from': 0, 'hour_to': 24, 'day_period': 'morning'}),
+            (0, 0, {'name': 'Tuesday', 'dayofweek': '1', 'hour_from': 0, 'hour_to': 24, 'day_period': 'morning'}),
+            (0, 0, {'name': 'Wednesday', 'dayofweek': '2', 'hour_from': 0, 'hour_to': 24, 'day_period': 'morning'}),
+            (0, 0, {'name': 'Thursday', 'dayofweek': '3', 'hour_from': 0, 'hour_to': 24, 'day_period': 'morning'}),
+            (0, 0, {'name': 'Friday', 'dayofweek': '4', 'hour_from': 0, 'hour_to': 24, 'day_period': 'morning'}),
+            (0, 0, {'name': 'Saturday', 'dayofweek': '5', 'hour_from': 0, 'hour_to': 24, 'day_period': 'morning'}),
+            (0, 0, {'name': 'Sunday', 'dayofweek': '6', 'hour_from': 0, 'hour_to': 24, 'day_period': 'morning'}),
+        ]})


### PR DESCRIPTION
overlook of https://github.com/odoo/odoo/pull/239717
### Before this commit:
Runbot was red on weekends, as there are no work intervals on weekends.

### After this commit:
Use Friday as a fallback on weekends. In addition, improve the test performance by mocking the total number of weeks of planning to 2 instead of 50 (before: 6s, after: 1s).

runbot-237575

---

Note: ran the test for the next 5 years, and it works :+1: 
```diff
diff --git a/addons/mrp/tests/test_bom.py b/addons/mrp/tests/test_bom.py
index 7acf19e89add..bfadc8e487c1 100644
--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -13,6 +13,7 @@ from odoo.tests.common import HttpCase, tagged, freeze_time
 from odoo.tools import float_compare, float_round, float_repr
 
 
+@tagged("-at_install", "post_install")
 @freeze_time(fields.Date.today())
 class TestBoM(TestMrpCommon):
 
@@ -963,6 +964,16 @@ class TestBoM(TestMrpCommon):
             self.assertEqual(report_values['lines']['operations_time'], 15.0)
             self.assertEqual(report_values['lines']['producible_qty'], 2)
 
+    def test_bom_report_planning_with_producible_qty_loop(self):
+        from datetime import date  # noqa: PLC0415
+        start, stop = date.today(), date.fromisoformat("2031-01-01")
+        with freeze_time(start) as frozen_date:
+            for i in range((stop - start).days):
+                print("date:", str(date.today()))
+                with self.subTest(str(date.today())):
+                    self.test_bom_report_planning_with_producible_qty()
+                    frozen_date.tick(timedelta(days=1))
+
     def test_21_bom_report_variant(self):
         """ Test a sub BoM process with multiple variants.
         BOM 1:
```