### PR TITLE
[FIX] mail: fix user ensure_one error on mail create

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -594,7 +594,7 @@ class Message(models.Model):
     def create(self, values_list):
         tracking_values_list = []
         for values in values_list:
-            if not (self.env.user.has_group('base.group_user') or self.env.su):
+            if not ((self.env.user and self.env.user.has_group('base.group_user')) or self.env.su):
                 values.pop('author_id', None)
                 values.pop('email_from', None)
                 self = self.with_context({k: v for k, v in self.env.context.items() if k not in ['default_author_id', 'default_email_from']})  # noqa: PLW0642
@@ -708,7 +708,7 @@ class Message(models.Model):
         return super().fetch(field_names)
 
     def write(self, vals):
-        if not (self.env.user.has_group('base.group_user') or self.env.su):
+        if not ((self.env.user and self.env.user.has_group('base.group_user')) or self.env.su):
             vals.pop('author_id', None)
             vals.pop('email_from', None)
         record_changed = 'model' in vals or 'res_id' in vals


### PR DESCRIPTION
'self.env.user' can be empty. User 'has_group' method has ensure_one check, so it must not be called on empty recordsets.
Bug introduced here: https://github.com/odoo/odoo/commit/3056facc07024d02829bf2e27c9ee2f56695c99e
