### PR TITLE
[FIX] website_slides: prevent error in back button

### DIFF
--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { uniqueId } from '@web/core/utils/functions';
-import { renderToElement } from "@web/core/utils/render";
+import { renderToElement, renderToFragment } from "@web/core/utils/render";
 import { getDataURLFromFile } from "@web/core/utils/urls";
 import Dialog from '@web/legacy/js/core/dialog';
 import publicWidget from '@web/legacy/js/public/public_widget';
@@ -514,7 +514,7 @@ var SlideUploadDialog = Dialog.extend({
             this.$modal.find('.modal-dialog').addClass('modal-lg');
         }
         this.$('.o_w_slide_upload_modal_container').empty();
-        this.$('.o_w_slide_upload_modal_container').append(renderToElement(tmpl, {widget: this}));
+        this.$('.o_w_slide_upload_modal_container').append(renderToFragment(tmpl, {widget: this}));
 
         this._resetModalButton();
 


### PR DESCRIPTION
Steps to reproduce:
1. install `website_slides`
2. Go to any course and click `Add content` > `Video`
3. Click on back button

Issue:
- When only website_slides is installed a traceback occurs `Error: The rendered template 'website.slide.upload.modal.select' contains multiple root nodes that will be ignored using renderToElement, you should consider using renderToFragment or refactoring the template.`

Cause:
- The template `website.slide.upload.modal.select` contains multiple root elements, but the code uses `renderToElement`, which expects a single root element.
https://github.com/odoo/odoo/blob/4876a54e8cfb3a115b5423db102fc2b7a40b196a/addons/website_slides/static/src/xml/website_slides_upload.xml#L15-L36

Solution:
- wrap template's elements inside a div

opw-5457124