### PR TITLE
[FIX] pos_loyalty: more control button visibility

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -1,4 +1,4 @@
-import { useState } from "@odoo/owl";
+import { useState, onWillRender } from "@odoo/owl";
 import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { TextInputPopup } from "@point_of_sale/app/components/popups/text_input_popup/text_input_popup";
@@ -11,7 +11,11 @@ patch(ControlButtons.prototype, {
     setup() {
         super.setup(...arguments);
         this.state = useState({
-            nbrRewards: [],
+            nbrRewards: 0,
+        });
+
+        onWillRender(() => {
+            this.state.nbrRewards = this.getPotentialRewards().length;
         });
     },
     _getEWalletRewards(order) {

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -28,9 +28,11 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "1"),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "2"),
             // At this point, AAA Test Partner has 4 points.
+            PosLoyalty.isMoreControlButtonActive(true),
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen", true, "3"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1"),
+            PosLoyalty.isMoreControlButtonActive(false),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.orderTotalIs("6.40"),
             PosLoyalty.finalizeOrder("Cash", "10"),

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -251,6 +251,14 @@ export function checkPartnerPoints(name, points) {
     ];
 }
 
+export function isMoreControlButtonActive(active) {
+    return {
+        content: "More control button is " + (active ? "active" : "not active"),
+        trigger: active
+            ? ".control-buttons .more-btn.active"
+            : ".control-buttons:not(:has(.more-btn.active))",
+    };
+}
 export function isLoyaltyPointsAvailable() {
     return {
         content: "Loyalty Points are visible on the receipt",


### PR DESCRIPTION
Before this commit:
=========
- The more control button was being highlighted even if rewards were not available.

After this commit:
=========
- The more control button will be highlighted if only valid rewards are there.

task-5438708
