### PR TITLE
[FIX] point_of_sale: category image in selector too big

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.js
+++ b/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.js
@@ -36,4 +36,7 @@ export class CategorySelector extends Component {
     setup() {
         this.ui = useService("ui");
     }
+    showCategoryImg(category) {
+        return category.imgSrc && !this.ui.isSmall;
+    }
 }

--- a/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.scss
@@ -1,5 +1,12 @@
 .category-button {
     --btn-border-color: #{$o-gray-200};
+
+    .line-clamp-3 {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
 }
 
 .category-list {

--- a/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/category_selector/category_selector.xml
@@ -6,14 +6,14 @@
                 <button t-on-click="() => props.onClick(category.id)"
                     t-attf-class="o_colorlist_item_color_{{!category.isSelected and !category.isChildren ? 'transparent_': ''}}{{category.color or 'none'}}"
                     t-att-class="{'opacity-50': !category.isChildren and !category.isSelected, 'justify-content-center': ui.isSmall}"
-                    class="category-button px-1 btn btn-light d-flex align-items-center rounded-3"
-                    style="height: 4rem;"
-                >
-                    <img t-if="category.imgSrc and !ui.isSmall" t-att-src="category.imgSrc"
-                        class="category-img-thumb h-100 rounded-3 object-fit-cover me-1"
-                        alt="Category"
-                    />
-                    <span t-if="category.name" class="text-wrap-categ text-center fs-5" t-esc="category.name" />
+                    class="category-button p-1 btn btn-light d-flex align-items-center rounded-3 gap-2"
+                    style="height: 4rem;">
+                    <div t-if="showCategoryImg(category)" class="overflow-hidden flex-shrink-0 ratio ratio-1x1" style="width:33%;">
+                        <img class="object-fit-cover h-100 w-100" t-att-src="category.imgSrc" alt="Category" />
+                    </div>
+                    <div class="line-clamp-3" t-att-class="{'w-100': !showCategoryImg(category)}" t-att-style="{'width: 67%;': showCategoryImg(category)}">
+                        <span t-if="category.name" class="text-center" t-esc="category.name" />
+                    </div>
                 </button>
             </t>
         </div>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
@@ -18,14 +18,6 @@
     color: #017e84 !important;
 }
 
-.text-wrap-categ {
-    box-sizing: border-box;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-
 .btn-switchpane, .pay-order-button {
     min-height: 70px;
 }

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -496,28 +496,28 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             {
-                trigger: '.category-button:eq(0) > span:contains("AAA")',
+                trigger: '.category-button:eq(0) > div span:contains("AAA")',
             },
             {
-                trigger: '.category-button:eq(1) > span:contains("AAB")',
+                trigger: '.category-button:eq(1) > div span:contains("AAB")',
             },
             {
-                trigger: '.category-button:eq(2) > span:contains("AAC")',
+                trigger: '.category-button:eq(2) > div span:contains("AAC")',
             },
             {
-                trigger: '.category-button:eq(1) > span:contains("AAB")',
+                trigger: '.category-button:eq(1) > div span:contains("AAB")',
                 run: "click",
             },
             ProductScreen.productIsDisplayed("Product in AAB and AAX", 0),
             {
-                trigger: '.category-button:eq(2) > span:contains("AAX")',
+                trigger: '.category-button:eq(2) > div span:contains("AAX")',
             },
             {
-                trigger: '.category-button:eq(2) > span:contains("AAX")',
+                trigger: '.category-button:eq(2) > div span:contains("AAX")',
                 run: "click",
             },
             {
-                trigger: '.category-button:eq(3) > span:contains("AAY")',
+                trigger: '.category-button:eq(3) > div span:contains("AAY")',
             },
         ].flat(),
 });


### PR DESCRIPTION
Before this commit, when a category image was too large, it would overflow and take all the space dedicated to the category name. Now we set the width of the image to 1/3 of the button and the name to 2/3, so that the image never takes too much space.

task-id: 5462315

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
