### PR TITLE
[FIX] microsoft_calendar: prevent event duplication on sync timeout

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -493,6 +493,9 @@ class Meeting(models.Model):
 
     def _microsoft_values(self, fields_to_sync, initial_values={}):
         values = dict(initial_values)
+        if not values.get('transactionId'):
+            values['transactionId'] = self._get_microsoft_transaction_id()
+
         if not fields_to_sync:
             return values
 

--- a/addons/microsoft_calendar/models/calendar_recurrence_rule.py
+++ b/addons/microsoft_calendar/models/calendar_recurrence_rule.py
@@ -162,7 +162,9 @@ class RecurrenceRule(models.Model):
         Get values to update the whole Outlook event recurrence.
         (done through the first event of the Outlook recurrence).
         """
-        return self.base_event_id._microsoft_values(fields_to_sync, initial_values={'type': 'seriesMaster'})
+        values = self.base_event_id._microsoft_values(fields_to_sync, initial_values={'type': 'seriesMaster'})
+        values['transactionId'] = self._get_microsoft_transaction_id()
+        return values
 
     def _ensure_attendees_have_email(self):
         self.calendar_event_ids.filtered(lambda e: e.active)._ensure_attendees_have_email()

--- a/addons/microsoft_calendar/models/microsoft_sync.py
+++ b/addons/microsoft_calendar/models/microsoft_sync.py
@@ -529,3 +529,11 @@ class MicrosoftSync(models.AbstractModel):
         future record synchronization for the original owner.
         """
         raise NotImplementedError()
+
+    def _get_microsoft_transaction_id(self):
+        """
+        Returns a deterministic transactionId for the record, used for idempotency
+        and recovering events from Outlook when the creation response was lost.
+        """
+        self.ensure_one()
+        return "%s_%s" % (self.env['ir.config_parameter'].sudo().get_param('database.uuid'), self.id)

--- a/addons/microsoft_calendar/tests/test_microsoft_event.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_event.py
@@ -11,6 +11,7 @@ class TestMicrosoftEvent(TestCommon):
     def setUp(self):
         super().setUp()
         self.create_events_for_tests()
+        self.db_uuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
 
     def test_already_mapped_events(self):
 
@@ -404,3 +405,149 @@ class TestMicrosoftEvent(TestCommon):
         recurrences = MicrosoftEvent(recurring_event_data)
         mapped = recurrences._load_odoo_ids_from_db(self.env)
         self.assertFalse(mapped, "No odoo record should correspond to the microsoft values")
