### PR TITLE
[FIX] html_editor: improve selfClosingElements list

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -5,6 +5,7 @@ import {
     isProtected,
     isProtecting,
     isUnprotecting,
+    selfClosingHtmlTags,
 } from "@html_editor/utils/dom_info";
 import {
     childNodes,
@@ -70,27 +71,8 @@ import { weakMemoize } from "@html_editor/utils/functions";
  * @property {number} offset
  */
 
-// https://developer.mozilla.org/en-US/docs/Glossary/Void_element
-const VOID_ELEMENT_NAMES = [
-    "AREA",
-    "BASE",
-    "BR",
-    "COL",
-    "EMBED",
-    "HR",
-    "IMG",
-    "INPUT",
-    "KEYGEN",
-    "LINK",
-    "META",
-    "PARAM",
-    "SOURCE",
-    "TRACK",
-    "WBR",
-];
-
 export function isNotAllowedContent(node) {
-    return isMediaElement(node) || VOID_ELEMENT_NAMES.includes(node.nodeName);
+    return isMediaElement(node) || selfClosingHtmlTags.includes(node.nodeName);
 }
 
 export const isHtmlContentSupported = weakMemoize(

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -261,7 +261,26 @@ export function isVisibleTextNode(testedNode) {
  * @param {Node} node
  * @returns {boolean}
  */
-const selfClosingElementTags = ["BR", "IMG", "INPUT", "T", "HR"];
+// https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+export const selfClosingHtmlTags = [
+    "AREA",
+    "BASE",
+    "BR",
+    "COL",
+    "EMBED",
+    "HR",
+    "IMG",
+    "INPUT",
+    "KEYGEN",
+    "LINK",
+    "META",
+    "PARAM",
+    "SOURCE",
+    "TRACK",
+    "WBR",
+];
+export const selfClosingXmlTags = ["T"];
+export const selfClosingElementTags = [...selfClosingHtmlTags, ...selfClosingXmlTags];
 export function isSelfClosingElement(node) {
     return node && selfClosingElementTags.includes(node.nodeName);
 }

--- a/addons/html_editor/static/tests/_helpers/selection.js
+++ b/addons/html_editor/static/tests/_helpers/selection.js
@@ -1,3 +1,4 @@
+import { selfClosingHtmlTags } from "@html_editor/utils/dom_info";
 import { manuallyDispatchProgrammaticEvent, animationFrame } from "@odoo/hoot-dom";
 
 /**
@@ -38,8 +39,6 @@ function getTextContent(node, selection, options) {
     }
     return text.replace(/\u00a0/g, "&nbsp;");
 }
-
-const VOID_ELEMS = new Set(["BR", "IMG", "INPUT", "HR"]);
 
 function _getElemContent(el, selection, options) {
     let result = "";
@@ -85,7 +84,7 @@ function getElemContent(el, selection, options) {
         attrs.push(`${attr.name}=${valueLimiter}${attr.value}${valueLimiter}`);
     }
     const attrStr = (attrs.length ? " " : "") + attrs.join(" ");
-    return VOID_ELEMS.has(el.tagName)
+    return selfClosingHtmlTags.includes(el.tagName)
         ? `<${tag + attrStr}>`
         : `<${tag + attrStr}>${_getElemContent(el, selection, options)}</${tag}>`;
 }


### PR DESCRIPTION
Description of the issue this PR addresses:

This PR refines the `selfClosingElements` list by introducing `selfClosingHtmlTags` and `selfClosingXmlTags`, which together form `selfClosingElements`.

`selfClosingHtmlTags` is used in contexts where XML-only tags must not be treated as HTML void elements.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
