### PR TITLE
[FIX] mail: fix style of chat hub hidden

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -44,7 +44,7 @@
 </t>
 
 <t t-name="mail.ChatHub.hiddenButton">
-    <Dropdown t-if="chatHub.folded.length > chatHub.maxFolded" state="more" position="'left-middle'" menuClass="'o-mail-ChatHub-hiddenMenu m-0 ' + store.discussDropdownMenuClass(this)" manual="true">
+    <Dropdown t-if="chatHub.folded.length > chatHub.maxFolded" state="more" position="'left-middle'" menuClass="'o-mail-ChatHub-hiddenMenu mx-1 my-0 bg-100 ' + store.discussDropdownMenuClass(this)" manual="true">
         <div class="o-mail-ChatBubble o-mail-ChatHub-hiddenBtn justify-content-center" t-att-class="{ 'o-active': more.isOpen }" t-on-click="() => store.chatHub.compact = true" t-ref="more-button">
             <div t-if="hiddenCounter > 0" class="o-mail-ChatHub-hiddenBtnCounter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow">
                 <t t-out="hiddenCounter"/>
@@ -54,7 +54,7 @@
             </button>
         </div>
         <t t-set-slot="content">
-            <ul class="m-0 p-0 overflow-auto o-scrollbar-thin" role="menu" t-ref="more-menu">
+            <ul class="m-0 p-0 overflow-auto o-scrollbar-thin bg-100" role="menu" t-ref="more-menu">
                 <t t-foreach="chatHub.folded.slice(chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
                     <li class="o-mail-ChatHub-hiddenItem gap-2 px-2 py-1" role="menuitem" t-att-name="cw.displayName" t-on-click="() => cw.open({ focus: true })">
                         <img class="o-mail-ChatHub-hiddenAvatar rounded-circle object-fit-cover" t-att-src="cw.thread?.avatarUrl" alt="Thread image" draggable="false"/>


### PR DESCRIPTION
In dark theme, the chat bubble message previews have dark background for improved readability of text. The chat hub hidden menu was intended to use same color scheme, but this was mistakenly removed from style improvements to discuss. The default style of popover is too light in dark theme.

This commit reverts to style before 19.0, using darker background. This improves accessibility of item selection and the "x" button.

Before / After

<img width="278" height="405" alt="Screenshot 2026-01-05 at 18 05 18" src="https://github.com/user-attachments/assets/d764adbf-5378-4d59-870d-baf159920898" /> <img width="288" height="410" alt="Screenshot 2026-01-05 at 18 31 03" src="https://github.com/user-attachments/assets/142605cf-fab6-499d-95fa-71fcbb7ec36a" />
