### PR TITLE
[IMP] website: prevent dropping some snippets in tabs/toc/and more

### DIFF
--- a/addons/website/static/src/builder/plugins/options/faq_horizontal_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/faq_horizontal_option_plugin.js
@@ -14,6 +14,10 @@ class FaqHorizontalOptionPlugin extends Plugin {
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(BEGIN, FaqHorizontalOption)],
+        dropzone_selector: {
+            selector: ".s_faq_horizontal",
+            excludeAncestor: ".s_table_of_content",
+        },
     };
 }
 registry.category("website-plugins").add(FaqHorizontalOptionPlugin.id, FaqHorizontalOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
@@ -45,6 +45,10 @@ class NavTabsStyleOptionPlugin extends Plugin {
         }),
         is_unremovable_selector: ".nav-item",
         unsplittable_node_predicates: this.isUnsplittable,
+        dropzone_selector: {
+            selector: ".s_tabs, .s_tabs_images",
+            excludeAncestor: ".s_table_of_content, .s_tabs, .s_tabs_images",
+        },
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -34,6 +34,7 @@ class PopupOptionPlugin extends Plugin {
         dropzone_selector: {
             selector: ".s_popup",
             exclude: "#website_cookies_bar",
+            excludeAncestor: ".s_popup, .s_table_of_content, .s_tabs, .s_tabs_images",
             dropIn: ":not(p).oe_structure:not(.oe_structure_solo):not([data-snippet] *), :not(.o_mega_menu):not(p)[data-oe-type=html]:not([data-snippet] *)",
         },
         builder_actions: {

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option_plugin.js
@@ -43,7 +43,7 @@ class TableOfContentOptionPlugin extends Plugin {
         // Prevent dropping a table of content inside another table of content.
         dropzone_selector: {
             selector: ".s_table_of_content",
-            excludeAncestor: ".s_table_of_content",
+            excludeAncestor: ".s_table_of_content, .s_tabs, .s_tabs_images",
         },
         // Only allow moving main parts of the table of content by using arrows.
         is_draggable_handlers: (el) => {

--- a/addons/website/static/tests/builder/snippets.test.js
+++ b/addons/website/static/tests/builder/snippets.test.js
@@ -1,0 +1,40 @@
+import { getDragHelper } from "@html_builder/../tests/helpers";
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilderWithSnippet,
+    waitForSnippetDialog,
+} from "./website_helpers";
+
+defineWebsiteModels();
+
+test("Can't drop some snippets in the s_table_of_content snippet", async () => {
+    await setupWebsiteBuilderWithSnippet("s_table_of_content");
+    const { moveTo, drop } = await contains(
+        ".o-snippets-menu #snippet_groups .o_snippet_thumbnail"
+    ).drag();
+    await moveTo(":iframe .s_table_of_content .oe_drop_zone");
+    await drop(getDragHelper());
+    await waitForSnippetDialog();
+    const snippetsToTest = ["s_popup", "s_tabs", "s_table_of_content", "s_faq_horizontal"];
+    for (const snippet of snippetsToTest) {
+        await contains(".o_add_snippet_dialog_search").edit(snippet);
+        expect(`.modal-dialog :iframe [data-snippet-id='${snippet}']`).toHaveCount(0);
+    }
+});
+
+test("Can't drop some snippets in the s_tabs snippet", async () => {
+    await setupWebsiteBuilderWithSnippet("s_tabs");
+    const { moveTo, drop } = await contains(
+        ".o-snippets-menu #snippet_groups .o_snippet_thumbnail"
+    ).drag();
+    await moveTo(":iframe .s_tabs_main .oe_drop_zone");
+    await drop(getDragHelper());
+    await waitForSnippetDialog();
+    const snippetsToTest = ["s_popup", "s_tabs", "s_table_of_content"];
+    for (const snippet of snippetsToTest) {
+        await contains(".o_add_snippet_dialog_search").edit(snippet);
+        expect(`.modal-dialog :iframe [data-snippet-id='${snippet}']`).toHaveCount(0);
+    }
+});


### PR DESCRIPTION
This commit prevents the following snippets to be dropped inside other snippets like tabs, toc, and more:
- s_popup
- s_newsletter_subscribe_popup
- s_newsletter_benefits_popup
- s_tabs
- s_table_of_content
- s_faq_horizontal

task-5439635
