### PR TITLE
[FIX] html_editor, *: override classes added by video plugin for embedded videos

### DIFF
--- a/addons/html_editor/static/src/main/youtube_plugin.js
+++ b/addons/html_editor/static/src/main/youtube_plugin.js
@@ -9,6 +9,9 @@ export const YOUTUBE_URL_GET_VIDEO_ID =
 export class YoutubePlugin extends Plugin {
     static id = "youtube";
     static dependencies = ["history", "dom"];
+
+    mediaSpecificClasses = VideoSelector.mediaSpecificClasses;
+
     /** @type {import("plugins").EditorResources} */
     resources = {
         ...(this.config.allowVideo && {
@@ -62,7 +65,7 @@ export class YoutubePlugin extends Plugin {
             start_from,
         });
         const savedVideo = this.createVideoElement(videoData);
-        savedVideo.classList.add(...VideoSelector.mediaSpecificClasses);
+        savedVideo.classList.add(...this.mediaSpecificClasses);
         return savedVideo;
     }
 

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_youtube_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_youtube_plugin.js
@@ -6,6 +6,9 @@ export class EmbeddedYoutubePlugin extends YoutubePlugin {
     static dependencies = [...super.dependencies, "embeddedComponents"];
 
     /** @override */
+    mediaSpecificClasses = EmbeddedVideoSelector.mediaSpecificClasses;
+
+    /** @override */
     createVideoElement(videoData) {
         const { video_id: videoId, platform, params } = videoData;
         return EmbeddedVideoSelector.createElements([{ videoId, platform, params }])[0];

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_selector_dialog/embedded_video_selector.js
@@ -3,6 +3,9 @@ import { renderToElement } from "@web/core/utils/render";
 
 export class EmbeddedVideoSelector extends VideoSelector {
     /** @override */
+    static mediaSpecificClasses = [];
+
+    /** @override */
     static createElements(selectedMedia) {
         return selectedMedia.map((media) =>
             renderToElement("html_editor.EmbeddedVideoBlueprint", {

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -929,13 +929,51 @@ test("Embed video by pasting video URL", async () => {
     // Press Enter to select first option in the powerbox ("Embed Youtube Video").
     await press("Enter");
     await animationFrame();
-    const videoIframe = queryOne("div.media_iframe_video");
+    const videoIframe = queryOne("div[data-embedded='video']");
     expect(videoIframe.nextElementSibling).toHaveOuterHTML(
         '<div class="o-paragraph" data-selection-placeholder=""><br></div>'
     );
     expect(
-        `div.media_iframe_video iframe[data-src="https://www.youtube.com/embed/${videoId}"]`
+        `div[data-embedded='video'] iframe[data-src="https://www.youtube.com/embed/${videoId}"]`
     ).toHaveCount(1);
+});
+
+test("Embedded video shouldn't have the 'media_iframe_video' class", async () => {
+    const videoId = "qxb74CMR748";
+    const videoURL = `https://www.youtube.com/watch?v=${videoId}`;
+
+    onRpc("/html_editor/video_url/data", async () => ({
+        platform: "youtube",
+        video_id: videoId,
+        embed_url: `https://www.youtube.com/embed/${videoId}`,
+    }));
+
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    setSelectionInHtmlField();
+
+    // Open the video tab of the media dialog
+    await insertText(htmlEditor, "/video");
+    await waitFor(".o-we-powerbox");
+    await press("Enter");
+    await waitFor(".o_select_media_dialog");
+    expect(".o_select_media_dialog .nav-link:contains('Videos')").toHaveClass("active");
+    await animationFrame();
+
+    await contains(".o_video_dialog_form textarea").edit(videoURL);
+    await waitFor(".modal-dialog .modal-footer .btn-primary:not(:disabled)", { timeout: 2000 });
+    await contains(".modal-dialog .modal-footer .btn-primary").click();
+    await animationFrame();
+
+    expect("div[data-embedded='video']").not.toHaveClass(".media_iframe_video");
 });
 
 test("isDirty should be false when the content is being transformed by the editor", async () => {

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -263,7 +263,7 @@ class ProductTemplate(models.Model):
         if (
             (description_ecommerce := vals.get('description_ecommerce'))
             and is_html_empty(description_ecommerce)
-            and 'media_iframe_video' not in description_ecommerce  # don't remove "empty" video div
+            and not ('media_iframe_video' in description_ecommerce or 'data-embedded' in description_ecommerce)  # don't remove "empty" video div
         ):
             vals['description_ecommerce'] = ''
         return super().write(vals)


### PR DESCRIPTION
*: website_sale

Steps to Reproduce the issue:
- Go to eLearning module and select any course, if exist, or create a new one.
- In the description tab, add a video link.
- Click on "Go to Website"
- Traceback occurs, and the video is not visible.

When the video tab was added to the Media Dialog, and EmbeddedVideoPlugin was introduced in [1], it was forgotten to override the classes added by the video plugin to embedded videos.
The issue happens because the video plugin adds a class to the video element, and MediaVideo Interaction generates a video iframe, but we already have a separate interaction for embedded components.

[1]: https://github.com//odoo/odoo/commit/a78ec7ab03973db54917e69d3d13b59f7410a3c7

task-5442928
opw-5224050
opw-5454714