### PR TITLE
[FIX] mail: replace deprecated t-esc with t-out in chatter templates

### DIFF
--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -3,9 +3,9 @@
     <data>
         <!-- Discuss utility templates for notifications -->
         <template id="message_user_assigned">
-    <span>Dear <t t-esc="object.user_id.sudo().name"/>,</span>
+    <span>Dear <t t-out="object.user_id.sudo().name"/>,</span>
     <br/><br/>
-    <span style="margin-top: 8px;">You have been assigned to the <t t-esc="model_description or 'document'"/> <t t-esc="object.display_name"/>.</span>
+    <span style="margin-top: 8px;">You have been assigned to the <t t-out="model_description or 'document'"/> <t t-out="object.display_name"/>.</span>
     <br/>
         </template>
 
@@ -23,7 +23,7 @@
     <div t-if="feedback">
         <div class="fw-bold">Feedback:</div>
         <t t-foreach="feedback.split('\n')" t-as="feedback_line">
-            <t t-esc="feedback_line"/>
+            <t t-out="feedback_line"/>
             <br t-if="not feedback_line_last"/>
         </t>
     </div>
@@ -37,8 +37,8 @@
     <p>
         <span t-field="activity.create_uid.name"/> has just assigned you the following activity:
         <ul>
-            <li>Document: "<t t-esc="activity.res_name"/>"
-                <t t-if="model_description"> (<t t-esc="model_description"/>)</t>
+            <li>Document: "<t t-out="activity.res_name"/>"
+                <t t-if="model_description"> (<t t-out="model_description"/>)</t>
             </li>
             <li t-if="activity.summary">Summary: <span t-field="activity.summary"/></li>
             <li>Deadline: <span t-field="activity.date_deadline"/></li>
@@ -49,10 +49,10 @@
 
         <template id="message_origin_link">
             <p>
-                <t t-if="edit">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been modified from:</t>
-                <t t-else="">This <t t-esc="self.env['ir.model']._get(self._name).name.lower()"/> has been created from:</t>
+                <t t-if="edit">This <t t-out="self.env['ir.model']._get(self._name).name.lower()"/> has been modified from:</t>
+                <t t-else="">This <t t-out="self.env['ir.model']._get(self._name).name.lower()"/> has been created from:</t>
                 <t t-foreach="origin" t-as="o">
-                    <a href="#" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id"> <t t-esc="o.display_name"/></a><span t-if="origin.ids[-1:] != o.ids">, </span>
+                    <a href="#" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id"> <t t-out="o.display_name"/></a><span t-if="origin.ids[-1:] != o.ids">, </span>
                 </t>
             </p>
         </template>


### PR DESCRIPTION
## Summary

Replace deprecated QWeb directive `@t-esc` with `@t-out` in mail chatter templates.

The `t-esc` directive has been deprecated since Odoo 15 and triggers warnings in the logs:

```
WARNING odoo.addons.base.models.ir_qweb: Found deprecated directive @t-esc='...' in template XXX. Replace by @t-out
```

## Changes

- `message_user_assigned`: 3 occurrences
- `message_activity_done`: 1 occurrence  
- `message_activity_assigned`: 2 occurrences
- `message_origin_link`: 3 occurrences

## Note

This aligns with the changes already applied in the `master` branch.

## Test plan

- [x] Run Odoo and verify no deprecation warnings for template 373
- [x] Verify mail notifications render correctly

Signed-off-by: Harrison Chumpitaz <hca@focuz.io>