### PR TITLE
[IMP] account: add default payment term configuration

### DIFF
--- a/addons/account/data/account_data.xml
+++ b/addons/account/data/account_data.xml
@@ -104,6 +104,13 @@
                 Command.create({'value': 'percent', 'value_amount': 100.0, 'delay_type': 'days_end_of_month_on_the','nb_days': 90, 'days_next_month': 10})]"/>
         </record>
 
+        <!-- Set default payment term for invoices to 'Immediate Payment' -->
+        <function
+            model="ir.default"
+            name="set"
+            eval="('account.move', 'invoice_payment_term_id', obj().env.ref('account.account_payment_term_immediate').id, False, False, 'move_type=out_invoice')"
+        />
+
         <!-- Account-related subtypes for messaging / Chatter -->
         <record id="mt_invoice_validated" model="mail.message.subtype">
             <field name="name">Validated</field>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_CO_10_line_extension_amount_sum_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_CO_10_line_extension_amount_sum_lines.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">210.67</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_S_08_tax_subtotal_taxable_amount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_S_08_tax_subtotal_taxable_amount.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">42.53</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_allowance_charge_custom_tax_recycling_contribution.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_allowance_charge_custom_tax_recycling_contribution.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">84.42</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_allowance_charge_fixed_tax_recycling_contribution.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_allowance_charge_fixed_tax_recycling_contribution.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">105.42</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_cash_rounding_add_invoice_line.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_cash_rounding_add_invoice_line.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">218.40</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_cash_rounding_biggest_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_cash_rounding_biggest_tax.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">218.41</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">105.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">105.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_item_description_name.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_item_description_name.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_manual_tax_amount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_manual_tax_amount.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">108.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_multiple_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_multiple_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">25.20</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_negative_discount_upsell.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_negative_discount_upsell.xml
@@ -104,7 +104,10 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
-    <cac:TaxTotal>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
+  <cac:TaxTotal>
     <cbc:TaxAmount currencyID="EUR">12.23</cbc:TaxAmount>
     <cac:TaxSubtotal>
       <cbc:TaxableAmount currencyID="EUR">58.23</cbc:TaxableAmount>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_negative_price_unit.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_negative_price_unit.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">18.90</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_payee_financial_account.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_payee_financial_account.xml
@@ -106,6 +106,9 @@
 			</cac:FinancialInstitutionBranch>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">180.49</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes_plus_free_product.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes_plus_free_product.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">12.58</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_price_unit_more_decimals.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_price_unit_more_decimals.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">959.07</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_send_and_print_additional_documents.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_send_and_print_additional_documents.xml
@@ -109,6 +109,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">218.40</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_sent_to_luxembourg_dig.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_sent_to_luxembourg_dig.xml
@@ -101,6 +101,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_sent_to_partner_with_gln.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_sent_to_partner_with_gln.xml
@@ -104,6 +104,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">21.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_currency_code_tax_totals_foreign_currency.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_currency_code_tax_totals_foreign_currency.xml
@@ -104,6 +104,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="RON">436.80</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_exempt.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_exempt.xml
@@ -103,6 +103,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_reverse_charge.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_reverse_charge.xml
@@ -104,6 +104,9 @@
 			<cbc:ID>BE15001559627230</cbc:ID>
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:TaxTotal>
 		<cbc:TaxAmount currencyID="EUR">210.00</cbc:TaxAmount>
 		<cac:TaxSubtotal>

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -383,7 +383,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
                 'move_type': 'out_invoice',
                 'currency_id': currency.id,
                 'invoice_date': fields.Date.from_string('2023-08-01'),
-                'invoice_date_due': fields.Date.from_string('2023-08-31'),
+                'invoice_date_due': fields.Date.from_string('2023-08-01'),  # Due to default payment term
                 'ref': 'INV/2023/00005',
                 'narration': '<p>Terms and conditions.</p>',
             },
@@ -395,7 +395,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
                 'move_type': 'out_invoice',
                 'currency_id': currency.id,
                 'invoice_date': fields.Date.from_string('2023-07-01'),
