### PR TITLE
[FIX] l10n_id_efaktur_coretax: Fix tax group restriction in efaktur coretax

### DIFF
--- a/addons/l10n_id_efaktur_coretax/models/account_move_line.py
+++ b/addons/l10n_id_efaktur_coretax/models/account_move_line.py
@@ -24,16 +24,23 @@ class AccountMoveLine(models.Model):
 
         # Separate tax into the regular and luxury component
         ChartTemplate = self.env['account.chart.template'].with_company(self.company_id)
+        default_tax_group = ChartTemplate.ref('default_tax_group', raise_if_not_found=False)
+        non_luxury_tax_group = ChartTemplate.ref('l10n_id_tax_group_non_luxury_goods', raise_if_not_found=False)
+        regular_tax_groups = {default_tax_group, non_luxury_tax_group}
+        regular_tax_groups.discard(False)
         luxury_tax_group = ChartTemplate.ref('l10n_id_tax_group_luxury_goods', raise_if_not_found=False)
         stlg_tax_group = ChartTemplate.ref('l10n_id_tax_group_stlg', raise_if_not_found=False)
         zero_tax_group_0 = ChartTemplate.ref('l10n_id_tax_group_0', raise_if_not_found=False)
         zero_tax_group_exempt = ChartTemplate.ref('l10n_id_tax_group_exempt', raise_if_not_found=False)
-        zero_tax_groups = {zero_tax_group_0, zero_tax_group_exempt} - {False}
+        zero_tax_groups = {zero_tax_group_0, zero_tax_group_exempt}
+        zero_tax_groups.discard(False)
+        ppn_tax_groups = regular_tax_groups | {luxury_tax_group, stlg_tax_group} | zero_tax_groups
+        ppn_tax_groups.discard(False)
 
         zero_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id in zero_tax_groups)
-        luxury_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id == luxury_tax_group)
         stlg_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id == stlg_tax_group)
-        regular_tax = self.tax_ids - luxury_tax - stlg_tax - zero_tax
+        regular_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id in regular_tax_groups)
+        ppn_tax = self.tax_ids.filtered(lambda tax: tax.tax_group_id in ppn_tax_groups)
 
         # "Price" is unit price calculation excluding tax and discount
         # "TotalDiscount" is total of "Price" * quantity * discount
@@ -48,13 +55,16 @@ class AccountMoveLine(models.Model):
             "Qty": self.quantity,
             "TotalDiscount": idr.round(self.discount * tax_res['total_excluded'] * self.quantity / 100),
             "TaxBase": idr.round(self.price_subtotal),  # DPP
-            "VATRate": 12,
+            "VATRate": 12 if ppn_tax else 0.0,
             "STLGRate": stlg_tax.amount if stlg_tax else 0.0,
         }
-        if self.move_id.l10n_id_kode_transaksi == "01" or (not regular_tax and not zero_tax):
-            line_val['OtherTaxBase'] = line_val['TaxBase']
+        if ppn_tax:
+            if self.move_id.l10n_id_kode_transaksi == "01" or (not regular_tax and not zero_tax):
+                line_val['OtherTaxBase'] = line_val['TaxBase']
+            else:
+                line_val['OtherTaxBase'] = idr.round(self.price_subtotal * 11 / 12)
         else:
-            line_val['OtherTaxBase'] = idr.round(self.price_subtotal * 11 / 12)
+            line_val['OtherTaxBase'] = 0
 
         line_val['VAT'] = idr.round(line_val['OtherTaxBase'] * line_val['VATRate'] / 100)
         line_val['STLG'] = idr.round(line_val['STLGRate'] * line_val['OtherTaxBase'] / 100)

--- a/addons/l10n_id_efaktur_coretax/tests/test_l10n_id_efaktur_coretax.py
+++ b/addons/l10n_id_efaktur_coretax/tests/test_l10n_id_efaktur_coretax.py
@@ -143,6 +143,30 @@ class TestEfakturCoretax(AccountTestInvoicingCommon):
         with self.assertRaisesRegex(ValidationError, "does not contain any taxes"):
             out_invoice_no_tax.download_efaktur()
 
