### PR TITLE
[FIX] html_editor: hide toolbar on mobile when popover or sidebar exists

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar.scss
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.scss
@@ -4,6 +4,9 @@
     z-index: 2000;
     bottom: 0;
 }
+:has(.o_app_menu_sidebar, .popover:not(.o_font_selector_menu, .o_font_size_selector_menu)) .o-toolbar-above-keyboard {
+    display: none;
+}
 
 .o-we-toolbar {
     height: 40px;

--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -33,7 +33,6 @@ function commonParentGet(node1, node2, root = undefined) {
 //--------------------------------------------------------------------------
 
 const RE_COL_MATCH = /(^| )col(-[\w\d]+)*( |$)/;
-const RE_COMMAS_OUTSIDE_PARENTHESES = /,(?![^(]*?\))/g;
 const RE_OFFSET_MATCH = /(^| )offset(-[\w\d]+)*( |$)/;
 const RE_PADDING_MATCH = /[ ]*padding[^;]*;/g;
 const RE_PADDING = /([\d.]+)/;
@@ -1211,6 +1210,26 @@ export function formatTables(element) {
         }
     }
 }
+export function splitSelectors(str) {
+    const result = [];
+    let current = "";
+    let depth = 0;
+    for (const char of str) {
+        if (char === "(") {
+            depth++;
+        } else if (char === ")") {
+            depth--;
+        }
+        if (char === "," && depth === 0) {
+            result.push(current.trim());
+            current = "";
+        } else {
+            current += char;
+        }
+    }
+    result.push(current.trim());
+    return result;
+}
 /**
  * Parse through the given document's stylesheets, preprocess(*) them and return
  * the result as an array of objects, each containing a selector string , a
@@ -1253,7 +1272,7 @@ export function getCSSRules(doc) {
             for (const subRule of subRules) {
                 const selectorText = subRule.selectorText || "";
                 // Split selectors, making sure not to split at commas in parentheses.
-                for (const selector of selectorText.split(RE_COMMAS_OUTSIDE_PARENTHESES)) {
+                for (const selector of splitSelectors(selectorText)) {
                     if (selector && !SELECTORS_IGNORE.test(selector)) {
                         cssRules.push({ selector: selector.trim(), rawRule: subRule });
                         if (selector === "body") {

--- a/addons/mail/static/tests/inline/convert_inline.test.js
+++ b/addons/mail/static/tests/inline/convert_inline.test.js
@@ -9,6 +9,7 @@ import {
     listGroupToTable,
     normalizeColors,
     normalizeRem,
+    splitSelectors,
 } from "@mail/views/web/fields/html_mail_field/convert_inline";
 import { beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
 import { enableTransitions } from "@odoo/hoot-mock";
@@ -1491,5 +1492,21 @@ describe("Properly add MSO conditions", () => {
         ).toEqual(`[if mso]><div>efgh</div><![endif]`, {
             message: "Should remove nested mso hide condition",
         });
+    });
+});
+
+describe("splitSelectors method", () => {
+    test("no parentheses", async () => {
+        expect(splitSelectors("abc, def, ghi")).toEqual(["abc", "def", "ghi"]);
+    });
+    test("one depth parentheses", async () => {
+        expect(splitSelectors("abc:has(xyz), def, ghi")).toEqual(["abc:has(xyz)", "def", "ghi"]);
+    });
+    test("two depth parentheses", async () => {
+        expect(splitSelectors("abc:has(xyz:not(.ooo)), def, ghi")).toEqual([
+            "abc:has(xyz:not(.ooo))",
+            "def",
+            "ghi",
+        ]);
     });
 });

--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -7,7 +7,6 @@ import { getAdjacentPreviousSiblings, isBlock, rgbToHex, commonParentGet } from 
 //--------------------------------------------------------------------------
 
 const RE_COL_MATCH = /(^| )col(-[\w\d]+)*( |$)/;
-const RE_COMMAS_OUTSIDE_PARENTHESES = /,(?![^(]*?\))/g;
 const RE_OFFSET_MATCH = /(^| )offset(-[\w\d]+)*( |$)/;
 const RE_PADDING_MATCH = /[ ]*padding[^;]*;/g;
 const RE_PADDING = /([\d.]+)/;
@@ -1061,6 +1060,26 @@ function formatTables($editable) {
         }
     }
 }
+function splitSelectors(str) {
+    const result = [];
+    let current = "";
+    let depth = 0;
+    for (const char of str) {
+        if (char === "(") {
+            depth++;
+        } else if (char === ")") {
+            depth--;
+        }
+        if (char === "," && depth === 0) {
+            result.push(current.trim());
+            current = "";
+        } else {
+            current += char;
+        }
+    }
+    result.push(current.trim());
+    return result;
+}
 /**
  * Parse through the given document's stylesheets, preprocess(*) them and return
  * the result as an array of objects, each containing a selector string , a
@@ -1103,7 +1122,7 @@ export function getCSSRules(doc) {
             for (const subRule of subRules) {
                 const selectorText = subRule.selectorText || '';
                 // Split selectors, making sure not to split at commas in parentheses.
-                for (const selector of selectorText.split(RE_COMMAS_OUTSIDE_PARENTHESES)) {
+                for (const selector of splitSelectors(selectorText)) {
                     if (selector && !SELECTORS_IGNORE.test(selector)) {
                         cssRules.push({ selector: selector.trim(), rawRule: subRule });
                         if (selector === 'body') {
@@ -1875,4 +1894,5 @@ export default {
     normalizeRem: normalizeRem,
     toInline: toInline,
     createMso: _createMso,
+    splitSelectors: splitSelectors,
 };

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1176,5 +1176,16 @@ QUnit.module('convert_inline', {}, function () {
         $styleSheet.remove();
     });
 });
+QUnit.module('splitSelectors', {}, function () {
+    QUnit.test('no parentheses', async function (assert) {
+        assert.deepEqual(convertInline.splitSelectors("abc, def, ghi"), ["abc", "def", "ghi"]);
+    });
+    QUnit.test('one depth parentheses', async function (assert) {
+        assert.deepEqual(convertInline.splitSelectors("abc:has(xyz), def, ghi"), ["abc:has(xyz)", "def", "ghi"]);
+    });
+    QUnit.test('two depth parentheses', async function (assert) {
+        assert.deepEqual(convertInline.splitSelectors("abc:has(xyz:not(.ooo)), def, ghi"), ["abc:has(xyz:not(.ooo))", "def", "ghi"]);
+    });
+});
 
 });


### PR DESCRIPTION
In mobile, when the side menu or a popover is opened, the toolbar remains displayed above the keyboard.

This commit hides the mobile toolbar while such elements are opened.

Steps to reproduce:
- In mobile, go to a "To do" note
- Put cursor inside text to display the toolbar
- Open the hamburger menu

=> The toolbar remained displayed on top of the side menu

- Open the gear menu

=> The toolbar remained displayed while the menu was opened

task-5222582
