### PR TITLE
[FIX] product_expiry: removal date is computed after modification

### DIFF
--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -14,7 +14,7 @@ class StockMoveLine(models.Model):
         string='Expiration Date', compute='_compute_expiration_date', store=True,
         help='This is the date on which the goods with this Serial Number may'
         ' become dangerous and must not be consumed.')
-    removal_date = fields.Datetime(string='Removal Date', compute='_compute_removal_date', store=True)
+    removal_date = fields.Datetime(string='Removal Date', compute='_compute_removal_date', readonly=False, store=True)
     is_expired = fields.Boolean(related='lot_id.product_expiry_alert')
     use_expiration_date = fields.Boolean(
         string='Use Expiration Date', related='product_id.use_expiration_date')

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -726,3 +726,37 @@ class TestStockLot(TestStockCommon):
         wizard = self.env['expiry.picking.confirmation'].with_context(context).create({})
         self.assertFalse(wizard.picking_ids.move_line_ids.removal_date)
         wizard.process_no_expired()
+
+    def test_lot_dates_form_update(self):
+        """
+        Ensure that we can edit the removal_date and expiration_date fields at the same time
+        Without triggering the compute method for the expiration when saving modifications.
+        """
+        delta = timedelta(seconds=10)
+        today = datetime.today()
+        receipt = self.env['stock.picking'].create({
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.picking_type_in.id,
+            'scheduled_date': today,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.apple_product.id,
+                    'location_id': self.supplier_location.id,
+                    'location_dest_id': self.stock_location.id,
+                    'product_uom_qty': 1,
+                }),
+            ],
+        })
+        receipt.action_confirm()
+        self.assertAlmostEqual(receipt.move_line_ids.expiration_date, today + timedelta(days=10), delta=delta)
+        self.assertAlmostEqual(receipt.move_line_ids.removal_date, today + timedelta(days=8), delta=delta)
+
+        with Form(receipt.move_ids_without_package, view="stock.view_stock_move_operations") as move_form:
+            with move_form.move_line_ids.edit(0) as line_form:
+                line_form.lot_name = 'lot 1'
+                line_form.expiration_date = today + timedelta(days=15)
+                line_form.removal_date = today + timedelta(days=10)
+
+        self.assertAlmostEqual(receipt.move_line_ids.expiration_date, today + timedelta(days=15), delta=delta)
+        self.assertAlmostEqual(receipt.move_line_ids.removal_date, today + timedelta(days=10), delta=delta)


### PR DESCRIPTION
version : saas-18.4+e

Steps to reproduce
------------------
Create a product tracked by lots and enable the expiration date use (use_expiration_date = True).

Create a receipt with this product and mark it as to do.

Open the stock.move.line list view using the "Details" button on the receipt form and try to modify expiration date, it should modify the removal date due to the compute method.

Then, try to modify the removal date and save the modifications. If you reopen the list view, the removal date has been computed again and its value changed.

The fix
------------------
We explicitly set the readonly field to False for the removal_date field from the stock.move.line model in product_expiry.

opw-5368007

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
