### PR TITLE
[FIX] l10n_pe: sync document number formatting with name field

### DIFF
--- a/addons/l10n_pe/models/account_move.py
+++ b/addons/l10n_pe/models/account_move.py
@@ -22,10 +22,16 @@ class AccountMove(models.Model):
     @api.onchange('l10n_latam_document_type_id', 'l10n_latam_document_number', 'partner_id')
     def _inverse_l10n_latam_document_number(self):
         """Inherit to complete the l10n_latam_document_number with the expected 8 characters after that a '-'
-        Example: Change FFF-32 by FFF-00000032, to avoid incorrect values on the reports"""
+
+        After formatting the document number with zfill(8), the name field is also synchronized
+        to ensure both fields remain consistent.
+
+        Example: Change F01-32 by F01-00000032, to avoid incorrect values on the reports
+        """
         super()._inverse_l10n_latam_document_number()
         to_review = self.filtered(
             lambda x: x.journal_id.type == "purchase"
+            and x.l10n_latam_document_type_id
             and x.l10n_latam_document_type_id.code in ("01", "03", "07", "08")
             and x.l10n_latam_document_number
             and "-" in x.l10n_latam_document_number
@@ -34,3 +40,12 @@ class AccountMove(models.Model):
         for rec in to_review:
             number = rec.l10n_latam_document_number.split("-")
             rec.l10n_latam_document_number = "%s-%s" % (number[0], number[1].zfill(8))
+
+            # Synchronize the name field with the formatted document number
+            # to ensure consistency between l10n_latam_document_number and name fields
+            expected_name = (
+                f"{rec.l10n_latam_document_type_id.doc_code_prefix} "
+                f"{rec.l10n_latam_document_number}"
+            )
+            if rec.name != expected_name:
+                rec.name = expected_name

--- a/doc/cla/individual/andyjquijada.md
+++ b/doc/cla/individual/andyjquijada.md
@@ -1,0 +1,11 @@
+Venezuela, 05/01/2025
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Andy Quijada. andyjquijada@gmail.com https://github.com/andyjquijada


### PR DESCRIPTION
When creating or editing Peruvian purchase invoices/credit notes, the l10n_latam_document_number field is formatted with zfill(8) (e.g., "F01-100" becomes "F01-00000100"), but the name field was not synchronized, causing data inconsistencies between these fields.

Steps to reproduce:
1. Create a purchase invoice for a Peruvian company
2. Select a document type (Factura, Boleta, or Credit/Debit Note)
3. Enter a document number like "F01-100"
4. Save the record
5. Observe that l10n_latam_document_number shows "F01-00000100" but name field may show a different format

This fix ensures that after formatting the document number, the name field is synchronized with the correctly formatted value, preventing inconsistencies in vendor invoices and reports.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
