### PR TITLE
[FIX] website: preserve delayed translations on update

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -522,10 +522,10 @@ class IrModuleModule(models.Model):
                 if not langs_update:
                     continue
                 # get dictionaries limited to the requested languages
-                generic_arch_db_en = generic_arch_db.get('en_US')
-                specific_arch_db_en = specific_arch_db.get('en_US')
-                generic_arch_db_update = {k: generic_arch_db[k] for k in langs_update}
-                specific_arch_db_update = {k: specific_arch_db.get(k, specific_arch_db_en) for k in langs_update}
+                generic_arch_db_en = generic_arch_db.get('_en_US', generic_arch_db.get('en_US'))
+                specific_arch_db_en = specific_arch_db.get('_en_US', specific_arch_db.get('en_US'))
+                generic_arch_db_update = {k: generic_arch_db.get('_' + k, generic_arch_db[k]) for k in langs_update}
+                specific_arch_db_update = {k: specific_arch_db.get('_' + k, specific_arch_db.get(k, specific_arch_db_en)) for k in langs_update}
                 generic_translation_dictionary = field.get_translation_dictionary(generic_arch_db_en, generic_arch_db_update)
                 specific_translation_dictionary = field.get_translation_dictionary(specific_arch_db_en, specific_arch_db_update)
                 # update specific_translation_dictionary
@@ -536,7 +536,9 @@ class IrModuleModule(models.Model):
                         if overwrite or term_en == specific_term_langs[lang]:
                             specific_term_langs[lang] = generic_term_lang
                 for lang in langs_update:
-                    specific_arch_db[lang] = field.translate(
+                    if specific_arch_db.get('_' + lang) == specific_arch_db.get(lang):
+                        specific_arch_db.pop('_' + lang, None)
+                    specific_arch_db[('_' + lang) if ('_' + lang) in specific_arch_db else lang] = field.translate(
                         lambda term: specific_translation_dictionary.get(term, {lang: None})[lang], specific_arch_db_en)
                 field._update_cache(View.with_context(prefetch_langs=True).browse(specific_id), specific_arch_db, dirty=True)
         default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)


### PR DESCRIPTION
In commit 03a85b13b2c46ef7174123d902e95d5103031c6c, delayed translations were restored.

Delayed translations of a view were lost on upgrade of the module that contains the corresponding generic view. This happened because the update of the view did not take into account the possible delayed translations when updating it and the translations in specific views.

This commit updates (and uses as source) the current versions, instead of the delayed ones.

Steps to reproduce:
- Install a second language for the website
- Set the default language for the website to the second language
- Edit footer by changing structure not just text (like changing a link to have a button appearance)
- Upgrade the "Website" app
- Bug: footer lost the last edit

Steps to reproduce:
- Install a second language for the website
- Edit footer by changing structure not just text (like changing a link to have a button appearance)
- (Observe that the change is not in the website in the second language)
- Upgrade the "Website" app
- Bug: the change is now in the website in the second language

task-5248173

Fixes #233723 
