### PR TITLE
[FIX] mail: no time wasted to test assert discuss badge text

### DIFF
--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -19,7 +19,7 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test, waitFor } from "@odoo/hoot";
 import { press, queryFirst, queryValue } from "@odoo/hoot-dom";
 import { Deferred, mockDate, tick } from "@odoo/hoot-mock";
 import {
@@ -951,7 +951,7 @@ test("Update unread counter when receiving new message", async () => {
     });
     await start();
     await openDiscuss(undefined);
-    await contains(".o-discuss-badge:text('1')");
+    await waitFor(".o-discuss-badge:text('1')");
 
     await withUser(userId, () =>
         rpc("/mail/message/post", {
@@ -964,7 +964,7 @@ test("Update unread counter when receiving new message", async () => {
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-discuss-badge:text('2')");
+    await waitFor(".o-discuss-badge:text('2')");
 });
 
 test("Show start message of conversation", async () => {


### PR DESCRIPTION
The test `"Update unread counter when receiving new message"` was very slow because the 2nd `contains(o-discuss-badge:text)` could take up to 3 seconds, as the `contains` of mail apparently sees no DOM mutation and thus observes the correct DOM after timeout of contains.

This commit fixes the test by using `waitFor()` instead of `contains()` of mail. The `waitFor()` function ticks every animation frame rather than observing DOM mutation, thus it's faster for the badge's text in this test.

Although `contains()` of mail has a tick mechanism too, it ticks only every second at best to not slow down running of whole test suite, but this is usually still slower than `waitFor()`.
