### PR TITLE
[PERF] bus: use orjson for faster notification serialization

### DIFF
--- a/addons/bus/__init__.py
+++ b/addons/bus/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 from . import models
+from . import tools
 from . import controllers
 from . import websocket

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -12,6 +12,7 @@ import time
 from psycopg2 import InterfaceError
 
 import odoo
+from ..tools import orjson
 from odoo import api, fields, models
 from odoo.service.server import CommonServer
 from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
@@ -175,7 +176,7 @@ class ImBus(models.Model):
         for notif in notifications:
             result.append({
                 'id': notif['id'],
-                'message': json.loads(notif['message']),
+                'message': orjson.loads(notif['message']),
             })
         return result
 
@@ -239,7 +240,7 @@ class ImDispatch(threading.Thread):
                     conn.poll()
                     channels = []
                     while conn.notifies:
-                        channels.extend(json.loads(conn.notifies.pop().payload))
+                        channels.extend(orjson.loads(conn.notifies.pop().payload))
                     # relay notifications to websockets that have
                     # subscribed to the corresponding channels.
                     websockets = set()

--- a/addons/bus/tools/__init__.py
+++ b/addons/bus/tools/__init__.py
@@ -1,0 +1,1 @@
+from . import orjson

--- a/addons/bus/tools/orjson.py
+++ b/addons/bus/tools/orjson.py
@@ -1,0 +1,16 @@
+try:
+    import orjson
+
+    def dumps(value):
+        return orjson.dumps(value)
+
+    def loads(value):
+        return orjson.loads(value)
+except ImportError:
+    import json
+
+    def dumps(value):
+        return json.dumps(value, separators=(",", ":")).encode()
+
+    def loads(value):
+        return json.loads(value)

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -2,7 +2,6 @@ import base64
 import bisect
 import functools
 import hashlib
-import json
 import logging
 import os
 import psycopg2
@@ -23,6 +22,7 @@ from werkzeug.local import LocalStack
 from werkzeug.exceptions import BadRequest, HTTPException, ServiceUnavailable
 
 import odoo
+from .tools import orjson
 from odoo import api
 from .models.bus import dispatch
 from odoo.http import root, Request, Response, SessionExpiredException, get_default_session
@@ -524,7 +524,7 @@ class Websocket:
         if isinstance(frame.payload, str):
             frame.payload = frame.payload.encode('utf-8')
         elif not isinstance(frame.payload, (bytes, bytearray)):
-            frame.payload = json.dumps(frame.payload).encode('utf-8')
+            frame.payload = orjson.dumps(frame.payload)
 
         output = bytearray()
         first_byte = (
@@ -819,7 +819,7 @@ class WebsocketRequest:
 
     def serve_websocket_message(self, message):
         try:
-            jsonrequest = json.loads(message)
+            jsonrequest = orjson.loads(message)
             event_name = jsonrequest['event_name']  # mandatory
         except KeyError as exc:
             raise InvalidWebsocketRequest(


### PR DESCRIPTION
When the gevent server is under high load, the time required to acquire a cursor and fetch notifications increases. This causes notifications to accumulate, leading to larger payloads.

Serializing these large payloads using the standard json library becomes a bottleneck. In a gevent environment, this monopolizes the event loop, delaying the processing of other greenlets.

This commit introduces optional support for `orjson`. If installed, it is used to significantly speed up JSON encoding, freeing up the event loop.

Using `orjson` increases the throughput by ~20% under high load.
