### PR TITLE
[FIX] pos_sale: prevent settle lines from being discounted twice

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -105,6 +105,18 @@ patch(PosStore.prototype, {
                 }
                 continue;
             }
+            const converted_line = converted_lines.find((l) => l.id === line.id);
+            if (converted_line?.coupon_id) {
+                const couponRecord = this.models['loyalty.card'].get(converted_line.coupon_id);
+                if (couponRecord?.program_id.trigger === "with_code") {
+                    debugger;
+                    const programRule = this.models["loyalty.rule"].find(
+                        rule => rule.program_id?.id === couponRecord.program_id.id && rule.mode === "with_code"
+                    );
+                    await this.activateCode(programRule.code);
+                        continue;
+                }
+            }
 
             if (line.is_downpayment) {
                 line.product_id = this.config.down_payment_product_id;
@@ -129,7 +141,6 @@ patch(PosStore.prototype, {
             const newLine = await this.addLineToCurrentOrder(newLineValues, {}, false);
             previousProductLine = newLine;
 
-            const converted_line = converted_lines.find((l) => l.id === line.id);
             if (
                 newLine.get_product().tracking !== "none" &&
                 (this.pickingType.use_create_lots || this.pickingType.use_existing_lots) &&

--- a/addons/pos_sale_loyalty/models/sale_order.py
+++ b/addons/pos_sale_loyalty/models/sale_order.py
@@ -10,4 +10,5 @@ class SaleOrderLine(models.Model):
     def _get_sale_order_fields(self):
         field_names = super()._get_sale_order_fields()
         field_names.append('reward_id')
+        field_names.append('coupon_id')
         return field_names


### PR DESCRIPTION
**Steps to reproduce:**
- Make a loyalty coupon program, like 10% on all products
- Make a quotation in Sales, enter the coupon code
- Go to PoS and click on settle this quotation
- Add another product
- The coupon discount is not applied on the new product
- Enter the coupon code in the PoS
- The coupon discount is applied on everthing including the already discounted items we are settling

**Why the fix:**
When settling a quotation, we should not count what has already been included in the discount in the Sales app. Instead we now update the discount line instead of importing the one from the quotation, then making a new one.
This way, the discounts stay on one single line per program.

opw-5171060