### PR TITLE
[FIX] stock: ensure each package start on new page in packages report

### DIFF
--- a/addons/stock/report/report_package_barcode.xml
+++ b/addons/stock/report/report_package_barcode.xml
@@ -7,7 +7,7 @@
         <t t-set="uom_unit_id" t-value="env.ref('uom.product_uom_unit').id"/>
         <t t-set="gs1_uom_patterns" t-value="{rule.associated_uom_id.id: rule.pattern[1:4] + str(len(str('{:.10f}'.format(rule.associated_uom_id.rounding).rstrip('0')).split('.')[1])) for rule in env['barcode.rule'].search([('associated_uom_id', '!=', False), ('associated_uom_id.id', '!=', uom_unit_id), ('is_gs1_nomenclature', '=', True)])}"/>
         <t t-foreach="docs" t-as="o">
-            <div class="page mt-4">
+            <div class="page mt-4" style="page-break-after: always;">
                 <div class="oe_structure"/>
                 <!-- HEADER: Package's information -->
                 <div class="row mb-5">


### PR DESCRIPTION
Issue before this PR:
=========================
- Currently, when printing a `Packages` report that contains `multiple packages` all `Package with Content` reports are printed as a `single continuous document` without any line or page separation between packages.

- This leads to issues because each `Package with Content` report is meant to be printed individually and physically attached to its corresponding package during packing and logistics operations. It creates `confusion and a risk of mislabeling`, as users must `manually interpret and separate package boundaries` when handling printed documents.

Steps to Reproduce:
=========================
1. Install the `Inventory` app.
2. Go to Configuration → Settings and enable the `Packages` option.
3. Create a new transfer with multiple product lines and click `Mark as Todo`.
4. In Detailed Operations, assign `different packages` to at least two different product lines and `Validate` the transfer.
5. Open the `Actions` menu, select `Print → Packages`.
6. Open the generated PDF. All packages are printed on the same page, without any page or line separation.

**Packages report before this PR:**

<img width="500" height="300" alt="combined" src="https://github.com/user-attachments/assets/6a6b8cb5-bcf3-488e-b95a-7670db8fc6ad" />

Cause of the issue:-
=========================
In the file `report_package_barcode.xml`, a `t-foreach` loop is used to iterate over the packages included in the report. However, the report template does not define any `page break or visual separation` between iterations. As a result,
each package is rendered consecutively in a single, continuous page instead of being split into separate pages.

After this PR:-
=========================
This PR ensures that, when printing a `Packages` report containing `multiple packages`, each `Package with Content` starts on a new page. This clear separation allows users to easily identify and handle `individual package details`, reducing confusion and the risk of mislabeling, while preserving the existing report layout and content.

**Packages report after this PR:**

<img width="491" height="500" alt="breaked (1)" src="https://github.com/user-attachments/assets/d87a52e5-8b54-49d4-911a-2e07e487c0d8" />

TaskID-5025192