### PR TITLE
[FIX] partnership: restore grade_id field position

### DIFF
--- a/addons/partnership/views/res_partner_views.xml
+++ b/addons/partnership/views/res_partner_views.xml
@@ -61,7 +61,7 @@
         <field name="priority">14</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <field name="vat" position="after">
+            <field name="website" position="after">
                 <field name="grade_id"/>
             </field>
         </field>


### PR DESCRIPTION
The following commit [1] modified the position of the VAT field, which caused
the grade_id field to be shifted. So this commit updates the xpath to restore
grade_id to its original location.

[1]: https://github.com/odoo/odoo/commit/3a56f59d466e72b3bf99f241c479cd3130173b41

task-5461569
