### PR TITLE
[FIX] mail: prevent traceback when opening 'View Reactions' in portal

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -6,6 +6,7 @@ import { registry } from "@web/core/registry";
 import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
+import { MessageReactionMenu } from "@mail/core/common/message_reaction_menu";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { rpc } from "@web/core/network/rpc";
 
@@ -126,7 +127,13 @@ registerMessageAction("reactions", {
     condition: ({ message }) => message.reactions.length,
     icon: "fa fa-smile-o",
     name: _t("View Reactions"),
-    onSelected: ({ owner }) => owner.openReactionMenu(),
+    onSelected: ({ message, owner, store }) => {
+        store.env.services.dialog.add(
+            MessageReactionMenu,
+            { message: toRaw(message) },
+            { context: owner }
+        );
+    },
     sequence: 50,
 });
 registerMessageAction("unfollow", {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -22,7 +22,15 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { LONG_PRESS_DELAY } from "@mail/utils/common/hooks";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, leave, pointerDown, press, queryFirst, waitFor } from "@odoo/hoot-dom";
+import {
+    animationFrame,
+    leave,
+    pointerDown,
+    press,
+    queryFirst,
+    rightClick,
+    waitFor,
+} from "@odoo/hoot-dom";
 import { advanceTime, mockDate, mockTouch, mockUserAgent, tick } from "@odoo/hoot-mock";
 import {
     contains as webContains,
@@ -2020,6 +2028,32 @@ test("Click on view reactions shows the reactions on the message", async () => {
     await contains(".o-mail-MessageReaction:text('😅 1')");
     await click(".o-mail-Message [title='Expand']");
     await click(".o-dropdown-item:text('View Reactions')");
+    await contains(".o-mail-MessageReactionMenu:has(:text('😅 1'))");
+});
+
+test("Click on view reactions from right-click on message shows the reactions", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    pyEnv["mail.message"].create({
+        body: "Hello world",
+        res_id: channelId,
+        message_type: "comment",
+        model: "discuss.channel",
+        reaction_ids: [
+            pyEnv["mail.message.reaction"].create({
+                content: "😅",
+                partner_id: serverState.partnerId,
+            }),
+        ],
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message");
+    await rightClick(".o-mail-Message");
+    await click(".o-dropdown-item:contains('View Reactions')");
     await contains(".o-mail-MessageReactionMenu:has(:text('😅 1'))");
 });
 


### PR DESCRIPTION
Before this PR:
- Clicking the 'View Reactions' button from the message right-click menu was throwing an error.

After this PR:
- Clicking the 'View Reactions' button from the message right-click menu now opens the reactions list correctly without errors.

task-5449199




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
