### PR TITLE
[FIX] product: ensure VAT-adjacent fields are properly labeled on contact form

### DIFF
--- a/addons/product/views/res_partner_views.xml
+++ b/addons/product/views/res_partner_views.xml
@@ -3,6 +3,7 @@
         <record id="view_partner_property_form" model="ir.ui.view">
             <field name="name">res.partner.product.property.form.inherit</field>
             <field name="model">res.partner</field>
+            <field name="priority">14</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
                 <group name="sale">


### PR DESCRIPTION
Currently, fields added using XPath expressions before or after the `VAT` field 
(such as `IE`, `IM`, and `SUFRAMA` from `l10n_br`) lose their labels and helpers in 
the Contacts form, making them hard to identify.

**Steps to reproduce:**
- Install the `l10n_br` module and switch to a `BR company`.
- Go to Contacts and open a contact form.
- Observe the Brazilian identification number fields (`IE`, `IM`, `SUFRAMA`).

**Obeservation:**
Missing labels and helpers for fields added around the `VAT` field in 
the `res.partner` form.

**Root Cause:**
After commit [1], `account.view_partner_property_form` inherits from
`product.view_partner_property_form` at [2], whose default priority (16) 
causes it to be applied after `base_vat.view_partner_base_vat_form`, 
which has priority (15) at [3].

As a result, the `base_vat` module moves the `VAT` field into the
`vat_vies_container` div. Consequently, any subsequent XPath
expressions targeting the `vat` field with position `before` or
`after`, when the view is inherited from `account.view_partner_property_form`, 
are applied inside this container instead of the original form layout.

The issue is not limited to the Brazilian localization, it impacts any module 
that inherits from the `account.view_partner_property_form` views and relies 
on XPath expressions positioned around the `VAT` field.

**Fix:**
This commit ensures that fields added before or after the VAT field remain
properly labeled and identifiable across all modules by assigning a higher
priority to `product.view_partner_property_form` than to
`base_vat.view_partner_base_vat_form`.

**Before:**
<img width="1908" height="616" alt="5443833_before" src="https://github.com/user-attachments/assets/f7d0819d-38bd-4fe8-8a22-5e22b342cd32" />

**After:**
<img width="1909" height="703" alt="5443833_after" src="https://github.com/user-attachments/assets/b205cb87-64ba-49fd-91c4-c20908d21429" />

[1]:
https://github.com/odoo/odoo/commit/4bff48d8233a9c1338252725f92ffcf580bd2b9d

[2]:
https://github.com/odoo/odoo/blob/229c2737edee601552ccceeed8602ec0e4686596/addons/account/views/partner_view.xml#L191

[3]:
https://github.com/odoo/odoo/blob/229c2737edee601552ccceeed8602ec0e4686596/addons/base_vat/views/res_partner_views.xml#L4-L26

opw-5443833