### PR TITLE
[FIX] html_builder: reintroduce image alignment options

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -33,6 +33,14 @@
 </t>
 
 <t t-name="html_builder.ImageAndFaOption">
+    <BuilderRow label.translate="Alignment">
+        <BuilderSelect>
+            <BuilderSelectItem classAction="''" title.translate="Unalign">None</BuilderSelectItem>
+            <BuilderSelectItem classAction="'me-auto float-start'" title.translate="Align Left">Left</BuilderSelectItem>
+            <BuilderSelectItem classAction="'mx-auto d-block'" title.translate="Align Center">Center</BuilderSelectItem>
+            <BuilderSelectItem classAction="'ms-auto float-end'" title.translate="Align Right">Right</BuilderSelectItem>
+        </BuilderSelect>
+    </BuilderRow>
     <BuilderRow label.translate="Style">
         <BuilderButton icon="'fa-square'" classAction="'rounded'" title.translate="Shape: Rounded"/>
         <BuilderButton icon="'fa-circle-o'" classAction="'rounded-circle'" title.translate="Shape: Circle"/>


### PR DESCRIPTION
Commit [1] removed the image options from the sidebar because a task is planned to move these image alignment options to a new "image toolbar".

Merging that commit before the toolbar task was ready was not a good idea, as it leaves us without these options for a long period of time.

With this commit, we restore the image alignment options in the sidebar. These options will be removed only when they can be properly moved to the new image toolbar.

[1]: https://github.com/odoo/odoo/commit/101d0c782cec6a7b5dadf062c75828aefff2e8a7