### PR TITLE
[IMP] hr_work_entry: optimize/refactor gantt view

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -557,21 +557,6 @@ class HrAttendance(models.Model):
     def action_refuse_overtime(self):
         self.linked_overtime_ids.action_refuse()
 
-    # def action_list_overtimes(self):
-    #     self.ensure_one()
-    #     assert self.date
-    #     return {
-    #         "type": "ir.actions.act_window",
-    #         "name": _("Overtime details"),
-    #         "res_model": "hr.attendance.overtime.line",
-    #         "view_mode": 'list',
-    #         "context": {
-    #             "create": 0,
-    #             "editable": 'top',
-    #         },
-    #         "domain": [('id', 'in', self._linked_overtimes().ids)]
-    #     }
-
     def _cron_auto_check_out(self):
         def check_in_tz(attendance):
             """Returns check-in time in calendar's timezone."""

--- a/addons/hr_work_entry/models/hr_employee.py
+++ b/addons/hr_work_entry/models/hr_employee.py
@@ -1,7 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields, _
+
+from collections import defaultdict
+from itertools import groupby
+
+from odoo import api, fields, models
+from odoo.fields import Domain
 from odoo.tools import SQL
+
+from odoo.addons.hr_work_entry.models.utils import (
+    date_list_to_ranges,
+    remove_days_from_range,
+)
 
 
 class HrEmployee(models.Model):
@@ -40,7 +50,7 @@ class HrEmployee(models.Model):
             ctx['initial_date'] = initial_date
         return {
             'type': 'ir.actions.act_window',
-            'name': _('%s work entries', self.display_name),
+            'name': self.env._('%s work entries', self.display_name),
             'view_mode': 'calendar,list,form',
             'res_model': 'hr.work.entry',
             'path': 'work-entries',
@@ -57,3 +67,87 @@ class HrEmployee(models.Model):
         else:
             versions = self._get_all_versions_with_contract_overlap_with_period(date_start, date_stop)
         return versions.generate_work_entries(date_start, date_stop, force=force)
+
+    @api.model
+    def regenerate_work_entries_from_dates(
+        self,
+        employee_dates: list[dict],
+    ):
+        """
+        Use this function if you want to regenerate work entries, but you don't
+        have the date ranges (i.e.: date_from and date_to), but instead
+        individual dates. This function will build the ranges from the given
+        dates.
+        employee_dates is in the format [{employee_id: 4, date: 1/1/2020}] to
+        facilitate batch regeneration for multiple employees at once.
+        """
+        # will be used as prefetch_ids to reduce number of db queries
+        all_employee_ids = []
+
+        # build ranges, and group employees by range
+        employee_by_range = defaultdict(list)
+        employee_dates.sort(key=lambda ed: ed['employee_id'])
+        for employee_id, group in groupby(
+            employee_dates,
+            lambda ed: ed['employee_id'],
+        ):
+            dates = [g['date'] for g in group]
+            ranges = date_list_to_ranges(dates)
+            for range in ranges:
+                date_from, date_to = range['start'], range['stop']
+                employee_by_range[date_from, date_to].append(employee_id)
+            all_employee_ids.append(employee_id)
+
+        for range, employee_ids in employee_by_range.items():
+            employee_ids = self.browse(employee_ids).with_prefetch(
+                all_employee_ids,
+            )
+            employee_ids.regenerate_work_entries(range[0], range[1])
+
+    def regenerate_work_entries(self, date_from, date_to):
+        """
+        Nullifies self's unvalidated work entries between date_from and date_to,
+        then generates work entries for all days between date_from and date_to
+        that do not have any validated work entries.
+        Regenerating a work entry is thus nullifying it, then generating it.
+        """
+        work_entries = self.env['hr.work.entry'].search(
+            Domain.AND(
+                [
+                    Domain('employee_id', 'in', self.ids),
+                    Domain('date', '>=', date_from),
+                    Domain('date', '<=', date_to),
+                ],
+            ),
+        )
+
+        # "archiving" all unvalidated work entries in the range
+        unvalidated_work_entries = work_entries.filtered_domain(
+            Domain('state', '!=', 'validated'),
+        )
+        fields_to_nullify = self.env[
+            'hr.work.entry'
+        ]._work_entry_fields_to_nullify()
+        unvalidated_work_entries.write(
+            {field: False for field in fields_to_nullify},
+        )
+
+        # regrouping the data to employees per range will allow us to then
+        # efficiently call `generate_work_entries()`
+        validated_work_entries = work_entries - unvalidated_work_entries
+        validated_we_by_employee = validated_work_entries.grouped('employee_id')
+        default_range = {'start': date_from, 'stop': date_to}
+        employees_by_range = defaultdict(lambda: self.env['hr.employee'])
+        for employee in self:
+            # days with validated work entries should not be generated, so we
+            # need to remove them from the employee's range
+            validated_work_entries = validated_we_by_employee.get(employee, [])
+            validated_days = [we.date for we in validated_work_entries]
+            ranges = remove_days_from_range(default_range, validated_days)
+            # assign the new range to the employee
+            for range in ranges:
+                date_from, date_to = range['start'], range['stop']
+                employees_by_range[date_from, date_to] |= employee
+
+        for range, employees in employees_by_range.items():
+            employees.generate_work_entries(range[0], range[1], True)

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -9,7 +9,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _, SUPERUSER_ID
 from odoo.exceptions import UserError
-from odoo.fields import Command, Domain
+from odoo.fields import Domain
 from odoo.tools import ormcache, float_is_zero
 from odoo.tools.intervals import Intervals
 
@@ -426,7 +426,7 @@ class HrVersion(models.Model):
             'date_generated_to': date_start,
         })
         domain_to_nullify = Domain(False)
