### PR TITLE
[FIX] pos_loyalty: handle second call postProcessLoyalty

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -853,13 +853,15 @@ patch(PosStore.prototype, {
                     }
                 }
             }
-            if (payload.coupon_report) {
+            if (payload.coupon_report && Object.keys(payload.coupon_report).length > 0) {
                 for (const [actionId, active_ids] of Object.entries(payload.coupon_report)) {
                     await this.env.services.report.doAction(actionId, active_ids);
                 }
                 order.has_pdf_gift_card = Object.keys(payload.coupon_report).length > 0;
             }
-            order.new_coupon_info = payload.new_coupon_info;
+            if (payload.new_coupon_info?.length) {
+                order.new_coupon_info = payload.new_coupon_info;
+            }
         }
     },
 });


### PR DESCRIPTION
Before this commit, when syncAllOrders was called more than once, for example when there were a preparation display, the second call to postProcessLoyalty would override the new_coupon_info set by the first call, resulting in the loss of information. The second call to confirm_coupon_programs is not an issue, as it's already handled.

opw-5440543

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
