### PR TITLE
[IMP] project_mrp: allow quick access to linked project on MO form

### DIFF
--- a/addons/project_mrp/models/mrp_production.py
+++ b/addons/project_mrp/models/mrp_production.py
@@ -18,3 +18,12 @@ class MrpProduction(models.Model):
         action = super().action_generate_bom()
         action['context']['default_project_id'] = self.project_id.id
         return action
+
+    def action_open_project(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'project.project',
+            'view_mode': 'form',
+            'res_id': self.project_id.id,
+        }

--- a/addons/project_mrp/views/mrp_production_views.xml
+++ b/addons/project_mrp/views/mrp_production_views.xml
@@ -16,6 +16,14 @@
         <field name="model">mrp.production</field>
         <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
         <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <button name="action_open_project" type="object" class="oe_stat_button" icon="fa-puzzle-piece"
+                    invisible="not project_id" groups="project.group_project_user">
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">Project</span>
+                    </div>
+                </button>
+            </div>
             <field name="bom_id" position="attributes">
                 <attribute name="context">{
                     'default_product_tmpl_id': product_tmpl_id,


### PR DESCRIPTION
When a MO is linked to a project and a user wants to check it, they have to find it in the miscellaneous section of the form, which is easy to miss and makes it harder for users to quickly navigate to the related project compared to other documents (for example, sales orders) where related records are directly accessible through a smart button. This change adds a 
`Project smart button` on the manufacturing order form when a project is set, allowing users with access to the Project app to open the related project directly from the MO.

TaskID-5438411