### PR TITLE
[FIX] mail: prevent crash when joining a call from mobile using invitation link

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -220,7 +220,7 @@ export class Store extends BaseStore {
 
     standaloneInboxMessages = fields.Many("mail.message", {
         compute() {
-            const messages = this.store.inbox.messages.filter((m) => !m.thread);
+            const messages = (this.store.inbox?.messages ?? []).filter((m) => !m.thread);
             return messages.sort(
                 (m1, m2) => compareDatetime(m2.datetime, m1.datetime) || m2.id - m1.id
             );


### PR DESCRIPTION
**Steps to Reproduce:**
- Log in with User A.
- Start a meeting.
- Send the invitation link to User B.
- Log in as User B/Guest and join the call from a mobile device.

Before this PR, joining the call from the public invitation page on mobile 
could crash due to accessing undefined inbox messages.

This PR fixes the issue by safely handling the messages access, 
ensuring the UI no longer crashes in this scenario.

task-[5428778](https://www.odoo.com/odoo/project/1519/tasks/5428778)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
