### PR TITLE
[FIX] website: keep all parameters on force redirect

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -148,7 +148,8 @@ class Website(Home):
             domain_to = get_base_domain(website.domain)
             if domain_from != domain_to:
                 # redirect to correct domain for a correct routing map
-                url_to = werkzeug.urls.url_join(website.domain, '/website/force/%s?isredir=1&path=%s' % (website.id, path))
+                query_params = werkzeug.urls.url_encode({'isredir': 1, 'path': path})
+                url_to = werkzeug.urls.url_join(website.domain, f'/website/force/{website.id}?{query_params}')
                 return request.redirect(url_to)
         website._force()
         return request.redirect(path)


### PR DESCRIPTION

Scenario from 17.0:

- set domain on website
- go to website /website/force/1?path=%2F%3Fa%3Db%26c%3Dd with another
  domain
=> you are redirected to {domain}/?a=b instead of {domain}/?a=b&c=d

Scenario from 18.0:

- set domain on website
- go to /appointment/1 on other domain, select person date and time
- click on "Editor"
=> you get error:

> TypeError: AppointmentController.appointment_type_id_form() missing 1
> required positional argument: 'duration'

Cause: the /website/force/ domain redirection doesn't encode the
parameter when redirecting, so we lose parameters after the first one.

Fix: encode parameters when redirecting domain in /website/force/ route.

opw-5441957
