### PR TITLE
[FIX] l10n_tw_edi_ecpay: `AllowanceDate` and `InvoiceRemark` parameter value update

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -580,9 +580,10 @@ class AccountMove(models.Model):
             "CustomerPhone": formatted_phone,
             "InvType": self.l10n_tw_edi_invoice_type,
             "TaxType": tax_type,
-            "InvoiceRemark": self.ref,
         }
 
+        if self.ref:
+            json_data["InvoiceRemark"] = self.ref
         if special_tax_type:
             json_data["SpecialTaxType"] = special_tax_type
 
@@ -651,7 +652,6 @@ class AccountMove(models.Model):
             })
         else:
             json_data.update({
-                "AllowanceDate": self.l10n_tw_edi_invoice_create_date.strftime("%Y-%m-%d %H:%M:%S"),
                 "CustomerEmail": self.partner_id.email,
             })
 

--- a/addons/l10n_tw_edi_ecpay/tests/test_edi.py
+++ b/addons/l10n_tw_edi_ecpay/tests/test_edi.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 from urllib.parse import urljoin
 
@@ -57,6 +57,7 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
         with patch(CALL_API_METHOD, new=self._test_01_mock):
             json_data = self.basic_invoice._l10n_tw_edi_generate_invoice_json()
         self.assertTrue(json_data)
+        self.assertNotIn("InvoiceRemark", json_data)
 
         # Validate the customer data
         self.assertEqual(json_data.get("MerchantID"), "1234")
@@ -64,6 +65,10 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
         self.assertEqual(json_data.get("CustomerEmail"), "partner_a@tsointsoin")
         self.assertEqual(json_data.get("CustomerPhone"), "0123456789")
         self.assertEqual(json_data.get("SalesAmount"), 1050.0)
+
+        self.basic_invoice.write({'ref': 'Test Reference'})
+        json_data_with_ref = self.basic_invoice._l10n_tw_edi_generate_invoice_json()
+        self.assertEqual(json_data_with_ref.get("InvoiceRemark"), "Test Reference")
 
     @freeze_time("2025-01-06 15:00:00")
     def test_02_basic_submission(self):
@@ -385,6 +390,48 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
         with patch(CALL_API_METHOD, new=self._test_12_mock):
             with self.assertRaises(UserError):
                 send_and_print.action_send_and_print()
+
+    @freeze_time("2025-01-13 15:00:00")
+    def test_13_b2b_refund_upload_deadline_restriction(self):
+        """Test B2B Refund compliance with ECPay's upload deadline restriction.
+
+        Context:
+        - Government Rule: Allowances must be uploaded within 7 days of creation.
+        - ECPay Restriction: The API rejects allowances where 'AllowanceDate' is older
+          than 6 days from the current upload time.
+
+        Scenario:
+        We simulate a refund for an ECPay-submitted invoice created 7 days ago.
+        We verify that 'AllowanceDate' is OMITTED from the JSON payload.
+        By omitting it, ECPay defaults the date to 'Now', ensuring the request
+        passes validation regardless of the gap. (not covered here)
+        """
+        seven_days_ago = datetime.now() - timedelta(days=7)
+        invoice = self.init_invoice("out_invoice", partner=self.partner_b, products=self.product_a)
+        invoice.write({
+            "invoice_date": seven_days_ago.date(),
+            "l10n_tw_edi_invoice_create_date": seven_days_ago,
+            "l10n_tw_edi_ecpay_invoice_id": "AB11100099"  # simulate it was already sent
+        })
+        invoice.action_post()
+
+        wizard_vals = {
+            "journal_id": invoice.journal_id.id,
+            "reason": "Refund 7 days later",
+            "l10n_tw_edi_refund_agreement_type": "offline",
+        }
+        wizard = self.env["account.move.reversal"].with_context(
+            active_ids=invoice.ids,
+            active_model="account.move"
+        ).create(wizard_vals)
+        wizard.reverse_moves()
+        credit_note = wizard.new_move_ids
+        credit_note.action_post()
+
+        json_data = credit_note._l10n_tw_edi_generate_issue_allowance_json()
+        self.assertNotIn("AllowanceDate", json_data,
+            "B2B Allowances should not include AllowanceDate to avoid >6 day limit errors."
+        )
 
     # -------------------------------------------------------------------------
     # Patched methods


