### PR TITLE
[IMP] project, website_project: send users to login page for shared project

### DIFF
--- a/addons/project/wizard/project_share_wizard.py
+++ b/addons/project/wizard/project_share_wizard.py
@@ -174,10 +174,8 @@ class ProjectShareWizard(models.TransientModel):
                 partner_ids_in_edit_mode.append(collaborator.partner_id.id)
         if partner_ids_in_edit_mode:
             new_collaborators = self.env['res.partner'].browse(partner_ids_in_edit_mode)
-            portal_partners = new_collaborators.filtered('user_ids')
             # send mail to users
-            self._send_public_link(portal_partners)
-            self._send_signup_link(partners=new_collaborators.with_context({'signup_valid': True}) - portal_partners)
+            self._send_signup_link(partners=new_collaborators.with_context({'signup_valid': True}))
         if partner_ids_in_readonly_mode:
             self.partner_ids = self.env['res.partner'].browse(partner_ids_in_readonly_mode)
             super().action_send_mail()

--- a/addons/website_project/tests/test_project_portal_access.py
+++ b/addons/website_project/tests/test_project_portal_access.py
@@ -15,17 +15,16 @@ class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):
         self.project_no_collabo.privacy_visibility = 'portal'
         message = self.get_project_share_link()
         share_link = str(message.body.split('href="')[1].split('">')[0])
-        match = search(r"access_token=([^&]+)&amp;pid=([^&]+)&amp;hash=([^&]*)", share_link)
-        access_token, pid, _hash = match.groups()
+        match = search(r"token=([^&]+)&amp;redirect=([^&]+)", share_link)
+        token, redirect = match.groups()
 
         with self.with_user('chell'), MockRequest(self.env, path=share_link):
             ThreadController().mail_message_post(
                 thread_model='project.task',
                 thread_id=self.task_no_collabo.id,
                 post_data={'body': '(-b ±√[b²-4ac]) / 2a'},
-                token=access_token,
-                pid=pid,
-                hash=_hash,
+                token=token,
+                redirect=redirect
             )
 
         self.assertTrue(


### PR DESCRIPTION
Task :  5354079

Description of the issue/feature this PR addresses: 
Updated "action_send_mail" in "project_share_wizard.py" to call "_send_signup_link" for all collaborators, not only non-user collaborators. "_send_signup_link" already handles generating the appropriate login or signup portal depending on the collaborator type, and it correctly skips the login form when the user is already authenticated.

Removed the separate link previously generated for user collaborators that redirected to the public project page when not logged in, as this is now fully replaced by the unified login/signup link discussed above.

Current behavior before PR:
When a project is shared with a portal user and that portal user clicks on the shared link while they are not login, they are sent to the public page of the shared project. This is only the case when the user is given the edit or edit with limited access rights

Desired behavior after PR is merged:
When a project is shared with a portal user and that portal user clicks on the shared link, they are sent to a login screen. Once logged-in they have the full view of the project depending on there access rights.  This is only the case when the user is given the edit or edit with limited access rights.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
