### PR TITLE
[FIX] l10n_dk_nemhandel: PrepaidAmount is not always empty

### DIFF
--- a/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
@@ -198,8 +198,9 @@ class AccountEdiXmlOIOUBL21(models.AbstractModel):
             ),
             'currencyID': vals['currency_name'],
         }
-        # PrepaidAmount must not be present if equal to 0 and is only filled with 0 in the parent method
-        document_node[monetary_total_tag]['cbc:PrepaidAmount'] = None
+        # PrepaidAmount must not be present if equal to 0
+        if document_node[monetary_total_tag].get('cbc:PrepaidAmount') and document_node[monetary_total_tag]['cbc:PrepaidAmount'].get('_text') == '0.00':
+            document_node[monetary_total_tag]['cbc:PrepaidAmount'] = None
 
     def _get_tax_category_node(self, vals):
         # EXTENDS account_edi_xml_ubl_20

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
@@ -195,7 +195,8 @@
     <cbc:LineExtensionAmount currencyID="DKK">1500.00</cbc:LineExtensionAmount>
     <cbc:TaxExclusiveAmount currencyID="DKK">375.00</cbc:TaxExclusiveAmount>
     <cbc:TaxInclusiveAmount currencyID="DKK">1875.00</cbc:TaxInclusiveAmount>
-    <cbc:PayableAmount currencyID="DKK">1875.00</cbc:PayableAmount>
+    <cbc:PrepaidAmount currencyID="DKK">1000.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="DKK">875.00</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:CreditNoteLine>
     <cbc:ID>___ignore___</cbc:ID>

--- a/addons/l10n_dk_nemhandel/tests/test_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/tests/test_xml_oioubl_21.py
@@ -76,7 +76,7 @@ class TestUBLDKOIOUBL21(TestUBLCommon, TestAccountMoveSendCommon):
         cls.dk_foreign_sale_tax_2 = cls.env["account.chart.template"].ref('tax_s7')
         cls.dk_local_purchase_tax_goods = cls.env["account.chart.template"].ref('tax_k1')
 
-    def create_post_and_send_invoice(self, partner=None, move_type='out_invoice'):
+    def create_post_and_send_invoice(self, partner=None, move_type='out_invoice', send=True):
         if not partner:
             partner = self.partner_a
 
@@ -112,12 +112,17 @@ class TestUBLDKOIOUBL21(TestUBLCommon, TestAccountMoveSendCommon):
             ],
         })
         invoice.action_post()
+        if send:
+            self._send_patched(invoice)
+        return invoice
+
+    @classmethod
+    def _send_patched(cls, invoice):
         with patch('odoo.addons.l10n_dk_nemhandel.models.res_partner.ResPartner._get_nemhandel_verification_state', return_value='not_valid'):
-            wizard = self.env['account.move.send.wizard'] \
+            wizard = cls.env['account.move.send.wizard'] \
                 .with_context(active_model=invoice._name, active_ids=invoice.ids) \
                 .create({})
             wizard.action_send_and_print()
-        return invoice
 
     @classmethod
     def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
@@ -167,7 +172,13 @@ class TestUBLDKOIOUBL21(TestUBLCommon, TestAccountMoveSendCommon):
 
     @freeze_time('2017-01-01')
     def test_export_credit_note_partner_dk(self):
-        refund = self.create_post_and_send_invoice(move_type='out_refund')
+        """ Check the export of a credit note that has been partially paid """
+        refund = self.create_post_and_send_invoice(move_type='out_refund', send=False)
+        self.env['account.payment.register'].with_context(active_model='account.move', active_ids=refund.ids).create({
+            'amount': 1000,
+        })._create_payments()
+
+        self._send_patched(refund)
         self.assertTrue(refund.ubl_cii_xml_id)
         self._assert_invoice_attachment(refund.ubl_cii_xml_id, xpaths=None, expected_file_path="from_odoo/oioubl_out_refund_partner_dk.xml")
 
@@ -205,12 +216,7 @@ class TestUBLDKOIOUBL21(TestUBLCommon, TestAccountMoveSendCommon):
             'invoice_line_ids': [Command.create(line_vals)],
         })
         invoice.action_post()
-        with patch('odoo.addons.l10n_dk_nemhandel.models.res_partner.ResPartner._get_nemhandel_verification_state',
-                   return_value='not_valid'):
-            wizard = self.env['account.move.send.wizard'] \
-                .with_context(active_model=invoice._name, active_ids=invoice.ids) \
-                .create({})
-            wizard.action_send_and_print()
+        self._send_patched(invoice)
         self.assertTrue(invoice.ubl_cii_xml_id)
         self._assert_invoice_attachment(invoice.ubl_cii_xml_id, xpaths=None, expected_file_path="from_odoo/oioubl_out_invoice_discount.xml")
         new_invoice = invoice.journal_id._create_document_from_attachment(invoice.ubl_cii_xml_id.ids)


### PR DESCRIPTION
To reproduce: create an invoice that is reconciled (typically a credit note) before Send&Print.
Check the validity of the xml with a schematron
=> it fails due to the value of the PrepaidAmount

The node PrepaidAmount gets removed because it was wrongly thought to be always empty.
We now only remove it if the value is at 0.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
