### PR TITLE
[FIX] stock_account, sale_stock: prevent error on posting invoice

### DIFF
--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -60,7 +60,7 @@ class AccountMoveLine(models.Model):
         if original_line:
             return original_line.price_unit
 
-        if not self.product_id:
+        if not self.product_id or self.product_uom_id.is_zero(self.quantity):
             return self.price_unit
 
         cogs_qty = self._get_cogs_qty()


### PR DESCRIPTION
Currently an error occurs when user tries to post an invoice with zero quantity.

Steps to replicate:
- Install `stock_account`, 'accountant' and `sale_management`.
- Go to Settings and set `Inventory Valuation` to `Perpetual (at Invoicing)` and `Inventory Cost Method` to `FIFO`.
- Go to Products and create a new one with name `test`, set Track Inventory.
- Open Sale orders, create new one with product `test` and confirm.
- Go to the delivery and Validate it. (set the quantity to meet the demand).
- Go back to the Sale Order and click Create Invoice.
- On the Invoice make the quantity to be `0` and confirm it.
- Error will occur.

Error:
```
  File /home/odoo/odoo18/community/addons/stock_account/models/account_move.py, line 37, in _post
    self.env['account.move.line'].create(self._stock_account_prepare_realtime_out_lines_vals())
  File /home/odoo/odoo18/community/addons/stock_account/models/account_move.py, line 122, in _stock_account_prepare_realtime_out_lines_vals
    price_unit = line.with_context(anglo_saxon_price_ctx)._get_cogs_value()
  File /home/odoo/odoo18/community/addons/stock_account/models/account_move_line.py, line 85, in _get_cogs_value
    return (price_unit * total_qty - posted_cogs_value) / self.quantity
ZeroDivisionError: float division by zero
```

Cause:
- Error occurs after a recent [fix], that added some logic to correctly calculate cogs.
- As the user made quantity as 0, it caused the error at line [1].

Solution:
- Early return from the function if the quantity is zero.

[fix]: https://github.com/odoo/odoo/pull/237119

[1]: https://github.com/odoo/odoo/blob/d088dbad84492234ae792b76545497c6cd62e4f4/addons/stock_account/models/account_move_line.py#L83

sentry-7157442021
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
