### PR TITLE
[IMP] mail: enhance activity reschedule and user list view

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -94,6 +94,7 @@ class ResUsers(models.Model):
     employee_public_ids = fields.One2many('hr.employee.public', 'user_id', string='Related employee (public)', domain=_employee_ids_domain, readonly=True)
     employee_id = fields.Many2one('hr.employee', string="Company employee",
         compute='_compute_company_employee', search='_search_company_employee', readonly=True)
+    department_id = fields.Many2one(related='employee_id.department_id', string='Department')
 
     job_title = field_employee(fields.Char, 'job_title', user_writeable=True)
     work_phone = field_employee(fields.Char, 'work_phone', user_writeable=True)

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -93,6 +93,7 @@ class ResUsers(models.Model):
     employee_public_ids = fields.One2many('hr.employee.public', 'user_id', string='Related employee (public)', domain=_employee_ids_domain, readonly=True)
     employee_id = fields.Many2one('hr.employee', string="Company employee",
         compute='_compute_company_employee', search='_search_company_employee', readonly=True)
+    department_name = fields.Char('Department', related='employee_id.department_id.name')
 
     job_title = field_employee(fields.Char, 'job_title', user_writeable=True)
     work_phone = field_employee(fields.Char, 'work_phone', user_writeable=True)

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -276,5 +276,17 @@
                 </xpath>
             </field>
         </record>
+
+        <record id="res_users_view_list" model="ir.ui.view">
+            <field name="name">res.users.view.list.inherit.hr</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_tree"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='role']" position="after">
+                    <field name="job_title" optional="hide"/>
+                    <field name="department_id" optional="hide"/>
+                </xpath>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -270,5 +270,17 @@
                 </xpath>
             </field>
         </record>
+
+        <record id="view_users_employee_tree" model="ir.ui.view">
+            <field name="name">res.users.list.inherit</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_tree"/>
+            <field name="arch" type="xml">
+                <list position="inside">
+                    <field name="job_title" optional="hide"/>
+                    <field name="department_name" optional="hide"/>
+                </list>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -716,6 +716,10 @@ class MailActivity(models.Model):
     def action_reschedule_nextweek(self):
         self.filtered('active').date_deadline = fields.Date.context_today(self) + relativedelta(weeks=1, weekday=MO(-1))
 
+    def action_reschedule_customdate(self, date_deadline):
+        date_deadline = fields.Date.to_date(date_deadline)
+        self.filtered('active').date_deadline = date_deadline
+
     def _store_activity_fields(self, res: Store.FieldList):
         res.attr("activity_category")
         res.one("activity_type_id", ["name"])

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -714,6 +714,10 @@ class MailActivity(models.Model):
     def action_reschedule_nextweek(self):
         self.filtered('active').date_deadline = date.today() + relativedelta(weeks=1, weekday=MO(-1))
 
+    def action_reschedule_customdate(self, date_deadline):
+        date_deadline = fields.Date.to_date(date_deadline)
+        self.filtered('active').date_deadline = date_deadline
+
     @api.readonly
     def activity_format(self):
         return Store().add(self, "_store_activity_fields")

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -285,6 +285,12 @@ class MailActivityMixin(models.AbstractModel):
         my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
         my_next_activity.action_reschedule_nextweek()
 
+    # Reschedules next my activity to specified date.
+    def action_reschedule_my_next_customdate(self, date_deadline):
+        self.ensure_one()
+        my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
+        my_next_activity.action_reschedule_customdate(date_deadline)
+
     def activity_send_mail(self, template_id):
         """ Automatically send an email based on the given mail.template, given
         its ID. """

--- a/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.js
+++ b/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.js
@@ -1,6 +1,8 @@
 import { Component } from "@odoo/owl";
+import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { serializeDate } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
@@ -13,7 +15,7 @@ const { DateTime } = luxon;
 
 // Version of the widget to use on mail.activity lists
 export class MailActivityListRescheduleDropdown extends Component {
-    static components = { Dropdown, DropdownItem };
+    static components = { Dropdown, DropdownItem, DateTimeInput };
     static props = {
         ...standardWidgetProps,
     };
@@ -36,15 +38,23 @@ export class MailActivityListRescheduleDropdown extends Component {
                 displayDay: today.plus({ weeks: 1 }).startOf("week").weekdayShort,
                 actionName: "action_reschedule_nextweek",
             },
+            customDate: {
+                actionName: "action_reschedule_customdate",
+            },
         };
     }
 
