### PR TITLE
[REV] spreadsheet_dashboard: go back to chart-only mobile dashboard

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.js
@@ -5,6 +5,7 @@ import { Status } from "./dashboard_loader_service";
 import { SpreadsheetComponent } from "@spreadsheet/actions/spreadsheet_component";
 import { useSetupAction } from "@web/search/action_hook";
 import { DashboardMobileSearchPanel } from "./mobile_search_panel/mobile_search_panel";
+import { MobileFigureContainer } from "./mobile_figure_container/mobile_figure_container";
 import { useService } from "@web/core/utils/hooks";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
 import { SpreadsheetShareButton } from "@spreadsheet/components/share_button/share_button";
@@ -25,6 +26,7 @@ export class SpreadsheetDashboardAction extends Component {
         ControlPanel,
         SpreadsheetComponent,
         DashboardMobileSearchPanel,
+        MobileFigureContainer,
         SpreadsheetShareButton,
         DashboardSearchBar,
     };

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -75,6 +75,10 @@
 
     /* In mobile */
     @media (max-width: 768px){
+        .o_control_panel {
+            /* We don't want the control panel to disappear when scrolling */
+            top: 0px !important
+        }
         .o_control_panel_main {
             /* We don't want a gap before the DashboardMobileSearchPanel */
             column-gap: 0px !important;

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -47,7 +47,8 @@
                     An error occured while loading the dashboard
                 </div>
                 <t t-else="">
-                    <div class="o_renderer" t-att-class="{'o-sample-dashboard': dashboard.isSample}">
+                    <MobileFigureContainer t-if="env.isSmall" spreadsheetModel="dashboard.model" t-key="dashboard.data.id"/>
+                    <div t-else="" class="o_renderer" t-att-class="{'o-sample-dashboard': dashboard.isSample}">
                         <SpreadsheetComponent
                             model="dashboard.model"
                             t-key="dashboard.data.id"/>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.js
@@ -1,0 +1,67 @@
+import * as spreadsheet from "@odoo/o-spreadsheet";
+
+import { Component, useSubEnv } from "@odoo/owl";
+const { registries, stores } = spreadsheet;
+const { figureRegistry } = registries;
+const { ModelStore, useStoreProvider } = stores;
+
+const EMPTY_FIGURE = { tag: "empty" };
+
+export class MobileFigureContainer extends Component {
+    static template = "documents_spreadsheet.MobileFigureContainer";
+    static props = {
+        spreadsheetModel: Object,
+    };
+
+    setup() {
+        const stores = useStoreProvider();
+        stores.inject(ModelStore, this.props.spreadsheetModel);
+        useSubEnv({
+            model: this.props.spreadsheetModel,
+            isDashboard: () => this.props.spreadsheetModel.getters.isDashboard(),
+            openSidePanel: () => {},
+        });
+    }
+
+    get figureRows() {
+        const sheetId = this.props.spreadsheetModel.getters.getActiveSheetId();
+        const sortedFigures = this.props.spreadsheetModel.getters
+            .getFigures(sheetId)
+            .sort((f1, f2) => (this.isBefore(f1, f2) ? -1 : 1));
+
+        const figureRows = [];
+        for (let i = 0; i < sortedFigures.length; i++) {
+            const figure = sortedFigures[i];
+            const nextFigure = sortedFigures[i + 1];
+            if (this.isScorecard(figure) && nextFigure && this.isScorecard(nextFigure)) {
+                figureRows.push([figure, nextFigure]);
+                i++;
+            } else if (this.isScorecard(figure)) {
+                figureRows.push([figure, EMPTY_FIGURE]);
+            } else {
+                figureRows.push([figure]);
+            }
+        }
+        return figureRows;
+    }
+
+    getFigureComponent(figure) {
+        return figureRegistry.get(figure.tag).Component;
+    }
+
+    isBefore(f1, f2) {
+        const sheetId = this.props.spreadsheetModel.getters.getActiveSheetId();
+        const fig1 = this.props.spreadsheetModel.getters.getFigureUI(sheetId, f1);
+        const fig2 = this.props.spreadsheetModel.getters.getFigureUI(sheetId, f2);
+        return fig1.x < fig2.x ? fig1.y < fig2.y : fig1.y < fig2.y;
+    }
+
+    isScorecard(figure) {
+        if (figure.tag !== "chart") {
+            return false;
+        }
+        const chartId = this.props.spreadsheetModel.getters.getChartIdFromFigureId(figure.id);
+        const definition = this.props.spreadsheetModel.getters.getChartDefinition(chartId);
+        return definition.type === "scorecard";
+    }
+}

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.scss
@@ -1,0 +1,18 @@
+.o-mobile-figure.o-figure {
+    padding: 4px;
+
+    .o-dashboard-chart-select {
+        visibility: visible !important;
+        /* Compensate for the padding of the figure */
+        top: 4px !important;
+        right: 4px !important;
+    }
+
+    .o-carousel-full-screen-button,
+    .o-carousel-tabs-dropdown,
+    .o-carousel-tab[data-type="carouselDataView"],
+    .o-chart-dashboard-item:not([name="chart-granularity"]) {
+        display: none !important;
+    }
+
+}

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="documents_spreadsheet.MobileFigureContainer">
+        <div class="o-spreadsheet">
+            <div t-if="!figureRows.length" class="m-3">
+                Only chart figures are displayed in small screens but this dashboard doesn't contain any
+            </div>
+            <t t-foreach="figureRows" t-as="figureRow" t-key="figureRow_index">
+                <div class="o_figure_row d-flex flex-row">
+                    <t t-foreach="figureRow" t-as="figure" t-key="figure_index">
+                        <div t-if="figure.tag === 'empty'" class="o_empty_figure o-mobile-figure o-figure position-relative"/>
+                        <t t-else="">
+                            <t t-set="minHeight" t-value="figureRow.length === 1 ? `min-height: ${figure.height}px;` : ''"/>
+                            <div t-att-style="minHeight + ' direction:ltr;'" class="o-mobile-figure o-figure position-relative">
+                                <t figureUI="figure" t-component="getFigureComponent(figure)"/>
+                            </div>
+                        </t>
+                    </t>
+                </div>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/mobile/mobile_dashboard_action.test.js
@@ -11,12 +11,120 @@ import { contains } from "@web/../tests/web_test_helpers";
 describe.current.tags("mobile");
 defineSpreadsheetDashboardModels();
 
+const TEST_LINE_CHART_DATA = {
+    type: "line",
+    dataSetsHaveTitle: false,
+    dataSets: [{ dataRange: "A1" }],
+    legendPosition: "top",
+    verticalAxisPosition: "left",
+    title: { text: "" },
+};
+
+const TEST_SCORECARD_CHART_DATA = {
+    type: "scorecard",
+    title: { text: "test" },
+    keyValue: "A1",
+    background: "#fff",
+    baselineMode: "absolute",
+};
+
+test("is empty with no figures", async () => {
+    await createSpreadsheetDashboard();
+    expect(".o_mobile_dashboard").toHaveCount(1);
+    expect(".o_mobile_dashboard").toHaveText(
+        "Only chart figures are displayed in small screens but this dashboard doesn't contain any"
+    );
+});
+
 test("with no available dashboard", async () => {
     const serverData = getDashboardServerData();
     serverData.models["spreadsheet.dashboard"].records = [];
     serverData.models["spreadsheet.dashboard.group"].records = [];
     await createSpreadsheetDashboard({ serverData });
-    expect(queryAllTexts`.o_mobile_dashboard`).toEqual(["No available dashboard"]);
+    expect(".o_mobile_dashboard").toHaveText("No available dashboard");
+});
+
+test("displays figures in first sheet", async () => {
+    const figure = {
+        tag: "chart",
+        height: 500,
+        width: 500,
+        col: 0,
+        row: 0,
+        offset: { x: 100, y: 100 },
+        data: TEST_LINE_CHART_DATA,
+    };
+    const spreadsheetData = {
+        sheets: [
+            { id: "sheet1", figures: [{ ...figure, id: "figure1" }] },
+            { id: "sheet2", figures: [{ ...figure, id: "figure2" }] },
+        ],
+    };
+    const serverData = getDashboardServerData();
+    serverData.models["spreadsheet.dashboard.group"].records = [
+        {
+            published_dashboard_ids: [789],
+            id: 1,
+            name: "Chart",
+        },
+    ];
+    serverData.models["spreadsheet.dashboard"].records = [
+        {
+            id: 789,
+            name: "Spreadsheet with chart figure",
+            json_data: JSON.stringify(spreadsheetData),
+            spreadsheet_data: JSON.stringify(spreadsheetData),
+            dashboard_group_id: 1,
+        },
+    ];
+    await createSpreadsheetDashboard({ serverData });
+    expect(".o-chart-container").toHaveCount(1);
+});
+
+test("scorecards are placed two per row", async () => {
+    const figure = {
+        tag: "chart",
+        height: 500,
+        width: 500,
+        offset: { x: 100, y: 100 },
+        col: 0,
+        row: 0,
+    };
+    const spreadsheetData = {
+        sheets: [
+            {
+                id: "sheet1",
+                figures: [
+                    { ...figure, id: "figure1", data: TEST_SCORECARD_CHART_DATA },
+                    { ...figure, id: "figure2", data: TEST_SCORECARD_CHART_DATA },
+                    { ...figure, id: "figure3", data: TEST_SCORECARD_CHART_DATA },
+                    { ...figure, id: "figure4", data: TEST_LINE_CHART_DATA },
+                ],
+            },
+        ],
+    };
+    const serverData = getDashboardServerData();
+    serverData.models["spreadsheet.dashboard.group"].records = [
+        { published_dashboard_ids: [789], id: 1, name: "Chart" },
+    ];
+    serverData.models["spreadsheet.dashboard"].records = [
+        {
+            id: 789,
+            name: "Spreadsheet with chart figure",
+            json_data: JSON.stringify(spreadsheetData),
+            spreadsheet_data: JSON.stringify(spreadsheetData),
+            dashboard_group_id: 1,
+        },
+    ];
+    await createSpreadsheetDashboard({ serverData });
+    const figureRows = queryAll(".o_figure_row");
+    expect(figureRows).toHaveLength(3);
+    expect(figureRows[0].querySelectorAll(".o-scorecard")).toHaveLength(2);
+
+    expect(figureRows[1].querySelectorAll(".o-scorecard")).toHaveLength(1);
+    expect(figureRows[1].querySelectorAll(".o_empty_figure")).toHaveLength(1);
+
+    expect(figureRows[2].querySelectorAll(".o-figure-canvas")).toHaveLength(1);
 });
 
 test("double clicking on a figure doesn't open the side panel", async () => {
@@ -30,15 +138,7 @@ test("double clicking on a figure doesn't open the side panel", async () => {
             x: 100,
             y: 100,
         },
-        data: {
-            chartId: "chartId",
-            type: "line",
-            dataSetsHaveTitle: false,
-            dataSets: [{ dataRange: "A1" }],
-            legendPosition: "top",
-            verticalAxisPosition: "left",
-            title: { text: "" },
-        },
+        data: TEST_LINE_CHART_DATA,
     };
     const spreadsheetData = {
         sheets: [


### PR DESCRIPTION
### [REV] spreadsheet_dashboard: go back to chart-only mobile dashboard

This commit reverts 5cde5114d971a9edc12c9708ae0ea86bfb6db3b2, so the
mobile dashboards go back to showing only the figures. Some adaptations
were necessary to make the new features (carousel, granularity
selector, ...) work.

Task: [5447027](https://www.odoo.com/web#id=5447027&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
