### PR TITLE
[FIX] html_editor: indent only contenteditable paragraph-related blocks

### DIFF
--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -1,7 +1,12 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { splitTextNode } from "@html_editor/utils/dom";
-import { isEditorTab, isTextNode, isZWS } from "@html_editor/utils/dom_info";
+import {
+    isEditorTab,
+    isParagraphRelatedElement,
+    isTextNode,
+    isZWS,
+} from "@html_editor/utils/dom_info";
 import {
     descendants,
     getAdjacentPreviousSiblings,
@@ -105,7 +110,12 @@ export class TabulationPlugin extends Plugin {
     indentBlocks(blocks) {
         const selectionToRestore = this.dependencies.selection.getEditableSelection();
         const tab = parseHTML(this.document, tabHtml);
-        for (const block of blocks) {
+        const indentableBlocks = [...blocks].filter(
+            (block) =>
+                block.isContentEditable &&
+                (isParagraphRelatedElement(block) || block.tagName === "BLOCKQUOTE")
+        );
+        for (const block of indentableBlocks) {
             block.prepend(tab.cloneNode(true));
         }
         this.dependencies.selection.setSelection(selectionToRestore, { normalize: false });

--- a/addons/html_editor/static/tests/tabs.test.js
+++ b/addons/html_editor/static/tests/tabs.test.js
@@ -406,6 +406,32 @@ describe("insert tabulation", () => {
                 `<blockquote>${oeTab(tabInBlockquote)}f${oeTab(tabAfterFinBlockquote)}]g</blockquote>`,
         });
     });
+
+    test("should indent only contenteditable paragraph-related blocks", async () => {
+        const tabInBlockquote = TAB_WIDTH - getIndentWidth("blockquote");
+
+        await testTabulation({
+            contentBefore:
+                `<p>[xxx</p>` +
+                `<div class="o-paragraph">ab</div>` +
+                `<div contenteditable="false">cd</div>` +
+                `<h1>ef</h1>` +
+                `<blockquote>gh]</blockquote>`,
+            stepFunction: keydownTab,
+            contentAfterEdit:
+                `<p>${oeTab(TAB_WIDTH, false)}[xxx</p>` +
+                `<div class="o-paragraph">${oeTab(TAB_WIDTH, false)}ab</div>` +
+                `<div contenteditable="false">cd</div>` +
+                `<h1>${oeTab(TAB_WIDTH, false)}ef</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote, false)}gh]</blockquote>`,
+            contentAfter:
+                `<p>${oeTab(TAB_WIDTH)}[xxx</p>` +
+                `<div>${oeTab(TAB_WIDTH)}ab</div>` +
+                `<div contenteditable="false">cd</div>` +
+                `<h1>${oeTab(TAB_WIDTH)}ef</h1>` +
+                `<blockquote>${oeTab(tabInBlockquote)}gh]</blockquote>`,
+        });
+    });
 });
 
 describe("delete backward tabulation", () => {


### PR DESCRIPTION
#### Description of the issue this PR addresses:

- Tab indentation was applied to non-paragraph and non-contenteditable blocks, leading to incorrect indentation behavior when a selection contained mixed block types.

#### Desired behavior after PR is merged:

- Filter selected blocks to indent only contenteditable paragraph-related elements (h1–h6, p, pre, blockquote, and div.o-paragraph), while excluding blocks marked as contenteditable="false".

#### Steps to Reproduce:

- Open a new to-do record.
- Insert: Table, Table of Content, Banners, attachment, (18.2 - Toggle List)
- Select all editor content using Ctrl + A.
- Press the Tab key multiple times.

=> Multiple editor tab characters are inserted at unintended positions.

task-5452410

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
