### PR TITLE
[IMP] point_of_sale: implement help for empty screen

### DIFF
--- a/addons/point_of_sale/views/pos_bill_view.xml
+++ b/addons/point_of_sale/views/pos_bill_view.xml
@@ -20,7 +20,7 @@
         <field name="name">pos.bill.list</field>
         <field name="model">pos.bill</field>
         <field name="arch" type="xml">
-            <list string="Bills" create="1" delete="1" editable="bottom">
+            <list string="Bills" create="1" delete="1" editable="bottom" sample="1">
                 <field name="name" />
                 <field name="value" />
                 <field name="pos_config_ids" widget="many2many_tags_placeholder_list_view" placeholder="For all point of sale."/>
@@ -32,6 +32,11 @@
         <field name="name">Coins/Bills</field>
         <field name="res_model">pos.bill</field>
         <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Add coins and bills
+            </p>
+        </field>
     </record>
 
     <menuitem

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -170,13 +170,26 @@
         </field>
     </record>
 
+    <record id="pos_product_attribute_action" model="ir.actions.act_window">
+        <field name="name">Attributes</field>
+        <field name="res_model">product.attribute</field>
+        <field name="view_id" ref="product.attribute_tree_view" />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create product attributes
+            </p><p>
+                Product attribute allow you to manage the different variation possible for a product. 
+            </p>
+        </field>
+    </record>
+
     <!-- Products sub Category -->
     <menuitem id="menu_products_pos_category"
         action="point_of_sale.product_pos_category_action"
         parent="point_of_sale.pos_menu_products_configuration"
         sequence="1"/>
     <menuitem id="pos_menu_products_attribute_action"
-        action="product.attribute_action"
+        action="pos_product_attribute_action"
         parent="point_of_sale.pos_menu_products_configuration"  groups="product.group_product_variant" sequence="2"/>
 
     <menuitem id="menu_pos_dashboard" action="action_pos_config_kanban" parent="menu_point_root" name="Dashboard" sequence="1"/>

--- a/addons/point_of_sale/views/pos_note_view.xml
+++ b/addons/point_of_sale/views/pos_note_view.xml
@@ -16,6 +16,13 @@
         <field name="name">Note Models</field>
         <field name="res_model">pos.note</field>
         <field name="view_mode">list</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create predefined notes
+            </p><p>
+                Set default notes that you can use in one click when taking an order.
+            </p>
+        </field>
     </record>
 
     <menuitem id="menu_pos_note_model"

--- a/addons/point_of_sale/views/pos_preset_view.xml
+++ b/addons/point_of_sale/views/pos_preset_view.xml
@@ -70,7 +70,7 @@
         <field name="name">pos.preset.list</field>
         <field name="model">pos.preset</field>
         <field name="arch" type="xml">
-            <list string="Presets">
+            <list string="Presets" sample="1">
                 <field name="name"/>
                 <field name="use_timing"/>
                 <field name="identification"/>
@@ -86,6 +86,8 @@
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Add a new preset
+            </p><p>
+                Presets are group of settings that you can apply in pos in one click (takeaway, delivery...).
             </p>
         </field>
     </record>

--- a/addons/point_of_sale/views/product_view.xml
+++ b/addons/point_of_sale/views/product_view.xml
@@ -52,6 +52,18 @@
         <field name="search_view_id" ref="product.product_category_search_view"/>
         <field name="view_id" ref="product.product_category_list_view"/>
     </record>
+    <record id="pos_product_combo_choice_action" model="ir.actions.act_window">
+        <field name="name">Combo Choices</field>
+        <field name="res_model">product.combo</field>
+        <field name="view_id" ref="product.product_combo_view_tree"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Add combo choices
+            </p><p>
+                Build flexible product combinations.
+            </p>
+        </field>
+    </record>
 
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product.template.form.inherit</field>
@@ -129,7 +141,7 @@
     <menuitem id="point_of_sale.menu_product_combo"
         name="Combo Choices"
         parent="point_of_sale.pos_config_menu_catalog"
-        action="product.product_combo_action"
+        action="pos_product_combo_choice_action"
         sequence="15"/>
     <menuitem id="pos_config_menu_action_product_pricelist"
         parent="point_of_sale.pos_config_menu_catalog"

--- a/addons/pos_restaurant/views/pos_course_views.xml
+++ b/addons/pos_restaurant/views/pos_course_views.xml
@@ -3,7 +3,7 @@
         <field name="name">pos.course.list</field>
         <field name="model">pos.course</field>
         <field name="arch" type="xml">
-            <list string="Courses" editable="bottom">
+            <list string="Courses" editable="bottom" sample="1">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="category_ids" widget="many2many_tags"/>
@@ -30,6 +30,13 @@
         <field name="name">Courses</field>
         <field name="res_model">pos.course</field>
         <field name="view_mode">list,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Add courses
+            </p><p>
+                Assign products to courses like starter, main or dessert to ensure dishes are prepared and served in the correct order.
+            </p>
+        </field>
     </record>
 
     <menuitem id="menu_pos_course"


### PR DESCRIPTION
Following this commit:
====
- Added help for following models to ease implementation for new user.
> pos.bill
> product.attribute
> pos.preset
> product.combo
> pos.course
> pos.note

task-5462933
