### PR TITLE
[FIX] sale: prevent traceback when accessing collapse_prices

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -927,6 +927,8 @@ class SaleOrder(models.Model):
     @api.onchange('order_line')
     def _onchange_order_line(self):
         for index, line in enumerate(self.order_line):
+            if line.display_type == 'line_subsection' and not line.parent_id:
+                line.display_type = 'line_section'
             combo_item_lines = line._get_linked_lines().filtered('combo_item_id')
             if line.product_template_id.type != 'combo':
                 if combo_item_lines:

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1325,8 +1325,18 @@ class SaleOrderLine(models.Model):
 
     def write(self, vals):
         values = vals
-        if 'display_type' in values and self.filtered(lambda line: line.display_type != values.get('display_type')):
-            raise UserError(_("You cannot change the type of a sale order line. Instead you should delete the current line and create a new line of the proper type."))
+        if 'display_type' in values:
+            new_type = values.get('display_type')
+            invalid_lines = self.filtered(
+                lambda line:
+                    line.display_type != new_type
+                    and not (line.display_type == 'line_subsection' and new_type == 'line_section')
+            )
+            if invalid_lines:
+                raise UserError(_(
+                    "You cannot change the type of a sale order line. Instead you should "
+                    "delete the current line and create a new line of the proper type."
+                ))
 
         if 'product_id' in values and any(
             sol.product_id.id != values['product_id']


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install sale_management with demo data
2. Create a new quotation/order and add a section and a subsection
3. Drag the subsection line above the section line
4. Confirm it and click on Preview

Issue:
------
```python
Traceback (most recent call last):
The error occurred while rendering the template sale_subscription.subscription_portal_content and evaluating the following expression: <t t-set="collapse_prices" t-value="current_section.collapse_prices or line.collapse_prices"/>

Error while rendering the template:
    AttributeError: 'NoneType' object has no attribute 'collapse_prices'
    Template: sale_subscription.subscription_portal_content
    Reference: 1713
    Path: /t/div[4]/section[1]/div[1]/table/tbody/t[4]/t[11]/t[3]
    Element: <t t-set="collapse_prices" t-value="current_section.collapse_prices or line.collapse_prices"/>
    From: (1712, '/t/t', '<t t-call="portal.portal_layout"/>')
          (1712, '/t/t/body/div[1]/div/div[2]/div[11]/div/t', '<t t-call="#{sale_order._get_name_portal_content_view()}"/>')
          (1713, '/t/div[4]/section[1]/div[1]/table/tbody/t[4]/t[11]/t[3]', '<t t-set="collapse_prices" t-value="current_section.collapse_prices or line.collapse_prices"/>')
```

Cause:
------
Since current_section is None in this case, it leads to the
above traceback when trying to fetch the collapse_prices value.

Solution:
---------
Convert subsection lines without a parent_id into section lines
to prevent the traceback.

Related enterprise PR: https://github.com/odoo/enterprise/pull/103686


opw-5367739





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
