### PR TITLE
[FIX] account_peppol: fix the acknowledgment

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -268,10 +268,10 @@ class AccountEdiProxyClientUser(models.Model):
                 move.peppol_move_state = content['state']
                 move._message_log(body=_('Peppol status update: %s', content['state']))
 
-                edi_user._call_peppol_proxy(
-                    "/api/peppol/1/ack",
-                    params={'message_uuids': list(message_uuids.keys())},
-                )
+            edi_user._call_peppol_proxy(
+                "/api/peppol/1/ack",
+                params={'message_uuids': list(message_uuids.keys())},
+            )
         if need_retrigger:
             self.env.ref('account_peppol.ir_cron_peppol_get_message_status')._trigger()
 


### PR DESCRIPTION
The acknowledgment should not happen in the loop, but after. In a case a problem happened in the loop, it's acceptable that we end up not acknowledging messages, their status will be retrieved again at the next call.

At the moment those continuous acks cause serialization issues on IAP side.

task-none
