### PR TITLE
[ADD] google_microsoft_calendar: prevent sync duplicates via iCalUID

### DIFF
--- a/addons/google_microsoft_calendar/__init__.py
+++ b/addons/google_microsoft_calendar/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/google_microsoft_calendar/__manifest__.py
+++ b/addons/google_microsoft_calendar/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    'name': 'Google/Microsoft Calendar Bridge',
+    'version': '1.0',
+    'category': 'Hidden/Tools',
+    'description': """
+Bridge module between Google and Microsoft Calendar to prevent duplicate events.
+""",
+    'depends': ['google_calendar', 'microsoft_calendar'],
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/google_microsoft_calendar/models/__init__.py
+++ b/addons/google_microsoft_calendar/models/__init__.py
@@ -1,0 +1,2 @@
+from . import calendar
+from . import calendar_recurrence

--- a/addons/google_microsoft_calendar/models/calendar.py
+++ b/addons/google_microsoft_calendar/models/calendar.py
@@ -1,0 +1,34 @@
+from odoo import api, models
+
+
+class Meeting(models.Model):
+    _inherit = 'calendar.event'
+
+    @api.model
+    def _odoo_values(self, google_event, default_reminders=()):
+        values = super()._odoo_values(google_event, default_reminders)
+        if google_event.iCalUID:
+            values['ms_universal_event_id'] = google_event.iCalUID
+        return values
+
+    def _get_post_sync_values(self, request_values, google_values):
+        values = super()._get_post_sync_values(request_values, google_values)
+        if google_values.get('iCalUID'):
+            values['ms_universal_event_id'] = google_values.get('iCalUID')
+        return values
+
+    @api.model
+    def _sync_google2odoo(self, google_events, write_dates=None, default_reminders=()):
+        uids = [e.iCalUID for e in google_events if e.iCalUID]
+        if uids:
+            existing_by_uids = self.with_context(active_test=False).search([
+                ('ms_universal_event_id', 'in', uids),
+                ('google_id', '=', False)
+            ])
+            if existing_by_uids:
+                mapping = {e.ms_universal_event_id: e for e in existing_by_uids}
+                for gevent in google_events:
+                    if gevent.iCalUID in mapping:
+                        mapping[gevent.iCalUID].google_id = gevent.id
+
+        return super()._sync_google2odoo(google_events, write_dates, default_reminders)

--- a/addons/google_microsoft_calendar/models/calendar_recurrence.py
+++ b/addons/google_microsoft_calendar/models/calendar_recurrence.py
@@ -1,0 +1,34 @@
+from odoo import api, models
+
+
+class RecurrenceRule(models.Model):
+    _inherit = 'calendar.recurrence'
+
+    @api.model
+    def _odoo_values(self, google_recurrence, default_reminders=()):
+        values = super()._odoo_values(google_recurrence, default_reminders)
+        if google_recurrence.iCalUID:
+            values['ms_universal_event_id'] = google_recurrence.iCalUID
+        return values
+
+    def _get_post_sync_values(self, request_values, google_values):
+        values = super()._get_post_sync_values(request_values, google_values)
+        if google_values.get('iCalUID'):
+            values['ms_universal_event_id'] = google_values.get('iCalUID')
+        return values
+
+    @api.model
+    def _sync_google2odoo(self, google_events, write_dates=None, default_reminders=()):
+        uids = [e.iCalUID for e in google_events if e.iCalUID]
+        if uids:
+            existing_by_uids = self.with_context(active_test=False).search([
+                ('ms_universal_event_id', 'in', uids),
+                ('google_id', '=', False)
+            ])
+            if existing_by_uids:
+                mapping = {e.ms_universal_event_id: e for e in existing_by_uids}
+                for gevent in google_events:
+                    if gevent.iCalUID in mapping:
+                        mapping[gevent.iCalUID].google_id = gevent.id
+
+        return super()._sync_google2odoo(google_events, write_dates, default_reminders)

--- a/addons/google_microsoft_calendar/tests/__init__.py
+++ b/addons/google_microsoft_calendar/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_bridging

