### PR TITLE
[FIX] point_of_sale: prevent leftpane from shrinking below its width

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ProductScreen">
         <div class="product-screen d-flex h-100">
-            <div t-att-class="{'flex-grow-1 w-100 mw-100': ui.isSmall, 'd-none': ui.isSmall and pos.mobile_pane !== 'left'}"
+            <div t-att-class="{'flex-grow-1 w-100 mw-100': ui.isSmall, 'flex-shrink-0': !ui.isSmall, 'd-none': ui.isSmall and pos.mobile_pane !== 'left'}"
                 class="leftpane d-flex flex-column p-2">
                 <OrderSummary />
                 <div class="pads">


### PR DESCRIPTION
In some scenarios, although not fully deterministic, the left pane is being pushed by its right pane sibling (i.e. the products grid), making it go below its specified with of `left-pane-width`, and making text non readable.

By setting `flex-shrink: 0` on this element, we tell the browser to respect the specified width, and not allow its siblings to shrink it.

We could have also set `min-width: $left-pane-width;`, but it's less descriptive. The problem happens because we are in a flex container, hencer we use `flex-shrink: 0`.

### Notes:
This issue only happened from time to time for the client, and it seems non deterministic. 
If we disable showing the product images, the issue stops happening.

The below before vs after screenshots are taken on MacBook Pro 14 inches.

### Before:
<img width="1493" height="868" alt="image" src="https://github.com/user-attachments/assets/70bc5a70-34a6-48c9-a60a-ab1de1fa0b9b" />

<img width="1496" height="867" alt="image" src="https://github.com/user-attachments/assets/e8ae9b25-3525-439b-93dd-18dc825613c7" />


### After:
<img width="1495" height="866" alt="Capture d’écran 2025-12-31 à 11 28 38" src="https://github.com/user-attachments/assets/23585d3d-b0bf-4316-8749-b39a56fc8cda" />

<img width="1497" height="866" alt="image" src="https://github.com/user-attachments/assets/f5654163-1dd3-4ff9-bb12-d8cd8fbc497b" />


opw-5392359