### PR TITLE
[PERF] hr{,_expense}: speed up salary simulation updates

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1360,13 +1360,13 @@ We can redirect you to the public employee list."""
         employees = employees.sorted(key=lambda employee: index_per_employee[employee])
         # Sudo in case HR officer doesn't have the Contact Creation group
         employees.filtered(lambda e: not e.work_contact_id).sudo()._create_work_contacts()
+        if self.env.context.get('salary_simulation'):
+            return employees
         for employee_sudo in employees.sudo():
             # creating 'svg/xml' attachments requires specific rights
             if not employee_sudo.image_1920 and self.env['ir.ui.view'].sudo(False).has_access('write'):
                 employee_sudo.image_1920 = employee_sudo._avatar_generate_svg()
                 employee_sudo.work_contact_id.image_1920 = employee_sudo.image_1920
-        if self.env.context.get('salary_simulation'):
-            return employees
         employee_departments = employees.department_id
         if employee_departments:
             self.env['discuss.channel'].sudo().search([

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -64,6 +64,7 @@ class HrExpense(models.Model):
         string="Employee",
         compute='_compute_employee_id', precompute=True, store=True, readonly=False,
         required=True,
+        index=True,
         default=_default_employee_id,
         check_company=True,
         domain=[('filter_for_expense', '=', True)],


### PR DESCRIPTION
Description
-----------
Add missing index on `hr.expense.employee_id` as it's used in a few places as a transitive dependency.

Avoid computing images for new employee versions during simulation, as it's loading external dependencies, incurring a performance cost.

Benchmark
---------
On a staging database, opening the salary configurator and clicking on 'Simulation' when selecting a new car took:

| Timings for        | Before | After  | Speed up |
|--------------------|--------|--------|----------|
| `onchange_benefit` | ~750ms | ~160ms | 4.6x     |
| `update_salary`    | 2.3s   | 1.1s   | 1.9x     |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
