### PR TITLE
[FIX] point_of_sale: fix currency conversion issue

### DIFF
--- a/addons/point_of_sale/models/product_product.py
+++ b/addons/point_of_sale/models/product_product.py
@@ -36,8 +36,8 @@ class ProductProduct(models.Model):
         different_currency = config.currency_id != self.env.company.currency_id
         if different_currency:
             for product in read_records:
-                product['lst_price'] = config.currency_id._convert(
-                    product['lst_price'], self.env.company.currency_id, self.env.company, fields.Date.today()
+                product['lst_price'] = self.env.company.currency_id._convert(
+                    product['lst_price'], config.currency_id, self.env.company, fields.Date.today()
                 )
         return read_records
 

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2065,3 +2065,20 @@ class TestPointOfSaleFlow(CommonPosTest):
         self.env.clear()
         data = current_session.with_company(self.env.company).filter_local_data({'product.product': [product.id]})
         self.assertIn(product.id, data['product.product'])
+
+    def test_product_price_conversion(self):
+        self.env['res.currency.rate'].create({
+            'name': '2010-01-01',
+            'rate': 2.0,
+            'currency_id': self.env.ref('base.EUR').id,
+        })
+        self.pos_config_eur.open_ui()
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+            'available_in_pos': True,
+            'lst_price': 200.0,
+        })
+        loaded_data = self.pos_config_eur.current_session_id.load_data([])
+        product_a_vals = next(p for p in loaded_data['product.product'] if p['id'] == product_a.id)
+        self.assertEqual(product_a_vals['lst_price'], 400.0)


### PR DESCRIPTION
Step to reproduce:
- create sale and invoice journal with different currency (say eur with rate=2)
- setup new pos with this journal
- open pos
- select a product

Observation:
- notice, the product prices halved instead of double.

Cause:
- during this commit [1], we mistakenly reverse the conversion logic, hence price become halved rather than double.

[1]https://github.com/odoo/odoo/commit/1ee02f8a47d42d3ba3fd11ffcf8d9768ea17678e

Fix:
- Fixed the conversion arguments

opw-5434403

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
