### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: zero vat line level exemption

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/data/template/l10n_tr_nilvera_einvoice.account.tax.code-tr.csv
+++ b/addons/l10n_tr_nilvera_einvoice/data/template/l10n_tr_nilvera_einvoice.account.tax.code-tr.csv
@@ -9,6 +9,7 @@
 "l10n_tr_nilvera_einvoice.account_tax_code_328","13/i Residential or Workplace Deliveries","13/i Konut veya İşyeri Teslimleri","328","0.0","exception"
 "l10n_tr_nilvera_einvoice.account_tax_code_338","Exports of Goods by Manufacturers","İmalatçıların Mal İhracatları","338","0.0","exception"
 "l10n_tr_nilvera_einvoice.account_tax_code_350","Other","İstisna Diğer","350","0.0","exception"
+"l10n_tr_nilvera_einvoice.account_tax_code_351","351 - Other Not Exempt from VAT","351 - KDV İstisna Olmayan Diğer","351","0.0","export_exception"
 "l10n_tr_nilvera_einvoice.account_tax_code_601","Construction Works and Engineering-Architecture and Survey-Project Services Performed Along with These Works","Yapım İşleri İle Bu İşlerle Birlikte İfa Edilen Mühendislik-Mimarlık ve Etüt-Proje Hizmetleri","601","0.4","withholding"
 "l10n_tr_nilvera_einvoice.account_tax_code_602","Survey, Plan-Project, Consultancy, Audit and Similar Services","Etüt, Plan-Proje, Danışmanlık, Denetim ve Benzeri Hizmetler","602","0.9","withholding"
 "l10n_tr_nilvera_einvoice.account_tax_code_603","Renovation, Maintenance and Repair Services for Machinery, Equipment, Fixed Assets and Vehicles","Makine, Teçhizat, Demirbaş ve Taşıtlara Ait Tadil, Bakım, Onarım Hizmetleri","603","0.7","withholding"

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -750,7 +750,7 @@ class AccountEdiXmlUblTr(models.AbstractModel):
                 'cbc:TaxTypeCode': {'_text': grouping_key['tax_category_code']}
             }
         }
-        tax_invoice_exemption = vals['invoice'].l10n_tr_exemption_code_id
+        tax_invoice_exemption = self._l10n_tr_get_exemption_code(vals)
         if self.env.context.get('skip_tr_reason_code') or not tax_invoice_exemption:
             return tax_category_node
         tax_category_node.update({
@@ -758,6 +758,40 @@ class AccountEdiXmlUblTr(models.AbstractModel):
             'cbc:TaxExemptionReason': {'_text': tax_invoice_exemption.with_context(lang='tr_TR').name},
         })
         return tax_category_node
+
+    def _l10n_tr_get_exemption_code(self, vals):
+        """Return the tax exemption code to apply at invoice level.
+
+        For SATIŞ invoices, the exemption must come from the grouped line data
+        each line can define its own exemption reason. For all other invoice
+        types, the exemption set on the invoice is used.
+
+        :param vals: Dict containing the invoice and grouping information.
+        :return: The exemption code record to apply.
+        """
+        invoice = vals["invoice"]
+        if invoice.l10n_tr_gib_invoice_type == 'SATIS' and (exemption_reason := vals.get('grouping_key')['tax_exemption_reason']):
+            return exemption_reason
+        return invoice.l10n_tr_exemption_code_id
+
+    def _get_tax_exemption_reason(self, customer, supplier, tax):
+        """Determine the exemption reason for the given tax.
+
+        The special export tax 0% VAT must use its dedicated exemption code.
+        When this tax is detected, the method returns that predefined exemption
+        reason.
+
+        :param customer: Customer partner.
+        :param supplier: Supplier partner.
+        :param tax: Tax record being exported.
+        :return: Dict with the exemption code and record, or the default result.
+        """
+        if tax == self.env['account.chart.template'].ref('tr_s_0_ex', raise_if_not_found=False) and (exemption_351 := self.env.ref("l10n_tr_nilvera_einvoice.account_tax_code_351", raise_if_not_found=False)):
+            return {
+                'tax_exemption_reason_code': exemption_351.code,
+                'tax_exemption_reason': exemption_351,
+            }
+        return super()._get_tax_exemption_reason(customer, supplier, tax)
 
     def _get_tax_subtotal_node(self, vals):
         # EXTENDS account.edi.xml.ubl_21

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -129,6 +129,7 @@ class AccountMove(models.Model):
         "list of available exemption codes based on the selected "
         "GIB Invoice Type or other criteria.",
     )
