### PR TITLE
[FIX] website: fix `snippet_carousel_clickable_slides` tour

### DIFF
--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -214,9 +214,9 @@ registerWebsitePreviewTour(
             run: "edit ",
         },
         {
-            content: "Press Enter in the URL input",
+            content: "Press Tab in the URL input",
             trigger: "div[data-action-id='setSlideAnchorUrl'] input",
-            run: "press Enter",
+            run: "press Tab",
         },
         {
             content: "Check that the anchor tag is removed",


### PR DESCRIPTION
__Before this commit:__
The tour `snippet_carousel_clickable_slides` sometimes fails because
the URL anchor does not get removed when Enter is pressed.

__Reason:__
When inputting in an `Autocomplete`, the `loadingPromise` is set and
it's only resolved after the sources are loaded. If Enter is pressed
before it is resolved, the `onchange` event is not fired because
[`preventDefault` is called inside `onInputKeydown`][1].

__Fix:__
Use Tab in `snippet_carousel_clickable_slides` instead of Enter
because Tab doesn't have this behavior.

[1]: https://github.com/odoo/odoo/blob/6c07ba93171eb25be64ef990d047915fac2f3381/addons/web/static/src/core/autocomplete/autocomplete.js#L401

runbot-234687