### PR TITLE
[FIX] mass_mailing: preserve transparency for images with alpha channel

### DIFF
--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -239,7 +239,7 @@ export class MassMailingHtmlField extends HtmlField {
             ...config,
             record: this.props.record,
             mobileBreakpoint: "md",
-            defaultImageMimetype: "image/jpeg",
+            defaultImageMimetype: "image/png",
             onEditorReady: () => this.commitChanges(),
         };
     }


### PR DESCRIPTION
Problem:
When adding an image with a transparent background in email marketing, the image ends up with a black background once processed.

Cause:
During image processing, a default `defaultImageMimetype` is applied. If the original image is a PNG and the default mimetype is set to `image/jpeg`, the transparency information is lost, resulting in a black background.

Solution:
Use `image/png` instead of `image/jpeg` as the
`defaultImageMimetype` to preserve transparency.
This was tested successfully in both Outlook and Gmail.

Steps to reproduce:
- Go to Email Marketing and add an image block.
- Add an image with a transparent background (usually a PNG).
- Observe that once added to the email, the image loses its transparency.

opw-5422685

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
