### PR TITLE
[IMP] core: signal on commit

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -605,6 +605,7 @@ class IrCron(models.Model):
         and exception handling. Note that the user running the server action
         is the user calling this method. """
         self.ensure_one()
+        cr = self.env.cr
         try:
             if self.pool != self.pool.check_signaling():
                 # the registry has changed, reload self in the new registry
@@ -612,18 +613,16 @@ class IrCron(models.Model):
 
             _logger.debug(
                 "cron.object.execute(%r, %d, '*', %r, %d)",
-                self.env.cr.dbname,
+                cr.dbname,
                 self.env.uid,
                 cron_name,
                 server_action_id,
             )
             self.env['ir.actions.server'].browse(server_action_id).run()
             self.env.flush_all()
-            self.pool.signal_changes()
-            self.env.cr.commit()
+            cr.commit()
         except Exception:
-            self.pool.reset_changes()
-            self.env.cr.rollback()
+            cr.rollback()
             raise
 
     def write(self, vals):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -128,6 +128,7 @@ endpoint
 """
 
 import odoo.init  # import first for core setup  # noqa: I001
+import odoo.api
 
 import base64
 import collections.abc
@@ -519,7 +520,6 @@ def retrying(func, env):
                     raise
                 env.cr.rollback()
                 env.transaction.reset()
-                env.registry.reset_changes()
                 if request:
                     request.session = request._get_session_and_dbname()[0]
                     # Rewind files in case of failure
@@ -561,12 +561,10 @@ def retrying(func, env):
 
     except Exception:
         env.transaction.reset()
-        env.registry.reset_changes()
         raise
 
     if not env.cr.closed:
         env.cr.commit()  # effectively commits and execute post-commits
-    env.registry.signal_changes()
     return result
 
 

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -990,8 +990,7 @@ class PreforkServer(CommonServer):
             if not registries:
                 return
             for registry in registries.values():
-                with registry.cursor() as cr:
-                    registry.check_signaling(cr)
+                registry.check_signaling()
             registries.clear()
             # Close all opened cursors
             sql_db.close_all()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Other workers should be aware of changes as of the moment they are committed. For example, if code wrapped in `check_signaling` and `signal_changes` is committing, changes after the first commit become visible to other workers, but they are not yet notified that something changed.

Similarly after a rollback, we should `reset_changes` because the thread may have rended the internal state invalid.

Still, during installation we exceptionnally don't signal registry changes to avoid reloading completely other workers as the installation continues.


Current behavior before PR:
Changes are checked manually and signaled/reset manually. Usually this is done for in a block like an HTTP request.

Desired behavior after PR is merged:
Changes are checked manually, but signal and reset is done after commit. They cannot be forgotten, can be part of the same transaction and are notified when data changed.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
