### PR TITLE
[FIX] *: prevent editing next post elements in "Title above Cover" layout

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_context.js
+++ b/addons/website_blog/static/tests/tours/blog_context.js
@@ -102,5 +102,34 @@ registerWebsitePreviewTour(
             content: "Check the blog info is available",
             trigger: ":iframe #o_wblog_post_info",
         },
+        {
+            content: "Go to 'All' blogs",
+            trigger: ":iframe a[href='/blog']",
+            run: "click",
+        },
+        {
+            content: "Click on the first blog post.",
+            trigger: ":iframe a:contains('First Post')",
+            run: "click",
+        },
+        {
+            content: "Verify next post elements are not editable.",
+            trigger: ":iframe #o_wblog_post_footer",
+            run() {
+                const nextPostNameEl = this.anchor.querySelector(
+                    "div.o_wblog_post_name.o_not_editable"
+                );
+                const nextPostSubtitleEl = this.anchor.querySelector(
+                    "div.o_wblog_post_subtitle.o_not_editable"
+                );
+                const nextPostCoverEl = this.anchor.querySelector(
+                    ".o_record_cover_container.o_we_no_overlay"
+                );
+
+                if (!nextPostNameEl || !nextPostSubtitleEl || !nextPostCoverEl) {
+                    throw new Error("Next post elements should be not editable.");
+                }
+            },
+        },
     ]
 );

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -58,6 +58,20 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         self.start_tour("/blog", 'blog_autocomplete_with_date')
 
     def test_blog_context_and_social_media(self):
+        blog = self.env['blog.blog'].create({'name': 'Test Non-Editable'})
+        Post = self.env['blog.post']
+        Post.create({
+            'name': 'First Post',
+            'blog_id': blog.id,
+            'is_published': True,
+        })
+        Post.create({
+            'name': 'Second Post',
+            'subtitle': 'Subtitle Test',
+            'blog_id': blog.id,
+            'is_published': True,
+        })
+
         self.env.ref('website.default_website').write({
             'social_facebook': "https://www.facebook.com/Odoo",
             'social_twitter': 'https://twitter.com/Odoo',
@@ -68,7 +82,9 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
             'social_tiktok': 'https://www.tiktok.com/@odoo',
             'social_discord': 'https://discord.com/servers/discord-town-hall-169256939211980800',
         })
-        self.env.ref('website_blog.opt_blog_sidebar_show').active = True
+        (self.env.ref('website_blog.opt_blog_post_regular_cover') +
+         self.env.ref('website_blog.opt_blog_post_read_next') +
+         self.env.ref('website_blog.opt_blog_sidebar_show')).write({'active': True})
         self.start_tour("/blog", "blog_context_and_social_media", login="admin")
 
     def test_avatar_comment(self):

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -342,14 +342,14 @@ list of filtered posts (by date or tag).
                             <div class="flex-grow-1 pe-3">
                                 <span class="bg-o-color-3 h6 d-inline-block py-1 px-2 rounded-1">Read Next</span>
                                 <a t-att-href="'/blog/' + slug(next_post.blog_id) + '/' + slug(next_post)" t-att-title="'Read next' + next_post.name">
-                                    <div t-field="next_post.name" t-att-data-blog-id="next_post.id" placeholder="Blog Post Title" class="h2 o_wblog_post_name"/>
-                                    <div t-field="next_post.subtitle" placeholder="Subtitle" class="lead o_wblog_post_subtitle"/>
+                                    <div t-field="next_post.name" t-att-data-blog-id="next_post.id" placeholder="Blog Post Title" class="h2 o_wblog_post_name o_not_editable"/>
+                                    <div t-field="next_post.subtitle" placeholder="Subtitle" class="lead o_wblog_post_subtitle o_not_editable"/>
                                 </a>
                             </div>
                             <a t-att-href="'/blog/' + slug(next_post.blog_id) + '/' + slug(next_post)" t-att-title="'Read next' + next_post.name" class="w-25 flex-shrink-0">
                                 <t t-call="website.record_cover">
                                     <t t-set="_record" t-value="next_post"/>
-                                    <t t-set="additionnal_classes" t-value="'rounded shadow-sm overflow-hidden h-100'"/>
+                                    <t t-set="additionnal_classes" t-value="'rounded shadow-sm overflow-hidden h-100 o_we_no_overlay'"/>
                                 </t>
                             </a>
                         </div>


### PR DESCRIPTION
> \* = website_blog

Issue
-----
When a blog post uses the "Title above Cover" layout, the post cover,
title & subtitle of the next article can still be edited from the
website builder. This leads to inconsistent behavior, as it should not
be customizable in this layout.

Steps to reproduce
------------------
1. Open a blog post
2. Set the layout to "Title above Cover"
3. Scroll to the next post section
4. Try to edit the cover image/post title/post subtitle of the next post.

It can be modified even though it should be read-only.

Fix
---
Add the `o_we_no_overlay` & `o_not_editable` class to the next blog post
cover templates to exclude them from the website editor selection,
preventing any editing/modification in this layout.

task-[5435878](https://www.odoo.com/odoo/project/974/tasks/5435878)
