### PR TITLE
[FIX] l10n_th: correct sign for tax tag report line

### DIFF
--- a/addons/l10n_th/data/account_tax_report_data.xml
+++ b/addons/l10n_th/data/account_tax_report_data.xml
@@ -41,7 +41,7 @@
                             <record id="tax_report_out_tax_less_sales_0_rate_tag" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">2. Less sales subject to 0% tax rate </field>
+                                <field name="formula">-2. Less sales subject to 0% tax rate </field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
Since v19.0, the sign was removed from tax tags. This caused the 'P.P. 30 – Less sales subject to 0% tax rate' line to have an incorrect sign.

This commit adds a negative sign directly in the formula to restore the correct behavior.

task-5448506
