### PR TITLE
[FIX] hr_work_entry: prevent overtime redistribution on bulk regenera…

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -463,6 +463,17 @@ class HrVersion(models.Model):
                         ('date', '<=', date_stop_work_entries.astimezone(tz).date()),
                         ('state', '!=', 'validated'),
                     ])
+                    if self.env.context.get('bulk'):
+                        local_start = date_start_work_entries.astimezone(tz)
+                        local_stop = date_stop_work_entries.astimezone(tz)
+                        current_date = local_start.date()
+                        end_date = local_stop.date()
+                        while current_date <= end_date:
+                            day_start = datetime.combine(current_date, datetime.min.time())
+                            day_end = datetime.combine(current_date, datetime.max.time())
+                            intervals_to_generate[day_start, day_end] |= version
+                            current_date += timedelta(days=1)
+                        continue
                     intervals_to_generate[date_start_work_entries, date_stop_work_entries] |= version
                     continue
 

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
@@ -110,7 +110,7 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
             valid_employees = self.employee_ids - self.validated_work_entry_employee_ids
             date_from = max(self.date_from, self.earliest_available_date) if self.earliest_available_date else self.date_from
             date_to = min(self.date_to, self.latest_available_date) if self.latest_available_date else self.date_to
-            valid_employees.generate_work_entries(date_from, date_to, True)
+            valid_employees.with_context(bulk=True).generate_work_entries(date_from, date_to, True)
         else:
             range_by_employee = defaultdict(list)
             slots.sort(key=lambda d: (d['employee_id'], d['date']))


### PR DESCRIPTION
When regenerating work entries in bulk over multiple days, attendance and overtime hours were redistributed across days, leading to incorrect work entries.

## Steps to reproduce:
- Create attendances with overtime for multiple consecutive days.
- Generate work entries (working fine!).
- Click on Reset->"Regenerate Work Entries” on the same period for bulk regeneration.
- Observe that attendance and overtime hours are shifted between days.

## Root cause:
Bulk regeneration was generating attendance-based work entries using a single continuous multi-day interval. Causing hours to spill across days.

## Fix:
During forced regeneration, split work entry generation into daily intervals instead of a single multi-day interval, ensuring attendance and overtime are computed independently per day.

task-[5189151](https://www.odoo.com/odoo/action-4043/5189151)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
