### PR TITLE
[FIX] html_editor: prevent splitting links when formatting

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -339,6 +339,17 @@ export class FormatPlugin extends Plugin {
                     this.getResource("format_class_predicates").some((cb) => cb(className))
                 );
 
+            // Special case: if the parent node is unsplittable and fully selected,
+            // we should make sure the span is applied outside of it.
+            if (
+                parentNode &&
+                !isBlock(parentNode) &&
+                this.dependencies.split.isUnsplittable(parentNode) &&
+                this.dependencies.selection.areNodeContentsFullySelected(parentNode)
+            ) {
+                inlineAncestors.push(parentNode);
+            }
+
             while (
                 parentNode &&
                 !isBlock(parentNode) &&

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -8,7 +8,7 @@ import {
     isVisible,
 } from "../utils/dom_info";
 import { prepareUpdate } from "../utils/dom_state";
-import { childNodes, closestElement, firstLeaf, lastLeaf } from "../utils/dom_traversal";
+import { childNodes, closestElement, firstLeaf, lastLeaf, findUpTo } from "../utils/dom_traversal";
 import { DIRECTIONS, childNodeIndex, nodeSize } from "../utils/position";
 import { isProtected, isProtecting } from "@html_editor/utils/dom_info";
 
@@ -131,8 +131,12 @@ export class SplitPlugin extends Plugin {
      * @returns {[HTMLElement|undefined, HTMLElement|undefined]}
      */
     splitElementBlock({ targetNode, targetOffset, blockToSplit }) {
-        // If the block is unsplittable, insert a line break instead.
-        if (this.isUnsplittable(blockToSplit)) {
+        // If the block is unsplittable or the targetNode is within an
+        // unsplittable element, insert a line break instead.
+        if (
+            this.isUnsplittable(blockToSplit) ||
+            findUpTo(targetNode, blockToSplit, (el) => this.isUnsplittable(el))
+        ) {
             // @todo: t-if, t-else etc are not blocks, but they are
             // unsplittable.  The check must be done from the targetNode up to
             // the block for unsplittables. There are apparently no tests for

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -5,7 +5,6 @@ import {
     hasAnyNodesColor,
     hasColor,
     TEXT_CLASSES_REGEX,
-    hasTextColorClass,
 } from "@html_editor/utils/color";
 import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import {
@@ -349,11 +348,7 @@ export class ColorPlugin extends Plugin {
                         node,
                         '[style*="color"]:not(li), [style*="background-color"]:not(li), [style*="background-image"]:not(li)'
                     ) ||
-                    closestElement(node, "span") ||
-                    closestElement(
-                        node,
-                        (node) => node.nodeName !== "LI" && hasTextColorClass(node, mode)
-                    );
+                    closestElement(node, "span");
 
                 const faNodes = font?.querySelectorAll(".fa");
                 if (faNodes && Array.from(faNodes).some((faNode) => faNode.contains(node))) {
@@ -372,10 +367,7 @@ export class ColorPlugin extends Plugin {
                 if (
                     font &&
                     font.nodeName !== "T" &&
-                    (font.nodeName !== "SPAN" ||
-                        font.style[mode] ||
-                        font.style.backgroundImage ||
-                        hasTextColorClass(font, mode)) &&
+                    (font.nodeName !== "SPAN" || font.style[mode] || font.style.backgroundImage) &&
                     (isColorGradient(color) ||
                         color === "" ||
                         !hasInlineGradient ||

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -272,6 +272,11 @@ export class LinkPlugin extends Plugin {
         ],
         legit_empty_link_predicates: (linkEl) => linkEl.hasAttribute("data-mimetype"),
         unsplittable_node_predicates: (node) => node.nodeName === "A",
+        // When the selection fully covers a link, we consider that the link is selected.
+        fully_selected_node_predicates: (node, selection) =>
+            node.nodeName === "A" &&
+            !node.classList.contains("btn") &&
+            cleanZWChars(selection.textContent()) === cleanZWChars(node.innerText),
 
         /** Handlers */
         beforeinput_handlers: withSequence(5, this.onBeforeInput.bind(this)),

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -271,6 +271,7 @@ export class LinkPlugin extends Plugin {
             ":has(>[data-oe-model])",
         ],
         legit_empty_link_predicates: (linkEl) => linkEl.hasAttribute("data-mimetype"),
+        unsplittable_node_predicates: (node) => node.nodeName === "A",
 
         /** Handlers */
         beforeinput_handlers: withSequence(5, this.onBeforeInput.bind(this)),

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -121,8 +121,10 @@ export function hasTextColorClass(element, mode) {
 export function hasColor(element, mode) {
     const style = element.style;
     const parent = element.parentNode;
-    if (element.classList.contains("btn")) {
-        // Ignore style applied on buttons from color detection
+    // Ignore class applied on links as those are hard coded in the templates
+    // and should not be considered as user defined colors.
+    if (element.classList.contains("btn") || element.tagName === "A") {
+        // Ignore style applied on buttons from color detection.
         return false;
     }
     if (isColorGradient(style["background-image"])) {

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -971,31 +971,29 @@ test("should remove remove color from `td`", async () => {
     });
 });
 
-test("should be able to remove color applied by 'text-*' classes (1)", async () => {
-    await testEditor({
-        contentBefore: '<p><span class="text-muted">[a]</span></p>',
-        stepFunction: setColor("", "color"),
-        contentAfter: "<p>[a]</p>",
-    });
-});
-
-test("should be able to remove color applied by 'text-*' classes (2)", async () => {
+test("should not remove template coded style on a link", async () => {
     await testEditor({
         contentBefore: '<p><a href="#" class="text-muted">[a]</a></p>',
-        contentBeforeEdit:
-            '<p>\ufeff<a href="#" class="text-muted o_link_in_selection">\ufeff[a]\ufeff</a>\ufeff</p>',
         stepFunction: setColor("", "color"),
-        contentAfterEdit:
-            '<p>\ufeff<a href="#" class="o_link_in_selection">\ufeff[a]\ufeff</a>\ufeff</p>',
-        contentAfter: '<p><a href="#">[a]</a></p>',
+        contentAfter: '<p><a href="#" class="text-muted">[a]</a></p>',
     });
 });
 
-test("should be able to remove color from block element", async () => {
+test("should be able to add style on a link with template coded style", async () => {
     await testEditor({
-        contentBefore: '<p><a href="#" class="nav-link text-muted">[a]</a></p>',
+        contentBefore: '<p><a href="#" class="text-muted">[a]</a></p>',
+        stepFunction: setColor("text-o-color-1", "color"),
+        contentAfter:
+            '<p><a href="#" class="text-muted"><font class="text-o-color-1">[a]</font></a></p>',
+    });
+});
+
+test("should be able to remove editor-added style on a link with template coded style", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><a href="#" class="text-muted"><font class="text-o-color-1">[a]</font></a></p>',
         stepFunction: setColor("", "color"),
-        contentAfter: '<p><a href="#" class="nav-link">[a]</a></p>',
+        contentAfter: '<p><a href="#" class="text-muted">[a]</a></p>',
     });
 });
 

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -887,6 +887,13 @@ test("should not split unsplittable element when applying color (2)", async () =
             '<div style="color: rgb(255, 0, 0);"><p>t<font style="color: rgb(0, 0, 255);">[es]</font>t</p></div>',
     });
 });
+test("should not split unsplittable element when applying color (3)", async () => {
+    await testEditor({
+        contentBefore: '<p><a href="#">[a]bc</a></p>',
+        stepFunction: setColor("rgb(0, 0, 255)", "color"),
+        contentAfter: '<p><a href="#"><font style="color: rgb(0, 0, 255);">[a]</font>bc</a></p>',
+    });
+});
 
 test("should be able to apply color on icon along with text", async () => {
     await testEditor({

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -586,14 +586,21 @@ describe("Selection collapsed", () => {
                 contentAfter: '<p>ab</p><p><a href="http://test.test/">[]cd</a></p>',
             });
         });
-        test("should insert a paragraph break in the middle of an anchor", async () => {
+        test("should insert a paragraph break in the middle of an inline node", async () => {
+            await testEditor({
+                contentBefore: "<p><strong>a[]b</strong></p>",
+                stepFunction: splitBlockA,
+                contentAfterEdit: "<p><strong>a</strong></p><p><strong>[]b</strong></p>",
+                contentAfter: "<p><strong>a</strong></p><p><strong>[]b</strong></p>",
+            });
+        });
+        test("should insert a <br> in the middle of an unsplittable anchor", async () => {
             await testEditor({
                 contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
                 stepFunction: splitBlockA,
                 contentAfterEdit:
-                    '<p>\ufeff<a href="http://test.test/">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
-                contentAfter:
-                    '<p><a href="http://test.test/">a</a></p><p><a href="http://test.test/">[]b</a></p>',
+                    '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeffa<br>[]b\ufeff</a>\ufeff</p>',
+                contentAfter: '<p><a href="http://test.test/">a<br>[]b</a></p>',
             });
         });
         test("should insert a paragraph break outside the ending edge of an anchor (1)", async () => {


### PR DESCRIPTION
Before this commit: when formatting partially a link, the link is split
at the selection and formatted. This causes duplicated links.

After this commit: we consider links are unsplittable, thus formatting
on links will wrap the selected part in a <font> tag.


commit 2: 
[FIX] html_editor: solve infinite loop of links with color class
Before this commit: we have a fix https://github.com/odoo/odoo/commit/96bc421d30f34a8bfc10dde93c2f283809a8a3e3
which to be able to remove the style classes in the link element

After this commit: We don't consider the style class in the link element
as `hasColor`, because the style classes come from the template code,
which is hard-coded xml. Removing them, the user won't be able to add it
back. For example, on a product page, edit the `Terms and conditions`
link, do nothing and save, the muted color is forced removed.

Note that another fix https://github.com/odoo/odoo/commit/f5fc55f19f89041c8391ff81b127ffce0898f89f is also
removed cause it was a fix for https://github.com/odoo/odoo/commit/96bc421d30f34a8bfc10dde93c2f283809a8a3e3.
The tests belonging to https://github.com/odoo/odoo/commit/96bc421d30f34a8bfc10dde93c2f283809a8a3e3 are
adapted, and those of https://github.com/odoo/odoo/commit/f5fc55f19f89041c8391ff81b127ffce0898f89f are kept
as future safeguards of list coloring.


commit 3:
[FIX] html_editor: extra check on targetnode when splitting blocks
Before this commit: we only check if the current block to be split is
splittable, but not the target node.

After this commit: if the current block is splittable but the current
target node is not, we won't split the block but insert a <br>


commit 4:
[FIX] html_editor: properly fill inlineAncestors when formatting
Before this commit: when the parent node of the current node is
unsplittable, the `inlineAncestors` stays empty.

After this commit: we handle this case and push the parent node in the
list when the parent node is fully selected. We also add a fully
selected predicate in link_plugin for the case when the selection
includes all the content (except for zws) of a non-button link


task-5244810


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
