### PR TITLE
[FIX] mrp: ensure variant synchronisation in BoM report

### DIFF
--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -62,7 +62,7 @@ export class BomOverviewComponent extends Component {
         this.variants = bomData["variants"];
         this.showVariants = bomData["is_variant_applied"];
         if (this.showVariants) {
-            this.state.currentVariantId ||= Object.keys(this.variants)[0];
+            this.state.currentVariantId ||= this.state.bomData.product_id;
         }
         this.state.precision = bomData["precision"];
     }

--- a/addons/mrp/static/tests/tours/mrp_report.js
+++ b/addons/mrp/static/tests/tours/mrp_report.js
@@ -1,0 +1,33 @@
+/** @odoo-module **/
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("mrp_bom_report_tour", {
+    test: true,
+    steps: () => [
+        {
+            content: "Wait for BoM report to load",
+            trigger: ".o_mrp_bom_report_page",
+            run: () => {},
+        },
+        {
+            content: "Check the current displayed variant",
+            trigger: ".o_mrp_bom_report_page h2 a:contains('[alpaca] Product Test Sync (L)')",
+            run: () => {},
+        },
+        {
+            content: "Open dropdown menu",
+            trigger: ".o-autocomplete--input",
+            run: "click",
+        },
+        {
+            content: "Select the other variant",
+            trigger: ".o-autocomplete--dropdown-menu.show li.o-autocomplete--dropdown-item:eq(1)",
+            run: "click",
+        },
+        {
+            content: "Ensure the second variant is displayed",
+            trigger: ".o_mrp_bom_report_page h2 a:contains('[zebra] Product Test Sync (S)')",
+            run: () => {},
+        },
+    ],
+});

--- a/addons/mrp/tests/__init__.py
+++ b/addons/mrp/tests/__init__.py
@@ -18,3 +18,4 @@ from . import test_smp
 from . import test_performance
 from . import test_consume_component
 from . import test_manual_consumption
+from . import test_mrp_reports

--- a/addons/mrp/tests/test_mrp_reports.py
+++ b/addons/mrp/tests/test_mrp_reports.py
@@ -1,0 +1,37 @@
+from odoo.tests import HttpCase, tagged
+from odoo.fields import Command
+
+
+@tagged('post_install', '-at_install')
+class TestReportBom(HttpCase):
+
+    def test_mrp_report_bom_variant_selection(self):
+        attribute = self.env['product.attribute'].create({'name': 'Size'})
+        value_S, value_L = self.env['product.attribute.value'].create([
+            {'name': 'S', 'attribute_id': attribute.id},
+            {'name': 'L', 'attribute_id': attribute.id}
+        ])
+
+        product_tmpl = self.env['product.template'].create({
+            'name': 'Product Test Sync',
+            'type': 'product',
+            'attribute_line_ids': [Command.create({
+                'attribute_id': attribute.id,
+                'value_ids': [Command.set([value_S.id, value_L.id])]
+            })]
+        })
+
+        [variant_s, variant_l] = product_tmpl.product_variant_ids
+
+        variant_s.default_code = 'zebra'
+        variant_l.default_code = 'alpaca'
+
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': product_tmpl.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+        })
+
+        action_id = self.env.ref('mrp.action_report_mrp_bom')
+        url = "/web#action=%s&active_id=%s" % (str(action_id.id), str(bom.id))
+        self.start_tour(url, "mrp_bom_report_tour", login="admin")


### PR DESCRIPTION
Steps to reproduce on runbot
------------------
Select a product with several variants and a Bill of Materials
(e.g. Stool).

Change the variants order so that their ids are not ordered, this can
be done by modifying the default_code for example (e.g. Internal
Reference for variant "Color: Green" set to "A").

When accessing the BoM report, you won’t be able to switch to one of
the possible variants (in the example the Dark Blue variant).

Why it is happening
------------------
The default variant to be displayed when opening the report is selected
in the backend using the product_variant_id field. This field is
computed as the first element in product_variant_ids as they are
ordered in the model.

We then send this variant’s information to the frontend and a
dictionary containing every variant (key= id and value = display_name).
In the serialization process, the object is reordered based on the
keys. Thus, if the variants were not ordered based on their ids in
python, the order will change.

The displayed variant is correct as it has been passed directly but the
frontend also computes the currentVariant attribute. This is computed
as the first element in the dictionary but in this case, it is not the
one that has been selected in the backend, as the order changed.

As a result, you see the report for a variant A but the frontend
considers you are on the report for variant B so you cannot switch to
variant B as you are supposed to be already on it.

The fix
------------------
I propose to use the explicitly passed id as the currentVariantId.

opw-5409493

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
