### PR TITLE
[FIX] hw_drivers: checkout new DB version on upgrade

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -82,7 +82,12 @@ def on_message(ws, messages):
             if iot_mac in payload['iotIdentifiers']:
                 helpers.disconnect_from_server()
                 close_server_log_sender_handler()
-        elif message_type not in ['print_confirmation', 'bundle_changed']:  # intended to be ignored
+        elif message_type == 'bundle_changed':
+            # This message is sent by the DB whenever the web JS asset bundle changes.
+            # While this is a bit of a hack we use this message to check if the DB has been upgraded,
+            # since we know the bundle will always change in this situation.
+            helpers.check_git_branch()
+        elif message_type != 'print_confirmation':  # intended to be ignored
             _logger.warning("message type not supported: %s", message_type)
 
 


### PR DESCRIPTION
Before this commit, when the DB was upgraded to a new version, the IoT box had to be manually restarted so that it would checkout and align with the new version.

After this commit, we check the DB branch whenever we receive a `bundle_changed` message on the websocket. If it has changed then the IoT will restart and checkout the new version.

task-5463520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
