### PR TITLE
[FIX] *: avoid resetting kit price unit at validation

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 from odoo import models
 
 
@@ -27,3 +29,16 @@ class StockMove(models.Model):
             m.bom_line_id.bom_id.type == 'phantom' and
             m.bom_line_id.bom_id == moves.bom_line_id.bom_id
         )
+
+    def _get_kit_price_unit(self, product, kit_bom, valuated_quantity):
+        """ Override the value for kit products """
+        _dummy, exploded_lines = kit_bom.explode(product, valuated_quantity)
+        total_price_unit = 0
+        component_qty_per_kit = defaultdict(float)
+        for line in exploded_lines:
+            component_qty_per_kit[line[0].product_id] += line[1]['qty']
+        for component, valuated_moves in self.grouped('product_id').items():
+            price_unit = super(StockMove, valuated_moves)._get_price_unit()
+            qty_per_kit = component_qty_per_kit[component] / kit_bom.product_qty
+            total_price_unit += price_unit * qty_per_kit
+        return total_price_unit

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -276,7 +276,7 @@ class PosOrder(models.Model):
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):
         moves = self.filtered(lambda o: o.partner_id.id == partner_id)\
             .mapped('picking_ids.move_ids')\
-            .filtered(lambda m: m.is_valued and m.product_id.valuation == 'real_time')\
+            .filtered(lambda m: m.is_valued and m.product_id.valuation == 'real_time' and m.product_id.id == product.id)\
             .sorted(lambda x: x.date)
         return moves._get_price_unit()
 

--- a/addons/sale_mrp/models/__init__.py
+++ b/addons/sale_mrp/models/__init__.py
@@ -5,6 +5,7 @@ from . import account_move
 from . import mrp_production
 from . import sale_order
 from . import sale_order_line
+from . import stock_move
 from . import stock_move_line
 from . import stock_rule
 from . import mrp_bom

--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _get_price_unit(self):
+        order_line = self.sale_line_id
+        if order_line and all(move.sale_line_id == order_line for move in self) and any(move.product_id != order_line.product_id for move in self):
+            product = self.product_id.with_company(order_line.company_id)
+            bom = product.env['mrp.bom']._bom_find(product, company_id=self.company_id.id, bom_type='phantom')[product]
+            if bom:
+                return self._get_kit_price_unit(product, bom, order_line.qty_delivered)
+        return super()._get_price_unit()

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -14,7 +14,6 @@ from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_c
 
 
 # these tests create accounting entries, and therefore need a chart of accounts
-@skip('Temporary to fast merge new valuation')
 class TestSaleMrpFlowCommon(ValuationReconciliationTestCommon, TestSaleCommon):
 
     @classmethod
@@ -210,6 +209,7 @@ class TestSaleMrpFlowCommon(ValuationReconciliationTestCommon, TestSaleCommon):
             move._action_done()
 
 
+@skip('Temporary to fast merge new valuation')
 @common.tagged('post_install', '-at_install')
 class TestSaleMrpFlow(TestSaleMrpFlowCommon):
     def test_00_sale_mrp_flow(self):

--- a/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.sale_mrp.tests import test_sale_mrp_flow
+from odoo.fields import Command
 from odoo.tests import common, Form
 
 
@@ -49,4 +50,73 @@ class TestSaleMrpFlow(test_sale_mrp_flow.TestSaleMrpFlowCommon):
         so = so_form.save()
         self.assertEqual(so.order_line.purchase_price, 60)
         so.action_confirm()
+        self.assertEqual(so.order_line.purchase_price, 60)
+
+    def test_kit_cost_calculation_2(self):
+        """ Check that the average cost price is computed correctly after receipt validation:
+            Lovely KIT BOM for 10:
+                - 1O unit of Kit $50
+                - 10 units of “component b” $10
+            -> $60 per Lovely Kit
+            SUB KIT BOM:
+                - 1 units of “component a” 1 x $30 = $30
+                - 2 units of “component b” 2 x $10 = $20
+            -> $50 per SUB Kit
+        """
+        sub_kit, kit = self._cls_create_product('Sub Kit', self.uom_unit), self._cls_create_product('Lovely Kit', self.uom_ten)
+        kit.uom_ids = [Command.set([self.uom_unit.id, self.uom_ten.id])]
+        self.product_category.property_cost_method = 'average'
+        (kit + sub_kit + self.component_a + self.component_b).categ_id = self.product_category
+        self.env['mrp.bom'].create([
+            {
+                'product_tmpl_id': sub_kit.product_tmpl_id.id,
+                'product_qty': 1.0,
+                'type': 'phantom',
+                'bom_line_ids': [
+                    Command.create({
+                        'product_id': self.component_a.id,
+                        'product_qty': 1.0,
+                    }),
+                    Command.create({
+                        'product_id': self.component_b.id,
+                        'product_qty': 2.0,
+                    }),
+                ],
+            },
+            {
+                'product_tmpl_id': kit.product_tmpl_id.id,
+                'product_uom_id': kit.uom_id.id,
+                'product_qty': 1.0,
+                'type': 'phantom',
+                'bom_line_ids': [
+                    Command.create({
+                        'product_id': sub_kit.id,
+                        'product_qty': 10.0,
+                    }),
+                    Command.create({
+                        'product_id': self.component_b.id,
+                        'product_qty': 10.0,
+                    }),
+                ],
+            },
+        ])
+        self.component_a.standard_price = 30
+        self.component_b.standard_price = 10
+        sub_kit.action_bom_cost()
+        kit.action_bom_cost()
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': kit.id,
+                'product_uom_qty': 3,
+                'product_uom_id': self.uom_unit.id
+            })]
+        })
+        self.assertEqual(so.order_line.purchase_price, 60)
+        so.action_confirm()
+        self.assertEqual(so.order_line.purchase_price, 60)
+        for move in so.picking_ids.move_ids:
+            move.quantity = move.product_uom_qty
+        so.picking_ids.button_validate()
+        self.assertEqual(so.picking_ids.state, 'done')
         self.assertEqual(so.order_line.purchase_price, 60)


