### PR TITLE
[FIX] iot_drivers: deprecation warning importing `PyKCS11`

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/l10n_eg_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/l10n_eg_driver.py
@@ -2,7 +2,7 @@
 import base64
 import json
 import logging
-import PyKCS11
+import warnings
 
 from passlib.context import CryptContext
 
@@ -10,6 +10,13 @@ from odoo import http
 from odoo.tools.config import config
 from odoo.addons.iot_drivers.tools import route
 from odoo.addons.iot_drivers.tools.system import IOT_SYSTEM, IS_RPI, IS_WINDOWS
+
+warnings.filterwarnings(
+    "ignore",
+    message=".*SwigPy(Object|Packed).*",
+    category=DeprecationWarning,
+)
+import PyKCS11  # noqa: E402
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Importing `PyKCS11` was raising the following warning:
```
py.warnings: <frozen importlib._bootstrap>:488: DeprecationWarning:
builtin type SwigPyObject has no __module__ attribute
```
It doesn't cause any issue, but adds two tracebacks in the logs on Odoo startup.
This commit simply hides the warning.
