### PR TITLE
[FIX] website_sale: s_add_to_cart button type = "button"

### DIFF
--- a/addons/website_sale/views/snippets/s_add_to_cart.xml
+++ b/addons/website_sale/views/snippets/s_add_to_cart.xml
@@ -7,7 +7,7 @@
             tracking utilities will be fully integrated into a service.
         -->
         <div class="s_add_to_cart oe_website_sale" data-action="add_to_cart">
-            <button class="s_add_to_cart_btn disabled btn btn-secondary mb-2" data-action="add_to_cart">
+            <button type="button" class="s_add_to_cart_btn disabled btn btn-secondary mb-2" data-action="add_to_cart">
                 <i class="fa fa-cart-plus me-2"/>Add to Cart
             </button>
         </div>


### PR DESCRIPTION
[Issue] Customer embedded the "Add to Cart" button id="s_add_to_cart" to the [form](https://github.com/odoo/odoo/blob/edaa02dc0e67d6ccd17cc3be9a98d94276bcd403/addons/website_sale/views/templates.xml#L2066) inside the product webpage. By default, buttons inside forms use the type="submit" attribute, which causes the form to refresh after the button is clicked. Therefore, the modal pop-up is essentially rendered useless because it just refreshes the page.

[Solution] added type="button" to the button inside "s_add_to_cart" to make it a normal button without the "submit" functionality

opw-5417500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
