### PR TITLE
[FIX] l10n_id: prevent duplicate taxes and fix tax group xml_id lookup

### DIFF
--- a/addons/l10n_id/migrations/1.3/end-migrate_update_taxes.py
+++ b/addons/l10n_id/migrations/1.3/end-migrate_update_taxes.py
@@ -6,7 +6,7 @@ def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {"lang": "en_US"})
 
     ChartTemplate = env["account.chart.template"]
-    companies = env["res.company"].search([("chart_template", "=", "id")], order="parent_path")
+    companies = env["res.company"].search([("chart_template", "=", "id"), ("parent_id", "=", False)], order="parent_path")
 
     new_tax_groups = ["l10n_id_tax_group_stlg", "l10n_id_tax_group_non_luxury_goods", "l10n_id_tax_group_luxury_goods", "l10n_id_tax_group_0"]
     new_taxes = [
@@ -31,7 +31,7 @@ def migrate(cr, version):
     for company in companies:
         new_tax_group_data = {}
         if (tax_group_data):
-            new_tax_group_data = {g: data for g, data in tax_group_data.items() if not env.ref(f"account._{company.id}_{g}", raise_if_not_found=False)}
+            new_tax_group_data = {g: data for g, data in tax_group_data.items() if not env.ref(f"account.{company.id}_{g}", raise_if_not_found=False)}
 
         # =============================
         # Load new tax data


### PR DESCRIPTION
Traceback
```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/odoo/service/server.py", line 1510, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'], reinit_modules=config['reinit'])
  File "/home/odoo/src/odoo/19.0/odoo/tools/func.py", line 88, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/odoo/orm/registry.py", line 199, in new
    load_modules(
  File "/home/odoo/src/odoo/19.0/odoo/modules/loading.py", line 493, in load_modules
    migrations.migrate_module(package, 'end')
  File "/home/odoo/src/odoo/19.0/odoo/modules/migration.py", line 220, in migrate_module
    exec_script(self.cr, installed_version, pyfile, pkg.name, stage, stageformat[stage] % version)
  File "/home/odoo/src/odoo/19.0/odoo/modules/migration.py", line 257, in exec_script
    mod.migrate(cr, installed_version)
  File "/home/odoo/src/odoo/19.0/addons/l10n_id/migrations/1.3/end-migrate_update_taxes.py", line 39, in migrate
    ChartTemplate.with_company(company)._load_data({
  File "/tmp/tmp1jbu491s/migrations/account/0.0.0/pre-ensure-deferred-accounts.py", line 36, in _load_data
    return super()._load_data(data, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/addons/account/models/chart_template.py", line 691, in _load_data
    created_records[model] = self.with_context(lang='en_US').env[model]._load_records(all_records_vals)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5191, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5098, in _load_records_create
    records = self.create(vals_list)
  File "/home/odoo/src/odoo/19.0/odoo/orm/decorators.py", line 365, in create
    return method(self, vals_list)
  File "/home/odoo/src/odoo/19.0/addons/account/models/account_tax.py", line 655, in create
    taxes = super(AccountTax, self.with_context(context)).create([self._sanitize_vals(vals) for vals in vals_list])
  File "/home/odoo/src/odoo/19.0/odoo/orm/decorators.py", line 365, in create
    return method(self, vals_list)
  File "/home/odoo/src/odoo/19.0/addons/mail/models/mail_thread.py", line 327, in create
    threads = super(MailThread, self).create(vals_list)
  File "/home/odoo/src/odoo/19.0/odoo/orm/decorators.py", line 365, in create
    return method(self, vals_list)
  File "/tmp/tmp1jbu491s/migrations/util/orm.py", line 248, in wrapper
    return f(*args, **kwargs)
  File "/tmp/tmp1jbu491s/migrations/base/0.0.0/pre-models-match_uniq.py", line 100, in create
    records = super().create([vals_list[idx] for idx in create_idx_list])
  File "/home/odoo/src/odoo/19.0/odoo/orm/decorators.py", line 365, in create
    return method(self, vals_list)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4706, in create
    records = self._create(data_list)
  File "/home/odoo/src/enterprise/19.0/ai_fields/models/models.py", line 43, in _create
    return super()._create(data_list)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4944, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 1268, in _validate_fields
    check(records)
  File "/home/odoo/src/odoo/19.0/addons/account/models/account_tax.py", line 226, in _constrains_name
    raise ValidationError(
odoo.exceptions.ValidationError: Tax names must be unique!
- 12% (Non-Luxury Good) in Sawo Coffee
- 12% (Non-Luxury Good) in Sawo Coffee
- 12% Pemungut PPN (Non-Luxury Good) in Sawo Coffee
- 12% Pemungut PPN in Sawo Coffee
- 20% Pemungut PPN (STLG) in Sawo Coffee
- 0% EXPORT in Sawo Coffee
- 20% (STLG) in Sawo Coffee
- 12% NCR in Sawo Coffee
- 12% IM in Sawo Coffee
```
```
rudo_3687325=> select id,name,chart_template,parent_id from res_company;
 id |     name      | chart_template | parent_id 
----+---------------+----------------+-----------
  1 | BERGAMOT      | id             |          
  2 | Sawo Coffee   | id             |          
  3 | Sawo Braga    | id             |         2
  4 | Sawo Rontgent | id             |         2
  5 | Sawo Roastery | id             |         2
(5 rows)

```
Current behavior:
1. **Duplicate Taxes:** When loading the chart template, the company search included both parent and child companies (branches). Iterating over child companies caused the tax generation logic to run again, ignoring the intended[ `_load()`](https://github.com/odoo/odoo/blob/19.0/addons/account/models/chart_template.py#L224-L227) logic where child companies should rely on the parent's data. This resulted in duplicate taxes.

   -       Log: @@@companies to migrate: res.company(1, 2, 3, 4, 5) (Where 3,4,5 is a child of 2).

2. **XML ID Typo:** The XML ID lookup for tax groups contained a typo (an extra underscore), generating IDs like `account._1_tax_group` instead of `account.1_tax_group`. This caused the system to fail to find existing tax groups, potentially leading to duplication or errors.

Desired behavior after PR is merged:

1. Correct Scope: The company search domain strictly excludes child companies (parent_id=False). The loading logic only runs for root companies, preventing duplicate tax generation for branches.

   -       Log: @@@companies to migrate after fix: res.company(1, 2).

2. Valid References: The tax group lookup uses the correct XML ID format (e.g., account.1_tax_group), ensuring existing records are correctly identified.


Description of the issue/feature this PR addresses: 
This PR fixes a traceback during chart template loading caused by duplicate taxes in a company (parent/branch) environment.

1. Update the `res.company` search domain to explicitly exclude child companies by adding `('parent_id', '=', False)`. This ensures the setup loop only iterates over companies.

2. Fix Typo: Removed the incorrect underscore in the tax group f-string reference


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

[OPW](https://www.odoo.com/odoo/project/70/tasks/5434556)
[UPG](https://upgrade.odoo.com/odoo/request/3687325?debug=)
[TGB](https://upgrade.odoo.com/odoo/request/3687325/tbg/2297?debug=)
