### PR TITLE
[FIX] website_sale: prevent crash when try to set delivery method

### DIFF
--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -371,7 +371,7 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
 
         // When no dm is set and a price span is hidden, hide the message and show the price span.
         if (amountDelivery.classList.contains('d-none')) {
-            amountDelivery.querySelector('span[name="o_message_no_dm_set"]').classList.add('d-none');
+            targetEl.querySelector('span[name="o_message_no_dm_set"]').classList.add('d-none');
             amountDelivery.classList.remove('d-none');
         }
 

--- a/addons/website_sale/static/tests/tours/website_sale_update_address.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_address.js
@@ -36,3 +36,45 @@ registry.category("web_tour.tours").add('update_billing_shipping_address', {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("checkout_change_address_then_select_delivery", {
+    url: "/shop",
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "Test Product", expectUnloadPage: true }),
+        tourUtils.goToCart({quantity: 1}),
+        tourUtils.goToCheckout(),
+        {
+            content: "Select the US address (no delivery available)",
+            trigger: '.o_address_kanban_card address:contains("United State")',
+            run: "click",
+        },
+        {
+            content: "Confirm address selection",
+            trigger: 'a[name="website_sale_main_button"]',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Go back to address step",
+            trigger: 'a:has(span:contains("Back to address"))',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Select the Australian delivery address",
+            trigger: '.o_address_kanban_card address:contains("Australia")',
+            run: "click",
+        },
+        {
+            content: "Select an available delivery method",
+            trigger: "li label:contains(Test carrier)",
+            run: "click",
+        },
+        {
+            content: "Click on Confirm button",
+            trigger: 'a[name="website_sale_main_button"]',
+            run: "click",
+            expectUnloadPage: true,
+        },
+    ],
+});


### PR DESCRIPTION
A traceback occurs when changing the delivery address and then selecting a delivery method in the checkout flow.

**Steps to produce:**
-  Install the `ecommerce` module without demo data.
- Go to Delivery Methods, set country(other than united states)
  in standard delivery method.
- Create any product and add it to the cart, then proceed to checkout.
- Add two addresses:
  - one with the country `United States`.
  - another with the country configured on the delivery methods.
- Select the `United States` address and confirm:
  - The next page displays `Sorry, we are unable to ship your order.`
- Go back to the address step.
- Select the other address and `choose a delivery method`.

**Issue:**
`TypeError: Cannot read properties of null (reading 'classList')`

**Root cause:**
- In the cart summary template, the spans `monetary_field` and `o_message_no_dm_set` are siblings ([1]). However, in the JavaScript code, the logic incorrectly tries to find `o_message_no_dm_set` inside the `monetary_field` span ([2]). When no delivery method is available, the delivery row is conditionally removed, causing the selector to return null and leading to the crash.

**Solution:-**
- Update the JavaScript logic to search for `o_message_no_dm_set` directly in the `o_order_delivery` row instead of inside `monetary_field`.

[1]: https://github.com/odoo/odoo/blob/ccf90d586b5e0beb120de2a8a99395e40e80b320/addons/website_sale/views/templates.xml#L3776-L3788
[2]: https://github.com/odoo/odoo/blob/ccf90d586b5e0beb120de2a8a99395e40e80b320/addons/website_sale/static/src/js/checkout.js#L374

opw-5447447
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
