### PR TITLE
[FIX] web: prevent error when unfold specification is not given

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -446,7 +446,7 @@ class Base(models.AbstractModel):
             all_records = self.browse().union(*recordset_groups)
             record_mapped = dict(zip(
                 all_records._ids,
-                all_records.web_read(unfold_read_specification),
+                all_records.web_read(unfold_read_specification or {}),
                 strict=True,
             ))
 


### PR DESCRIPTION
An error occurs when `web_read_group` is called without an unfold specification.

**Error:**
`TypeError - 'NoneType' object is not iterable`

**Cause:**
Here the method `web_read_group` unconditionally calls `all_records.web_read(unfold_read_specification)` - [1]

However, `web_read` requires a valid read specification. If `unfold_read_specification` is None [2], it fails when trying to iterate over it during record mapping.

**Fix:**
This commit only unfold and reads group records when `unfold_read_specification` is given.

[1] - https://github.com/odoo/odoo/blob/e8a41b5b50ac71974d98c18fa9d47e37e0f7763f/addons/web/models/models.py#L449-L449
[2] - https://github.com/odoo/odoo/blob/e8a41b5b50ac71974d98c18fa9d47e37e0f7763f/addons/web/models/models.py#L317

sentry-7112641140