### PR TITLE
[IMP] mail: bigger buttons in discuss meeting view

### DIFF
--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -14,6 +14,10 @@
         &:not(.o-hasBtnBg) {
             background-color: inherit;
         }
+    
+        &.o-simulateDarkTheme.o-hasBtnBg:hover {
+            filter: brightness(1.3);
+        }
 
         &.o-inline {
             &:where(:has(i:first-child:last-child)) {

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -81,21 +81,22 @@
         'o-mx-0_5': props.inline and !hasBtnBg and !action.icon,
     })"/>
     <!-- padding -->
+    <t t-set="inMeetingViewCallButtonsFullscreen" t-value="props.inline and env.inMeetingView and !env.inComposer and !env.inDiscussActionPanel and store.rtc.isFullscreen"/>
     <t t-set="btnClass" t-value="attClassObjectToString({
         [btnClass]: true,
-        'px-2 o-py-1_5': props.inline   and   env.inMeetingView and !env.inComposer,
+        'px-2 o-py-2_5': inMeetingViewCallButtonsFullscreen,
         'o-px-1_5 py-1': props.inline   and  ((hasBtnBg and !isInlineCircleButton and !env.inMeetingView) or (!hasBtnBg and env.inComposer)),
         'o-p-1_5':       props.inline   and  !env.inMeetingView and hasBtnBg and isInlineCircleButton and !env.inChatWindow,
         'o-px-0_5':      props.inline   and  !env.inMeetingView and !hasBtnBg and !action.icon,
         'p-1':           props.inline   and  hasBtnBg and isInlineCircleButton and env.inChatWindow,
-        'o-p-0_5':       props.inline   and  !hasBtnBg and !env.inComposer,
+        'o-p-0_5':       props.inline   and  !env.inMeetingView and !hasBtnBg and !env.inComposer,
         'px-3 py-2':     props.dropdown and   ui.isSmall,
         'px-2 py-1':     props.dropdown and  !ui.isSmall,
     })"/>
     <!-- opacity -->
     <t t-set="btnClass" t-value="attClassObjectToString({
         [btnClass]: true,
-        'opacity-75 opacity-100-hover': action.tags.includes('CALL_LAYOUT'),
+        'opacity-75 opacity-100-hover': action.tags.includes('CALL_LAYOUT') or env.inMeetingSideActions,
     })"/>
     <!-- simulated dark theme -->
     <t t-set="btnClass" t-value="attClassObjectToString({
@@ -127,7 +128,7 @@
     <t t-if="action.icon?.template" t-call="{{ action.icon.template }}">
         <t t-set="templateParams" t-value="action.icon.params"/>
     </t>
-    <i t-elif="action.icon" t-attf-class="{{ action.icon }}" t-att-class="{ 'o-fs-small': props.dropdown, 'fa-fw': props.fw }"/>
+    <i t-elif="action.icon" t-attf-class="{{ action.icon }}" t-att-class="{ 'o-fs-small': props.dropdown, 'fa-fw': props.fw, 'fa-lg': inMeetingViewCallButtonsFullscreen }"/>
     <i t-elif="props.dropdown" class="fa-question fa-fw opacity-0" t-att-class="props.fw ? 'fa-fw' : ''"/>
     <span t-if="action.name and (props.dropdown or (props.inline and (!action.icon or action.inlineName)))" class="o-mail-ActionList-actionLabel" t-attf-class="{{ action.nameClass }}" t-att-class="{ 'mx-1': props.dropdown }" t-out="(props.inline and action.inlineName) or action.name"/>
     <t t-if="props.dropdown and action.badge" t-call="mail.Action.badge"/>

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -117,7 +117,6 @@ export class Store extends BaseStore {
                 ctx?.env.isDiscussPipBanner ||
                 ctx?.env?.inWelcomePage) &&
             this.isOdooWhiteTheme &&
