### PR TITLE
[FIX] mail: prevent crash when opening recipients list without partner

### DIFF
--- a/addons/mail/static/src/core/common/message_notification_popover.xml
+++ b/addons/mail/static/src/core/common/message_notification_popover.xml
@@ -6,7 +6,7 @@
             <t t-set="otherNotifications" t-value="this.props.message.notification_ids.filter((notif) => !notif._proxy.isFollowerNotification)"/>
             <t t-set="followerNotifications" t-value="this.props.message.notification_ids.filter((notif) => notif._proxy.isFollowerNotification)"/>
             <div t-foreach="otherNotifications" t-as="notification" t-key="notification.id">
-                <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id.email"/>
+                <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id?.email"/>
                 <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
                 <span t-if="notification.res_partner_id">
                     <t t-esc="props.message.getPersonaName(notification.res_partner_id)"/>
@@ -21,7 +21,7 @@
                 <span t-if="incomingEmail[1]" t-out="incomingEmail[1]" class="ps-1"/>
             </div>
             <div t-foreach="followerNotifications" t-as="notification" t-key="notification.id">
-                <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id.email"/>
+                <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id?.email"/>
                 <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
                 <span t-if="notification.res_partner_id">
                     <t t-esc="props.message.getPersonaName(notification.res_partner_id)"/>

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1221,6 +1221,26 @@ test("Notification Error", async () => {
     expect(".o-mail-MessageNotificationPopover i.fa-times.text-danger").toHaveCount(1);
 });
 
+test("click on notification icon opens recipients list when no recipient", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Someone", partner_share: true });
+    const messageId = pyEnv["mail.message"].create({
+        body: "not empty",
+        message_type: "email",
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_status: "exception",
+        notification_type: "email",
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click(".o-mail-Message-notification");
+    await contains(".o-mail-MessageNotificationPopover:text('(Exception)')");
+});
+
 test('Quick edit (edit from Composer with ArrowUp) ignores empty ("deleted") messages.', async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
Since- #233442
Steps to reproduce:
- Install VoIP
- Call a phone number without any related record
- Open VoIP
- Open the previously created call record
- Send a text message to the number by clicking on `Send SMS`
- Click on the notification icon on the message in the chatter

This caused a crash because the code tried to access the email from `res_partner_id` while no related partner was set.

This PR fixes the issue by safely handling messages without a related partner, allowing the recipients list to open without crashing.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
