### PR TITLE
[FIX] web: prevent excessive gradient updates during angle knob drag

### DIFF
--- a/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.js
+++ b/addons/web/static/src/core/color_picker/gradient_picker/gradient_picker.js
@@ -228,13 +228,21 @@ export class GradientPicker extends Component {
         };
 
         updateAngle(ev);
-        this.onColorGradientChange();
+
+        // Only update the visual CSS gradient preview during drag and
+        // defer the onGradientChange callback to mouseup to avoid
+        // triggering heavy operations (e.g. SCSS generation) on every
+        // mousemove.
+        this.updateCssGradients();
 
         const onKnobMouseMove = (ev) => {
             updateAngle(ev);
+            this.updateCssGradients();
+        };
+        const onKnobMouseUp = () => {
+            document.removeEventListener("mousemove", onKnobMouseMove);
             this.onColorGradientChange();
         };
-        const onKnobMouseUp = () => document.removeEventListener("mousemove", onKnobMouseMove);
 
         document.addEventListener("mousemove", onKnobMouseMove);
         document.addEventListener("mouseup", onKnobMouseUp, { once: true });


### PR DESCRIPTION
Cause:
======
Because the debounce function is called with await, the execution of
`debouncedSCSSColorsCusto` pauses for every mousemove event.
This prevents subsequent calls from overlapping, meaning the debounce
logic never triggers to cancel previous timers. This results in the
heavy SCSS generation running sequentially for every single mouse
movement, causing performance lag.

In other words, the await forced the browser to handle one request at
a time, completely finishing it before accepting the next one.

Solution:
==========
In the gradient picker, only update the visual CSS gradient preview
during drag and defer the `onGradientChange` callback to mouseup to
avoid triggering heavy operations (e.g. SCSS generation) on every
mousemove.

Steps to reproduce:
===================
1. Go to website & edit mode.
2. Click on Header block.
3. Click on background color preview & select Gradient & Custom.
4. Click and drag the Angle knob.
=> The website preview triggers excessive updates dragging the knob

opw-5411628