--- a/addons/google_microsoft_calendar/tests/test_bridging.py
+++ b/addons/google_microsoft_calendar/tests/test_bridging.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timedelta
+
+from odoo.addons.google_calendar.tests.test_sync_common import TestSyncGoogle
+from odoo.addons.google_calendar.utils.google_event import GoogleEvent
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestBridging(TestSyncGoogle):
+
+    def setUp(self):
+        super().setUp()
+        self.google_user1 = mail_new_test_user(self.env, login='google_user1', email='g1@google.com')
+        self.outlook_user1 = mail_new_test_user(self.env, login='outlook_user1', email='o1@outlook.com')
+
+        self.outlook_user1.microsoft_calendar_sync_token = 'mock_token'
+
+    def test_google_then_microsoft(self):
+        """ Test that an event synced from Google first is correctly matched by Microsoft sync. """
+        google_id = 'gid_123'
+        ical_uid = 'universal_456'
+
+        event_values = {
+            'id': google_id,
+            'iCalUID': ical_uid,
+            'summary': 'Google First Meeting',
+            'start': {'dateTime': '2023-01-01T10:00:00Z'},
+            'end': {'dateTime': '2023-01-01T11:00:00Z'},
+            'organizer': {'email': self.google_user1.email, 'self': True},
+            'attendees': [
+                {'email': self.google_user1.email, 'responseStatus': 'accepted', 'self': True},
+                {'email': self.outlook_user1.email, 'responseStatus': 'needsAction'},
+            ],
+            'reminders': {'useDefault': True},
+            'updated': '2023-01-01T09:00:00Z',
+        }
+        google_events = GoogleEvent([event_values])
+        self.env['calendar.event'].with_user(self.google_user1)._sync_google2odoo(google_events)
+
+        ms_id = 'ms_abc_123'
+        ms_event_values = {
+            'id': ms_id,
+            'iCalUId': ical_uid,
+            'subject': 'Google First Meeting',
+            'start': {'dateTime': '2023-01-01T10:00:00.0000000Z', 'timeZone': 'UTC'},
+            'end': {'dateTime': '2023-01-01T11:00:00.0000000Z', 'timeZone': 'UTC'},
+            'showAs': 'busy',
+            'isAllDay': False,
+            'responseStatus': {'response': 'none'},
+            'organizer': {'emailAddress': {'address': self.google_user1.email}},
+            'attendees': [
+                {'emailAddress': {'address': self.google_user1.email}, 'status': {'response': 'accepted'}},
+                {'emailAddress': {'address': self.outlook_user1.email}, 'status': {'response': 'none'}},
+            ],
+            'lastModifiedDateTime': '2026-01-01T09:05:00Z',
+        }
+        ms_events = MicrosoftEvent([ms_event_values])
+        self.env['calendar.event'].with_user(self.outlook_user1)._sync_microsoft2odoo(ms_events)
+
+        all_events = self.env['calendar.event'].search([('name', '=', 'Google First Meeting')])
+
+        self.assertEqual(len(all_events), 1, "Should NOT have created a duplicate")
+
+        event = all_events[0]
+        self.assertEqual(event.name, 'Google First Meeting')
+        self.assertEqual(len(event.attendee_ids), 2)
+
+    def test_microsoft_then_google(self):
+        """ Test that an event synced from Microsoft first is correctly matched by Google sync. """
+        ical_uid = 'universal_789'
+        ms_id = 'ms_def_456'
+
+        ms_event_values = {
+            'id': ms_id,
+            'iCalUId': ical_uid,
+            'subject': 'Microsoft First Meeting',
+            'start': {'dateTime': '2023-01-01T14:00:00.0000000Z', 'timeZone': 'UTC'},
+            'end': {'dateTime': '2023-01-01T15:00:00.0000000Z', 'timeZone': 'UTC'},
+            'showAs': 'busy',
+            'isAllDay': False,
+            'responseStatus': {'response': 'none'},
+            'organizer': {'emailAddress': {'address': self.outlook_user1.email}},
+            'attendees': [
+                {'emailAddress': {'address': self.outlook_user1.email}, 'status': {'response': 'accepted'}},
+                {'emailAddress': {'address': self.google_user1.email}, 'status': {'response': 'none'}},
+            ],
+            'lastModifiedDateTime': '2023-01-01T09:00:00Z',
+        }
+        ms_events = MicrosoftEvent([ms_event_values])
+        self.outlook_user1.microsoft_calendar_token_validity = datetime.now() + timedelta(hours=1)
+        self.env['calendar.event'].with_user(self.outlook_user1)._sync_microsoft2odoo(ms_events)
+
+        google_id = 'gid_456'
+        event_values = {
+            'id': google_id,
+            'iCalUID': ical_uid,
+            'summary': 'Microsoft First Meeting',
+            'start': {'dateTime': '2023-01-01T14:00:00Z'},
+            'end': {'dateTime': '2023-01-01T15:00:00Z'},
+            'organizer': {'email': self.outlook_user1.email, 'self': False},
+            'attendees': [
+                {'email': self.outlook_user1.email, 'responseStatus': 'accepted'},
+                {'email': self.google_user1.email, 'responseStatus': 'needsAction', 'self': True},
+            ],
+            'reminders': {'useDefault': True},
+            'updated': '2026-01-01T12:00:00Z',
+        }
+        google_events = GoogleEvent([event_values])
+        self.env['calendar.event'].with_user(self.google_user1)._sync_google2odoo(google_events)
+
+        all_events = self.env['calendar.event'].search([('name', '=', 'Microsoft First Meeting')])
+
+        self.assertEqual(len(all_events), 1, "Should NOT have created a duplicate")
+
+        event = all_events[0]
+        self.assertEqual(event.name, 'Microsoft First Meeting')
+        self.assertEqual(len(event.attendee_ids), 2)


