### PR TITLE
[IMP] pos_self_order: set fixed-size order note input

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.scss
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.scss
@@ -4,6 +4,9 @@
      max-width: 120px;
    }
 
+  .order-note-textarea {
+    resize: none;
+  }
 
   .delete-fade-out {
     animation: deleteFadeOut 0.25s forwards;


### PR DESCRIPTION
In this commit -
-------------
- Make the self order note textarea non-resizable and enforce a fixed size to avoid UI shifts in self/kiosk mode

Task-5469804

