### PR TITLE
[IMP] l10n_my_edi_pos: enable self-service invoicing in pos for edi

### DIFF
--- a/addons/l10n_my_edi_pos/__init__.py
+++ b/addons/l10n_my_edi_pos/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import controllers
 from . import models
 from . import wizard

--- a/addons/l10n_my_edi_pos/__manifest__.py
+++ b/addons/l10n_my_edi_pos/__manifest__.py
@@ -13,7 +13,15 @@
         "views/myinvois_document_pos_views.xml",
         "views/pos_order_views.xml",
         "views/product_view.xml",
+        "views/portal_address_templates.xml",
+        "views/ticket_validation_screen.xml",
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'l10n_my_edi_pos/static/src/interactions/address.js',
+        ],
+    },
+
     'auto_install': True,
     'author': 'Odoo S.A.',
     "license": "LGPL-3",

--- a/addons/l10n_my_edi_pos/controllers/__init__.py
+++ b/addons/l10n_my_edi_pos/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/addons/l10n_my_edi_pos/controllers/portal.py
+++ b/addons/l10n_my_edi_pos/controllers/portal.py
@@ -1,0 +1,99 @@
+from odoo.http import request
+
+from odoo.addons.account.controllers.portal import PortalAccount
+
+
+class L10nMYPortalAccount(PortalAccount):
+
+    def _prepare_address_form_values(self, *args, **kwargs):
+        rendering_values = super()._prepare_address_form_values(*args, **kwargs)
+
+        l10n_my_identification_types = dict(request.env['res.partner']._fields['l10n_my_identification_type'].selection)
+        # BRN applies only to companies. It must not be selectable for individuals, and it's enforced companies.
+        l10n_my_identification_types.pop('BRN')
+        default_classification = request.env.ref(
+            'l10n_my_edi.class_00000', raise_if_not_found=False,
+        )
+        rendering_values.update({
+            'l10n_my_identification_types': l10n_my_identification_types,
+            'l10n_my_edi_industrial_classifications': request.env['l10n_my_edi.industry_classification'].sudo().search([]),
+            'default_industrial_classification_id': default_classification.id if default_classification else False,
+        })
+        return rendering_values
+
+    def _parse_form_data(self, form_data):
+        address_values, extra_form_data = super()._parse_form_data(form_data)
+
+        is_my_company = (
+            request.env['res.country'].browse(address_values.get('country_id'))
+            .exists().code == 'MY'
+        )
+
+        # MyInvois requires VAT, identification number and type; placeholders are used in certain cases which are handled below.
+        if form_data.get('company_type') == 'person':
+            tax_identifier = 'vat' if is_my_company else 'l10n_my_edi_malaysian_tin'
+            if not address_values.get(tax_identifier) and address_values.get('l10n_my_identification_number'):
+                address_values[tax_identifier] = 'EI00000000010'
+
+            if (
+                not address_values.get('l10n_my_identification_number')
+                and address_values.get('vat')
+                and is_my_company
+            ):
+                address_values['l10n_my_identification_number'] = '000000000000'
+
+        if form_data.get('company_type') == 'company':
+            address_values['l10n_my_identification_type'] = 'BRN'
+            if not is_my_company and not address_values['l10n_my_identification_number']:
+                address_values['l10n_my_identification_number'] = '000000000000'
+        return address_values, extra_form_data
+
+    def _validate_address_values(self, address_values, partner_sudo, address_type, *args, **kwargs):
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values, partner_sudo, address_type, *args, **kwargs
+        )
+
+        is_my_company = (
+            request.env['res.country'].browse(address_values.get('country_id'))
+            .exists().code == 'MY'
+        )
+        company_type = request.params.get('company_type')
+        _ = self.env._
+
+        def _validate_required_fields(fields, message):
+            missing = [field for field in fields if not address_values.get(field)]
+            if missing:
+                missing_fields.update(missing)
+                error_messages.append(message)
+
+        if company_type == 'person':
+            if is_my_company:
+                if not address_values.get('l10n_my_identification_number') and not address_values.get('vat'):
+                    _validate_required_fields(
+                        ['l10n_my_identification_number', 'vat'],
+                        _("Please provide at least an Identification Number or a TIN (Income Tax Number) to issue an invoice"),
+                    )
+            else:
+                if (
+                    not address_values.get('l10n_my_identification_number')
+                    or address_values.get('l10n_my_identification_type') != 'PASSPORT'
+                ):
+                    error_messages.append(_("Some fields are missing or have wrong values"))
+                    if not address_values.get('l10n_my_identification_number'):
+                        missing_fields.add('l10n_my_identification_number')
+                    if address_values.get('l10n_my_identification_type') != 'PASSPORT':
+                        missing_fields.add('l10n_my_identification_type')
+
+        elif company_type == 'company':
+            if is_my_company:
+                _validate_required_fields(
+                    ['l10n_my_identification_number', 'vat'],
+                    _("Please enter your Business Registration Number (BRN) and TIN (Income Tax Number) to proceed."),
+                )
+            else:
+                _validate_required_fields(
+                    ['l10n_my_edi_malaysian_tin'],
+                    _("Malaysian VAT is required to process invoice"),
+                )
+
+        return invalid_fields, missing_fields, error_messages

