### PR TITLE
[FIX] l10n_sa_edi: Partner address data cleared by related contacts

### DIFF
--- a/addons/l10n_sa_edi/data/res_country_data.xml
+++ b/addons/l10n_sa_edi/data/res_country_data.xml
@@ -10,23 +10,23 @@
                     <field name="parent_id" invisible="1"/>
                     <field name="type" invisible="1"/>
                     <field name="street" placeholder="Street..." class="o_address_street"
-                           readonly="type == 'contact' and parent_id"/>
+                           readonly="type == 'contact' and parent_id" force_save="1"/>
                     <field name="street2" placeholder="District..." class="o_address_street"
-                            readonly="type == 'contact' and parent_id"/>
+                            readonly="type == 'contact' and parent_id" force_save="1"/>
                     <field name="city" placeholder="City" class="o_address_city"
-                           readonly="type == 'contact' and parent_id"/>
+                           readonly="type == 'contact' and parent_id" force_save="1"/>
                     <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}'
-                           readonly="type == 'contact' and parent_id"/>
+                           readonly="type == 'contact' and parent_id" force_save="1"/>
                     <field name="zip" placeholder="ZIP" class="o_address_zip"
-                           readonly="type == 'contact' and parent_id"/>
+                           readonly="type == 'contact' and parent_id" force_save="1"/>
                     <field name="country_id" placeholder="Country" class="o_address_country" options='{"no_open": True, "no_create": True}'
-                           readonly="type == 'contact' and parent_id"/>
+                           readonly="type == 'contact' and parent_id" force_save="1"/>
                     <field name="l10n_sa_edi_building_number" placeholder="Building Number" invisible="country_code != 'SA'"
                            class="o_address_building_number" options='{"no_open": True, "no_create": True}'
-                           readonly="type == 'contact' and parent_id"/>
+                           readonly="type == 'contact' and parent_id" force_save="1"/>
                     <field name="l10n_sa_edi_plot_identification" placeholder="Plot Identification" invisible="country_code != 'SA'"
                            class="o_address_plot_identification" options='{"no_open": True, "no_create": True}'
-                           readonly="type == 'contact' and parent_id"/>
+                           readonly="type == 'contact' and parent_id" force_save="1"/>
                 </div>
             </form>
         </field>


### PR DESCRIPTION
All Saudi partners use the saudi_o_address_format. As a result, contacts created from a company partner also inherit this address format, which includes fields such as street, city, zip, and state. These fields are set as read-only by the address format. When child_ids are written on the parent partner, those read-only fields are written with False values. Due to the address field synchronization between parent and related contacts, these False values are then propagated back to the parent partner, causing its address data to be cleared. This fix prevents address fields from being unintentionally reset when related contacts are created or updated.

task-5349050
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
