### PR TITLE
[IMP] stock_account: remove dependency to mail.tracking

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -7,6 +7,7 @@ class AccountMove(models.Model):
 
     stock_move_ids = fields.One2many('stock.move', 'account_move_id', string='Stock Move')
     inventory_closing = fields.Boolean(string='Inventory Closing', default=False)
+    closing_datetime = fields.Datetime(string='Closing Date')
 
     # -------------------------------------------------------------------------
     # OVERRIDE METHODS

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -320,19 +320,7 @@ class TestAccountMove(TestStockValuationCommon):
         self._use_inventory_location_accounting()
         with freeze_time(fields.Datetime.now() - timedelta(seconds=10)):
             self._make_in_move(product, 10, location_id=self.inventory_location.id)
-            mail_context = {
-                'tracking_disable': False,
-                'mail_create_nolog': False,
-                'mail_create_nosubscribe': False,
-                'mail_notrack': False,
-            }
-            action = self.company.with_context(mail_context).action_close_stock_valuation()
-            closing = self.env['account.move'].with_context(mail_context).browse(action['res_id'])
-            # First flush to clean precommit data
-            self.env.cr.flush()
-            closing._post()
-            # Second flush to post the tracking values
-            self.env.cr.flush()
+            closing = self._close()
             self.assertRecordValues(closing.line_ids, [
                 {'account_id': self.account_inventory.id, 'debit': 0.0, 'credit': 100.0},
                 {'account_id': self.account_stock_valuation.id, 'debit': 100.0, 'credit': 0.0},


### PR DESCRIPTION
Usecase:
- Add an account on location and valuation periodic:
- Inventory adj. 10 units at 10$
- Close (suggest 100$ to inv location acc.)
- Inventory adj. 10 units at 100$
- Close again.

We expect 100$ again. However we always want to retrieve moves from the last closing. But the closing is an `account.move` and the post date is not a datetime. To retrieve the value we search for the tracking value linked to the message post.

Instead now, we just store it on a field.