### PR TITLE
[FIX] point_of_sale:  fix margin in pos order report

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -89,7 +89,7 @@ class ReportPosOrder(models.Model):
                 s.pricelist_id,
                 s.session_id,
                 s.account_move IS NOT NULL AS invoiced,
-                l.price_subtotal - COALESCE(l.total_cost,0) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS margin,
+                (l.price_subtotal * CASE WHEN s.is_refund THEN -1 ELSE 1 END) - COALESCE(l.total_cost,0) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS margin,
                 pm.payment_method_id AS payment_method_id,
                 fpc.id AS pos_categ_id
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1686,6 +1686,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         current_session.post_closing_cash_details(total_cash_payment)
         current_session.close_session_from_ui()
         self.assertEqual(current_session.state, 'closed')
+        report_refund_order, report_order = self.env['report.pos.order'].sudo().search([('order_id', 'in', current_session.order_ids.ids)])
+        self.assertEqual(report_order.margin, 20.0)
+        self.assertEqual(report_refund_order.margin, -20.0)
 
     def test_product_combo_price(self):
         """ Check that the combo has the expected price """


### PR DESCRIPTION
Step To Reproduce:
- have a product with cost price
- settle a order in pos with that product and refund it
- go to reporting > orders > pivot view
- check margin for that refund order

Observation:
- the margin is calculated wrong, as we do not consider order sign
- as `margin = price_subtotal - total_cost`
- so with price_subtotal `200` and total_cost `-100` margin becomes 300

Fix:
- consider order sign i.e. -ve for refund order else +ve for `price_subtotal`
- so with price_subtotal `-200` and total_cost `-100` margin becomes -100

**Before**
<img width="317" alt="image" src="https://github.com/user-attachments/assets/9e23bc1c-363a-44dd-83c0-da478d9c73d0" />

**After:**
<img width="343"  alt="image" src="https://github.com/user-attachments/assets/56027cb4-a6c2-4b73-8db8-393e5af0b057" />



Note: for this to be applied, app update is needed

opw-5418964


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
