### PR TITLE
[FIX] base: Error logging when using etree nodes in QWeb

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -534,13 +534,14 @@ class QWebError(Exception):
 
 
 class QWebErrorInfo:
-    def __init__(self, error: str, ref_name: str | int | None, ref: int | None, path: str | None, element: str | None, source: list[tuple[int | str, str, str]]):
+    def __init__(self, error: str, ref_name: str | int | None, ref: int | None, path: str | None, element: str | None, source: list[tuple[int | str, str, str]], surrounding: str):
         self.error = error
         self.template = ref_name
         self.ref = ref
         self.path = path
         self.element = element
         self.source = source
+        self.surrounding = surrounding
 
     def __str__(self):
         info = [self.error]
@@ -555,6 +556,8 @@ class QWebErrorInfo:
         if self.source:
             source = '\n          '.join(str(v) for v in self.source)
             info.append(f'From: {source}')
+        if self.surrounding:
+            info.append(f'QWeb generated code:\n{self.surrounding}')
         return '\n    '.join(info)
 
 
@@ -850,6 +853,8 @@ class IrQweb(models.AbstractModel):
             raise
 
     def _get_error_info(self, error, stack: list[QwebStackFrame], frame: QwebStackFrame) -> QWebErrorInfo:
+        no_id_ref = 'etree._Element'
+
         path = None
         html = None
         loaded_codes = self.env.context['__qweb_loaded_codes']
@@ -859,7 +864,7 @@ class IrQweb(models.AbstractModel):
                 options = self.env.context['__qweb_loaded_options'].get(frame.params.view_ref) or {}
             ref = options.get('ref') or frame.params.view_ref  # The template can have a null reference, for example for a provided etree.
             ref_name = options.get('ref_name') or None
-            code = loaded_codes.get(frame.params.view_ref) or loaded_codes.get(False)
+            code = loaded_codes.get(frame.params.view_ref) or loaded_codes.get(no_id_ref)
             if ref == self.env.context['_qweb_error_path_xml'][0]:
                 path = self.env.context['_qweb_error_path_xml'][1]
                 html = self.env.context['_qweb_error_path_xml'][2]
@@ -868,23 +873,25 @@ class IrQweb(models.AbstractModel):
             options = stack[-2].options or {}  # The compilation may have failed before the compilation options were loaded.
             ref = options.get('ref')
             ref_name = options.get('ref_name')
-            code = loaded_codes.get(ref) or loaded_codes.get(False)
+            code = loaded_codes.get(ref) or loaded_codes.get(no_id_ref)
             if frame.params.path_xml:
                 path = frame.params.path_xml[1]
                 html = frame.params.path_xml[2]
 
+        source_file_ref = None if ref == no_id_ref else ref
         line_nb = 0
         trace = traceback.format_exc()
         for error_line in reversed(trace.split('\n')):
-            if f'File "<{ref}>"' in error_line or (ref is None and 'File "<' in error_line):
+            if f'File "<{source_file_ref}>"' in error_line or (ref is None and 'File "<' in error_line):
                 line_function = error_line.split(', line ')[1]
                 line_nb = int(line_function.split(',')[0])
                 break
 
         source = [info.params.path_xml for info in stack if info.params.path_xml]
+        code_lines = (code or '').split('\n')
 
         found = False
-        for code_line in reversed((code or '').split('\n')[:line_nb]):
+        for code_line in reversed(code_lines[:line_nb]):
             if code_line.startswith('def '):
                 break
             match = re.match(r'\s*# element: (.*) , (.*)', code_line)
@@ -904,7 +911,24 @@ class IrQweb(models.AbstractModel):
         if path:
             source.append((ref, path, html))
 
-        return QWebErrorInfo(f'{error.__class__.__name__}: {error}', ref if ref_name is None else ref_name, ref, path, html, source)
+        surrounding = None
+        if self.env.context.get('dev_mode') and line_nb:
+            if html and ' t-if=' in html and ' if ' in '\n'.join(code_lines[line_nb - 2:line_nb - 1]):
+                line_nb -= 1
+            previous_lines = '\n'.join(code_lines[max(line_nb - 25, 0):line_nb - 1])
+            line = code_lines[line_nb - 1]
+            next_lines = '\n'.join(code_lines[line_nb:line_nb + 5])
+            indent = re.search(r"^(\s*)", line).group(0)
+            surrounding = textwrap.indent(
+                textwrap.dedent(
+                    f"{previous_lines}\n"
+                    f"{indent}########### Line triggering the error ############\n{line}\n"
+                    f"{indent}##################################################\n{next_lines}"
+                ),
+                ' ' * 8
+            )
+
+        return QWebErrorInfo(f'{error.__class__.__name__}: {error}', ref if ref_name is None else ref_name, ref, path, html, source, surrounding)
 
     # assume cache will be invalidated by third party on write to ir.ui.view
     def _get_template_cache_keys(self):


### PR DESCRIPTION
This PR fixes the error logging when QWeb is used with an `etree` node instead of a standard xmlid or id, to display the path of the directives (xml node) crossed.

I have also improved the logging output when running with `--dev=qweb`: the error message now includes the generated code snippet surrounding the line that caused the error.

This should make debugging much more intuitive by providing immediate context for the failure.