### PR TITLE
[18.0] Backport improvements to the odoo-mailgate script in 19.0 to 18.0

### DIFF
--- a/addons/mail/static/scripts/odoo-mailgate.py
+++ b/addons/mail/static/scripts/odoo-mailgate.py
@@ -21,18 +21,23 @@ import sys
 import traceback
 import xmlrpclib
 
+
 def main():
-    op = optparse.OptionParser(usage='usage: %prog [options]', version='%prog v1.2')
+    op = optparse.OptionParser(usage='usage: %prog [options]', version='%prog v1.3')
     op.add_option("-d", "--database", dest="database", help="Odoo database name (default: %default)", default='odoo')
     op.add_option("-u", "--userid", dest="userid", help="Odoo user id to connect with (default: %default)", default=1, type=int)
     op.add_option("-p", "--password", dest="password", help="Odoo user password (default: %default)", default='admin')
     op.add_option("--host", dest="host", help="Odoo host (default: %default)", default='localhost')
     op.add_option("--port", dest="port", help="Odoo port (default: %default)", default=8069, type=int)
+    op.add_option("--proto", dest="protocol", help="Protocol to use (default: %default), http or https", default='http')
     (o, args) = op.parse_args()
+    if o.protocol not in ['http', 'https']:
+        op.print_help()
+        sys.exit(2)
 
     try:
         msg = sys.stdin.read()
-        models = xmlrpclib.ServerProxy('http://%s:%s/xmlrpc/2/object' % (o.host, o.port), allow_none=True)
+        models = xmlrpclib.ServerProxy('%s://%s:%s/xmlrpc/2/object' % (o.protocol, o.host, o.port), allow_none=True)
         models.execute_kw(o.database, o.userid, o.password, 'mail.thread', 'message_process', [False, xmlrpclib.Binary(msg)], {})
     except xmlrpclib.Fault as e:
         # reformat xmlrpc faults to print a readable traceback
@@ -41,6 +46,7 @@ def main():
     except Exception as e:
         traceback.print_exc(None, sys.stderr)
         sys.exit(2)
+
 
 if __name__ == '__main__':
     main()

--- a/addons/mail/static/scripts/odoo-mailgate.py
+++ b/addons/mail/static/scripts/odoo-mailgate.py
@@ -15,38 +15,98 @@
 #
 # Note python2 was chosen on purpose for backward compatibility with old mail
 # servers.
-#
-import optparse
+
+# Dev Note exit codes should comply with https://www.unix.com/man-page/freebsd/3/sysexits/
+# see http://www.postfix.org/aliases.5.html, output may end up in bounce mails
+EX_USAGE = 64
+EX_NOUSER = 67
+EX_NOHOST = 68
+EX_UNAVAILABLE = 69
+EX_SOFTWARE = 70
+EX_TEMPFAIL = 75
+EX_NOPERM = 77
+EX_CONFIG = 78
+
+
 import sys
-import traceback
-import xmlrpclib
+try:
+    import traceback
+    import xmlrpclib
+    import socket
+    from optparse import OptionParser as _OptionParser
+except ImportError as e:
+    sys.stderr.write("%s only supports python2: %s" % (__file__, e))
+    sys.exit(EX_SOFTWARE)
+
+
+class OptionParser(_OptionParser):
+    def exit(self, status=0, msg=None):
+        if msg:
+            sys.stderr.write(msg)
+        sys.stderr.write(" optparse status: %s\n" % status)
+        sys.exit(EX_USAGE)
+
+
+def postfix_exit(exit_code=EX_SOFTWARE, message=None, debug=False):
+    try:
+        if debug:
+            traceback.print_exc(None, sys.stderr)
+        if message:
+            sys.stderr.write(message)
+    except Exception:
+        pass  # error handling failed, exit
+    finally:
+        sys.exit(exit_code)
 
 
 def main():
