### PR TITLE
[REF] web_tour: allow keys for debug only in debug

### DIFF
--- a/addons/purchase_stock/static/tests/tours/purchase_catalog_suggest.js
+++ b/addons/purchase_stock/static/tests/tours/purchase_catalog_suggest.js
@@ -97,7 +97,7 @@ registry.category("web_tour.tours").add("test_purchase_order_suggest_search_pane
 
         // --- Check with Forecasted quantities
         ...catalogSuggestion.setParameters({ basedOn: "Forecasted", nbDays: 18, factor: 100 }),
-        { trigger: "span[name='suggest_total']:visible:contains('1,000')", pause: true },
+        { trigger: "span[name='suggest_total']:visible:contains('1,000')" },
         ...catalogSuggestion.assertCatalogRecord("test_product", { forecast: 50, suggest: 50 }), // 18 days --> forecast uses only one 50 delivery
 
         ...catalogSuggestion.setParameters({ nbDays: 7 }),

--- a/addons/sale_pdf_quote_builder/static/tests/tours/custom_content_kanban_like_tests.js
+++ b/addons/sale_pdf_quote_builder/static/tests/tours/custom_content_kanban_like_tests.js
@@ -13,7 +13,6 @@ registry.category("web_tour.tours").add('custom_content_kanban_like_tour', {
         },
         {
             trigger: "h5:contains(custom_1) ~ div textarea",
-            break: true,
             run: "edit Test",
         },
         ...stepUtils.saveForm(),

--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -43,9 +43,13 @@ const stepSchema = {
     },
     trigger: { type: String },
     expectUnloadPage: { type: Boolean, optional: true },
-    //ONLY IN DEBUG MODE
+};
+
+const stepSchemaDebug = {
+    ...stepSchema,
     pause: { type: Boolean, optional: true },
     break: { type: Boolean, optional: true },
+    observe: { type: Boolean, optional: true },
 };
 
 const tourSchema = {
@@ -270,7 +274,7 @@ export class TourService {
      * @param {boolean} [options.fromDB=false] - Whether the tour should be loaded from the database.
      * @param {string} [options.url] - URL to start the tour.
      * @param {"auto"|"manual"} [options.mode="auto"] - Tour start mode ("auto" or "manual").
-     * @param {number} [options.delayToCheckUndeterminisms=0] - Delay to check for indeterminisms in steps.
+     * @param {number} [options.observeDelay=3000] - Delay to check for indeterminisms in steps.
      * @param {number} [options.stepDelay=0] - Delay between each tour step.
      * @param {boolean} [options.keepWatchBrowser=false] - Whether to keep watching the browser continuously.
      * @param {number} [options.showPointerDuration=0] - Duration to show the pointer on each step.
@@ -291,13 +295,13 @@ export class TourService {
         }
 
         const tourConfig = {
-            delayToCheckUndeterminisms: 0,
             stepDelay: 0,
             keepWatchBrowser: false,
             mode: "auto",
             showPointerDuration: 0,
             debug: false,
             redirect: true,
+            observeDelay: 3000,
             ...options,
         };
 
@@ -324,8 +328,9 @@ export class TourService {
      * @param {Object} step - The step object to validate.
      */
     validateStep(step) {
+        const tourConfig = tourState.getCurrentConfig();
         try {
-            validate(step, stepSchema);
+            validate(step, tourConfig.debug ? stepSchemaDebug : stepSchema);
         } catch (error) {
             console.error(
                 `Error in schema for TourStep ${JSON.stringify(step, null, 4)}\n${error.message}`

--- a/addons/web_tour/static/tests/check_undeterminisms.test.js
+++ b/addons/web_tour/static/tests/check_undeterminisms.test.js
@@ -45,17 +45,21 @@ registry.category("web_tour.tours").add("tour_to_check_undeterminisms", {
         {
             trigger: ".button0",
             run: "click",
+            observe: true,
         },
         {
             trigger: ".button1",
             run: "click",
+            observe: true,
         },
         {
             trigger: ".container",
+            observe: true,
         },
         {
             trigger: ".button2",
             run: "click",
+            observe: true,
         },
     ],
 });
@@ -68,18 +72,19 @@ beforeEach(async () => {
         },
     });
     patchWithCleanup(browser.console, {
-        log: (s) => expect.step(`log: ${s}`),
-        error: (s) => {
+        log: () => {},
+        error: () => {},
+        warn: (s) => {
             s = s.replace(/\n +at.*/g, ""); // strip stack trace
             expect.step(`error: ${s}`);
         },
-        warn: () => {},
         dir: () => {},
     });
     await mountWithCleanup(Root);
     await odoo.startTour("tour_to_check_undeterminisms", {
         mode: "auto",
-        delayToCheckUndeterminisms: 300,
+        debug: true,
+        observeDelay: 300,
     });
 });
 
@@ -98,8 +103,6 @@ test("element is no longer visible", async () => {
     await waitForMacro();
     const expectedError = `Initial element is no longer visible`;
     expect.verifySteps([
-        "log: [1/4] Tour tour_to_check_undeterminisms → Step .button0",
-        "log: [2/4] Tour tour_to_check_undeterminisms → Step .button1",
         `error: FAILED: [2/4] Tour tour_to_check_undeterminisms → Step .button1.
 ${mainErrorMessage(".button1")}
 ${expectedError}`,
@@ -116,8 +119,6 @@ test("change text", async () => {
     };
     await waitForMacro();
     expect.verifySteps([
-        "log: [1/4] Tour tour_to_check_undeterminisms → Step .button0",
-        "log: [2/4] Tour tour_to_check_undeterminisms → Step .button1",
         `error: FAILED: [2/4] Tour tour_to_check_undeterminisms → Step .button1.
 ${mainErrorMessage(".button1")}
 Initial element has changed:
@@ -161,8 +162,6 @@ test("change attributes", async () => {
   ]
 }`;
     expect.verifySteps([
-        "log: [1/4] Tour tour_to_check_undeterminisms → Step .button0",
-        "log: [2/4] Tour tour_to_check_undeterminisms → Step .button1",
         `error: FAILED: [2/4] Tour tour_to_check_undeterminisms → Step .button1.
 ${mainErrorMessage(".button1")}
 Initial element has changed:
@@ -197,9 +196,6 @@ test("add child node", async () => {
   ]
 }`;
     expect.verifySteps([
-        "log: [1/4] Tour tour_to_check_undeterminisms → Step .button0",
-        "log: [2/4] Tour tour_to_check_undeterminisms → Step .button1",
-        "log: [3/4] Tour tour_to_check_undeterminisms → Step .container",
         `error: FAILED: [3/4] Tour tour_to_check_undeterminisms → Step .container.
 ${mainErrorMessage(".container")}
 Initial element has changed:
@@ -226,8 +222,6 @@ test.skip("snapshot is the same but has mutated", async () => {
   "attribute: class"
 ]`;
     expect.verifySteps([
-        "log: [1/4] Tour tour_to_check_undeterminisms → Step .button0",
-        "log: [2/4] Tour tour_to_check_undeterminisms → Step .button1",
         `error: FAILED: [2/4] Tour tour_to_check_undeterminisms → Step .button1.
 ${mainErrorMessage(".button1")}
 ${expectedError}`,

--- a/addons/web_tour/static/tests/tour_automatic.test.js
+++ b/addons/web_tour/static/tests/tour_automatic.test.js
@@ -313,10 +313,10 @@ test("a failing tour logs the step that failed", async () => {
         "log: [3/9] Tour tour1 → Step content (trigger: .button2)",
         "log: [4/9] Tour tour1 → Step content (trigger: .button3)",
         "log: [5/9] Tour tour1 → Step content (trigger: .wrong_selector)",
+        `runbot: {"content":"content","trigger":".button1","run":"click"},{"content":"content","trigger":".button2","run":"click"},{"content":"content","trigger":".button3","run":"click"},FAILED:[5/9]Tourtour1→Stepcontent(trigger:.wrong_selector){"content":"content","trigger":".wrong_selector","run":"click","timeout":111},{"content":"content","trigger":".button4","run":"click"},{"content":"content","trigger":".button5","run":"click"},{"content":"content","trigger":".button6","run":"click"},`,
         `error: FAILED: [5/9] Tour tour1 → Step content (trigger: .wrong_selector).
 Element (.wrong_selector) has not been found.
 TIMEOUT step failed to complete within 111 ms.`,
-        `runbot: {"content":"content","trigger":".button1","run":"click"},{"content":"content","trigger":".button2","run":"click"},{"content":"content","trigger":".button3","run":"click"},FAILED:[5/9]Tourtour1→Stepcontent(trigger:.wrong_selector){"content":"content","trigger":".wrong_selector","run":"click","timeout":111},{"content":"content","trigger":".button4","run":"click"},{"content":"content","trigger":".button5","run":"click"},{"content":"content","trigger":".button6","run":"click"},`,
     ]);
 });
 

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -149,7 +149,6 @@ export function assertCartContains({
         steps.push({
             content: `Checking if the cart line holds the expected quantity.`,
             trigger: `${backend ? ":iframe" : ""} ${quantityTrigger}`,
-            break: true,
         })
     }
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2559,7 +2559,6 @@ class HttpCase(TransactionCase):
             'keepWatchBrowser': kwargs.get('watch', False),
             'debug': kwargs.get('debug', False),
             'startUrl': url_path,
-            'delayToCheckUndeterminisms': kwargs.pop('delay_to_check_undeterminisms', int(os.getenv("ODOO_TOUR_DELAY_TO_CHECK_UNDETERMINISMS", "0")) or 0),
         }
         code = kwargs.pop('code', f"odoo.startTour({tour_name!r}, {json.dumps(options)})")
         ready = kwargs.pop('ready', f"odoo.isTourReady({tour_name!r})")
@@ -2567,9 +2566,6 @@ class HttpCase(TransactionCase):
 
         if step_delay is not None:
             self._logger.warning('step_delay is only suitable for local testing')
-        if options["delayToCheckUndeterminisms"] > 0:
-            timeout = timeout + 1000 * options["delayToCheckUndeterminisms"]
-            _logger.runbot("Tour %s is launched with mode: check for undeterminisms.", tour_name)
         Users = self.registry['res.users']
 
         def setup(_):


### PR DESCRIPTION
With this commit, we allow few keys (pause, break, observe) for a step only in debug mode.
- pause: pause the step with a promised infinite timeout to be resolved by hand with play() in console
- break: set a break point at the start of step
- observe: an helper to debug a step if a undeterminism is suspected in a step. This helper watch for mutations or modifications of the trigger.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
