### PR TITLE
[FIX] ir_http: Fixed selecting correct modules to translate

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -292,7 +292,7 @@ class IrHttp(models.AbstractModel):
     def _get_translation_frontend_modules_name(cls):
         mods = super()._get_translation_frontend_modules_name()
         installed = request.registry._init_modules.union(odoo.tools.config['server_wide_modules'])
-        return mods + [mod for mod in installed if mod.startswith('website')]
+        return mods + [mod for mod in installed if 'website' in mod]
 
     @classmethod
     def _serve_page(cls):


### PR DESCRIPTION

Current behavior before PR:

Only the modules with names starting with 'website' were added to the website translated modules.

Causing modules such as  'ai_website' to miss translations.

Desired behavior after PR is merged:

All the modules related to 'website' are selected and added.

task-5375210
parent support task-5210084

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
