### PR TITLE
[FIX] crm: leads' stage must always be "New"

### DIFF
--- a/addons/crm/data/crm_lead_demo.xml
+++ b/addons/crm/data/crm_lead_demo.xml
@@ -815,7 +815,7 @@ Andrew</p>]]></field>
             <field name="date_open" eval="False"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="stage_lead2"/>
+            <field name="stage_id" ref="stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_mailing"/>
@@ -918,7 +918,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -940,7 +940,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -962,7 +962,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -983,7 +983,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -1005,7 +1005,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -1027,7 +1027,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -1071,7 +1071,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -1093,7 +1093,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -1115,7 +1115,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -1137,7 +1137,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>
@@ -1159,7 +1159,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_email_campaign_products"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_search_engine"/>


### PR DESCRIPTION
This PR corrects the stage_id of some crm.lead demo data. It must be "New" for crm.lead records of lead type as they are the first step of the prospecting. When the leads have chance of succeeding, they are converted in opportunity and then the stage can change. 

Task-5380531