-    op = optparse.OptionParser(usage='usage: %prog [options]', version='%prog v1.3')
+    op = OptionParser(usage='usage: %prog [options]', version='%prog v1.3')
     op.add_option("-d", "--database", dest="database", help="Odoo database name (default: %default)", default='odoo')
     op.add_option("-u", "--userid", dest="userid", help="Odoo user id to connect with (default: %default)", default=1, type=int)
     op.add_option("-p", "--password", dest="password", help="Odoo user password (default: %default)", default='admin')
     op.add_option("--host", dest="host", help="Odoo host (default: %default)", default='localhost')
     op.add_option("--port", dest="port", help="Odoo port (default: %default)", default=8069, type=int)
     op.add_option("--proto", dest="protocol", help="Protocol to use (default: %default), http or https", default='http')
+    op.add_option("--debug", dest="debug", action="store_true", help="Enable debug (may lead to stack traces in bounce mails)", default=False)
+    op.add_option("--retry-status", dest="retry", action="store_true", help="Send temporary failure status code on connection errors.", default=False)
     (o, args) = op.parse_args()
+    if args:
+        op.print_help()
+        sys.stderr.write("unknown arguments: %s\n" % args)
+        sys.exit(EX_USAGE)
     if o.protocol not in ['http', 'https']:
         op.print_help()
-        sys.exit(2)
+        sys.stderr.write("unknown protocol: %s\n" % o.protocol)
+        sys.exit(EX_USAGE)
 
     try:
         msg = sys.stdin.read()
         models = xmlrpclib.ServerProxy('%s://%s:%s/xmlrpc/2/object' % (o.protocol, o.host, o.port), allow_none=True)
         models.execute_kw(o.database, o.userid, o.password, 'mail.thread', 'message_process', [False, xmlrpclib.Binary(msg)], {})
     except xmlrpclib.Fault as e:
-        # reformat xmlrpc faults to print a readable traceback
-        err = "xmlrpclib.Fault: %s\n%s" % (e.faultCode, e.faultString)
-        sys.exit(err)
-    except Exception as e:
-        traceback.print_exc(None, sys.stderr)
-        sys.exit(2)
+        if e.faultString == 'Access denied' and e.faultCode == 3:
+            postfix_exit(EX_NOPERM, debug=False)
+        elif 'database' in e.faultString and 'does not exist' in e.faultString and e.faultCode == 1:
+            postfix_exit(EX_CONFIG, "database does not exist: %s\n" % o.database, o.debug)
+        elif 'No possible route' in e.faultString and e.faultCode == 1:
+            postfix_exit(EX_NOUSER, "alias does not exist in odoo\n", o.debug)
+        else:
+            postfix_exit(EX_SOFTWARE, "xmlrpclib.Fault\n", o.debug)
+    except (socket.error, socket.gaierror) as e:
+        postfix_exit(
+            exit_code=EX_TEMPFAIL if o.retry else EX_NOHOST,
+            message="connection error: %s: %s (%s)\n" % (e.__class__.__name__, e, o.host),
+            debug=o.debug,
+        )
+    except Exception:
+        postfix_exit(EX_SOFTWARE, "", o.debug)
 
 
-if __name__ == '__main__':
-    main()
+try:
+    if __name__ == '__main__':
+        main()
+except Exception:
+    # Handle all unhandled exceptions to prevent postfix from sending
+    # a bounce mail that includes the invoked command with args which
+    # may include the password for the odoo user.
+    postfix_exit(EX_SOFTWARE, "", True)

--- a/doc/cla/individual/ljmnoonan.md
+++ b/doc/cla/individual/ljmnoonan.md
@@ -1,0 +1,11 @@
+USA, 2025-12-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Liam Noonan ljmnoonan@gmail.com https://github.com/ljmnoonan


### PR DESCRIPTION
Backport of d09d8c5fe3c42dc408241fb514b7d20bfffa81fc, 502a8ef8b2db17742e6ab59f9ac9db2d017b09c8, and 31730c7f60179b28dfbdd29aa59dea9186085fa8

These changes are very helpful for running a mailserver, especially as [docker-mailserver](https://github.com/docker-mailserver/docker-mailserver) does not support python 2. Could we get them backported?

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
