### PR TITLE
[IMP] pos_self_order: transform table selection UI in new design

### DIFF
--- a/addons/pos_self_order/static/src/app/components/popup_table/popup_table.js
+++ b/addons/pos_self_order/static/src/app/components/popup_table/popup_table.js
@@ -28,6 +28,10 @@ export class PopupTable extends Component {
         this.props.selectTable(null);
     }
 
+    selectTable(table) {
+        this.state.selectedTable = table.id;
+    }
+
     get validSelection() {
         return Boolean(this.selectedTable);
     }

--- a/addons/pos_self_order/static/src/app/components/popup_table/popup_table.scss
+++ b/addons/pos_self_order/static/src/app/components/popup_table/popup_table.scss
@@ -3,6 +3,29 @@
     animation: popupAnimation 0.2s ease-in-out forwards;
 }
 
+.self_order_popup_table {
+  max-height: calc(100vh - 48px);
+  overflow: hidden;
+
+  .popup-body {
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+.table-card {
+  border: 1px solid transparent;
+  border-radius: 10px;
+
+  &.selected {
+    background: linear-gradient(180deg, rgba(47,118,247,0.08), rgba(47,118,247,0.03));
+    border-color: $primary;
+  }
+}
+
+.tables-grid {
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+}
+
 @keyframes popupAnimation {
     0% {
       bottom: -40vh;

--- a/addons/pos_self_order/static/src/app/components/popup_table/popup_table.xml
+++ b/addons/pos_self_order/static/src/app/components/popup_table/popup_table.xml
@@ -2,39 +2,29 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.PopupTable">
         <div class="position-absolute bg-dark bg-opacity-25 w-100 h-100 fixed-top" />
-        <div class="self_order_popup_table shadow-lg position-absolute fixed-bottom bg-white w-100 p-4 flex-column d-flex justify-content-between">
-            <div class="mb-5 d-flex justify-content-between align-items-start">
-                <div>
-                    <h3>Table selection</h3>
-                    <span>Could you please confirm your table number?<br/>Thanks a lot!</span>
+        <div class="self_order_popup_table shadow-lg position-absolute fixed-bottom bg-white w-100 p-3 d-flex flex-column align-items-stretch overflow-hidden">
+            <div class="popup-header mb-2 d-flex justify-content-between align-items-start border-bottom">
+                <div class="fs-3 fw-bold mb-1 d-flex justify-content-center w-100">
+                    Select Your Table
                 </div>
                 <button class="btn btn-close" t-on-click="close"/>
             </div>
-            <select class="form-select form-select-lg mb-5" t-model="state.selectedTable">
-                <option value="0">
-                    Select a table
-                </option>
+
+            <div class="popup-body table-grid-wrap pt-2 pb-3 px-0 flex-fill overflow-auto">
                 <t t-foreach="selfOrder.models['restaurant.floor'].getAll()" t-as="floor" t-key="floor.id">
-                    <option value="floor" disabled="true">
-                        <t t-esc="floor.name" />
-                    </option>
-                    <option t-foreach="floor.sortedTable" t-as="table" t-key="table.id" t-att-value="table.id">
-                        <t t-esc="table.table_number" />
-                    </option>
+                    <h3 class="floor-title mt-3" t-esc="floor.name"/>
+                    <div class="tables-grid d-grid gap-3">
+                        <t t-foreach="floor.sortedTable" t-as="table" t-key="table.id">
+                        <button class="table-card w-100 flex-grow-1 d-flex justify-content-center align-items-center flex-column gap-2 p-2" t-att-class="{'selected': state.selectedTable == table.id}" t-on-click="() => this.selectTable(table)">
+                            <div class="table-number" t-esc="table.table_number"/>
+                        </button>
+                        </t>
+                    </div>
                 </t>
-            </select>
-            <a
-                type="button"
-                t-on-click="() => this.setTable()"
-                t-att-class="{'disabled': !this.validSelection}"
-                class="btn btn-primary py-3 my-2">
-                    <t t-if="this.validSelection">
-                        Continue with table <t t-esc="this.selectedTable.table_number" />
-                    </t>
-                    <t t-else="">
-                        Select a table
-                    </t>
-            </a>
+            </div>
+            <button class="btn btn-primary py-3 my-2" t-att-class="{'disabled': !this.validSelection}" t-on-click="setTable" >
+                Confirm Table
+            </button>
         </div>
     </t>
 </templates>

--- a/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/cart_page_util.js
@@ -17,21 +17,22 @@ export function selectTable(table) {
     return [
         {
             content: `Select table ${table}`,
-            trigger: `.self_order_popup_table select`,
+            trigger: `.self_order_popup_table .table-card`,
             run: (helpers) => {
                 // The default select (run: select 3) doesn't work here
-                const options = document.querySelectorAll(".self_order_popup_table option");
-                const targetOption = Array.from(options).find((option) =>
-                    option.textContent.includes(table)
+                const buttons = document.querySelectorAll(".self_order_popup_table .table-card");
+                const target = Array.from(buttons).find(
+                    (b) => b.textContent && b.textContent.trim().includes(String(table))
                 );
-                const optionValue = targetOption.value;
-                helpers.anchor.value = optionValue;
-                helpers.anchor.dispatchEvent(new Event("change"));
+                if (!target) {
+                    throw new Error(`Table button "${table}" not found`);
+                }
+                target.dispatchEvent(new Event("click"));
             },
         },
         {
             content: `Click on 'Confirm' button`,
-            trigger: `.self_order_popup_table .btn:contains('Continue with table ${table}')`,
+            trigger: `.self_order_popup_table .btn:contains('Confirm Table')`,
             run: "click",
         },
     ];


### PR DESCRIPTION
Before this commit:
====================
Table selection was shown as a basic popup with limited visual clarity and poor user experience.

After this commit:
====================
Redesigned the table selection popup with a modern design. Improved usability, clarity, and overall user experience.

Task-5407613

