### PR TITLE
[IMP] html_editor,*: enhance withSequence to accept multiple objects

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -43,9 +43,8 @@ class ImageToolOptionPlugin extends Plugin {
     resources = {
         builder_options: [
             withSequence(REPLACE_MEDIA, ReplaceMediaOption),
-            withSequence(IMAGE_TOOL, ImageToolOption),
+            ...withSequence(IMAGE_TOOL, ImageToolOption, VideoSizeOption),
             withSequence(ALIGNMENT_STYLE_PADDING, ImageAndFaOption),
-            withSequence(IMAGE_TOOL, VideoSizeOption),
         ],
         builder_actions: {
             CropImageAction,

--- a/addons/html_editor/static/src/utils/resource.js
+++ b/addons/html_editor/static/src/utils/resource.js
@@ -9,17 +9,26 @@ export const resourceSequenceSymbol = Symbol("resourceSequence");
 /**
  * @template T
  * @param {number} sequenceNumber
- * @param {T} object
- * @returns {ResourceWithSequence<T>}
+ * @param {...T} objects - One or more objects to assign the sequence number to
+ * Single wrapped object if one object passed, array if multiple
+ * @returns {ResourceWithSequence<T> | ResourceWithSequence<T>[]}
  */
-export function withSequence(sequenceNumber, object) {
+export function withSequence(sequenceNumber, ...objects) {
     if (typeof sequenceNumber !== "number") {
         throw new Error(
             `sequenceNumber must be a number. Got ${sequenceNumber} (${typeof sequenceNumber}).`
         );
     }
-    return {
+    if (objects.length === 0) {
+        throw new Error("At least one object must be provided to withSequence.");
+    }
+
+    const wrappedObjects = objects.map((object) => ({
         [resourceSequenceSymbol]: sequenceNumber,
         object,
-    };
+    }));
+
+    // Return single object for backward compatibility with non-array resources
+    // Return array when multiple objects are passed (for spreading in arrays)
+    return wrappedObjects.length === 1 ? wrappedObjects[0] : wrappedObjects;
 }

--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -19,10 +19,7 @@ class accordionOptionPlugin extends Plugin {
     static id = "accordionOptionPlugin";
     /** @type {import("plugins").WebsiteResources} */
     resources = {
-        builder_options: [
-            withSequence(SNIPPET_SPECIFIC, AccordionOption),
-            withSequence(SNIPPET_SPECIFIC, AccordionItemOption),
-        ],
+        builder_options: [...withSequence(SNIPPET_SPECIFIC, AccordionOption, AccordionItemOption)],
         so_content_addition_selector: [".s_accordion"],
         builder_actions: {
             DefineCustomIconAction,

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
@@ -32,8 +32,7 @@ class NavTabsStyleOptionPlugin extends Plugin {
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [
-            withSequence(SNIPPET_SPECIFIC_END, NavTabsStyleOption),
-            withSequence(SNIPPET_SPECIFIC_END, NavTabsImagesStyleOption),
+            ...withSequence(SNIPPET_SPECIFIC_END, NavTabsStyleOption, NavTabsImagesStyleOption),
         ],
         builder_actions: {
             SetStyleAction,

--- a/addons/website/static/src/builder/plugins/translation/options/translate_webpage_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation/options/translate_webpage_option_plugin.js
@@ -251,7 +251,7 @@ export class TranslateWebpageOptionPlugin extends Plugin {
         builder_actions: {
             TranslateToAction,
         },
-        builder_options: withSequence(1, TranslateWebpageOption),
+        builder_options: [withSequence(1, TranslateWebpageOption)],
     };
 
     getTranslationState() {

--- a/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/dynamic_snippet_blog_posts_option_plugin.js
@@ -20,7 +20,7 @@ class DynamicSnippetBlogPostsOptionPlugin extends Plugin {
     modelNameFilter = "blog.post";
     /** @type {import("plugins").WebsiteResources} */
     resources = {
-        builder_options: withSequence(DYNAMIC_SNIPPET, DynamicSnippetBlogPostsOption),
+        builder_options: [withSequence(DYNAMIC_SNIPPET, DynamicSnippetBlogPostsOption)],
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
     };
     setup() {

--- a/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
+++ b/addons/website_mass_mailing/static/src/website_builder/newsletter_subscribe_common_option_plugin.js
@@ -3,7 +3,10 @@ import { POPUP } from "@website/builder/plugins/options/popup_option_plugin";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
-import { NewsletterSubscribeCommonOption, NewsletterSubscribeCommonPopupOption } from "./newsletter_subscribe_common_option";
+import {
+    NewsletterSubscribeCommonOption,
+    NewsletterSubscribeCommonPopupOption,
+} from "./newsletter_subscribe_common_option";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { renderToFragment } from "@web/core/utils/render";
 
@@ -18,8 +21,11 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {
     static id = "newsletterSubscribeCommonOption";
     resources = {
         builder_options: [
-            withSequence(NEWSLETTER_SELECT, NewsletterSubscribeCommonOption),
-            withSequence(NEWSLETTER_SELECT, NewsletterSubscribeCommonPopupOption),
+            ...withSequence(
+                NEWSLETTER_SELECT,
+                NewsletterSubscribeCommonOption,
+                NewsletterSubscribeCommonPopupOption
+            ),
             withSequence(SNIPPET_SPECIFIC, MailingListSubscribeFormOption),
         ],
         dropzone_selector: [
@@ -39,13 +45,14 @@ class NewsletterSubscribeCommonOptionPlugin extends Plugin {
                 const mailingLists = await this.services.orm.searchRead(
                     "mailing.list",
                     [["is_public", "=", true]],
-                    ["id", "name"],
+                    ["id", "name"]
                 );
                 if (mailingLists.length) {
                     const parentEl = sampleEl.parentElement;
                     sampleEl.remove();
                     const checkboxesFragment = renderToFragment(
-                        "website_mass_mailing.NewsletterMailingListsCheckboxes", { mailingLists }
+                        "website_mass_mailing.NewsletterMailingListsCheckboxes",
+                        { mailingLists }
                     );
                     parentEl.append(...checkboxesFragment.children);
                 } else {

--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_products_option_plugin.js
@@ -14,7 +14,7 @@ class DynamicSnippetProductsOptionPlugin extends Plugin {
     static shared = ["fetchCategories", "getModelNameFilter"];
     modelNameFilter = "product.product";
     resources = {
-        builder_options: withSequence(DYNAMIC_SNIPPET_CAROUSEL, DynamicSnippetProductsOption),
+        builder_options: [withSequence(DYNAMIC_SNIPPET_CAROUSEL, DynamicSnippetProductsOption)],
         dynamic_snippet_template_updated: this.onTemplateUpdated.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
     };

--- a/addons/website_slides/static/src/website_builder/courses_list_page_option_plugin.js
+++ b/addons/website_slides/static/src/website_builder/courses_list_page_option_plugin.js
@@ -1,5 +1,5 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
-import { after, DEFAULT } from "@html_builder/utils/option_sequence";
+import { DEFAULT } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
@@ -26,8 +26,7 @@ export class CoursesListPageOptionPlugin extends Plugin {
     static id = "coursesListPageOption";
     resources = {
         builder_options: [
-            withSequence(COURSES_LIST_PAGE, CoursesListPageOption),
-            withSequence(after(COURSES_LIST_PAGE), CoursesListAsidePageOption),
+            ...withSequence(COURSES_LIST_PAGE, CoursesListPageOption, CoursesListAsidePageOption),
         ],
     };
 }


### PR DESCRIPTION
[*]: website[_blog, _mass_mailing, _sale, _slide]

Enhanced the `withSequence` utility function to accept multiple objects with a single sequence number, reducing code repetition when registering builder options.

Key changes:
- Updated `withSequence` to accept variadic arguments (...objects)
- Returns single wrapped object for backward compatibility (1 arg)
- Returns array of wrapped objects when multiple args provided
- Use spread operator (...) when passing multiple objects in arrays

Before:
```js
  builder_options: [
    withSequence(REPLACE_MEDIA, ReplaceMediaOption),
    withSequence(IMAGE_TOOL, ImageToolOption),
    withSequence(IMAGE_TOOL, VideoSizeOption),
]
```

After:
```js
  builder_options: [
    withSequence(REPLACE_MEDIA, ReplaceMediaOption),
    ...withSequence(IMAGE_TOOL, ImageToolOption, VideoSizeOption),
]
```

This improves code clarity and reduces duplication when multiple options share the same sequence position. The function maintains backward compatibility with existing single-object usage for non-array resources like handlers and overrides.

Updated multiple plugin files to use the new syntax where applicable and some linting issues were fixed as well.