+    l10n_tr_zero_vat_warning = fields.Binary(compute="_compute_l10n_tr_l10n_tr_zero_vat_warning")
     l10n_tr_nilvera_customer_status = fields.Selection(
         string="Partner Nilvera Status",
         related='partner_id.l10n_tr_nilvera_customer_status',
@@ -146,6 +147,12 @@ class AccountMove(models.Model):
         depends=['l10n_tr_nilvera_pdf_file'],
     )
     l10n_tr_original_invoice_date = fields.Date(string="Original Invoice Date")
+
+    @api.depends('invoice_line_ids.tax_ids')
+    def _compute_l10n_tr_l10n_tr_zero_vat_warning(self):
+        exempt_zero_tax = self.env['account.chart.template'].ref('tr_s_0_ex', raise_if_not_found=False)
+        for invoice in self:
+            invoice.l10n_tr_zero_vat_warning = exempt_zero_tax and invoice.l10n_tr_gib_invoice_type == 'SATIS' and exempt_zero_tax in invoice.line_ids.tax_ids
 
     @api.depends("l10n_tr_gib_invoice_scenario", "l10n_tr_gib_invoice_type", "l10n_tr_is_export_invoice")
     def _compute_l10n_tr_exemption_code_domain_list(self):

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_zero_export_vat_line_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_zero_export_vat_line_einvoice.xml
@@ -1,0 +1,196 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice
+  xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+  xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+  xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+  <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
+  <cbc:ID>EIN2025000000001</cbc:ID>
+  <cbc:CopyIndicator>false</cbc:CopyIndicator>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>SATIS</cbc:InvoiceTypeCode>
+  <cbc:Note>3 products</cbc:Note>
+  <cbc:Note>YALNIZ : DÖRTYÜZELLIALTI TRY SIFIR KURUS</cbc:Note>
+  <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+  <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
+  <cac:OrderReference>
+    <cbc:ID>EIN/2025/1</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3281. Cadde</cbc:StreetName>
+        <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+        <cbc:CityName>Düzce</cbc:CityName>
+        <cbc:PostalZone>06810</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">1729171602</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>einvoice_partner</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>einvoice_partner</cbc:RegistrationName>
+        <cbc:CompanyID>1729171602</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+        <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>TR0123456789</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:AllowanceCharge>
+    <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+    <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+    <cbc:Amount currencyID="TRY">48.00</cbc:Amount>
+  </cac:AllowanceCharge>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="TRY">54.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">0.00</cbc:TaxAmount>
+      <cbc:Percent>0.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:TaxExemptionReasonCode>351</cbc:TaxExemptionReasonCode>
+        <cbc:TaxExemptionReason>351 - KDV İstisna Olmayan Diğer</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">270.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">54.00</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="TRY">402.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="TRY">402.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="TRY">456.00</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="TRY">48.00</cbc:AllowanceTotalAmount>
+    <cbc:PayableAmount currencyID="TRY">456.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
+      <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="TRY">0.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">0.00</cbc:TaxAmount>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="DZN">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="TRY">270.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:MultiplierFactorNumeric>0.10</cbc:MultiplierFactorNumeric>
+      <cbc:Amount currencyID="TRY">30.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="TRY">54.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">270.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">54.00</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_b</cbc:Description>
+      <cbc:Name>product_b</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="TRY">100.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -1,4 +1,5 @@
 from freezegun import freeze_time
