### PR TITLE
[FIX] stock: keep ordered quantity aligned with demand on delivery slip

### DIFF
--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -242,7 +242,7 @@ class TestMrpStockReports(TestReportsCommon):
             ],
         })
 
-        for back_order, expected_vals in [('never', [12, 12]), ('always', [24, 12])]:
+        for back_order, expected_vals in [('never', [24, 12]), ('always', [24, 12])]:
             picking_form = Form(self.env['stock.picking'])
             picking_form.picking_type_id = self.picking_type_in
             picking_form.partner_id = self.partner

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -886,13 +886,24 @@ class StockMoveLine(models.Model):
         returns: dictionary {product_id+name+description+uom: {product, name, description, quantity, uom_id}, ...}
         """
         aggregated_move_lines = {}
-
+        strict = kwargs.get('strict')
         # Loops to get backorders, backorders' backorders, and so and so...
         backorders = self.env['stock.picking']
-        pickings = self.picking_id
+        orig_picking = self.picking_id
+        if orig_picking.move_ids.move_orig_ids:
+            while orig_picking.move_ids.move_orig_ids:
+                orig_picking = orig_picking.move_ids.move_orig_ids.picking_id
+        pickings = orig_picking
         while pickings.backorder_ids:
             backorders |= pickings.backorder_ids
             pickings = pickings.backorder_ids
+        if pickings.backorder_id:
+            pickings = orig_picking
+            while pickings.backorder_id:
+                backorders |= pickings.backorder_id
+                pickings = pickings.backorder_id
+        if orig_picking:
+            backorders |= orig_picking
 
         for move_line in self:
             if kwargs.get('except_package') and move_line.result_package_id:
@@ -902,39 +913,33 @@ class StockMoveLine(models.Model):
             quantity = move_line.uom_id._compute_quantity(move_line.quantity, uom)
             packaging_quantity = move_line.uom_id._compute_quantity(quantity, move_line.move_id.packaging_uom_id)
             if line_key not in aggregated_move_lines:
-                qty_ordered = None
+                qty_ordered = 0 if strict else move_line.move_id.product_uom_qty
                 packaging_qty_ordered = None
-                if backorders and not kwargs.get('strict'):
-                    qty_ordered = move_line.move_id.product_uom_qty
+                if backorders and not strict:
+                    qty_ordered = move_line.move_id.product_uom_qty if not orig_picking else 0
                     # Filters on the aggregation key (product, description and uom) to add the
                     # quantities delayed to backorders to retrieve the original ordered qty.
                     following_move_lines = backorders.move_line_ids.filtered(
                         lambda ml: line_key.startswith(self._get_aggregated_properties(move=ml.move_id)['line_key'])
                     )
                     qty_ordered += sum(following_move_lines.move_id.mapped('product_uom_qty'))
-                    # Remove the done quantities of the other move lines of the stock move
-                    previous_move_lines = move_line.move_id.move_line_ids.filtered(
-                        lambda ml: line_key.startswith(self._get_aggregated_properties(move=ml.move_id)['line_key']) and ml.id != move_line.id
-                    )
-                    qty_ordered -= sum(m.uom_id._compute_quantity(m.quantity, uom) for m in previous_move_lines)
                     packaging_qty_ordered = move_line.uom_id._compute_quantity(qty_ordered, move_line.move_id.packaging_uom_id)
                 aggregated_move_lines[line_key] = {
                     **aggregated_properties,
                     'quantity': quantity,
                     'packaging_quantity': packaging_quantity,
-                    'qty_ordered': qty_ordered or quantity,
+                    'qty_ordered': quantity if strict else qty_ordered,
                     'packaging_qty_ordered': packaging_qty_ordered or packaging_quantity,
                     'product': move_line.product_id,
                 }
             else:
-                aggregated_move_lines[line_key]['qty_ordered'] += quantity
                 aggregated_move_lines[line_key]['packaging_qty_ordered'] += packaging_quantity
                 aggregated_move_lines[line_key]['quantity'] += quantity
                 aggregated_move_lines[line_key]['packaging_quantity'] += packaging_quantity
 
         # Does the same for empty move line to retrieve the ordered qty. for partially done moves
         # (as they are splitted when the transfer is done and empty moves don't have move lines).
-        if kwargs.get('strict'):
+        if strict:
             return aggregated_move_lines
         pickings = (self.picking_id | backorders)
         for empty_move in pickings.move_ids:
@@ -951,6 +956,11 @@ class StockMoveLine(models.Model):
 
             if not any(aggregated_key.startswith(line_key) for aggregated_key in aggregated_move_lines) and not to_bypass:
                 qty_ordered = empty_move.product_uom_qty
+                if backorders and not kwargs.get('except_package'):
+                    relevant_backorder_moves = backorders.move_ids.filtered(
+                        lambda m: m != empty_move and self._get_aggregated_properties(move=m)['line_key'] == line_key
+                    )
+                    qty_ordered += sum(relevant_backorder_moves.mapped('product_uom_qty'))
                 aggregated_move_lines[line_key] = {
                     **aggregated_properties,
                     'quantity': False,

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5707,13 +5707,13 @@ class TestStockMove(TestStockCommon):
         aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}_Description2_{sml2.uom_id.id}_{sml2.move_id.packaging_uom_id.id}']
         aggregate_val_3 = aggregate_values[f'{product3.id}_{product3.name}_Description3_{sml3.uom_id.id}_{sml3.move_id.packaging_uom_id.id}']
         aggregate_val_4 = aggregate_values[f'{product4.id}_{product4.name}__{sml4.uom_id.id}_{sml4.move_id.packaging_uom_id.id}']
-        self.assertEqual(aggregate_val_1['qty_ordered'], 4)
+        self.assertEqual(aggregate_val_1['qty_ordered'], 10)
         self.assertEqual(aggregate_val_1['quantity'], 4)
-        self.assertEqual(aggregate_val_2['qty_ordered'], 8)
+        self.assertEqual(aggregate_val_2['qty_ordered'], 10)
         self.assertEqual(aggregate_val_2['quantity'], 6)
         self.assertEqual(aggregate_val_3['qty_ordered'], 10)
         self.assertEqual(aggregate_val_3['quantity'], 7)
-        self.assertEqual(aggregate_val_4['qty_ordered'], 8)
+        self.assertEqual(aggregate_val_4['qty_ordered'], 10)
         self.assertEqual(aggregate_val_4['quantity'], 8)
         # Check line descriptions
         self.assertFalse(aggregate_val_1['description'])
@@ -5754,13 +5754,13 @@ class TestStockMove(TestStockCommon):
         aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}_Description2_{sml2.uom_id.id}_{sml2.move_id.packaging_uom_id.id}']
         aggregate_val_3 = aggregate_values[f'{product3.id}_{product3.name}_Description3_{sml3.uom_id.id}_{sml3.move_id.packaging_uom_id.id}']
         aggregate_val_4 = aggregate_values[f'{product4.id}_{product4.name}__{sml4.uom_id.id}_{sml4.move_id.packaging_uom_id.id}']
-        self.assertEqual(aggregate_val_1['qty_ordered'], 4)
+        self.assertEqual(aggregate_val_1['qty_ordered'], 10)
         self.assertEqual(aggregate_val_1['quantity'], 4)
-        self.assertEqual(aggregate_val_2['qty_ordered'], 8)
+        self.assertEqual(aggregate_val_2['qty_ordered'], 10)
         self.assertEqual(aggregate_val_2['quantity'], 6)
         self.assertEqual(aggregate_val_3['qty_ordered'], 10)
         self.assertEqual(aggregate_val_3['quantity'], 7)
-        self.assertEqual(aggregate_val_4['qty_ordered'], 8)
+        self.assertEqual(aggregate_val_4['qty_ordered'], 10)
         self.assertEqual(aggregate_val_4['quantity'], 8)
         # Checks the values for the second back order.
         aggregate_values = second_backorder.move_line_ids._get_aggregated_product_quantities()
@@ -5769,9 +5769,9 @@ class TestStockMove(TestStockCommon):
         sm2 = second_backorder.move_ids.filtered(lambda ml: ml.product_id == product2)
         aggregate_val_1 = aggregate_values[f'{product3.id}_{product3.name}_Description3_{sml1.uom_id.id}_{sml1.move_id.packaging_uom_id.id}']
         aggregate_val_2 = aggregate_values[f'{product2.id}_{product2.name}_Description2_{sm2.uom_id.id}_{sml2.move_id.packaging_uom_id.id}']
-        self.assertEqual(aggregate_val_1['qty_ordered'], 3)
+        self.assertEqual(aggregate_val_1['qty_ordered'], 10)
         self.assertEqual(aggregate_val_1['quantity'], 3)
-        self.assertEqual(aggregate_val_2['qty_ordered'], 2)
+        self.assertEqual(aggregate_val_2['qty_ordered'], 10)
         self.assertEqual(aggregate_val_2['quantity'], 0)
 
     def test_move_line_aggregated_product_quantities_duplicate_stock_move(self):


### PR DESCRIPTION
Before this commit:
-------------------------
- In transfers, the delivery slip showed the ordered quantity as original demand
  but in case of backorder ordered quantity is not aligned to the original
  ordered quantity causing a mismatch that confused users when the delivered
  quantity differed from the initial demand.

Steps to reproduce:
-------------------------
1. Install the stock module.
2. Create a Delivery Order with:
    - Product A → Demand: 10 units
3. Confirm the transfer and click Mark as To Do.
4. Set the done quantity:
    - Product A → Done: 1 Unit
5. Validate the transfer and create a backorder.
6. Open the generated backorder:
    - Product A → Demand: 9 Units
7. Validate the backorder without creating another backorder.
8. Print the Delivery Slip.
    - - Product A → Ordered Quantity is shown as 9 instead of 10.

Cause of the issue:
-------------------------
- When a delivery order is created, the ordered quantity is directly set to the
  delivered quantity as per this  [PR](https://github.com/odoo/odoo/pull/250587), but in case of backorder,
  the original order quantity is not set to The ordered quantity.

After this commit:
-----------------------
- The ordered quantity shown on delivery slips now always reflects the
  original demanded quantity, including for backorders.
- The related test cases have been updated to align with the new logic.
- This ensures consistency and avoids confusion when reviewing delivery
  documents.

Task ID: 5322054