### PR TITLE
[FIX] website: fix image gallery template

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -289,6 +289,14 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
             }
         });
 
+        // TODO: Remove in master. This should be replaced with a simple
+        // `style="margin: 0 12px;"` in the snippet template, similar to
+        // the one used for building carousel items.
+        const imageGalleryCarouselEl = html.querySelector(".s_image_gallery.o_slideshow .carousel");
+        if (imageGalleryCarouselEl) {
+            imageGalleryCarouselEl.style.margin = "0 12px";
+        }
+
         // TODO remove in master: fixes the selector for the "Ratio" setting in
         // cards, preventing the setting of a parent to leak onto children when
         // cards are nested.

--- a/addons/website/static/src/snippets/s_image_gallery/001.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/001.xml
@@ -4,7 +4,7 @@
         <div t-attf-id="#{id}" t-attf-class="carousel slide #{colorContrast}" t-att-data-bs-ride="ride" t-attf-data-bs-interval="#{interval}" style="margin: 0 12px;">
             <div class="carousel-inner">
                 <t t-foreach="images" t-as="image" t-key="image_index">
-                    <div t-attf-class="carousel-item #{image_index == index and 'active' or None}">
+                    <div t-attf-class="carousel-item #{image_index == index and 'active' or ''}">
                         <img t-if="!hideImage" class="img img-fluid d-block" t-att-src="image.getAttribute('src')" t-att-alt="image.alt" data-name="Image"/>
                     </div>
                 </t>
@@ -69,7 +69,7 @@
         <div t-attf-id="#{id}" class="carousel slide" t-att-data-bs-ride="ride" t-attf-data-bs-interval="#{interval}" style="margin: 0 12px;">
             <div class="carousel-inner" style="padding: 0;">
                  <t t-foreach="images" t-as="image" t-key="image_index">
-                    <div t-attf-class="carousel-item #{image_index == index and 'active' or None}">
+                    <div t-attf-class="carousel-item #{image_index == index and 'active' or ''}">
                         <img t-if="!hideImage" class="img img-fluid d-block" t-att-src="image.getAttribute('src')" t-att-alt="image.alt" data-name="Image"/>
                     </div>
                  </t>


### PR DESCRIPTION
This commit fixes a few minor issues in the new carousel items template
introduced in [1]: items having an `"undefined"` class, and a missing margin
style in the main snippet template.

[1]: https://github.com/odoo/odoo/commit/9042b1cae7b630b20e0670788b7a4ed9e4c97609

linked-task-3414281