### PR TITLE
[IMP] payment: make Pay Now label translatable

### DIFF
--- a/addons/payment/models/res_company.py
+++ b/addons/payment/models/res_company.py
@@ -15,6 +15,19 @@ class ResCompany(models.Model):
         ],
         compute='_compute_onboarding_payment_module',
     )
+    # Labels to be displayed on the payment buttons
+    pay_now_label = fields.Char(
+        string="Pay Now Label",
+        help="The label to be displayed on the payment buttons for 'Pay Now' payment methods.",
+        default="Pay now",
+        translate=True,
+    )
+    pay_later_label = fields.Char(
+        string="Pay Later Label",
+        help="The label to be displayed on the payment buttons for 'Pay Later' payment methods.",
+        default="Confirm",
+        translate=True,
+    )
 
     @api.depends('currency_id', 'country_id')
     def _compute_onboarding_payment_module(self):

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -375,14 +375,26 @@
 
     <template id="payment.submit_button" name="Submit Button">
         <!-- Parameters description:
-            - label: The label of the submit button.
+            - submit_button_label: The label of the submit button (Optional). If passed, it
+              overwrites Pay Now/Pay Later labels.
         -->
         <button name="o_payment_submit_button"
                 type="submit"
                 t-out="submit_button_label"
                 class="btn btn-primary w-100 w-md-auto ms-auto px-5"
                 disabled="true"
-        />
+        >   
+            <t t-if="not submit_button_label">
+                <div name="o_payment_default_submit_labels">
+                    <span name="o_pay_now_label" t-field="res_company.pay_now_label"/>
+                    <span 
+                        name="o_pay_later_label"
+                        t-field="res_company.pay_later_label"
+                        class="d-none"
+                    />
+                </div>
+            </t>
+        </button>
     </template>
 
     <template id="payment.no_pms_available_warning">

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1545,7 +1545,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'errors': self._get_shop_payment_errors(order),
             'partner': order.partner_invoice_id,
             'order': order,
-            'submit_button_label': _("Pay now"),
         }
         payment_form_values = {
             **sale_portal.CustomerPortal._get_payment_values(

--- a/addons/website_sale/models/res_company.py
+++ b/addons/website_sale/models/res_company.py
@@ -1,10 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import fields, models
 
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
+
+    # Labels to be displayed on the payment buttons, see the rest in payment/models/res_company.py
+    free_order_label = fields.Char(
+        string="Free Order Label",
+        help="The label to be displayed on the payment buttons for orders with Total Amount zero",
+        default="Confirm Order",
+        translate=True,
+    )
 
     def _get_default_pricelist_vals(self):
         """ Override of product. Called at company creation or activation of the pricelist setting.

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -54,8 +54,8 @@
                             <input type="hidden"
                                    name="csrf_token"
                                    t-att-value="request.csrf_token()"/>
-                            <t t-if="not hide_payment_button" t-call="payment.submit_button"
-                                submit_button_label.translate="Confirm Order"/>
+                            <t t-if="not hide_payment_button" t-call="payment.submit_button"/>
+                               
                         </form>
                     </div>
                     <t t-elif="not hide_payment_button" t-call="payment.submit_button"/>

--- a/addons/website_sale/templates/checkout/payment_templates.xml
+++ b/addons/website_sale/templates/checkout/payment_templates.xml
@@ -43,4 +43,15 @@
         </t>
     </template>
 
+    <template id="website_sale.submit_button" inherit_id="payment.submit_button">
+        <div name="o_payment_default_submit_labels" position="replace">    
+            <t t-if="website_sale_order and not website_sale_order.amount_total">
+                <span name="o_free_order_label" t-field="res_company.free_order_label"/>
+            </t>
+            <t t-else=""> 
+                <t>$0</t>
+            </t>
+        </div>
+    </template>
+    
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Pay now button is one of the only label in the eCommerce that is not correctly translatable.

Desired behavior after PR is merged: Pay buttons made translatable by adding the label as a field at the company level.


task-5410658
