### PR TITLE
[IMP] hr_holidays: Clarify Accrued Time Reset Without Carry-Over

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -113,7 +113,7 @@ class HrLeaveAccrualLevel(models.Model):
     can_be_carryover = fields.Boolean(related='accrual_plan_id.can_be_carryover', readonly=True,
         export_string_translation=False)
     action_with_unused_accruals = fields.Selection(
-        [('lost', 'Lost'),
+        [('lost', 'Lost (Reset)'),
          ('all', 'Carried over')],
         compute="_compute_action_with_unused_accruals",
         store=True,

--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
@@ -76,7 +76,7 @@
                         <div class="mt-1" t-if="level.data.can_be_carryover || level.data.cap_accrued_time_yearly || level.data.maximum_leave">
                             <t t-if="level.data.can_be_carryover">
                                 <t t-if="level.data.action_with_unused_accruals == 'lost'">
-                                    Unused days will be lost.<br/>
+                                    Unused days will be reset.<br/>
                                 </t>
                                 <t t-elif="level.data.carryover_options == 'unlimited'">
                                     Unused days will be transferred totally on each <t t-esc="state.carryOverDate"/>.

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -64,7 +64,7 @@
                             </span>
                         </group>
                         <group class="o_accrual" invisible="not can_be_carryover" string="Carry Over Options">
-                            <label class="fw-bold" for="action_with_unused_accruals" string="After a year, unused time off will be :"/>
+                            <label class="fw-bold" for="action_with_unused_accruals" string="After a year, unused accrued time will be :"/>
                             <span>
                                 <span name="unused_accruals">
                                     <field nolabel="1" class="ms-1" name="action_with_unused_accruals"
@@ -179,14 +179,17 @@
                                         <template id="is_based_on_worked_time_no">No, always consider the entire accrual period (whole calendar days).
                                         </template>
                                     </span>
-                                    <label class="fw-bold" for="can_be_carryover"
-                                           string="Do you need a carry-over of the accrued days from one year to another?"/>
-                                    <span>
-                                        <field class="ms-1" name="can_be_carryover"/>
-                                    </span>
-                                    <label class="fw-bold" invisible="not can_be_carryover" for="carryover_date"
-                                           string="When do you want the accrued time left to be carried-over?"/>
-                                    <span name="carryover" invisible="not can_be_carryover">
+                                    <label class="fw-bold" for="can_be_carryover" string="What should happen to the unused accrued time?"/>
+                                    <field nolabel="1" class="ms-1" name="can_be_carryover" widget="boolean_radio" options="{
+                                                    'yes_label_element_id': 'can_be_carryover_yes',
+                                                    'no_label_element_id': 'can_be_carryover_no'}"/>
+                                    <template id="can_be_carryover_no">They should be lost (reset).
+                                    </template>
+                                     <template id="can_be_carryover_yes">They should be carried over.
+                                    </template>
+                                    <label class="fw-bold" for="carryover_date"
+                                           string="When should unused accrued time be reset/carried over?"/>
+                                    <span name="carryover">
                                         <field class="ms-1" name="carryover_date"
                                                widget="radio_followed_by_element"
                                                options="{'links': {'other': 'carryover_custom_date'}, 'observe': 'carryover'}"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
. When configuring an accrual plan, users may want no carry-over of accrued days, while still ensuring that accrued balances expire or reset on a specific date (for example, at the allocation start or on a fixed annual date).
. This task aims to make the configuration explicit, intuitive, and self-explanatory, without changing the underlying behavior.

Current behavior before PR:
The UI implicitly ties the ability to set an expiry/reset date to enabling carry-over, which misleads users into believing that this is a functional limitation in v19.0. In reality, the system supports this behavior, but only through a non-intuitive configuration that forces users to enable carry-over and then mark it as lost at a milestone.

Desired behavior after PR is merged:
. Remove can_be_carryover boolean field with accrued_gain_action selection
. Always show the carryover_ date selection field
. Hide carry-over options in case of lost accrued time


task-5468596

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
