### PR TITLE
[FIX] point_of_sale: consider tax setting in unit price on receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.js
@@ -122,7 +122,10 @@ export class Orderline extends Component {
             !basic &&
             line.getQuantityStr() != 1 &&
             (mode === "receipt" || (line.price_type !== "original" && !line.combo_parent_id));
-        const priceUnit = `${line.currencyDisplayPriceUnit} / ${
+        const { total_included, total_excluded } = line.unitPrices;
+        const config = (this.env.services.pos ?? this.env.services.self_order).config;
+        const price = config.iface_tax_included === "total" ? total_included : total_excluded;
+        const priceUnit = `${formatCurrency(price, line.currency.id)} / ${
             line.product_id?.uom_id?.name || ""
         }`;
         return {

--- a/addons/point_of_sale/static/tests/unit/components/receipt_screen.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/receipt_screen.test.js
@@ -2,7 +2,8 @@ import { test, expect } from "@odoo/hoot";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupPosEnv, getFilledOrder } from "../utils";
 import { definePosModels } from "../data/generate_model_definitions";
-import { queryOne } from "@odoo/hoot-dom";
+import { queryFirst, queryOne } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
 import { ReceiptScreen } from "@point_of_sale/app/screens/receipt_screen/receipt_screen";
 
 definePosModels();
@@ -14,9 +15,14 @@ test("Total on receipt always incl", async () => {
     await mountWithCleanup(ReceiptScreen, {
         props: { orderUuid: order.uuid },
     });
+    let unitPrice = queryFirst(".info-list .price-per-unit");
     const total = queryOne(".pos-receipt-amount .pos-receipt-right-align");
+    expect(unitPrice.innerHTML).toBe("$&nbsp;3.45 / Units");
     expect(total.innerHTML).toBe("$&nbsp;17.85");
     order.config.iface_tax_included = "subtotal";
+    await animationFrame();
+    unitPrice = queryFirst(".info-list .price-per-unit");
+    expect(unitPrice.innerHTML).toBe("$&nbsp;3.00 / Units");
     const subtotal = queryOne(".pos-receipt-amount .pos-receipt-right-align");
     expect(subtotal.innerHTML).toBe("$&nbsp;17.85");
 });


### PR DESCRIPTION
Step To Reproduce:
- for a pos-config, select `Tax-Included Price`
- open a pos, and settle a order
- in receipt screen, notice the unit price in receipt

Observation:
- whether we have selected `Tax-Included Price` or `Tax-Excluded Price` only untaxed unit price is displayed.

Cause:
- in this commit [1], `unitDisplayPrice()` is removed, which considered  tax setting, but now `currencyDisplayPriceUnit` which depends on `total_excluded` is used.
[1] https://github.com/odoo/odoo/commit/9538698f13d5763b49b00f4c06a1a2afc0d6b39e

Fix:
- Now, we display price considering tax configuration.

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img width="250" height="300" alt="image" src="https://github.com/user-attachments/assets/f2426648-a062-4b0a-9c0c-02f57a113d23" /></td>
<td><img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/2871eeff-d0cb-4ce9-bb52-95dc831930ae" /></td>
</tr>
</table>




opw-5447258



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