-            !ctx?.env.inMeetingSideActions &&
             !ctx?.env.inDiscussActionPanel
         );
     }

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -82,7 +82,7 @@ registerThreadAction("meeting-chat", {
     actionPanelComponent: MeetingChat,
     actionPanelOuterClass: "bg-100 border border-secondary",
     badge: ({ thread }) => thread.isUnread,
-    badgeIcon: ({ thread }) => !thread.importantCounter && "fa fa-circle text-700",
+    badgeIcon: ({ thread }) => !thread.importantCounter && "fa fa-circle o-text-white opacity-75",
     badgeText: ({ thread }) => thread.importantCounter || undefined,
     condition: ({ owner }) => owner.env.inMeetingView,
     icon: "fa fa-fw fa-comments",

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -53,7 +53,7 @@
                 <div t-if="hasCallNotifications" class="position-absolute d-flex flex-column-reverse start-0 bottom-0" t-att-class="{ 'ps-5 pb-5': rtc.isFullscreen, 'ps-2 pb-2': !rtc.isFullscreen }">
                     <span class="o-discuss-Call-notification text-bg-800 shadow-lg rounded-1 m-1" t-att-class="{ 'p-4 fs-4': rtc.isFullscreen, 'p-2': !rtc.isFullscreen }" t-foreach="rtc.notifications.values()" t-as="notification" t-key="notification.id" t-esc="notification.text"/>
                 </div>
-                <div class="o-discuss-Call-layoutActions position-absolute z-2 bottom-0 end-0">
+                <div t-if="!env.inMeetingView" class="o-discuss-Call-layoutActions position-absolute z-2 bottom-0 end-0">
                     <ActionList actions="layoutActions" inline="true"/>
                 </div>
             </div>

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -11,7 +11,7 @@ import { ACTION_TAGS } from "@mail/core/common/action";
 
 export class CallActionList extends Component {
     static components = { ActionList };
-    static props = ["channel", "compact?"];
+    static props = ["channel", "className?", "compact?"];
     static template = "discuss.CallActionList";
 
     setup() {

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallActionList">
-        <div class="o-discuss-CallActionList d-flex flex-column justify-content-center" t-attf-class="{{ className }}" t-ref="root">
+        <div class="o-discuss-CallActionList d-flex flex-column justify-content-center" t-attf-class="{{ props.className }}" t-ref="root">
             <div class="o-discuss-CallActionList-bar d-flex align-items-center justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
                 <ActionList actions="actions" inline="true" hasBtnBg="true"/>
             </div>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -58,8 +58,8 @@
 }
 
 .o-discuss-CallParticipantCard-avatar img {
-    max-height: #{"min(100%, 100px)"}; // interpolated as not supported by Sass
-    max-width: #{"min(100%, 100px)"};
+    max-height: #{"min(100%, 80px)"}; // interpolated as not supported by Sass
+    max-width: #{"min(100%, 80px)"};
     aspect-ratio: 1;
     border: none;
 
@@ -109,7 +109,8 @@
 }
 
 .o-discuss-CallParticipantCard-overlayBottomName {
-    background-color: rgba(0, 0, 0, 0.75);
+    opacity: .85;
+    text-shadow: 4px 4px 4px black, 0px 0px 4px black, 0px 0px 4px black;
 }
 
 .o-discuss-CallParticipantCard-overlay-replayButton {

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -12,7 +12,6 @@
                 'o-active': isActiveRtcSession and !props.inset and props.compact,
                 'p-1 rounded-1': !isActiveRtcSession,
             }"
-            t-att-title="name"
             t-att-aria-label="name"
             t-att-data-is-context-menu-available="isContextMenuAvailable"
             t-attf-class="{{ props.className }}"
@@ -30,7 +29,7 @@
                 </div>
             </t>
             <CallParticipantVideo t-elif="hasVideo" session="rtcSession" type="props.cardData.type" inset="props.inset"/>
-            <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized, 'o-isRemoteVideo': isRemoteVideo }" draggable="false">
+            <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-3" t-att-class="{ 'o-minimized': props.minimized, 'o-isRemoteVideo': isRemoteVideo }" draggable="false">
                 <img t-if="!showRemoteWarning" alt="Avatar" class="h-100 rounded-circle border-5 object-fit-cover" t-att-src="channelMember?.avatarUrl" draggable="false" t-att-class="{
                     'o-isTalking': isTalking and props.minimized,
                     'o-isInvitation': !rtcSession,
@@ -38,14 +37,14 @@
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->
-                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1" t-att-class="{ 'o-proportional-container w-50': isSmall }" t-att-data-connection-state="rtcSession.connectionState">
-                    <span t-if="!props.minimized and !props.inset" class="rounded-1 text-truncate opacity-75 o-proportional-text o-discuss-CallParticipantCard-overlayBottomName" t-att-class="{'o-minimized px-1': isSmall, 'p-0': !isSmall }" t-esc="name"/>
+                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-3" t-att-class="{ 'o-proportional-container w-50': isSmall }" t-att-data-connection-state="rtcSession.connectionState">
+                    <span t-if="!props.minimized and !props.inset" class="rounded-3 text-truncate o-proportional-text o-discuss-CallParticipantCard-overlayBottomName" t-att-class="{'o-minimized px-1 small': isSmall, 'o-px-1_5 py-1': !isSmall }" t-esc="name"/>
                     <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-proportional-text o-minimized rounded text-bg-danger d-flex align-items-center fw-bolder p-1" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
                 <span t-if="showRemoteWarning" class="o-discuss-CallParticipantCard-overlay o-proportional-container z-1 w-50 position-absolute d-flex align-items-center justify-content-center overflow-hidden">
-                    <span class="fw-bolder p-1 rounded-1 o-video-text o-proportional-text">Video visible in the call tab</span>
+                    <span class="fw-bolder p-1 rounded-3 o-video-text o-proportional-text">Video visible in the call tab</span>
                 </span>
                 <CallDropdown t-if="isContextMenuAvailable and ((!isMobileOS and rootHover.isHover) or (isMobileOS and !props.minimized))" class="'position-absolute top-0 end-0'" menuClass="'d-flex o-discuss-CallParticipantCard-contextMenu'">
                     <button class="o-discuss-CallParticipantCard-contextButton btn btn-secondary btn-sm rounded-circle border-0 smaller p-1" title="Participant options">

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.CallParticipantVideo">
-        <video class="w-100 h-100 cursor-pointer"
-            t-att-class="{ 'o-inset rounded-1': props.inset }"
+        <video class="h-100 cursor-pointer"
+            t-att-class="{ 'o-inset rounded-1': props.inset, 'rounded-3': !props.session.eq(props.session.channel?.activeRtcSession) }"
             t-att-type="props.type"
             t-att-data-facing-mode="store.settings.cameraFacingMode"
             playsinline="true"

--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -10,10 +10,9 @@
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="threadActions.activeAction.actionPanelComponentProps"/>
                 </div>
             </div>
-            <div class="pt-2 d-flex justify-content-between overflow-x-auto flex-shrink-0" t-att-class="{'p-2 pb-3': ui.isSmall}">
-                <div/>
-                <CallActionList channel="channel"/>
-                <MeetingSideActions threadActions="threadActions"/>
+            <div class="pt-2 d-flex align-items-center justify-content-center overflow-x-auto flex-shrink-0" t-att-class="{'p-2 pb-3': ui.isSmall}">
+                <CallActionList channel="channel" className="'ms-auto'"/>
+                <MeetingSideActions threadActions="threadActions" isSmall="ui.isSmall or rtc.isPipMode"/>
             </div>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/call/common/meeting_side_actions.js
+++ b/addons/mail/static/src/discuss/call/common/meeting_side_actions.js
@@ -3,6 +3,8 @@ import { ActionList } from "@mail/core/common/action_list";
 import { Component, useSubEnv } from "@odoo/owl";
 
 import { useService } from "@web/core/utils/hooks";
+import { useCallActions } from "./call_actions";
+import { ACTION_TAGS } from "@mail/core/common/action";
 
 /** @typedef {"chat"|"invite"} MeetingPanel */
 
@@ -13,16 +15,17 @@ import { useService } from "@web/core/utils/hooks";
  */
 export class MeetingSideActions extends Component {
     static template = "mail.MeetingSideActions";
-    static props = ["threadActions"];
+    static props = ["threadActions", "isSmall?"];
     static components = { ActionList };
 
     setup() {
         this.store = useService("mail.store");
+        this.callActions = useCallActions({ channel: () => this.store.rtc.channel });
         useSubEnv({ inMeetingSideActions: true });
     }
 
     computeActions() {
-        const quickThreadActionIds = ["invite-people", "meeting-chat"];
+        const quickThreadActionIds = this.props.isSmall ? [] : ["invite-people", "meeting-chat"];
         const threadActions = this.props.threadActions;
         const { quick, other, group } = threadActions.partition;
         const partitionedActions = {
@@ -45,5 +48,11 @@ export class MeetingSideActions extends Component {
             })
         );
         this.actions = actions;
+    }
+
+    get layoutActions() {
+        return this.callActions.actions.filter((action) =>
+            action.tags.includes(ACTION_TAGS.CALL_LAYOUT)
+        );
     }
 }

--- a/addons/mail/static/src/discuss/call/common/meeting_side_actions.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_side_actions.xml
@@ -2,8 +2,11 @@
 <templates xml:space="preserve">
     <t t-name="mail.MeetingSideActions">
         <t t-set="dummy" t-value="computeActions()"/>
-        <div class="o-mail-MeetingSideActions d-flex">
-            <ActionList actions="actions" inline="true" hasBtnBg="true" odooControlPanelSwitchStyle="true"/>
+        <div class="o-mail-MeetingSideActions d-flex ms-auto">
+            <div class="o-discuss-Call-layoutActions ms-auto">
+                <ActionList actions="layoutActions" inline="true"/>
+            </div>
+            <ActionList actions="actions" inline="true"/>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -635,7 +635,7 @@ test("start call when accepting from push notification", async () => {
         })
     );
     await contains(".o-mail-DiscussContent-threadName[title=General]");
