### PR TITLE
[FIX] base: the .1s timeout in the SMTPD tests is overly conservative

### DIFF
--- a/odoo/addons/base/tests/test_ir_mail_server_smtpd.py
+++ b/odoo/addons/base/tests/test_ir_mail_server_smtpd.py
@@ -24,6 +24,7 @@ except ImportError:
     aiosmtpd = None
 
 
+SMTP_TIMEOUT = 5
 PASSWORD = 'secretpassword'
 _openssl = shutil.which('openssl')
 _logger = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ class Certificate:
 @unittest.skipUnless(aiosmtpd, "aiosmtpd couldn't be imported")
 @unittest.skipUnless(_openssl, "openssl not found in path")
 # fail fast for timeout errors
-@patch('odoo.addons.base.models.ir_mail_server.SMTP_TIMEOUT', .1)
+@patch('odoo.addons.base.models.ir_mail_server.SMTP_TIMEOUT', SMTP_TIMEOUT)
 # prevent the CLI from interfering with the tests
 @patch.dict(config.options, {'smtp_server': ''})
 class TestIrMailServerSMTPD(TransactionCaseWithUserDemo):
@@ -258,12 +259,13 @@ class TestIrMailServerSMTPD(TransactionCaseWithUserDemo):
                             'smtp_ssl_private_key': private_key,
                         })
                         if error_pattern:
-                            with self.assertRaises(UserError) as error_capture:
+                            timeout = .1 if 'timed out' in error_pattern else SMTP_TIMEOUT
+                            with self.assertRaises(UserError) as error_capture, \
+                                 patch('odoo.addons.base.models.ir_mail_server.SMTP_TIMEOUT', timeout):
                                 mail_server.test_smtp_connection()
                             self.assertRegex(error_capture.exception.args[0], error_pattern)
                         else:
                             mail_server.test_smtp_connection()
-
 
     def test_authentication_login_matrix(self):
         """
@@ -310,7 +312,9 @@ class TestIrMailServerSMTPD(TransactionCaseWithUserDemo):
                                   password=password):
                     with self.start_smtpd(encryption, ssl_context, auth_required):
                         if error_pattern:
-                            with self.assertRaises(UserError) as capture:
+                            timeout = .1 if 'timed out' in error_pattern else SMTP_TIMEOUT
+                            with self.assertRaises(UserError) as capture, \
+                                 patch('odoo.addons.base.models.ir_mail_server.SMTP_TIMEOUT', timeout):
                                 mail_server.test_smtp_connection()
                             self.assertRegex(capture.exception.args[0], error_pattern)
                         else:
@@ -367,7 +371,9 @@ class TestIrMailServerSMTPD(TransactionCaseWithUserDemo):
                               client_encryption=client_encryption):
                 mail_server.smtp_encryption = client_encryption
                 with self.start_smtpd(server_encryption, ssl_context, auth_required=False):
-                    with self.assertRaises(UserError) as capture:
+                    timeout = .1 if 'timed out' in error_pattern else SMTP_TIMEOUT
+                    with self.assertRaises(UserError) as capture, \
+                         patch('odoo.addons.base.models.ir_mail_server.SMTP_TIMEOUT', timeout):
                         mail_server.test_smtp_connection()
                     self.assertRegex(capture.exception.args[0], error_pattern)
 


### PR DESCRIPTION
There are multiple cases where the SMTPD tests fail due to a timeout error. It is much worse to get a red runbot due to a silly timeout than to sometime wait a bit longer than .1 second.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
