### PR TITLE
[FIX] purchase_stock: doubled description on receipts form

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -47,11 +47,14 @@ class StockMove(models.Model):
         super()._compute_description_picking()
         for move in self:
             if move.purchase_line_id:
+                current_description = move.description_picking
                 seller = move.purchase_line_id.sudo().selected_seller_id
                 vendor_reference = f'[{seller.product_code}]' if seller.product_code else ''
                 vendor_reference += f' {seller.product_name}' if seller.product_name else ''
+                if vendor_reference.strip() in current_description:
+                    vendor_reference = ''
                 no_variant_attributes = '\n'.join(f'{attribute.attribute_id.name}: {attribute.name}' for attribute in move.purchase_line_id.sudo().product_no_variant_attribute_value_ids)
-                move.description_picking = (no_variant_attributes + '\n' + vendor_reference + '\n' + move.description_picking).strip()
+                move.description_picking = (no_variant_attributes + '\n' + vendor_reference + '\n' + current_description).strip()
 
     def _get_description(self):
         return self.purchase_line_id.name if self.purchase_line_id else super()._get_description()

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -892,3 +892,30 @@ class TestCreatePicking(ProductVariantsCommon):
         po.order_line.name += '\nRandom purchase notes'
         po.button_confirm()
         self.assertEqual(po.picking_ids.move_ids.description_picking, ('No variant: extra\n' if product_matrix_installed else '') + '[123] ABC\nReceive with care')
+
+    def test_duplicate_move_description(self):
+        """ Ensure the vendor reference appears only once in the description. """
+
+        self.product_id_1.update({
+            "seller_ids": [Command.create({
+                "partner_id": self.partner_id.id,
+                "min_qty": 4,
+                "price": 35,
+                "product_name": "Product 1",
+                "product_code": "P01"
+            })]
+        })
+
+        po = self.env["purchase.order"].create({
+            "partner_id": self.partner_id.id,
+            "order_line": [Command.create({
+                "product_id": self.product_id_1.id,
+                "product_qty": 4.0,
+                "price_unit": 35.0,
+            })]
+        })
+
+        po.button_confirm()
+        move = po.picking_ids.move_ids
+
+        self.assertEqual(move.description_picking, "[P01] Product 1", f'The vendor reference "{move.description_picking}" is not the expected one.')


### PR DESCRIPTION
Version : saas-18.4+e

Steps to reproduce
------------------
Create a product and add a line in the purchase tab with a “Vendor Product Name” and/or a “Vendor Product Code”.

Create a purchase order for this product with the right vendor and confirm it.

Go to the delivery receipt, the vendor code and/or name are added twice in the description.

Why is it happening
------------------
The _compute_description_picking method from stock.move, which is overridden in purchase_stock module, adds the vendor code and name to the description. However, if no description_picking has been set on the product, the description is already defined as the vendor code and name.

Solution
------------------
I propose to remove the code and the name from the vendor_reference variable if the original description already contains them.

opw-5392855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
