### PR TITLE
[FIX] html_editor*: prevent removing unremovable on pasting in iframe

### DIFF
--- a/addons/html_editor/static/src/@types/plugins.d.ts
+++ b/addons/html_editor/static/src/@types/plugins.d.ts
@@ -8,7 +8,7 @@ declare module "plugins" {
     import { content_editable_providers, content_not_editable_providers, contenteditable_to_remove_selector, valid_contenteditable_predicates } from "@html_editor/core/content_editable_plugin";
     import { before_delete_handlers, delete_backward_line_overrides, delete_backward_overrides, delete_backward_word_overrides, delete_forward_line_overrides, delete_forward_overrides, delete_forward_word_overrides, delete_handlers, delete_range_overrides, DeleteShared, functional_empty_node_predicates, is_empty_predicates, removable_descendants_providers, system_node_selectors, unremovable_node_predicates } from "@html_editor/core/delete_plugin";
     import { DialogShared } from "@html_editor/core/dialog_plugin";
-    import { after_insert_handlers, before_insert_processors, DomShared, node_to_insert_processors, system_attributes, system_classes, system_style_properties } from "@html_editor/core/dom_plugin";
+    import { after_insert_handlers, before_insert_processors, DomShared, node_to_insert_processors, system_attributes, system_classes, system_style_properties, are_inlines_allowed_at_root_predicates } from "@html_editor/core/dom_plugin";
     import { format_class_predicates, format_selection_handlers, FormatShared, has_format_predicates } from "@html_editor/core/format_plugin";
     import { attribute_change_handlers, attribute_change_processors, before_add_step_handlers, before_filter_mutation_record_handlers, content_updated_handlers, external_step_added_handlers, handleNewRecords, history_cleaned_handlers, history_reset_from_steps_handlers, history_reset_handlers, history_step_processors, HistoryShared, post_redo_handlers, post_undo_handlers, restore_savepoint_handlers, savable_mutation_record_predicates, serializable_descendants_processors, set_attribute_overrides, step_added_handlers, unreversible_step_predicates } from "@html_editor/core/history_plugin";
     import { beforeinput_handlers, input_handlers } from "@html_editor/core/input_plugin";
@@ -212,6 +212,7 @@ declare module "plugins" {
         unreversible_step_predicates: unreversible_step_predicates;
         unsplittable_node_predicates: unsplittable_node_predicates;
         valid_contenteditable_predicates: valid_contenteditable_predicates;
+        are_inlines_allowed_at_root_predicates: are_inlines_allowed_at_root_predicates;
 
         // Processors
         attribute_change_processors: attribute_change_processors;

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -75,6 +75,8 @@ function getConnectedParents(nodes) {
  * @typedef {((container: Element, block: Element) => container)[]} before_insert_processors
  * @typedef {((arg: { nodeToInsert: Node, container: HTMLElement }) => nodeToInsert)[]} node_to_insert_processors
  *
+ * @typedef {((el: HTMLElement) => Promise<boolean>)[]} are_inlines_allowed_at_root_predicates
+ *
  * @typedef {string[]} system_attributes
  * @typedef {string[]} system_classes
  * @typedef {string[]} system_style_properties
@@ -425,7 +427,7 @@ export class DomPlugin extends Plugin {
         let insertedNodesParents = getConnectedParents(allInsertedNodes);
         for (const parent of insertedNodesParents) {
             if (
-                !this.config.allowInlineAtRoot &&
+                !this.areInlinesAllowedAtRoot(parent) &&
                 this.isEditionBoundary(parent) &&
                 allowsParagraphRelatedElements(parent)
             ) {
@@ -512,6 +514,16 @@ export class DomPlugin extends Plugin {
             return true;
         }
         return isContentEditableAncestor(node);
+    }
+
+    areInlinesAllowedAtRoot(node) {
+        const results = this.getResource("are_inlines_allowed_at_root_predicates")
+            .map((p) => p(node))
+            .filter((r) => r !== undefined);
+        if (!results.length) {
+            return this.config.allowInlineAtRoot;
+        }
+        return results.every((r) => r);
     }
 
     /**

--- a/addons/website/static/src/builder/plugins/options/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header_option_plugin.js
@@ -75,7 +75,7 @@ export class HeaderScrollEffectOption extends BaseOptionComponent {
     static editableOnly = false;
 }
 
-class HeaderOptionPlugin extends Plugin {
+export class HeaderOptionPlugin extends Plugin {
     static id = "headerOption";
     static dependencies = ["customizeWebsite"];
 
@@ -95,6 +95,11 @@ class HeaderOptionPlugin extends Plugin {
             SetShadowModeHeaderAction,
             SetShadowHeaderAction,
         },
+        // we consider the container of Contact Us allows inline element at root
+        // to avoid wrapping the button in a <p> or <div>, which would remove
+        // this button if it's empty
+        are_inlines_allowed_at_root_predicates: (node) =>
+            node.matches("#o_main_nav .oe_structure_solo .oe_unremovable [contenteditable='true']"),
     };
 }
 

--- a/addons/website/static/tests/builder/website_builder/header_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/header_option.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { pasteText } from "@html_editor/../tests/_helpers/user_actions";
+import { setupEditor } from "@html_editor/../tests/_helpers/editor";
+import { getContent } from "@html_editor/../tests/_helpers/selection";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { HeaderOptionPlugin } from "@website/builder/plugins/options/header_option_plugin";
+import { Plugin } from "@html_editor/plugin";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { cleanLinkArtifacts } from "@html_editor/../tests/_helpers/format";
+
+defineMailModels();
+class FakeCustomizeWebsitePlugin extends Plugin {
+    static id = "customizeWebsite";
+}
+
+describe("Navbar Contact Us button", () => {
+    test("should keep the unremovable Contact Us button on paste", async () => {
+        const { el, editor } = await setupEditor(
+            `<div id="o_main_nav">
+                <div class="oe_structure oe_structure_solo o_editable">
+                    <section class="oe_unremovable" contenteditable="false">
+                        <div contenteditable="true">
+                            a[a<a class="btn btn-primary oe_unremovable" href="/contactus">Contact Us</a>a]a
+                        </div>
+                    </section>
+                </div>
+            </div>`,
+            {
+                props: { iframe: true },
+                config: {
+                    Plugins: [...MAIN_PLUGINS, FakeCustomizeWebsitePlugin, HeaderOptionPlugin],
+                },
+            }
+        );
+        pasteText(editor, "should keep unremovable");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            `<div id="o_main_nav">
+                <div class="oe_structure oe_structure_solo o_editable">
+                    <section class="oe_unremovable" contenteditable="false">
+                        <div contenteditable="true">
+                            ashould keep unremovable<a class="btn btn-primary oe_unremovable" href="/contactus"></a>[]a
+                        </div>
+                    </section>
+                </div>
+            </div>`
+        );
+    });
+});


### PR DESCRIPTION
*: website

Before this commit: when a editable container is wrapped inside a
non-contenteditable, which could happen inside an iframe, pasting on a
selection including an unremovable element will remove the element. This
is because the config parameter `allowInlineAtRoot` is false by default,
the editable container of Contact us button is considered as the edition
boundary, and then `wrapInlinesInBlocks` is called on it at insert,
which removes invisible nodes in the wrapping process.

After this commit: we now use predicates to decide areInlinesAllowedAtRoot
We add a predicate specifically for the container of Contact Us button,
to allow inline element in the root. The `wrapInlinesInBlocks` won't be
called on the container on paste anymore.

task-5109662



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
