### PR TITLE
[FIX] website_sale: added hover transition class to list product view

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -1104,6 +1104,11 @@ $_wsale_products_roundness_map: (
         @content;
     }
 }
+// Default opacity for secondary images, prevents PNG transparency from showing
+// the underlying image when hover effect: None
+.o_wsale_products_opt_img_secondary_show .oe_product_image_link_has_secondary {
+    --o-wsale-card-img-opacity-hover: 0;
+}
 
 .o_wsale_products_opt_img_hover_zoom_in {
     --o-wsale-card-img-transition: all .25s;
@@ -1111,7 +1116,6 @@ $_wsale_products_roundness_map: (
     --o-wsale-card-img-transition-hover: all .25s;
 
     @include o-wsale-card-when-secondary-img() {
-        --o-wsale-card-img-opacity-hover: 0;
         --o-wsale-card-img-transition: all .5s ease-in-out;
         --o-wsale-card-img-secondary-transition: all .5s ease-in-out;
         --o-wsale-card-img-secondary-opacity-hover: 1;
@@ -1123,7 +1127,6 @@ $_wsale_products_roundness_map: (
     --o-wsale-card-img-transform-hover: scale(1.04);
 
     @include o-wsale-card-when-secondary-img() {
-        --o-wsale-card-img-opacity-hover: 0;
         --o-wsale-card-img-transition: all .5s ease-in-out;
         --o-wsale-card-img-secondary-transition: all .5s;
         --o-wsale-card-img-secondary-opacity-hover: 1;
@@ -1138,7 +1141,6 @@ $_wsale_products_roundness_map: (
     --o-wsale-card-img-transition-hover: all .1s;
 
     @include o-wsale-card-when-secondary-img() {
-        --o-wsale-card-img-opacity-hover: 0;
         --o-wsale-card-img-transition: all .5s ease-in-out;
         --o-wsale-card-img-secondary-transform: scale(1.08);
         --o-wsale-card-img-secondary-transition: all .5s ease-in-out;
@@ -1153,7 +1155,6 @@ $_wsale_products_roundness_map: (
     --o-wsale-card-img-transition-hover: all .1s;
 
     @include o-wsale-card-when-secondary-img() {
-        --o-wsale-card-img-opacity-hover: 0;
         --o-wsale-card-img-transition: all .5s ease-in-out;
         --o-wsale-card-img-secondary-transform: scale(1.04);
         --o-wsale-card-img-secondary-transition: all .5s ease-in-out;


### PR DESCRIPTION
Before this commit :
---
when the  none type hover effect selected on the shop page  product hover is 
supported by default but in this hover transition images are stacked instead of 
replacing.


https://github.com/user-attachments/assets/04801451-842d-4072-bfcf-249767962823



Why this commit :
---
adding  'o_wsale_products_opt_img_hover_none' class to manage this image 
stacking issue
The none type is default for all the list layout views hence the image stacking issue
observed in all the list views where product image is uploaded in the png without 
background image.



https://github.com/user-attachments/assets/8ad8832f-f2e8-486c-a638-32ea3595493a


OPW: 5406434


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
