### PR TITLE
[FIX] website: clear container width on template change

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -49,6 +49,7 @@ import { BuilderAction } from "@html_builder/core/builder_action";
  */
 
 export const DYNAMIC_SNIPPET = SNIPPET_SPECIFIC_END;
+export const CONTAINER_CLASSES = ["container", "container-fluid", "o_container_small"];
 
 class DynamicSnippetOptionPlugin extends Plugin {
     static id = "dynamicSnippetOption";
@@ -208,9 +209,7 @@ class DynamicSnippetOptionPlugin extends Plugin {
         if (oldTemplate) {
             const snippetContainerEl = el.querySelector(".s_dynamic_snippet_container");
             const snippetContentEl = el.querySelector(".s_dynamic_snippet_content");
-            snippetContainerEl.classList.remove(
-                ...(oldTemplate.containerClasses?.split(" ") || [])
-            );
+            snippetContainerEl.classList.remove(...CONTAINER_CLASSES);
             snippetContainerEl.classList.add(
                 ...(template.containerClasses || "container").split(" ")
             );

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
@@ -4,6 +4,7 @@ import {
     insertSnippet,
     registerWebsitePreviewTour,
     goBackToBlocks,
+    changeOption,
 } from "@website/js/tours/tour_utils";
 
 const dynamicSnippet = {
@@ -50,6 +51,20 @@ registerWebsitePreviewTour(
         {
             content: "Check That the `Template` option is visible",
             trigger: `.options-container [data-label="Template"]`,
+        },
+        // Check that the content width classes resets when the template is changed.
+        {
+            content: "Set Full-Width on the snippet",
+            ...changeOption("Dynamic Snippet", "[data-action-param='container-fluid']"),
+        },
+        ...changeOptionInPopover(
+            "Dynamic Snippet",
+            "Template",
+            "[data-action-param*='blog_post_single_circle']"
+        ),
+        {
+            content: "Check if the content width is not set as 'Full-width'",
+            trigger: ":iframe .s_dynamic_snippet_container.o_container_small:not(.container-fluid)",
         },
     ]
 );


### PR DESCRIPTION
Steps to Reproduce:
1. Drop a dynamic snippet from debug block.
2. Set the fetched elements to 1.
3. Set the content width to Thin (o_container_small).
4. Change the template of the snippet.

When changing a dynamic snippet's template, previously set container
widths (e.g., "Thin") could persist even though the option resets.

Issue:
Only template defined containerClasses were removed, leaving
manually set classes like "o_container_small" behind.

Fix:
All container classes are cleared before applying the new
template's containerClasses or falling back to "container".