### PR TITLE
[FIX] html_editor: fix keyboard selection for contenteditable=false elements

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -12,7 +12,6 @@ import {
 } from "../utils/dom";
 import {
     allowsParagraphRelatedElements,
-    getDeepestPosition,
     isContentEditable,
     isContentEditableAncestor,
     isEmptyBlock,
@@ -28,6 +27,7 @@ import {
     listElementSelector,
     isEditorTab,
     isPhrasingContent,
+    getDeepestEditablePosition,
 } from "../utils/dom_info";
 import {
     childNodes,
@@ -440,7 +440,7 @@ export class DomPlugin extends Plugin {
 
         if (!this.config.allowInlineAtRoot && this.isEditionBoundary(lastPosition[0])) {
             // Correct the position if it happens to be in the editable root.
-            lastPosition = getDeepestPosition(...lastPosition);
+            lastPosition = getDeepestEditablePosition(...lastPosition);
         }
         this.dependencies.selection.setSelection(
             { anchorNode: lastPosition[0], anchorOffset: lastPosition[1] },

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -1,5 +1,6 @@
 import { closestBlock } from "@html_editor/utils/blocks";
 import {
+    getDeepestEditablePosition,
     getDeepestPosition,
     isMediaElement,
     isProtected,
@@ -241,8 +242,8 @@ export class SelectionPlugin extends Plugin {
         const selection = this.getEditableSelection();
         const containerSelector = "#wrap > *, .oe_structure > *, [contenteditable]";
         const container = selection && closestElement(selection.anchorNode, containerSelector);
-        const [anchorNode, anchorOffset] = getDeepestPosition(container, 0);
-        const [focusNode, focusOffset] = getDeepestPosition(container, nodeSize(container));
+        const [anchorNode, anchorOffset] = getDeepestEditablePosition(container, 0);
+        const [focusNode, focusOffset] = getDeepestEditablePosition(container, nodeSize(container));
         this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
     }
 

--- a/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.scss
+++ b/addons/html_editor/static/src/others/embedded_components/core/toggle_block/toggle_block.scss
@@ -2,7 +2,7 @@
     [data-embedded-editable] > p {
         margin: 0;
     }
-    button:has(i.fa-caret-down, i.fa-caret-right){
+    button:has(i.fa-caret-down:only-child, i.fa-caret-right:only-child) {
         cursor: pointer !important;
         width: 1.5rem; // Equivalent to ps-4
         aspect-ratio: 1 / 1;

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -1,7 +1,7 @@
 import { baseContainerGlobalSelector } from "./base_container";
 import { closestBlock, isBlock } from "./blocks";
 import { childNodes, closestElement, firstLeaf, lastLeaf } from "./dom_traversal";
-import { DIRECTIONS, nodeSize } from "./position";
+import { childNodeIndex, DIRECTIONS, nodeSize } from "./position";
 
 export function isEmpty(el) {
     if (isProtecting(el) || isProtected(el)) {
@@ -644,6 +644,76 @@ export function getDeepestPosition(node, offset) {
         next = !isSelfClosingElement(next) && next;
     }
     return [node, offset];
+}
+
+/**
+ * Return the deepest editable position from a given DOM position.
+ *
+ * This resolves a [node, offset] pair to the deepest descendant that is
+ * allowed to contain the caret. If the resolved deepest position is inside
+ * a non-editable element, the function walks up the DOM until it reaches
+ * an editable ancestor and adjusts the offset so the caret sits just before
+ * or after the non-editable region.
+ *
+ * Example:
+ *   <div contenteditable="true">
+ *       <span contenteditable="false">X</span>
+ *   </div>
+ *   getDeepestEditablePosition(div, 1)
+ *   → [div, 1]
+ *
+ * @param {node} node   - Node in which the position is being resolved.
+ * @param {number} offset - Offset within node.
+ * @returns {[Node, number]} A corrected editable node and offset.
+ */
+export function getDeepestEditablePosition(node, offset) {
+    const [deepNode, deepOffset] = getDeepestPosition(node, offset);
+
+    // If deepest node is already editable, nothing to correct.
+    if (isContentEditable(deepNode)) {
+        return [deepNode, deepOffset];
+    }
+
+    // The direct child of root that contains the deepest resolved node.
+    const nodeLevelAncestor =
+        isTextNode(deepNode) && deepNode.parentElement === node
+            ? deepNode
+            : closestElement(deepNode, (el) => el.parentElement === node);
+
+    // The closest non-editable ancestor whose parent is editable.
+    const closestNonEditable = closestElement(
+        deepNode,
+        (el) => !isContentEditable(el) && isContentEditable(el.parentElement)
+    );
+
+    const nodeLevelAncestorIndex = childNodeIndex(nodeLevelAncestor);
+    const closestNonEditableIndex = childNodeIndex(closestNonEditable);
+
+    // Decide whether the caret should be placed before or after
+    // the non-editable element based on the requested offset.
+    const deepEditableNode = closestNonEditable.parentElement;
+    const deepEditableOffset =
+        nodeLevelAncestorIndex < offset ? closestNonEditableIndex + 1 : closestNonEditableIndex;
+
+    // If caret lands on non-editable, resolve it from previous sibling.
+    if (deepEditableOffset === closestNonEditableIndex) {
+        const previousSiblingOfNonEditable = closestNonEditable.previousSibling;
+        if (previousSiblingOfNonEditable) {
+            if (isTextNode(previousSiblingOfNonEditable)) {
+                return [previousSiblingOfNonEditable, nodeSize(previousSiblingOfNonEditable)];
+            } else if (
+                isElement(previousSiblingOfNonEditable) &&
+                previousSiblingOfNonEditable.childNodes.length
+            ) {
+                return getDeepestEditablePosition(
+                    previousSiblingOfNonEditable,
+                    nodeSize(previousSiblingOfNonEditable)
+                );
+            }
+        }
+    }
+
+    return [deepEditableNode, deepEditableOffset];
 }
 
 export function previousLeaf(node, editable, skipInvisible = false) {

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -34,7 +34,6 @@ test("should insert a banner with focus inside followed by a paragraph", async (
     await insertText(editor, "banner");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
-
 });
 
 test("press 'ctrl+a' inside a banner should select all the banner content", async () => {
@@ -127,8 +126,8 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     await press(["ctrl", "a"]);
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">[💡</i>
+        `[<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
                 <div class="w-100 px-3" contenteditable="true">
                     <p><br></p>
                 </div>
@@ -169,7 +168,7 @@ test("Everything gets selected with ctrl+a, including a contenteditable=false as
     );
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
-        '<div data-oe-role="status" contenteditable="false" role="status">[a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
+        '[<div data-oe-role="status" contenteditable="false" role="status">a</div><div data-oe-role="status" contenteditable="false" role="status">b</div><p>cd]</p>'
     );
 
     await press("Backspace");

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -17,7 +17,7 @@ import {
     toggleBlockEmbedding,
 } from "@html_editor/others/embedded_components/core/toggle_block/toggle_block";
 import { onMounted } from "@odoo/owl";
-import { animationFrame, queryOne, tick } from "@odoo/hoot-dom";
+import { animationFrame, press, queryOne, tick } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 import { browser } from "@web/core/browser/browser";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
@@ -210,6 +210,29 @@ describe("deleteBackward applied to toggle", () => {
         expect(queryOne("[data-embedded='toggleBlock']").nextElementSibling).toHaveOuterHTML(`
             <p>Riddance</p>
         `);
+    });
+    test("press 'ctrl+a' with leading toggle block should select and delete all content", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(`
+                <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
+                    <div data-embedded-editable="title">
+                        <p>HelloWorld</p>
+                    </div>
+                    <div data-embedded-editable="content">
+                        <p>Good</p>
+                        <p>Riddance</p>
+                    </div>
+                </div>
+                <div class="o-paragraph">hello[]</div>
+            `),
+            { config: getConfig([toggleBlockEmbedding]) }
+        );
+        await embeddedToggleMountedPromise;
+        await press(["CTRL", "A"]); // select all
+        deleteBackward(editor);
+        expect(getContent(el)).toBe(
+            `<div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></div>`
+        );
     });
 });
 describe("deleteForward applied to toggle", () => {

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -15,6 +15,7 @@ import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, tripleClick } from "./_helpers/user_actions";
+import { unformat } from "./_helpers/format";
 import { withSequence } from "@html_editor/utils/resource";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { SelectionPlugin } from "@html_editor/core/selection_plugin";
@@ -264,6 +265,28 @@ test("press 'ctrl+a' in 'contenteditable' should only select his content", async
     await press(["ctrl", "a"]);
     expect(getContent(el)).toBe(
         `<div contenteditable="false"><p contenteditable="true">[ab]</p><p contenteditable="true">cd</p></div>`
+    );
+});
+
+test("press 'ctrl+a' with 'contenteditable=false' at start should anchors selection in editable", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+                <div contenteditable="false">
+                    <div>abc</div>
+                    <div contenteditable="true">def</div>
+                </div>
+                <div class="o-paragraph">ghi[]</div>
+            `)
+    );
+    await press(["ctrl", "a"]);
+    expect(getContent(el)).toBe(
+        unformat(`
+                [<div contenteditable="false">
+                    <div>abc</div>
+                    <div contenteditable="true">def</div>
+                </div>
+                <div class="o-paragraph">ghi]</div>
+            `)
     );
 });
 

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -1,4 +1,5 @@
 import {
+    getDeepestEditablePosition,
     getDeepestPosition,
     isEmptyBlock,
     isShrunkBlock,
@@ -10,6 +11,7 @@ import {
 import { describe, expect, test } from "@odoo/hoot";
 import { insertTestHtml } from "../_helpers/editor";
 import { isBlock } from "../../src/utils/blocks";
+import { unformat } from "../_helpers/format";
 
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
@@ -363,6 +365,172 @@ describe("getDeepestPosition", () => {
         const zwnbsp = editable.firstChild;
         const [node, offset] = getDeepestPosition(editable, 0);
         expect([node, offset]).toEqual([zwnbsp, 0]);
+    });
+});
+
+describe("getDeepestEditablePosition", () => {
+    test("should get deepest editable position on the paragraph itself", () => {
+        const [p] = insertTestHtml(`<p><span contenteditable="false"><span>test</span></span></p>`);
+
+        expect(getDeepestEditablePosition(p, 0)).toEqual([p, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([p, 1]);
+    });
+
+    test("should get deepest editable position before or after a non-editable sibling", () => {
+        const [p] = insertTestHtml(
+            `<p>abc<span contenteditable="false"><span>test</span></span>def</p>`
+        );
+
+        const abc = p.firstChild;
+        const def = p.lastChild;
+
+        expect(getDeepestEditablePosition(p, 0)).toEqual([abc, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([abc, 3]);
+        expect(getDeepestEditablePosition(p, 2)).toEqual([def, 0]);
+        expect(getDeepestEditablePosition(p, 3)).toEqual([def, 3]);
+    });
+
+    test("should get deepest editable position inside nested formatting on both sides of a non-editable", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <strong><i>abc</i></strong>
+                    <span contenteditable="false"><span>test</span></span>
+                    <u><em>def</em></u>
+                </p>
+            `)
+        );
+
+        const abc = p.querySelector("strong i").firstChild;
+        const def = p.querySelector("u em").firstChild;
+
+        expect(getDeepestEditablePosition(p, 0)).toEqual([abc, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([abc, 3]);
+        expect(getDeepestEditablePosition(p, 2)).toEqual([def, 0]);
+        expect(getDeepestEditablePosition(p, 3)).toEqual([def, 3]);
+    });
+
+    test("should get deepest editable position when previous editable sibling ends with non-editable leaf", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <strong contenteditable="true">
+                        <span contenteditable="false">A</span>
+                    </strong>
+                    <span contenteditable="false">B</span>
+                </p>
+            `)
+        );
+
+        const strong = p.firstChild;
+        expect(getDeepestEditablePosition(p, 1)).toEqual([strong, 1]);
+    });
+
+    test("should get deepest editable position when non-editable content following text", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    abc
+                    <span contenteditable="false">B</span>
+                </p>
+            `)
+        );
+
+        const abc = p.firstChild;
+        expect(getDeepestEditablePosition(p, 1)).toEqual([abc, 3]);
+    });
+
+    test("should get deepest editable position inside an editable descendant wrapped by non-editable ancestors", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <span contenteditable="false"><strong><u contenteditable="true">test</u></strong></span>
+                    <span contenteditable="false">test</span>
+                </p>
+            `)
+        );
+
+        const test = p.querySelector("u").firstChild;
+        expect(getDeepestEditablePosition(p, 0)).toEqual([test, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([test, 4]);
+        expect(getDeepestEditablePosition(p, 2)).toEqual([p, 2]);
+    });
+
+    test("should get deepest editable position on the paragraph when non-editable descendants contain only text nodes", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <span contenteditable="false">test</span>
+                    <span contenteditable="false">test</span>
+                </p>
+            `)
+        );
+
+        expect(getDeepestEditablePosition(p, 0)).toEqual([p, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([p, 1]);
+        expect(getDeepestEditablePosition(p, 2)).toEqual([p, 2]);
+    });
+
+    test("should get deepest editable position on the paragraph when non-editable descendants contain elements", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <span contenteditable="false"><strong>test</strong></span>
+                    <span contenteditable="false">test</span>
+                </p>
+            `)
+        );
+
+        expect(getDeepestEditablePosition(p, 0)).toEqual([p, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([p, 1]);
+        expect(getDeepestEditablePosition(p, 2)).toEqual([p, 2]);
+    });
+
+    test("should get deepest editable position on the paragraph when previous sibling is empty and non-editable", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <span contenteditable="false"></span>
+                    <span contenteditable="false">test</span>
+                </p>
+            `)
+        );
+
+        expect(getDeepestEditablePosition(p, 1)).toEqual([p, 1]);
+    });
+
+    test("should get deepest editable position around a shallow inline ancestor containing a non-editable child", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <i>
+                        <span contenteditable="false">test</span>
+                    </i>
+                </p>
+            `)
+        );
+
+        const italic = p.firstChild;
+        expect(getDeepestEditablePosition(p, 0)).toEqual([italic, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([italic, 1]);
+    });
+
+    test("should get deepest editable position around a deep inline ancestor containing a non-editable descendant", () => {
+        const [p] = insertTestHtml(
+            unformat(`
+                <p>
+                    <i>
+                        <u>
+                            <span contenteditable="false">test</span>
+                        </u>
+                    </i>
+                </p>
+            `)
+        );
+
+        const underline = p.querySelector("u");
+        expect(getDeepestEditablePosition(p, 0)).toEqual([underline, 0]);
+        expect(getDeepestEditablePosition(p, 1)).toEqual([underline, 1]);
     });
 });
 


### PR DESCRIPTION
Description of the issue this PR addresses:

- When an element with `contenteditable="false"` is the first node in the editable, pressing Ctrl+A followed by Delete does not remove the entire selection and instead deletes only the last character.

Desired behavior after PR is merged:

- Ensure that the selection is anchored to the deepest editable position when performing a select-all operation so that the full editable content is correctly selected and removed.

Steps to reproduce:

- Insert a toggle list using `/togglelist` in a new todo
- Add one or more paragraphs below it and enter some text
- Select all content using Ctrl+A
- Press Backspace to delete the selection
- Observe that only the last character is removed

Backport of: 67e6a617def3bf4f9eb6b63b0850f5cfc773bccc

task-5363926

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
