### PR TITLE
[FIX] html_builder: keep image alignment with links

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -38,10 +38,10 @@
 <t t-name="html_builder.ImageAndFaOption">
     <BuilderRow label.translate="Alignment">
         <BuilderSelect>
-            <BuilderSelectItem classAction="''" title.translate="Unalign">None</BuilderSelectItem>
-            <BuilderSelectItem classAction="'me-auto float-start'" title.translate="Align Left">Left</BuilderSelectItem>
-            <BuilderSelectItem classAction="'mx-auto d-block'" title.translate="Align Center">Center</BuilderSelectItem>
-            <BuilderSelectItem classAction="'ms-auto float-end'" title.translate="Align Right">Right</BuilderSelectItem>
+            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="''" title.translate="Unalign">None</BuilderSelectItem>
+            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'me-auto float-start'" title.translate="Align Left">Left</BuilderSelectItem>
+            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'mx-auto d-block'" title.translate="Align Center">Center</BuilderSelectItem>
+            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'ms-auto float-end'" title.translate="Align Right">Right</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Style">

--- a/addons/html_builder/static/tests/options/image_link_alignment.test.js
+++ b/addons/html_builder/static/tests/options/image_link_alignment.test.js
@@ -1,0 +1,22 @@
+import { setupHTMLBuilder } from "@html_builder/../tests/helpers";
+import { describe, expect, test } from "@odoo/hoot";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+
+test("image link mirrors alignment classes", async () => {
+    onRpc("/html_editor/get_image_info", () => ({}));
+    await setupHTMLBuilder(
+        `<section class="s_test"><div class="d-flex">
+            <img class="img img-fluid test-img mx-auto d-block"
+                 src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="/>
+        </div></section>`
+    );
+    await contains(":iframe .test-img").click();
+    await contains("[data-action-id='setLink']").click();
+    expect(":iframe .d-flex a").toHaveClass("mx-auto");
+    await contains("[data-label='Alignment'] .btn-secondary ").click();
+    await contains("[data-action-id='imageAlignClassAction']:contains('Right')").click();
+    expect(":iframe .d-flex a").toHaveClass("ms-auto");
+    expect(":iframe .d-flex a").not.toHaveClass("mx-auto");
+});


### PR DESCRIPTION
Steps to reproduce:
- Add an image to a page and align it center or right via options.
- Use the link option to wrap the image in a link.
- In a flex container (e.g., carousel), the image alignment is lost.

Before this commit, the alignment classes stayed on the image while the link wrapper was missing them, so linked images in flex layouts shifted left.

After this commit, the link mirrors the image alignment classes when linking or changing alignment, keeping linked images positioned correctly.

task-5187840
