### PR TITLE
[FIX] mail: remove correspondent for group type channels

### DIFF
--- a/addons/mail/static/src/core/common/message_seen_indicator.js
+++ b/addons/mail/static/src/core/common/message_seen_indicator.js
@@ -42,7 +42,7 @@ export class MessageSeenIndicator extends Component {
 
     get summary() {
         if (this.props.message.hasEveryoneSeen) {
-            if (this.props.thread.channelMembers.length === 2) {
+            if (this.props.thread.correspondent && this.props.thread.channelMembers.length === 2) {
                 return _t("Seen by %(user)s", { user: this.props.thread.correspondent.name });
             }
             return _t("Seen by everyone");

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -436,7 +436,7 @@ export class Thread extends Record {
     }
 
     computeCorrespondent() {
-        if (this.channel_type === "channel") {
+        if (["channel", "group"].includes(this.channel_type)) {
             return undefined;
         }
         const correspondents = this.correspondents;


### PR DESCRIPTION
Before this commit, the "correspondent" property of Thread would be computed for channels of type group (group DMs) having less than 3 members.

This would lead to various confusing behaviours, including:
1. The "back on" banner being shown.
2. The chat bubble showing an IM status.
3. The notification item not showing the message author's name.

This commit fixes the issues by not computing `correspondent` for channels of type group.

task-5462395