### PR TITLE
[FIX] html_editor: fix removeAllColor traceback

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -227,8 +227,8 @@ export class ColorPlugin extends Plugin {
         if (selection.isCollapsed) {
             let zws;
             if (
-                selection.anchorNode.nodeType !== Node.TEXT_NODE &&
-                selection.anchorNode.textContent !== "\u200b"
+                selection.anchorNode.nodeType === Node.TEXT_NODE &&
+                selection.anchorNode.textContent === "\u200b"
             ) {
                 zws = selection.anchorNode;
             } else {

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -713,6 +713,33 @@ test("should remove backgroundColor from selected cells using removeFormat (2)",
     });
 });
 
+test("should remove text color from empty element", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">[]\u200B</font></p>',
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfterEdit: `<p placeholder='Type "/" for commands' class="o-we-hint">[]\u200b</p>`,
+    });
+});
+
+test("should remove text color from empty element in a single selected cell", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+            <table class="table table-bordered o_table o_selected_table"><tbody>
+                <tr><td class="o_selected_td"><p><font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">[]\u200B</font></p></td></tr>
+                <tr><td><p><br></p></td></tr>
+            </tbody></table>
+        `),
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfterEdit: unformat(`
+            <table class="table table-bordered o_table o_selected_table"><tbody>
+                <tr><td class="o_selected_td"><p placeholder='Type "/" for commands' class="o-we-hint">[]\u200b</p></td></tr>
+                <tr><td><p><br></p></td></tr>
+            </tbody></table>
+        `),
+    });
+});
+
 test("should remove all formats when having multiple formats", async () => {
     await testEditor({
         contentBefore:


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- Create a m x n table
- Write some text in a cell, apply color on text
- Delete text and keep empty colored element
- Select cell
- Trying to remove format throws infinite loop error in removeAllColor

**Desired behavior after PR is merged:**

Clicking on remove format button should remove color from empty colored element without causing traceback.

task-5454993




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
