### PR TITLE
[FIX] base: why does the admin partner need a company?

### DIFF
--- a/odoo/addons/base/data/res_partner_data.xml
+++ b/odoo/addons/base/data/res_partner_data.xml
@@ -21,7 +21,6 @@
 
         <record model="res.partner" id="base.partner_admin">
             <field name="name">Administrator</field>
-            <field name="company_id" ref="main_company"/>
         </record>
 
         <record id="public_partner" model="res.partner">


### PR DESCRIPTION
When we create a new website for a new company and use Mitchell Admin to create a sale order it will
not allow it because the partner Mitchell Admin is linked to company_id 1 and the SO to another company.

I actually do not see a good standard reason to give the partner of a user a company. It is also not done when you create a user manually.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
