### PR TITLE
[IMP] mail: add domain to force activity assignment to internal users only.

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -147,7 +147,7 @@
                         <group>
                             <field name="date_deadline"/>
                         </group>
-                        <field name="user_id" widget="many2one_avatar_user"/>
+                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
                     </group>
                     <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..." widget="html_mail" />
                     <footer>

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -49,7 +49,7 @@
                             </group>
                             <group>
                                 <field name="date_deadline" string="Due Date"/>
-                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
+                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned" domain="[('share', '=', False)]"/>
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')" required="activity_user_id != context.get('uid')"/>
                             </group>


### PR DESCRIPTION
Problem:
Currently, portal users can be assigned to activities. This is invalid behavior
as portal users do not have the necessary permissions to access or manage 
activities, leading to dead-end assignments.

Solution:
Implemented UI-level filtering to restrict activity assignment to internal
users only. A model-level constraint was avoided to prevent potential side
effects on existing data and automated background processes.

task-5424577