### PR TITLE
[FIX] website: avoid horizontal scrollbar when header reappears

### DIFF
--- a/addons/website/static/src/interactions/header/base_header.js
+++ b/addons/website/static/src/interactions/header/base_header.js
@@ -24,6 +24,9 @@ export class BaseHeader extends Interaction {
                 "o_header_is_scrolled": this.isScrolled,
                 "o_header_no_transition": !this.transitionActive,
             }),
+            "t-att-style": () => ({
+                transform: this.transformValue,
+            }),
         },
         ".offcanvas": {
             "t-on-show.bs.offcanvas": this.disableScroll,
@@ -54,6 +57,8 @@ export class BaseHeader extends Interaction {
         this.isVisible = true;
         this.isScrolled = false;
         this.forcedScroll = 0;
+
+        this.transformValue = "";
 
         this.isOverlay = !!this.el.closest(".o_header_overlay, .o_header_overlay_theme");
 
@@ -183,13 +188,15 @@ export class BaseHeader extends Interaction {
 
     transformShow() {
         this.isVisible = true;
-        this.el.style.transform = this.atTop ? "" : `translate(0, -${this.forcedScroll + this.topGap}px)`;
+        this.transformValue = this.atTop
+            ? ""
+            : `translate(0, -${this.forcedScroll + this.topGap}px)`;
         this.adaptToHeaderChangeLoop(1);
     }
 
     transformHide() {
         this.isVisible = false;
-        this.el.style.transform = "translate(0, -100%)";
+        this.transformValue = "translate(0, -100%)";
         this.adaptToHeaderChangeLoop(1);
     }
 

--- a/addons/website/static/src/interactions/header/header_fade_out.js
+++ b/addons/website/static/src/interactions/header/header_fade_out.js
@@ -25,7 +25,7 @@ export class HeaderFadeOut extends BaseHeaderSpecial {
         this.isVisible = false;
         // We want to translate the header after the transition is complete
         this.fadeTimeout = this.waitForTimeout(
-            () => (this.el.style.transform = "translate(0, -100%)"),
+            () => (this.transformValue = "translate(0, -100%)"),
             400
         );
         this.adaptToHeaderChangeLoop(1);

--- a/addons/website/static/src/interactions/header/header_standard.js
+++ b/addons/website/static/src/interactions/header/header_standard.js
@@ -56,6 +56,7 @@ export class HeaderStandard extends BaseHeader {
         if (this.atTop == reachHeaderBottom) {
             this.el.classList.add("o_transformed_not_affixed");
         }
+        this.el.style.transition = this.atTop == reachHeaderBottom ? "none" : "";
         this.atTop = !reachHeaderBottom;
 
         reachTransitionPoint


### PR DESCRIPTION
There was an horizontal scrollbar that would appear for a short time after scrolling back to the top of the page. This would occur because the header would still have the "transform" property but the class "o_header_affixed" was already removed.

To fix the issue, the header transform is now applied using dynamicContent, to synchronize the style and class correctly. This requires the standard header to have "transition: none" applied after it is scrolled since "translate(0, -100%)" would trigger an animation when hiding the header.

task-5155878