### PR TITLE
[FIX] html_builder: Set color filter to video background

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -163,6 +163,10 @@ export class SelectFilterColorAction extends StyleAction {
         // Find the filter element.
         let filterEl = editingElement.querySelector(":scope > .o_we_bg_filter");
 
+        // If no value is provided, use the current one if any.
+        if (filterEl && value === undefined) {
+            value = filterEl.style.backgroundImage;
+        }
         // If the filter would be transparent, remove it / don't create it.
         const rgba = value && convertCSSColorToRgba(value);
         if (!value || (rgba && rgba.opacity < 0.001)) {


### PR DESCRIPTION
The color filter applied to a video background would disappear after selecting the block and saving the page again.

Steps to reproduce:
===================
1. Enter Edit mode on the website.
2. Drag and drop a snippet (e.g., "Intro").
3. Set a video background for the block and apply a color filter.
4. Save the page.
5. Enter Edit mode again, click the block to select it, and Save.

-> The color filter is removed from the video background.

Cause:
======
Selecting the block triggers the `toggleBgImageClasses()` function. This function attempts to determine the background configuration. Since a video background is used, there is no standard image URL, so the code proceeds to call `setImageBackground` with an empty URL ([1]). This update process involves re-applying the color filter via the `selectFilterColor` action. However, the current background image style (the filter color) was not being passed to this function during this specific update flow. Consequently, the function assumed no filter existed and removed it ([2]).

Solution:
=========
Retrieve the current `filterColor` (which exists in background-image style) and pass it explicitly when calling the apply function.

[1]: https://github.com/odoo/odoo/blob/fa482e36bc36809e55b6a11ebcc5bb130f20fd31/addons/html_builder/static/src/plugins/background_option/background_image_option.js#L18-L20
[2]: https://github.com/odoo/odoo/blob/fa482e36bc36809e55b6a11ebcc5bb130f20fd31/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js#L170

opw-5448696

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
