### PR TITLE
[FIX] html_editor: hide Clear content for empty rows and columns

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -4,6 +4,8 @@ import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
+import { isEmpty } from "@html_editor/utils/dom_info";
+import { getBaseContainerSelector } from "@html_editor/utils/base_container";
 
 export class TableMenu extends Component {
     static template = "html_editor.TableMenu";
@@ -83,6 +85,24 @@ export class TableMenu extends Component {
         );
     }
 
+    get hasContent() {
+        const baseContainerSelector = getBaseContainerSelector();
+        const cell = this.props.target;
+        const table = closestElement(cell, "table");
+        const targetCells =
+            this.props.type === "row"
+                ? [...cell.parentElement.children]
+                : [...table.rows].map((row) => row.cells[getColumnIndex(cell)]);
+        return targetCells.some((td) => {
+            const { children } = td;
+            return !(
+                children.length === 1 &&
+                children[0].matches(baseContainerSelector) &&
+                isEmpty(children[0])
+            );
+        });
+    }
+
     onSelected(item) {
         item.action(this.props.target);
         this.props.overlay.close();
@@ -159,7 +179,7 @@ export class TableMenu extends Component {
                 text: _t("Reset table size"),
                 action: (target) => this.props.resetTableSize(target.closest("table")),
             },
-            {
+            this.hasContent && {
                 name: "clear_content",
                 icon: "fa-times-circle",
                 text: _t("Clear content"),
@@ -238,7 +258,7 @@ export class TableMenu extends Component {
                 text: _t("Reset table size"),
                 action: (target) => this.props.resetTableSize(target.closest("table")),
             },
-            {
+            this.hasContent && {
                 name: "clear_content",
                 icon: "fa-times-circle",
                 text: _t("Clear content"),

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -74,15 +74,10 @@ export class TableMenu extends Component {
         return rowHasHeight || cellHasWidth;
     }
 
-    get hasCustomRowHeight() {
-        return !!this.props.target.closest("tr").style.height;
-    }
-
-    get hasCustomColumnWidth() {
-        return (
-            !!this.props.target.closest("td")?.style?.width ||
-            !!this.props.target.closest("th")?.style?.width
-        );
+    get hasCustomSize() {
+        return this.props.type === "row"
+            ? !!this.props.target.parentElement.style?.height
+            : !!this.props.target.style?.width;
     }
 
     get hasContent() {
@@ -167,7 +162,7 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: this.props.removeColumn.bind(this),
             },
-            this.hasCustomColumnWidth && {
+            this.hasCustomSize && {
                 name: "reset_column_size",
                 icon: "fa-table",
                 text: _t("Reset column size"),
@@ -246,7 +241,7 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: (target) => this.props.removeRow(target.parentElement),
             },
-            this.hasCustomRowHeight && {
+            this.hasCustomSize && {
                 name: "reset_row_size",
                 icon: "fa-table",
                 text: _t("Reset row size"),

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -7,6 +7,7 @@
                 class="o-we-table-menu oi"
                 t-attf-class="oi-ellipsis-{{ props.type === 'column' ? 'h w-100' : 'v h-100 px-0' }}"
                 title="Click to open options&#10;Drag to move"
+                t-on-pointerdown.prevent="() => {}"
             />
             <t t-set-slot="content">
                 <div t-on-pointerdown.stop="() => {}">

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -369,6 +369,64 @@ test("open/close table menu", async () => {
     expect(".dropdown-menu").toHaveCount(0);
 });
 
+test("clear content is hidden in row menu when row has no content", async () => {
+    const { el } = await setupEditor(`
+        <table>
+            <tbody>
+                <tr>
+                    <td class="a"><p>[]<br></p></td>
+                    <td class="b"><p><br></p></td>
+                </tr>
+                <tr>
+                    <td class="c"><p><br></p></td>
+                    <td class="d"><p><br></p></td>
+                </tr>
+            </tbody>
+        </table>`);
+
+    await hover(el.querySelector("td.a"));
+    await expectElementCount("[data-type='row'].o-we-table-menu", 1);
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        "make_header",
+        "move_down",
+        "insert_above",
+        "insert_below",
+        "toggle_alternating_rows",
+        "delete",
+        // no clear content
+    ]);
+});
+
+test("clear content is hidden in column menu when column has no content", async () => {
+    const { el } = await setupEditor(`
+        <table>
+            <tbody>
+                <tr>
+                    <td class="a"><p>[]<br></p></td>
+                    <td class="b"><p><br></p></td>
+                </tr>
+                <tr>
+                    <td class="c"><p><br></p></td>
+                    <td class="d"><p><br></p></td>
+                </tr>
+            </tbody>
+        </table>`);
+
+    await hover(el.querySelector("td.a"));
+    await expectElementCount("[data-type='row'].o-we-table-menu", 1);
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu");
+    expect(availableCommands(queryOne(".dropdown-menu"))).toEqual([
+        "move_right",
+        "insert_left",
+        "insert_right",
+        "delete",
+        // no clear content
+    ]);
+});
+
 test("basic delete column operation", async () => {
     const { el, editor } = await setupEditor(
         unformat(`


### PR DESCRIPTION
### Purpose of this PR:

- The table menu was showing the `Clear content` option even when the selected row or column contained only empty cells. Since clearing in this case does not change the table content, the option is now hidden for both row and column menus when there is nothing to clear.
- `this.props.target` is always a `td/th` element. For row actions,the custom size can be detected directly on the parent `tr`, & for column actions width can be checked on the cell itself. This removes need for `closest()` calls and simplifies the size detection logic.

task-5454945

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
