### PR TITLE
[FIX] hr: avoid access error when editing employee form

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -477,7 +477,7 @@ class HrEmployee(models.Model):
         version_fields = self.env['hr.version']._fields
         copy_vals = {
             k: v
-            for k, v in version_to_copy.copy_data()[0].items()
+            for k, v in version_to_copy.sudo().copy_data()[0].items()
             if not (k in new_version_vals and version_fields[k].type in ['one2many', 'many2many'])
         } | copy_vals
         new_version = self.env['hr.version'].sudo().create(copy_vals).sudo(False)
@@ -1143,7 +1143,11 @@ We can redirect you to the public employee list."""
 
         employee = super().new(new_vals, origin, ref)
         version_vals['employee_id'] = employee
-        self.env['hr.version'].new(version_vals)
+        self.env['hr.version'].new({
+            f_name: value
+            for f_name, value in version_vals.items()
+            if self.env['hr.version']._has_field_access(self.env['hr.version']._fields[f_name], 'read')
+        })
         return employee
 
     @api.model_create_multi

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -155,7 +155,7 @@ class HrVersion(models.Model):
         help="Select a contract template to auto-fill the contract form with predefined values. You can still edit the fields as needed after applying the template.")
     structure_type_id = fields.Many2one('hr.payroll.structure.type', string="Salary Structure Type",
                                         compute="_compute_structure_type_id", readonly=False, store=True, tracking=True,
-                                        groups="hr.group_hr_user", default=_default_salary_structure)
+                                        groups="hr.group_hr_manager", default=_default_salary_structure)
     active_employee = fields.Boolean(related="employee_id.active", string="Active Employee", groups="hr.group_hr_user")
     currency_id = fields.Many2one(string="Currency", related='company_id.currency_id', readonly=True)
     wage = fields.Monetary('Wage', tracking=True, help="Employee's monthly gross wage.", aggregator="avg",

--- a/addons/hr_work_entry/views/hr_employee_views.xml
+++ b/addons/hr_work_entry/views/hr_employee_views.xml
@@ -9,7 +9,7 @@
             <button name="action_open_versions" position="before">
                 <field name="has_work_entries" invisible="1"/>
                 <button invisible="not has_work_entries" type="object" class="oe_stat_button" id="open_work_entries"
-                    icon="fa-calendar" name="action_open_work_entries">
+                    icon="fa-calendar" name="action_open_work_entries" groups="hr.group_hr_manager">
                     <div class="o_stat_info">
                             <span class="o_stat_text">
                             Work Entries


### PR DESCRIPTION
Issue:
HR users could hit access errors when editing the employee form.

Cause:
Tracked and stored fields on hr.version exposed payroll models to hr.group_hr_user, triggering access right violations during recompute.

Fix:
Restrict payroll-related fields to HR managers to align visibility with actual access rights.

Impact:
HR users can edit the employee form without errors.

Task - 5404676