### PR TITLE
[FIX] account_edi_ubl_cii: leitweg-id

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -564,6 +564,12 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 }
             }
 
+        # For B2G transactions in Germany: set the buyer_reference to the Leitweg-ID (code 0204)
+        if vals['customer'].peppol_eas == "0204":
+            document_node.update({
+                'cbc:BuyerReference': {'_text': vals['customer'].peppol_endpoint},
+            })
+
     def _add_invoice_delivery_nodes(self, document_node, vals):
         """ [BR-IC-12]-In an Invoice with a VAT breakdown (BG-23) where the VAT category code (BT-118) is
         "Intra-community supply" the Deliver to country code (BT-80) shall not be blank.

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
@@ -309,6 +309,8 @@ class TestUBLDE(TestUBLCommon):
         self.assertTrue(created_bill)
 
     def test_leitweg_id(self):
+        self.env['ir.config_parameter'].sudo().set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True)
+
         partner = self.partner_2
         partner.write({
             'peppol_eas': '0204',


### PR DESCRIPTION
Correction of the forward port for the leitweg-id in the
'cbc:BuyerReference' field for the xRechnung invoice.
The 'export_invoice_vals' function is an old helper that
is not used by default anymore (but used by the tests, that
is why the tests did not catch the error). I added the if statement
in the corresponding new helper: '_add_invoice_header_nodes'  and
changed the test for it to catch the error.

Related: #236333

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
