### PR TITLE
[IMP] iot_drivers: move status page pairing code to left

### DIFF
--- a/addons/iot_drivers/iot_handlers/__init__.py
+++ b/addons/iot_drivers/iot_handlers/__init__.py
@@ -1,20 +1,20 @@
 import logging
-import platform
 import importlib
 from pathlib import Path
 from itertools import chain
+from ..tools.system import IS_WINDOWS, IS_TEST
 
 _logger = logging.getLogger(__name__)
 
 # Only import files that correspond to the current platform (Linux or Windows)
-exclude_suffix = '_L' if platform.system() == 'Windows' else '_W'
+exclude_suffix = '_L' if IS_WINDOWS else '_W'
 
 drivers_path = Path(__file__).parent / 'drivers'
 interfaces_path = Path(__file__).parent / 'interfaces'
 
 for file_path in chain(drivers_path.glob('*.py'), interfaces_path.glob('*.py')):
     module = file_path.stem
-    if any(module.endswith(suffix) for suffix in ['__', exclude_suffix]):
+    if IS_TEST or any(module.endswith(suffix) for suffix in ['__', exclude_suffix]):
         continue
 
     try:

--- a/addons/iot_drivers/static/src/app/status.js
+++ b/addons/iot_drivers/static/src/app/status.js
@@ -46,6 +46,19 @@ class StatusPage extends Component {
         <div t-else="" class="container-fluid">
             <!-- QR Codes shown on status page -->
             <div class="qr-code-box">
+                <div t-if="(state.data.pairing_code || state.data.pairing_code_expired) and !state.data.is_access_point_up" class="status-display-box">
+                    <h4 class="text-center mb-3">Pairing Code</h4>
+                    <hr/>
+                    <t t-if="state.data.pairing_code and !state.data.pairing_code_expired">
+                        <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
+                        <p class="text-center mb-3">
+                            Enter this code in the IoT app in your Odoo database to pair the IoT Box.
+                        </p>
+                    </t>
+                    <p t-else="" class="text-center mb-3">
+                        The pairing code has expired. Please restart your IoT Box to generate a new one.
+                    </p>
+                </div>
                 <div class="status-display-box qr-code">
                     <div>
                         <h4 class="text-center mb-1">IoT Box Configuration</h4>
@@ -95,19 +108,6 @@ class StatusPage extends Component {
                 </div>
             </div>
             <div class="status-display-boxes">
-                <div t-if="(state.data.pairing_code || state.data.pairing_code_expired) and !state.data.is_access_point_up" class="status-display-box">
-                    <h4 class="text-center mb-3">Pairing Code</h4>
-                    <hr/>
-                    <t t-if="state.data.pairing_code and !state.data.pairing_code_expired">
-                        <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
-                        <p class="text-center mb-3">
-                            Enter this code in the IoT app in your Odoo database to pair the IoT Box.
-                        </p>
-                    </t>
-                    <p t-else="" class="text-center mb-3">
-                        The pairing code has expired. Please restart your IoT Box to generate a new one.
-                    </p>
-                </div>
                 <div t-if="state.data.is_access_point_up and accessPointSsid" class="status-display-box">
                     <h4 class="text-center mb-3">No Internet Connection</h4>
                     <hr/>


### PR DESCRIPTION
For IoT Boxes with many devices connected, the pairing code is pushed to the top of the status page, making it invisible/unreadable. We moved it to the left so that it's never pushed to the top.

In addition, we add a check on the operating system to avoid loading drivers/interfaces on "Test" system, to avoid errors when running the IoT Service locally.