### PR TITLE
[FIX] point_of_sale: Wrong JE for POS Refund with payment method other than original

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1103,6 +1103,7 @@ class PosSession(models.Model):
         if float_compare(amounts['amount'], 0, precision_rounding=self.currency_id.rounding) < 0:
             # revert the accounts because account.payment doesn't accept negative amount.
             account_payment.write({
+                'force_outstanding_account_id': account_payment.destination_account_id,
                 'outstanding_account_id': account_payment.destination_account_id,
                 'destination_account_id': account_payment.outstanding_account_id,
                 'payment_type': 'outbound',

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1103,9 +1103,6 @@ class PosSession(models.Model):
         if float_compare(amounts['amount'], 0, precision_rounding=self.currency_id.rounding) < 0:
             # revert the accounts because account.payment doesn't accept negative amount.
             account_payment.write({
-                'force_outstanding_account_id': account_payment.destination_account_id,
-                'outstanding_account_id': account_payment.destination_account_id,
-                'destination_account_id': account_payment.outstanding_account_id,
                 'payment_type': 'outbound',
             })
 

--- a/doc/cla/individual/kamilmuhammed.md
+++ b/doc/cla/individual/kamilmuhammed.md
@@ -1,0 +1,11 @@
+Kuwait, 2026-01-05
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Kamil Muhammed kamilmhd1@gmail.com https://github.com/kamilmuhammed


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Wrong JE for POS Refund with payment method other than original

Current behavior before PR: POS on session close - for refund, the Payment JE has same Payment Account credited and debited

Desired behavior after PR is merged: POS on session close - for refund, the Payment JE should be as follows:

Bank Account - Credited
Recievable Account - Debit
And Recievable account should reconcile with recievable on sale side

Fixes #241959 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
