### PR TITLE
[FIX] project: Access rights error when creating a private task

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -428,6 +428,8 @@ class ProjectTask(models.Model):
     def _onchange_project_id(self):
         if self.state != '04_waiting_normal':
             self.state = '01_in_progress'
+        if not self.project_id and len(self.user_ids) == 0:
+            self.user_ids += self.env.user
 
     def is_blocked_by_dependences(self):
         return any(blocking_task.state not in CLOSED_STATES for blocking_task in self.depend_on_ids)

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -446,6 +446,7 @@
                             <field name="user_ids"
                                 class="o_task_user_field"
                                 options="{'no_open': True}"
+                                required="not project_id"
                                 widget="many2many_avatar_user"/>
                             <field name="role_ids" invisible="not has_project_template or is_template" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
                         </group>


### PR DESCRIPTION
When users would follow the following step as they are makeing a private task,  they would be hit by an incorrect access error.

### Steps to reproduce:
1.Open the form view to create a new task.
2.Clear the Project field. When empty, it should display the Private placeholder. 3.Ensure no user is assigned to the task.
4.Create the private task.
5.An access rights error occurs, stating that the user does not have permission to create the record.

#### ⚠️ Note:
This access rights error only occurs when the task is created directly as private. If a task is created normally and then its project_id and user_ids are removed afterward, no access rights error occurs.

### Root cause:
When a task is created without a project_id and without assigned users, Odoo checks access rights on creation. Since no project members or assigned users exist, no user has access to the record, including the creator. This results in an access rights error during creation.

This issue does not occur when modifying an existing task because, after creation, the creator is automatically added as a follower. As a follower, the creator retains access to the task even if it has no project and no assigned users.

### Fix (implemented):
Tasks that have no assigned users and are not linked to any project (private tasks) did not make sense, as they were effectively assigned to nothing.
To address this, we now require at least one user to be assigned to a task when it is not attached to a project.  This change was made inside of the "project_task_view.xml" file in the "view_task_form_2" record

Task:  [5403926](https://www.odoo.com/odoo/project/4105/tasks/5403926)
Version: 19.2a1+e
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
