### PR TITLE
[FIX] stock: handle no longer entire pack more easily

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -55,6 +55,7 @@
         'wizard/stock_warn_insufficient_qty_views.xml',
         'wizard/product_replenish_views.xml',
         'wizard/product_label_layout_views.xml',
+        'wizard/stock_not_entire_pack_warning_views.xml',
         'wizard/stock_orderpoint_snooze_views.xml',
         'wizard/stock_package_destination_views.xml',
         'wizard/stock_inventory_adjustment_name.xml',

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1304,7 +1304,7 @@ class StockPicking(models.Model):
             if pickings._is_single_transfer() and pickings._check_move_lines_map_quant_package(package):
                 move_lines_to_pack = pickings.move_line_ids.filtered(lambda ml: ml.package_id == package and not ml.result_package_id and ml.state not in ('done', 'cancel'))
                 if package.package_type_id.package_use != 'reusable':
-                    move_lines_to_pack.write({
+                    move_lines_to_pack.with_context(skip_entire_packs_check=True).write({
                         'result_package_id': package.id,
                         'is_entire_pack': True,
                     })
@@ -1476,6 +1476,10 @@ class StockPicking(models.Model):
                     break
             if has_quantity and not has_pick:
                 picking.move_ids.picked = True
+        if not self.env.context.get('skip_entire_packs'):
+            ml_with_issues_ids = self._check_entire_packages()
+            if ml_with_issues_ids:
+                return self._action_generate_not_entire_pack_wizard(ml_with_issues_ids)
         if not self.env.context.get('skip_backorder'):
             pickings_to_backorder = self._check_backorder()
             if pickings_to_backorder:
@@ -1516,6 +1520,24 @@ class StockPicking(models.Model):
             'context': dict(self.env.context, default_show_transfers=show_transfers, default_pick_ids=[(4, p.id) for p in self]),
         }
 
+    def _action_generate_not_entire_pack_wizard(self, ml_with_issues_ids):
+        view = self.env.ref('stock.stock_not_entire_pack_warning_view_form', raise_if_not_found=False)
+        if view:
+            return {
+                'name': self.env._('Incomplete packages'),
+                'type': 'ir.actions.act_window',
+                'view_mode': 'form',
+                'res_model': 'stock.not.entire.pack.warning',
+                'views': [(view.id, 'form')],
+                'view_id': view.id,
+                'target': 'new',
+                'context': {
+                    **self.env.context,
+                    'default_move_line_ids': [Command.set(ml_with_issues_ids)],
+                },
+            }
+        return self.with_context(skip_entire_packs=True)._pre_action_done_hook()
+
     def action_toggle_is_locked(self):
         self.ensure_one()
         self.is_locked = not self.is_locked
@@ -1535,6 +1557,19 @@ class StockPicking(models.Model):
             ):
                 backorder_pickings |= picking
         return backorder_pickings
