### PR TITLE
[FIX] iot_drivers: send mac address for record upgrade

### DIFF
--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -81,6 +81,7 @@ class Manager(Thread):
         """
         iot_box = {
             'identifier': self.identifier,
+            'mac': helpers.get_mac_address(),
             'ip': self.domain,
             'token': helpers.get_token(),
             'version': self.version,


### PR DESCRIPTION
When upgrading from <v19.0 to v19.0+, the IoT Box needs to provide its mac address along with its serial number in order for the IoT Box record in the db updates the identifier from mac to serial no.

see odoo/enterprise#103331
