### PR TITLE
[FIX] l10n_hu_edi, l10n_de: keep manual currency rate when posting invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -358,6 +358,7 @@ class AccountMove(models.Model):
         copy=False,
         store=True,
         compute='_compute_delivery_date',
+        inverse='_inverse_delivery_date',
         precompute=True,
         readonly=False,
     )
@@ -2205,6 +2206,9 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
     # INVERSE METHODS
     # -------------------------------------------------------------------------
+
+    def _inverse_delivery_date(self):
+        pass
 
     def _inverse_tax_totals(self):
         with self._disable_recursion({'records': self}, 'skip_invoice_sync') as disabled:

--- a/addons/l10n_de/tests/test_account_move.py
+++ b/addons/l10n_de/tests/test_account_move.py
@@ -32,3 +32,24 @@ class TestAccountMoveDE(AccountTestInvoicingCommon):
         move.action_post()
         self.assertEqual(fields.Date.from_string('2025-01-01'), move.invoice_date)
         self.assertEqual(fields.Date.from_string('2025-01-01'), move.delivery_date)
+
+    def test_out_invoice_custom_currency_rate_with_missing_delivery_date(self):
+
+        if not self.env['ir.module.module'].search([('name', '=', 'l10n_hu_edi'), ('state', '=', 'installed')]):
+            self.skipTest("This test requires the installation of the l10n_hu_edi module.")
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'currency_id': self.env['res.currency'].create({'name': "XYZ", 'symbol': 'X'}).id,
+            'invoice_currency_rate': 5,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id})],
+        })
+        expected_lines_vals = [
+            {'balance': -200.0, 'amount_currency': -1000.0},
+            {'balance': -38.0, 'amount_currency': -190.0},
+            {'balance': 238.0, 'amount_currency': 1190.0},
+        ]
+        self.assertRecordValues(move.line_ids, expected_lines_vals)
+        move.action_post()
+        self.assertRecordValues(move.line_ids, expected_lines_vals)

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -124,10 +124,6 @@ class AccountMove(models.Model):
                 raise ValidationError(_('Cannot reset to draft or cancel invoice %s because an electronic document was already sent to NAV!', move.name))
 
     # === Computes === #
-    @api.depends('delivery_date')
-    def _compute_invoice_currency_rate(self):
-        # In Hungary, the currency rate should be based on the delivery date.
-        super()._compute_invoice_currency_rate()
 
     @api.depends('delivery_date')
     def _compute_expected_currency_rate(self):
@@ -161,6 +157,12 @@ class AccountMove(models.Model):
     def _compute_l10n_hu_edi_attachment_filename(self):
         for move in self:
             move.l10n_hu_edi_attachment_filename = f'{move.name.replace("/", "_")}.xml' if move.name else 'nav30.xml'
+
+    # === Inverses === #
+
+    def _inverse_delivery_date(self):
+        super()._inverse_delivery_date()
+        self._conditional_add_to_compute('invoice_currency_rate', lambda m: m.country_code == 'HU')
 
     # === Overrides === #
 


### PR DESCRIPTION
Initial setup: Install  l10n_hu_edi and l10n_de.

When creating a customer invoice DE in a foreign currency, a manually edited
currency rate was overridden at posting time with the rate from the currency
table.

Reason: l10n_de overrides `move._post` to assign the `delivery_date`. l10n_hu_edi recompute currency rates when the `delivery_date` changes.

Ensure that any manually entered rate is preserved during posting by making sure that l10n_hu_edi override only affect HU moves.

task-5391774

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
