### PR TITLE
[FIX] purchase, sale: show sale warning message from partner's company

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -132,6 +132,9 @@ class AccountMove(models.Model):
             warnings = OrderedSet()
             if partner_msg := move.partner_id.purchase_warn_msg:
                 warnings.add((move.partner_id.name or move.partner_id.display_name) + ' - ' + partner_msg)
+            if partner_parent_msg := move.partner_id.parent_id.purchase_warn_msg:
+                parent = move.partner_id.parent_id
+                warnings.add((parent.name or parent.display_name) + ' - ' + partner_parent_msg)
             for product in move.invoice_line_ids.product_id:
                 if product_msg := product.purchase_line_warn_msg:
                     warnings.add(product.display_name + ' - ' + product_msg)

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -293,6 +293,9 @@ class PurchaseOrder(models.Model):
             warnings = OrderedSet()
             if partner_msg := order.partner_id.purchase_warn_msg:
                 warnings.add((order.partner_id.name or order.partner_id.display_name) + ' - ' + partner_msg)
+            if partner_parent_msg := order.partner_id.parent_id.purchase_warn_msg:
+                parent = order.partner_id.parent_id
+                warnings.add((parent.name or parent.display_name) + ' - ' + partner_parent_msg)
             for line in order.order_line:
                 if product_msg := line.purchase_line_warn_msg:
                     warnings.add(line.product_id.display_name + ' - ' + product_msg)

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -913,7 +913,8 @@ class TestPurchase(AccountTestInvoicingCommon):
                              'Test Product 1 - Highly corrosive',
                              'Test Product 2 - Toxic pollutant')
         expected_warnings_for_purchase_order2 = ('Test Partner, Invoice - Slightly infectious disease',
-                                             'Test Product 2 - Toxic pollutant')
+                                                 'Test Partner - Highly infectious disease',
+                                                 'Test Product 2 - Toxic pollutant')
         self.assertEqual(purchase_order.purchase_warning_text, '\n'.join(expected_warnings))
         self.assertEqual(purchase_order2.purchase_warning_text, '\n'.join(expected_warnings_for_purchase_order2))
         self.assertEqual(invoice.purchase_warning_text, '\n'.join(expected_warnings_for_purchase_order2))

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -60,6 +60,9 @@ class AccountMove(models.Model):
             warnings = OrderedSet()
             if partner_msg := move.partner_id.sale_warn_msg:
                 warnings.add((move.partner_id.name or move.partner_id.display_name) + ' - ' + partner_msg)
+            if partner_parent_msg := move.partner_id.parent_id.sale_warn_msg:
+                parent = move.partner_id.parent_id
+                warnings.add((parent.name or parent.display_name) + ' - ' + partner_parent_msg)
             for product in move.invoice_line_ids.product_id:
                 if product_msg := product.sale_line_warn_msg:
                     warnings.add(product.display_name + ' - ' + product_msg)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -819,6 +819,9 @@ class SaleOrder(models.Model):
             warnings = OrderedSet()
             if partner_msg := order.partner_id.sale_warn_msg:
                 warnings.add((order.partner_id.name or order.partner_id.display_name) + ' - ' + partner_msg)
+            if partner_parent_msg := order.partner_id.parent_id.sale_warn_msg:
+                parent = order.partner_id.parent_id
+                warnings.add((parent.name or parent.display_name) + ' - ' + partner_parent_msg)
             for line in order.order_line:
                 if product_msg := line.sale_line_warn_msg:
                     warnings.add(line.product_id.display_name + ' - ' + product_msg)

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -731,6 +731,7 @@ class TestSaleOrder(SaleCommon):
                              'Test Product 1 - Highly corrosive',
                              'Test Product 2 - Toxic pollutant')
         expected_warnings_for_sale_order2 = ('Test Partner, Invoice - Slightly infectious disease',
+                                             'Test Partner - Highly infectious disease',
                                              'Test Product 1 - Highly corrosive',
                                              'Test Product 2 - Toxic pollutant')
         self.assertEqual(sale_order.sale_warning_text, '\n'.join(expected_warnings))


### PR DESCRIPTION
### Issue:
Due to this issue, the sale warning message is only shown when the warning message is set on partner itself, not partner's company.

#### Steps to reproduce (with demo data):
1- Enable `Sale warnings` from setting.
2- On `Contacts` app, open `Azure Interior`, and add a sale warning from `Notes` tab.
3- Create a SO with `Brandon Freeman` from `Azure Interior` as the customer.
4- No sale warning is shown.

### Cause:
The IMP #192211 replaces warning popup with a message. However, it doesn't check for the warning from `partner_id.parent_id`, which was the case before that PR.

This is the case with purchase as well.

opw-5404983
