### PR TITLE
[FIX] payment: fix name splitting logic for single-word names

### DIFF
--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -144,7 +144,11 @@ def split_partner_name(partner_name):
     :return: The splitted first name and last name
     :rtype: tuple
     """
-    return " ".join(partner_name.split()[:-1]), partner_name.split()[-1]
+    parts = partner_name.split()
+    if len(parts) == 1:
+        return parts[0], ""
+
+    return " ".join(parts[:-1]), parts[-1]
 
 
 # Security


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The name splitting logic fails when the partner name contains only one word, resulting in an empty first name.

Current behavior before PR:
Splitting a single-word name returns an empty first name and assigns the word to the last name.

Desired behavior after PR is merged:
A single-word name is correctly assigned to the first name field, leaving the last name empty.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
