### PR TITLE
[FIX] html_editor: prevent Firefox from creating empty buttons and links

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -831,6 +831,19 @@ export class LinkPlugin extends Plugin {
                 ev.preventDefault();
             }
         }
+        // Firefox: avoid corrupted selection inside link.
+        const selection = this.document.getSelection();
+        if (
+            ev.inputType === "insertText" &&
+            selection.isCollapsed &&
+            selection.anchorNode.nodeType === Node.TEXT_NODE &&
+            selection.anchorNode.parentElement.tagName === "A"
+        ) {
+            // Reset hidden internal selection state.
+            const offset = selection.anchorOffset;
+            selection.collapse(selection.anchorNode, 0);
+            selection.collapse(selection.anchorNode, offset);
+        }
         this.updateCurrentLinkSyncState();
     }
 

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -3,7 +3,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts, unformat } from "../_helpers/format";
 import { animationFrame, click, select, waitFor, waitForNone } from "@odoo/hoot-dom";
 import { getContent, simulateDoubleClickSelect } from "../_helpers/selection";
-import { insertText } from "../_helpers/user_actions";
+import { deleteBackward, insertText } from "../_helpers/user_actions";
 import { contains } from "@web/../tests/web_test_helpers";
 
 describe("button style", () => {
@@ -103,5 +103,16 @@ describe("button edit", () => {
         expect(cleanLinkArtifacts(getContent(el))).toBe('<p>this is a <a href="#">[link]</a></p>');
         await insertText(editor, "X");
         expect(cleanLinkArtifacts(getContent(el))).toBe('<p>this is a <a href="#">X[]</a></p>');
+    });
+});
+
+test.tags("firefox");
+describe("firefox", () => {
+    test("text should be inserted inside link after backspace", async () => {
+        const { el, editor } = await setupEditor('<p><a href="#">link</a>t[]est</p>');
+        deleteBackward(editor);
+        deleteBackward(editor);
+        await insertText(editor, "X");
+        expect(cleanLinkArtifacts(getContent(el))).toBe('<p><a href="#">linX[]</a>est</p>');
     });
 });


### PR DESCRIPTION
In some situations Firefox behaves strangely when adding a character add the end of a button, by duplicating the button element without children and inserting the text between both buttons.
It seems Firefox maintains an internal selection state that is corrupted after some operations.

This commit resets the collapsed selection inside links in order to reset this internal state in Firefox.

Steps to reproduce:
- Insert a link
- Put some text after the link
- Delete the first character from the text
- Keep deleting until the last character from the button is deleted
- Type a character

=> The button was duplicated and the text was inserted between both buttons.

- Note that if you undo/redo, then typing a character did work fine

task-5033890
