### PR TITLE
[IMP] livechat: show agent company in channel overview

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -117,6 +117,7 @@
                                         <list no_open="1" create="0">
                                             <field name="partner_id" string="Agent" widget="many2one_avatar_user" width="175px" context="{'im_livechat_hide_partner_company': True}"/>
                                             <field name="livechat_is_in_call" widget="boolean_phone" nolabel="1"/>
+                                            <field name="company_id" optional="hide"/>
                                             <field string="Languages" name="livechat_lang_ids" widget="many2many_tags" optional="show"/>
                                             <field string="Expertise" name="livechat_expertise_ids" widget="many2many_tags" optional="show"/>
                                             <field string="Ongoing Sessions" name="livechat_ongoing_session_count" width="150px" optional="show"/>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

To have a better overview of connected agents per company, it is useful to display the user’s default company in the list of connected agents in the Agents tab of the live chat channel overview.

**Current behavior before PR:**
---------------------------------

- The agent’s company is not visible  

**Desired behavior after PR is merged:**
-----------------------------------------

- The agent’s default company is displayed in the Agents tab  

**Task:** 5117549

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
