### PR TITLE
[FIX] html_editor: avoid creating font tags for invisible text nodes

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -12,6 +12,7 @@ import {
     isEmptyBlock,
     isRedundantElement,
     isTextNode,
+    isVisibleTextNode,
     isWhitespace,
     isZwnbsp,
 } from "@html_editor/utils/dom_info";
@@ -329,7 +330,9 @@ export class ColorPlugin extends Plugin {
                         font = [];
                     }
                 } else if (
-                    (node.nodeType === Node.TEXT_NODE && !isZwnbsp(node)) ||
+                    (node.nodeType === Node.TEXT_NODE &&
+                        !isZwnbsp(node) &&
+                        isVisibleTextNode(node)) ||
                     (node.nodeName === "BR" && isEmptyBlock(node.parentNode)) ||
                     (node.nodeType === Node.ELEMENT_NODE &&
                         ["inline", "inline-block"].includes(getComputedStyle(node).display) &&

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -56,6 +56,24 @@ test("can set background color", async () => {
     );
 });
 
+test("should not create font tags for invisible text nodes", async () => {
+    // Invisible spaces between elements in snippets
+    const { el } = await setupEditor("<p>[test</p>\n\u0020<p>test]</p>");
+
+    await expandToolbar();
+    await expectElementCount(".o_font_color_selector", 0);
+
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await expectElementCount(".o_font_color_selector", 1);
+
+    await click(".o_color_button[data-color='#6BADDE']");
+    await expectElementCount(".o-we-toolbar", 1);
+    await expectElementCount(".o_font_color_selector", 0); // selector closed
+    expect(getContent(el)).toBe(
+        `<p><font style="color: rgb(107, 173, 222);">[test</font></p>\n\u0020<p><font style="color: rgb(107, 173, 222);">test]</font></p>`
+    );
+});
+
 test("should add opacity to custom background colors but not to theme colors", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
 


### PR DESCRIPTION
#### Description of the issue this PR addresses:

- When applying font color, <font> tags were created for text nodes that contained only invisible content (whitespace or newlines).
- These whitespace-only text nodes are not visually rendered, but wrapping them in <font> tags caused unnecessary nodes to be inserted and broke the DOM structure in snippets.

#### Desired behavior after PR is merged:

- Apply font tags only to text nodes that contain visible content.
- Ignore whitespace-only (invisible) text nodes when wrapping content with <font> elements.

#### Steps to Reproduce:

- Open the website editor.
- Insert a content snippet (e.g., s_numbers_framed, s_comparisons).
- Select multiple blocks.
- Apply font color from toolbar.

=> <font> tags are created for whitespace-only text nodes too, breaking
   the snippet structure.

task-5454805

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
