### PR TITLE
[IMP] web: tooltip padding for string tooltips

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip.scss
+++ b/addons/web/static/src/core/tooltip/tooltip.scss
@@ -33,6 +33,10 @@
         margin: map-get($spacers, 1) map-get($spacers, 2) map-get($spacers, 2);
     }
 
+    .o-tooltip--string {
+        display: inline-block;
+    }
+    
     .o-tooltip--help, .o-tooltip--string {
         white-space: pre-line;
         padding: 0 map-get($spacers, 2);


### PR DESCRIPTION
After https://github.com/odoo/odoo/pull/239198, we need to adjust the padding of multiline tooltips to avoid having too much space around the text.

No task ID
