### PR TITLE
[IMP] l10n_in_pos: handle missing HSN at session closing

### DIFF
--- a/addons/l10n_in_pos/__manifest__.py
+++ b/addons/l10n_in_pos/__manifest__.py
@@ -12,6 +12,7 @@
     ],
     'data': [
         'views/pos_order_line_views.xml',
+        'views/product_view.xml',
         'views/res_config_settings_views.xml',
         'data/pos_bill_data.xml',
     ],

--- a/addons/l10n_in_pos/models/__init__.py
+++ b/addons/l10n_in_pos/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import pos_order_line
+from . import product
 from . import product_template
 from . import account_move
 from . import account_move_line
@@ -10,3 +11,4 @@ from . import pos_bill
 from . import pos_session
 from . import pos_order
 from . import pos_config
+from . import res_company

--- a/addons/l10n_in_pos/models/pos_session.py
+++ b/addons/l10n_in_pos/models/pos_session.py
@@ -21,3 +21,26 @@ class PosSession(models.Model):
                 'product_uom_id': key['uom_id'],
             })
         return res
+
+    def set_missing_hsn_codes_in_pos_orders(self):
+        self.ensure_one()
+        PosOrderLine = self.env['pos.order.line']
+        base_domain = [
+            ('order_id.session_id', '=', self.id),
+            ('order_id.account_move', '=', False),
+            ('l10n_in_hsn_code', '=', False),
+            ('tax_ids', '!=', False),
+        ]
+
+        # Lines where product already has HSN
+        lines_with_product_hsn = PosOrderLine.search(
+            base_domain + [('product_id.l10n_in_hsn_code', '!=', False)]
+        )
+        for line in lines_with_product_hsn:
+            line.l10n_in_hsn_code = line.product_id.l10n_in_hsn_code
+
+        # Lines where product itself is missing HSN
+        missing_hsn_lines = PosOrderLine.search(
+            base_domain + [('product_id.l10n_in_hsn_code', '=', False)]
+        )
+        return missing_hsn_lines

--- a/addons/l10n_in_pos/models/product.py
+++ b/addons/l10n_in_pos/models/product.py
@@ -1,0 +1,70 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    l10n_in_hsn_missing_in_pos = fields.Boolean(
+        search="_search_l10n_in_hsn_missing_in_pos",
+        store=False,
+        string="HSN Missing in POS",
+    )
+
+    def _search_l10n_in_hsn_missing_in_pos(self, operator, value):
+        if operator not in ("=", "!="):
+            return NotImplemented
+
+        domain = [
+            ("order_id.session_id.state", "!=", "closed"),
+            ("order_id.account_move", "=", False),
+            ("product_id.product_tmpl_id.l10n_in_hsn_code", "=", False),
+            ("product_id.product_tmpl_id.taxes_id", "!=", False),
+        ]
+        grouped_data = self.env["pos.order.line"]._read_group(
+            domain,
+            aggregates=["__count"],
+            groupby=["product_id"],
+        )
+
+        product_ids = [row[0].id for row in grouped_data]
+        positive = (operator == "=" and value) or (operator == "!=" and not value)
+
+        return [("id", "in" if positive else "not in", product_ids)]
+
+    @api.model
+    def l10n_in_get_hsn_code_action(self):
+        """
+        Returns the action to open the HSN code dialog with the given products.
+        FIXME: This method dynamically creates a view at runtime.
+        FIXME: Remove this method and the dynamic view in master.
+        """
+
+        action_xml_id = 'l10n_in_pos.action_missing_hsn_product'
+        action = self.env.ref(action_xml_id, False)
+        if not action:
+            action = self.env['ir.actions.act_window'].sudo().create({
+                'name': 'Missing HSN Products',
+                'type': 'ir.actions.act_window',
+                'res_model': 'product.product',
+                'view_mode': 'kanban,list,form',
+                'domain': [
+                    ('l10n_in_hsn_missing_in_pos', '=', True)
+                ],
+                'help': """
+                    <p class="o_view_nocontent_smiling_face">
+                        Create a new product variant
+                    </p>
+                    <p>
+                        You must define an HSN for every product you sell through
+                        the point of sale interface.
+                    </p>
+                """,
+            })
+            self.env['ir.model.data']._update_xmlids([{
+                'xml_id': action_xml_id,
+                'record': action,
+            }])
+
+        return action_xml_id

--- a/addons/l10n_in_pos/models/res_company.py
+++ b/addons/l10n_in_pos/models/res_company.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    @api.model
+    def _load_pos_data_fields(self, config):
+        fields = super()._load_pos_data_fields(config)
+        if self.env.company.country_id.code == 'IN':
+            fields += ['l10n_in_is_gst_registered']
+        return fields

--- a/addons/l10n_in_pos/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/l10n_in_pos/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -1,14 +1,33 @@
 import { ClosePosPopup } from "@point_of_sale/app/components/popups/closing_popup/closing_popup";
 
 import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
 import { companyStateDialog } from "@l10n_in_pos/app/components/popups/company_state_dialog/company_state_dialog";