### PR DESCRIPTION
When users sync the same calendar meeting from both Google Calendar and Microsoft Outlook, Odoo creates duplicate events that multiply with each sync cycle.

### Reproduction steps

1. User A connects their Google Calendar account to Odoo
2. User B connects their Microsoft Outlook account to Odoo
3. User A creates a meeting in Google Calendar and invites User B
4. User A syncs Google Calendar - the event is created in Odoo
5. User B syncs Microsoft Outlook - a duplicate event is created in Odoo instead of linking to the existing one
6. Continue syncing both accounts periodically
7. Observe: duplicates multiply with each sync cycle, flooding both calendars vents appear and multiply in both calendars

### Root cause

When a calendar event is created in Google Calendar or Microsoft Outlook, each service assigns it two identifiers: a service-specific ID (google_id or microsoft_id) and a universa identifier called iCalUID. The iCalUID is part of the iCalendar standard and remains constant across different calendar systems for the same event.

When User A syncs from Google Calendar, the google_calendar module retrieves the event including both the Google-specific ID and the iCalUID. However, the module only stores the google_id in Odoo's database. The iCalUID is received but never persisted to any field.

When User B syncs from Microsoft Outlook, the microsoft_calendar module retrieves the same meeting and stores both microsoft_id and ms_universal_event_id (containing the iCalUID). When searching for existing events, it queries for records matching either field. Since the Google-synced event has neither field populated, the search finds nothing and creates a second calendar.event record.

On the next Google sync, the google_calendar module sees the Microsoft-created event (which has no google_id) and interprets it as a new Odoo event requiring upload to Google. It creates a new event in Google Calendar, causing User A to see a duplicate. Subsequent Microsoft syncs propagate the duplicate back to Outlook. This cycle repeats indefinitely: eac module treats events from the other system as new, creating exponentially growing duplicates with every sync operation.

The fundamental problem is that google_calendar never stores the iCalUID, breaking the universal matching mechanism the iCalendar standard provides.

### Fix rationale

A new bridge module, `google_microsoft_calendar`, is introduced to ensure the `iCalUID` acts as the definitive link between the two services.

First, the module intercepts the Google synchronization process to persist the `iCalUID`. When an event arrives from Google, its `iCalUID` is now explicitly saved into the `ms_universal_event_id` field on the Odoo record. This ensures that events originating from Google are recognized by the Microsoft module during its sync.

Second, the Google synchronization logic is enhanced to perform a lookup by this universal ID. Before creating a new event, the system checks if an existing record already has the matching `ms_universal_event_id`. If a match is found (indicating the event was already created by Outlook), the system links the incoming Google ID to that existing record.

This ensures that regardless of which provider syncs first, Odoo recognizes the event as the same entity, preventing the creation of duplicates and breaking the synchronization loop.

opw-5045720
