### PR TITLE
[FIX] point_of_sale: correct applied rounding logic

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -77,8 +77,11 @@ export class PosOrderAccounting extends Base {
             return 0;
         }
 
-        const tolerance = this.orderIsRounded ? this.config.rounding_method.rounding : 0;
-        const amount = Math.abs(total - this.amountPaid) <= tolerance ? 0 : Math.abs(remaining);
+        const amount =
+            this.orderIsRounded &&
+            this.config.rounding_method.asymmetricRound(isNegative ? -remaining : remaining) == 0
+                ? 0
+                : Math.abs(remaining);
         return isNegative ? this.currency.round(-amount) : this.currency.round(amount);
     }
     get change() {
@@ -109,8 +112,11 @@ export class PosOrderAccounting extends Base {
         const total = this.prices.taxDetails.total_amount_no_rounding;
         const isNegative = this.amountPaid > total;
         const remaining = total - this.amountPaid;
-        const tolerance = this.orderIsRounded ? this.config.rounding_method.rounding : 0;
-        const amount = Math.abs(total - this.amountPaid) <= tolerance ? Math.abs(remaining) : 0;
+        const amount =
+            this.orderIsRounded &&
+            this.config.rounding_method.asymmetricRound(total < 0 ? -remaining : remaining) == 0
+                ? Math.abs(remaining)
+                : 0;
         return isNegative ? this.currency.round(amount) : this.currency.round(-amount);
     }
 

--- a/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
@@ -47,6 +47,14 @@ test("Rounding sale HALF-UP 0.05 (all methods)", async () => {
     expect(order.canBeValidated()).toBe(true);
     expect(order.appliedRounding).toBe(0.01);
     expect(order.change).toBe(0);
+
+    order.payment_ids[0].delete();
+    order.addPaymentline(cashPm);
+    order.payment_ids[0].setAmount(52.5);
+    expect(order.payment_ids[0].amount).toBe(52.5);
+    expect(order.appliedRounding).toBe(0);
+    expect(order.remainingDue).toBe(0.05);
+    expect(order.canBeValidated()).toBe(false);
 });
 
 test("Rounding sale UP 10  (cash only)", async () => {


### PR DESCRIPTION
When using rounding methods in POS with cash payments, the applied rounding was not being calculated correctly in some edge cases, leading to situations where the order could be validated even when the amount paid did not match the rounded total.

opw-5460460

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
