### PR TITLE
[FIX] mail: add hover effect on discuss call layout action

### DIFF
--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -75,6 +75,7 @@
         'o-text-white border-0 o-simulateDarkTheme': store.shouldSimulateDarkTheme(this),
         'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and !action.tags.includes('CALL_LAYOUT'),
         'bg-transparent': store.shouldSimulateDarkTheme(this) and action.tags.includes('CALL_LAYOUT'),
+        'opacity-75 opacity-100-hover': action.tags.includes('CALL_LAYOUT'),
     })"/>
     <t t-set="attrs" t-value="{ 'aria-label': action.name, 'disabled': action.disabledCondition, 'name': action.id, 'data-sequence': action.sequence, 'data-sequence-group': action.sequenceGroup, 'data-sequence-quick': action.sequenceQuick }"/>
     <t t-if="action.component and action.componentCondition" t-component="action.component" t-props="action.componentProps"/>


### PR DESCRIPTION
Before this commit, when in a discuss call, the buttons "Picture-in-picture" and "Fullscreen" in the bottom right had no mouse hover effect. As these buttons are visually just icons, the lack of hover effect makes it hard to tell which button is hovered thus making the click harder than it should.

This commit reduces slightly the opacity of items, so that on mouse hover the opacity is removed. This acts as a small hover effect that makes it easier to click on these buttons reliably.

![Jan-02-2026 13-23-42](https://github.com/user-attachments/assets/87f04158-d425-4ed8-abc9-93eb3af587ef)