-                'invoice_date_due': fields.Date.from_string('2023-07-31'),
+                'invoice_date_due': fields.Date.from_string('2023-07-01'),  # Due to default payment term
                 'ref': 'INV/2023/00006',
                 'narration': '<p>Legal References.</p>',
             },

--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
@@ -55,7 +55,7 @@
                     <currencyCode>EUR</currencyCode>
                     <exchangeRate>380.770000</exchangeRate>
                     <paymentMethod>TRANSFER</paymentMethod>
-                    <paymentDate>2024-02-01</paymentDate>
+                    <paymentDate>2024-01-31</paymentDate>
                     <cashAccountingIndicator>false</cashAccountingIndicator>
                     <invoiceAppearance>PAPER</invoiceAppearance>
                 </invoiceDetail>

--- a/addons/l10n_it_edi/tests/export_xmls/prezzio_unitario_converted_company_currency.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/prezzio_unitario_converted_company_currency.xml
@@ -96,7 +96,7 @@
             <CondizioniPagamento>TP02</CondizioniPagamento>
             <DettaglioPagamento>
                 <ModalitaPagamento>MP05</ModalitaPagamento>
-                <DataScadenzaPagamento>2025-03-07</DataScadenzaPagamento>
+                <DataScadenzaPagamento>2025-02-24</DataScadenzaPagamento>
                 <ImportoPagamento>122.00</ImportoPagamento>
                 <IstitutoFinanziario>BIG BANK</IstitutoFinanziario>
                 <BIC>BIGGBANQ</BIC>

--- a/addons/l10n_jo_edi/tests/test_files/type_1.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_1.xml
@@ -67,6 +67,9 @@
 			</cac:PartyIdentification>
 		</cac:Party>
 	</cac:SellerSupplierParty>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
 		<cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_jo_edi/tests/test_files/type_3.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_3.xml
@@ -67,6 +67,9 @@
 			</cac:PartyIdentification>
 		</cac:Party>
 	</cac:SellerSupplierParty>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
 		<cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_jo_edi/tests/test_files/type_5.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_5.xml
@@ -66,6 +66,9 @@
 			</cac:PartyIdentification>
 		</cac:Party>
 	</cac:SellerSupplierParty>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
 		<cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_jo_edi/tests/test_files/type_7.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_7.xml
@@ -66,6 +66,9 @@
             </cac:PartyIdentification>
         </cac:Party>
     </cac:SellerSupplierParty>
+    <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
     <cac:AllowanceCharge>
         <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
         <cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_jo_edi/tests/test_files/type_8.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_8.xml
@@ -64,6 +64,9 @@
             </cac:PartyIdentification>
         </cac:Party>
     </cac:SellerSupplierParty>
+    <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
     <cac:AllowanceCharge>
         <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
         <cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_sa_edi/tests/common.py
+++ b/addons/l10n_sa_edi/tests/common.py
@@ -276,6 +276,7 @@ class TestSaEdiCommon(AccountEdiTestCommon):
             'company_id': (company_id or self.company).id,
             'partner_id': partner_id.id,
             'invoice_date': invoice_date,
