### PR TITLE
[FIX] microsoft_calendar: make Graph timeout configurable

### DIFF
--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -85,16 +85,18 @@ class MicrosoftSync(models.AbstractModel):
         result = super().write(vals)
 
         if self.env.user._get_microsoft_sync_status() != "sync_paused":
+            timeout = self._get_microsoft_graph_timeout()
+
             for record in self:
                 if record.need_sync_m and record.ms_organizer_event_id:
                     if not vals.get('active', True):
                         # We need to delete the event. Cancel is not sufficient. Errors may occur.
-                        record._microsoft_delete(record._get_organizer(), record.ms_organizer_event_id, timeout=3)
+                        record._microsoft_delete(record._get_organizer(), record.ms_organizer_event_id, timeout=timeout)
                     elif fields_to_sync:
                         values = record._microsoft_values(fields_to_sync)
                         if not values:
                             continue
-                        record._microsoft_patch(record._get_organizer(), record.ms_organizer_event_id, values, timeout=3)
+                        record._microsoft_patch(record._get_organizer(), record.ms_organizer_event_id, values, timeout=timeout)
 
         return result
 
@@ -106,9 +108,11 @@ class MicrosoftSync(models.AbstractModel):
         records = super().create(vals_list)
 
         if self.env.user._get_microsoft_sync_status() != "sync_paused":
+            timeout = self._get_microsoft_graph_timeout()
+
             for record in records:
                 if record.need_sync_m and record.active:
-                    record._microsoft_insert(record._microsoft_values(self._get_microsoft_synced_fields()), timeout=3)
+                    record._microsoft_insert(record._microsoft_values(self._get_microsoft_synced_fields()), timeout=timeout)
         return records
 
     @api.depends('microsoft_id')
@@ -515,6 +519,18 @@ class MicrosoftSync(models.AbstractModel):
         :return: dict of Odoo formatted values
         """
         raise NotImplementedError()
+
+    @api.model
+    def _get_microsoft_graph_timeout(self):
+        """Return Microsoft Graph request timeout (seconds).
+
+        Keep current behavior by default (5s), but allow admins to increase it
+        through a system parameter.
+        """
+        timeout = self.env['ir.config_parameter'].sudo().get_param('microsoft_calendar.graph_timeout')
+        if not timeout or not timeout.isdigit():
+            return 5
+        return max(1, int(timeout))
 
     def _microsoft_values(self, fields_to_sync):
         """

--- a/doc/cla/individual/p4v3.md
+++ b/doc/cla/individual/p4v3.md
@@ -1,0 +1,11 @@
+Germany, 2025-10-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Ole Warrink warrink.ole@googlemail.com https://github.com/p4v3


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Microsoft calendar synchronization may fail in environments with slower Microsoft Graph responses or large calendars because Graph API calls triggered after commit use a fixed 3-second timeout. This can lead to repeated synchronization failures even though the operation would succeed with slightly more time.

Additionally, when creating events, the Microsoft Graph request may time out after the event is successfully created on Microsoft’s side but before the response containing the event ID is returned. In this case, Odoo does not store the ID of the event and may create the same event again during the next sync, resulting in duplicate events.

**Current behavior before PR:**

Microsoft Graph requests (insert, update, delete) are executed with a hardcoded 3-second timeout. If the Graph API response takes longer:
	•	the synchronization fails,
	•	and in the case of event creation, Odoo may not receive the Microsoft event ID even though the event was created remotely, which can lead to duplicate events in Odoo.

**Desired behavior after PR is merged:**

The Microsoft Graph request timeout is configurable via the optional system parameter `microsoft_calendar.graph_timeout`.

If the parameter is not set, the behavior remains unchanged (default 3 seconds).
Administrators can increase the timeout to allow successful synchronization in slower environments or with large datasets, reducing synchronization failures and avoiding duplicate event creation caused by missing Microsoft IDs.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
