### PR TITLE
[FIX] account_peppol: allow unregistering when participant is missing…

### DIFF
--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -62,6 +62,8 @@ class ResConfigSettings(models.TransientModel):
                 params=params,
             )
         except AccountEdiProxyError as e:
+            if e.code == 'no_such_user_found' and 'cancel_peppol_registration' in endpoint:
+                return {'error': _("There is no such user in proxy server")}
             raise UserError(e.message)
 
         if 'error' in response:


### PR DESCRIPTION
… on proxy

In some cases, a Peppol participant can be removed from the proxy (IAP side) while the local Odoo database still considers the connection active.

When a user tries to click "Remove from Peppol" or "Update Contact Details" in this desynchronized state, the proxy returns a 'no_such_user_found' error. Because this error is unhandled, the Odoo transaction rolls back, leaving the user in a "dead-end" where they cannot unregister or fix the connection locally.

This commit wraps the deregistration proxy call in a try-except block. If the proxy returns a 'no_such_user_found' error, we catch it and proceed with the local cleanup (resetting the proxy state and unlinking the edi_user). This ensures the local database can return to a clean 'not_registered' state regardless of the remote status.

Task-5441091

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
