### PR TITLE
[FIX] html_editor: arrow up/down navigation around code blocks

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
@@ -11,6 +11,7 @@ import {
     highlightPre,
 } from "../../core/syntax_highlighting/syntax_highlighting_utils";
 import { CodeToolbar } from "./code_toolbar";
+import { nodeSize } from "@html_editor/utils/position";
 
 export class EmbeddedSyntaxHighlightingComponent extends Component {
     static template = "html_editor.EmbeddedSyntaxHighlighting";
@@ -21,6 +22,7 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
         languageId: { type: String },
         onTextareaFocus: { type: Function },
         convertToParagraph: { type: Function },
+        setSelection: { type: Function },
         host: { type: Object },
     };
 
@@ -152,6 +154,27 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
                 ev.preventDefault();
                 this.props.convertToParagraph({ target: this.pre });
             }
+        } else if (ev.key === "ArrowUp" || ev.key === "ArrowDown") {
+            const { value, selectionStart, selectionEnd } = this.textarea;
+            if (selectionStart !== selectionEnd) {
+                return;
+            }
+            const isArrowUp = ev.key === "ArrowUp";
+            const isCursorAtBoundary = isArrowUp
+                ? value.slice(0, selectionStart).lastIndexOf("\n") === -1
+                : value.indexOf("\n", selectionEnd) === -1;
+            if (!isCursorAtBoundary) {
+                return;
+            }
+            ev.preventDefault();
+            this.textarea.blur();
+            const node = isArrowUp
+                ? this.props.host.previousElementSibling
+                : this.props.host.nextElementSibling;
+            this.props.setSelection({
+                anchorNode: node,
+                anchorOffset: isArrowUp ? nodeSize(node) : 0,
+            });
         }
     }
 

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -7,6 +7,8 @@ import {
     newlinesToLineBreaks,
 } from "../../core/syntax_highlighting/syntax_highlighting_utils";
 import { removeInvisibleWhitespace } from "@html_editor/utils/dom";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { closestBlock } from "@html_editor/utils/blocks";
 
 const CODE_BLOCK_CLASS = "o_syntax_highlighting";
 const CODE_BLOCK_SELECTOR = `div.${CODE_BLOCK_CLASS}`;