+from odoo import Command
 
 from odoo.addons.l10n_tr_nilvera_einvoice.tests.test_xml_ubl_tr_common import TestUBLTRCommon
 from odoo.tests import tagged
@@ -15,6 +16,7 @@ class TestUBLTR(TestUBLTRCommon):
         cls.company_data['company'].partner_id.write({'l10n_tr_tax_office_id': cls.env.ref("l10n_tr_nilvera_einvoice.tax_office_1009").id})
         cls.einvoice_partner.write({'l10n_tr_tax_office_id': cls.env.ref("l10n_tr_nilvera_einvoice.tax_office_1009").id})
 
+        cls.tax_0 = cls.env['account.chart.template'].ref('tr_s_0_ex')
         cls.tax_20 = cls.env['account.chart.template'].ref('tr_s_20')
         cls.tax_20_withholding = cls.env['account.chart.template'].ref('tr_s_vat_wh_20_OGH')
         # Registered for Export Reason
@@ -26,6 +28,9 @@ class TestUBLTR(TestUBLTRCommon):
 
         # Export Reason
         cls.reason_301 = cls.env['account.chart.template'].ref('l10n_tr_nilvera_einvoice.account_tax_code_301')
+
+        # Line Level Zero Tax Exemption Reason
+        cls.reason_351 = cls.env['account.chart.template'].ref('l10n_tr_nilvera_einvoice.account_tax_code_351')
         cls.incoterm = cls.env['account.chart.template'].ref('l10n_tr_nilvera_einvoice.incoterm_DAF')
 
     def test_xml_invoice_basic_export_registered_einvoice(self):
@@ -60,6 +65,31 @@ class TestUBLTR(TestUBLTRCommon):
             generated_xml = self._generate_return_invoice_xml(self.einvoice_partner)
 
         with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_return_einvoice.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))
+
+    def test_xml_invoice_basic_sale_zero_export_vat_line_einvoice(self):
+        with freeze_time('2025-03-05'):
+            invoice_line_ids = [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 50.00,
+                    'quantity': 3,
+                    'discount': 12,
+                    'tax_ids': [Command.set(self.tax_0.ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_b.id,
+                    'price_unit': 100.00,
+                    'quantity': 3,
+                    'discount': 10,
+                    'tax_ids': [Command.set(self.tax_20.ids)],
+                }),
+            ]
+            generated_xml = self._generate_invoice_xml(self.einvoice_partner, l10n_tr_gib_invoice_type="SATIS", invoice_line_ids=invoice_line_ids)
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_zero_export_vat_line_einvoice.xml', 'rb') as expected_xml_file:
             expected_xml = expected_xml_file.read()
 
         self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -84,6 +84,11 @@
             <xpath expr="//group[@name='sale_info_group']/field[@name='ref']" position="after">
                 <field name="l10n_tr_original_invoice_date" string="Original Invoice Date" invisible="country_code != 'TR' or move_type != 'out_refund' or reversed_entry_id" required="country_code == 'TR' and not reversed_entry_id and move_type == 'out_refund'"/>
             </xpath>
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-info d-flex justify-content-between align-items-center" role="alert" invisible="not l10n_tr_zero_vat_warning">
+                    For 0% EX VAT on sales invoices, an exemption reason is required. Odoo has set the default as "351 - Other Non-Exempt VAT"
+                </div>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Turkish sales invoices with 0% VAT require an exemption reason 351 "KDV – İstisna Olmayan Diğer". This change adds exemption reason 351 and notifies the user that the UBL Document with exemption 351 will be automatically set whenever a line uses a 0% sales VAT, ensuring compliance with GİB/Nilvera validations.

task-5244886
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