-    async rescheduleActivity(click, actionName) {
+    async rescheduleActivity(click, actionName, customDate) {
+        if (this.targetDays.customDate.actionName === actionName && !customDate) {
+            return;
+        }
+
         await this.action.doActionButton({
             type: "object",
             name: actionName,
             resModel: this.props.record.resModel,
             resId: this.props.record.resId,
+            ...(customDate ? { args: JSON.stringify([serializeDate(customDate)]) } : {}),
             onClose: async () => {
                 await this.props.record.model.root.load();
                 this.props.record.model.notify();
@@ -62,6 +72,7 @@ export class MailActivityMixinListRescheduleDropdown extends MailActivityListRes
         this.targetDays.today.actionName = "action_reschedule_my_next_today";
         this.targetDays.tomorrow.actionName = "action_reschedule_my_next_tomorrow";
         this.targetDays.nextWeek.actionName = "action_reschedule_my_next_nextweek";
+        this.targetDays.customDate.actionName = "action_reschedule_my_next_customdate";
     }
 }
 

--- a/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.js
+++ b/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.js
@@ -1,6 +1,8 @@
 import { Component } from "@odoo/owl";
+import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { serializeDate } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
@@ -13,7 +15,7 @@ const { DateTime } = luxon;
 
 // Version of the widget to use on mail.activity lists
 export class MailActivityListRescheduleDropdown extends Component {
-    static components = { Dropdown, DropdownItem };
+    static components = { Dropdown, DropdownItem, DateTimeInput };
     static props = {
         ...standardWidgetProps,
     };
@@ -36,15 +38,19 @@ export class MailActivityListRescheduleDropdown extends Component {
                 displayDay: today.plus({ weeks: 1 }).startOf("week").weekdayShort,
                 actionName: "action_reschedule_nextweek",
             },
+            customDate: {
+                actionName: "action_reschedule_customdate",
+            },
         };
     }
 
-    async rescheduleActivity(click, actionName) {
+    async rescheduleActivity(click, actionName, customDate) {
         await this.action.doActionButton({
             type: "object",
             name: actionName,
             resModel: this.props.record.resModel,
             resId: this.props.record.resId,
+            ...(customDate ? { args: JSON.stringify([serializeDate(customDate)]) } : {}),
             onClose: async () => {
                 await this.props.record.model.root.load();
                 this.props.record.model.notify();
@@ -62,6 +68,7 @@ export class MailActivityMixinListRescheduleDropdown extends MailActivityListRes
         this.targetDays.today.actionName = "action_reschedule_my_next_today";
         this.targetDays.tomorrow.actionName = "action_reschedule_my_next_tomorrow";
         this.targetDays.nextWeek.actionName = "action_reschedule_my_next_nextweek";
+        this.targetDays.customDate.actionName = "action_reschedule_my_next_customdate";
     }
 }
 

--- a/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.xml
+++ b/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.xml
@@ -30,6 +30,18 @@
                         <span t-out="this.targetDays.nextWeek.displayDay" class="ms-2 text-muted"/>
                     </div>
                 </DropdownItem>
+                <DropdownItem closingMode="'none'">
+                    <div class="d-flex justify-content-between">
+                        <label for="activity_reschedule_date_picker">
+                            <i class="fa fa-calendar me-1"/>
+                        </label>
+                        <span class="ms-2 text-muted">
+                            <DateTimeInput type="'date'" id="'activity_reschedule_date_picker'" placeholder.translate="Select date"
+                                onApply="(value) => this.rescheduleActivity(false, this.targetDays.customDate.actionName, value)"
+                            />
+                        </span>
+                    </div>
+                </DropdownItem>
             </t>
         </Dropdown>
     </span>

--- a/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.xml
+++ b/addons/mail/static/src/views/web/list/mail_activity_list_reschedule.xml
@@ -30,6 +30,18 @@
                         <span t-out="this.targetDays.nextWeek.displayDay" class="ms-2 text-muted"/>
                     </div>
                 </DropdownItem>
+                <DropdownItem closingMode="'none'">
+                    <div class="d-flex justify-content-between">
+                        <label for="activity_reschedule_date_picker">
+                            <i class="fa fa-calendar me-1"/>
+                        </label>
+                        <span class="ms-2 text-muted">
+                            <DateTimeInput type="'date'" id="'activity_reschedule_date_picker'" placeholder.translate="Select date"
+                                onApply="(value) => (value &amp;&amp; this.rescheduleActivity(false, targetDays.customDate.actionName, value))"
+                            />
+                        </span>
+                    </div>
+                </DropdownItem>
             </t>
         </Dropdown>
     </span>


### PR DESCRIPTION
Purpose
=======
- The reschedule action is limited to predefined dates. Also, add the
  possibility to choose a custom date.
- Improve employee identification in users list views, especially in
  organizations where multiple employees may share the same name.

Specification
===============
- Add support for rescheduling an activity on custom dates.
- Add the `department_id` and `job_title` fields to the users
  list view to help distinguish employees with identical names.

Task-5424205