+
+    def test_match_using_transaction_id(self):
+        event = self.env["calendar.event"].with_user(self.organizer_user).create({
+            "name": "Unsynced Event",
+            "start": "2023-10-25 10:00:00",
+            "stop": "2023-10-25 11:00:00",
+            "microsoft_id": False,
+            "ms_universal_event_id": False,
+        })
+        transaction_id = f"{self.db_uuid}_{event.id}"
+        events = MicrosoftEvent([{
+            "type": "singleInstance",
+            "id": "MS_ID_123",
+            "iCalUId": "MS_UID_123",
+            "transactionId": transaction_id,
+            "subject": "Unsynced Event",
+        }])
+
+        mapped = events._load_odoo_ids_from_db(self.env)
+
+        self.assertEqual(len(mapped._events), 1)
+        self.assertEqual(mapped._events["MS_ID_123"]["_odoo_id"], event.id)
+
+        event.invalidate_recordset()
+        self.assertEqual(event.microsoft_id, "MS_ID_123")
+        self.assertEqual(event.ms_universal_event_id, "MS_UID_123")
+
+    def test_match_using_transaction_id_recurrence(self):
+        base_event = self.env["calendar.event"].with_user(self.organizer_user).create({
+            "name": "Unsynced Recurrence",
+            "start": "2023-10-26 10:00:00",
+            "stop": "2023-10-26 11:00:00",
+            "recurrency": True,
+            "rrule_type": "daily",
+            "interval": 1,
+            "count": 3,
+            "microsoft_id": False,
+            "ms_universal_event_id": False,
+        })
+        recurrence = base_event.recurrence_id
+        recurrence.microsoft_id = False
+        recurrence.ms_universal_event_id = False
+
+        transaction_id = f"{self.db_uuid}_{recurrence.id}"
+
+        events = MicrosoftEvent([{
+            "type": "seriesMaster",
+            "id": "MS_REC_ID",
+            "iCalUId": "MS_REC_UID",
+            "transactionId": transaction_id,
+            "subject": "Unsynced Recurrence",
+        }])
+
+        mapped = events._load_odoo_ids_from_db(self.env, force_model=self.env["calendar.recurrence"])
+
+        self.assertEqual(len(mapped._events), 1)
+        self.assertEqual(mapped._events["MS_REC_ID"]["_odoo_id"], recurrence.id)
+
+        recurrence.invalidate_recordset()
+        self.assertEqual(recurrence.microsoft_id, "MS_REC_ID")
+        self.assertEqual(recurrence.ms_universal_event_id, "MS_REC_UID")
+
+    def test_transaction_id_ignores_wrong_database(self):
+        """Ensure transactionIds from other databases are ignored"""
+        event = self.env["calendar.event"].with_user(self.organizer_user).create({
+            "name": "Unsynced Event",
+            "start": "2023-10-25 10:00:00",
+            "stop": "2023-10-25 11:00:00",
+            "microsoft_id": False,
+        })
+
+        wrong_uuid = "00000000-0000-0000-0000-000000000000"
+        transaction_id = f"{wrong_uuid}_{event.id}"
+
+        events = MicrosoftEvent([{
+            "type": "singleInstance",
+            "id": "MS_ID_WRONG_DB",
+            "iCalUId": "MS_UID_WRONG_DB",
+            "transactionId": transaction_id,
+            "subject": "Event from another database",
+        }])
+
+        mapped = events._load_odoo_ids_from_db(self.env)
+        self.assertEqual(len(mapped._events), 0, "Should not match events from different database")
+
+    def test_transaction_id_with_already_synced_event(self):
+        """Ensure transactionId doesn't override already synced events"""
+        event = self.env["calendar.event"].with_user(self.organizer_user).create({
+            "name": "Already Synced Event",
+            "start": "2023-10-25 10:00:00",
+            "stop": "2023-10-25 11:00:00",
+            "microsoft_id": "EXISTING_MS_ID",
+            "ms_universal_event_id": "EXISTING_UID",
+        })
+
+        transaction_id = f"{self.db_uuid}_{event.id}"
+
+        events = MicrosoftEvent([{
+            "type": "singleInstance",
+            "id": "DIFFERENT_MS_ID",
+            "iCalUId": "DIFFERENT_UID",
+            "transactionId": transaction_id,
+            "subject": "Duplicate attempt",
+        }])
+
+        mapped = events._load_odoo_ids_from_db(self.env)
+
+        self.assertEqual(len(mapped._events), 0)
+        event.invalidate_recordset()
+        self.assertEqual(event.microsoft_id, "EXISTING_MS_ID", "Should preserve existing microsoft_id")
+
+    def test_transaction_id_ignores_malformed_format(self):
+        """Ensure malformed transactionIds don't crash or incorrectly match"""
+        event = self.env["calendar.event"].with_user(self.organizer_user).create({
+            "name": "Unsynced Event",
+            "start": "2023-10-25 10:00:00",
+            "stop": "2023-10-25 11:00:00",
+            "microsoft_id": False,
+        })
+
+        malformed_ids = [
+            "no-underscore-at-all",
+            f"{self.db_uuid}_not_a_number",
+            f"{self.db_uuid}_{event.id}_extra_parts",
+            f"{self.db_uuid}_-5",
+            f"{self.db_uuid}_0",
+        ]
+
+        for malformed_id in malformed_ids:
+            events = MicrosoftEvent([{
+                "type": "singleInstance",
+                "id": f"MS_ID_{malformed_id}",
+                "iCalUId": f"MS_UID_{malformed_id}",
+                "transactionId": malformed_id,
+                "subject": "Test Event",
+            }])
+
+            mapped = events._load_odoo_ids_from_db(self.env)
+            self.assertEqual(
+                len(mapped._events),
+                0,
+                f"Should not match malformed transactionId: {malformed_id}"
+            )
+
+        event.invalidate_recordset()
+        self.assertFalse(event.microsoft_id, "Event should remain unsynced")

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -24,6 +24,7 @@ class TestUpdateEvents(TestCommon):
     def setUp(self):
         super(TestUpdateEvents, self).setUp()
         self.create_events_for_tests()