+        # Report invoice contains no ppn taxes but have new tax with new created tax group
+        new_tax = self.env["account.tax"].create({
+            'type_tax_use': 'sale',
+            'name': 'PPH',
+            'amount': -5.0,
+            'tax_group_id': self.env["account.tax.group"].create({'name': 'PPH Tax Group'}).id,
+        })
+        out_invoice_with_new_tax_group_and_no_ppn_taxes = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-05-01',
+            'date': '2019-05-01',
+            'invoice_line_ids': [
+                (0, 0, {'name': 'line1', 'price_unit': 100000, 'quantity': 1, 'tax_ids': [new_tax.id]})
+            ],
+        })
+        out_invoice_with_new_tax_group_and_no_ppn_taxes.action_post()
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            r"need to have at least one PPN or STLG tax group."
+        ):
+            out_invoice_with_new_tax_group_and_no_ppn_taxes.download_efaktur()
+
         # Report invoice contains luxury and non-luxury
         out_invoice_luxury_non_luxury = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -157,7 +181,7 @@ class TestEfakturCoretax(AccountTestInvoicingCommon):
 
         with self.assertRaisesRegex(
             ValidationError,
-            r"can only have one tax group \(excluding STLG\)[\s\S]*Luxury-Goods and Non-Luxury-Goods taxes"
+            r"can only have one PPN tax group \(excluding STLG\)[\s\S]*Luxury-Goods and Non-Luxury-Goods taxes"
         ):
             out_invoice_luxury_non_luxury.download_efaktur()
 
