### PR TITLE
[FIX] product: don't assign specific pricelist if it matches default

### DIFF
--- a/addons/product/models/res_partner.py
+++ b/addons/product/models/res_partner.py
@@ -35,12 +35,9 @@ class ResPartner(models.Model):
             partner.property_product_pricelist = res.get(partner.id)
 
     def _inverse_product_pricelist(self):
+        defaults = self.env['product.pricelist']._get_country_pricelist_multi(self.country_id.ids)
         for partner in self:
-            pls = self.env['product.pricelist'].search(
-                [('country_group_ids.country_ids.code', '=', partner.country_id and partner.country_id.code or False)],
-                limit=1
-            )
-            default_for_country = pls
+            default_for_country = defaults.get(partner.country_id.id)
             actual = partner.specific_property_product_pricelist
             # update at each change country, and so erase old pricelist
             if partner.property_product_pricelist or (actual and default_for_country and default_for_country.id != actual.id):

--- a/addons/product/tests/test_pricelist.py
+++ b/addons/product/tests/test_pricelist.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from unittest.mock import patch
+
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tests import tagged, Form
@@ -17,7 +19,7 @@ class TestPricelist(ProductCommon):
         cls.datacard = cls.env['product.product'].create({'name': 'Office Lamp'})
         cls.usb_adapter = cls.env['product.product'].create({'name': 'Office Chair'})
 
-        cls.sale_pricelist_id = cls.env['product.pricelist'].create({
+        cls.sale_pricelist_id, cls.pricelist_eu = cls.env['product.pricelist'].create([{
             'name': 'Sale pricelist',
             'item_ids': [
                 Command.create({
@@ -41,7 +43,11 @@ class TestPricelist(ProductCommon):
                     'applied_on': '3_global',
                 }),
             ],
-        })
+        }, {
+            'name': "EU Pricelist",
+            'country_group_ids': cls.env.ref('base.europe').ids,
+        }])
+
         # Enable pricelist feature
         cls.env.user.groups_id += cls.env.ref('product.group_product_pricelist')
 
@@ -136,6 +142,62 @@ class TestPricelist(ProductCommon):
 
         self.assertEqual(res_partner.property_product_pricelist, pl_first)
 
+    def test_40_specific_property_product_pricelist(self):
+        """Ensure that that ``specific_property_product_pricelist`` value only gets set
+        when changing ``property_product_pricelist`` to a non-default value for the partner.
+        """
+        pricelist_1, pricelist_2 = self.pricelist, self.sale_pricelist_id
+        self.env['product.pricelist'].search([
+            ('id', 'not in', [pricelist_1.id, pricelist_2.id, self.pricelist_eu.id]),
+        ]).active = False
+
+        # Set country to BE -> property defaults to EU pricelist
+        with Form(self.partner) as partner_form:
+            partner_form.country_id = self.env.ref('base.be')
+        self.assertEqual(self.partner.property_product_pricelist, self.pricelist_eu)
+        self.assertFalse(self.partner.specific_property_product_pricelist)
+
+        # Set country to KI -> property defaults to highest sequence pricelist
+        with Form(self.partner) as partner_form:
+            partner_form.country_id = self.env.ref('base.ki')
+        self.assertEqual(self.partner.property_product_pricelist, pricelist_1)
+        self.assertFalse(self.partner.specific_property_product_pricelist)
+
+        # Setting non-default pricelist as property should update specific property
+        with Form(self.partner) as partner_form:
+            partner_form.property_product_pricelist = pricelist_2
+        self.assertEqual(self.partner.property_product_pricelist, pricelist_2)
+        self.assertEqual(self.partner.specific_property_product_pricelist, pricelist_2)
+
+        # Changing partner country shouldn't update (specific) pricelist property
+        with Form(self.partner) as partner_form:
+            partner_form.country_id = self.env.ref('base.be')
+        self.assertEqual(self.partner.property_product_pricelist, pricelist_2)
+        self.assertEqual(self.partner.specific_property_product_pricelist, pricelist_2)
+
+    def test_45_property_product_pricelist_config_parameter(self):
+        """Check that the ``ir.config_parameter`` is accounted for as fallback
+        for both ``property_product_pricelist`` & ``specific_property_product_pricelist``
+        """
+        pricelist_1, pricelist_2 = self.pricelist, self.sale_pricelist_id
+        self.env['product.pricelist'].search([
+            ('id', 'not in', [pricelist_1.id, pricelist_2.id]),
+        ]).active = False
+        self.assertEqual(self.partner.property_product_pricelist, pricelist_1)
+
+        self.partner.invalidate_recordset(['property_product_pricelist'])
+        ICP = self.env['ir.config_parameter'].sudo()
+        ICP.set_param('res.partner.property_product_pricelist', pricelist_2.id)
+        with patch.object(
+            self.pricelist.__class__, '_get_partner_pricelist_multi_search_domain_hook',
+            return_value=[(0, '=', 1)],  # ensures pricelist falls back on ICP
+        ):
+            with Form(self.partner) as partner_form:
+                self.assertEqual(partner_form.property_product_pricelist, pricelist_2)
+                partner_form.property_product_pricelist = pricelist_1
+            self.assertEqual(self.partner.property_product_pricelist, pricelist_1)
+            self.assertEqual(self.partner.specific_property_product_pricelist, pricelist_1)
+
     def test_pricelists_multi_comp_checks(self):
         first_company = self.env.company
         second_company = self.env['res.company'].create({'name': 'Test Company'})
@@ -177,11 +239,7 @@ class TestPricelist(ProductCommon):
             self.pricelist.company_id = second_company
 
     def test_pricelists_res_partner_form(self):
-        pricelist_europe = self.env['product.pricelist'].create({
-            'name': 'Sale pricelist',
-            'country_group_ids': self.env.ref('base.europe').ids,
-        })
-
+        pricelist_europe = self.pricelist_eu
         default_pricelist = self.env['product.pricelist'].search([('name', 'ilike', ' ')], limit=1)
 
         with Form(self.env['res.partner']) as partner_form:


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a way to check the `specific_property_product_pricelist` field;
2. create a pricelist for EU countries;
3. delete all other regional pricelists;
4. create a new partner in a EU country;
5. create a new partner outside a EU country;
6. create a new partner without a country.

Issue
-----
Inconsistent behavior:
- EU partner has no `specific_property_product_pricelist` value set, as it's identical to the default `property_product_pricelist`.
- The other partners do have a `specific_property_product_pricelist` value set to the default value, as if a user manually assigned them.

Cause
-----
In the `_inverse_product_pricelist` method, the `default_for_country` pricelist is an empty recordset if the partner has no `country_id` or none of the pricelists have a country groups with the partner's `country_id` in it.

Solution
--------
Introduce a `_get_country_pricelist_multi` method that can be used by `_get_partner_pricelist_multi` and `_inverse_product_pricelist` to ensure that they both return the same result for any given country (including none), and use this as the `default_for_country`.

> [!Note]
> An alternative approach could be to replace the `_inverse_product_pricelist` method with an `onchange` method, as the docstring of the `_get_partner_pricelist_multi` method states:
>> First, the pricelist of the specific property (res_id set), this one is created when saving a pricelist on the partner form view.
>
> This suggests a behavior that more closely resembles the purpose of an `onchange` method, instead of an `inverse`.

opw-5385213

Enterprise PR: https://github.com/odoo/enterprise/pull/103116 (only modifies a test)