### PR TITLE
[IMP] website: wrap s_cover content in a column to make it draggable

### DIFF
--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -2,7 +2,6 @@ import {
     clickOnSnippet,
     insertSnippet,
     registerWebsitePreviewTour,
-    changeOptionInPopover,
     changeBackgroundShape,
 } from "@website/js/tours/tour_utils";
 
@@ -66,10 +65,8 @@ registerWebsitePreviewTour(
             content: "Check that the shape element is present",
             trigger: ":iframe #wrap .s_cover .o_we_shape",
         },
-        // Add a column
-        ...changeOptionInPopover("Cover", "Layout", "[data-action-value='1']"),
         {
-            content: "Click on the created column",
+            content: "Click on the column",
             trigger: ":iframe #wrap .s_cover .row > :first-child",
             run: "click",
         },

--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -592,7 +592,10 @@ overridden by modules), because:
 
 <template id="new_page_template_about_s_cover" inherit_id="website.new_page_template_s_cover" primary="True">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt40 pb40" remove="pt232 pb232" separator=" "/>
+        <attribute name="class" add="pt40 pb40" remove="pt72 pb72" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div" position="attributes">
+        <attribute name="class" remove="pt160 pb160" separator=" "/>
     </xpath>
     <xpath expr="//h1" position="replace">
         <h1 style="text-align: center;">About Us</h1>
@@ -602,8 +605,8 @@ overridden by modules), because:
 <template id="new_page_template_landing_s_cover" inherit_id="website.new_page_template_s_cover" primary="True"/>
 
 <template id="new_page_template_landing_0_s_cover" inherit_id="website.new_page_template_landing_s_cover" primary="True">
-    <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt256 pb256" remove="pt232 pb232" separator=" "/>
+    <xpath expr="//div[hasclass('row')]/div" position="attributes">
+        <attribute name="class" add="pt184 pb184" remove="pt160 pb160" separator=" "/>
     </xpath>
     <xpath expr="//h1" position="replace">
         <h1 style="text-align: center;">Coming Soon</h1>
@@ -619,6 +622,9 @@ overridden by modules), because:
 <template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_s_cover" primary="True">
     <xpath expr="//section" position="attributes">
         <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
+    </xpath>
+    <xpath expr="//div[hasclass('row')]/div" position="attributes">
+        <attribute name="class" add="pt40 pb40" remove="pt160 pb160" separator=" "/>
     </xpath>
     <xpath expr="//h1" position="replace">
         <h1 style="text-align: center;">We Are Coming Soon</h1>

--- a/addons/website/views/snippets/s_cover.xml
+++ b/addons/website/views/snippets/s_cover.xml
@@ -2,19 +2,23 @@
 <odoo>
 
 <template id="s_cover" name="Cover">
-    <section class="s_cover parallax s_parallax_is_fixed o_cc o_cc5 pt232 pb232" data-scroll-background-ratio="1">
+    <section class="s_cover parallax s_parallax_is_fixed o_cc o_cc5 pt72 pb72" data-scroll-background-ratio="1">
         <span class="s_parallax_bg_wrap">
             <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_cover_default_image'); background-position: 50% 75%;"/>
         </span>
         <div class="o_we_bg_filter bg-black-50"/>
         <div class="container s_allow_columns">
-            <h1 class="display-3" style="text-align: center;">Your journey starts here</h1>
-            <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
-            <p style="text-align: center;">
-                <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2 o_translate_inline"><t t-out="cta_btn_text">Discover more</t></a>
-                <t t-set="contact_us_label">Contact us</t>
-                <a href="/contactus" class="btn btn-outline-secondary mb-2 o_translate_inline"><t t-out="contact_us_label"/></a>
-            </p>
+            <div class="row">
+                <div class="col-lg-12 pt160 pb160">
+                    <h1 class="display-3" style="text-align: center;">Your journey starts here</h1>
+                    <p class="lead" style="text-align: center;">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</p>
+                    <p style="text-align: center;">
+                        <a t-att-href="cta_btn_href" class="btn btn-secondary mb-2 o_translate_inline"><t t-out="cta_btn_text">Discover more</t></a>
+                        <t t-set="contact_us_label">Contact us</t>
+                        <a href="/contactus" class="btn btn-outline-secondary mb-2 o_translate_inline"><t t-out="contact_us_label"/></a>
+                    </p>
+                </div>
+            </div>
         </div>
     </section>
 </template>


### PR DESCRIPTION
Previously, the s_cover snippet did not support intuitive repositioning
of text over a background image. Users had to manually toggle grid mode
and adjust padding to place content freely.

The snippet content is now wrapped in a column (`col-lg-12`), so
dragging it in the website builder automatically activates grid mode
and allows free placement anywhere over the background image without
manual steps.

The section's base padding changes from `pt232/pb232` to `pt72/pb72`, and
the new column receives `pt160/pb160`. The total visual spacing remains
the same (`72 + 160 = 232`). Page templates that override padding now
target the column instead of (or in addition to) the section.

task-[5346415](https://www.odoo.com/odoo/project/974/tasks/5346415)
Design PR: https://github.com/odoo/design-themes/pull/1205