@@ -50,6 +52,44 @@ export class SyntaxHighlightingPlugin extends Plugin {
 
     setup() {
         this.addCodeBlocks();
+        this.addDomListener(this.editable, "keydown", (ev) => {
+            const arrowHandled = ["arrowup", "control+arrowup", "arrowdown", "control+arrowdown"];
+            if (arrowHandled.includes(getActiveHotkey(ev))) {
+                this.navigateAroundCodeBlock(ev);
+            }
+        });
+    }
+
+    navigateAroundCodeBlock(ev) {
+        const isArrowUp = ev.key === "ArrowUp";
+        const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        if (!selection.isCollapsed) {
+            return;
+        }
+        const anchorNode = selection.anchorNode;
+        const currentBlock = closestBlock(anchorNode);
+        const adjacentBlock = isArrowUp
+            ? currentBlock.previousElementSibling
+            : currentBlock.nextElementSibling;
+        if (!adjacentBlock?.matches(CODE_BLOCK_SELECTOR)) {
+            return;
+        }
+
+        const actualSelection = this.document.getSelection();
+        const preserveSelection = this.dependencies.selection.preserveSelection();
+        actualSelection.modify("extend", isArrowUp ? "backward" : "forward", "line");
+        const reachedBlock = closestBlock(actualSelection.focusNode);
+        preserveSelection.restore();
+
+        // If extending the selection reaches another block, the cursor
+        // is at the block boundary.
+        if (currentBlock !== reachedBlock) {
+            ev.preventDefault();
+            const textarea = adjacentBlock.querySelector("textarea");
+            const position = isArrowUp ? textarea.value.length : 0;
+            textarea.focus({ preventScroll: true });
+            textarea.setSelectionRange(position, position);
+        }
     }
 
     cleanForSave(root) {
@@ -128,6 +168,7 @@ export class SyntaxHighlightingPlugin extends Plugin {
                     this.dependencies.selection.setCursorStart(baseContainer);
                     this.dependencies.history.addStep();
                 },
+                setSelection: (selection) => this.dependencies.selection.setSelection(selection),
             });
             props.host.removeAttribute("data-syntax-highlighting-autofocus");
         }

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { getContent, setSelection } from "./_helpers/selection";
 import { animationFrame, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
 import { insertText, splitBlock } from "./_helpers/user_actions";
@@ -1254,4 +1254,97 @@ test("should keep textarea focused after copying code content", async () => {
 
     // Ensure focus remains on the textarea after copying
     expect(document.activeElement).toBe(textarea);
+});
+
+describe("Arrow navigation (up/down) across syntax-highlighted code blocks", () => {
+    test("ArrowUp from start of paragraph moves caret to end of previous code block", async () => {
+        await testEditorWithHighlightedContent({
+            contentBefore: "<p>before</p><pre>a<br>b</pre><p>[]<br><br>after</p>",
+            contentBeforeEdit:
+                "<p>before</p>" + highlightedPre({ value: "a\nb" }) + "<p>[]<br><br>after</p>",
+            stepFunction: async () => {
+                await pressAndWait("ArrowUp");
+            },
+            contentAfterEdit:
+                "<p>before</p>" +
+                highlightedPre({
+                    value: "a\nb",
+                    // cursor at end of code block: ("a\nb[]")
+                    textareaRange: 3,
+                }) +
+                "<p><br><br>after</p>",
+            contentAfter:
+                "<p>before</p>" +
+                `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext">a<br>b</pre>[]` +
+                "<p><br><br>after</p>",
+        });
+    });
+
+    test("ArrowDown from end of paragraph moves caret to start of next code block", async () => {
+        await testEditorWithHighlightedContent({
+            contentBefore:
+                "<p>before<br><strong>abcd<br>[]<br></strong></p><pre>a<br>b</pre><p>after</p>",
+            contentBeforeEdit:
+                "<p>before<br><strong>abcd<br>[]<br></strong></p>" +
+                highlightedPre({ value: "a\nb" }) +
+                "<p>after</p>",
+            stepFunction: async () => {
+                await pressAndWait("ArrowDown");
+            },
+            contentAfterEdit:
+                "<p>before<br><strong>abcd<br><br></strong></p>" +
+                highlightedPre({
+                    value: "a\nb",
+                    // cursor at start of code block: ("[]a\nb")
+                    textareaRange: 0,
+                }) +
+                "<p>after</p>",
+            contentAfter:
+                "<p>before<br><strong>abcd<br><br></strong></p>" +
+                `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext">a<br>b</pre>[]` +
+                "<p>after</p>",
+        });
+    });
+
+    test("ArrowUp from start of code block moves caret to end of previous paragraph", async () => {
+        await testEditorWithHighlightedContent({
+            contentBefore: "<p>before</p><pre><br><br>abcd</pre><p>after</p>",
+            contentBeforeEdit:
+                "<p>before</p>" + highlightedPre({ value: "\n\nabcd" }) + "<p>after</p>",
+            stepFunction: async () => {
+                await click("textarea");
+                const textarea = queryOne("textarea");
+                // Cursor at start of code block: "[]\n\nabcd"
+                textarea.setSelectionRange(0, 0);
+                await pressAndWait("ArrowUp");
+            },
+            contentAfterEdit:
+                "<p>before[]</p>" + highlightedPre({ value: "\n\nabcd" }) + "<p>after</p>",
+            contentAfter:
+                "<p>before[]</p>" +
+                `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext"><br><br>abcd</pre>` +
+                "<p>after</p>",
+        });
+    });
+
+    test("ArrowDown from end of code block moves caret to start of next paragraph", async () => {
+        await testEditorWithHighlightedContent({
+            contentBefore: "<p>before</p><pre>a<br>bc<br>d</pre><p>after</p>",
+            contentBeforeEdit:
+                "<p>before</p>" + highlightedPre({ value: "a\nbc\nd" }) + "<p>after</p>",
+            stepFunction: async () => {
+                await click("textarea");
+                const textarea = queryOne("textarea");
+                // Cursor at end of code block: "a\nbc\nd[]"
+                textarea.setSelectionRange(6, 6);
+                await pressAndWait("ArrowDown");
+            },
+            contentAfterEdit:
+                "<p>before</p>" + highlightedPre({ value: "a\nbc\nd" }) + "<p>[]after</p>",
+            contentAfter:
+                "<p>before</p>" +
+                `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext">a<br>bc<br>d</pre>` +
+                "<p>[]after</p>",
+        });
+    });
 });


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- When navigating with ArrowUp/ArrowDown around a code block, the caret could end up in an unexpected position.
- Arrow navigation from start or end of a paragraph did not correctly enter the adjacent code block.
- Arrow navigation from the start or end of a code block did not correctly move the caret to the previous or next sibling block.

### Desired behavior after PR is merged:

- Paragraph start + ArrowUp moves to the end of the previous code block.
- Paragraph end + ArrowDown moves to the start of the next code block.
- Code block start + ArrowUp moves to the end of the previous paragraph.
- Code block end + ArrowDown moves to the start of the next paragraph.

task-5384549

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
