### PR TITLE
[FIX] hr: fix calculation of Worked Days and Worked Entries

### DIFF
--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -701,3 +701,28 @@ class TestHrVersion(TransactionCase):
         self.assertEqual(len(employee.version_ids), 2)
         version.unlink()
         self.assertEqual(len(employee.version_ids), 1)
+
+    def test_date_version_sync_contract_date_start_for_single_version(self):
+        """
+        This test is to ensure that in case when an employee has only one version, writing contract_date_start on the employee
+        will synchronize the version.date_version with that contract_date_start
+        """
+        with freeze_time(date(2025, 12, 20)), self.enter_registry_test_mode():
+            employee = self.env['hr.employee'].create({
+                'name': 'John Doe',
+            })
+            version = employee.version_id
+            self.assertEqual(version.date_version, date(2025, 12, 20))
+
+            employee.write({'contract_date_start': '2025-12-10'})
+            self.assertEqual(version.contract_date_start, date(2025, 12, 10))
+            self.assertEqual(version.date_version, date(2025, 12, 10))
+
+            # date_version should not be reset if contract_date_start is cleared
+            employee.write({'contract_date_start': False})
+            self.assertEqual(version.date_version, date(2025, 12, 10))
+
+            # and setting it again should re-sync
+            employee.write({'contract_date_start': '2025-12-15'})
+            self.assertEqual(version.contract_date_start, date(2025, 12, 15))
+            self.assertEqual(version.date_version, date(2025, 12, 15))

--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -378,6 +378,9 @@ class HrVersion(models.Model):
         for tz, versions in self.grouped("tz").items():
             tz = pytz.timezone(tz) if tz else pytz.utc
             for version in versions:
+                if not version.contract_date_start:
+                    continue
+
                 version_start = tz.localize(fields.Datetime.to_datetime(version.date_start)).astimezone(pytz.utc).replace(tzinfo=None)
                 version_stop = tz.localize(datetime.combine(fields.Datetime.to_datetime(version.date_end or date_stop),
                                                  datetime.max.time())).astimezone(pytz.utc).replace(tzinfo=None)


### PR DESCRIPTION
Problems:
-------
1. For a new employee, with a contract starting in the current month but before today:
in the payslip for the current month number of days of attendance and days of out of contract
are not correct

Same for an employee, with a contract ending in the current month (before today)

2. In both cases above worked entries are not generated correctly
(from today to the end of month)

3. Additional bug:
If we create an employee with no contract and create a payslip draft for him
for the current month, work entries with type "Attendance" will be created

Objective:
---------
Problems 1 and 2 :
date_version was equal to today (date of the employee's creation),
so number of attendance days was calculated as
( end_of_payslip_month - today ) or ( today - start_of_payslip_month )

Problem 3 :
Work entries are generated even when there is no active contract

Solution:
---------
Problems 1 and 2: This commit adds an additional part (already exists in v19) in the method
write() of hr.version which sets date_version = contract_date_start

Problem 3: by generating work entries check if contract_date_start is filled

Tests ware added in odoo/hr: test_hr_version.py
and in enterprise/hr_payroll:
test_new_employee_worked_days, test_payslip_empty_contract.py

task-5430759