### PR TITLE
[FIX] mail: display files in chatter for activities

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -54,7 +54,7 @@
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')" required="activity_user_id != context.get('uid')"/>
                             </group>
-                            <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..."/>
+                            <field name="note" class="oe-bordered-editor embedded-editor-height-4" options="{'embedded_components': false}" placeholder="Log a note..."/>
                         </group>
                         <div role="alert" class="alert alert-danger mb8" invisible="not has_error">
                             <field name="error"/>


### PR DESCRIPTION
Currently, when a user creates an activity with a note containing a file using `/file`, the attached file is not displayed in the chatter.

**Steps to produce:**
* Install `crm` with demo data
* crm > open any lead > Activity > use `/file` to attach  a file > Save

**Observed Behavior:**
The user cannot see attached files in the chatter.

**Root cause:**
* This behavior occurs because after commit [1], the `EmbeddedFilePlugin` started being used for all HTML fields with embedded components enabled, and since commit [2], all HTML fields have `embedded_component` set to true by default.

* As a result, file attachments may not display correctly, since embedded components do not render when HTML content is shown outside the editor.

**Solution:**
Disable the embedded component option for the note field in the activity to display the full HTML and make the attachment visible, instead of rendering-related data.

**Before:**
<img width="640" height="150" alt="image" src="https://github.com/user-attachments/assets/edabbe9f-eedf-4ef1-8f0d-749e0145ce8f" />
**After:**
<img width="651" height="148" alt="image" src="https://github.com/user-attachments/assets/8a3d1d3d-a5f8-4726-83be-6134e96db689" />

[1]:
https://github.com/odoo/odoo/pull/216572/commits/86c7176833fc36b9ca7d2989d31587c353bd5800 
[2]:
https://github.com/odoo/odoo/commit/a44b05fd06d8c157b5edacbd6a7061197eb4ee5f

opw-5426126,5361933