### PR TITLE
[FIX] point_of_sale: keep product cards aligned for long names in combo popup

### DIFF
--- a/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/combo_configurator_popup/combo_configurator_popup.xml
@@ -10,13 +10,13 @@
                 <div class="product-list d-grid gap-1">
                     <div t-foreach="combo.combo_item_ids" t-as="combo_item" t-key="combo_item.id" class="m-2" t-att-class="{'ptav-not-available' : isArchived(combo_item)}">
                         <t t-set="product" t-value="combo_item.product_id"/>
-                        <input type="radio"
+                        <input type="radio" class="position-absolute"
                             t-attf-name="combo-{{combo.id}}"
                             t-attf-id="combo-{{combo.id}}-combo_item-{{combo_item.id}}"
                             t-attf-value="{{combo_item.id}}"
                             t-model="state.combo[combo.id]"
                             t-att-class="{ 'selected': state.combo[combo.id] == combo_item.id }" />
-                        <label t-attf-for="combo-{{combo.id}}-combo_item-{{combo_item.id}}" class="combo-item h-100 w-100 rounded cursor-pointer transition-base">
+                        <label t-attf-for="combo-{{combo.id}}-combo_item-{{combo_item.id}}" class="combo-item d-block h-100 w-100 rounded cursor-pointer transition-base">
                             <ProductCard name="product.display_name"
                                 class="'flex-column h-100 border'"
                                 productId="product.id"


### PR DESCRIPTION
Before this commit:
=================
Product cards with long names caused a slight vertical misalignment in the combo configurator popup, resulting in inconsistent card sizes within the grid.

After this commit:
==================
Ensure all product cards remain uniformly aligned and maintain consistent dimensions in the combo configurator popup, even when product names are long.

Task:5447320


