### PR TITLE
[FIX] point_of_sale: fix runbot error

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -622,7 +622,9 @@ registry.category("web_tour.tours").add("test_confirm_coupon_programs_one_by_one
                     // Create 5 orders that will be synced one by one
                     for (let i = 0; i < 5; i++) {
                         const order = posmodel.createNewOrder();
-                        const product = posmodel.models["product.product"].getFirst();
+                        const product = posmodel.models["product.product"].find(
+                            (el) => el.attribute_line_ids.length == 0
+                        );
                         const pm = posmodel.models["pos.payment.method"].getFirst();
                         const program = posmodel.models["loyalty.program"].find(
                             (p) => p.program_type === "gift_card"


### PR DESCRIPTION
In certain cases, the product selected in the tour would be a product that require a configuration (having attribute lines), which would lead opening a popup that is not handled in the tour, leading to a failure.

When selecting the product we now make sure that we select a product that does not require any configuration.

same fix as this one : https://github.com/odoo/odoo/pull/241098

runbot-234734