### PR TITLE
[FIX] purchase_stock: value not taken from the bill

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -177,6 +177,8 @@ class StockMove(models.Model):
 
         other_candidates_qty = 0
         for move in self.purchase_line_id.move_ids:
+            if move == self:
+                continue
             if move.product_id != self.product_id:
                 continue
             if move.date > self.date or (move.date == self.date and move.id > self.id):


### PR DESCRIPTION
It's due to commit 47345b1fc8b805e232a4287cc6d5c54b2f5886cb It will consider it's onw as another candidate and will count himself as quantity already invoiced. It will then take the PO value instead of the bill.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