+        self.db_uuid = self.env['ir.config_parameter'].sudo().get_param('database.uuid')
 
     # -------------------------------------------------------------------------------
     # Update from Odoo to Outlook
@@ -68,7 +69,7 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.simple_event.microsoft_id,
-            {"subject": "my new simple event", "isOnlineMeeting": False},
+            {"subject": "my new simple event", "isOnlineMeeting": False, "transactionId": f"{self.db_uuid}_{self.simple_event.id}"},
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )
@@ -92,7 +93,7 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.simple_event.microsoft_id,
-            {"subject": "my new simple event", "isOnlineMeeting": False},
+            {"subject": "my new simple event", "isOnlineMeeting": False, "transactionId": f"{self.db_uuid}_{self.simple_event.id}"},
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )
@@ -123,7 +124,7 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.recurrent_events[modified_event_id].microsoft_id,
-            {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name},
+            {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name, "transactionId": f"{self.db_uuid}_{self.recurrent_events[modified_event_id].id}"},
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )
@@ -168,7 +169,8 @@ class TestUpdateEvents(TestCommon):
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
                     'timeZone': 'Europe/London'
                 },
-                'isAllDay': False
+                'isAllDay': False,
+                'transactionId': f"{self.db_uuid}_{self.recurrent_events[modified_event_id].id}",
             },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
@@ -228,7 +230,7 @@ class TestUpdateEvents(TestCommon):
         self.assertTrue(res)
         mock_patch.assert_called_once_with(
             self.recurrent_events[modified_event_id].microsoft_id,
-            {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name},
+            {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name, "transactionId": f"{self.db_uuid}_{self.recurrent_events[modified_event_id].id}"},
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
         )
@@ -266,7 +268,7 @@ class TestUpdateEvents(TestCommon):
         for i in range(modified_event_id, self.recurrent_events_count):
             mock_patch.assert_any_call(
                 self.recurrent_events[i].microsoft_id,
-                {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name},
+                {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name, "transactionId": f"{self.db_uuid}_{self.recurrent_events[i].id}"},
                 token=mock_get_token(self.organizer_user),
                 timeout=ANY,
             )
@@ -348,7 +350,8 @@ class TestUpdateEvents(TestCommon):
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
                     'timeZone': 'Europe/London'
                 },
-                'isAllDay': False
+                'isAllDay': False,
+                'transactionId': f"{self.db_uuid}_{self.recurrent_events[modified_event_id].id}",
             },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
@@ -421,7 +424,8 @@ class TestUpdateEvents(TestCommon):
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
                     'timeZone': 'Europe/London'
                 },
-                'isAllDay': False
+                'isAllDay': False,
+                'transactionId': f"{self.db_uuid}_{self.recurrent_events[modified_event_id].id}",
             },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
@@ -489,7 +493,8 @@ class TestUpdateEvents(TestCommon):
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
                     'timeZone': 'Europe/London'
                 },
-                'isAllDay': False
+                'isAllDay': False,
+                'transactionId': f"{self.db_uuid}_{self.recurrent_events[modified_event_id].id}",
             },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
@@ -525,7 +530,7 @@ class TestUpdateEvents(TestCommon):
         for i in range(self.recurrent_events_count):
             mock_patch.assert_any_call(
                 self.recurrent_events[i].microsoft_id,
-                {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name},
+                {'seriesMasterId': 'REC123', 'type': 'exception', "subject": new_name, "transactionId": f"{self.db_uuid}_{self.recurrent_events[i].id}"},
                 token=mock_get_token(self.organizer_user),
                 timeout=ANY,
             )
