### PR TITLE
[FIX] project: avoid duplicate new button in task list

### DIFF
--- a/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
+++ b/addons/project/static/src/views/project_task_list/project_task_list_controller.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="project.ProjectTaskListView.Buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
         <button class="btn btn-primary o_list_button_add" position="replace">
-            <ProjectTaskTemplateDropdown t-if="!editedRecord and activeActions.create"
+            <ProjectTaskTemplateDropdown t-if="!env.inDialog and !editedRecord and activeActions.create"
                 projectId="props.context.default_project_id"
                 onCreate="() =&gt; this.onClickCreate()"
                 newButtonClasses="'btn btn-primary o_list_button_add'"


### PR DESCRIPTION
Steps to Reproduce
---
1. Enable Task Dependencies in Project settings
2. Create project with no task templates
3. Open task form -> Blocked By tab -> Add a line
4. Observe duplicate "New" and "Create New" buttons

Issue
---
- The task list view displays both “New” and “Create New” buttons, resulting in duplicated creation actions.

Current Behaviour
---
- Two different creation buttons are displayed simultaneously

Expected Behaviour
---
- Only a single “New” button should be displayed

Root cause
---
- ControlPanel refactoring removed props.showButtons without adding !env.inDialog check to task views.

Fix
---
- Add !env.inDialog check , this prevents the ProjectTaskTemplateDropdown component from rendering in dialog contexts, eliminating the duplicate button issue.

Related - https://github.com/odoo/odoo/pull/220325 
task - 5403917
