### PR TITLE
[FIX] hr_contract: prevent error when setting the resource on resource leaves

### DIFF
--- a/addons/hr_contract/models/resource_calendar_leaves.py
+++ b/addons/hr_contract/models/resource_calendar_leaves.py
@@ -3,12 +3,13 @@
 from datetime import datetime
 from pytz import timezone, utc
 
-from odoo import models
+from odoo import api, models
 
 
 class ResourceCalendarLeaves(models.Model):
     _inherit = 'resource.calendar.leaves'
 
+    @api.depends('date_from')
     def _compute_calendar_id(self):
         def date2datetime(date, tz):
             dt = datetime.fromordinal(date.toordinal())
@@ -26,7 +27,7 @@ class ResourceCalendarLeaves(models.Model):
             end_dt = date2datetime(contract.date_end, tz) if contract.date_end else datetime.max
             # only modify leaves that fall under the active contract
             leaves.filtered(
-                lambda leave: start_dt <= leave.date_from < end_dt
+                lambda leave: leave.date_from and start_dt <= leave.date_from < end_dt
             ).calendar_id = contract.resource_calendar_id
 
         super(ResourceCalendarLeaves, remaining)._compute_calendar_id()

--- a/addons/hr_contract/tests/test_contract.py
+++ b/addons/hr_contract/tests/test_contract.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 from odoo.exceptions import ValidationError
 from odoo.addons.hr_contract.tests.common import TestContractCommon
-from odoo.tests import tagged
+from odoo.tests import tagged, Form
 
 @tagged('test_contracts')
 class TestHrContracts(TestContractCommon):
@@ -337,3 +337,17 @@ class TestHrContracts(TestContractCommon):
         contract_1.state = 'open'
         result = self.employee._get_unusual_days('2024-11-06 01:00:00', '2024-11-18 22:00:00')
         self.assertEqual(result, get_expected_days('multiple_contracts'), 'Calender of Both contract should be selected')
+
+    def test_employee_resource_contract_without_and_with_date_from(self):
+        """
+        Test setting the resource with an employee contract on resource leave without and with start date.
+        """
+        contract = self.create_contract('open', 'normal', date(2018, 1, 1), date(2018, 1, 2))
+        leave_form = Form(self.env['resource.calendar.leaves'])
+        leave_form.date_from = False
+
+        leave_form.resource_id = self.employee.resource_id
+        self.assertFalse(leave_form.calendar_id)
+
+        leave_form.date_from = datetime(2018, 1, 1, 0, 0, 0)
+        self.assertEqual(leave_form.calendar_id, contract.resource_calendar_id)


### PR DESCRIPTION
Currently, an error occurs when user sets the resource on a resource leave.

**Steps to Reproduce:**

 - Install `hr_contract` with demo data.
 - Go to `Resource Time Off`.
 - Create a new record and remove the `start date` value.
 - Select the `Anita Oliver` resource `(employee record with running contract)`.

**Error:**
`TypeError: '<=' not supported between instances of 'datetime.datetime' and 'bool'`

**Cause:**
This error occurs when the user removes the start date and sets a resource that is linked to an employee with a contract. In this case, the system groups leave records based on the contract [1], and while computing calendar_id for the leave, it filters records by checking whether the leave start date falls between the contract start and end dates [2]. Since the leave start date is False, the comparison raises the error.

Another issue is that when the user changes the start date, the calendar_id should be updated based on the employee’s current contract.

**Fix:**
This commit ensures that when setting or changing the resource_id, for contracts with and without a start date, the calendar_id is computed correctly.

[1]: https://github.com/odoo/odoo/blob/5f8336c7d8ab891103a3035a9ebb5242cfa46ce6/addons/hr_contract/models/resource_calendar_leaves.py#L17

[2]- https://github.com/odoo/odoo/blob/5f8336c7d8ab891103a3035a9ebb5242cfa46ce6/addons/hr_contract/models/resource_calendar_leaves.py#L29

**No Task ID**


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
