### PR TITLE
[FIX] mail: fullscreen button unclickable due to call actions overlay

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -53,7 +53,7 @@
                 <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': rtc.state.isFullscreen, 'ps-2 pb-2': !rtc.state.isFullscreen }">
                     <span class="o-discuss-Call-notification text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': rtc.state.isFullscreen, 'p-2': !rtc.state.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
                 </div>
-                <div class="o-discuss-Call-layoutActions position-absolute bottom-0 end-0">
+                <div class="o-discuss-Call-layoutActions position-absolute z-2 bottom-0 end-0">
                     <ActionList actions="layoutActions" inline="true"/>
                 </div>
             </div>


### PR DESCRIPTION
**Purpose of this PR:**

When the call control overlay is floating, it overlaps the fullscreen button, making it difficult to enter fullscreen mode.

for reference:
<img width="711" height="257" alt="image" src="https://github.com/user-attachments/assets/4a7a7448-4988-4cf6-bcfb-6a91491be80d" />

This commit ensures the fullscreen action remains accessible by adjusting the layout layering so controls no longer overlap each other.

Task-[5240896](https://www.odoo.com/odoo/project/1519/tasks/5240896)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
