### PR TITLE
[FIX] hr_holidays: fixing leave days allocation use priority

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -201,7 +201,10 @@ class HrEmployeeBase(models.AbstractModel):
                         allocations_with_date_to |= leave_allocation
                     else:
                         allocations_without_date_to |= leave_allocation
-                sorted_leave_allocations = allocations_with_date_to.sorted(key='date_to') + allocations_without_date_to
+                sorted_leave_allocations = (
+                    allocations_with_date_to.sorted(key='date_to') +
+                    allocations_without_date_to.filtered(lambda alloc: alloc.allocation_type == 'accrual') +
+                    allocations_without_date_to.filtered(lambda alloc: alloc.allocation_type == 'regular'))
 
                 if leave_type.request_unit in ['day', 'half_day']:
                     leave_duration_field = 'number_of_days'

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -3075,4 +3075,4 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         self._test_get_allocation_future_leaves_regular(regular_before=False)
 
     def test_get_allocation_future_leaves_regular2(self):
-        self._test_get_allocation_future_leaves_regular(regular_before=False)
+        self._test_get_allocation_future_leaves_regular(regular_before=True)


### PR DESCRIPTION
Fixing a typo introduced in commit 211330e083baaf16279d938a2b485a8fa20083a2.

Also, leave days should first use accrual plan allocation (as they can expires or will be likely to reach their maximum number of days).

**This bug has already been fixed in 18.0, see community#240282.**

runbot-build-error-234921
task-5449396