@@ -582,7 +587,8 @@ class TestUpdateEvents(TestCommon):
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
                     'timeZone': 'Europe/London'
                 },
-                'isAllDay': False
+                'isAllDay': False,
+                'transactionId': f"{self.db_uuid}_{self.recurrent_events[0].id}",
             },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,
@@ -646,7 +652,8 @@ class TestUpdateEvents(TestCommon):
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
                     'timeZone': 'Europe/London'
                 },
-                'isAllDay': False
+                'isAllDay': False,
+                'transactionId': f"{self.db_uuid}_{self.recurrent_events[0].id}",
             },
             token=mock_get_token(self.organizer_user),
             timeout=ANY,


### PR DESCRIPTION
When creating an event in Odoo that syncs to Outlook, a timeout or network error during the response from Microsoft can leave the system in an inconsistent state, leading to duplicate events in both Odoo and Outlook during subsequent synchronizations.

### Steps to reproduce

1. Create a calendar event in Odoo with Outlook synchronization enabled.
2. Simulate a network timeout (currently set to `3 seconds`) after Microsoft processes the creation request but before Odoo receives the response (e.g., by mocking a timeout in `_microsoft_insert`).
3. Observe that the event exists in Outlook but the Odoo record lacks the `microsoft_id`.
4. Run the synchronization manually.
5. A duplicate event is created in Outlook (due to retry) and/or a duplicate event is created in Odoo (fetched from Outlook as "new").

### Root Cause

The synchronization logic in
`microsoft_calendar/models/microsoft_sync.py` relies on receiving a successful response from the Microsoft Graph API to link the Odoo record with the created Outlook event.

Specifically, in the `_microsoft_insert` method, the call to `microsoft_service.insert` sends the creation request. If Microsoft successfully processes this request and creates the event, but the network connection times out while waiting for the response, the subsequent line `self.write({'microsoft_id': event_id, ...})` is never executed.

At this point, the Odoo record remains with `microsoft_id=False` and `need_sync_m=True`, even though the event actually exists in Outlook.

During the next synchronization:

1. `_sync_odoo2microsoft` identifies the Odoo record as unsynced (`microsoft_id=False`) and sends a new insertion request, creating a second event in Outlook.
2. `_sync_microsoft2odoo` fetches the original event from Outlook. To match Outlook events back to Odoo records, the logic in `MicrosoftEvent._load_odoo_ids_from_db` searches for Odoo records having a matching `microsoft_id` or `ms_universal_event_id` (a global ID provided by Microsoft). Since the Odoo record was never updated with these IDs, the match fails. Odoo treats the incoming event as a new external item and creates a duplicate record in Odoo.

### Fix Rationale

To resolve this, we utilize the `transactionId` property of the Microsoft Event resource. The `transactionId` is an optional, client-provided string that Odoo can attach to an event during creation. This ID is stored by Microsoft and remains accessible in the event's properties, allowing the client to identify the event independently of the server-generated IDs.

1. We now generate a deterministic `transactionId` for each insertion using the format `<database.uuid>_<record.id>`. This ID is unique to the Odoo record and remains stable across synchronization retries.
2. This `transactionId` is included in the payload of the event creation request within the `_microsoft_values` method of the `calendar.event` and `calendar.recurrence` models.
3. The matching logic in `MicrosoftEvent._load_odoo_ids_from_db` is extended with a fallback mechanism. If an incoming Outlook event cannot be matched by its server-generated IDs, the code checks for a `transactionId`. If the `transactionId` matches the current database UUID and contains a valid Odoo record ID, Odoo identifies the record it originally intended to create and links them.

This ensures that if an insertion response was previously lost due to a timeout, Odoo can still find and link the existing Outlook event during the next synchronization instead of creating a duplicate.

opw-5031073