### PR TITLE
[FIX] analytic: skip __update__ field in the analytic

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -61,10 +61,10 @@ class AnalyticMixin(models.AbstractModel):
 
     @api.depends('analytic_distribution')
     def _compute_distribution_analytic_account_ids(self):
-        all_ids = {int(_id) for rec in self for key in (rec.analytic_distribution or {}) for _id in key.split(',')}
+        all_ids = {int(_id) for rec in self for key in (rec.analytic_distribution or {}) for _id in key.split(',') if _id.isdigit()}
         existing_accounts_ids = set(self.env['account.analytic.account'].browse(all_ids).exists().ids)
         for rec in self:
-            ids = list(unique(int(_id) for key in (rec.analytic_distribution or {}) for _id in key.split(',') if int(_id) in existing_accounts_ids))
+            ids = list(unique(int(_id) for key in (rec.analytic_distribution or {}) for _id in key.split(',') if _id.isdigit() and int(_id) in existing_accounts_ids))
             rec.distribution_analytic_account_ids = self.env['account.analytic.account'].browse(ids)
 
     def _search_distribution_analytic_account_ids(self, operator, value):


### PR DESCRIPTION
Issue:
Before this commit, the analytic distribution field contained a mix of integers (account IDs) and strings (such as '__update__'). When attempting to retrieve the account ID, converting the '__update__' string to an integer caused an error.

Fix:
As a generic solution, instead of skipping only the '__update__' key—which may not be the only non-numeric string in the future—we now process only the strings that can be safely interpreted as numbers.

opw-5450293