### PR TITLE
[REF] iot_drivers: cleanup homepage

### DIFF
--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -190,34 +190,6 @@ class IotBoxOwlHomePage(http.Controller):
             'availableWiFi': wifi.get_available_ssids(),
         })
 
-    @route.iot_route('/iot_drivers/version_info', type="http", cors='*', linux_only=True)
-    def get_version_info(self):
-        # Check branch name and last commit hash on IoT Box
-        current_commit = system.git("rev-parse", "HEAD")
-        current_branch = system.git("rev-parse", "--abbrev-ref", "HEAD")
-        if not current_commit or not current_branch:
-            return json.dumps({
-                'status': 'error',
-                'message': 'Failed to retrieve current commit or branch',
-            })
-
-        last_available_commit = system.git("ls-remote", "origin", current_branch)
-        if not last_available_commit:
-            _logger.error("Failed to retrieve last commit available for branch origin/%s", current_branch)
-            return json.dumps({
-                'status': 'error',
-                'message': 'Failed to retrieve last commit available for branch origin/' + current_branch,
-            })
-        last_available_commit = last_available_commit.split()[0].strip()
-
-        return json.dumps({
-            'status': 'success',
-            # Checkout requires db to align with its version (=branch)
-            'odooIsUpToDate': current_commit == last_available_commit or not bool(helpers.get_odoo_server_url()),
-            'imageIsUpToDate': IS_RPI and not bool(system.check_image()),
-            'currentCommitHash': current_commit,
-        })
-
     @route.iot_route('/iot_drivers/log_levels', type="http", cors='*')
     def log_levels(self):
         drivers_list = helpers.get_handlers_files_to_load(

--- a/addons/iot_drivers/static/src/app/components/dialog/credentials_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/credentials_dialog.js
@@ -61,10 +61,7 @@ export class CredentialsDialog extends Component {
             </t>
         </LoadingFullScreen>
 
-        <Dialog identifier="'credential-configuration'" btnName="'Credentials'">
-            <t t-set-slot="header">
-                Configure Credentials
-            </t>
+        <Dialog name="'Configure Credentials'" btnName="'Credentials'">
             <t t-set-slot="body">
                 <div class="alert alert-info fs-6" role="alert">
                     Set the Database UUID and your Contract Number you want to use to validate your subscription.

--- a/addons/iot_drivers/static/src/app/components/dialog/database_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/database_dialog.js
@@ -56,10 +56,10 @@ export class DatabaseDialog extends Component {
             </t>
         </LoadingFullScreen>
 
-        <Dialog identifier="'server-configuration'" btnName="'Configure'">
-            <t t-set-slot="header">
-                Configure Odoo Database
-            </t>
+        <Dialog
+            name="'Configure Odoo Database'"
+            help="'https://www.odoo.com/documentation/latest/applications/general/iot/connect.html'"
+            btnName="'Configure'">
             <t t-set-slot="body">
                 <div class="alert alert-warning fs-6 pb-0" role="alert" t-if="!store.base.server_status">
                     <ol>

--- a/addons/iot_drivers/static/src/app/components/dialog/debugging_tools_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/debugging_tools_dialog.js
@@ -93,10 +93,10 @@ export class DebuggingToolsDialog extends Component {
 
     static template = xml`
     <t t-translation="off">
-        <Dialog identifier="'remote-debug-configuration'" btnName="'Debugging Tools'">
-            <t t-set-slot="header">
-                Debugging Tools
-            </t>
+        <Dialog
+            name="'Debugging Tools'"
+            help="'https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/ssh_connect.html'"
+            btnName="'Debugging Tools'">
             <t t-set-slot="body">
                 <h6>Remote Debug</h6>
                 <div t-if="!state.remoteDebug" class="alert alert-warning fs-6" role="alert">

--- a/addons/iot_drivers/static/src/app/components/dialog/device_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/device_dialog.js
@@ -50,10 +50,11 @@ export class DeviceDialog extends Component {
 
     static template = xml`
     <t t-translation="off">
-        <Dialog identifier="'device-list'" btnName="'Show'" isLarge="true">
-            <t t-set-slot="header">
-                Devices list
-            </t>
+        <Dialog
+            name="'Devices list'"
+            help="'https://www.odoo.com/documentation/latest/applications/general/iot/devices.html'"
+            btnName="'Show'"
+            isLarge="true">
             <t t-set-slot="body">
                 <div t-if="Object.keys(devices).length === 0" class="alert alert-warning fs-6" role="alert">
                     No devices found.

--- a/addons/iot_drivers/static/src/app/components/dialog/dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/dialog.js
@@ -4,8 +4,9 @@ const { Component, xml, useEffect, useRef } = owl;
 
 export class Dialog extends Component {
     static props = {
-        identifier: String,
         slots: Object,
+        name: String,
+        help: { type: String, optional: true },
         btnName: { type: String, optional: true },
         isLarge: { type: Boolean, optional: true },
         onOpen: { type: Function, optional: true },
@@ -38,14 +39,19 @@ export class Dialog extends Component {
         );
     }
 
+    get identifier() {
+        return this.props.name.toLowerCase().replace(/\s+/g, "-");
+    }
+
     static template = xml`
     <t t-translation="off">
-        <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" t-att-data-bs-target="'#'+this.props.identifier" t-esc="this.props.btnName" />
-        <div t-ref="dialog" t-att-id="this.props.identifier" class="modal modal-dialog-scrollable fade" t-att-class="{'modal-lg': props.isLarge}" tabindex="-1" aria-hidden="true">
+        <button type="button" class="btn btn-primary btn-sm" data-bs-toggle="modal" t-att-data-bs-target="'#'+identifier" t-esc="this.props.btnName" />
+        <div t-ref="dialog" t-att-id="identifier" class="modal modal-dialog-scrollable fade" t-att-class="{'modal-lg': props.isLarge}" tabindex="-1" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">
-                    <div class="modal-header">
-                        <t t-slot="header" />
+                    <div class="modal-header gap-1">
+                        <t t-out="props.name"/>
+                        <a t-if="props.help" t-att-href="props.help" class="fa fa-question-circle text-decoration-none text-dark" target="_blank"/>
                     </div>
                     <div class="modal-body position-relative dialog-body">
                         <t t-slot="body" />

--- a/addons/iot_drivers/static/src/app/components/dialog/handlers_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/handlers_dialog.js
@@ -80,10 +80,7 @@ export class HandlerDialog extends Component {
             </t>
         </LoadingFullScreen>
 
-        <Dialog identifier="'handler-configuration'" btnName="'Handlers Configuration'" onOpen.bind="getHandlerData" onClose.bind="onClose">
-            <t t-set-slot="header">
-                Handlers Configuration
-            </t>
+        <Dialog name="'Handlers Configuration'" btnName="'Handlers Configuration'" onOpen.bind="getHandlerData" onClose.bind="onClose">
             <t t-set-slot="body">
                 <div t-if="this.state.initialization" class="position-absolute top-0 start-0 bg-white h-100 w-100 justify-content-center align-items-center d-flex flex-column gap-3 always-on-top handler-loading">
                     <div class="spinner-border" role="status">

--- a/addons/iot_drivers/static/src/app/components/dialog/six_terminal_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/six_terminal_dialog.js
@@ -58,10 +58,10 @@ export class SixTerminalDialog extends Component {
             </t>
         </LoadingFullScreen>
 
-        <Dialog identifier="'six-configuration'" btnName="'Configure'">
-            <t t-set-slot="header">
-                Configure a Six Terminal
-            </t>
+        <Dialog
+            name="'Configure a Six Terminal'"
+            help="'https://www.odoo.com/documentation/latest/applications/sales/point_of_sale/payment_methods/terminals/six.html'"
+            btnName="'Configure'">
             <t t-set-slot="body">
                 <div class="alert alert-info fs-6" role="alert">
                     Set the Terminal ID (TID) of the terminal you want to use.

--- a/addons/iot_drivers/static/src/app/components/dialog/time_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/time_dialog.js
@@ -48,10 +48,7 @@ export class TimeDialog extends Component {
     }
 
     static template = xml`
-        <Dialog identifier="'time-dialog'" btnName="'View Uptime'">
-            <t t-set-slot="header">
-                IoT Box Uptime
-            </t>
+        <Dialog name="'IoT Box Uptime'" btnName="'View Uptime'">
             <t t-set-slot="body">
                 <div class="d-flex flex-column gap-4">
                   <div>

--- a/addons/iot_drivers/static/src/app/components/dialog/update_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/update_dialog.js
@@ -13,40 +13,11 @@ export class UpdateDialog extends Component {
     setup() {
         this.store = useStore();
         this.state = useState({
-            initialization: true,
-            loading: false,
             waitRestart: false,
-            odooIsUpToDate: false,
-            imageIsUpToDate: false,
-            currentCommitHash: "",
         });
     }
 
-    onClose() {
-        this.state.initialization = [];
-    }
-
-    async getVersionInfo() {
-        try {
-            const data = await this.store.rpc({
-                url: "/iot_drivers/version_info",
-            });
-
-            if (data.status === "error") {
-                console.error(data.message);
-                return;
-            }
-
-            this.state.odooIsUpToDate = data.odooIsUpToDate;
-            this.state.imageIsUpToDate = data.imageIsUpToDate;
-            this.state.currentCommitHash = data.currentCommitHash;
-            this.state.initialization = false;
-        } catch {
-            console.warn("Error while fetching version info");
-        }
-    }
-
-    async updateGitTree() {
+    async update() {
         this.state.waitRestart = true;
         try {
             const data = await this.store.rpc({
@@ -63,10 +34,6 @@ export class UpdateDialog extends Component {
         }
     }
 
-    get everythingIsUpToDate() {
-        return this.state.odooIsUpToDate && this.state.imageIsUpToDate;
-    }
-
     static template = xml`
     <t t-translation="off">
         <LoadingFullScreen t-if="this.state.waitRestart">
@@ -75,63 +42,19 @@ export class UpdateDialog extends Component {
             </t>
         </LoadingFullScreen>
 
-        <Dialog identifier="'update-configuration'" btnName="'Update'" onOpen.bind="getVersionInfo" onClose.bind="onClose">
-            <t t-set-slot="header">
-                <div>
-                    Update
-                    <a href="https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/updating_iot.html" class="fa fa-question-circle text-decoration-none text-dark" target="_blank"></a>
-                </div>
-            </t>
+        <Dialog
+            name="'IoT Box update'"
+            help="'https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/updating_iot.html'"
+            btnName="'Update'">
             <t t-set-slot="body">
-                <div t-if="this.state.initialization" class="position-absolute top-0 start-0 bg-white h-100 w-100 justify-content-center align-items-center d-flex flex-column gap-3 always-on-top">
-                    <div class="spinner-border" role="status">
-                        <span class="visually-hidden">Loading...</span>
-                    </div>
-                    <p>Currently fetching update data...</p>
+                <div class="alert alert-info" role="alert">
+                    The IoT Box is automatically updated <b>every Monday</b> at midnight. 
                 </div>
-
-                <div class="mb-3" t-if="this.store.isLinux">
-                    <h6>Operating System Update</h6>
-                    <div t-if="this.state.imageIsUpToDate" class="text-success px-2 small">
-                        Operating system is up to date
-                    </div>
-                    <div t-else="" class="alert alert-warning small mb-0">
-                        A new version of the operating system is available, see:
-                        <a href="https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank" class="alert-link">
-                            Flashing the SD Card on IoT Box
-                        </a>
-                    </div>
-                    <div t-if="this.store.dev" class="alert alert-light small">
-                        <a href="https://nightly.odoo.com/master/iotbox/" target="_blank" class="alert-link">
-                            Current: <t t-esc="this.store.base.version"/>
-                        </a>
-                    </div>
-                </div>
-
-                <div class="mb-3">
-                    <h6>IoT Box Update</h6>
-                    <div t-if="this.state.odooIsUpToDate" class="text-success px-2 small">
-                        IoT Box is up to date.
-                    </div>
-                    <div t-else="" class="d-flex justify-content-between align-items-center alert alert-warning small">
-                        A new version of the IoT Box is available
-                        <button class="btn btn-primary btn-sm" t-on-click="updateGitTree">Update</button>
-                    </div>
-                    <div t-if="this.store.dev" class="alert alert-light small">
-                        Current: 
-                        <a t-att-href="'https://github.com/odoo/odoo/commit/' + this.state.currentCommitHash" target="_blank" class="alert-link">
-                            <t t-esc="this.state.currentCommitHash"/>
-                        </a>
-                    </div>
-                </div>
+                If you are experiencing issues that may have been fixed since the last update, you can manually trigger an update here.
             </t>
             <t t-set-slot="footer">
-                <button 
-                    type="button"
-                    t-att-class="'btn btn-sm ' + (this.everythingIsUpToDate ? 'btn-primary' : 'btn-secondary')"
-                    data-bs-dismiss="modal">
-                    Close
-                </button>
+                <button type="button" class="btn btn-sm btn-primary" t-on-click="update">Update</button>
+                <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Close</button>
             </t>
         </Dialog>
     </t>

--- a/addons/iot_drivers/static/src/app/components/dialog/wifi_dialog.js
+++ b/addons/iot_drivers/static/src/app/components/dialog/wifi_dialog.js
@@ -131,10 +131,12 @@ export class WifiDialog extends Component {
             </div>
         </div>
 
-        <Dialog identifier="'wifi-configuration'" btnName="'Configure'" onOpen.bind="getWiFiNetworks" onClose.bind="onClose">
-            <t t-set-slot="header">
-                Configure Wi-Fi
-            </t>
+        <Dialog
+            name="'Configure Wi-Fi'"
+            help="'https://www.odoo.com/documentation/latest/applications/general/iot/iot_box.html#iot-iot-box-network-wifi'"
+            btnName="'Configure'"
+            onOpen.bind="getWiFiNetworks"
+            onClose.bind="onClose">
             <t t-set-slot="body">
                 <div t-if="this.state.scanning" class="position-absolute top-0 start-0 bg-white h-100 w-100 justify-content-center align-items-center d-flex flex-column gap-3 always-on-top">
                     <div class="spinner-border" role="status">

--- a/addons/iot_drivers/static/src/app/components/loading_full_screen.js
+++ b/addons/iot_drivers/static/src/app/components/loading_full_screen.js
@@ -12,7 +12,7 @@ export class LoadingFullScreen extends Component {
     setup() {
         this.store = useStore();
 
-        // We delay the RPC verification for 10 seconds to be sure that the Odoo service
+        // We delay the RPC verification to be sure that the Odoo service
         // was already restarted
         onMounted(() => {
             setTimeout(() => {
@@ -26,7 +26,7 @@ export class LoadingFullScreen extends Component {
                         console.warn("Odoo service is probably rebooting.");
                     }
                 }, 750);
-            }, 10000);
+            }, 2000);
         });
     }
 

--- a/addons/iot_drivers/tools/system.py
+++ b/addons/iot_drivers/tools/system.py
@@ -4,7 +4,6 @@ import configparser
 import logging
 import netifaces
 import re
-import requests
 import secrets
 import socket
 import subprocess
@@ -107,48 +106,6 @@ def get_version(detailed_version=False):
             version += f'#{commit_hash or "unknown"}'
 
     return version
-
-
-def get_img_name():
-    major, minor = get_version()[1:].split('.')
-    return f'iotboxv{major}_{minor}.zip'
-
-
-def check_image():
-    """Check if the current image of IoT Box is up to date
-
-    :return: dict containing major and minor versions of the latest image available
-    :rtype: dict
-    """
-    try:
-        response = requests.get('https://nightly.odoo.com/master/iotbox/SHA1SUMS.txt', timeout=5)
-        response.raise_for_status()
-        data = response.text
-    except requests.exceptions.HTTPError:
-        _logger.exception('Could not reach the server to get the latest image version')
-        return False
-
-    current, latest = '', ''
-    hashes = {}
-    for line in data.splitlines():
-        if not line.strip():
-            continue
-        value, name = line.split('  ')
-        hashes[value] = name
-        if name == 'iotbox-latest.zip':
-            latest = value
-        elif name == get_img_name():
-            current = value
-    if current == latest:
-        return False
-
-    version = (
-        hashes.get(latest, 'Error')
-        .removeprefix('iotboxv')
-        .removesuffix('.zip')
-        .split('_')
-    )
-    return {'major': version[0], 'minor': version[1]}
 
 
 def update_conf(values, section='iot.box'):


### PR DESCRIPTION
- Replace the `header` slot in dialogs by a standard `name` + `(optional) help`,
- Remove the use of `identifier` props and compute it from provided `name`,
- simplify the update dialog to only inform about the weekly update and show an update button,
- add documentation link on all concerned modals.
