### PR TITLE
[FIX] point_of_sale: remove useless method `orderDone` from pos_store

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
@@ -48,7 +48,7 @@ export class FeedbackScreen extends Component {
                         this.state.loading = false;
                         if (this.isAutoSkip && !this.ignoreTimeout) {
                             this.state.timeout = setTimeout(() => {
-                                this.pos.orderDone(this.currentOrder);
+                                this.goNext();
                             }, this.pos.feedbackScreenAutoSkipDelay);
                         }
                     }
@@ -112,7 +112,13 @@ export class FeedbackScreen extends Component {
     }
 
     goNext() {
-        this.pos.orderDone(this.currentOrder);
+        this.currentOrder.setScreenData({ name: "" });
+        if (!this.pos.config.module_pos_restaurant) {
+            this.pos.selectedOrderUuid = this.pos.getEmptyOrder().uuid;
+        }
+        this.pos.searchProductWord = "";
+        const nextPage = this.pos.defaultPage;
+        this.pos.navigate(nextPage.page, nextPage.params);
     }
 
     get canSendReceipt() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2810,16 +2810,6 @@ export class PosStore extends WithLazyGetterTrap {
         return date.toFormat("hh:mm");
     }
 
-    orderDone(order) {
-        order.setScreenData({ name: "" });
-        if (!this.config.module_pos_restaurant) {
-            this.selectedOrderUuid = this.getEmptyOrder().uuid;
-        }
-        this.searchProductWord = "";
-        const nextPage = this.defaultPage;
-        this.navigate(nextPage.page, nextPage.params);
-    }
-
     displayPrinterWarning(printResult, printerName) {
         let notification;
         if (printResult.warningCode === "ROLL_PAPER_HAS_ALMOST_RUN_OUT") {


### PR DESCRIPTION
Remove useless method `orderDone` from pos_store and extract code directly inside `feedback_screen` which is the only place where it was used.

Task-id: 5405595

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
