### PR TITLE
[FIX] account_peppol: missing destructuring of loop var

### DIFF
--- a/addons/account_peppol/wizard/account_invoice_send.py
+++ b/addons/account_peppol/wizard/account_invoice_send.py
@@ -146,7 +146,7 @@ class AccountInvoiceSend(models.TransientModel):
                     params={'documents': documents},
                 )
             except AccountEdiProxyError as e:
-                for invoice in invoices_data.items():
+                for invoice, invoice_data in invoices_data.items():
                     invoice.peppol_move_state = 'error'
                     invoice_data['error'] = e.message
             else:


### PR DESCRIPTION
There is a `for invoice in invoices_data.items()` loop. The var `invoices_data` is a dict (account_move -> invoice_data dict). But in the loop body we use the variables `invoice` as account_move and `invoice_data` as dict as if we did `for invoice, invoice_data in ...`.

Thus there is a traceback
```
AttributeError: 'tuple' object has no attribute 'peppol_move_state'
```

It can easily be reproduced by setting the timeout in `_make_request` to `0.01`.

task-None
