### PR TITLE
[FIX] mail: prevent enabling tracking on HTML fields

### DIFF
--- a/addons/mail/views/ir_model_views.xml
+++ b/addons/mail/views/ir_model_views.xml
@@ -35,7 +35,7 @@
         <field name="arch" type="xml">
             <field name="copied" position="after">
                 <field name="state" invisible="1"/>
-                <field name="tracking" invisible="ttype == 'binary'" readonly="state != 'manual'"/>
+                <field name="tracking" invisible="ttype in ['binary', 'html']" readonly="state != 'manual'"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
From https://github.com/odoo/odoo/pull/241367#issuecomment-3711040501

Nothing prevent tracking from being enabled on HTML fields, but if it is enabled, updates of the field systematically fail.

This commit avoids this error by hiding the "Enable Ordered Tracking" for HTML fields.

Steps to reproduce:
- Install sale and web_studio
- Activate debug mode
- Add a custom HTML field inside the invoice form view
- Open the "More..." of the field (or go to Settings/Technical/Field) and go to the new field
- Set "Enable Ordered Tracking" to 1
- Save
- Go to an invoice and modify the new field
- Save

=> An error was displayed

task-5236436
