### PR TITLE
[FIX] mail: prevent opening full composer when editing a message

### DIFF
--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -126,6 +126,7 @@ registerComposerAction("upload-files", {
 });
 registerComposerAction("open-full-composer", {
     condition: ({ composer, owner }) =>
+        !composer.message &&
         owner.props.showFullComposer &&
         composer.targetThread &&
         composer.targetThread.model !== "discuss.channel" &&

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -294,6 +294,25 @@ test("Can edit message comment in chatter", async () => {
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });
 });
 
+test("Basic list of edit message actions in chatter", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "original message",
+        message_type: "comment",
+        model: "res.partner",
+        res_id: partnerId,
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer.o-focused");
+    await click(".o-mail-Message .o-mail-Composer button[title='More Actions']");
+    await contains(".dropdown-menu .dropdown-item", { count: 1 });
+    await contains(".dropdown-menu .dropdown-item:has(:text('Attach Files'))");
+});
+
 test("Cursor is at end of composer input on edit", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({


### PR DESCRIPTION
Steps to reproduce:
===================
1- Go to a project task & log any note.
2- Edit & Click the additional "+" and click "Open Full Composer"
3- Click on Save.

-> traceback.

Cause:
======
When entering edit mode, the composer was created without a thread
reference, causing "Cannot read properties of undefined
(`this.props.composer.thread is undefined`)" errors in
`onClickFullComposer`.

Solution:
=========
We shouldn't have "open-full-composer" action in editing messages

opw-5443985
