### PR TITLE
[FIX] oauth: changed error code order for correct exception handling

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -165,11 +165,11 @@ class OAuthController(http.Controller):
         except AccessDenied:
             # oauth credentials not valid, user could be on a temporary session
             _logger.info('OAuth2: access denied, redirect to main page in case a valid session exists, without setting cookies')
-            url = "/web/login?oauth_error=3"
+            url = "/web/login?oauth_error=2"
         except Exception:
             # signup error
             _logger.exception("Exception during request handling")
-            url = "/web/login?oauth_error=2"
+            url = "/web/login?oauth_error=3"
 
         redirect = request.redirect(url, 303)
         redirect.autocorrect_location_header = False

--- a/doc/cla/individual/oliverf01.md
+++ b/doc/cla/individual/oliverf01.md
@@ -1,0 +1,11 @@
+Germany, 2026-01-06
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Oliver Freriks oliver.freriks@t-systems.com https://github.com/oliverf01


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR should fix the order of error codes in the oauth controller.

Current behavior before PR:

Currently the user gets redirected to a different error.
For instance: AccessDenied error will redirect the user to "You do not have access to this database or your invitation has expired. Please ask for an invitation and be sure to follow the link in your invitation email."

Desired behavior after PR is merged:

AccessDenied error should show "Access Denied"

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
