### PR TITLE
[FIX] account_edi_ubl_cii: fix account holder on new bank accounts

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -482,7 +482,7 @@ class AccountEdiCommon(models.AbstractModel):
         # clear the context, because creation of partner when importing should not depend on the context default values
         ResPartnerBank = self.env['res.partner.bank'].with_env(self.env(context=clean_context(self.env.context)))
         bank_details = list(set(map(sanitize_account_number, bank_details)))
-        partner = self.env.company.partner_id if invoice.is_inbound() else invoice.partner_id
+        partner = self.env.company.partner_id if invoice.is_outbound() else invoice.partner_id
         banks_to_create = []
         acc_number_partner_bank_dict = {
             bank.sanitized_acc_number: bank


### PR DESCRIPTION
The bank accounts created when importing peppol invoices are linked to the wrong partner.

`_import_partner_bank` is called for the UBL `PayeeFinancialAccount`, so the bank account holder must be the supplier (invoice partner) for supplier invoices (inbound) and the company for customer invoice (outbound). Before this commit the logic was reversed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
