### PR TITLE
[FIX] website: fix option leaking in nested snippets

### DIFF
--- a/addons/website/static/src/builder/plugins/options/accordion_option.xml
+++ b/addons/website/static/src/builder/plugins/options/accordion_option.xml
@@ -12,7 +12,7 @@
         </BuilderButton>
     </BuilderRow>
 
-    <BuilderContext applyTo="'.accordion'">
+    <BuilderContext applyTo="':scope > .accordion'">
         <BuilderRow label.translate="Style" >
             <BuilderSelect>
                 <BuilderSelectItem id="'accordion_style_boxed_opt'" title.translate="Boxed" classAction="''">Boxed</BuilderSelectItem>
@@ -23,7 +23,7 @@
             <BuilderCheckbox classAction="'accordion-flush'"/>
         </BuilderRow>
         <BuilderRow label.translate="Round Corners" level="1">
-            <BuilderNumberInput applyTo="'.accordion-item'" styleAction="'--accordion-border-radius'" unit="'px'" min="0" composable="true"/>
+            <BuilderNumberInput applyTo="':scope > .accordion-item'" styleAction="'--accordion-border-radius'" unit="'px'" min="0" composable="true"/>
         </BuilderRow>
 
         <BuilderRow label.translate="Icons">
@@ -52,7 +52,7 @@
                 <BuilderSelectItem title.translate="Translate" classAction="'o_transition o_transition_translate'">Translate</BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>
-        <BuilderRow label.translate="Position" level="1" applyTo="'.accordion-header'">
+        <BuilderRow label.translate="Position" level="1" applyTo="':scope > .accordion-item > .accordion-header'">
             <BuilderButtonGroup>
                 <BuilderButton title.translate="Left" classAction="'justify-content-end flex-row-reverse o_icons_position_reversed'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
                 <BuilderButton title.translate="Right" classAction="'justify-content-between'" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>

