### PR TITLE
[FIX] account_payment: default values for qr payment link

### DIFF
--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -177,9 +177,5 @@ class AccountMove(models.Model):
         self.ensure_one()
         payment_link_wizard = self.env['payment.link.wizard'].with_context(
             active_id=self.id, active_model=self._name
-        ).create({
-            'amount': self.amount_residual,
-            'res_model': self._name,
-            'res_id': self.id,
-        })
+        ).create({})
         return payment_link_wizard.link


### PR DESCRIPTION
The link from QR code in invoice pdf was explicitly passing `amount`, `res_model`, `res_id` to create `payment.link.wizard` using create method which overrides default_get() of wizard. As a result, installment-based invoices were generating payment links for the full residual amount.
Also the `active_id` and `active_model` is passed in context which writes to `res_model` and `res_id` so no need to add it in create again.

By letting default_get() populate the wizard values, the payment link now correctly reflects the next payable installment.

task-5401335

