### PR TITLE
[IMP] iot_drivers: Replace Ghostscript with SumatraPDF

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from escpos import printer
 import escpos.exceptions
 import io
+import subprocess
 import win32print
 import pywintypes
 import ghostscript
@@ -90,32 +91,48 @@ class PrinterDriver(PrinterDriverBase):
 
     def print_report(self, data):
         with win32print_lock:
-            helpers.write_file('document.pdf', data, 'wb')
             file_name = helpers.path_file('document.pdf')
-            printer = self.device_name
+            file_name.write_bytes(data)
+            sumatra_pdf_path = helpers.path_file("SumatraPDF") / "SumatraPDF.exe"
+            use_sumatra = sumatra_pdf_path.exists()
 
             args = [
+                str(sumatra_pdf_path),
+                "-print-to",
+                self.device_name,
+                str(file_name),
+                "-silent",
+                "-print-settings",
+                "duplex"
+            ] if use_sumatra else [
                 "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT",
                 "-q",
                 "-sDEVICE#mswinpr2",
-                f'-sOutputFile#%printer%{printer}',
+                f'-sOutputFile#%printer%{self.device_name}',
                 f'{file_name}'
             ]
 
-            _logger.debug("Printing report with ghostscript using %s", args)
-            stderr_buf = io.BytesIO()
-            stdout_buf = io.BytesIO()
-            stdout_log_level = logging.DEBUG
-            try:
-                ghostscript.Ghostscript(*args, stdout=stdout_buf, stderr=stderr_buf)
-                self.send_status(status='success')
-            except Exception:
-                _logger.exception("Error while printing report, ghostscript args: %s, error buffer: %s", args, stderr_buf.getvalue())
-                stdout_log_level = logging.ERROR  # some stdout value might contains relevant error information
-                self.send_status(status='error', message='ERROR_FAILED')
-                raise
-            finally:
-                _logger.log(stdout_log_level, "Ghostscript stdout: %s", stdout_buf.getvalue())
+            _logger.debug("Printing report with %s using %s", "SumatraPDF" if use_sumatra else "Ghostscript", args)
+            if use_sumatra:
+                try:
+                    subprocess.run(args, check=True)
+                    self.send_status(status='success')
+                except subprocess.CalledProcessError as error:
+                    _logger.exception("Error while printing report, SumatraPDF args: %s, exit code: %s", args, error.returncode)
+            else:
+                stderr_buf = io.BytesIO()
+                stdout_buf = io.BytesIO()
+                stdout_log_level = logging.DEBUG
+                try:
+                    ghostscript.Ghostscript(*args, stdout=stdout_buf, stderr=stderr_buf)
+                    self.send_status(status='success')
+                except Exception:
+                    _logger.exception("Error while printing report, ghostscript args: %s, error buffer: %s", args, stderr_buf.getvalue())
+                    stdout_log_level = logging.ERROR  # some stdout value might contains relevant error information
+                    self.send_status(status='error', message='ERROR_FAILED')
+                    raise
+                finally:
+                    _logger.log(stdout_log_level, "Ghostscript stdout: %s", stdout_buf.getvalue())
 
     def _action_default(self, data):
         _logger.debug("_action_default called for printer %s", self.device_name)

--- a/setup/win32/conf/iot/sumatrapdfrestrict.ini
+++ b/setup/win32/conf/iot/sumatrapdfrestrict.ini
@@ -1,0 +1,10 @@
+; This file restricts SumatraPDF to have the minimum required permissions.
+; SumatraPDF is used on Windows IoT when printing a PDF report.
+[Policies]
+InternetAccess = 0
+DiskAccess = 0
+SavePreferences = 0
+RegistryAccess = 0
+CopySelection = 0
+FullscreenAccess = 0
+PrinterAccess = 1

--- a/setup/win32/setup-iot.nsi
+++ b/setup/win32/setup-iot.nsi
@@ -134,6 +134,7 @@ LangString DESC_FinishPage_Link ${LANG_ENGLISH} "Contact Odoo for Partnership an
 LangString TITLE_Odoo_IoT ${LANG_ENGLISH} "Odoo IoT"
 LangString TITLE_Nginx ${LANG_ENGLISH} "Nginx WebServer"
 LangString TITLE_Ghostscript ${LANG_ENGLISH} "Ghostscript interpreter"
