### PR TITLE
[IMP] mail: meeting channel revamp

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -382,7 +382,7 @@ export class Thread extends Record {
         let res;
         try {
             res = await this.fetchMessagesData({ after, around, before });
-            this.hasLoadingFailedCause = undefined;
+            this.hasLoadingFailedError = undefined;
             this.hasLoadingFailed = false;
         } catch (e) {
             this.hasLoadingFailed = true;

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MeetingChat">
-        <ActionPanel t-if="channel" title.translate="Chat" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
+        <ActionPanel t-if="channel" title.translate="In call messages" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
             <Thread thread="channel.thread" jumpPresent="state.jumpPresent"/>
             <t t-call="mail.ChatWindow.memberTyping"/>
             <Composer

--- a/addons/mail/static/src/discuss/call/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/message_model_patch.js
@@ -1,0 +1,19 @@
+import { Message } from "@mail/core/common/message_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Message} */
+const messagePatch = {
+    get notificationHidden() {
+        if (
+            this.store.discuss?.thread?.eq(this.thread) &&
+            this.thread.channel.default_display_mode === "video_full_screen" &&
+            this.store?.meetingViewOpened &&
+            this.notificationType === "call"
+        ) {
+            return true;
+        }
+        return super.notificationHidden;
+    },
+};
+patch(Message.prototype, messagePatch);

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -42,6 +42,9 @@ export class DiscussChannel extends models.ServerModel {
         relation: "discuss.category",
         string: "Discuss Category",
     });
+    display_name_mode = fields.Selection({
+        selection: [["meeting_channel", "Meeting channel name"]],
+    });
     group_public_id = fields.Generic({
         default: () => serverState.groupId,
     });
@@ -258,8 +261,10 @@ export class DiscussChannel extends models.ServerModel {
         return [
             "avatar_cache_key",
             "channel_type",
+            "create_date",
             "create_uid",
             "default_display_mode",
+            "display_name_mode",
             "description",
             "group_public_id",
             "last_interest_dt",
@@ -527,6 +532,8 @@ export class DiscussChannel extends models.ServerModel {
                 Command.create({ partner_id: partner.id })
             ),
             default_display_mode,
+            display_name_mode:
+                default_display_mode === "video_full_screen" && !name ? "meeting_channel" : false,
             name,
         });
         this._broadcast(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -644,6 +644,24 @@ class TestChannelInternals(MailCommon, HttpCase):
         test_channel.image_128 = base64.b64encode(("<svg/>").encode())
         self.assertEqual(test_channel.avatar_128, test_channel.image_128)
 
+    def test_create_group_display_name_mode(self):
+        unnamed_group = self.env["discuss.channel"]._create_group(
+            partners_to=self.user_employee.partner_id.ids
+        )
+        unnamed_meeting_group = self.env["discuss.channel"]._create_group(
+            partners_to=self.user_employee.partner_id.ids,
+            default_display_mode="video_full_screen",
+        )
+        named_meeting_group = self.env["discuss.channel"]._create_group(
+            partners_to=self.user_employee.partner_id.ids,
+            default_display_mode="video_full_screen",
+            name="Standup",
+        )
+
+        self.assertFalse(unnamed_group.display_name_mode)
+        self.assertEqual(unnamed_meeting_group.display_name_mode, "meeting_date")
+        self.assertFalse(named_meeting_group.display_name_mode)
+
     def test_channel_write_should_send_notification(self):
         channel = self.env['discuss.channel'].create({"name": "test", "description": "test"})
         with self.assertBus(


### PR DESCRIPTION
Meeting channel = Channels created via. New Meeting button (refer image below)
<img width="300" height="100" alt="image" src="https://github.com/user-attachments/assets/68fc8afa-3aae-4d40-8f79-945ef4651dfa" />




**Purpose of this commit:**

For meeting channels:
- When a user created a new meeting channel, the channel should have a default 
  name in the format"Meeting-{date}"
- In the meeting view, the chat panel of the meeting channel should not contains 
  any "call" type notification message
- When the current user disconnects the call, the channel should be 
  automatically unpinned, along with all it sub-channels
- When the channel is unpinned, the undo notification should be shown
- When click on the undo option, the channel should be pinned back along with 
  all its sub channel
- Rename meeting view's chat panel's name from "Chat" ->  "In Call Messages"

Task-5460982
