### PR TITLE
[FIX] stock_account: prevent crash when scrapping kit products

### DIFF
--- a/addons/mrp_account/tests/__init__.py
+++ b/addons/mrp_account/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_analytic_account
 from . import test_mrp_account
 from . import test_valuation_layers
 from . import test_valuation_operation
+from . import test_scrap_kit

--- a/addons/mrp_account/tests/test_scrap_kit.py
+++ b/addons/mrp_account/tests/test_scrap_kit.py
@@ -1,0 +1,20 @@
+from odoo.addons.mrp.tests.common import TestMrpCommon
+
+
+class TestScrapKit(TestMrpCommon):
+
+    def test_scrap_kit_does_not_crash(self):
+        self.env['stock.quant']._update_available_quantity(
+            self.product_3, self.stock_location, 3
+        )
+        self.env['stock.quant']._update_available_quantity(
+            self.product_4, self.stock_location, 2
+        )
+        scrap = self.env['stock.scrap'].create({
+            'product_id': self.product_5.id,
+            'scrap_qty': 1,
+            'location_id': self.stock_location.id,
+            'scrap_location_id': self.scrap_location.id,
+        })
+        scrap.action_validate()
+        self.assertEqual(scrap.state, 'done')

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -169,9 +169,9 @@ class StockMove(models.Model):
         # Use _is_out() instead of is_out since the move is not done
         # It's called before action_done since we need the current fifo
         # stack. Limitation when validating at same time out and ins
-        moves_out = self.filtered(lambda m: m._is_out())
-        moves_out._set_value()
         moves = super()._action_done(cancel_backorder=cancel_backorder)
+        moves_out = moves.filtered(lambda m: m._is_out())
+        moves_out._set_value()
         moves_in = moves.filtered(lambda m: m.is_in or m.is_dropship)
         moves_in._set_value()
         moves._create_account_move()


### PR DESCRIPTION
### Problem

When scrapping a product that uses a *Kit (phantom) BOM*, Odoo [explodes](https://github.com/odoo/odoo/blob/19.0/addons/mrp/models/stock_move.py#L357) the kit into its component products during the stock move [validation](https://github.com/odoo/odoo/blob/19.0/addons/stock/models/stock_scrap.py#L206-L231) process.

During this process:
- The original stock move of the kit product is [deleted](https://github.com/odoo/odoo/blob/19.0/addons/mrp/models/stock_move.py#L391).
- New stock moves are created for each component.
- However, during accounting processing, Odoo still attempts to use the deleted stock move.

This results in the following error:
"Record does not exist or has been deleted"
<img width="1400" height="600" alt="kit_issue" src="https://github.com/user-attachments/assets/2074e48e-d69f-4aac-954a-f9d64aee8267" />

The issue occurs inside `stock_account` during [_action_done()](https://github.com/odoo/odoo/blob/19.0/addons/stock_account/models/stock_move.py#L161-L174) the system tries to compute accounting values using:
    moves_out.product_id

At this point, `moves_out` contains deleted stock moves, especially when dealing with kit products.

---

In recent versions, `_update_standard_price()` is called inside `_action_done()` to ensure correct FIFO valuation.

However, when scrapping kit products:
- The parent (kit) stock move is removed during the [explosion](https://github.com/odoo/odoo/blob/19.0/addons/mrp/models/stock_move.py#L364-L402) step.
- The record still exists in memory, but no longer exists in the database.
- Accessing its fields causes a crash.

This problem does not appear for normal (non-kit) products because their stock moves are not deleted during scrap.

---

Before performing accounting operations, ensure that only existing stock moves are used.

This is done by calling `.exists()` before accessing move records:

 ### Steps to reproduce:
- Create  a database of version 19
- Install the Manufacturing and Accounting Nodule
- Create a product with BOM type set to "Kit".
- Create and validate a scrap record for the kit product.

OPW - [5410174](https://www.odoo.com/odoo/project/70/tasks/5410174)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