@@ -758,4 +782,114 @@ class TestEfakturCoretax(AccountTestInvoicingCommon):
             '''
         )
 
+        self.assertXmlTreeEqual(result_tree, expected_tree)
+
+    def test_efaktur_with_new_tax_group(self):
+        """ Test efaktur with move line using new created tax & tax groups along with the luxury tax,
+        expected to work as normal and the new tax group not considered as regular tax which will make the
+        OtherTaxBase has 11/12 of the original value"""
+        # create new tax and new group
+        new_tax = self.env["account.tax"].create({
+            'type_tax_use': 'sale',
+            'name': 'PPH',
+            'amount': -5.0,
+            'tax_group_id': self.env["account.tax.group"].create({'name': 'PPH Tax Group'}).id,
+            'price_include': True
+        })
+
+        # create invoice containing the new tax along with one of the ppn tax group
+        move = self.env["account.move"].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-05-01',
+            'date': '2019-05-01',
+            'invoice_line_ids': [
+                (0, 0, {'product_id': self.product_a.id, 'name': 'line1', 'price_unit': 100000, 'quantity': 1, 'tax_ids': [new_tax.id, self.luxury_tax.id]}),
+            ],
+            'l10n_id_kode_transaksi': '04',
+        })
+        move.action_post()
+        move.download_efaktur()
+
+        result_tree = etree.fromstring(move.l10n_id_coretax_document._generate_efaktur_invoice())
+        expected_tree = self.with_applied_xpath(
+            etree.fromstring(self.sample_xml),
+            '''
+            <xpath expr="//TrxCode" position="replace">
+                <TrxCode>04</TrxCode>
+            </xpath>
+            <xpath expr="//Price" position="replace">
+                <Price>105263.16</Price>
+            </xpath>
+            <xpath expr="//TaxBase" position="replace">
+                <TaxBase>105263.16</TaxBase>
+            </xpath>
+            <xpath expr="//OtherTaxBase" position="replace">
+                <OtherTaxBase>105263.16</OtherTaxBase>
+            </xpath>
+            <xpath expr="//VAT" position="replace">
+                <VAT>12631.58</VAT>
+            </xpath>
+            <xpath expr="//VATRate" position="replace">
+                <VATRate>12</VATRate>
+            </xpath>
+            '''
+        )
+        self.assertXmlTreeEqual(result_tree, expected_tree)
+
+    def test_efaktur_with_new_tax_group_in_different_line(self):
+        """ Test efaktur with multiple invoice line where one is valid ppn invoice line
+        and the other one line have the new created tax group only
+
+        Expected to work since there is a valid invoice line for product_a while
+        the <GoodService> for product_b will still show up in the efaktur but their OtherTaxBase, VATRate, VAT are 0"""
+
+        # create new tax and new group
+        new_tax = self.env["account.tax"].create({
+            'type_tax_use': 'sale',
+            'name': 'PPH',
+            'amount': -5.0,
+            'tax_group_id': self.env["account.tax.group"].create({'name': 'PPH Tax Group'}).id,
+            'price_include': False
+        })
+
+        # Create the product and the invoice with 1 valid ppn invoice line and 1 that is not
+        product_2 = self.env['product.product'].create({'name': "Product B"})
+        out_invoice = self.env["account.move"].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-05-01',
+            'date': '2019-05-01',
+            'invoice_line_ids': [
+                (0, 0, {'product_id': self.product_a.id, 'name': 'line1', 'price_unit': 100000, 'quantity': 1}),
+                (0, 0, {'product_id': product_2.id, 'name': 'line2', 'price_unit': 100000, 'quantity': 1, 'tax_ids': [new_tax.id]})
+            ],
+            'l10n_id_kode_transaksi': '04',
+        })
+        out_invoice.action_post()
+        out_invoice.download_efaktur()
+
+        result_tree = etree.fromstring(out_invoice.l10n_id_coretax_document._generate_efaktur_invoice())
+        expected_tree = self.with_applied_xpath(
+            etree.fromstring(self.sample_xml),
+            '''
+            <xpath expr="//ListOfGoodService" position="inside">
+                <GoodService>
+                    <Opt>A</Opt>
+                    <Code>000000</Code>
+                    <Name>Product B</Name>
+                    <Unit>UM.0018</Unit>
+                    <Price>100000.00</Price>
+                    <Qty>1.0</Qty>
+                    <TotalDiscount>0.00</TotalDiscount>
+                    <TaxBase>100000.00</TaxBase>
+                    <OtherTaxBase>0.00</OtherTaxBase>
+                    <VATRate>0.0</VATRate>
+                    <VAT>0.00</VAT>
+                    <STLGRate>0.0</STLGRate>
+                    <STLG>0.00</STLG>
+                </GoodService>
+            </xpath>
+            '''
+        )
         self.assertXmlTreeEqual(result_tree, expected_tree)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This issue occured because in the previous update we add a condition to restrict multiple tax groups excluding the STLG.
Apparently there is a case where some users create their own tax groups (for example for PPH) so when they want to print an efaktur it will raise an error.

Current behavior before PR:
If a user create their own tax with a new tax group (outside of the 6 groups defined in `l10n_id`) and use it in invoice line along with one of the 6 tax groups excluding the STLG then it will blocked the print efaktur because it will raise an error  

Desired behavior after PR is merged:
- The restriction in tax groups only applied for the 6 tax groups in l10n_id so if an invoice line
  has multiple tax groups as long as there no more than one of the 6 tax groups excluding the STLG then
  it should be able to print the efaktur.
- Also when building the efaktur coretax value, the new tax group should not be included in the regular_tax
  variable which will cause the value to be 11/12 of the original value.
- Add new condition to block the print efaktur if there is a tax inside the invoice but none of it
  belong to the 6 ppn tax groups (there is already a condition to block if no tax is given, but now since there
  are cases where they use tax group outside of the defined tax groups then it will print the efaktur)
- If an invoice line does not have any ppn_tax_groups but there are other line in the same invoice
  that has it then it will still be able to print the efaktur, but the line without the ppn tax will
  have the OtherTaxBase and VATRate set to zero which will calculate the VAT as 0 too.

[5434656](https://www.odoo.com/odoo/project.task/5434656)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