--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -77,7 +77,9 @@ export class DefineCustomIconAction extends BuilderAction {
 export class CustomAccordionIconAction extends BuilderAction {
     static id = "customAccordionIcon";
     apply({ editingElement, params, value }) {
-        const accordionButtonEls = editingElement.querySelectorAll(".accordion-button");
+        const accordionButtonEls = editingElement.querySelectorAll(
+            ":scope > .accordion-item > .accordion-button"
+        );
         const activeCustomIcon = editingElement.dataset.activeCustomIcon || "fa fa-arrow-up";
         const inactiveCustomIcon = editingElement.dataset.inactiveCustomIcon || "fa fa-arrow-down";
         if (value) {

--- a/addons/website/static/src/builder/plugins/options/blockquote_option.xml
+++ b/addons/website/static/src/builder/plugins/options/blockquote_option.xml
@@ -19,7 +19,7 @@
         <BuilderColorPicker styleAction="'background-color'" enabledTabs="['solid', 'custom', 'gradient']"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Author Alignment" applyTo="'.s_blockquote_infos'">
+    <BuilderRow label.translate="Author Alignment" applyTo="':scope > .s_blockquote_infos'">
         <BuilderSelect>
             <BuilderSelectItem classAction="'flex-row align-items-start justify-content-start text-start'">Left</BuilderSelectItem>
             <BuilderSelectItem classAction="'flex-column align-items-center text-center'">Center</BuilderSelectItem>

--- a/addons/website/static/src/snippets/s_accordion/000.scss
+++ b/addons/website/static/src/snippets/s_accordion/000.scss
@@ -23,7 +23,7 @@
     .o_icons_side_to_bottom {
         --accordion-btn-icon-transform: rotate(0deg);
 
-        .accordion-button.collapsed {
+        > .accordion-item > .accordion-button.collapsed {
             &.o_icons_position_reversed:after {
                 transform: rotate(-90deg);
             }
@@ -40,7 +40,7 @@
     }
 
     .o_icons_plus_to_minus {
-        .o_custom_icons_wrap {
+        > .accordion-item > .accordion-header > .o_custom_icons_wrap {
             &:before, &:after {
                 content: '';
                 position: absolute;
@@ -53,34 +53,34 @@
             }
         }
 
-        .accordion-button.collapsed .o_custom_icons_wrap:after {
+        > .accordion-item > .accordion-button.collapsed .o_custom_icons_wrap:after {
             transform: rotate(90deg);
         }
     }
 
     .o_custom_icons {
-        .accordion-button:after {
+        > .accordion-item > .accordion-button:after {
             display: none;
         }
 
-        &.o_transition .o_custom_icons_wrap > span {
+        &.o_transition > .accordion-item > .accordion-button > .o_custom_icons_wrap > span {
             transition: opacity nth($transition-base, 2) nth($transition-base, 3), transform nth($transition-base, 2) nth($transition-base, 3);
         }
 
-        .accordion-button {
+        > .accordion-item > .accordion-button {
             &.collapsed .o_custom_icon_active, &:not(.collapsed) .o_custom_icon_inactive {
                 opacity: 0;
             }
         }
 
-        &.o_transition_scale .accordion-button {
+        &.o_transition_scale > .accordion-item > .accordion-button {
             &.collapsed .o_custom_icon_active, &:not(.collapsed) .o_custom_icon_inactive {
                 transform: scale(0);
                 opacity: 1;
             }
         }
 
-        &.o_transition_translate .accordion-button {
+        &.o_transition_translate > .accordion-item > .accordion-button {
             &.collapsed .o_custom_icon_active, &:not(.collapsed) .o_custom_icon_inactive {
                 opacity: 1;
             }
@@ -96,13 +96,13 @@
     }
 
     .s_accordion_highlight {
-        .accordion-item {
+        > .accordion-item {
             border: 0;
             border-radius: var(--#{$prefix}accordion-border-radius);
             overflow: hidden;
 
             // This removes the bg color when the item isn't displayed.
-            &:has(.collapsed) {
+            &:has(> .collapsed) {
                 background: transparent !important;
                 color: inherit;
             }
@@ -112,7 +112,7 @@
             // replaced by a color preset or a custom color.
             // This avoids color conflicts and preserves the colors
             // selected by the user when changing the accordion template.
-            &:not(:has(.collapsed))::before {
+            &:not(:has(> .collapsed))::before {
                 position: absolute;
                 inset: 0;
                 display: block;

--- a/addons/website/static/src/snippets/s_blockquote/001.scss
+++ b/addons/website/static/src/snippets/s_blockquote/001.scss
@@ -14,7 +14,7 @@
         width: map-get($spacers, 1);
     }
 
-    &:not(.s_blockquote_with_line) .s_blockquote_line_elt, &:not(.s_blockquote_with_icon) .s_blockquote_wrap_icon, .s_blockquote_infos {
+    &:not(.s_blockquote_with_line) > .s_blockquote_line_elt, &:not(.s_blockquote_with_icon) > .s_blockquote_wrap_icon, .s_blockquote_infos {
         display: none;
     }
 }


### PR DESCRIPTION
This commit fixes some issues that occur when editing nested instances of `s_accordion` and `s_blockquote` snippets. In all cases, changes applied to a parent unintentionally propagate to nested snippets.

**Accordion issues**
How to reproduce: drop two nested `s_accordion` snippets. Then:
1. Change the outer "Style" from "boxed" to "highlight active" -> both accordion change,
2. Change the outer "Round Corners" -> both accordion change,
3. Change the outer "Icon Position" ->  both accordion change,
4. Change the outer "Icons" style -> both accordion change.

**Blockquote issues**
How to reproduce: drop two nested `s_blockquote` snippets. Then:
1. Change the outer "Decoration" -> both blockquotes change,
2. Set the inner "Decoration" to "Icon" -> works only if the outer snippet has icon too,
3. Change the outer "Author Alignment" -> only the inner blockquote changes.

**Cause**
The above issues occur because certain `applyTo` and certain CSS selectors match all nested elements rather than restricting the scope only to the snippet being edited.

**Fix**
The relevant `applyTo` and CSS rules now use more specific selectors.

**Note**
See also https://github.com/odoo/odoo/pull/237733

task-5362171

