### PR TITLE
[FIX] mrp_subcontracting: include subcontracting location also for qty_available

### DIFF
--- a/addons/mrp_subcontracting/models/product.py
+++ b/addons/mrp_subcontracting/models/product.py
@@ -24,3 +24,9 @@ class ProductProduct(models.Model):
         if params and params.get('subcontractor_ids'):
             return super()._prepare_sellers(params=params).filtered(lambda s: s.partner_id in params.get('subcontractor_ids'))
         return super()._prepare_sellers(params=params)
+
+    def _get_domain_locations_new(self, location_ids):
+        if not self.env.context.get('location') and not self.env.context.get('warehouse'):
+            subcontracting_locations = self.env['stock.location'].search([('is_subcontracting_location', '=', True)])
+            set(location_ids).update(subcontracting_locations.ids)
+        return super()._get_domain_locations_new(location_ids)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
It is skipped because currently only internal location as part of a warehouse are being taken into consideration.


**Current behavior before PR:**
Inconsistent behavior when trying to retrieve stock levels in reports at a certain time (product views)

**Desired behavior after PR is merged:**
Now quantity available take these locations into consideration.

Info: @wt-io-at




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