### PR DESCRIPTION
*mrp_account, sale_mrp{,_margin}, point_of_sale

## Issue 1: Kit sale price
 
### Steps to reproduce:

- Install sale_margin, sale_management, mrp
- Create a kit product with an avco product category:
    - 1 x COMP1, cost 10
    - 1 x COMP2, cost 20
- On the kit product update the cost accroding to the bom
- Create an SO for 1 unit of your kit
- Validate the associated receipt
#### > The cost (purchase_price) of the sol of the kit has been reset from 30 to 0.

### Cause of the issue:

Validating the receipt will trigger the dependence of the `purchase_price` compute method since the moves are now done: https://github.com/odoo/odoo/blob/18dc738c710f87d1f937b0d1fbb619c75f5ad952/addons/sale_margin/models/sale_order_line.py#L15-L18 However, the `_get_price_unit` will `return 0` since `sol` is linked to both component moves:
https://github.com/odoo/odoo/blob/18dc738c710f87d1f937b0d1fbb619c75f5ad952/addons/sale_stock_margin/models/sale_order_line.py#L10-L20

### Issue 2: POS with multiple products
Currently, when a pos order contains more than 1 product, inventory valuation lines are not generated when invoicing the order.

Steps to reproduce:
-------------------
* Using anglo-saxon accounting
* In the settings search for inventory valuation
  * Set inventory valuation to Perpetual
  * Choose standard cost method
  * Set up valuation account and journal
* Create two different products
  * Type -> Goods
  * Track inventory by quantity
  * Set a purchase cost
  * Put some quantity on hand
  * Add category
* In the settings of the category
  * Set up Stock account
  * Set up costing methog, standard
  * Set inventory valuation to perpetual
* Open pos session
* Make 3 orders, invoice them
  * Order 1, only product 1
  * Order 2, only product 2
  * Order 3, both products
> Observation: The invoces for orders 1 & 2 have entries regarding
inventory valuation while the invoice for order 3 does not have any.

### Cause of the issue:

Stock valuation entries are not created for order 3 because the price unit computed is 0.
https://github.com/odoo/odoo/blob/008e69e8215fecc1f3fe45a36189592577cdc593/addons/stock_account/models/account_move.py#L122-L126

The reason why the price unit is 0 is because in `_get_pos_anglo_saxon_price_unit` we have multiple records in `moves` related to multiple products.
https://github.com/odoo/odoo/blob/008e69e8215fecc1f3fe45a36189592577cdc593/addons/point_of_sale/models/pos_order.py#L276-L281

`_get_price_unit` was not designed to treat moves with different products https://github.com/odoo/odoo/blob/008e69e8215fecc1f3fe45a36189592577cdc593/addons/stock_account/models/stock_move.py#L225-L228

This leads to think we should filter moves in `_get_pos_anglo_saxon_price_unit` regarding the product.

The end result is now the same as when we make a SO with the two products in the Sales app and invoice it. This results in 2 valorisation lines (1 per product) but this does not change the valorisation when the pos order is not invoice and we close the session (still 1 valorisation line).

### Fix:

The filter on the product_id in the `_get_pos_anglo_saxon_price_unit` has been removed in https://github.com/odoo/odoo/commit/08b62a4bbcc6f9a391b2cc00a621ef4c76100229
Prior to that change the price unit were computed on moves sharing a common product:
https://github.com/odoo/odoo/blob/9cb6476e0f8d319dce4baf65904b8bd5d535c83c/addons/point_of_sale/models/pos_order.py#L271-L275
https://github.com/odoo/odoo/blob/9cb6476e0f8d319dce4baf65904b8bd5d535c83c/addons/stock_account/models/stock_move.py#L28-L29
We reintroduce this filter as it should not have been removed.


#### Issue 1: opw-5420977
#### Issue 2: opw-5328152

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
