### PR TITLE
[REV] account: revert invoice PDF download doesn't return proforma

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6549,9 +6549,6 @@ class AccountMove(models.Model):
         This is necessary to avoid the re-generation of the PDF through the action_report.
         Indeed, once a legal PDF is generated, it should be used and not re-generated.
         """
-        report = self.env['ir.actions.report'].search([('report_name', '=', 'account.report_invoice_with_payments'), ('binding_model_id', '!=', False)], limit=1)
-        if report:
-            return []
         return [{
             'key': 'download_pdf',
             'description': _('PDF'),

--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -3,7 +3,7 @@
     <data>
         <!-- QWeb Reports -->
         <record id="account_invoices" model="ir.actions.report">
-            <field name="name">PDF</field>
+            <field name="name">Invoice PDF</field>
             <field name="model">account.move</field>
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice_with_payments</field>
@@ -11,8 +11,7 @@
             <field name="is_invoice_report">True</field>
             <field name="print_report_name">(object._get_report_base_filename())</field>
             <field name="attachment"/>
-            <field name="binding_model_id" ref="model_account_move"/>
-            <field name="binding_type">report</field>
+            <field name="binding_model_id" eval="False"/>  <!-- removes the action from the Print menu (forced False value for update) -->
             <field name="groups_id" eval="[(4, ref('account.group_account_invoice')),
  (4, ref('account.group_account_readonly'))]"/>
         </record>


### PR DESCRIPTION
This reverts commit a1251a8adc0c0f6639f653e414784f37326f82a1

The previous behavior as been confirm to be expected
The change caused some issue where the PDF option wasn't displayed anymore

opw-5111272