### PR TITLE
[FIX] base: set Bulgaria currency to EUR

### DIFF
--- a/doc/cla/individual/tomatomov.md
+++ b/doc/cla/individual/tomatomov.md
@@ -1,0 +1,11 @@
+Bulgaria, 2026-01-03 
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Toma Tomov toma.tomov@gmail.com https://github.com/tomatomov

--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -142,7 +142,7 @@
         <record id="bg" model="res.country">
             <field name="name">Bulgaria</field>
             <field name="code">bg</field>
-            <field name="currency_id" ref="BGN" />
+            <field name="currency_id" ref="EUR" />
             <field eval="359" name="phone_code" />
             <field name="vat_label">VAT</field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Bulgaria adopted the euro as official currency as of 2026-01-01. Update the base country data accordingly.

Current behavior before PR:
In `res_country_data.xml`, Bulgaria is linked to BGN.

Desired behavior after PR is merged:
Bulgaria is linked to EUR in `res_country_data.xml`.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
