### PR TITLE
[FIX] repair: cancel draft stock moves on repair order deletion

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -331,7 +331,7 @@ class Repair(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_confirmed(self):
-        repairs_to_cancel = self.filtered(lambda ro: ro.state not in ('draft', 'cancel'))
+        repairs_to_cancel = self.filtered(lambda ro: ro.state != 'cancel')
         repairs_to_cancel.action_repair_cancel()
 
     def action_assign(self):

--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -13,7 +13,7 @@ MAP_REPAIR_LINE_TYPE_TO_MOVE_LOCATIONS_FROM_REPAIR = {
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    repair_id = fields.Many2one('repair.order', check_company=True)
+    repair_id = fields.Many2one('repair.order', check_company=True, ondelete='cascade')
     repair_line_type = fields.Selection([
         ('add', 'Add'),
         ('remove', 'Remove'),

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -893,3 +893,17 @@ class TestRepair(common.TransactionCase):
         repair_order.action_repair_start()
         repair_order.action_repair_end()
         self.assertEqual(sale_line.discount, 15)
+
+    def test_delete_repair_resets_outgoing_stock_moves(self):
+        """
+        Test that deleting draft repair order clears its outgoing stock quantities and
+        related moves are unlinked
+        """
+        repair = self._create_simple_repair_order()
+        self._create_simple_part_move(repair.id, 1.0)
+        moves = repair.move_ids
+        self.assertEqual(repair.state, 'draft')
+        self.assertEqual(moves.state, 'draft')
+        repair.unlink()
+        self.assertFalse(repair.exists())
+        self.assertFalse(moves.exists())


### PR DESCRIPTION
**Steps to reproduce:**
* Install the *repair* module.
* Create a *storable product* and set some **On Hand** quantity.
* Go to *Repairs* and create a new **Repair Order**.
  Keep the repair order in *draft* state (do not confirm).
* In the **Parts** tab, add the storable product with the operation type set
  to *Add*.
* Open the **Stock Forecasted** report for the added product.
  Note the quantity shown under *Outgoing Draft Transfer*.
* Delete the **Repair Order**.
* Open the **Stock Forecasted** report for the same product again.

**Observed behavior:**
* The quantity still appears in the **Stock Forecasted** report under
  *Outgoing Draft Transfer* even after the repair order is deleted.

**Cause:**
* Deleting a draft repair order triggers `_unlink_except_confirmed`.
* This method prevents related stock moves from changing their state to
cancel when the repair order is deleted.
* The *Outgoing Draft Transfer* value is calculated as the sum of quantities
of stock moves in draft state at draft state.
https://github.com/odoo/odoo/blob/75ca0fec9a0d3b1e3a05a8bf3101bbe21846ac7a/addons/stock/report/stock_forecasted.py#L49

https://github.com/odoo/odoo/blob/75ca0fec9a0d3b1e3a05a8bf3101bbe21846ac7a/addons/stock/report/stock_forecasted.py#L90

* As a result, deleting a draft repair order leaves related stock moves in
draft state, causing them to appear under *Outgoing Draft Transfer*
https://github.com/odoo/odoo/blob/20d96c54b795b8d617776afe9877fb5c6632c666/addons/repair/models/repair.py#L332-L335

**Fix:**
* Ensure that related stock moves are properly cancelled when a draft repair
  order is deleted.

---

opw-5449323
