### PR TITLE
[IMP] website: improve full-size popup with margin and background

### DIFF
--- a/addons/website/static/src/snippets/s_popup/001.scss
+++ b/addons/website/static/src/snippets/s_popup/001.scss
@@ -24,10 +24,11 @@
     .s_popup_size_full {
         padding: 0 !important;
         max-width: 100%;
+        margin: 0 10px !important;
 
         > .modal-content {
             // Use the backdrop color as background-color
-            background-color: transparent;
+            background-color: #FFFFFF;
             box-shadow: none;
             border-radius: 0;
         }


### PR DESCRIPTION
The full-size option for popups could be misleading when using
transparent backgrounds, as the dialog content could visually merge
with the page and become hard to read.

This change keeps the same behavior as other popup sizes while adding a
10px margin on both sides of the snippet. It also applies a default white
background in full-size mode, ensuring better visual separation and improved readability.

| Before  | After |
| ------------- | ------------- |
| <img width="1646" height="456" alt="image" src="https://github.com/user-attachments/assets/122b266d-8391-45fe-a6be-08177b97f99c" /> | <img width="1659" height="466" alt="image" src="https://github.com/user-attachments/assets/df4e09de-850e-4735-9169-5115465c1372" /> |
| <img width="1641" height="707" alt="image" src="https://github.com/user-attachments/assets/51d549f8-f7ff-42de-aba1-52ab0b4adaf0" /> | <img width="1655" height="687" alt="image" src="https://github.com/user-attachments/assets/2085b8ec-f318-4f04-a9ed-af8ecb0d6fa8" /> |

task-5435802