-        work_entry_null_vals = {field: False for field in self.env["hr.work.entry.regeneration.wizard"]._work_entry_fields_to_nullify()}
+        work_entry_null_vals = {field: False for field in self.env["hr.work.entry"]._work_entry_fields_to_nullify()}
 
         for tz, versions in self.grouped("tz").items():
             tz = ZoneInfo(tz) if tz else UTC
@@ -691,13 +691,11 @@ class HrVersion(models.Model):
 
     def _recompute_work_entries(self, date_from, date_to):
         self.ensure_one()
-        if self.employee_id:
-            wizard = self.env['hr.work.entry.regeneration.wizard'].create({
-                'employee_ids': [Command.set(self.employee_id.ids)],
-                'date_from': date_from,
-                'date_to': date_to,
-            })
-            wizard.with_context(work_entry_skip_validation=True, active_test=False).regenerate_work_entries()
+        if not self.employee_id:
+            return
+        self.employee_id.with_context(
+            active_test=False,
+        ).regenerate_work_entries(date_from, date_to)
 
     def _get_fields_that_recompute_we(self):
         # Returns the fields that should recompute the work entries

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -344,3 +344,6 @@ class HrWorkEntry(models.Model):
             raise UserError(self.env._("This work entry was created manually and has no source attendance."))
         action.update(self._get_source_action_values())
         return action
+
+    def _work_entry_fields_to_nullify(self):
+        return ['active']

