### PR TITLE
[IMP] sale,stock,*: Convert day-based fields to integers

### DIFF
--- a/addons/purchase_stock/models/res_company.py
+++ b/addons/purchase_stock/models/res_company.py
@@ -7,6 +7,6 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    days_to_purchase = fields.Float(
+    days_to_purchase = fields.Integer(
         string='Days to Purchase',
         help="Days needed to confirm a PO, define when a PO should be validated")

--- a/addons/purchase_stock/models/res_config_settings.py
+++ b/addons/purchase_stock/models/res_config_settings.py
@@ -8,7 +8,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     module_stock_dropshipping = fields.Boolean("Dropshipping")
-    days_to_purchase = fields.Float(
+    days_to_purchase = fields.Integer(
         related='company_id.days_to_purchase', readonly=False)
     is_installed_sale = fields.Boolean(string="Is the Sale Module Installed")
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -213,7 +213,7 @@ class SaleOrderLine(models.Model):
         compute='_compute_price_reduce_taxinc',
         store=True, precompute=True)
 
-    customer_lead = fields.Float(
+    customer_lead = fields.Integer(
         string="Lead Time",
         compute='_compute_customer_lead',
         store=True, readonly=False, required=True, precompute=True,

--- a/addons/sale_stock/models/res_company.py
+++ b/addons/sale_stock/models/res_company.py
@@ -7,8 +7,8 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    security_lead = fields.Float(
-        'Sales Safety Days', default=0.0, required=True,
+    security_lead = fields.Integer(
+        'Sales Safety Days', default=0, required=True,
         help="Margin of error for dates promised to customers. "
              "Products will be scheduled for procurement and delivery "
              "that many days earlier than the actual promised date, to "

--- a/addons/sale_stock/models/res_config_settings.py
+++ b/addons/sale_stock/models/res_config_settings.py
@@ -7,7 +7,7 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    security_lead = fields.Float(related='company_id.security_lead', string="Security Lead Time", readonly=False)
+    security_lead = fields.Integer(related='company_id.security_lead', string="Security Lead Time", readonly=False)
     use_security_lead = fields.Boolean(
         string="Security Lead Time for Sales",
         config_parameter='sale_stock.use_security_lead',

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -21,7 +21,7 @@ class SaleOrderLine(models.Model):
     qty_to_deliver = fields.Float(compute='_compute_qty_to_deliver', digits='Product Unit')
     is_mto = fields.Boolean(compute='_compute_is_mto')
     display_qty_widget = fields.Boolean(compute='_compute_qty_to_deliver')
-    customer_lead = fields.Float(
+    customer_lead = fields.Integer(
         compute='_compute_customer_lead', store=True, readonly=False, precompute=True,
         inverse='_inverse_customer_lead')
 

--- a/addons/sale_stock/views/res_config_settings_views.xml
+++ b/addons/sale_stock/views/res_config_settings_views.xml
@@ -11,7 +11,7 @@
                     <field name="use_security_lead"/>
                     <div class="content-group">
                         <div class="mt16" invisible="not use_security_lead">
-                            <span>Move forward expected delivery dates by <field name="security_lead" class="oe_inline"/> days</span>
+                            <span>Move forward expected delivery dates by <br/><field name="security_lead" class="oe_inline"/> days</span>
                         </div>
                     </div>
                 </setting>

--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -45,7 +45,7 @@ class ResCompany(models.Model):
         string='Day of the month', default=31,
         help="""Day of the month when the annual inventory should occur. If zero or negative, then the first day of the month will be selected instead.
         If greater than the last day of a month, then the last day of the month will be selected instead.""")
-    horizon_days = fields.Float(string="Replenishment Horizon", required=True, default=365,
+    horizon_days = fields.Integer(string="Replenishment Horizon", required=True, default=365,
                                 help="""Configure your horizon to trigger reordering rules earlier to get
                                 a head start on replenishment and avoid delays, or trigger it just-in-time
                                 ('0 days') to avoid overstocking.""")

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -56,7 +56,7 @@ class ResConfigSettings(models.TransientModel):
     replenish_on_order = fields.Boolean("Replenish on Order (MTO)", compute='_compute_replenish_on_order', inverse='_inverse_replenish_on_order')
     stock_text_confirmation = fields.Boolean(related='company_id.stock_text_confirmation', string='Stock Text Validation with stock move', readonly=False)
     stock_confirmation_type = fields.Selection(related='company_id.stock_confirmation_type', string='Stock Text Validation type', readonly=False)
-    horizon_days = fields.Float(related='company_id.horizon_days', readonly=False)
+    horizon_days = fields.Integer(related='company_id.horizon_days', readonly=False)
     picking_policy = fields.Selection(related="company_id.picking_policy", readonly=False, required=True)
 
     def _compute_replenish_on_order(self):


### PR DESCRIPTION
*= sale_stock,purchase_stock

Customer lead time defines the delay in days between order confirmation and
product shipment. Sales safety days add extra days to absorb supply chain
delays, replenishment horizon defines the number of days in advance
reordering rules are checked, and days to purchase defines the delay required
to confirm a purchase order. Fractional day values are not meaningful for
these fields.

This change enforces integer values for customer delivery days, sales safety
days, replenishment horizon, and the days to purchase, improving clarity and
consistency in sales and inventory planning while preserving the same visual
behavior as before.

Task - 4890380