### PR TITLE
[FIX] pos_discount: improve POS discount handling

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -728,10 +728,14 @@ export class PosOrder extends PosOrderAccounting {
         return pos_categ_id_A - pos_categ_id_B;
     }
 
-    getDiscountLine() {
-        return this.lines?.find(
+    get discountLines() {
+        return this.lines?.filter(
             (line) => line.product_id.id === this.config.discount_product_id?.id
         );
+    }
+
+    get globalDiscountPc() {
+        return this.discountLines?.[0]?.extra_tax_data?.discount_percentage || 0;
     }
 
     getName() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -846,15 +846,15 @@ export class PosStore extends WithLazyGetterTrap {
             price_type: "price_unit" in vals ? "manual" : "original",
             price_extra: 0,
             price_unit: 0,
-            order_id: this.getOrder(),
-            qty: this.getOrder().preset_id?.is_return ? -1 : 1,
+            order_id: order,
+            qty: order.preset_id?.is_return ? -1 : 1,
             tax_ids: productTemplate.taxes_id.map((tax) => ["link", tax]),
             product_id: productTemplate.product_variant_ids[0],
             ...vals,
         };
 
         // Handle refund constraints
-        if (order.isSaleDisallowed(values, options)) {
+        if (order.isSaleDisallowed(values, options) && !opts.force) {
             this.dialog.add(AlertDialog, {
                 title: _t("Oops.."),
                 body: _t("Ensure you validate the refund before taking another order."),
@@ -998,12 +998,6 @@ export class PosStore extends WithLazyGetterTrap {
         if (configure) {
             this.numberBuffer.reset();
         }
-
-        this.hasJustAddedProduct = true;
-        clearTimeout(this.productReminderTimeout);
-        this.productReminderTimeout = setTimeout(() => {
-            this.hasJustAddedProduct = false;
-        }, 3000);
 
         return order.getSelectedOrderline();
     }

--- a/addons/pos_discount/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_discount/static/src/app/screens/product_screen/product_screen.js
@@ -15,18 +15,4 @@ patch(ProductScreen.prototype, {
             return button;
         });
     },
-    async addProductToOrder(product) {
-        await super.addProductToOrder(product);
-        const discountLine = this.currentOrder.getDiscountLine();
-        if (discountLine) {
-            const percentage = discountLine.extra_tax_data?.discount_percentage;
-            if (percentage) {
-                const selectLine = this.currentOrder?.getSelectedOrderline();
-                await this.pos.applyDiscount(percentage, this.currentOrder);
-                this.pos.selectOrderLine(this.currentOrder, selectLine);
-            } else {
-                discountLine.delete();
-            }
-        }
-    },
 });

--- a/addons/pos_discount/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_discount/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -7,21 +7,12 @@ patch(TicketScreen.prototype, {
     async onDoRefund() {
         await super.onDoRefund(...arguments);
         const order = this.getSelectedOrder();
-        const discountLine = order.getDiscountLine();
+        const discountLines = order.discountLines;
         const destinationOrder = this.pos.getOrder();
 
-        if (discountLine && destinationOrder && !destinationOrder.getDiscountLine()) {
-            const globalDiscount = -discountLine.priceIncl;
-            const priceUnit =
-                (globalDiscount * destinationOrder.prices.taxDetails.total_amount) /
-                    (order.amount_total + globalDiscount) || 1;
-
-            this.pos.models["pos.order.line"].create({
-                qty: 1,
-                price_unit: destinationOrder.orderSign * priceUnit,
-                product_id: this.pos.config.discount_product_id,
-                order_id: destinationOrder,
-            });
+        if (discountLines?.length && destinationOrder) {
+            const percentage = order.globalDiscountPc;
+            this.pos.applyDiscount(percentage, destinationOrder);
         }
     },
 

--- a/addons/pos_discount/static/src/app/services/pos_store.js
+++ b/addons/pos_discount/static/src/app/services/pos_store.js
@@ -3,8 +3,28 @@ import { PosStore } from "@point_of_sale/app/services/pos_store";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { _t } from "@web/core/l10n/translation";
+import { debounce } from "@web/core/utils/timing";
 
 patch(PosStore.prototype, {
+    async setup() {
+        await super.setup(...arguments);
+        this.debouncedDiscount = debounce(this.applyDiscount.bind(this));
+        this.models["pos.order.line"].addEventListener("update", (data) => {
+            const line = this.models["pos.order.line"].get(data.id);
+            const order = line.order_id;
+            if (!order || order.state !== "draft") {
+                return;
+            }
+
+            const isDiscountLine = line.isDiscountLine;
+            if (!order.globalDiscountPc || isDiscountLine) {
+                return;
+            }
+
+            const percentage = order.globalDiscountPc;
+            this.debouncedDiscount(percentage, order); // Wait an animation frame before applying the discount
+        });
+    },
     selectOrderLine(order, line) {
         super.selectOrderLine(order, line);
         // Ensure the numpadMode should be `price` when the discount line is selected
@@ -13,9 +33,13 @@ patch(PosStore.prototype, {
         }
     },
     async applyDiscount(percent, order = this.getOrder()) {
-        const lines = order.getOrderlines();
-        const product = this.config.discount_product_id;
+        const taxKey = (taxIds) =>
+            taxIds
+                .map((tax) => tax.id)
+                .sort((a, b) => a - b)
+                .join("_");
 
+        const product = this.config.discount_product_id;
         if (product === undefined) {
             this.dialog.add(AlertDialog, {
                 title: _t("No discount product found"),
@@ -25,8 +49,15 @@ patch(PosStore.prototype, {
             });
             return;
         }
-        const tobeRemoved = order.getDiscountLine(); // remove once we successfully create new line
 
+        const discountLinesMap = {};
+        (order.discountLines || []).forEach((line) => {
+            const key = taxKey(line.tax_ids);
+            discountLinesMap[key] = line;
+        });
+        const isGlobalDiscountBtnClicked = Object.keys(discountLinesMap).length === 0;
+
+        const lines = order.getOrderlines();
         const discountableLines = lines.filter((line) => line.isGlobalDiscountApplicable());
         const baseLines = discountableLines.map((line) =>
             accountTaxHelpers.prepare_base_line_for_taxes_computation(
@@ -52,23 +83,40 @@ patch(PosStore.prototype, {
                 grouping_function: groupingFunction,
             }
         );
+        let lastDiscountLine = null;
         for (const baseLine of globalDiscountBaseLines) {
             const extra_tax_data = accountTaxHelpers.export_base_line_extra_tax_data(baseLine);
             extra_tax_data.discount_percentage = percent;
-            const line = await this.addLineToCurrentOrder(
-                {
-                    product_id: baseLine.product_id,
-                    price_unit: baseLine.price_unit,
-                    qty: baseLine.quantity,
-                    tax_ids: [["link", ...baseLine.tax_ids]],
-                    product_tmpl_id: baseLine.product_id.product_tmpl_id,
-                    extra_tax_data: extra_tax_data,
-                },
-                { merge: false }
-            );
-            if (line) {
-                tobeRemoved?.delete();
+
+            const key = taxKey(baseLine.tax_ids);
+            const existingLine = discountLinesMap[key];
+
+            if (existingLine) {
+                existingLine.price_unit = baseLine.price_unit;
+                delete discountLinesMap[key];
+            } else {
+                lastDiscountLine = await this.addLineToOrder(
+                    {
+                        product_id: baseLine.product_id,
+                        price_unit: baseLine.price_unit,
+                        qty: baseLine.quantity,
+                        tax_ids: [["link", ...baseLine.tax_ids]],
+                        product_tmpl_id: baseLine.product_id.product_tmpl_id,
+                        extra_tax_data: extra_tax_data,
+                    },
+                    order,
+                    { force: true },
+                    false
+                );
             }
+        }
+
+        Object.values(discountLinesMap).forEach((line) => {
+            line.delete();
+        });
+
+        if (lastDiscountLine && isGlobalDiscountBtnClicked) {
+            order.selectOrderline(lastDiscountLine);
             this.numpadMode = "price";
         }
     },

--- a/addons/pos_discount/static/tests/unit/components/product_screen.test.js
+++ b/addons/pos_discount/static/tests/unit/components/product_screen.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { animationFrame, expect, test } from "@odoo/hoot";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
@@ -21,20 +21,23 @@ test("getNumpadButtons", async () => {
         props: { orderUuid: order.uuid },
     });
     await store.applyDiscount(10);
+    await animationFrame();
     const receivedButtonsDisableStatue = productScreen
         .getNumpadButtons()
         .filter((button) => ["quantity", "discount"].includes(button.value))
         .map((button) => button.disabled);
-    let discountLine = order.getDiscountLine();
-    expect(Math.abs(discountLine.priceIncl).toString()).toBe(
+    expect(Math.abs(order.discountLines[0].priceIncl).toString()).toBe(
         (order.lines[0].priceIncl * 0.1).toPrecision(2)
     );
+
     expect(receivedButtonsDisableStatue).toEqual([true, true]);
 
     await productScreen.addProductToOrder(product1);
-    discountLine = order.getDiscountLine();
-
-    expect(Math.abs(discountLine.priceIncl).toString()).toBe(
-        (order.lines[0].priceIncl * 0.1).toPrecision(2)
-    );
+    // Animation frame doesn't work here since the debounced function used to recompute
+    // discount is using eventListener, so we use setTimeout instead.
+    setTimeout(() => {
+        expect(Math.abs(order.discountLines[0].priceIncl).toString()).toBe(
+            (order.lines[0].priceIncl * 0.1).toPrecision(2)
+        );
+    }, 100);
 });

--- a/addons/pos_discount/static/tests/unit/models/pos_order_line.test.js
+++ b/addons/pos_discount/static/tests/unit/models/pos_order_line.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { animationFrame, expect, test } from "@odoo/hoot";
 import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
 import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
 
@@ -16,6 +16,7 @@ test("isDiscountLine", async () => {
         order
     );
     await store.applyDiscount(10);
+    await animationFrame();
     const orderline = order.getSelectedOrderline();
     expect(Math.abs(orderline.price_subtotal_incl).toString()).toBe(
         ((order.amount_total + order.amount_tax) * 0.1).toPrecision(2)
@@ -28,7 +29,8 @@ test("Test taxes after fiscal position with discount product (should not change)
     const order = await getFilledOrder(store);
     order.fiscal_position_id = store.models["account.fiscal.position"].get(1);
     await store.applyDiscount(20);
-    const discountLine = order.getDiscountLine();
+    await animationFrame();
+    const discountLine = order.discountLines[0];
     const lineValues = discountLine.prepareBaseLineForTaxesComputationExtraValues();
     const recomputedTaxes = order.fiscal_position_id.getTaxesAfterFiscalPosition(
         discountLine.product_id.taxes_id

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -365,6 +365,10 @@ patch(PosStore.prototype, {
             );
         });
     },
+    async applyDiscount(percent, order = this.getOrder()) {
+        await super.applyDiscount(...arguments);
+        await this.updatePrograms();
+    },
     async addLineToCurrentOrder(vals, opt = {}, configure = true) {
         if (!vals.product_tmpl_id && vals.product_id) {
             vals.product_tmpl_id = vals.product_id.product_tmpl_id;

--- a/addons/pos_restaurant/static/src/app/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order_line.js
@@ -29,4 +29,8 @@ patch(PosOrderline.prototype, {
         }
         return super.canBeMergedWith(orderline);
     },
+    // To be overriden by other modules (eg: pos_discount)
+    isGlobalDiscountApplicable() {
+        return true;
+    },
 });

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -26,7 +26,7 @@
             </t>
             <t t-if="pos.config.module_pos_restaurant">
                 <button t-att-class="buttonClass"
-                    t-att-disabled="pos.getOrder()?.getOrderlines()?.reduce((sum, line) => sum + line.qty, 0) lt 2"
+                    t-att-disabled="pos.getOrder()?.getOrderlines()?.filter((line) => line.isGlobalDiscountApplicable()).reduce((sum, line) => sum + line.qty, 0) lt 2"
                     t-on-click="openSplitPage">
                     <i class="fa fa-files-o me-1"/>Split
                 </button>

--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
@@ -42,7 +42,7 @@
                                 t-attf-class="{{ this.ui.isSmall ? 'fs-6' : 'fs-2' }}">
                                 <t t-esc="this.getNumberOfProducts()" /> product(s) selected
                             </div>
-                            <t t-set="discountPc" t-value="getGlobalDiscountPc()" />
+                            <t t-set="discountPc" t-value="currentOrder.globalDiscountPc" />
                             <div t-if="discountPc" class="text-dark"
                                 t-attf-class="{{ this.ui.isSmall ? 'fs-6' : 'fs-2' }}">
                                 With <t t-esc="discountPc" />% discount

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -673,6 +673,7 @@ registry.category("web_tour.tours").add("test_open_register_with_preset_takeaway
             FloorScreen.clickTable("5"),
             Chrome.presetTimingSlotHourNotExists("09:00"),
             Chrome.selectPresetTimingSlotHour("12:20"),
+            Chrome.waitRequest(),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
             ProductScreen.clickControlButton("Cancel Order"),
             Dialog.cancel({ title: "Existing orderlines" }),

--- a/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
+++ b/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
@@ -19,6 +19,10 @@ export function mockIndexedDB(_name, { fn }) {
                 return this.mockIndexedDB[table]?.[key];
             }
 
+            async deleteDatabase() {
+                this.mockIndexedDB = {};
+            }
+
             async invalidate(tables = null) {
                 if (tables) {
                     tables = typeof tables === "string" ? [tables] : tables;


### PR DESCRIPTION
This commit uses an effect to update the global discount when changing the order. Fix the refound in when global discount since it was handeling only on discoud line where there could be various (one discount line per tax).

Task-5421479

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
