### PR TITLE
[FIX] l10n_fr_account: fix vat exigibility mention on printed invoice

### DIFF
--- a/addons/l10n_fr_account/views/report_invoice.xml
+++ b/addons/l10n_fr_account/views/report_invoice.xml
@@ -52,8 +52,8 @@
 
         <xpath expr="//div[@name='qr_code_placeholder']" position="before">
             <div class="mb-3">
-                <p t-if="o.l10n_fr_is_company_french and o.move_type.startswith('out_') and 'on_invoice' in o.invoice_line_ids.mapped('tax_ids.tax_exigibility')">
-                    Option to pay tax on debits
+                <p t-if="o.l10n_fr_is_company_french and o.move_type.startswith('out_') and o.l10n_fr_account_show_tax_exigibility">
+                    Tax exigibility on debits
                 </p>
             </div>
         </xpath>


### PR DESCRIPTION
The VAT exigibility mention on French invoices was incorrectly displayed.

- For goods, VAT on debits is the default regime, therefore the mention is not mandatory and must not be shown.
- For services, VAT is normally due on payment. The mention “TVA payée sur les débits” must be displayed only when a service VAT uses tax exigibility based on invoice.

This commit updates the logic to display the mention only in this specific case and omits it otherwise.

Task:5418502



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
