### PR TITLE
[FIX] html_editor: restore text/plain in HtmlViewer's clipboard

### DIFF
--- a/addons/html_editor/static/src/components/html_viewer/html_viewer.js
+++ b/addons/html_editor/static/src/components/html_viewer/html_viewer.js
@@ -160,7 +160,7 @@ export class HtmlViewer extends Component {
         range.setStart(deepAnchorNode, deepAnchorOffset);
         range.setEnd(deepFocusNode, deepFocusOffset);
         const clonedContents = range.cloneContents();
-        fillClipboardData(ev, clonedContents);
+        fillClipboardData(ev, clonedContents, selection.toString());
     }
 
     /**

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -163,14 +163,13 @@ export class ClipboardPlugin extends Plugin {
         for (const processor of this.getResource("clipboard_text_processors")) {
             textContent = processor(textContent);
         }
-        ev.clipboardData.setData("text/plain", textContent);
 
         // Prepare html content for clipboard.
         for (const processor of this.getResource("clipboard_content_processors")) {
             clonedContents = processor(clonedContents, selection) || clonedContents;
         }
         this.removeSystemProperties(clonedContents);
-        fillClipboardData(ev, clonedContents);
+        fillClipboardData(ev, clonedContents, textContent);
     }
 
     /**

--- a/addons/html_editor/static/src/utils/clipboard.js
+++ b/addons/html_editor/static/src/utils/clipboard.js
@@ -18,13 +18,17 @@ function prependOriginToImages(doc, origin) {
  * on paste inside an editor.
  * @param {ClipboardEvent} ev copy event
  * @param {DocumentFragment} clonedContents
+ * @param {string} textContent
  */
-export function fillClipboardData(ev, clonedContents) {
+export function fillClipboardData(ev, clonedContents, textContent) {
     const doc = ev.target.ownerDocument;
     const dataHtmlElement = doc.createElement("data");
     dataHtmlElement.append(clonedContents);
     prependOriginToImages(dataHtmlElement, doc.defaultView.location.origin);
     const htmlContent = dataHtmlElement.innerHTML;
+    if (textContent) {
+        ev.clipboardData.setData("text/plain", textContent);
+    }
     ev.clipboardData.setData("text/html", htmlContent);
     ev.clipboardData.setData("application/vnd.odoo.odoo-editor", htmlContent);
 }

--- a/addons/html_editor/static/tests/html_viewer.test.js
+++ b/addons/html_editor/static/tests/html_viewer.test.js
@@ -60,6 +60,7 @@ test(`copy from HtmlViewer must support application/vnd.odoo.odoo-editor`, async
     const ev = new ClipboardEvent("copy", { bubbles: true, clipboardData });
     beforeNode.dispatchEvent(ev);
 
+    expect(clipboardData.getData("text/plain").trim()).toBe("A");
     expect(clipboardData.getData("text/html")).toInclude("background-color");
     expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe(
         clipboardData.getData("text/html")


### PR DESCRIPTION
Since [1] when `vnd.odoo.odoo-editor` was added to the `HtmlViewer` clipboard, the `text/plain` mimetype was lost.

This commit restores the plain text version of the clipboard.

Steps to reproduce:
- In knowledge, lock a page
- Select some content
- Copy
- Paste into a plain text editor

=> No content was pasted

[1]: https://github.com/odoo/odoo/commit/62a7c50b434e3f47ad58e20e96970cbd90b979b6

task-5449435
