### PR TITLE
[FIX] mail: fix race condition in partner suggestion sort test

### DIFF
--- a/addons/mail/static/tests/discuss/core/suggestion.test.js
+++ b/addons/mail/static/tests/discuss/core/suggestion.test.js
@@ -132,6 +132,9 @@ test("Sort partner suggestions by recent chats", async () => {
     await click(".o-mail-Composer-send:enabled");
     await contains(".o-mail-Message-content", { text: "This is a test" });
     await click(".o-mail-DiscussSidebarChannel", { text: "General" });
+    await contains(
+        ".o-mail-DiscussSidebarCategory-chat + .o-mail-DiscussSidebarChannel-container:text(User 2)"
+    );
     await insertText(".o-mail-Composer-input[placeholder='Message #General…']", "@");
     await insertText(".o-mail-Composer-input", "User");
     await contains(".o-mail-Composer-suggestion strong", { count: 3 });


### PR DESCRIPTION
Before this commit, the test "Sort partner suggestions by recent chats" fails non-deterministically due to a race condition.

This failure occurs because the test relies on the `last_interest_dt` timestamp being updated after sending a message to "User 2". Although the message post triggers a bus notification to update the store, the UI displays the message optimistically. As a result, the assertion for the message's existence occasionally passes before the bus notification was processed, leaving the sorting logic to run with stale data (where "User 2" was still ranked behind "User 3").

This commit fixes the issue by waiting for the sidebar to reorder "User 2" to the top. Since the sidebar ordering relies on the same server data (last_interest_dt) as the suggestion sorting, this ensures the store has processed the bus event before the test verifies the suggestion order.

runbot-237553