### PR TITLE
[FIX] auth_signup, mail: skip portal users in first-connection notification

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -80,7 +80,7 @@ class ResUsers(models.Model):
                 values.pop('login', None)
                 values.pop('name', None)
                 partner_user.write(values)
-                if not partner_user.login_date:
+                if not partner_user.login_date and partner_user._is_internal():
                     partner_user._notify_inviter()
                 return (partner_user.login, values.get('password'))
             else:
@@ -94,7 +94,6 @@ class ResUsers(models.Model):
                     values['company_id'] = partner.company_id.id
                     values['company_ids'] = [(6, 0, [partner.company_id.id])]
                 partner_user = self._signup_create_user(values)
-                partner_user._notify_inviter()
         else:
             # no token, sign up an external user
             values['email'] = values.get('email') or values.get('login')

--- a/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_core_web_service.js
@@ -22,10 +22,9 @@ export class DiscussCoreWeb {
             // If the current user invited a new user, and the new user is
             // connecting for the first time while the current user is present
             // then open a chat for the current user with the new user.
-            const notification = _t(
-                "%(user)s connected. This is their first connection. Wish them luck.",
-                { user: username }
-            );
+            const notification = _t("%(user)s just connected for the first time. Wish them luck!", {
+                user: username,
+            });
             this.notificationService.add(notification, { type: "info" });
             if (!this.multiTab.isOnMainTab()) {
                 return;

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -942,7 +942,7 @@ test("Open chat window of new inviter", async () => {
     });
     await contains(".o-mail-ChatWindow", { text: "Newbie" });
     await contains(".o_notification", {
-        text: "Newbie connected. This is their first connection. Wish them luck.",
+        text: "Newbie just connected for the first time. Wish them luck!",
     });
 });
 


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------
When a user was invited to Odoo, the inviter received a first-connection notification when the invited user connected for the first time. This notification was triggered for **all user types**, including portal users.

For portal users, this resulted in unnecessary toast notifications and chat window pop-ups.

**Current behavior before PR:**
---------------------------------
- The inviter is notified when any invited user connects for the first time.
- This includes portal users.
- Unnecessary notifications and chat pop-ups are shown for portal user connections.

**Desired behavior after PR is merged:**
-----------------------------------------
- The inviter is notified **only when an internal user** connects for the first time.
- Portal users no longer trigger first-connection notifications.
- The notification message is updated to:  “[Username] just connected for the first time. Wish them luck!”

**Task:** [4105780](https://www.odoo.com/odoo/project/1519/tasks/4105780)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