--- a/addons/l10n_my_edi_pos/models/__init__.py
+++ b/addons/l10n_my_edi_pos/models/__init__.py
@@ -2,3 +2,4 @@
 from . import account_edi_xml_ubl_my
 from . import myinvois_document_pos
 from . import pos_order
+from . import res_partner

--- a/addons/l10n_my_edi_pos/models/res_partner.py
+++ b/addons/l10n_my_edi_pos/models/res_partner.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    def _get_frontend_writable_fields(self):
+        frontend_writable_fields = super()._get_frontend_writable_fields()
+        frontend_writable_fields.update({'l10n_my_edi_malaysian_tin'})
+
+        return frontend_writable_fields

--- a/addons/l10n_my_edi_pos/static/src/interactions/address.js
+++ b/addons/l10n_my_edi_pos/static/src/interactions/address.js
@@ -1,0 +1,75 @@
+import { patch } from "@web/core/utils/patch";
+import { patchDynamicContent } from "@web/public/utils";
+import { CustomerAddress } from "@portal/interactions/address";
+
+patch(CustomerAddress.prototype, {
+    setup() {
+        super.setup();
+
+        patchDynamicContent(this.dynamicContent, {
+            'input[name="company_type"]': {
+                "t-on-change": this.onChangeType.bind(this),
+            },
+        });
+    },
+
+    start() {
+        super.start();
+        this.onChangeType();
+    },
+
+    onChangeType(ev = null) {
+        const radio = this.el.querySelector('input[name="company_type"]:checked');
+
+        if (!radio) {
+            return;
+        }
+
+        if (ev) {
+            const l10nClassificationNumberLabel = this.el.querySelector(
+                'label[for="l10n_my_identification_number"]'
+            );
+
+            if (l10nClassificationNumberLabel) {
+                l10nClassificationNumberLabel.textContent =
+                    radio.value === "company"
+                        ? "Business Registration Number"
+                        : "Identification Number";
+            }
+
+            const nameInput = this.el.querySelector('input[name="name"]');
+            if (nameInput) {
+                nameInput.value = "";
+            }
+
+            const errorBlock = this.el.querySelector(".o_portal_address_error");
+            if (errorBlock) {
+                errorBlock.style.display = "none";
+            }
+        }
+
+        if (radio.value === "person") {
+            this._hideInput("l10n_my_edi_industrial_classification");
+            this._showInput("l10n_my_identification_type");
+        } else {
+            this._hideInput("l10n_my_identification_type");
+            this._showInput("l10n_my_edi_industrial_classification");
+        }
+    },
+
+    async _onChangeCountry(init = false) {
+        await super._onChangeCountry(init);
+
+        if (!this.el.querySelector('input[name="l10n_my_edi_malaysian_tin"]')) {
+            return;
+        }
+
+        if (this._getSelectedCountryCode() === "MY") {
+            this._hideInput("l10n_my_edi_malaysian_tin");
+            this._showInput("vat");
+        } else {
+            this._showInput("l10n_my_edi_malaysian_tin");
+            this._hideInput("vat");
+        }
+    },
+});

--- a/addons/l10n_my_edi_pos/views/portal_address_templates.xml
+++ b/addons/l10n_my_edi_pos/views/portal_address_templates.xml
@@ -1,0 +1,22 @@
+<odoo>
+
+    <template id="portal_address_form_fields_my" inherit_id="portal.address_form_fields">
+
+        <xpath expr="//div[@id='div_vat']" position="after">
+            <div id="div_my_tin" class="col-lg-6 mb-2"
+                t-if="pos_order and pos_order.company_id.account_fiscal_country_id.code == 'MY'">
+                <label class="col-form-label fw-normal label-optional">
+                    Malaysian TIN
+                </label>
+                <input
+                    type="text"
+                    name="l10n_my_edi_malaysian_tin"
+                    class="form-control"
+                    t-att-value="partner.l10n_my_edi_malaysian_tin"
+                />
+            </div>
+        </xpath>
+
+    </template>
+
+</odoo>

