### PR TITLE
Master journal dashboard changes yagho

### DIFF
--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -7,7 +7,7 @@
             <field name="model">account.journal</field>
             <field name="priority">1</field>
             <field name="arch" type="xml">
-                <list string="Account Journal">
+                <list create="False">
                     <field name='sequence' widget='handle'/>
                     <field name="name"/>
                     <field name="type"/>
@@ -201,7 +201,7 @@
             <field name="model">account.journal</field>
             <field name="priority">1</field>
             <field name="arch" type="xml">
-                <kanban class="o_kanban_mobile">
+                <kanban on_create="account_accountant.action_journal_create_wizard" class="o_kanban_mobile">
                     <templates>
                         <t t-name="card" class="row g-0">
                             <div class="col-6">


### PR DESCRIPTION
In the accounting dashboard, clicking the "New" button would open the new journal creation wizard which was confusing, the button was completely removed and can now be accessed from the cog menu, the wizard is now also applied on the journal list view
task-5422121