### PR TITLE
[IMP] mail: add a dropdown to the `activity_type_id` field

### DIFF
--- a/addons/mail/static/src/views/fields/badge_selection_icons/activity_badge_selection_icons.js
+++ b/addons/mail/static/src/views/fields/badge_selection_icons/activity_badge_selection_icons.js
@@ -1,0 +1,79 @@
+import { useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { SIZES } from "@web/core/ui/ui_service";
+import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+import { getFieldDomain } from "@web/model/relational_model/utils";
+import { useSpecialData } from "@web/views/fields/relational_utils";
+import {
+    BadgeSelectionWithIconsField,
+    badgeSelectionWithIconsField,
+} from "./badge_selection_icons_field";
+
+export class ActivityTypeBadgeIconsField extends BadgeSelectionWithIconsField {
+    static template = "mail.ActivityTypeBadgeIconsField";
+
+    setup() {
+        super.setup();
+        this.ui = useState(useService("ui"));
+        this.specialData = useSpecialData(async (orm, props) => {
+            const model = this.env.model.action.currentController?.props?.resModel;
+
+            const user_activity_domain = [
+                ["create_uid", "=", user.userId],
+            ];
+
+            if (model) {
+                user_activity_domain.push(
+                    "|",
+                    ["res_model", "=", model],
+                    ["res_model", "=", false]
+                );
+            } else {
+                user_activity_domain.push(["res_model", "=", false]);
+            }
+
+            const grouped = await orm.call("mail.activity", "web_read_group", [], {
+                domain: user_activity_domain,
+                groupby: ["activity_type_id"],
+                order: "__count desc",
+                context: { active_test: false },
+            });
+
+            const domain = getFieldDomain(props.record, props.name, props.domain);
+            const { relation } = props.record.fields[props.name];
+
+            const ret = await orm.call(relation, "search_read", [], {
+                domain,
+                fields: ["id", "name", props.relatedIconField],
+            });
+
+            const orderMap = new Map(grouped.groups.map((g, i) => [g.activity_type_id?.[0], i]));
+            ret.sort((a, b) => (orderMap.get(a.id) ?? Infinity) - (orderMap.get(b.id) ?? Infinity));
+
+            return ret.map((opt) => {
+                const iconValue = opt[props.relatedIconField] || props.defaultIcon;
+                return [opt.id, opt.name, iconValue];
+            });
+        });
+    }
+
+    get visibleOptionCount() {
+        return this.ui.size >= SIZES.XL ? 6 : 2;
+    }
+
+    get visibleOptions() {
+        return this.options.slice(0, this.visibleOptionCount);
+    }
+
+    get overflowOptions() {
+        return this.options.slice(this.visibleOptionCount);
+    }
+}
+
+export const activityTypeBadgeIconsField = {
+    ...badgeSelectionWithIconsField,
+    component: ActivityTypeBadgeIconsField,
+};
+
+registry.category("fields").add("activity_type_badge_icons", activityTypeBadgeIconsField);

--- a/addons/mail/static/src/views/fields/badge_selection_icons/activity_badge_selection_icons.xml
+++ b/addons/mail/static/src/views/fields/badge_selection_icons/activity_badge_selection_icons.xml
@@ -1,0 +1,27 @@
+<templates>
+
+    <div t-name="mail.ActivityTypeBadgeIconsField" t-inherit="mail.BadgeSelectionIconsField" t-inherit-mode="primary">
+        <xpath expr="//t[@t-foreach='options']" position="attributes">
+            <attribute name="t-foreach">visibleOptions</attribute>
+        </xpath>
+
+        <xpath expr="//div[@class='d-flex flex-wrap gap-1 mb-3']" position="inside">
+            <div class="dropdown" t-if="overflowOptions.length">
+                <button class="btn btn-secondary dropdown-toggle"
+                        data-bs-toggle="dropdown">
+                    Other
+                </button>
+                <div class="dropdown-menu">
+                    <t t-foreach="overflowOptions" t-as="option" t-key="option[0]">
+                        <button class="dropdown-item"
+                                t-on-click="() => this.onChange(option[0])">
+                            <span t-att-class="`fa ${option[2]} pe-1`"/>
+                            <span t-out="option[1]"/>
+                        </button>
+                    </t>
+                </div>
+            </div>
+        </xpath>
+    </div>
+
+</templates>

--- a/addons/mail/tests/common_activity.py
+++ b/addons/mail/tests/common_activity.py
@@ -53,6 +53,21 @@ class ActivityScheduleCase(MailCommon):
             self.activity_create_mocked = activity_create_mocked
             yield
 
+    def _expected_default_activity_type(self, res_model):
+        activity = self.env["mail.activity"].with_context(active_test=False)._read_group(
+            domain=[
+                ("create_uid", "=", self.env.user.id),
+                ("res_model", "in", [False, res_model]),
+            ],
+            groupby=["activity_type_id"],
+            aggregates=["id:count"],
+            order="__count desc, activity_type_id asc",
+            limit=1,
+        )
+        return (
+            activity[0][0] if activity else self.env["mail.activity"]._default_activity_type_for_model(res_model)
+        )
+
     def assertActivityValues(self, activity, activity_values):
         self.assertEqual(len(activity), 1)
         for fname, fvalue in activity_values.items():

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -156,7 +156,7 @@
                     </group>
 
                     <group>
-                        <field name="activity_type_id" required="1" widget="selection_badge_icons" options="{'related_icon_field': 'icon'}" nolabel="1"/>
+                        <field name="activity_type_id" required="1" widget="activity_type_badge_icons" options="{'related_icon_field': 'icon'}" nolabel="1"/>
                         <field name="summary" placeholder="e.g. Discuss Proposal" class="fs-3 pb-2"/>
                         <group>
                             <field name="date_deadline"/>
@@ -211,7 +211,7 @@
                     <field name="display_name" invisible="1"/>
                     <group>
                         <field name="activity_type_id" required="1"
-                        widget="selection_badge_icons" options="{'related_icon_field': 'icon'}" nolabel="1"/>
+                        widget="activity_type_badge_icons" options="{'related_icon_field': 'icon'}" nolabel="1"/>
                         <field name="summary" placeholder="e.g. Discuss proposal"/>
                         <group>
                             <field name="date_deadline"/>

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -257,7 +257,19 @@ class MailActivitySchedule(models.TransientModel):
             if not scheduler.activity_type_id or (
                 scheduler.activity_type_id.res_model and scheduler.res_model and scheduler.activity_type_id.res_model != scheduler.res_model
             ):
-                scheduler.activity_type_id = scheduler.env['mail.activity']._default_activity_type_for_model(scheduler.res_model)
+                activity = scheduler.env['mail.activity'].with_context(active_test=False)._read_group(
+                    domain=[
+                        ("create_uid", "=", self.env.user.id),
+                        ("res_model", "in", [False, scheduler.res_model]),
+                    ],
+                    groupby=["activity_type_id"],
+                    aggregates=["id:count"],
+                    order="__count desc, activity_type_id asc",
+                    limit=1,
+                )
+                scheduler.activity_type_id = (
+                    activity[0][0].id if activity else scheduler.env["mail.activity"]._default_activity_type_for_model(scheduler.res_model)
+                )
 
     @api.onchange('activity_type_id')
     def _onchange_activity_type_id(self):

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -23,7 +23,7 @@
                         <br/>
                         <field name="activity_type_id"
                             required="not plan_id"
-                            widget="selection_badge_icons"
+                            widget="activity_type_badge_icons"
                             options="{'related_icon_field': 'icon'}"
                             nolabel="1"/>
                         <group invisible="not plan_id">

--- a/addons/test_mail/tests/test_mail_activity_plan.py
+++ b/addons/test_mail/tests/test_mail_activity_plan.py
@@ -131,10 +131,11 @@ class TestActivitySchedule(ActivityScheduleCase):
                         form.save().action_schedule_activities()
 
                 for record in test_records:
+                    expected_type = self._expected_default_activity_type(record._name)
                     self.assertActivityCreatedOnRecord(record, {
-                        'activity_type_id': self.activity_type_todo,
+                        'activity_type_id': expected_type,
                         'automated': False,
-                        'date_deadline': self.reference_now.date() + timedelta(days=4),  # activity type delay
+                        'date_deadline': self.reference_now.date() + timedelta(days=expected_type.delay_count),  # activity type delay
                         'note': '<p>Useful link ...</p>',
                         'summary': 'Write specification',
                         'user_id': self.user_admin,
@@ -165,10 +166,11 @@ class TestActivitySchedule(ActivityScheduleCase):
                         ).action_schedule_activities()
 
                 for record in test_records:
+                    expected_type = self._expected_default_activity_type(record._name)
                     self.assertActivityCreatedOnRecord(record, {
-                        'activity_type_id': self.activity_type_call,
+                        'activity_type_id': expected_type,
                         'automated': False,
-                        'date_deadline': self.reference_now.date() + timedelta(days=1),  # activity call delay
+                        'date_deadline': self.reference_now.date() + timedelta(days=expected_type.delay_count),  # activity call delay
                         'note': False,
                         'summary': 'TodoSumCallSummary',
                         'user_id': self.user_admin,


### PR DESCRIPTION
**Purpose:**
When there are many activity types, it can be difficult to find the relevant one. Add a dropdown to group additional activity types.

**Specifications:**
- When too many activity types exist, add an “Other” button that displays them in a dropdown.
- Store the activity types used by the user so that the most relevant ones are displayed first.

Task-5430692