+            'invoice_payment_term_id': False,  # Need to set False in order to use the invoice due date
             'invoice_date_due': invoice_date_due,
             'currency_id': (currency_id or self.company.currency_id).id,
             'invoice_line_ids': [

--- a/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/downpayment_invoice.xml
@@ -162,10 +162,13 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode listID="UN/ECE 4461">1</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2022-09-22</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2022-09-05</cbc:PaymentDueDate>
     <cbc:InstructionID>INV/2022/00001</cbc:InstructionID>
     <cbc:PaymentID>INV/2022/00001</cbc:PaymentID>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="SAR">15.00</cbc:TaxAmount>
     <cac:TaxSubtotal>

--- a/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
+++ b/addons/l10n_sa_edi/tests/test_files/final_invoice.xml
@@ -162,10 +162,13 @@
   </cac:Delivery>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode listID="UN/ECE 4461">1</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2022-09-22</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2022-09-05</cbc:PaymentDueDate>
     <cbc:InstructionID>INV/2022/00001</cbc:InstructionID>
     <cbc:PaymentID>INV/2022/00001</cbc:PaymentID>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="SAR">150.00</cbc:TaxAmount>
     <cac:TaxSubtotal>

--- a/addons/l10n_tr_nilvera_edispatch/tests/test_files/invoice_with_edispatches.xml
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_files/invoice_with_edispatches.xml
@@ -84,11 +84,14 @@
     </cac:AccountingCustomerParty>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-        <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+        <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
         <cac:PayeeFinancialAccount>
             <cbc:ID>TR0123456789</cbc:ID>
         </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
+    <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
     <cac:AllowanceCharge>
         <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
         <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml
@@ -87,11 +87,14 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_earchive.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_earchive.xml
@@ -91,11 +91,14 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_einvoice.xml
@@ -87,11 +87,14 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_tax_exempt_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_tax_exempt_einvoice.xml
@@ -87,11 +87,14 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_withholding_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_withholding_einvoice.xml
@@ -87,11 +87,14 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
@@ -94,11 +94,14 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
@@ -90,11 +90,14 @@
   </cac:AccountingCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_earchive.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_earchive.xml
@@ -113,11 +113,14 @@
   </cac:BuyerCustomerParty>
   <cac:PaymentMeans>
     <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
     <cac:PayeeFinancialAccount>
       <cbc:ID>TR0123456789</cbc:ID>
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
+  <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_ipac_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_ipac_einvoice.xml
@@ -87,11 +87,14 @@
     </cac:AccountingCustomerParty>
     <cac:PaymentMeans>
         <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-        <cbc:PaymentDueDate>2026-01-20</cbc:PaymentDueDate>
+        <cbc:PaymentDueDate>2025-03-03</cbc:PaymentDueDate>
         <cac:PayeeFinancialAccount>
             <cbc:ID>TR0123456789</cbc:ID>
         </cac:PayeeFinancialAccount>
     </cac:PaymentMeans>
+    <cac:PaymentTerms>
+		<cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+	</cac:PaymentTerms>
     <cac:AllowanceCharge>
         <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
         <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -119,7 +119,7 @@ class TestUBLTR(TestUBLTRCommon):
         self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))
 
     def test_xml_invoice_export_ipac_einvoice(self):
-        with freeze_time('2026-01-20'):
+        with freeze_time('2025-03-03'):
             generated_xml = self._generate_invoice_xml(
                 self.einvoice_partner,
                 l10n_tr_exemption_code_id=self.reason_702.id,

--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -25,6 +25,7 @@ This module contains all the common features of Sales Management and eCommerce.
 
         'data/analytic_plan_data.xml',
         'data/ir_cron.xml',
+        'data/ir_default.xml',
         'data/ir_sequence_data.xml',
         'data/mail_message_subtype_data.xml',
         'data/mail_template_data.xml',

--- a/addons/sale/data/ir_default.xml
+++ b/addons/sale/data/ir_default.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Set default payment term for sale orders to 'Immediate Payment' -->
+        <function
+            model="ir.default"
+            name="set"
+            eval="('sale.order', 'payment_term_id', obj().env.ref('account.account_payment_term_immediate').id)"
+        />
+    </data>
+</odoo>

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -614,6 +614,10 @@ class TestCheckoutAddress(WebsiteSaleCommon):
             self.assertTrue(so.payment_term_id, "A payment term should still be set on the sale order")
 
             so.website_id = False
+            # Temporarily set `False` to default payment term too
+            default_term_id = self.env['ir.default']._get(model_name='sale.order', field_name='payment_term_id')
+            if default_term_id:
+                self.env['ir.default'].set(model_name='sale.order', field_name='payment_term_id', value=False)
             so._compute_payment_term_id()
             self.assertFalse(so.payment_term_id, "The website default payment term should not be set on a sale order not coming from the website")
 


### PR DESCRIPTION
Currently, when creating a sales order or an invoice, the payment term (or due date) defaults to immediate payment.

In practice, most companies use the same payment term for the majority of their documents. This improvement introduces a default payment term at the company level, allowing it to be automatically applied on sales orders and invoices.

This avoids having to manually change the payment term each time or define it explicitly on every partner.

Task-5387239
see https://github.com/odoo/enterprise/pull/103168

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