+import { hsnCodeDialog } from "@l10n_in_pos/app/components/popups/hsn_code_dialog/hsn_code_dialog";
 
 patch(ClosePosPopup.prototype, {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+    },
+
     async confirm() {
         await this.pos.data.read("res.company", [this.pos.company.id]);
         if (this.pos.company.country_id?.code === "IN" && !this.pos.company.state_id) {
             this.dialog.add(companyStateDialog);
             return;
+        }
+
+        if (this.pos.company.l10n_in_is_gst_registered) {
+            const missingHsnLines = await this.orm.call(
+                "pos.session",
+                "set_missing_hsn_codes_in_pos_orders",
+                [this.pos.session.id]
+            );
+            if (missingHsnLines?.length) {
+                this.dialog.add(hsnCodeDialog);
+                return;
+            }
         }
         return await super.confirm();
     },

--- a/addons/l10n_in_pos/static/src/app/components/popups/hsn_code_dialog/hsn_code_dialog.js
+++ b/addons/l10n_in_pos/static/src/app/components/popups/hsn_code_dialog/hsn_code_dialog.js
@@ -1,0 +1,27 @@
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+
+export class hsnCodeDialog extends Component {
+    static components = { Dialog };
+    static template = "l10n_in_pos.hsnCodeDialog";
+    static props = {
+        close: Function,
+    };
+
+    setup() {
+        this.pos = usePos();
+    }
+
+    async redirect() {
+        // Close dialog first
+        this.props.close();
+        const action_xml_id = await this.pos.data.call(
+            "product.product",
+            "l10n_in_get_hsn_code_action",
+            []
+        );
+        const url = `/odoo/action-${action_xml_id}`;
+        window.open(url, "_blank");
+    }
+}

--- a/addons/l10n_in_pos/static/src/app/components/popups/hsn_code_dialog/hsn_code_dialog.xml
+++ b/addons/l10n_in_pos/static/src/app/components/popups/hsn_code_dialog/hsn_code_dialog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="l10n_in_pos.hsnCodeDialog">
+        <Dialog size="'md'" title.translate="Missing HSN/SAC Codes">
+            <div>
+                <p>
+                    As POS sales are reported in GSTR-1, HSN/SAC codes must be set on all taxable products.<br/>
+                    Some products are missing this information, which prevents the session from being closed.
+                </p>
+                <p>
+                    If you know the HSN codes, you can go to Products and set the missing ones there.
+                </p>
+            </div>
+            <t t-set-slot="footer">
+                <div class="modal-footer-right d-flex gap-2">
+                    <button class="button icon btn btn-lg btn-primary" t-on-click="redirect">
+                        Go to Products
+                    </button>
+                </div>
+            </t>
+        </Dialog>
+    </t>
+
+</templates>

--- a/addons/l10n_in_pos/views/product_view.xml
+++ b/addons/l10n_in_pos/views/product_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="l10n_in_pos.product_template_view_form_normalized_pos" model="ir.ui.view">
+        <field name="name">l10n_in_pos.product.template.view.form.normalized.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="point_of_sale.product_template_view_form_normalized_pos"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='pos_categ_ids']" position="before">
+                <field name="l10n_in_hsn_code" invisible="'IN' not in fiscal_country_codes or not l10n_in_is_gst_registered_enabled"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="l10n_in_pos.product_tree_hsn_code" model="ir.ui.view">
+        <field name="name">l10n_in_pos.product.list.hsn_code.pos</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_product_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="l10n_in_hsn_code" string="HSN/SAC Code" optional="show"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="action_missing_hsn_product" model="ir.actions.act_window">
+        <field name="name">Missing HSN Products</field>
+        <field name="res_model">product.product</field>
+        <field name="view_mode">kanban,list,form</field>
+        <field name="domain">[('l10n_in_hsn_missing_in_pos', '=', True)]</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new product variant
+            </p>
+            <p>
+                You must define an HSN for every product you sell through
+                the point of sale interface.
+            </p>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Before this PR:
- POS order validation did not enforce the presence of HSN/SAC codes on products. Products without HSN could be sold via POS, and missing HSN values were only detected downstream during GST reporting, after the POS closing entry was generated.

After this PR:
- HSN/SAC validation is deferred to POS session closing. During the close flow, POS order lines with GST taxes and missing HSN/SAC codes are detected, and the user is required to complete the missing values before the closing journal entry is generated. POS order validation remains unblocked.

Why:
For Indian localization, POS closing entries are reported in GSTR-1, Table 12 (B2C HSN Summary). Missing HSN/SAC values on POS order lines result in incomplete or incorrect GST reporting. Deferring validation to session closing ensures all required HSN values are captured and propagated into the closing entry, while preserving the POS sales workflow.

Task Id: 5404786
