### PR TITLE
[FIX] purchase_stock: valuation

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -179,7 +179,7 @@ class StockMove(models.Model):
         for move in self.purchase_line_id.move_ids:
             if move.product_id != self.product_id:
                 continue
-            if move.date > self.date or (move.date == self.date and move.id > self.id):
+            if move.date > self.date or (move.date == self.date and move.id >= self.id):
                 continue
             if move.is_in or move.is_dropship:
                 other_candidates_qty += move._get_valued_qty()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Assume the following use case:
- Create a PO for 2 units with unit price 1000
- Receive 1 units -> Create a back order
- Receive the backorder
- Create a bill for 1 unit at 200
- Create a bill for the second unit at 500

Expected behavior:
The moves have a total value of 700 (350 each)

Current behavior:
One move is valued correctly at 350 whereas the other one is valued at 1000 (in total 1350)

This is a result of 47345b1fc8b805e232a4287cc6d5c54b2f5886cb removing the valued qty of all moves whose date is earlier than the current move or whose date is the same and having a smaller or **equal** id. This is unexpected as the same id should probably not be subtracted, as this is the QTY we are interested in.

Tested on runbot.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
