### PR TITLE
[FIX] html_editor: disable default editing of static file box file name

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -285,6 +285,7 @@ export class ToolbarPlugin extends Plugin {
             .filter(
                 (node) =>
                     this.dependencies.selection.isNodeEditable(node) &&
+                    this.getResource("toolbar_visibility_predicates").every((p) => p(node)) &&
                     (!isTextNode(node) || (node.textContent.trim().length && !isZWS(node)))
             );
     }

--- a/addons/html_editor/static/src/others/embedded_components/core/file/static_file.xml
+++ b/addons/html_editor/static/src/others/embedded_components/core/file/static_file.xml
@@ -6,10 +6,10 @@
             <span class="o_file_image d-flex o_image user-select-none"
                 t-att-title="fileModel.filename" t-att-data-mimetype="fileModel.mimetype"/>
             <!-- file name -->
-            <span class="o_file_name_container mx-2">
-                <a class="o_link_readonly o-contenteditable-true" t-att-href="fileModel.downloadUrl"
+            <span class="o_file_name_container mx-2 d-flex flex-grow-1">
+                <a class="o_link_readonly w-100" t-att-href="fileModel.downloadUrl"
                     t-out="fileModel.filename"
-                    contenteditable="true"/>
+                    contenteditable="false"/>
             </span>
         </span>
     </t>


### PR DESCRIPTION
### Purpose of this PR:

- In the static file box, the file name is contenteditable by default, which leads to unexpected caret movement and arrow-key navigation behavior.
- Change the behavior so that the file name is contenteditable="false" by default and becomes editable only when the user explicitly clicks on it. The editability is reverted when clicking outside of the file name.
- This ensures consistent keyboard navigation while keeping the change limited to the static file box.

task-5427329

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
