### PR TITLE
[FIX] sale: use tax name in order web preview

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -595,7 +595,7 @@
                                             </strong>
                                         </td>
                                         <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
-                                            <span t-out="', '.join(map(lambda x: (x.description or x.name), line.tax_id))"/>
+                                            <span t-out="', '.join(map(lambda x: (x.name), line.tax_id))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>


### PR DESCRIPTION
Currently, the `Tax name` configured on taxes is not applied in 
the web preview of orders.

**Steps to reproduce:**
- Install the `sale_management` module.
- Go to Invoicing > Configuration > Accounting > Taxes.
- Create a new tax, `Tax Type: Sale`and set `Description`.
- Create a new quotation and apply this tax to a product.
- Click Preview > observe the `Taxes` value.

**Observation:**
- Web preview incorrectly displays `description` instead of `tax name`.

**Root Cause:**
At [1], the sale portal web preview template uses `description or name`, 
which causes an incorrect tax description to be displayed in the preview.

**Fix:**
This commit ensures that `Tax Name` is used when rendering taxes 
in the portal preview for Reantal, Sales, and Subscriptions apps.
This aligns with the behavior in the next versions.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/106830

[1]:
https://github.com/odoo/odoo/blob/849ec71acbaea0061fd4b13888a486e4aebb6463/addons/sale/views/sale_portal_templates.xml#L598

opw-5411496