--- a/addons/hr_work_entry/models/utils.py
+++ b/addons/hr_work_entry/models/utils.py
@@ -1,0 +1,67 @@
+from datetime import timedelta
+
+from odoo import fields
+
+
+def date_list_to_ranges(dates: list) -> list[dict]:
+    """
+    Converts a list of dates to a list of ranges, considering dates to be
+    neighbors if they are maximum a day apart
+    e.g.:
+        input: [20/12/20205, 21/12/2025, 10/10/2010]
+        output: [
+        {start: 20/12/2025, stop: 21/12/2025},
+        {start: 10/10/2010, stop: 10/10/2010},
+    ]
+    """
+    def _is_in_next_day(date_a, date_b) -> bool:
+        return date_a <= date_b and date_b <= date_a + timedelta(days=1)
+
+    # special case. no date means no ranges
+    if not dates:
+        return []
+
+    ranges = []
+    # so that we iterate day by day in order
+    dates = sorted(fields.Date.to_date(date) for date in dates)
+    range_start = dates[0]
+    for i in range(1, len(dates) + 1):
+        if i < len(dates) and _is_in_next_day(dates[i - 1], dates[i]):
+            continue
+        # range end found. Adding it to the list
+        ranges.append({
+            'start': range_start,
+            'stop': dates[i - 1],
+        })
+        if i < len(dates):  # avoid out of bounds if end of iteration
+            range_start = dates[i]
+    return ranges
+
+
+def remove_days_from_range(range: dict, days: list) -> list[dict]:
+    """
+    Returns a list of range, being the result of removing `days` from
+    `range`.
+    e.g.:
+        input:
+        days = [date(2025, 5, 4)]
+        range = {'start': date(2025, 5, 1), 'stop': date(2025, 5, 10)}
+        output:
+        [
+            {'start': date(2025, 5, 1), 'stop': date(2025, 5, 3)},
+            {'start': date(2025, 5, 5), 'stop': date(2025, 5, 10)},
+        ]
+    """
+    days = sorted(fields.Date.to_date(day) for day in days)
+    days = filter(lambda d: range['start'] <= d <= range['stop'], days)
+    start = range['start']
+    ranges = []
+    for day in days:
+        if day == start:
+            start = day + timedelta(days=1)
+            continue
+        ranges.append({'start': start, 'stop': day - timedelta(days=1)})
+        start = day + timedelta(days=1)
+    if start <= range['stop']:
+        ranges.append({'start': start, 'stop': range['stop']})
+    return ranges

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_controller.js
@@ -85,11 +85,7 @@ export class WorkEntryCalendarController extends CalendarController {
     }
 
     onResetWorkEntries(selectedCells) {
-        const records = this.getSelectedRecords(selectedCells);
-        const dates = this.getDatesWithoutValidatedWorkEntry(selectedCells, records);
-        this.model.resetWorkEntries(
-            dates,
-            records.filter((r) => r.state !== "validated").map((r) => r.id)
-        );
+        const dates = this.getDates(selectedCells);
+        this.model.resetWorkEntries(dates);
     }
 }

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -111,16 +111,10 @@ export class WorkEntryCalendarModel extends CalendarModel {
         return this.load();
     }
 
-    async resetWorkEntries(dates, recordIds) {
-        const cellsFormattedData = dates.map((date) => ({
-            date,
-            employee_id: this.meta.context.default_employee_id,
-        }));
-        await this.orm.call("hr.work.entry.regeneration.wizard", "regenerate_work_entries", [
-            [],
-            cellsFormattedData,
-            recordIds,
-        ]);
+    async resetWorkEntries(dates) {
+        const employeeId = this.meta.context.default_employee_id;
+        const employeeDates = dates.map(date => ({employee_id: employeeId, date}))
+        await this.orm.call("hr.employee", "regenerate_work_entries_from_dates", [employeeDates]);
         return this.load();
     }
 }

--- a/addons/hr_work_entry/tests/__init__.py
+++ b/addons/hr_work_entry/tests/__init__.py
@@ -1,8 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import (
+    test_date_list_to_ranges,
     test_global_time_off,
     test_hr_work_entry,
+    test_remove_days_from_range,
     test_work_entry,
     test_work_entry_type_data,
 )

