### PR TITLE
[FIX] point_of_sale: removed unit price for products inside a combo.

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.js
@@ -120,8 +120,10 @@ export class Orderline extends Component {
         ].join(" ");
         const showPrice =
             !basic &&
-            line.getQuantityStr() != 1 &&
-            (mode === "receipt" || (line.price_type !== "original" && !line.combo_parent_id));
+            line.getQuantityStr().qtyStr != 1 &&
+            !line.combo_parent_id &&
+            line.currencyDisplayPriceUnit != 0.0 &&
+            (mode === "receipt" || line.price_type !== "original");
         const priceUnit = `${line.currencyDisplayPriceUnit} / ${
             line.product_id?.uom_id?.name || ""
         }`;

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -114,6 +114,10 @@ registry.category("web_tour.tours").add("ProductComboPriceCheckTour", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.isShown(),
+            ReceiptScreen.comboOrderLineDoesntShowPricePerUnit("Desk Combo", "1", "0.00"),
+            ReceiptScreen.comboOrderLineDoesntShowPricePerUnit("Desk Organizer", "1", "4.45"),
+            ReceiptScreen.comboOrderLineDoesntShowPricePerUnit("Desk Pad", "1", "1.59"),
+            ReceiptScreen.comboOrderLineDoesntShowPricePerUnit("Whiteboard Pen", "1", "0.96"),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -215,3 +215,11 @@ export function containsOrderLine(name, quantity, price_unit, line_price) {
         },
     ];
 }
+export function comboOrderLineDoesntShowPricePerUnit(name, quantity, price_unit) {
+    return [
+        {
+            content: `Combo child order line with name: ${name}, quantity: ${quantity}, doesn't show price per unit`,
+            trigger: `.pos-receipt .orderline:has(.product-name:contains('${name}')):has(.qty:contains('${quantity}')):not(:has(.price-per-unit:contains('${price_unit}')))`,
+        },
+    ];
+}


### PR DESCRIPTION
Steps to reproduce:
- In POS, select a combo product, confirm, and pay for it. 
- When the receipt is shown, the price per unit for the combo and for each product inside the combo is showing.

Issue:
- The price calculation of the individual products constituting the combo and showing the unit price of the combo when the combo quantity is 1 is confusing for the customer.

Fix:
- Since Odoo 19.0, we stopped showing prices for child lines in a combo on the cashier side; the same logic was followed here for the receipt.
- The price per unit for a combo isn't necessary to appear when the quantity of the combo is 1.