### PR TITLE
[FIX] mail: avoid crash on session.persona doesn't exists

### DIFF
--- a/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.js
+++ b/addons/mail/static/src/discuss/call/web/discuss_sidebar_call_participants_patch.js
@@ -14,11 +14,11 @@ patch(DiscussSidebarCallParticipants.prototype, {
     get attClass() {
         return {
             ...super.attClass,
-            "o-active cursor-pointer rounded-4": this.session.persona.main_user_id,
+            "o-active cursor-pointer rounded-4": this.session.persona?.main_user_id,
         };
     },
     onClickParticipant(ev, session) {
-        if (!session.persona.main_user_id) {
+        if (!session.persona?.main_user_id) {
             return;
         }
         if (!this.avatarCard.isOpen) {


### PR DESCRIPTION
<img width="889" height="290" alt="image" src="https://github.com/user-attachments/assets/c2519e22-f7c4-4d53-885d-01674b248260" />
