### PR TITLE
[FIX] sale: enable SaleOrderLineListRenderer to be sorted

### DIFF
--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -210,6 +210,12 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
         return !!record.data.combo_item_id;
     }
 
+    isSortable(column) {
+        const { hasLabel, name, options } = column;
+        const { sortable } = this.fields[name];
+        return (sortable || options.allow_order) && hasLabel;
+    }
+
     shouldDuplicateSectionItem(record) {
         return !this.isCombo(record) && !this.isComboItem(record);
     }


### PR DESCRIPTION
#### Versions:
19.0+

### Issue:
Sale order line rendered is not sortable anymore like it was in previous versions.

#### Steps to reproduce:
1- Create a sale order.
2- Add multiple sale lines.
3- As you see sale lines are not sortable.

### Cause:
This is done due to #219253, which has overridden `isSortable` to return `False` on `SectionAndNoteListRenderer`. `SectionAndNoteListRenderer` is a superclass of `SaleOrderLineListRenderer`, which causes it not to be sortable.

opw-5407880