-    await contains(`.o-discuss-CallParticipantCard[title='${serverState.partnerName}']`);
+    await contains(`.o-discuss-CallParticipantCard[aria-label='${serverState.partnerName}']`);
 });
 
 test("Clicking sidebar call participant opens avatar card", async () => {
@@ -673,9 +673,9 @@ test("Use saved volume settings", async () => {
     await click("[title='Join the Call']");
     await contains(".o-discuss-Call");
     await contains(
-        `.o-discuss-CallParticipantCard[title='${partnerName}'][data-is-context-menu-available]`
+        `.o-discuss-CallParticipantCard[aria-label='${partnerName}'][data-is-context-menu-available]`
     );
-    await hover(`.o-discuss-CallParticipantCard[title='${partnerName}']`);
+    await hover(`.o-discuss-CallParticipantCard[aria-label='${partnerName}']`);
     await click("button[title='Participant options']");
     await contains(".o-discuss-CallContextMenu");
     const rangeInput = queryFirst(".o-discuss-CallContextMenu input[type='range']");
@@ -893,7 +893,7 @@ test("single 'join' (with camera) button when last call had camera on", async ()
     await start();
     await openDiscuss(channelId);
     await click("button[title='Join Video Call']");
-    await contains(".o-discuss-CallParticipantCard[title='Mitchell Admin'] video");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Mitchell Admin'] video");
     await click("button[title='Disconnect']");
     await click("button[title='Join Video Call']:text('Join')", {
         contains: [".fa-video-camera"],
@@ -922,20 +922,20 @@ test("dynamic focus switches to talking participant", async () => {
     const rtc = env.services["discuss.rtc"];
     await openDiscuss(channelId);
     await click("[title='Join Call']");
-    await click(".o-discuss-CallParticipantCard[title='Alice']");
-    await contains(".o-discuss-CallParticipantCard[title='Alice']");
-    await contains(".o-discuss-CallParticipantCard[title='Bob']", {
+    await click(".o-discuss-CallParticipantCard[aria-label='Alice']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Alice']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob']", {
         count: 0,
     });
     rtc.updateSessionInfo({ [bobSessionId]: { isTalking: true } });
-    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob']");
     rtc.updateSessionInfo({ [aliceSessionId]: { isTalking: true } });
-    await contains(".o-discuss-CallParticipantCard[title='Bob']", {
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob']", {
         count: 0,
     });
-    await contains(".o-discuss-CallParticipantCard[title='Alice']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Alice']");
     rtc.updateSessionInfo({ [aliceSessionId]: { isTalking: false } });
-    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob']");
     await click("button[aria-label='Video Settings']");
     await click(".o-discuss-QuickVideoSettings button:has(:text('Advanced Settings'))");
     await click("input[title='Auto-focus speaker']:checked");
@@ -958,18 +958,18 @@ test("should not show context menu on participant card when not in a call", asyn
     ]);
     await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-CallParticipantCard[title='Awesome Partner']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Awesome Partner']");
     await contains(
-        ".o-discuss-CallParticipantCard[title='Awesome Partner'][data-is-context-menu-available]",
+        ".o-discuss-CallParticipantCard[aria-label='Awesome Partner'][data-is-context-menu-available]",
         { count: 0 }
     );
     await click("[title='Join Call']");
     await contains(
-        ".o-discuss-CallParticipantCard[title='Awesome Partner'][data-is-context-menu-available]"
+        ".o-discuss-CallParticipantCard[aria-label='Awesome Partner'][data-is-context-menu-available]"
     );
-    await hover(".o-discuss-CallParticipantCard[title='Awesome Partner']");
+    await hover(".o-discuss-CallParticipantCard[aria-label='Awesome Partner']");
     await click(
-        ".o-discuss-CallParticipantCard[title='Awesome Partner'] .o-discuss-CallParticipantCard-contextButton"
+        ".o-discuss-CallParticipantCard[aria-label='Awesome Partner'] .o-discuss-CallParticipantCard-contextButton"
     );
     await contains(".o-discuss-CallContextMenu");
 });
@@ -1067,9 +1067,9 @@ test("Show connecting state on cards", async () => {
     const bobRemote = network.makeMockRemote(channelMemberId);
     await openDiscuss(channelId);
     await click("[title='Join Call']");
-    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob']");
     await bobRemote.updateConnectionState("connecting");
-    await contains(".o-discuss-CallParticipantCard[title='Bob'] .fa-exclamation-triangle");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob'] .fa-exclamation-triangle");
     await bobRemote.updateConnectionState("connected");
     await contains("span[data-connection-state='connected']");
 });
@@ -1086,10 +1086,10 @@ test("Can see raised hands from other call participants", async () => {
     const bobRemote = network.makeMockRemote(channelMemberId);
     await openDiscuss(channelId);
     await click("[title='Join Call']");
-    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob']");
     await bobRemote.updateConnectionState("connected");
     await bobRemote.updateInfo({ isRaisingHand: true });
-    await contains(".o-discuss-CallParticipantCard[title='Bob'] .fa-hand-paper-o");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob'] .fa-hand-paper-o");
     await contains(".o-discuss-Call-notification:contains('Bob raised their hand')");
 });
 
@@ -1105,10 +1105,10 @@ test("Can see videos from other call participants", async () => {
     const bobRemote = network.makeMockRemote(channelMemberId);
     await openDiscuss(channelId);
     await click("[title='Join Call']");
-    await contains(".o-discuss-CallParticipantCard[title='Bob']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob']");
     await bobRemote.updateConnectionState("connected");
     await bobRemote.updateUpload("screen", createVideoStream().getVideoTracks()[0]);
-    await contains(".o-discuss-CallParticipantCard[title='Bob'] video");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Bob'] video");
 });
 
 test("show all participants on other user stops screen share", async () => {
@@ -1128,7 +1128,7 @@ test("show all participants on other user stops screen share", async () => {
     await streamerRemote.updateUpload("screen", createVideoStream().getVideoTracks()[0]);
     await contains(".o-discuss-CallParticipantCard-avatar", { count: 2 });
     await contains(".o-discuss-CallParticipantCard video");
-    await click(".o-discuss-CallParticipantCard[title='Streamer'] video");
+    await click(".o-discuss-CallParticipantCard[aria-label='Streamer'] video");
     await contains(".o-discuss-CallParticipantCard-avatar");
     await contains(".o-discuss-CallParticipantCard video");
     await streamerRemote.updateUpload("screen", null);
@@ -1190,14 +1190,14 @@ test("auto-focus participant video in one-to-one call in chat window", async () 
     await contains(".o-discuss-CallParticipantCard", { count: 2 });
     await mockedRemote.updateConnectionState("connected");
     await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);
-    await contains(".o-discuss-CallParticipantCard[title='Batman'] video");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Batman'] video");
     await contains(".o-discuss-CallParticipantCard");
     await mockedRemote.updateUpload("camera", null);
-    await click(".o-discuss-CallParticipantCard[title='Batman']");
+    await click(".o-discuss-CallParticipantCard[aria-label='Batman']");
     await click("[title='Fullscreen']");
     await contains(".o-mail-Meeting");
     await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);
-    await contains(".o-discuss-CallParticipantCard[title='Batman'] video");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Batman'] video");
     await contains(".o-discuss-CallParticipantCard", { count: 2 }); // card does not get focused in meeting view
 });
 

--- a/addons/mail/static/tests/discuss/call/call_integration.test.js
+++ b/addons/mail/static/tests/discuss/call/call_integration.test.js
@@ -75,7 +75,7 @@ onlineTest("Can join a call in p2p", async (assert) => {
     await openDiscuss(channelId);
     await click("[title='Join Call']");
     await contains(".o-discuss-Call");
-    await contains(".o-discuss-CallParticipantCard[title='Remote']");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Remote']");
     await Promise.all([localUserConnected, remoteUserConnected]);
     await contains("span[data-connection-state='connected']");
 });


### PR DESCRIPTION
- bottom buttons in meeting view are bigger
- layout buttons in meeting view are moved with side meeting actions
- side meeting actions uses non-bg visual
- meeting bottom buttons now have hover effect

Also makes these other UI changes to discuss calls:

- card name has text-shadow instead of dark bg color
- avatar img size has been reduced (100px to 80px, was too big)

Task-5462123

Before / After
<img width="959" height="644" alt="Screenshot 2026-01-02 at 18 16 50" src="https://github.com/user-attachments/assets/b2bd4128-c298-4bfe-9843-4ff9aa2a7595" />
<img width="954" height="639" alt="Screenshot 2026-01-02 at 18 01 24" src="https://github.com/user-attachments/assets/5b954d86-e65e-4c97-8485-9c62200f60b0" />