+LangString TITLE_SumatraPDF ${LANG_ENGLISH} "PDF interpreter"
 LangString DESC_FinishPageText ${LANG_ENGLISH} "Start Odoo"
 LangString UnsafeDirText ${LANG_ENGLISH} "Installing outside of $PROGRAMFILES64 is not recommended.$\nDo you want to continue ?"
 
@@ -143,6 +144,7 @@ LangString DESC_FinishPage_Link ${LANG_FRENCH} "Contactez Odoo pour un Partenari
 LangString TITLE_Odoo_IoT ${LANG_FRENCH} "Odoo IoT"
 LangString TITLE_Nginx ${LANG_FRENCH} "Installation du serveur web Nginx"
 LangString TITLE_Ghostscript ${LANG_FRENCH} "Installation de l'interpréteur Ghostscript"
+LangString TITLE_SumatraPDF ${LANG_FRENCH} "Installation de l'interpréteur PDF"
 LangString DESC_FinishPageText ${LANG_FRENCH} "Démarrer Odoo"
 LangString UnsafeDirText ${LANG_FRENCH} "Installer en dehors de $PROGRAMFILES64 n'est pas recommandé.$\nVoulez-vous continuer ?"
 
@@ -262,6 +264,27 @@ Section -$(TITLE_Ghostscript) SectionGhostscript
         /D=$INSTDIR\Ghostscript'
 SectionEnd
 
+Section -$(TITLE_SumatraPDF) SectionSumatraPDF
+    SetOutPath '$TEMP'
+    VAR /GLOBAL sumatra_exe_filename
+    VAR /GLOBAL sumatra_url
+
+    StrCpy $sumatra_exe_filename "SumatraPDF-3.5.2-64-install.exe"
+    StrCpy $sumatra_url "https://www.sumatrapdfreader.org/dl/rel/3.5.2/$sumatra_exe_filename"
+
+    DetailPrint "Downloading Sumatra PDF"
+    NScurl::http get "$sumatra_url" "$TEMP\$sumatra_exe_filename" /PAGE /END
+    DetailPrint "Temp dir: $TEMP\$sumatra_exe_filename"
+
+    Rmdir /r "INSTDIR\SumatraPDF"
+    DetailPrint "Installing Sumatra PDF"
+    ExecWait '"$TEMP\$sumatra_exe_filename" \
+        -install -silent \
+        -d "$INSTDIR\SumatraPDF"'
+    SetOutPath "$INSTDIR\SumatraPDF"
+    File "conf\iot\sumatrapdfrestrict.ini"
+SectionEnd
+
 Section -Post
     WriteRegExpandStr HKLM "${UNINSTALL_REGISTRY_KEY}" "UninstallString" "$INSTDIR\Uninstall.exe"
     WriteRegExpandStr HKLM "${UNINSTALL_REGISTRY_KEY}" "InstallLocation" "$INSTDIR"
@@ -289,6 +312,7 @@ Section "Uninstall"
     ReadRegStr $0 HKLM "${UNINSTALL_REGISTRY_KEY_SERVER}" "UninstallString"
     ExecWait '"$0" /S'
     ExecWait '"$INSTDIR\Ghostscript\uninstgs.exe" /S'
+    ExecWait '"$INSTDIR\SumatraPDF\SumatraPDF.exe" -uninstall -silent'
 
     nsExec::Exec "net stop ${SERVICENAME}"
     nsExec::Exec "sc delete ${SERVICENAME}"


### PR DESCRIPTION
When printing a PDF using the Windows IoT, first the PDF file is temporarily saved, and then it is printed using Ghostscript which handles parsing the PDF and saving it to the printer. Unfortunately, Ghostscript is unable to print using duplex (double-sided) no matter what settings are provided.

To fix this, we replace Ghostscript with [SumatraPDF](https://github.com/sumatrapdfreader/sumatrapdf), which is an open source PDF viewer for Windows, but it is also capable of being used from the command line to print.

We simply provide the duplex printing option in the command to SumatraPDF, and it works as expected.

[1]: https://github.com/sumatrapdfreader/sumatrapdf

task-5149706

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
