### PR TITLE
[FIX] fleet: allow officers to edit 'Make Vehicle Available' field

### DIFF
--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -109,10 +109,10 @@
                             <field name="manager_id" domain="[('share', '=', False), ('company_id', '=', company_id)]" widget="many2one_avatar_user"/>
                             <field name="location"/>
                             <label string="Make Vehicle Available" for="plan_to_change_car" class="text-nowrap" invisible="vehicle_type != 'car'"/>
-                            <field name="plan_to_change_car" groups="fleet.fleet_group_manager" invisible="vehicle_type != 'car'" nolabel="1"
+                            <field name="plan_to_change_car" groups="fleet.fleet_group_user" invisible="vehicle_type != 'car'" nolabel="1"
                                 help="This will allow this vehicle to be selectable for the Salary Configurator" class="text-nowrap"/>
                             <label string="Make Vehicle Available" for="plan_to_change_bike" class="text-nowrap" invisible="vehicle_type != 'bike'"/>
-                            <field name="plan_to_change_bike" groups="fleet.fleet_group_manager"  invisible="vehicle_type != 'bike'" nolabel="1"
+                            <field name="plan_to_change_bike" groups="fleet.fleet_group_user"  invisible="vehicle_type != 'bike'" nolabel="1"
                                 help="This will allow this vehicle to be selectable for the Salary Configurator"/>
                         </group>
                     </group>


### PR DESCRIPTION
Issue:
The 'plan_to_change_car' and 'plan_to_change_bike' fields were restricted to Fleet Managers, preventing Fleet Officers from editing it.

Fix:
Changed the view-level group restriction from Fleet Manager to Fleet Officer for both fields..

task-5443107