### PR TITLE
[FIX] sale_project: fix missing milestone display name context

### DIFF
--- a/addons/sale_project/views/project_views.xml
+++ b/addons/sale_project/views/project_views.xml
@@ -79,12 +79,20 @@
         <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
     </record>
     <record id="project.open_view_project_all_config_group_stage" model="ir.actions.act_window">
-        <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True}</field>
+        <field name="context">{
+            'default_allow_billable': True,
+            'sale_show_partner_name': True,
+            'display_milestone_deadline': True,
+        }</field>
     </record>
     <record id="project.open_view_project_all" model="ir.actions.act_window">
         <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True, 'display_milestone_deadline': True}</field>
     </record>
     <record id="project.open_view_project_all_group_stage" model="ir.actions.act_window">
-        <field name="context">{'default_allow_billable': True, 'sale_show_partner_name': True}</field>
+        <field name="context">{
+            'default_allow_billable': True,
+            'sale_show_partner_name': True,
+            'display_milestone_deadline': True,
+        }</field>
     </record>
 </odoo>


### PR DESCRIPTION
**Steps to Reproduce:**
- Install the Sale Project module.
- Navigate to the Project module.
- Enable Project Stages.
- Go to the Project list view.
- Observe that the Next Milestone does not display the deadline along with the milestone name.

**Issue:**
The milestone display name is incomplete and does not include the deadline date.

**Cause:**
The context overridden in sale project did not pass the required context, cause the display_name computation did not add deadline to the display name.

**Fix:**
Passed the appropriate context in the action context to ensure the display name is correctly computed and displayed with its deadline.

Task: 5255295






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
