### PR TITLE
[FIX] hr: adding name on employee form view group

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -160,7 +160,7 @@
                             <page name="work_information" string="Work">
                                 <div class="row" id="o_hr_work_information_container">
                                     <div id="o_work_information" class="o_hr_column col-lg-7 d-flex flex-column">
-                                        <group string="work">
+                                        <group name="work" string="work">
                                             <field name="company_id" groups="base.group_multi_company" domain="[('id', 'in', allowed_company_ids)]"/>
                                             <field name="department_id"/>
                                             <field name="job_id" string="Job Position" context="{'default_no_of_recruitment': 0, 'default_is_favorite': False}" placeholder="e.g. Sales Manager"/>


### PR DESCRIPTION
Technical:
- The 'Work' group did not have names assigned to them.
- Assigning name to this group would be better if we want to extend the view.

task: 5002712

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
