### PR TITLE
[FIX] loyalty: correct grammar in action helper text

### DIFF
--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -529,12 +529,12 @@ class LoyaltyProgram(models.Model):
             return {
                 'gift_card': {
                     'title': _("Gift Card"),
-                    'description': _("Sell Gift Cards, that allows to purchase products"),
+                    'description': _("Sell gift cards that people can use to buy products."),
                     'icon': 'gift_card',
                 },
                 'ewallet': {
                     'title': _("eWallet"),
-                    'description': _("Fill in your eWallet, to pay future orders"),
+                    'description': _("Add money to your eWallet to pay for future orders."),
                     'icon': 'ewallet',
                 },
             }

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -248,7 +248,7 @@
         <field name="help" type="html">
             <div class="o_loyalty_not_found container mt64">
                 <h1>No loyalty program found.</h1>
-                <p class="lead">Create a new one from scratch, or use one of the templates below.</p>
+                <p class="lead">Create one from scratch, or use a template below.</p>
             </div>
         </field>
     </record>


### PR DESCRIPTION
Steps to produce:
- Install `Sale` module without demo data.
- From the settings, enable `Discounts, Loyalty & Gift Card`.
- Go to `Sales > Products > Gift Cards & ewallets`.

Observation:
- Observed that the action helper text contained incorrect English grammar.

Solution:
- The changes were made according to the PO’s requirements.

Before:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/ac4d2461-000e-4979-b956-5cf0cc24419d" />

After:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/ab41ed14-8933-493d-8803-b8834371bf9d" />

opw-4859713
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
