### PR TITLE
[FIX] account_edi_ubl_cii: removes blocking XML node for cash rounding with peppol

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -938,9 +938,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         # Add 'tax_currency_code'.
         self._ubl_add_values_tax_currency_code(vals)
 
-        # Add 'tax_totals'.
-        self._ubl_add_values_tax_totals(vals)
-
         # Add 'payable_rounding_amount' to manage cash rounding.
         self._ubl_add_values_payable_rounding_amount(vals)
 
@@ -950,6 +947,9 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             for base_line in vals['base_lines']
             if base_line not in vals['_ubl_values']['payable_rounding_base_lines']
         ]
+
+        # Add 'tax_totals'.
+        self._ubl_add_values_tax_totals(vals)
 
         # Add 'allowance_charge_early_payment' to manage the early payment discount.
         self._ubl_add_values_allowance_charge_early_payment(vals)

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_cash_rounding_add_invoice_line.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_cash_rounding_add_invoice_line.xml
@@ -110,18 +110,6 @@
 				</cac:TaxScheme>
 			</cac:TaxCategory>
 		</cac:TaxSubtotal>
-		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">0.01</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
-			<cac:TaxCategory>
-				<cbc:ID>E</cbc:ID>
-				<cbc:Percent>0.0</cbc:Percent>
-				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:TaxCategory>
-		</cac:TaxSubtotal>
 	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
 		<cbc:LineExtensionAmount currencyID="EUR">1039.99</cbc:LineExtensionAmount>


### PR DESCRIPTION

Issue:
A TaxSubtotal node was blocking the XML validation for peppol invoices with Cash Rounding

Step to reproduce:
1. Select BE Company CoA
2. Enable Cash Rounding in the settings
3. Create a cash rounding method (in the settings where cash rounding can be enabled):
   - precision `1.00`
   - strategy: Add a rounding line
   - profit / loss account: any
4. Create an invoice
   - Set a Belgian partner (e.g. "BE Company CoA" is okay)
   - Set the cash rounding method from step 2
   - Single Line with price=70.00€ and a 21% tax
5. The total should be 85.00 € (84.70 € w/o the rounding) In the journal items there should be the following non-payment term items:
   - 70.00€ base
   - 14.70€ tax
   -  0.30€ rounding
6. Confirm & Send (with PEPPOL)

Current Behavior:
Look at the UBL BIS 3 XML in the `Invoice` element
   - `TaxTotal/TaxAmount`: 14.70€
   - `TaxTotal/TaxSubtotal/TaxableAmount`: 70.00€
   - `TaxTotal/TaxSubtotal/TaxAmount`: 14.70€
   - `TaxTotal/TaxSubtotal/TaxableAmount`: 0.30€
   - `TaxTotal/TaxSubtotal/TaxAmount`: 00.00€
   - `TaxTotal/TaxSubtotal/TaxCategory/TaxExemptionReason`: "Exempt from tax"
   - `LegalMonetaryTotal/TaxExclusiveAmount`: 70.00€
   - `LegalMonetaryTotal/TaxInclusiveAmount`: 84.70€
   - `LegalMonetaryTotal/PayableRoundingAmount`: 00.30€
   - `LegalMonetaryTotal/PayableAmount`: 85.00€ This fails validation `BR-E-08`:
"In a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Exempt from VAT" the VAT category taxable amount BT-116 [is equal to: `BT-116 = sum(BT-131) - sum(BT-92) + sum(BT-99)` i.e. `VAT category taxable amount = Invoice net - allowance + charge`] where all the VAT category codes (BT-151, BT-95, BT-102) are "Exempt from VAT""

Expected behavior:
Look at the UBL BIS 3 XML in the `Invoice` element
   - `TaxTotal/TaxAmount`: 14.70€
   - `TaxTotal/TaxSubtotal/TaxableAmount`: 70.00€
   - `TaxTotal/TaxSubtotal/TaxAmount`: 14.70€
   - `LegalMonetaryTotal/TaxExclusiveAmount`: 70.00€
   - `LegalMonetaryTotal/TaxInclusiveAmount`: 84.70€
   - `LegalMonetaryTotal/PayableRoundingAmount`: 00.30€
   - `LegalMonetaryTotal/PayableAmount`: 85.00€

Solution:

Per the calculation of the VAT category taxable amount (BT-116). There should have a TaxSubtotal for tax Category having invoice lines.
https://docs.peppol.eu/poacc/billing/3.0/bis/#_calculation_of_totals 
As invoice lines should contain their item name. Rounding line won't have one.
https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-25/
As rounding appear in the LegalMonetaryTotal, removing the related TaxSubtotal doesn't remove information.
https://docs.peppol.eu/poacc/billing/3.0/bis/#_element_for_rounding_amount_the_payableroundingamount

Rounding base_lines are removed from `vals['base_lines']` as they need to have a product label. https://github.com/odoo/odoo/blob/366d7122ee30e16c157d026363b731c066a564c5/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py#L305-L310

As `_ubl_add_values_payable_rounding_amount` needs rounding lines within base_lines and `_ubl_add_values_tax_totals` shouldn't have them, this commit exchanges their processing order.

This commit also:
- fix the test file `test_invoice_cash_rounding_add_invoice_line.xml` as it failed the XML validation (BR-E-08).

opw-5434335


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
