### PR TITLE
[FIX] base_import: import action: allow to specify model in params

### DIFF
--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -93,7 +93,9 @@ export class ImportAction extends Component {
 
     async onWillStart() {
         const action = await this.actionService.currentAction;
-        const activeModel = this.props.action.params?.active_model;
+        // this.props.action.params.model is there for retro-compatiblity issues
+        const activeModel =
+            this.props.action.params?.model || this.props.action.params?.active_model;
         if (activeModel) {
             this.resModel = activeModel;
             if (action?.type === "ir.actions.act_window" && action?.res_model === this.resModel) {


### PR DESCRIPTION
This commit follows up the commit [1] and allows adding an `model` to the parameters of the `import` action, for retrocompatibility purposes.

Note that, this retrocompatibility existed before the commit [2], which was partially reverted by the commit [1].

[1] https://github.com/odoo/odoo/commit/7e351d87a5b6faad5bef447bdb077b7637f9c936
[2] https://github.com/odoo/odoo/commit/033d6afe36426067a7bada8b812898169d7968de