### PR TITLE
[FIX] hw_drivers: prevent error while update certificate status

### DIFF
--- a/addons/hw_drivers/tools/certificate.py
+++ b/addons/hw_drivers/tools/certificate.py
@@ -55,14 +55,12 @@ def get_certificate_end_date():
     # Ensure cryptography compatibility with python < 3.13
     if platform.system() == 'Linux' and float(get_version()[1:8]) < 2025.10:
         cert_end_date = cert.not_valid_after
-        now = datetime.datetime.now()
     else:
-        cert_end_date = cert.not_valid_after_utc
-        now = datetime.datetime.now(datetime.timezone.utc)
+        cert_end_date = cert.not_valid_after_utc.replace(tzinfo=None)
 
     if (
         common_name == 'OdooTempIoTBoxCertificate'
-        or now > cert_end_date - datetime.timedelta(days=10)
+        or datetime.datetime.now() > cert_end_date - datetime.timedelta(days=10)
     ):
         _logger.debug("SSL certificate '%s' must be updated.", common_name)
         return None


### PR DESCRIPTION
Currently an error occurs when the `iot/box/update_certificate_status` controller tries
to write `ssl_certificate_end_date` as `cert.not_valid_after_utc`.

Error: `ValueError: unconverted data remains: +00:00`

This is because when we convert `cert.not_valid_after_utc` to a string, it will convert
the UTC date as ` "2026-03-08 13:06:39+00:00"` and while the system converts this
string date with +00:00, it will throw an error.

This commit fixes the issue by using a `timezone-naive` value derived from
`cert.not_valid_after_utc`. Applying `replace(tzinfo=None)` removes the `+00:00`
timezone information and converts the datetime to a `timezone-naive` object.

sentry-7016111455