--- a/addons/hr_work_entry/tests/test_date_list_to_ranges.py
+++ b/addons/hr_work_entry/tests/test_date_list_to_ranges.py
@@ -1,0 +1,99 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date
+
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.hr_work_entry.models.utils import date_list_to_ranges
+
+
+@tagged('-at_install', 'post_install')
+class TestDateListToRanges(TransactionCase):
+    """
+    date_list_to_ranges() is used to mege all neighboring days into range.
+    It's mainly used for work entries generation. This test ensures the function
+    works in some specific cases.
+    """
+    def test_basic_case(self):
+        days = [
+            date(2025, 5, 2),
+            date(2025, 5, 3),
+            date(2025, 5, 4),
+            date(2025, 6, 6),
+            date(2025, 6, 7),
+        ]
+        expected_ranges = [
+            {'start': date(2025, 5, 2), 'stop': date(2025, 5, 4)},
+            {'start': date(2025, 6, 6), 'stop': date(2025, 6, 7)},
+        ]
+        ranges = date_list_to_ranges(days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_basic_case_string(self):
+        """
+        _date_list_to_ranges should be able to convert the dates when needed
+        This is useful when calling the date objects have beeen created in the
+        frontend
+        """
+        days = [
+            '2025-5-2',
+            '2025-5-3',
+            '2025-5-4',
+            '2025-6-6',
+            '2025-6-7',
+        ]
+        expected_ranges = [
+            {'start': date(2025, 5, 2), 'stop': date(2025, 5, 4)},
+            {'start': date(2025, 6, 6), 'stop': date(2025, 6, 7)},
+        ]
+        ranges = date_list_to_ranges(days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_no_days(self):
+        days = []
+        expected_ranges = []
+        ranges = date_list_to_ranges(days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_single_day(self):
+        days = [date(2003, 11, 6)]
+        expected_ranges = [
+            {'start': date(2003, 11, 6), 'stop': date(2003, 11, 6)},
+        ]
+        ranges = date_list_to_ranges(days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_duplicate_days(self):
+        days = [
+            date(2003, 11, 6),
+            date(2003, 11, 7),
+            date(2003, 11, 7),
+            date(2003, 11, 8),
+        ]
+        expected_ranges = [
+            {'start': date(2003, 11, 6), 'stop': date(2003, 11, 8)},
+        ]
+        ranges = date_list_to_ranges(days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_mixed_days(self):
+        days = [
+            date(2020, 5, 4),
+            date(2025, 5, 2),
+            date(2020, 5, 2),
+            date(2025, 5, 4),
+            date(2003, 11, 6),
+            '2025-06-06',
+            date(2020, 5, 3),
+            date(2025, 5, 3),
+            date(2025, 6, 7),
+            date(2020, 5, 3),
+        ]
+        expected_ranges = [
+            {'start': date(2003, 11, 6), 'stop': date(2003, 11, 6)},
+            {'start': date(2020, 5, 2), 'stop': date(2020, 5, 4)},
+            {'start': date(2025, 5, 2), 'stop': date(2025, 5, 4)},
+            {'start': date(2025, 6, 6), 'stop': date(2025, 6, 7)},
+        ]
+        ranges = date_list_to_ranges(days)
+        self.assertEqual(ranges, expected_ranges)

--- a/addons/hr_work_entry/tests/test_remove_days_from_range.py
+++ b/addons/hr_work_entry/tests/test_remove_days_from_range.py
@@ -1,0 +1,114 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import random
+from datetime import date
+
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.hr_work_entry.models.utils import remove_days_from_range
+
+
+@tagged('-at_install', 'post_install')
+class TestRemoveDaysFromRange(TransactionCase):
+    """
+    remove_days_from_range() is mainly used to split work entries ranges when
+    needing to ignore specific days (e.g.: days with validated work entries)
+    The function should be able to split a range even if the days are shuffled,
+    out of bounds, on bounds, etc.
+    """
+
+    def test_basic_split(self):
+        days = [
+            date(2025, 5, 4),
+        ]
+        range = {
+            'start': date(2025, 5, 1),
+            'stop': date(2025, 5, 10),
+        }
+        expected_ranges = [
+            {'start': date(2025, 5, 1), 'stop': date(2025, 5, 3)},
+            {'start': date(2025, 5, 5), 'stop': date(2025, 5, 10)},
+        ]
+        ranges = remove_days_from_range(range, days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_days_on_bounds(self):
+        days = [
+            date(2025, 5, 1),
+            date(2025, 5, 10),
+        ]
+        range = {
+            'start': date(2025, 5, 1),
+            'stop': date(2025, 5, 10),
+        }
+        expected_ranges = [
+            {'start': date(2025, 5, 2), 'stop': date(2025, 5, 9)},
+        ]
+        ranges = remove_days_from_range(range, days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_days_out_of_bounds(self):
+        days = [
+            date(2025, 4, 1),
+            date(2025, 5, 11),
+        ]
+        range = {
+            'start': date(2025, 5, 1),
+            'stop': date(2025, 5, 10),
+        }
+        expected_ranges = [range]
+        ranges = remove_days_from_range(range, days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_empty_days(self):
+        days = []
+        range = {
+            'start': date(2025, 5, 1),
+            'stop': date(2025, 5, 10),
+        }
+        expected_ranges = [range]
+        ranges = remove_days_from_range(range, days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_mixed_shuffled(self):
+        days = [
+            date(2019, 3, 3),  # out of bound
+            date(2020, 2, 19),  # out of bound
+            date(2020, 2, 20),  # is bound
+            date(2021, 5, 11),
+            date(2022, 1, 1),
+            date(2022, 4, 10),  # is bound
+            date(2022, 4, 11),  # out of bound
+            date(2023, 3, 2),  # out of bound
+        ]
+        range = {
+            'start': date(2020, 2, 20),
+            'stop': date(2022, 4, 10),
+        }
+        expected_ranges = [
+            {'start': date(2020, 2, 21), 'stop': date(2021, 5, 10)},
+            {'start': date(2021, 5, 12), 'stop': date(2021, 12, 31)},
+            {'start': date(2022, 1, 2), 'stop': date(2022, 4, 9)},
+        ]
+
+        # days can be in any order. A seed is specified to make it consistent
+        random.seed(0)
+        random.shuffle(days)
+
+        ranges = remove_days_from_range(range, days)
+        self.assertEqual(ranges, expected_ranges)
+
+    def test_gap_of_one_day(self):
+        """
+        The function should still work even if a returned range should have the
+        same start and stop dates.
+        """
+        days = [date(2026, 1, 3), date(2026, 1, 5)]
+        range = {'start': date(2026, 1, 1), 'stop': date(2026, 1, 7)}
+        expected_ranges = [
+          {'start': date(2026, 1, 1), 'stop': date(2026, 1, 2)},
+          {'start': date(2026, 1, 4), 'stop': date(2026, 1, 4)},
+          {'start': date(2026, 1, 6), 'stop': date(2026, 1, 7)},
+        ]
+        ranges = remove_days_from_range(range, days)
+        self.assertEqual(ranges, expected_ranges)

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
@@ -1,9 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from collections import defaultdict
-from itertools import groupby
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.exceptions import ValidationError
-from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
 
@@ -91,40 +88,15 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
         user_date_format = self.env['res.lang']._get_data(code=self.env.user.lang).date_format
         return date.strftime(user_date_format)
 
-    def _work_entry_fields_to_nullify(self):
-        return ['active']
-
-    def regenerate_work_entries(self, slots=None, record_ids=None):
-        write_vals = {field: False for field in self._work_entry_fields_to_nullify()}
-        if not slots:
-            if not self.env.context.get('work_entry_skip_validation'):
-                if not self.search_criteria_completed:
-                    raise ValidationError(_("In order to regenerate the work entries, you need to provide the wizard with an employee_id, a date_from and a date_to."))
-
-                if self.date_from < self.earliest_available_date or self.date_to > self.latest_available_date:
-                    raise ValidationError(_("The from date must be >= '%(earliest_available_date)s' and the to date must be <= '%(latest_available_date)s', which correspond to the generated work entries time interval.", earliest_available_date=self._date_to_string(self.earliest_available_date), latest_available_date=self._date_to_string(self.latest_available_date)))
-
-                if not self.valid:
-                    raise ValidationError(self.env._("No work entry can be regenerated in this range of dates and these employees."))
-
-            valid_employees = self.employee_ids - self.validated_work_entry_employee_ids
-            date_from = max(self.date_from, self.earliest_available_date) if self.earliest_available_date else self.date_from
-            date_to = min(self.date_to, self.latest_available_date) if self.latest_available_date else self.date_to
-            valid_employees.generate_work_entries(date_from, date_to, True)
-        else:
-            range_by_employee = defaultdict(list)
-            slots.sort(key=lambda d: (d['employee_id'], d['date']))
-            for employee_id, records in groupby(slots, lambda d: d['employee_id']):
-                dates = [fields.Date.from_string(r['date']) for r in records]
-                start = end = dates[0]
-                for current in dates[1:]:
-                    if current - end != timedelta(days=1):
-                        range_by_employee[start, end].append(employee_id)
-                        start = current
-                    end = current
-                range_by_employee[start, end].append(employee_id)
-            work_entries = self.env['hr.work.entry'].browse(record_ids)
-            work_entries.write(write_vals)
-            for (date_from, date_to), employee_ids in range_by_employee.items():
-                valid_employees = self.env["hr.employee"].browse(employee_ids)
-                valid_employees.generate_work_entries(date_from, date_to, True)
+    def regenerate_work_entries(self):
+        if not self.env.context.get('work_entry_skip_validation'):
+            if not self.search_criteria_completed:
+                raise ValidationError(self.env._("In order to regenerate the work entries, you need to provide the wizard with an employee_id, a date_from and a date_to."))
+            if self.date_from < self.earliest_available_date or self.date_to > self.latest_available_date:
+                raise ValidationError(self.env._("The from date must be >= '%(earliest_available_date)s' and the to date must be <= '%(latest_available_date)s', which correspond to the generated work entries time interval.", earliest_available_date=self._date_to_string(self.earliest_available_date), latest_available_date=self._date_to_string(self.latest_available_date)))
+            if not self.valid:
+                raise ValidationError(self.env._("No work entry can be regenerated in this range of dates and these employees."))
+        valid_employees = self.employee_ids - self.validated_work_entry_employee_ids
+        date_from = max(self.date_from, self.earliest_available_date) if self.earliest_available_date else self.date_from
+        date_to = min(self.date_to, self.latest_available_date) if self.latest_available_date else self.date_to
+        valid_employees.regenerate_work_entries(date_from, date_to)

--- a/addons/hr_work_entry_holidays/tests/test_work_entry.py
+++ b/addons/hr_work_entry_holidays/tests/test_work_entry.py
@@ -226,9 +226,9 @@ class TestWorkeEntryHolidaysWorkEntry(TestWorkEntryHolidaysBase):
         leave_work_entry = self.env['hr.work.entry'].search([('employee_id', '=', self.employee_external.id), ('work_entry_type_id', '=', leave.holiday_status_id.work_entry_type_id.id)])
         self.assertIsNotNone(leave_work_entry)
 
-        self.env["hr.work.entry.regeneration.wizard"].regenerate_work_entries(
-            slots=[{"date": leave_start_date, "employee_id": self.employee_external.id}],
-            record_ids=leave_work_entry.ids,
+        employee_dates = [{"date": leave_start_date, "employee_id": self.employee_external.id}]
+        self.env["hr.employee"].regenerate_work_entries_from_dates(
+            employee_dates,
         )
         leave_work_entry = self.env['hr.work.entry'].search([('employee_id', '=', self.employee_external.id), ('work_entry_type_id', '=', leave.holiday_status_id.work_entry_type_id.id)])
         self.assertIsNotNone(leave_work_entry, "Leave's work entry should have the same work entry type")


### PR DESCRIPTION
`regenerate_work_entries()` was poorly implemented: using the `slots` and `record_ids` parameters as flags to change the logic. Since this function was used to regenerate work entries, some part of the code had to create a wizard just to call the function (while not needing a wizard).

Since we seem to often regenerate work entries from two scenarios:
- One from ranges and employee ids
- One directly from work entries ids

For the first one, people would call the function from the wizard and pass the range in the wizard constructor. Now it's simply in hr.employee.regenerate_work_entries()

For the second one, hr.employee.regenerate_work_entries_from_dates() has been made to just pass the dates individually, then the function will merge the dates into ranges by itself.

People from the second case would have to call the second part of the original wizard function, which would build a range from the given record ids. Now it's almost the same, there is no need for a wizard anymore.

`_work_entry_fields_to_nullify()` was previously in the wizard, which made no sense. So I moved it to `hr_work_entry.py`.

the number of employees created in test_performance has beeen decreased, because it created 100 employees was unnecessary and taking too much time.

A bug in the gantt view, when the weekend was the first day of the month, displayed the weekend unfolded for some users. This was a bug that happened due to incorrect timezones passed to `_get_unavailability_intervals()`. This is now fixed by specifying explicitly the user timezone (otherwise it would default to UTC)

Again, in the gantt, employees that did not have work entries (or employees that had all their work entries deleted) disappeared from the gantt view. This is a common problem in the gantt view when grouping by `employee_id` (no employee in the date range have work entries, thus no work entry with `employee_id` is in the result).
Since this PR also adds pagination to the gantt view, this bug has been fixed by simulating the pagination manually using a `search()` call. Then refilling the result of `super().get_gantt_data()` with the missing employees.

task-5148888

