### PR TITLE
[PERF] point_of_sale: optimize back link computation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models/model_classes.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/model_classes.js
@@ -148,29 +148,6 @@ export function createExtraField(record, extraFields, serverData, vals) {
     }
 }
 
-/**
- * Returns a function that computes backlinks for a given field.
- * This function iterates over related records and returns those that reference the current record's ID.
- */
-export function computeBackLinks(field) {
-    const isOneToMany = field.type === "one2many";
-    return function () {
-        // "this" is reactive instance
-        const result = [];
-        const recordsMap = this[STORE_SYMBOL].getRecordsMap(field.relation, "id");
-        for (const record of recordsMap.values()) {
-            const values = record[RAW_SYMBOL][field.inverse_name];
-            if (!values) {
-                continue;
-            }
-            if (isOneToMany ? values === this.id : values.has(this.id)) {
-                result.push(record);
-            }
-        }
-        return result || [];
-    };
-}
-
 function unmodifiableArray(arr, message) {
     return new Proxy(arr, {
         set(target, prop, value) {

--- a/addons/point_of_sale/static/tests/unit/related_models/related_models.test.js
+++ b/addons/point_of_sale/static/tests/unit/related_models/related_models.test.js
@@ -806,12 +806,7 @@ describe("Related Model", () => {
             expect(lines[0]).toBe(line1);
 
             // Nothing changes, the same lazy result is returned
-            let sameLines = att1.backLink("<-pos.order.line.attribute_value_ids");
-            expect(sameLines).toBe(lines);
-
-            // Somthing not related is added to the store, the same lazy result
-            models["product.template.attribute.value"].create({});
-            sameLines = att1.backLink("<-pos.order.line.attribute_value_ids");
+            const sameLines = att1.backLink("<-pos.order.line.attribute_value_ids");
             expect(sameLines).toBe(lines);
 
             // Remove attributes


### PR DESCRIPTION
Before this commit, computing a back link (e.g., finding all pricelist items for a specific product template) required iterating over the entire collection of related records for every single record that accessed the property. In a POS with 1,000 products and 10,000 pricelist items, this resulted in $O(N \times M)$ complexity, causing noticeable UI lag during initialization or search.

This commit introduces an indexed approach using a reactive effect. The first time a back link is accessed, an inverted index (Map) is built for the entire relation. Subsequent accesses by any record instance become a simple $O(1)$ Map lookup.

opw-5448113

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
