### PR TITLE
[FIX] mrp: child MO qty update with UoM conversion

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -103,9 +103,10 @@ class StockRule(models.Model):
                     new_productions_values_by_company[procurement.company_id.id]['procurements'].append(procurement)
                     procurement_qty -= batch_size
             else:
+                procurement_product_uom_qty = procurement.product_uom._compute_quantity(procurement.product_qty, procurement.product_id.uom_id)
                 self.env['change.production.qty'].sudo().with_context(skip_activity=True).create({
                     'mo_id': mo.id,
-                    'product_qty': mo.product_id.uom_id._compute_quantity((mo.product_uom_qty + procurement.product_qty), mo.product_uom_id)
+                    'product_qty': mo.product_id.uom_id._compute_quantity((mo.product_uom_qty + procurement_product_uom_qty), mo.product_uom_id),
                 }).change_prod_qty()
 
         for company_id in new_productions_values_by_company:

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1116,3 +1116,54 @@ class TestProcurement(TestMrpCommon):
         })
         update_quantity_wizard.change_prod_qty()
         self.assertEqual(replenishment.product_uom_qty, 7)
+
+    def test_update_mo_producing_qty_mto_chain(self):
+        """
+        Test that an MTO child MO correctly handles UoM conversions between the component UoM and
+        the child MO UoM when the source MO's production quantity is updated.
+        """
+        self.productA.write({'uom_id': self.uom_dozen})
+
+        self.route_mto.write({'active': True})
+        self.productA.route_ids = [
+            Command.link(self.route_mto.id),
+            Command.link(self.route_manufacture.id),
+        ]
+
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': self.productA.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'product_uom_id': self.productA.uom_id.id,
+            'bom_line_ids': [
+                Command.create({'product_id': self.productB.id, 'product_qty': 1}),
+            ],
+        })
+        bomC = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.productC.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'bom_line_ids': [
+                Command.create({'product_id': self.productA.id, 'product_qty': 6.0, 'product_uom_id': self.uom_unit.id}),
+            ],
+        })
+
+        mo = self.env['mrp.production'].create({
+            'product_id': self.productC.id,
+            'bom_id': bomC.id,
+            'product_qty': 1,
+        })
+        mo.action_confirm()
+        mo_child = mo._get_children()
+
+        self.assertEqual(mo.move_raw_ids.product_uom, self.uom_unit)
+        self.assertEqual(mo_child.product_uom_id, self.uom_dozen)
+        self.assertEqual(mo_child.product_qty, 0.5)
+
+        update_quantity_wizard = self.env['change.production.qty'].create({
+            'mo_id': mo.id,
+            'product_qty': 2,
+        })
+        update_quantity_wizard.change_prod_qty()
+
+        self.assertEqual(mo_child.product_qty, 1.0)


### PR DESCRIPTION
Problem: When a manufactured product uses a component whose UoM is different from its reference UoM, for example the component’s UoM is dozens but units are used on the BoM line, updating the quantity to produce on the parent MO causes the child MO’s quantity to roduce to update incorrectly. This is because the new quantity to produce on the child MO is calculated with quantities in different UoMs.

Purpose: To ensure that the child MO’s quantity to produce updates correctly when the parent MO’s quantity to produce is updated. This is achieved by making sure the quantities that get added together are both the same UoM, in this case the product’s UoM.

Steps to Reproduce on Runbot:
1. Create product_a with the MTO route and UoM set to pack of 6.
2. Create a BoM for product_a that creates 1 pack of 6 products.
3. Create product_b.
4. Create a BoM for product_b that creates 1 unit and uses 3 units of product_a. Make sure the component line shows 3 units instead of 0.5 pack of 6.
5. Create a manufacturing order for 1 unit of product_b and confirm it.
6. There should be a child MO for 0.5 pack of 6 of product_a.
7. On the parent MO update the production quantity to 2 units.
8. Observe that the child MO is now for 3.5 pack of 6 instead of 1 pack of 6.

opw-5414085

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
