### PR TITLE
[PERF] point_of_sale: optimize product search and sorting

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -1,5 +1,6 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
+import { normalize } from "@web/core/l10n/utils";
 
 // When adding a method to this class, please pay attention to naming.
 // As in the backend, when trying to access taxes_id on product.product,
@@ -20,10 +21,11 @@ export class ProductProduct extends Base {
 
     get searchString() {
         const fields = ["display_name", "barcode", "default_code"];
-        return fields
+        const raw = fields
             .map((field) => this[field] || "")
             .filter(Boolean)
             .join(" ");
+        return normalize(raw);
     }
 }
 

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 import { markup } from "@odoo/owl";
 import { ProductTemplateAccounting } from "./accounting/product_template_accounting";
+import { normalize } from "@web/core/l10n/utils";
 
 /**
  * ProductProduct, shadow of product.product in python.
@@ -134,10 +135,19 @@ export class ProductTemplate extends ProductTemplateAccounting {
 
     get searchString() {
         const fields = ["name", "default_code", "barcode"];
-        return fields
+        const raw = fields
             .map((field) => this[field] || "")
             .filter(Boolean)
             .join(" ");
+
+        const templateContent = normalize(raw);
+        const variantContent = this.product_variant_ids.map((v) => v.searchString).join(" ");
+
+        return variantContent ? templateContent + " " + variantContent : templateContent;
+    }
+
+    get normalizedName() {
+        return normalize(this.name || "");
     }
 }
 registry.category("pos_available_models").add(ProductTemplate.pythonModel, ProductTemplate);

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2782,30 +2782,31 @@ export class PosStore extends WithLazyGetterTrap {
         }
     }
 
-    sortByWordIndex(products, words) {
-        return products.sort((a, b) => {
-            const nameA = normalize(a.name);
-            const nameB = normalize(b.name);
-
-            const indexA = nameA.indexOf(words);
-            const indexB = nameB.indexOf(words);
-            return (
-                (indexA === -1) - (indexB === -1) || indexA - indexB || nameA.localeCompare(nameB)
-            );
-        });
-    }
-
     getProductsBySearchWord(searchWord, products) {
-        const words = normalize(searchWord);
-        const matches = products.filter(
-            (p) =>
-                normalize(p.searchString).includes(words) ||
-                p.product_variant_ids.some((variant) =>
-                    normalize(variant.searchString).includes(words)
-                )
+        const query = normalize(searchWord);
+        const matches = [];
+
+        for (const product of products) {
+            const searchStr = product.searchString;
+
+            if (searchStr.includes(query)) {
+                const normName = product.normalizedName;
+                matches.push({
+                    product: product,
+                    index: normName.indexOf(query),
+                    name: normName,
+                });
+            }
+        }
+
+        matches.sort(
+            (a, b) =>
+                (a.index === -1) - (b.index === -1) ||
+                a.index - b.index ||
+                (a.name == b.name ? 0 : a.name > b.name ? 1 : -1)
         );
 
-        return this.sortByWordIndex(matches, words);
+        return matches.map((m) => m.product);
     }
     getPaymentMethodFmtAmount(pm, order) {
         const amount = order.getDefaultAmountDueToPayIn(pm);


### PR DESCRIPTION
Previously, the product search performed normalization inside the filter and sort loops. Because sort algorithms perform O(n log n) comparisons, the `normalize` function was called redundantly thousands of times for the same product, leading to UI lag when handling large products.

This commit optimizes the search by:
- Moving normalization to the model getters
- Flattening the template search string to include all variants, removing the need for nested `.some()` loops during filtering.
- Replacing `localeCompare` with primitive string comparison for faster sorting.

opw-5448113

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
