### PR TITLE
[FIX] html_editor: traceback on undo

### DIFF
--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -22,7 +22,7 @@ export class SelectionPlaceholderPlugin extends Plugin {
     static dependencies = ["baseContainer", "history", "selection"];
     resources = {
         external_history_step_handlers: this.updatePlaceholders.bind(this),
-        normalize_handlers: this.updatePlaceholders.bind(this),
+        normalize_handlers: withSequence(100, this.updatePlaceholders.bind(this)),
         step_added_handlers: this.updatePlaceholders.bind(this),
         selectionchange_handlers: (selectionData) => this.onSelectionChange(selectionData),
         clean_for_save_handlers: withSequence(0, ({ root }) => {
@@ -37,7 +37,11 @@ export class SelectionPlaceholderPlugin extends Plugin {
             }
         },
         selection_blocker_predicates: (blocker) => {
-            if ((blocker.nodeType === Node.ELEMENT_NODE && blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE)) || !isBlock(blocker)) {
+            if (
+                (blocker.nodeType === Node.ELEMENT_NODE &&
+                    blocker.hasAttribute(PLACEHOLDER_ATTRIBUTE)) ||
+                !isBlock(blocker)
+            ) {
                 return false;
             } else if (isNotEditableNode(blocker)) {
                 return true;

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, expect, test } from "@odoo/hoot";
-import { getContent } from "./_helpers/selection";
+import { getContent, setSelection } from "./_helpers/selection";
 import { animationFrame, click, press, queryOne, waitFor } from "@odoo/hoot-dom";
 import { insertText, splitBlock } from "./_helpers/user_actions";
 import {
@@ -182,6 +182,31 @@ test("inserting a code block in an empty paragraph with a style placeholder acti
             <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
         contentAfter: `<p><br></p><pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext"><br></pre>[]`,
+    });
+});
+
+test("inserting text and undo after an empty code block activates the syntax highlighting plugin with an empty textarea", async () => {
+    await testEditorWithHighlightedContent({
+        contentBefore: "<p><br>[]</p>",
+        stepFunction: async (editor) => {
+            await insertPre(editor);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                '<p data-selection-placeholder=""><br></p>' +
+                    highlightedPre({ value: "", textareaRange: 0 }) +
+                    '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+                editor
+            );
+            const p = document.querySelector("p");
+            setSelection({ anchorNode: p, anchorOffset: 0 });
+            await insertText(editor, "a");
+            await pressAndWait(["ctrl", "z"]);
+        },
+        contentAfterEdit:
+            `<p data-selection-placeholder="" class="o-horizontal-caret o-we-hint" o-we-hint-text='Type "/" for commands'>[]<br></p>` +
+            highlightedPre({ value: "" }) +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+        contentAfter: `[]<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext"><br></pre>`,
     });
 });
 


### PR DESCRIPTION
Current behavior before PR:

- Inserting a /code block, then adding text above it and performing an undo would trigger a traceback.

Desired behavior after PR is merged:

- Undo now correctly removes the inserted character without causing any traceback.

task-5445873
