### PR TITLE
[FIX] Switched error codes for oauth_error

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -166,11 +166,11 @@ class OAuthController(http.Controller):
         except AccessDenied:
             # oauth credentials not valid, user could be on a temporary session
             _logger.info('OAuth2: access denied, redirect to main page in case a valid session exists, without setting cookies')
-            url = "/web/login?oauth_error=3"
+            url = "/web/login?oauth_error=2"
         except Exception:
             # signup error
             _logger.exception("Exception during request handling")
-            url = "/web/login?oauth_error=2"
+            url = "/web/login?oauth_error=3"
 
         redirect = request.redirect(url, 303)
         redirect.autocorrect_location_header = False


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR should fix the order of error codes in the oauth controller.

Current behavior before PR:

Currently the user gets redirected to a different error.
For instance: AccessDenied error will redirect the user to "You do not have access to this database or your invitation has expired. Please ask for an invitation and be sure to follow the link in your invitation email."

Desired behavior after PR is merged:

AccessDenied error should show "Access Denied"




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
