### PR TITLE
[FIX] lock registry cross worker

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2069,8 +2069,12 @@ class IrModelAccess(models.Model):
         """, [lang, lang, model_name])
         return [('%s/%s' % x) if x[0] else x[1] for x in self.env.cr.fetchall()]
 
+    # make method public for debug to avoid to have to call get_views
+    def get_access_groups(self, model_name, access_mode='read'):
+        return self._get_access_groups(model_name, access_mode)
+
     @api.model
-    @tools.ormcache('model_name', 'access_mode', cache='stable')
+    #@tools.ormcache('model_name', 'access_mode', cache='stable')
     def _get_access_groups(self, model_name, access_mode='read'):
         """ Return the group expression object that represents the users who
         have ``access_mode`` to the model ``model_name``.

--- a/odoo/addons/base/models/res_groups.py
+++ b/odoo/addons/base/models/res_groups.py
@@ -386,6 +386,7 @@ class ResGroups(models.Model):
     @tools.ormcache(cache='groups')
     def _get_group_definitions(self):
         """ Return the definition of all the groups as a :class:`~odoo.tools.SetDefinitions`. """
+        print('_get_group_definitions')
         groups = self.sudo().search([], order='id')
         id_to_ref = groups.get_external_id()
         data = {

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -264,6 +264,7 @@ def load_module_graph(
             package.state = 'installed'
             module.env.flush_all()
             module.env.cr.commit()
+            registry.signal_changes()
             if module_name == 'project':
                 # sleep to allow to reproduce issue
                 print('pausing install after project commit')

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -264,6 +264,11 @@ def load_module_graph(
             package.state = 'installed'
             module.env.flush_all()
             module.env.cr.commit()
+            if module_name == 'project':
+                # sleep to allow to reproduce issue
+                print('pausing install after project commit')
+                time.sleep(30)
+
 
         test_time = 0.0
         test_queries = 0

--- a/odoo/tools/set_expression.py
+++ b/odoo/tools/set_expression.py
@@ -120,6 +120,7 @@ class SetDefinitions:
         if keep_subsets:
             ids = set(ids)
             ids = [leaf_id for leaf_id in ids if not any((self.__leaves[leaf_id].subsets - {leaf_id}) & ids)]
+
         return Union(Inter([self.__leaves[leaf_id]]) for leaf_id in ids)
 
     def from_key(self, key: str) -> SetExpression:

--- a/test.py
+++ b/test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import subprocess
+import time
+import os
+import signal
+import threading
+from requests import Session
+try:
+    if True:
+        print('droping database')
+        subprocess.run("dropdb test_concurrency_xdo > /dev/null 2>&1", shell=True)
+        print('creating database')
+        subprocess.run("python3 odoo-bin -d test_concurrency_xdo -i base,web --stop-after-init --skip-auto-install", shell=True)
+        print('running odoo instances')
+
+    p1 = subprocess.Popen("python3 odoo-bin -d test_concurrency_xdo --workers=1 --http-port 9069 --gevent-port 9169 --max-cron-thread=0".split(' '))
+    p2 = subprocess.Popen("python3 odoo-bin -d test_concurrency_xdo --workers=1 --http-port 9070 --gevent-port 9170 --max-cron-thread=0".split(' '))
+
+    s = Session()
+    time.sleep(5)  # wait for servers to be up
+    csrf_token = s.get('http://127.0.0.1:9069/web/login').text.split('name="csrf_token" value="')[1].split('"')[0]
+    print(csrf_token)
+
+    response = s.post('http://127.0.0.1:9069/web/login', data={
+        'csrf_token': csrf_token,
+        'login': 'admin',
+        'password': 'admin',
+        'type': 'password',
+    })
+
+    # _get_group_definitions should be warm at this
+
+    # install module project
+
+    url = 'http://127.0.0.1:9070/web/dataset/call_button/ir.module.module/button_immediate_install'
+    headers = {
+        'Content-Type': 'application/json',
+    }
+    data = {
+        "id": 6,
+        "jsonrpc": "2.0",
+        "method": "call",
+        "params": {
+            "args": [[434]],  # project
+            "kwargs": {
+            },
+            "method": "button_immediate_install",
+            "model": "ir.module.module",
+        },
+    }
+
+    def install_project():
+        s.post(url, headers=headers, json=data)
+
+    instal_thread = threading.Thread(target=install_project)
+    instal_thread.start()
+
+
+    for i in range(100):
+        # looping will work because the cache is removed but in theory we need to wait for the install to be finished
+        print()
+        time.sleep(1)
+        url = 'http://127.0.0.1:9069/web/dataset/call_kw/ir.model.access/get_access_groups'
+        headers = {
+            'content-type': 'application/json',
+        }
+        data = {
+            "id": 23,
+            "jsonrpc": "2.0",
+            "method": "call",
+            "params": {
+                "model": "ir.model.access",
+                "method": "get_access_groups",
+                "args": [[], 'res.partner', 'read'],
+                "kwargs": {
+                    "context": {},
+                }
+            }
+        }
+        response = s.post(url, headers=headers, json=data)
+        print('access groups response:', response.status_code, response.text)
+
+    instal_thread.join()
+    p1.wait()
+
+    response = s.post(url, headers=headers, json=data)
+
+except Exception as e:
+    print('error occurred:', e)
+
+finally:
+    print('killing odoo instances')
+    os.killpg(0, signal.SIGKILL)


### PR DESCRIPTION
This pr ensures that a registry can only be loaded by one process at a time.

This is a poc to solve potential registry/cache inconsistency while a module is being installed

Note that this was not tested in depth, it just solves the initial issue but this could be a problem on production where all worker would be loaded sequentially and this could be a huge issue.

**We should actually only need to acquire the lock when a module is being installed/updated.**
**This current version would be a problem on production, we need a multiple reader/one writer kind of lock**