### PR TITLE
[FIX] project,sale_project: hide templates filter outside of project module

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -162,7 +162,8 @@
                     <filter string="Start Date" name="start_date" date="date_start" end_month="1" end_year="1"/>
                     <filter string="End Date" name="end_date" date="date" end_month="1" end_year="1"/>
                     <separator/>
-                    <filter string="Templates" context="{'render_project_templates': True}" name="templates" domain="[('is_template', '=', True)]"/>
+                    <filter string="Templates" context="{'render_project_templates': True}" name="templates" domain="[('is_template', '=', True)]"
+                        invisible="not context.get('display_milestone_deadline')"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <separator invisible="1"/>

--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -90,13 +90,21 @@
         <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
     </record>
     <record id="project.open_view_project_all_config_group_stage" model="ir.actions.act_window">
-        <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True}</field>
+        <field name="context">{
+            'default_allow_billable': True,
+            'sale_show_partner_name': True,
+            'display_milestone_deadline': True
+        }</field>
     </record>
     <record id="project.open_view_project_all" model="ir.actions.act_window">
         <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
     </record>
     <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
-        <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True}</field>
+        <field name="context">{
+            'default_allow_billable': True,
+            'sale_show_partner_name': True,
+            'display_milestone_deadline': True
+        }</field>
     </record>
 
     <record id="project_templates_view_list" model="ir.ui.view">


### PR DESCRIPTION
**Steps to reproduce:**
 - Open the Planning app or any app where project_id field
 - Click New
 - Click on the Project field
 - Click Search More
 - Look at the search filters
 - The Templates filter is visible

**Issue:**
The Templates filter shows up when choosing a project from there, even though it is not useful there.

**Cause:**
They uses the same project search view as the main project app, so the templates filter appears everywhere.

**Fix:**
Add a condition check in filter to make invisible in other module and show only in project.


**Dev Notes (sale_project):**
The context was already used for milestone display name computation, but it was
missing in the sale_project override.

Due to this, when Project Stages were enabled, the milestone display name did
not include the deadline.

task-5255295






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
