### PR TITLE
[FIX] point_of_sale: Fix restricted access to ir.module.module

### DIFF
--- a/addons/point_of_sale/models/account_payment.py
+++ b/addons/point_of_sale/models/account_payment.py
@@ -31,7 +31,7 @@ class AccountPayment(models.Model):
         # a specific customer. We ensure that account.payment are not created using the sepa_ct
         # account.payment.method.line. If not, closing the session would not be possible unless
         # having an account.payment.method.line with a smaller sequence than sepa_ct.
-        account_sepa = self.env['ir.module.module'].search([('name', '=', 'account_sepa')])
+        account_sepa = self.env['ir.module.module'].sudo().search([('name', '=', 'account_sepa')])
         if account_sepa.state == 'installed':
             sepa_ct = self.env.ref('account_sepa.account_payment_method_sepa_ct', raise_if_not_found=False)
             if sepa_ct and 'pos_payment' in self.env.context and sepa_ct.code not in res:


### PR DESCRIPTION
Steps to reproduce:
1. Install the Point of Sale module without installing the base_install_request module.
2. Log in with an accountant user.
3. Navigate to Invoicing → Customers → Payments.
4. An error occurs when accessing the screen:

```
You are not allowed to access 'Module' (ir.module.module) records.

This operation is allowed for the following groups:
	- Administration/Settings

Contact your administrator to request access if necessary.
```






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
