### PR TITLE
[IMP] project: add tooltip to share link for private projects

### DIFF
--- a/addons/project/wizard/project_task_share_wizard_views.xml
+++ b/addons/project/wizard/project_task_share_wizard_views.xml
@@ -19,6 +19,9 @@
             <xpath expr="//field[@name='partner_ids']" position="attributes">
                 <attribute name="invisible">project_privacy_visibility in ['invited_users', 'followers']</attribute>
             </xpath>
+            <xpath expr="//group[@name='share_link']" position="before">
+                <div class="alert text-center mt-4 alert-warning" role="alert" invisible="not (project_privacy_visibility in ['invited_users', 'followers'])">You can only share this task by copying the link and sending it, because the privacy of the project is too restricted. This link is not revokable once it has been shared.</div>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
Users were confused on how sharing a task through a link for private projects worked. Added tooltip to help.

### Current behavior before PR:
Regardless of the project’s privacy level, the task share link field did not display any warning or tooltip explaining the risks of sharing access via a link.

### Desired behavior after PR is merged:
When a user opens the Share Task wizard from a private project, the share link field now displays a tooltip explaining that:

- "You can only share this task by copying the link and send sending it, because the privacy of the project is too restricted. This link is not revokable once it has been shared."

### Implementation details:
The wizard contains two versions of the share link field, one without a tooltip and one with. Only one link field is displayed at a time, depending on the project’s privacy settings. This approach was necessary because conditional logic cannot be applied directly to XPath tags.

#### Task [5079214](https://www.odoo.com/odoo/project/4105/tasks/5079214)

#### Version : 19.2a1+e (Enterprise Edition)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
