### PR TITLE
[IMP] mail: add domain to force activity assignment to internal users only.

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -50,7 +50,7 @@
                             </group>
                             <group>
                                 <field name="date_deadline" string="Due Date"/>
-                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
+                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned" domain="[('share', '=', False)]"/>
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')" required="activity_user_id != context.get('uid')"/>
                             </group>


### PR DESCRIPTION
Description:
- Added an domain on the 'activity_user_id' field in the mail_activity_schedule_views xml file. The domain blocks the assignment of activities to users who are not internal.

task-5424577

