### PR TITLE
[IMP] hr: add data warning banner to employee form

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -301,6 +301,7 @@ class HrEmployee(models.Model):
         compute='_compute_has_country_contract_type',
         groups="hr.group_hr_user",
     )
+    employee_issues = fields.Json(compute='_compute_employee_issues')
 
     def _prepare_create_values(self, vals_list):
         result = super()._prepare_create_values(vals_list)
@@ -321,6 +322,39 @@ class HrEmployee(models.Model):
                 **{k: v for k, v in version_vals.items() if k in version_fields},
             })
         return new_vals_list
+
+    @api.depends('is_trusted_bank_account', 'is_in_contract', 'bank_account_ids')
+    def _compute_employee_issues(self):
+        for employee in self:
+            issues = {}
+            cnt = 0
+            if not employee.is_in_contract:
+                issues[cnt] = {
+                    'message': _("Employee does not have running contract."),
+                }
+                cnt += 1
+            if not employee.bank_account_ids:
+                issues[cnt] = {
+                    'message': _("Employee does not have a bank account."),
+                }
+                cnt += 1
+            elif any(not b.allow_out_payment for b in employee.bank_account_ids):
+                untrusted_banks = employee.bank_account_ids.filtered(lambda b: not b.allow_out_payment)
+                issues[cnt] = {
+                    'message': _("Untrusted bank accounts"),
+                    'action_text': _("Bank Accounts"),
+                    'action': {
+                        'type': 'ir.actions.act_window',
+                        'name': _('Bank Accounts'),
+                        'res_model': 'res.partner.bank',
+                        'view_mode': 'list,form',
+                        'views': [[False, 'list'], [False, 'form']],
+                        'domain': [('id', 'in', untrusted_banks.ids)],
+                        'context': {'create': False},
+                    },
+                }
+                cnt += 1
+            employee.employee_issues = issues
 
     @api.depends('bank_account_ids.allow_out_payment')
     def _compute_is_trusted_bank_account(self):

--- a/addons/hr/static/src/js/work_entry_warnings/work_entry_warnings.js
+++ b/addons/hr/static/src/js/work_entry_warnings/work_entry_warnings.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { useService } from "@web/core/utils/hooks";
+
+export class WorkEntryWarnings extends Component {
+    static template = "hr_work_entry_enterprise.WorkEntryWarnings";
+    static props = { ...standardFieldProps };
+
+    setup() {
+        this.actionService = useService("action");
+    }
+
+    async onActionClick(action) {
+        if (!action) return;
+        await this.actionService.doAction(action, {
+            onClose: () => this.env.model.load(),
+        });
+    }
+
+    get issues() {
+        const value = this.props.record.data[this.props.name];
+        return value ? Object.values(value) : [];
+    }
+}
+
+export const workEntryWarnings = {
+    component: WorkEntryWarnings,
+};
+
+registry.category("fields").add("work_entry_warnings", workEntryWarnings);

--- a/addons/hr/static/src/js/work_entry_warnings/work_entry_warnings.xml
+++ b/addons/hr/static/src/js/work_entry_warnings/work_entry_warnings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="hr_work_entry_enterprise.WorkEntryWarnings">
+        <div t-if="issues.length > 0" class="alert alert-warning mb-2 px-3 py-2" role="alert">
+            <div t-foreach="issues" t-as="issue" t-key="issue_index" class="d-flex align-items-center">
+                <span class="me-2"><t t-esc="issue.message"/></span>
+
+                <t t-if="issue.action">
+                    <a href="#" class="alert-link fw-bold" t-on-click.prevent="() => this.onActionClick(issue.action)">
+                        <i class="oi oi-arrow-right me-1"/>
+                        <t t-esc="issue.action_text"/>
+                    </a>
+                </t>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -113,6 +113,7 @@
                             groups="hr.group_hr_user" invisible="not active or not id" context="{'sort_by_responsible': True}"/>
                         <field name="version_id" widget="versions_timeline" invisible="not id" options="{'clickable': True}" readonly="False"/>
                     </header>
+                    <field name="employee_issues" invisible="not employee_issues" widget="work_entry_warnings"/>
                     <sheet>
                         <div name="button_box" class="oe_button_box">
                             <button name="action_open_versions"


### PR DESCRIPTION
To ensure HR officers can quickly identify missing or incorrect employee data, this commit adds a warning banner to the top of the Employee form view.

This visual feedback is crucial for validating data integrity (e.g., missing bank accounts or contracts) without needing to navigate to separate menus or wait for payroll errors.

Changes:
1. **Model (`hr.employee`):**
   - Added `employee_issues`: A JSON computed field that aggregates warnings (e.g., "No bank account", "Untrusted bank accounts", "No running contract").
   - Implemented logic to check `bank_account_ids` and `is_in_contract`.

2. **UI/Widget:**
   - Introduced `work_entry_warnings`: A new Javascript/Owl widget that renders the `employee_issues` JSON as an orange alert banner.
   - The widget supports actionable links (e.g., clicking "Bank Accounts" redirects the user to the `res.partner.bank` list view).

3. **View:**
   - Updated `hr.view_employee_form` to display this banner immediately after the header.

task-5118781

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
