### PR TITLE
[IMP] iot_drivers: Replace Ghostscript with SumatraPDF

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -6,9 +6,9 @@ from datetime import datetime, timezone
 from escpos import printer
 import escpos.exceptions
 import io
+import subprocess
 import win32print
 import pywintypes
-import ghostscript
 
 from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import PrinterDriverBase
@@ -78,30 +78,32 @@ class PrinterDriver(PrinterDriverBase):
         with win32print_lock:
             file_name = system.path_file('document.pdf')
             file_name.write_bytes(data)
-            printer = self.device_name
+            sumatra_pdf_path = system.path_file("SumatraPDF") / "SumatraPDF.exe"
 
-            args = [
-                "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT",
-                "-q",
-                "-sDEVICE#mswinpr2",
-                f'-sOutputFile#%printer%{printer}',
-                f'{file_name}'
+            sumatra_pdf_args = [
+                str(sumatra_pdf_path),
+                "-print-to",
+                self.device_name,
+                str(file_name),
+                "-silent",
+                "-print-settings",
+                "duplex"
             ]
 
-            _logger.debug("Printing report with ghostscript using %s", args)
+            _logger.debug("Printing report with SumatraPDF using %s", sumatra_pdf_args)
             stderr_buf = io.BytesIO()
             stdout_buf = io.BytesIO()
             stdout_log_level = logging.DEBUG
             try:
-                ghostscript.Ghostscript(*args, stdout=stdout_buf, stderr=stderr_buf)
+                subprocess.run(sumatra_pdf_args, check=True)
                 self.send_status(status='success')
             except Exception:
-                _logger.exception("Error while printing report, ghostscript args: %s, error buffer: %s", args, stderr_buf.getvalue())
+                _logger.exception("Error while printing report, SumatraPDF args: %s, error buffer: %s", sumatra_pdf_args, stderr_buf.getvalue())
                 stdout_log_level = logging.ERROR  # some stdout value might contains relevant error information
                 self.send_status(status='error', message='ERROR_FAILED')
                 raise
             finally:
-                _logger.log(stdout_log_level, "Ghostscript stdout: %s", stdout_buf.getvalue())
+                _logger.log(stdout_log_level, "SumatraPDF stdout: %s", stdout_buf.getvalue())
 
     def _action_default(self, data):
         _logger.debug("_action_default called for printer %s", self.device_name)

--- a/setup/iot_box_builder/configuration/requirements.txt
+++ b/setup/iot_box_builder/configuration/requirements.txt
@@ -2,7 +2,6 @@
 gatt; sys_platform == "linux" and "rpi" in platform_release
 
 # The following requirements are needed only on Windows Virtual IoT:
-ghostscript==0.8.1; sys_platform == "win32"
 decorator; sys_platform == "win32"
 
 # The following requirements are needed on every platforms, but are installed

--- a/setup/package.py
+++ b/setup/package.py
@@ -428,7 +428,7 @@ class DockerIot(DockerWine):
         self.nt_service_name = "odoo-iot"
 
     def build_image(self):
-        shutil.copy(os.path.join(self.args.build_dir, 'odoo/setup/iot_box_builder/configuration/requirements.txt'), self.docker_dir / 'requirements-iot.txt')
+        shutil.copy(os.path.join(self.args.build_dir, 'setup/iot_box_builder/configuration/requirements.txt'), self.docker_dir / 'requirements-iot.txt')
         self.tag = f'{self.tag}-iot'
         super().build_image()
 

--- a/setup/win32/setup-iot.nsi
+++ b/setup/win32/setup-iot.nsi
@@ -133,7 +133,7 @@ LangString DESC_Odoo_IoT ${LANG_ENGLISH} "Install the Odoo Server with IoT modul
 LangString DESC_FinishPage_Link ${LANG_ENGLISH} "Contact Odoo for Partnership and/or Support"
 LangString TITLE_Odoo_IoT ${LANG_ENGLISH} "Odoo IoT"
 LangString TITLE_Nginx ${LANG_ENGLISH} "Nginx WebServer"
-LangString TITLE_Ghostscript ${LANG_ENGLISH} "Ghostscript interpreter"
+LangString TITLE_SumatraPDF ${LANG_ENGLISH} "PDF interpreter"
 LangString DESC_FinishPageText ${LANG_ENGLISH} "Start Odoo"
 LangString UnsafeDirText ${LANG_ENGLISH} "Installing outside of $PROGRAMFILES64 is not recommended.$\nDo you want to continue ?"
 
@@ -142,7 +142,7 @@ LangString DESC_Odoo_IoT ${LANG_FRENCH} "Installation du Serveur Odoo avec les m
 LangString DESC_FinishPage_Link ${LANG_FRENCH} "Contactez Odoo pour un Partenariat et/ou du Support"
 LangString TITLE_Odoo_IoT ${LANG_FRENCH} "Odoo IoT"
 LangString TITLE_Nginx ${LANG_FRENCH} "Installation du serveur web Nginx"
-LangString TITLE_Ghostscript ${LANG_FRENCH} "Installation de l'interpréteur Ghostscript"
+LangString TITLE_SumatraPDF ${LANG_FRENCH} "Installation de l'interpréteur PDF"
 LangString DESC_FinishPageText ${LANG_FRENCH} "Démarrer Odoo"
 LangString UnsafeDirText ${LANG_FRENCH} "Installer en dehors de $PROGRAMFILES64 n'est pas recommandé.$\nVoulez-vous continuer ?"
 
@@ -239,27 +239,27 @@ Section -$(TITLE_Nginx) Nginx
     CreateDirectory $INSTDIR\nginx\logs
     File "conf\nginx\nginx.conf"
     # Temporary certs for the first start
-    File "..\..\odoo\setup\iot_box_builder\overwrite_after_init\etc\ssl\certs\nginx-cert.crt"
-    File "..\..\odoo\setup\iot_box_builder\overwrite_after_init\etc\ssl\private\nginx-cert.key"
+    File "..\..\setup\iot_box_builder\overwrite_after_init\etc\ssl\certs\nginx-cert.crt"
+    File "..\..\setup\iot_box_builder\overwrite_after_init\etc\ssl\private\nginx-cert.key"
 SectionEnd
 
-Section -$(TITLE_Ghostscript) SectionGhostscript
+Section -$(TITLE_SumatraPDF) SectionSumatraPDF
     SetOutPath '$TEMP'
-    VAR /GLOBAL ghostscript_exe_filename
-    VAR /GLOBAL ghostscript_url
+    VAR /GLOBAL sumatra_exe_filename
+    VAR /GLOBAL sumatra_url
 
-    StrCpy $ghostscript_exe_filename "gs10012w64.exe"
-    StrCpy $ghostscript_url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10012/$ghostscript_exe_filename"
+    StrCpy $sumatra_exe_filename "SumatraPDF-3.5.2-64-install.exe"
+    StrCpy $sumatra_url "https://www.sumatrapdfreader.org/dl/rel/3.5.2/$sumatra_exe_filename"
 
-    DetailPrint "Downloading Ghostscript"
-    NScurl::http get "$ghostscript_url" "$TEMP\$ghostscript_exe_filename" /PAGE /END
-    DetailPrint "Temp dir: $TEMP\$ghostscript_exe_filename"
+    DetailPrint "Downloading Sumatra PDF"
+    NScurl::http get "$sumatra_url" "$TEMP\$sumatra_exe_filename" /PAGE /END
+    DetailPrint "Temp dir: $TEMP\$sumatra_exe_filename"
 
-    Rmdir /r "INSTDIR\Ghostscript"
-    DetailPrint "Installing Ghostscript"
-    ExecWait '"$TEMP\$ghostscript_exe_filename" \
-        /S \
-        /D=$INSTDIR\Ghostscript'
+    Rmdir /r "INSTDIR\SumatraPDF"
+    DetailPrint "Installing Sumatra PDF"
+    ExecWait '"$TEMP\$sumatra_exe_filename" \
+        -install -silent \
+        -d "$INSTDIR\SumatraPDF"'
 SectionEnd
 
 Section -Post
@@ -288,7 +288,7 @@ Section "Uninstall"
     Pop $R0
     ReadRegStr $0 HKLM "${UNINSTALL_REGISTRY_KEY_SERVER}" "UninstallString"
     ExecWait '"$0" /S'
-    ExecWait '"$INSTDIR\Ghostscript\uninstgs.exe" /S'
+    ExecWait '"$INSTDIR\SumatraPDF\SumatraPDF.exe" -uninstall -silent'
 
     nsExec::Exec "net stop ${SERVICENAME}"
     nsExec::Exec "sc delete ${SERVICENAME}"


### PR DESCRIPTION
When printing a PDF using the Windows IoT, first the PDF file is temporarily saved, and then it is printed using Ghostscript which handles parsing the PDF and saving it to the printer. Unfortunately, Ghostscript is unable to print using duplex (double-sided) no matter what settings are provided.

To fix this, we replace Ghostscript with [SumatraPDF](https://github.com/sumatrapdfreader/sumatrapdf), which is an open source PDF viewer for Windows, but it is also capable of being used from the command line to print.

We simply provide the duplex printing option in the command to SumatraPDF, and it works as expected.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
