### PR TITLE
[IMP] hr_work_entry, hr_holidays: postponed paid time off

### DIFF
--- a/addons/hr_holidays/data/hr_work_entry_type_data.xml
+++ b/addons/hr_holidays/data/hr_work_entry_type_data.xml
@@ -362,6 +362,22 @@
         <field name="country_id" ref="base.be"/>
     </record>
 
+    <record id="hr_work_entry.l10n_be_work_entry_type_postponed_paid_time_off_n1" model="hr.work.entry.type">
+        <field name="requires_allocation">True</field>
+        <field name="employee_requests">False</field>
+        <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
+        <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
+    </record>
+
+    <record id="hr_work_entry.l10n_be_work_entry_type_postponed_paid_time_off_n2" model="hr.work.entry.type">
+        <field name="requires_allocation">True</field>
+        <field name="employee_requests">False</field>
+        <field name="request_unit">half_day</field>
+        <field name="unit_of_measure">day</field>
+        <field name="leave_notif_subtype_id" ref="hr_holidays.mt_leave"/>
+    </record>
+
 <!-- CH: Switzerland -->
 
     <record id="hr_work_entry.l10n_ch_swissdec_unpaid_wt" model="hr.work.entry.type">

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -1205,6 +1205,24 @@
         <field name="count_as">absence</field>
     </record>
 
+    <record id="l10n_be_work_entry_type_postponed_paid_time_off_n1" model="hr.work.entry.type">
+        <field name="name">Postponed Paid Time Off N-1</field>
+        <field name="code">PPTO1</field>
+        <field name="color">11</field>
+        <field name="display_code">PN1</field>
+        <field name="country_id" ref="base.be"/>
+        <field name="count_as">absence</field>
+    </record>
+
+    <record id="l10n_be_work_entry_type_postponed_paid_time_off_n2" model="hr.work.entry.type">
+        <field name="name">Postponed Paid Time Off N-2</field>
+        <field name="code">PPTO2</field>
+        <field name="color">11</field>
+        <field name="display_code">PN2</field>
+        <field name="country_id" ref="base.be"/>
+        <field name="count_as">absence</field>
+    </record>
+
     <record id="l10n_be_work_entry_type_adoption_company" model="hr.work.entry.type">
         <field name="name">Employer-paid adoption and foster parent leave</field>
         <field name="code">LEAVE242</field>


### PR DESCRIPTION
purpose: Since 2024, if you are unable to take a paid time off (your legal rights to time off), you can have them back for next year.

- added 2 work entry types for postponed paid time off

task-id: 5429948

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
