### PR TITLE
[FIX] hr_attendance: prevent access error on Monthly Hours smart button

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -527,8 +527,11 @@ class HrAttendance(models.Model):
     def _read_group_employee_id(self, resources, domain):
         user_domain = Domain(self.env.context.get('user_domain') or Domain.TRUE)
         employee_domain = Domain('company_id', 'in', self.env.context.get('allowed_company_ids', []))
-        if not self.env.user.has_group('hr_attendance.group_hr_attendance_user'):
+        if self.env.user.has_group('hr_attendance.group_hr_attendance_officer') \
+            and not self.env.user.has_group('hr_attendance.group_hr_attendance_user'):
             employee_domain &= Domain('attendance_manager_id', '=', self.env.user.id)
+        elif not self.env.user.has_group('hr_attendance.group_hr_attendance_officer'):
+            employee_domain &= Domain('user_id', '=', self.env.user.id)  # user can only see his own attendances
         if user_domain.is_true():
             # Workaround to make it work only for list view.
             if 'gantt_start_date' in self.env.context:


### PR DESCRIPTION
Steps to reproduce:
- Log in as a user without attendance access rights
- Open the current user's employee record (public view)
- Click the "Monthly Hours" smart button

Issue:
- Public users cannot access the `attendance_manager_id` field, which was used to group records by employee in the Gantt view.

Fix:
- Add a permission check before accessing `attendance_manager_id`
- Restrict non-attendance officers to viewing only their own attendance

task-5440612

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
