### PR TITLE
[FIX] l10n_be_hr_payroll: prevent multiple dimona activities

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -395,7 +395,9 @@ class HrEmployee(models.Model):
                 employee.current_version_id = new_current_version
 
     def _cron_update_current_version_id(self):
-        self.search([])._compute_current_version_id()
+        all_emps = self.search([])
+        all_emps._compute_current_version_id()
+        all_emps.current_version_id.filtered('contract_date_start')._trigger_l10n_be_next_activities()
 
     def _search_version_id(self, operator, value):
         if operator == 'any':


### PR DESCRIPTION
create an instance on saas-18.4 with l10n_be_hr_payroll settings > company > my company > update infos > country: Belgium
employee > new > payroll > contract > start_date: any date (this should create a first dimona activity)
settings > technical > automation > scheduled actions > "HR Employee: Update Current Version" > run manually

`_trigger_l10n_be_next_activities` in `hr.version` of `l10n_be_hr_payroll` is duplicating Dimona activities on records that already have one.

We check if a dimona activity already exists for a given `hr.employee` before creating the new activity. Same is done for dimona declaration of part times. The activity now redirects to the employee form (instead of the version form) and appears in it.

tasks-5134380

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
