### PR TITLE
[FIX] website_slides: Prevent merging contacts with duplicate courses

### DIFF
--- a/addons/website_slides/models/__init__.py
+++ b/addons/website_slides/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import base_partner_merge
 from . import gamification_challenge
 from . import gamification_karma_tracking
 from . import slide_slide_partner  # decorated m2m, import before

--- a/addons/website_slides/models/base_partner_merge.py
+++ b/addons/website_slides/models/base_partner_merge.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, models
+from odoo.exceptions import UserError
+
+
+class BasePartnerMergeAutomaticWizard(models.TransientModel):
+    _inherit = 'base.partner.merge.automatic.wizard'
+
+    @api.model
+    def _update_foreign_keys(self, src_partners, dst_partner):
+        # check if the list of partners to merge have duplicate course
+        courses_set = set(dst_partner.sudo().slide_channel_ids.ids)
+        for partner in src_partners:
+            for slide_channel in partner.sudo().slide_channel_ids:
+                if slide_channel.id in courses_set:
+                    raise UserError(self.env._("You cannot merge contacts that are enrolled in the same course."))
+                courses_set.add(slide_channel.id)
+
+        super()._update_foreign_keys(src_partners, dst_partner)

--- a/addons/website_slides/tests/test_slide_channel.py
+++ b/addons/website_slides/tests/test_slide_channel.py
@@ -162,6 +162,38 @@ class TestSlidesManagement(slides_common.SlidesCase):
                 for mail in created_mails)
         )
 
+    def test_merge_partners_with_unique_courses(self):
+        """ Test merging partners with unique courses """
+        course1 = self.env['slide.channel'].create({'name': 'Course 1'})
+        course2 = self.env['slide.channel'].create({'name': 'Course 2'})
+        partner1 = self.env['res.partner'].create({'name': 'Partner 1', 'email': 'partner1@example.com'})
+        partner2 = self.env['res.partner'].create({'name': 'Partner 2', 'email': 'partner2@example.com'})
+        course1.sudo()._action_add_members(partner1)
+        course2.sudo()._action_add_members(partner2)
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+        wizard._merge([partner1.id, partner2.id], partner1)
+
+        self.assertFalse(partner2.exists(), "Source partner should be deleted after merge")
+        self.assertTrue(partner1.exists(), "Destination partner should exist after merge")
+        self.assertIn(course1, partner1.slide_channel_ids, "Course 1 should belong to destination partner")
+        self.assertIn(course2, partner1.slide_channel_ids, "Course 2 should belong to destination partner")
+
+    def test_merge_partners_with_duplicate_course(self):
+        """ Test merging partners with duplicate courses. Merging should fail in that case. """
+        course1 = self.env['slide.channel'].create({'name': 'Course 1'})
+        partner1 = self.env['res.partner'].create({'name': 'Partner 1', 'email': 'partner1@example.com'})
+        partner2 = self.env['res.partner'].create({'name': 'Partner 2', 'email': 'partner2@example.com'})
+        course1.sudo()._action_add_members(partner1 | partner2)
+        wizard = self.env['base.partner.merge.automatic.wizard'].create({})
+
+        with self.assertRaises(UserError) as user_error:
+            wizard._merge([partner1.id, partner2.id], partner1)
+
+        self.assertEqual(
+            user_error.exception.args[0],
+            "You cannot merge contacts that are enrolled in the same course."
+        )
+
     def test_mail_completed_with_different_templates(self):
         """ When the completion email is generated, it must take into account different templates. """
 


### PR DESCRIPTION
Expected Behaviour:
Contacts with Duplicate courses should not be merged and the merge should fail.

Actual Behaviour before the Fix:
Contacts with duplicate courses are getting merged and the duplicate course is kept in the destination contact.

Behaviour with the Fix:
Contacts with duplicate courses are blocked from being merged and an error message
is shown to the user saying that the reason the merge is blocked is a duplicate course.

Steps to reproduce:
1- Go to one of the courses
2- Add two attendees to the course
3- Go to Contacts App
4- Select the two attendees you added to the course
5- Try merging the two contacts

Before the fix, the merging will happen.
After the fix, the merging will stop and an error message will appear.