### PR TITLE
[FIX] mail, *: conversation description should work in livechat

### DIFF
--- a/addons/im_livechat/static/tests/discuss_app_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_app_patch.test.js
@@ -160,3 +160,23 @@ test("open visitor's partner profile if visitor has one", async () => {
     await click("a[title='View Contact']");
     await contains("div.o_field_widget > input:value(Joel Willis)");
 });
+
+test("Conversation description works in livechat", async () => {
+    const pyEnv = await startServer();
+    const livechatPartner = pyEnv["res.partner"].create({ name: "Joel Willis" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ partner_id: livechatPartner, livechat_member_type: "visitor" }),
+        ],
+        channel_type: "livechat",
+        description: "Yup, that customer again...",
+        livechat_operator_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-input:focus");
+    await contains(
+        "input.o-mail-DiscussContent-threadDescription:value(Yup, that customer again...)"
+    );
+});

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -86,11 +86,11 @@ export class DiscussChannel extends Record {
             (this.channel_type === "channel" && !this.group_public_id)
         );
     }
-    get allowDescriptionsTypes() {
+    get allowDescriptionTypes() {
         return ["channel", "group"];
     }
     get allowDescription() {
-        return this.allowDescriptionsTypes.includes(this.channel_type);
+        return this.allowDescriptionTypes.includes(this.channel_type);
     }
     get allowedToLeaveChannelTypes() {
         return ["channel", "group"];

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -178,9 +178,7 @@ test("can change the thread description of #general", async () => {
     await insertText(
         "input.o-mail-DiscussContent-threadDescription:enabled",
         "I want a burger today!",
-        {
-            replace: true,
-        }
+        { replace: true }
     );
     triggerHotkey("Enter");
     await expect.waitForSteps(["/web/dataset/call_kw/discuss.channel/channel_change_description"]);


### PR DESCRIPTION
*: im_livechat

Accidental regression from https://github.com/odoo/odoo/pull/237749

The code had getter named `allowDescriptionsTypes` and the patch was `allowDescriptionTypes`. While this looks the same at a glance, there's is a "s" in "description(s)" that differs.

This subtle change was not caught due to lack of test coverage, which this commit adds.