### PR TITLE
[FIX] web: fix dropdown shrinking near window edges

### DIFF
--- a/addons/web/static/src/core/position/utils.js
+++ b/addons/web/static/src/core/position/utils.js
@@ -235,18 +235,13 @@ function computePosition(popper, target, { container, flip, margin, position, sh
             result.top -= directionOverflow;
             return { result, malus: 0 };
         } else if (shrink) {
-            const minTop = Math.floor(!vertical && v[0] === "s" ? targetBox.top : contBox.top);
-            result.top = Math.max(minTop, result.top);
+            result.top = Math.max(Math.floor(contBox.top), result.top);
 
             let height;
             if (vertical) {
                 height = Math.abs(targetBox[direction] - (d === "t" ? directionMin : directionMax));
             } else {
-                height = {
-                    s: variantMax - targetBox.top,
-                    m: variantMax - variantMin,
-                    e: targetBox.bottom - variantMin,
-                }[v[0]];
+                height = variantMax - variantMin;
             }
             result.maxHeight = Math.floor(height);
         }

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -832,7 +832,7 @@ test(
 test(
     "max height to prevent container overflow - right-start",
     shrinkPopperTest("right-start", 0, ({ c, p, t }) => {
-        expect(p.top).toBe(t.top);
+        expect(p.top).toBe(c.top);
         expect(p.bottom).toBe(c.bottom);
     })
 );
@@ -846,8 +846,8 @@ test(
 test(
     "max height to prevent container overflow - right-end",
     shrinkPopperTest("right-end", 0, ({ c, p, t }) => {
-        expect(p.bottom).toBe(t.bottom);
         expect(p.top).toBe(c.top);
+        expect(p.bottom).toBe(c.bottom);
     })
 );
 test(


### PR DESCRIPTION
This commit resolves an issue where dropdowns shrank incorrectly when positioned close to the window's edges.

Following changes in https://github.com/odoo/odoo/pull/239601, only one positioning variant is tested per direction, with the popper shifting to stay inside the container. However, the existing shrinking logic attempted to strictly adhere to that specific variant. This conflict led to unsatisfactory rendering when space was tight near the edges.

The fix is to decouple the shrinking logic from the specific positioning variant. The shrinking computation now ignores the variant preference and only reduces the size when the popper physically exceeds the container dimensions.

task-5462517