--- a/addons/l10n_my_edi_pos/views/ticket_validation_screen.xml
+++ b/addons/l10n_my_edi_pos/views/ticket_validation_screen.xml
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+
+    <template id="ticket_validation_screen" inherit_id="point_of_sale.ticket_validation_screen">
+
+        <xpath expr="//div[@id='get_info_div']/parent::div" position="after">
+            <t t-if="pos_order.company_id.account_fiscal_country_id.code == 'MY'">
+                <div class="form-check form-check-inline">
+                    <input type="radio" class="form-check-input"
+                        name="company_type" value="person" id="company_type_person" checked="checked" />
+                    <label class="form-check-label" for="company_type_person">Individual</label>
+                </div>
+
+                <div class="form-check form-check-inline">
+                    <input type="radio" class="form-check-input"
+                        name="company_type" value="company" id="company_type_company" />
+                    <label class="form-check-label" for="company_type_company">Company</label>
+                </div>
+
+                <t t-if="invalid_field and messages">
+                    <div class="fs-5 text-danger o_portal_address_error">
+                        <t t-foreach="messages" t-as="err">
+                            <t t-out="err" />
+                        </t>
+                    </div>
+                </t>
+            </t>
+        </xpath>
+
+        <xpath expr="//t[@t-call='portal.address_form_fields']" position="after">
+            <t t-if="pos_order.company_id.account_fiscal_country_id.code == 'MY'">
+                <t t-if="len(l10n_my_identification_types) > 1">
+                    <div class="mb-3 col-xl-6">
+                        <label class="col-form-label" for="l10n_my_identification_type">Identification
+                            Type</label>
+                        <select name="l10n_my_identification_type" class="form-select">
+                            <option
+                                t-foreach="l10n_my_identification_types"
+                                t-as="type"
+                                t-att-value="type"
+                                t-att-selected="l10n_my_identification_type == type"
+                                t-out="type_value"
+                            />
+                        </select>
+                    </div>
+                </t>
+                <div t-attf-class="mb-3 col-xl-6">
+                    <label class="col-form-label label-optional o_identification_label" for="l10n_my_identification_number">Identification
+                        Number</label>
+                    <input type="text" name="l10n_my_identification_number" t-attf-class="form-control"
+                        t-att-value="l10n_my_identification_number or partner_sudo.l10n_my_identification_number" />
+                </div>
+                <div t-attf-class="mb-3 col-xl-6">
+                    <label class="col-form-label label-optional"
+                        for="l10n_my_edi_industrial_classification">Identification Classification</label>
+                    <select name="l10n_my_edi_industrial_classification" t-attf-class="form-select">
+                        <option
+                            t-foreach="l10n_my_edi_industrial_classifications"
+                            t-as="industrial_classification"
+                            t-att-value="industrial_classification.id"
+                            t-att-selected="industrial_classification.id == int(l10n_my_edi_industrial_classification) if l10n_my_edi_industrial_classification else industrial_classification.id == default_industrial_classification_id"
+                            t-out="industrial_classification.name"
+                        />
+                    </select>
+                </div>
+            </t>
+        </xpath>
+
+    </template>
+
+</odoo>


### PR DESCRIPTION
**PURPOSE**
 - For Malaysian e-invoicing, if a buyer requests an e-invoice for the order 
   that was previously not e- invoiced, they can request a vendor for can 
   e-invoice later, as long as it has not been consolidated yet.
 - Currently validation form of the ticket does not have the EDI fields, so it 
   can't process the invoice.
 - The invoice processing is different for both 'Individual' and 'Company' types
   partner.

**SPECIFICATION**
 - Allow buyers to request a Malaysian e-Invoice for a previously non–e-invoiced
   order, as long as the invoice has not been consolidated.
 - Extend the invoice validation form (/pos/ticket/validation) to include
   mandatory Malaysian EDI fields required for e-Invoice processing.
 - Validate invoice eligibility before processing (not already e-Invoiced, not 
   consolidated, Malaysian buyer).
 - Handle e-Invoice processing differently based on buyer type 
   (Individual and Company).

task-5216103