### PR TITLE
[FIX] point_of_sale: apply 0 min qty pricelist rule for negative qty too

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
@@ -95,7 +95,7 @@ export class ProductTemplateAccounting extends Base {
         const generalRulesIds = pricelist.getGeneralRulesIdsByCategories(this.parentCategories);
         const rules = this.models["product.pricelist.item"]
             .readMany([...productRulesSet, ...tmplRulesSet, ...generalRulesIds])
-            .filter((r) => r.min_quantity <= quantity);
+            .filter((r) => !r.min_quantity || r.min_quantity <= quantity);
 
         const rule = rules.length && rules[0];
         if (!rule) {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/pricelist_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/pricelist_util.js
@@ -72,6 +72,7 @@ export function setUp() {
                 assertProductPrice(product_letter_tray, "Public Pricelist", 0, 4.8)()
                     .then(assertProductPrice(product_letter_tray, "Public Pricelist", 1, 4.8))
                     .then(assertProductPrice(product_letter_tray, "Fixed", 1, 1))
+                    .then(assertProductPrice(product_letter_tray, "Fixed", -1, 1))
                     .then(assertProductPrice(product_wall_shelf, "Fixed", 1, 2))
                     .then(assertProductPrice(product_small_shelf, "Fixed", 1, 13.95))
                     .then(assertProductPrice(product_wall_shelf, "Percentage", 1, 0))


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create a pricelist with a rule of 50% discount on all product, and a `min_quantity` of ZERO.
2. In PoS select this pricelist, and add a product originally priced at 10; the pricelist is well applied and the new price is 5.
3. Now, from the numpad, click change the quantity from 1 to -1 (click on the "+/-" button.

Observation: The pricelist rule is not applied anymore. The price is -10 and not -5.

Why it's an issue
-----------------
`getPrice` on frontend is a port of `_get_product_price` on product.pricelist. There, in `_is_applicable_for`, we apply the price rule if it's `min_quantity` is 0, regardless of the bought quantity. So there's a mismatch between applying the rule on backend and frontend.

This worked well on 18.0, before 43bfda63faeb4713dbeb1d11457673aafaa544b4.

opw-5431651
