### PR TITLE
[FIX] website_blog, *: prevent horizontal scrollbar on long titles

### DIFF
--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -45,6 +45,8 @@ $o-wblog-loader-size: 50px;
 // Website Blog
 //------------------------------------------------------------------------------
 .website_blog {
+     word-break: break-word;
+
     .css_website_mail {
         .o_has_error {
             border-color: red;

--- a/addons/website_event/static/src/scss/event_templates_page.scss
+++ b/addons/website_event/static/src/scss/event_templates_page.scss
@@ -1,5 +1,6 @@
 .o_wevent_event {
     min-height: calc(95vh - 70px);
+    word-break: break-word;
 
     // Multi-line event title, even in mobile mode
     nav > div > a.navbar-brand {
@@ -22,7 +23,6 @@
     }
 
     .o_wevent_event_title {
-
         .o_wevent_event_name {
             font-weight: $display-font-weight;
             line-height: $display-line-height;

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -218,8 +218,12 @@ $input-border-color: $gray-400;
     }
 }
 
-#product_detail ~ .oe_structure.oe_empty > section:first-child {
-    border-top: $border-width solid $border-color;
+#product_detail {
+    word-break: break-word;
+
+    ~ .oe_structure.oe_empty > section:first-child {
+        border-top: $border-width solid $border-color;
+    }
 }
 
 .o_alternative_product {

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -372,6 +372,8 @@ $line-height-truncate: 1.25em;
 
 
 .o_wslides_course_header {
+    word-break: break-word;
+
     @include media-breakpoint-up(md)  {
         @include o-wslides-header-bar();
     }


### PR DESCRIPTION
*:website_event, website_slides

Before this commit, long titles in blog posts, events, and eLearning courses
caused horizontal page overflow with an unnecessary scrollbar.

This commit ensures long titles wrap correctly, preventing horizontal scrolling
while keeping the text intact.

Steps to reproduce the issue:
1. Install blog, events and eLearning modules
2. Add long titles to a blog post, event and course
3. Observe the text overflow causing a horizontal scrollbar

 | Before  | After |
   | ------------- | ------------- |
   Blog Module
   | <img width="1631" height="422" alt="image" src="https://github.com/user-attachments/assets/8faa6e22-ac7a-4b59-9b54-f674978dc931" /> | <img width="1633" height="420" alt="image" src="https://github.com/user-attachments/assets/66a2de39-95e2-4871-827e-4965e571ed33" /> |
   | <img width="882" height="394" alt="image" src="https://github.com/user-attachments/assets/b807245f-0d84-47b6-a65b-ce0005037c50" /> | <img width="888" height="385" alt="image" src="https://github.com/user-attachments/assets/3c35cd12-08f2-4775-9c4d-d9d6e4555f00" /> |
   Event Module
   | <img width="1335" height="398" alt="image" src="https://github.com/user-attachments/assets/7d3af438-58f7-4a56-acd0-46e6dc90fe2a" /> | <img width="981" height="376" alt="image" src="https://github.com/user-attachments/assets/fb419243-4c0d-4c72-97ec-47812f81b378" /> |
   E-Learning Module
   | <img width="1534" height="317" alt="image" src="https://github.com/user-attachments/assets/3b03835c-c72b-40fb-bbf0-8fc91d3fafe5" /> | <img width="1423" height="393" alt="image" src="https://github.com/user-attachments/assets/551e332d-25af-453a-bfda-b669b04fdd39" /> |



task-[5457179](https://www.odoo.com/odoo/project/974/tasks/5457179)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
