### PR TITLE
[IMP] mail: allow regenerating invite link from invite people popover

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -4,6 +4,7 @@ import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { Component, onWillStart, useState } from "@odoo/owl";
 
 import { useSequential } from "@mail/utils/common/hooks";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
@@ -138,6 +139,21 @@ export class ChannelInvitation extends Component {
     onInput() {
         this.searchStr = this.inputRef.el.value;
         this.debouncedFetchPartnersToInvite();
+    }
+
+    onClickGenerateNewLink() {
+        this.env.services.dialog.add(ConfirmationDialog, {
+            title: _t("Warning"),
+            body: _t(
+                "You're about to create a new invite link. The current link will no longer grant guests access to the channel. Do you want to proceed?"
+            ),
+            cancel: () => {},
+            confirmLabel: _t("Generate"),
+            confirm: () =>
+                this.orm.call("discuss.channel", "action_reset_invitation_uuid", [
+                    [this.props.channel.id],
+                ]),
+        });
     }
 
     onClickSelectablePartner(partner) {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -63,6 +63,14 @@
                     <button class="btn btn-primary px-2 o-py-0_5" t-on-click="onClickCopy">
                         <i class="fa fa-copy"/>
                     </button>
+                    <button
+                        t-if= "['owner', 'admin'].includes(props.channel.self_member_id?.channel_role)"
+                        class="btn btn-secondary px-2 o-py-0_5"
+                        t-on-click="onClickGenerateNewLink"
+                        title="Generate new invite link"
+                    >
+                        <i class="fa fa-refresh"/>
+                    </button>
                 </div>
                 <div t-if="props.channel?.accessRestrictedToGroupText" class="mt-2 text-muted smaller mx-1" t-esc="props.channel.accessRestrictedToGroupText"/>
             </div>

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from markupsafe import Markup
 
 from odoo import Command, fields
+from odoo.addons.base.models.avatar_mixin import get_random_ui_color_from_seed
 from odoo.addons.bus.models.bus import json_dump
 from odoo.addons.mail.models.discuss.discuss_channel import channel_avatar, group_avatar
 from odoo.addons.mail.tests.common import mail_new_test_user
@@ -633,15 +634,13 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     def test_channel_should_generate_correct_default_avatar(self):
         test_channel = self.env['discuss.channel']._create_channel(name='Channel', group_id=self.env.ref('base.group_user').id)
-        test_channel.uuid = 'channel-uuid'
         private_group = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
-        private_group.uuid = 'group-uuid'
-        bgcolor_channel = html_escape('#F48935')  # depends on uuid
-        bgcolor_group = html_escape('#EA6175')  # depends on uuid
-        expceted_avatar_channel = (channel_avatar.replace('fill="#875a7b"', f'fill="{bgcolor_channel}"')).encode()
+        bgcolor_channel = html_escape(get_random_ui_color_from_seed(str(test_channel.id)))
+        bgcolor_group = html_escape(get_random_ui_color_from_seed(str(private_group.id)))
+        expected_avatar_channel = (channel_avatar.replace('fill="#875a7b"', f'fill="{bgcolor_channel}"')).encode()
         expected_avatar_group = (group_avatar.replace('fill="#875a7b"', f'fill="{bgcolor_group}"')).encode()
 
-        self.assertEqual(base64.b64decode(test_channel.avatar_128), expceted_avatar_channel)
+        self.assertEqual(base64.b64decode(test_channel.avatar_128), expected_avatar_channel)
         self.assertEqual(base64.b64decode(private_group.avatar_128), expected_avatar_group)
 
         test_channel.image_128 = base64.b64encode(("<svg/>").encode())

--- a/addons/mail/tests/discuss/test_discuss_channel_invite.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_invite.py
@@ -196,3 +196,17 @@ class TestDiscussChannelInvite(HttpCase, MailCommon):
             group_chat.invite_by_email(["alfred@test.com"])
         last_message = group_chat._get_last_messages()
         self.assertEqual(last_message.message_type, "user_notification")
+
+    def test_07_invite_link_rotation_revokes_old_access(self):
+        public_channel = self.env["discuss.channel"].create(
+            {"name": "Rotation Test Channel", "group_public_id": False},
+        )
+        old_url = public_channel.invitation_url
+        response = self.url_open(old_url)
+        self.assertEqual(response.status_code, 200)
+        public_channel.action_reset_invitation_uuid()
+        new_url = public_channel.invitation_url
+        response = self.url_open(old_url)
+        self.assertEqual(response.status_code, 404)
+        response = self.url_open(new_url)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
Currently, channel owners and discuss administrators cannot regenerate an
existing invite link directly from the Invite People popover. If an invite
link is accidentally shared or needs to be invalidated, there is no clear
way to reset it from the UI, which limits control over guest access.

**Current behavior before PR:**
----------------------------------------------
- Invite links are generated once and remain valid indefinitely
- No UI action exists to regenerate or invalidate an existing invite link
- Channel owners must rely on indirect or manual workarounds

**Desired behavior after PR is merged:**
----------------------------------------------
- Channel owners and discuss administrators can generate a new invite link
- Regenerating the link invalidates the previous one
- A confirmation dialog prevents accidental link resets
- The updated invite link is immediately reflected in the UI

Task-4758265

----------------------------------------------

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
