### PR TITLE
[FIX] portal: redirect logout to '/'

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -110,7 +110,7 @@
                     <i class="fa fa-fw fa-th me-1 small text-primary-emphasis"/> Apps
                 </a>
                 <div id="o_logout_divider" class="dropdown-divider"/>
-                <form method="POST" action="/web/session/logout" role="menuitem" class="dropdown-item p-0">
+                <form method="POST" action="/web/session/logout?redirect=/" role="menuitem" class="dropdown-item p-0">
                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                     <button id="o_logout" type="submit" class="btn w-100 ps-3 text-start">
                         <i class="fa fa-fw fa-sign-out small text-primary-emphasis"/> Logout


### PR DESCRIPTION
During the change of the logout route to POST only, this redirect was omitted. We add it back.

task-5262619

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
