### PR TITLE
[FIX] account_edi_ubl_cii: prioritize partner legal entity name

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -726,8 +726,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'vat': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:CompanyID[string-length(text()) > 5]', tree),
             'phone': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:Telephone', tree),
             'mail': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:ElectronicMail', tree),
-            'name': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:Name', tree) or
-                    self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:RegistrationName', tree),
+            'name': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:RegistrationName', tree) or
+                    self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:Name', tree),
             'country_code': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cac:Country//cbc:IdentificationCode', tree),
             'street': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:StreetName', tree),
             'street2': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cbc:AdditionalStreetName', tree),


### PR DESCRIPTION
When we create an account.move from an XML file, Odoo first searches for an existing partner via some values fetched with `_import_retrieve_partner_vals()`.

Amongst those vals, the name can be fetched from either the `Contact:Name` or the `PartyLegalEntity:RegistrationName`.

Currently, the contact name is prioritized over the legal entity name. After discussion with CHKL, this should be the opposite.
Discord link: https://discord.com/channels/678381219515465750/694447009679147068/1457691361959608413

Related ticket: opw-5269360

