### PR TITLE
[FIX] bus: race between terminate and notification dispatching

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -376,7 +376,9 @@ class Websocket:
         }
         if self.__notif_sock_r not in readables:
             # Send a random bit to mark the socket as readable.
-            self.__notif_sock_w.send(b'x')
+            # Ignore if the socket was closed in the meantime.
+            with suppress(OSError):
+                self.__notif_sock_w.send(b'x')
 
     # ------------------------------------------------------
     # PRIVATE METHODS


### PR DESCRIPTION
Since [1], sockets used to wake up the websocket coroutines are properly closed upon termination. However, there can be a race where the dispatcher coroutine tries to write on the notif socket, leading to OS error. This commit fixes this error.

[1]: https://github.com/odoo/odoo/pull/241330

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
