### PR TITLE
[FIX] base: prevent error when user timezone is unset

### DIFF
--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1738,6 +1738,63 @@ class TestCompute(common.TransactionCase):
         })
         assert_history(action, expected)
 
+    def test_server_action_code_history_wizard_with_no_timezone(self):
+        self.env.user.tz = False
+
+        def get_history(action):
+            return self.env["ir.actions.server.history"].search([("action_id", "=", action.id)])
+
+        def assert_history(action, expected):
+            history = get_history(action)
+            self.assertRecordValues(history, expected)
+
+        expected = []
+
+        with freeze_time("2025-05-01 10:00:00"):
+            self.env.cr._now = datetime.datetime.now()  # reset transaction's NOW
+            action = self.env["ir.actions.server"].create({
+                "name": "Test Action",
+                "model_id": self.env["ir.model"]._get("res.partner").id,
+                "state": "code",
+                "code": "pass",
+            })
+        expected.insert(0, {
+            "code": "pass",
+            "display_name": WhitespaceInsensitive(f"May 1, 2025, 10:00:00 AM - {self.env.ref('base.user_root').name}"),
+        })
+        assert_history(action, expected)
+
+        with freeze_time("2025-05-01 10:00:00"):
+            self.env.cr._now = datetime.datetime.now()  # reset transaction's NOW
+            action.with_user(self.env.ref('base.user_admin')).write({"code": "hello"})
+        expected.insert(0, {
+            "code": "hello",
+            "display_name": WhitespaceInsensitive(f"May 1, 2025, 10:00:00 AM - {self.env.ref('base.user_admin').name}"),
+        })
+        assert_history(action, expected)
+
+        with freeze_time("2025-05-12 10:00:00"):
+            self.env.cr._now = datetime.datetime.now()  # reset transaction's NOW
+            with Form(self.env['server.action.history.wizard'].with_context(default_action_id=action.id)) as wizard_form:
+                self.assertRecordValues(wizard_form.revision, [
+                    {
+                        "code": "pass",
+                        "display_name": WhitespaceInsensitive(f"May 1, 2025, 10:00:00 AM - {self.env.ref('base.user_root').name}"),
+                    }
+                ])
+                first_diff = str(wizard_form.code_diff)
+                wizard_form.revision = get_history(action)[-1]
+                second_diff = str(wizard_form.code_diff)
+                self.assertNotEqual(first_diff, second_diff)
+            wizard_form.record.restore_revision()
+
+        self.assertEqual(action.code, "pass")
+        expected.insert(0, {
+            "code": "pass",
+            "display_name": WhitespaceInsensitive(f"May 12, 2025, 10:00:00 AM - {self.env.ref('base.user_root').name}"),
+        })
+        assert_history(action, expected)
+
 
 @common.tagged("post_install", "-at_install")
 class TestHttp(common.HttpCase):

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -512,7 +512,7 @@ class IrActionsServerHistory(models.Model):
         self.display_name = False
         for history in self.filtered('create_date'):
             locale = get_lang(self.env).code
-            tzinfo = pytz.timezone(self.env.user.tz)
+            tzinfo = self.env.tz
             datetime = history.create_date.replace(microsecond=0)
             datetime = pytz.utc.localize(datetime, is_dst=False)
             datetime = datetime.astimezone(tzinfo) if tzinfo else datetime


### PR DESCRIPTION
This error occurs when clicking the `Code History` button in Server Action.

Steps to reproduce:
- Search `Server Actions` > Open any server action
- Change `Code` and Save > Click `Code History` button

Traceback:
`AttributeError: 'bool' object has no attribute 'upper'`

This error occurs when the `Code History` button is clicked and, at that point, the user’s timezone is `False` because it is not set in the user’s calendar.

[1]- https://github.com/odoo/odoo/blob/54681272e9f00a171fe49f690979e2a8353ff5fb/odoo/addons/base/models/ir_actions.py#L515

sentry-7167683304

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
