### PR TITLE
[FIX] account_edi_ubl_cii: use RegistrationName over Contact/Name for partner

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1082,8 +1082,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'vat': self._find_value(f'.//cac:{role}Party//cbc:CompanyID[string-length(text()) > 5]', tree),
             'phone': self._find_value(f'.//cac:{role}Party//cac:Contact//cbc:Telephone', tree),
             'email': self._find_value(f'.//cac:{role}Party//cac:Contact//cbc:ElectronicMail', tree),
-            'name': self._find_value(f'.//cac:{role}Party//cac:Contact//cbc:Name', tree) or
-                    self._find_value(f'.//cac:{role}Party//cbc:RegistrationName', tree),
+            'name': self._find_value(f'.//cac:{role}Party//cbc:RegistrationName', tree) or
+                    self._find_value(f'.//cac:{role}Party//cac:Contact//cbc:Name', tree),
             'postal_address': self._get_postal_address(tree, role),
         }
 

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_example.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_example.xml
@@ -41,7 +41,7 @@
         <cbc:CompanyID>LU12977109</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:Name>ALD Automotive LU</cbc:Name>
+        <cbc:Name>Sales Department</cbc:Name>
         <cbc:ElectronicMail>adl@test.com</cbc:ElectronicMail>
       </cac:Contact>
     </cac:Party>


### PR DESCRIPTION
Steps To Reproduce
------------------

1- Go to Accounting > Vendors > Bills.
2- Upload a UBL XML file containing both RegistrationName and Contact/Name (you can use one of the two attached in the ticked).
3- Check the Vendor field.

Issue
-----

The vendor name is set to the contact person name instead of the company's legal name.

Cause
-----

In `_import_retrieve_partner_vals`, the XPath prioritizes `cac:Contact//cbc:Name` (contact person) over `cbc:RegistrationName` (company legal name).

Fix
---

Swap the priority to check `RegistrationName` first, falling back to `Contact/Name` only when no registration name exists.

Legal/Standards Proof (OASIS UBL 2.1 Specification) according to sources:

https://www.datypic.com/sc/ubl21/e-cac_PartyLegalEntity.html
- cbc:RegistrationName: "The name of the party as registered with the relevant legal authority."

http://www.datypic.com/sc/ubl21/e-cac_Contact.html
- cac:Contact/cbc:Name: "The name of this contact. It is recommended that this be used for a functional name and not a personal name."

The RegistrationName is the official legal company name, while Contact/Name is just a contact point at the company.

Test
------
For the test I updated a test file so that `test_import_partner_fields` fails without these changes.


opw-5392139

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
