### PR TITLE
[FIX] account: Check if accounts on move lines have correct companies

### DIFF
--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -1289,3 +1289,59 @@ class TestAccountMove(AccountTestInvoicingCommon):
         })
         self.env.flush_all()
         self.assertEqual(fields_recomputed, [])
+
+    def test_post_invoice_fails_when_account_company_differs_from_journal_company(self):
+        """
+        Ensure that an invoice cannot be posted when at least one line account
+        belongs to a different company than the journal.
+
+        The test verifies that:
+        - Using a journal from a branch company (child of the account's company) is allowed
+        - Using a journal from an unrelated company correctly raises a UserError
+        """
+        move_form = Form(self.env['account.move'])
+
+        with move_form.line_ids.new() as line_form:
+            line_form.name = 'debit_line'
+            line_form.account_id = self.company_data['default_account_revenue']
+            line_form.amount_currency = 100.0
+
+        with move_form.line_ids.new() as line_form:
+            line_form.name = 'credit_line'
+            line_form.account_id = self.company_data['default_account_revenue']
+            line_form.amount_currency = -100.0
+        move = move_form.save()
+
+        # Ensure branch company aren't considered as inconsistency
+        company_branch = self.env['res.company'].create({
+            'name': 'Company Branch',
+            'parent_id': self.env.company.id,
+        })
+        journal_branch = self.env['account.journal'].create({
+            'name': 'Company Branch Journal',
+            'type': 'sale',
+            'code': 'CBrJ',
+            'company_id': company_branch.id,
+        })
+
+        with Form(move.copy()) as move_form:
+            move_form.company_id = company_branch
+            move_form.journal_id = journal_branch
+            branch_move = move_form.save()
+        branch_move.action_post()
+
+        # Ensure posting fails when the account's company is different than the journal's company
+        company_b = self.env['res.company'].create({'name': 'Company B'})
+        journal_b = self.env['account.journal'].create({
+            'name': 'Company B Journal',
+            'type': 'sale',
+            'code': 'CBJ',
+            'company_id': company_b.id,
+        })
+
+        with Form(move.copy()) as move_form:
+            move_form.company_id = company_b
+            move_form.journal_id = journal_b
+            b_move = move_form.save()
+        with self.assertRaises(UserError):
+            b_move.action_post()


### PR DESCRIPTION
This issue was already fixed in this PR:
https://github.com/odoo/odoo/pull/234357
But that was revert because there was a bug with company branches

### Steps to reproduce:
- Create Company A and Company B
- Create an invoice on Company A with one line having an account in Company A
- On the same invoice, change the company to Company B and change the journal to a journal of Company B
- Save, then confirm the invoice.

### Issue:
The invoice, now belonging to Company B, still has the same account from company A, and we are able to post it on the journal from company B

opw-5167958