### PR TITLE
[FIX] html_editor: keep cursor inside formatting tags on shortcuts

### DIFF
--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -2,6 +2,7 @@ import { Plugin, isValidTargetForDomListener } from "../plugin";
 import { closestBlock } from "@html_editor/utils/blocks";
 import { fillEmpty } from "@html_editor/utils/dom";
 import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 /**
  * @typedef {Object} Shortcut
@@ -112,7 +113,7 @@ export class ShortCutPlugin extends Plugin {
                 this.dependencies.selection.extractContent(
                     this.dependencies.selection.getEditableSelection()
                 );
-                fillEmpty(blockEl);
+                fillEmpty(closestElement(selection.focusNode));
                 command.run(matchedShortcut.commandParams);
             }
         }

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -25,6 +25,20 @@ test("Typing '1. ' at the start of existing text should create a numbered list",
     expect(getContent(el)).toBe(`<ol><li>[]abc</li></ol>`);
 });
 
+test("typing '1. ' should keep cursor inside formatting element when creating a list", async () => {
+    const { el, editor } = await setupEditor("<p><strong><u>[]</u></strong></p>");
+    await insertText(editor, "1. ");
+    expect(getContent(el)).toBe(
+        unformat(
+            `<ol>
+                <li o-we-hint-text="List" class="o-we-hint">
+                    <strong><u data-oe-zws-empty-inline="">[]\u200b</u></strong>
+                </li>
+            </ol>`
+        )
+    );
+});
+
 test("should convert simple number list into bullet list", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
     await insertText(editor, "1. ");


### PR DESCRIPTION
#### Description of the issue this PR addresses:

- When using shortcuts (e.g. typing '1. ') after applying inline formatting, newly typed text did not inherit the formatting.
- This occurred because extracting the shortcut text left the formatting element empty, causing the cursor to move outside it.

#### Desired behavior after PR is merged:

- Ensure the caret remains inside the formatting element by filling the closest element of `focusNode` when it becomes empty during shortcut handling.

#### Steps to Reproduce:

- Go to To-Do, Create a new record.
- Type formatted text (e.g. Ctrl+[b|u|i]).
- Press Enter.
- Type '1. ' to create a list.
- Type text inside the list item.

=> The text inside the list does not retain the formatting.

task-5468358

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