### PR DESCRIPTION
**AllowanceDate**:
l10n_tw_edi_ecpay has an issue on Credit Notes (Allowances).
When we `_l10n_tw_edi_generate_issue_allowance_json()`, we send the
`l10n_tw_edi_invoice_create_date` which is was set to the associated
invoices creation date, and not the Allowance's creation date.

This creates a potential issue where allowances issued more than 6 days
after the original invoice would bounce back from ECpay with errors.
To be consistent with invoices send to ECPay, we do not send the
`AllowanceDate` parameter at all

Manual Testing/Verification:
1. Create an invoice that has a `l10n_tw_edi_invoice_create_date`,
visible in the Invoice's ECPay tab more than 6 days ago. (Requires
sending to ECPay via the custom wizard via the "Send" button)
2. Create a credit note from the invoice and send to ECPay.
3a. Before this, see that an error would appear.
3b. Now, there would be no error

*InvoiceRemark*:
When Customer Reference `ref` is not set, the code sets the parameter
value as `False`, displaying it's string on the e-invoice and official
printout. We only set the parameter if there exists the `ref` now,
eliminating the issue.

Tests:
1. (both cases) undo the `account_move.py` changes and run the tests.

task-[5455847](https://www.odoo.com/odoo/project/967/tasks/5455847)

---

# New test failed output
<img width="1458" height="353" alt="image" src="https://github.com/user-attachments/assets/77df8e51-5005-4d99-985c-71757c0f62a6" />

```bash
07:47:53,055 ERROR l10n_tw_edi_ecpay-demo-vy2vd3s0 odoo.addons.l10n_tw_edi_ecpay.tests.test_edi: FAIL: L10nTWITestEdi.test_01_can_generate_file
Traceback (most recent call last):
  File "/home/odoo/odev/worktrees/18.0-l10n_tw_edi_ecpay-fix-allowance-date-erle/odoo/addons/l10n_tw_edi_ecpay/tests/test_edi.py", line 61, in test_01_can_generate_file
    self.assertIsInstance(json_data["InvoiceRemark"], str)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: False is not an instance of <class 'str'>
 
07:48:02,516 ERROR l10n_tw_edi_ecpay-demo-vy2vd3s0 odoo.addons.l10n_tw_edi_ecpay.tests.test_edi: FAIL: L10nTWITestEdi.test_13_b2b_refund_upload_deadline_restriction
Traceback (most recent call last):
  File "/home/odoo/odev/virtualenvs/18.0/lib/python3.13/site-packages/freezegun/api.py", line 885, in wrapper
    result = func(*args, **kwargs)
  File "/home/odoo/odev/worktrees/18.0-l10n_tw_edi_ecpay-fix-allowance-date-erle/odoo/addons/l10n_tw_edi_ecpay/tests/test_edi.py", line 430, in test_13_b2b_refund_upload_deadline_restriction
    self.assertNotIn("AllowanceDate", json_data,
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        "B2B Allowances should not include AllowanceDate to avoid >6 day limit errors."
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: 'AllowanceDate' unexpectedly found in {'MerchantID': '1234', 'Details': [{'OriginalInvoiceNumber': 'AB11100099', 'OriginalInvoiceDate': '2025-01-06', 'OriginalSequenceNumber': 0, 'ItemName': 
                                                                                                                                                                                                              'product_a', 'ItemCount': 1.0, 'ItemPrice': 1000.0, 'ItemAmount': 1000.0}], 'TotalAmount': 1000.0, 'TaxAmount': 50.0, 'CustomerEmail': 'partner_b@tsointsoin', 'AllowanceDate': '2025-01-06 15:00:00'} : B2B 
                                                                                                                                                                                                            Allowances should not include AllowanceDate to avoid >6 day limit errors.
```

---

Things to think about:
- FWP
- [ ] 19.0
- [ ] master