### PR TITLE
[FIX] iot_drivers: se blackbox traceback on supported

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_se_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_se_driver.py
@@ -235,7 +235,7 @@ class SwedishBlackBoxDriver(SerialDriver):
         retries = 0
         while ACK != "ACK" and retries < retry:
             connection.write(packet)
-            response = connection.readline().decode().split("#")
+            response = connection.readline().decode(errors="ignore").split("#")
 
             try:
                 if response[3] != "NAK":


### PR DESCRIPTION
If a non utf-8 chracter is returned by a serial-connected device, the supported method of the swedish bb raises a traceback.