### PR TITLE
[FIX] hr_timesheet: revert timesheet list view to add new entries at the bottom

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -42,7 +42,7 @@
                     </t>
                     <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor or has_project_template or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
                     <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': '', 'form_view_ref': 'hr_timesheet.timesheet_view_form_user'}">
-                        <list editable="top" string="Timesheet Activities" decoration-muted="readonly_timesheet == True">
+                        <list editable="bottom" string="Timesheet Activities" decoration-muted="readonly_timesheet == True">
                             <field name="readonly_timesheet" column_invisible="True"/>
                             <field name="date" readonly="readonly_timesheet"/>
                             <field name="user_id" column_invisible="True"/>


### PR DESCRIPTION
Steps to Reproduce:
- Open the Task form view
- Add a new Timesheet entry
- Notice that the newly created timesheet appears at the top of the list

Cause:
- The timesheet list view was configured with editable="top", which forces newly created records to be inserted at the top of the    list instead of following the chronological order.

Solution:
- Restore the list view configuration to use editable="bottom" and apply default_order="date", ensuring new timesheet entries are  consistently added at the bottom of the list.

task-5309676

