### PR TITLE
[FIX] account: restore tour compatibility by toggling product column

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -112,7 +112,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/components/**/*',
             'account/static/src/services/*.js',
             'account/static/src/views/**/*',
-            'account/static/src/js/tours/account.js',
+            'account/static/src/js/tours/*',
             'account/static/src/js/search/search_bar/search_bar.js',
             'account/static/src/helpers/*.js',
         ],
@@ -127,7 +127,6 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/helpers/*.js',
         ],
         'web.assets_tests': [
-            'account/static/src/js/tours/tour_utils.js',
             'account/static/tests/tours/**/*',
         ],
         'web.report_assets_common': [

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -1,6 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
+import { showProductColumn } from "@account/js/tours/tour_utils";
 
 import { markup } from "@odoo/owl";
 
@@ -67,6 +68,7 @@ registry.category("web_tour.tours").add('account_tour', {
         content: _t("Add a line to your invoice"),
         run: "click",
     },
+    ...showProductColumn(),
     {
         trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id]`,
         content: _t("Fill in the details of the product or see the suggestion."),

--- a/addons/account/static/src/js/tours/tour_utils.js
+++ b/addons/account/static/src/js/tours/tour_utils.js
@@ -1,3 +1,28 @@
+export function showProductColumn() {
+    // Show product column if Sale is not installed.
+    return [
+        {
+            content: "Open line fields list",
+            trigger: ".o_optional_columns_dropdown_toggle",
+            run: "click",
+        },
+        {
+            content: "Show product column",
+            trigger: '.o-dropdown-item input[name="product_id"]',
+            run: function (actions) {
+                if (!this.anchor.checked) {
+                    actions.click();
+                }
+            },
+        },
+        {
+            content: "Close line fields list",
+            trigger: ".o_optional_columns_dropdown_toggle",
+            run: "click",
+        },
+    ];
+}
+
 export function addSectionFromProductCatalog() {
     return [
         {

--- a/addons/account/static/tests/tours/account_product_catalog_tests.js
+++ b/addons/account/static/tests/tours/account_product_catalog_tests.js
@@ -1,4 +1,4 @@
-import { addSectionFromProductCatalog } from "@account/js/tours/tour_utils";
+import { addSectionFromProductCatalog, showProductColumn } from "@account/js/tours/tour_utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_use_product_catalog_on_invoice", {
@@ -22,6 +22,7 @@ registry.category("web_tour.tours").add("test_use_product_catalog_on_invoice", {
             trigger: ".o-kanban-button-back",
             run: "click",
         },
+        ...showProductColumn(),
         {
             content: "Ensure product is added",
             trigger: ".o_field_product_label_section_and_note_cell:contains(Test Product)",

--- a/addons/sale/static/tests/tours/sale_catalog.js
+++ b/addons/sale/static/tests/tours/sale_catalog.js
@@ -1,4 +1,4 @@
-import { addSectionFromProductCatalog } from "@account/js/tours/tour_utils";
+import { addSectionFromProductCatalog, showProductColumn } from "@account/js/tours/tour_utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('sale_catalog', {
@@ -93,6 +93,7 @@ registry.category("web_tour.tours").add('test_add_section_from_product_catalog_o
             trigger: '.o_field_res_partner_many2one .dropdown-item:not([id$="_loading"]):first',
             run: 'click',
         },
+        ...showProductColumn(),
         ...addSectionFromProductCatalog(),
     ]
 });


### PR DESCRIPTION
Commit 9c8e012 changed the visibility of the product column on invoices and bills. This caused several tours to fail as they expected the column to be visible by default.

This commit fixes the failures by explicitly toggling the column visibility within the affected tours when required.

runbot-234710
runbot-234871
runbot-234872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