+
+    def _check_entire_packages(self):
+        """ Checks if all move lines within the pickings that are supposed to be entire packs are still entire at the validation.
+            :return: A list of all move line ids that are no longer entire packs.
+        """
+        ml_with_issues_ids = set()
+        for (pickings, package), move_lines in self.move_line_ids.grouped(lambda ml: (ml._get_related_pickings(), ml.package_id)).items():
+            if not package:
+                continue
+            if not package._check_move_lines_map_quant(move_lines):
+                ml_with_issues_ids.update(move_lines.filtered(lambda ml: ml.package_id == ml.result_package_id).ids)
+
+        return list(ml_with_issues_ids)
 
     def _autoconfirm_picking(self):
         """ Automatically run `action_confirm` on `self` if one of the

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -76,3 +76,4 @@ access_stock_quant_relocate,access.stock.quant.relocate,model_stock_quant_reloca
 access_stock_package_history_user,access_stock_package_history_user,model_stock_package_history,stock.group_stock_user,1,1,1,0
 access_stock_put_in_pack_user,acess.stock.put.in.pack.user,model_stock_put_in_pack,stock.group_stock_user,1,1,1,0
 access_stock_reference,access_stock_reference,stock.model_stock_reference,base.group_user,1,1,1,0
+access_stock_not_entire_pack_warning,access.stock.not.entire.pack.warning,model_stock_not_entire_pack_warning,stock.group_stock_user,1,1,1,0

--- a/addons/stock/views/stock_package_views.xml
+++ b/addons/stock/views/stock_package_views.xml
@@ -42,7 +42,7 @@
                         <group>
                             <field name="package_type_id"/>
                             <field name='owner_id' groups="stock.group_tracking_owner"/>
-                            <field name="location_id" options="{'no_create': True}"/>
+                            <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                             <field name="parent_package_id" domain="[('id', '!=', id), '|', ('location_id', '=', location_id), ('location_id', '=', False)]" widget="package_m2o" context="{'show_src_package': 1}"/>
                         </group>
                         <group>
@@ -86,7 +86,7 @@
                 <field name="name" string="Package Name"/>
                 <field name="parent_package_id" string="Container" widget="package_m2o" context="{'show_src_package': 1}"/>
                 <field name="package_type_id"/>
-                <field name="location_id" options="{'no_create': True}"/>
+                <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
             </list>
         </field>

--- a/addons/stock/wizard/__init__.py
+++ b/addons/stock/wizard/__init__.py
@@ -19,3 +19,4 @@ from . import stock_request_count
 from . import stock_replenishment_info
 from . import stock_quant_relocate
 from . import stock_put_in_pack
+from . import stock_not_entire_pack_warning

--- a/addons/stock/wizard/stock_not_entire_pack_warning.py
+++ b/addons/stock/wizard/stock_not_entire_pack_warning.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class StockNotEntirePackWarning(models.TransientModel):
+    _name = 'stock.not.entire.pack.warning'
+    _description = 'Package No Longer Entire Warning'
+
+    move_line_ids = fields.Many2many('stock.move.line')
+    package_ids = fields.Many2many('stock.package', compute='_compute_package_ids')
+
+    def _compute_package_ids(self):
+        for wizard in self:
+            wizard.package_ids = wizard.move_line_ids.package_id
+
+    def unpack(self):
+        self.move_line_ids.with_context(skip_entire_packs_check=True).write({
+            'result_package_id': False,
+        })
+        picking_ids_to_validate = self.env.context.get('button_validate_picking_ids')
+        if picking_ids_to_validate:
+            pickings_to_validate = self.env['stock.picking'].browse(picking_ids_to_validate)
+            return pickings_to_validate.with_context(skip_entire_packs=True).button_validate()
+        return True

--- a/addons/stock/wizard/stock_not_entire_pack_warning_views.xml
+++ b/addons/stock/wizard/stock_not_entire_pack_warning_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="stock_not_entire_pack_warning_view_form" model="ir.ui.view">
+        <field name="name">stock.not.entire.pack.warning.form</field>
+        <field name="model">stock.not.entire.pack.warning</field>
+        <field name="arch" type="xml">
+            <form string="Incomplete packages">
+                <p name="explanation-text">
+                    Some packages were intended to be entirely moved but some of the products they contain have not been moved and are still in their source location :
+                </p>
+                <field name="package_ids" nolabel="1">
+                    <list create="0" edit="0">
+                        <field name="display_name" string="Name" context="{'show_src_package': 1}"/>
+                    </list>
+                </field>
+                <p>
+                    Unpack the moved products from these packages to validate the transfer.
+                </p>
+                <footer>
+                    <button name="unpack" string="Unpack" type="object" class="oe_highlight" data-hotkey="q"/>
+                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x" />
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -399,3 +399,9 @@ class StockMoveLine(models.Model):
 
         description = ', '.join(description_items)
         return description
+
+    def _get_related_pickings(self):
+        pickings = super()._get_related_pickings()
+        if pickings.batch_id:
+            pickings |= pickings.batch_id.picking_ids
+        return pickings


### PR DESCRIPTION
Steps to reproduce:
- Have two packages containing:
  - Pack 1: 5 Product A, 5 Product B
  - Pack 2: 10 Product A
- Create a transfert that moves 5 Product A & 5 Product B
- Confirm, Pack 1 should be reserved
- In Product A's move, change the pick from to Pack 2

Issues:
After the change, Pack 1 remains the destination package of both moves, resulting in an error at validation, since part of the package (product A) is still at the source location while we try to move Product B into another location with the same package.

The solution to this is two-fold:
- When updating the source of a move line having the same package as source and destination, clear its destination package.
- When validating a picking with packages that are no longer entire, display a wizard showing which packages are now non-complete and allowing the user to unpack them before validating the transfer.

task-5222941

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
