### PR TITLE
[FIX] website: prevent sub menu hover behavior on hamburger header

### DIFF
--- a/addons/website/static/src/js/content/menu.js
+++ b/addons/website/static/src/js/content/menu.js
@@ -627,7 +627,7 @@ publicWidget.registry.FadeOutHeader = BaseDisappearingHeader.extend({
 });
 
 publicWidget.registry.hoverableDropdown = animations.Animation.extend({
-    selector: 'header.o_hoverable_dropdown',
+    selector: 'header.o_hoverable_dropdown:not(:has(.o_header_hamburger_right_col))',
     disabledInEditableMode: false,
     effects: [{
         startEvents: 'resize',

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -641,6 +641,9 @@
             <t t-set="_txt_elt_content" t-valuef="phone_mail"/>
         </t>
     </xpath>
+    <xpath expr="//header" position="attributes">
+         <attribute name="t-attf-class" remove="o_hoverable_dropdown" separator=" "/>
+     </xpath>
 </template>
 
 <template id="template_header_hamburger_align_right" inherit_id="website.template_header_hamburger" active="False">


### PR DESCRIPTION
### Issue:
- When the 'Sub Menus' option is set to 'On Hover' in the default header
  and the header template is later switched to the 'Hamburger Menu', the
  hover behavior is still applied.
- This is unintended because the hamburger header does not support sub
  menus, which results in confusing behavior.

### Steps to reproduce:
- Go to Website > Site > Menu Editor.
- Click 'Add Mega Menu Item' and set a title.
- Enter edit mode and select the header.
- Under 'Navbar', set 'Sub Menus' to 'On Hover'.
- Hover the mega menu item to confirm the behavior works.
- Change the header template to 'Hamburger Menu'.
- Open the hamburger menu and hover the mega menu item.
- The hover behavior remains active (should not happen)

### Reason:
The 'Sub Menus' option adds the `o_hoverable_dropdown` class directly to
the `<header>` element. When switching header templates, only the navbar
is replaced, not the header itself. Consequently, the class remains
attached, allowing the hover behavior to continue even with the
hamburger template.

### Fix:
Introduced a new template `disable_header_hover_dropdown` that removes
the `o_hoverable_dropdown` class from the header element. This template
is activated when switching to the hamburger layout, ensuring the hover
behavior is properly disabled.

task-5156627





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
