### PR TITLE
[FIX] sale{,_management}: hide update prices button when no pricelist is set

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -800,7 +800,7 @@ class SaleOrder(models.Model):
 
     @api.onchange('pricelist_id')
     def _onchange_pricelist_id_show_update_prices(self):
-        self.show_update_pricelist = bool(self.order_line)
+        self.show_update_pricelist = bool(self.order_line and self._origin.pricelist_id != self.pricelist_id)
 
     @api.onchange('prepayment_percent')
     def _onchange_prepayment_percent(self):

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -497,3 +497,22 @@ class TestSaleOrder(SaleManagementCommon):
         sale_order.action_update_prices()
 
         self.assertEqual(sale_order.order_line[1].price_unit, pricelist_2.item_ids.fixed_price)
+
+    def test_show_update_pricelist_false_on_sale_order_open(self):
+        """Ensure the update pricelist button is disabled when opening a sale order
+        with a default quotation template applied.
+        """
+        quotation_template = self.env['sale.order.template'].create({
+            'name': 'Test Quotation Template',
+            'sale_order_template_line_ids': [
+                Command.create({
+                    'product_id': self.product.id,
+                }),
+            ],
+        })
+        self.env['ir.default'].set('sale.order', 'sale_order_template_id', quotation_template.id)
+        with Form(self.env['sale.order']) as sale_order_form:
+            self.assertTrue(sale_order_form.sale_order_template_id)
+            self.assertTrue(sale_order_form.order_line)
+            self.assertFalse(sale_order_form.show_update_pricelist)
+            sale_order_form.partner_id = self.partner


### PR DESCRIPTION
**Steps to produce:**
- Install the `Sales` module.
- Enable `Pricelists` in settings and set the `default quotation template`.
- Create a new Sales Order.

**Issue:**
- The `Update Prices` button is visible even when no pricelist is set on the sales order.

**Root cause:**
- In the onchange logic (see [1]), show_update_pricelist is set to True based solely on the presence of order lines, without checking whether a pricelist is defined.

**Solution**:
- Update the condition so that button is shown only
  when sale order line is present and the current pricelist value is not
  the previous one.

[1]: https://github.com/odoo/odoo/blob/849ec71acbaea0061fd4b13888a486e4aebb6463/addons/sale/models/sale_order.py#L801-L803

Before:
<img width="1215" height="466" alt="image" src="https://github.com/user-attachments/assets/f29b1ccf-eec8-4114-b4c9-a8083947ad28" />

After:
<img width="1207" height="428" alt="image" src="https://github.com/user-attachments/assets/e358b633-d11b-413d-94c4-3837c430eac4" />


opw-5414897

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
