### PR TITLE
[IMP] account: add ZIP export for move attachments

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1813,5 +1813,17 @@ if records:
             </field>
         </record>
 
+        <record id="action_move_export_zip" model="ir.actions.server">
+            <field name="name">Export ZIP</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="binding_model_id" ref="account.model_account_move"/>
+            <field name="binding_view_types">list,form</field>
+            <field name="state">code</field>
+            <field name="sequence">7</field>
+            <field name="code">
+                if records:
+                    action = records.action_export_zip()
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
before:
- In v17, account moves (invoices, vendor bills, etc.) did not provide any ZIP export.
- Users wanting to download move attachments (e.g. for vendor bills) had to download each file individually.

after:
- Add an Action on account moves to export attachments as a ZIP archive.
- The ZIP contains all attachments linked to the move (PDF, XML, and any other files present in the mail thread), not only the report PDF.
- The action is available for all move types (customer invoices, vendor bills, journal entries, etc.)

task-5232551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
