### PR TITLE
[FIX] html_editor: sanitize odoo-editor dataTransfer on drag and drop

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -671,6 +671,7 @@ export class ClipboardPlugin extends Plugin {
         }
         if (odooEditorHtml) {
             const fragment = parseHTML(this.document, odooEditorHtml);
+            this.dependencies.sanitize.sanitize(fragment);
             if (fragment.hasChildNodes()) {
                 this.dependencies.dom.insert(fragment);
                 this.dependencies.history.addStep();

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -1015,8 +1015,8 @@ test("should drag and drop image with its caption(1)", async () => {
             <p>a</p>
             <p>b</p>
             <figure contenteditable="false">
-                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
-                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                <img data-caption="${caption}" data-caption-id="${captionId}" src="${base64Img}" class="img-fluid test-image o_editable_media">
+                <figcaption placeholder="${caption}" data-embedded-props='{"id":"${captionId}","focusInput":false}' class="mt-2" contenteditable="false" data-oe-protected="true" data-embedded="caption">
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
@@ -1068,8 +1068,8 @@ test("should drag and drop image with its caption(2)", async () => {
             <p>a</p>
             <p>b</p>
             <figure contenteditable="false">
-                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
-                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                <img data-caption="${caption}" data-caption-id="${captionId}" src="${base64Img}" class="img-fluid test-image o_editable_media">
+                <figcaption placeholder="${caption}" data-embedded-props='{"id":"${captionId}","focusInput":false}' class="mt-2" contenteditable="false" data-oe-protected="true" data-embedded="caption">
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>
@@ -1118,8 +1118,8 @@ test("should drag and drop image with caption along with selected text", async (
             <p><br></p>
             <p>ca</p>
             <figure contenteditable="false">
-                <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="${caption}">
-                <figcaption ${getFigcaptionAttributes(captionId, caption)}>
+                <img data-caption="${caption}" data-caption-id="${captionId}" src="${base64Img}" class="img-fluid test-image o_editable_media">
+                <figcaption placeholder="${caption}" data-embedded-props='{"id":"${captionId}","focusInput":false}' class="mt-2" contenteditable="false" data-oe-protected="true" data-embedded="caption">
                     <input ${CAPTION_INPUT_ATTRIBUTES}>
                 </figcaption>
             </figure>

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -4592,7 +4592,7 @@ describe("onDrop", () => {
         await animationFrame();
 
         expect(getContent(el)).toBe(
-            `<p>ab<img class="img-fluid" data-file-name="image.png" src="${base64Image}">[]c</p>`
+            `<p>ab<img src="${base64Image}" data-file-name="image.png" class="img-fluid">[]c</p>`
         );
     });
     test("should drag and drop an image after another image", async () => {
@@ -4633,7 +4633,7 @@ describe("onDrop", () => {
         await animationFrame();
 
         expect(getContent(el)).toBe(
-            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image2}"><img class="img-fluid" data-file-name="image.png" src="${base64Image}">[]</p>`
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image2}"><img src="${base64Image}" data-file-name="image.png" class="img-fluid">[]</p>`
         );
     });
     test("should drag and drop third image after first image", async () => {
@@ -4673,7 +4673,7 @@ describe("onDrop", () => {
         await animationFrame();
 
         expect(getContent(el)).toBe(
-            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img class="img-fluid" data-file-name="image.png" src="${base64Image3}">[]<img class="img-fluid" data-file-name="image.png" src="${base64Image2}"></p>`
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img src="${base64Image3}" data-file-name="image.png" class="img-fluid">[]<img class="img-fluid" data-file-name="image.png" src="${base64Image2}"></p>`
         );
     });
     test("should drag and drop multiple images after another image", async () => {
@@ -4716,7 +4716,7 @@ describe("onDrop", () => {
         await animationFrame();
 
         expect(getContent(el)).toBe(
-            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image3}"><img class="img-fluid" data-file-name="image.png" src="${base64Image1}"><img class="img-fluid" data-file-name="image.png" src="${base64Image2}">[]</p>`
+            `<p><img class="img-fluid" data-file-name="image.png" src="${base64Image3}"><img src="${base64Image1}" data-file-name="image.png" class="img-fluid"><img src="${base64Image2}" data-file-name="image.png" class="img-fluid">[]</p>`
         );
     });
     test("should drag and drop banner", async () => {
@@ -4755,9 +4755,9 @@ describe("onDrop", () => {
 
         expect(getContent(el)).toBe(
             `<p><br></p><p>ca
-            </p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
-                <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
-                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+            </p><div role="status" contenteditable="false" data-oe-role="status" class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3">
+                <i aria-label="Banner Info" data-oe-aria-label="Banner Info" class="o_editor_banner_icon mb-3 fst-normal">💡</i>
+                <div contenteditable="true" class="o_editor_banner_content o-contenteditable-true w-100 px-3">
                     <p>Test</p>
                 </div>
             </div><p>b[]</p>`


### PR DESCRIPTION
Purpose:

Ensure that content transferred via drag and drop using the `application/vnd.odoo.odoo-editor` MIME type is sanitized before insertion.

