### PR TITLE
[REF] account,l10n_ar{*}: test AR modules properly 

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -25,11 +25,26 @@ from unittest.mock import patch
 _logger = logging.getLogger(__name__)
 
 
+def skip_unless_external(func):
+    """
+    Skip a test unless the test is run in external mode.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if 'EXTERNAL_MODE' in (config['test_tags'] or {}):
+            return func(*args, **kwargs)
+        else:
+            raise SkipTest("Skipping this test as it is meant to run in external mode")
+
+    return wrapper
+
+
 class AccountTestInvoicingCommon(ProductCommon):
     # to override by the helper methods setup_country and setup_chart_template to adapt to a localization
     chart_template = False
     country_code = False
-    extra_tags = ['SAVE_XML', *(['-standard', 'external'] if 'EXTERNAL_MODE' in (config['test_tags'] or {}) else [])]
+    extra_tags = ('-standard', 'external') if 'EXTERNAL_MODE' in (config['test_tags'] or {}) else ()
 
     @classmethod
     def safe_copy(cls, record):
@@ -716,7 +731,7 @@ class AccountTestInvoicingCommon(ProductCommon):
             .create(kwargs)
 
     @classmethod
-    def _reverse_invoice(cls, invoice, post=False, **reversal_args):
+    def _reverse_invoice(cls, invoice, is_modify=False, post=False, **reversal_args):
         reverse_action_values = (
             cls.env['account.move.reversal']
             .with_context(active_model='account.move', active_ids=invoice.ids)
@@ -724,7 +739,7 @@ class AccountTestInvoicingCommon(ProductCommon):
                 'journal_id': invoice.journal_id.id,
                 **reversal_args,
             })
-            .reverse_moves()
+            .reverse_moves(is_modify=is_modify)
         )
         credit_note = cls.env['account.move'].browse(reverse_action_values['res_id'])
 
@@ -732,6 +747,26 @@ class AccountTestInvoicingCommon(ProductCommon):
             credit_note.action_post()
 
         return credit_note
+
+    @classmethod
+    def _create_debit_note(cls, invoice, post=False, **debit_note_args):
+        cls.ensure_installed('account_debit_note')
+        debit_note_values = (
+            cls.env['account.debit.note']
+            .with_context(
+                active_model='account.move',
+                active_ids=invoice.ids,
+                default_copy_lines=True,
+            )
+            .create(debit_note_args)
+            .create_debit()
+        )
+        debit_note = cls.env['account.move'].browse(debit_note_values['res_id'])
+
+        if post:
+            debit_note.action_post()
+
+        return debit_note
 
     @classmethod
     def _register_payment(cls, record, **kwargs):
@@ -995,8 +1030,24 @@ class AccountTestInvoicingCommon(ProductCommon):
                 self.assertDictEqual(current_tax_group, expected_tax_group)
 
     ####################################################
-    # Xml Comparison
+    # Xml / JSON Comparison
     ####################################################
+
+    @classmethod
+    def _get_ignore_schema(cls, subfolder: str, ignore_schema_name: str) -> bytes | None:
+        subfolders = subfolder.split('/')
+        ignore_schema_paths = []
+        while subfolders:
+            ignore_schema_paths.append(f"{cls.test_module}/tests/test_files/{'/'.join(subfolders)}/{ignore_schema_name}")
+            subfolders.pop()
+        ignore_schema_paths.append(f"{cls.test_module}/tests/test_files/{ignore_schema_name}")
+
+        for ignore_schema_path in ignore_schema_paths:
+            try:
+                with file_open(ignore_schema_path, 'rb') as f:
+                    return f.read()
+            except FileNotFoundError:
+                pass
 
     @classmethod
     def _get_xml_ignore_schema(cls, subfolder: str) -> etree._Element | None:
@@ -1015,19 +1066,13 @@ class AccountTestInvoicingCommon(ProductCommon):
         :param subfolder: the subfolder of the path of XML file to save/assert. (e.g. "folder_1", "folder_outer/folder_inner")
         :return: _Element object if an `ignore_schema.xml` file is found, otherwise nothing will be returned.
         """
-        subfolders = subfolder.split('/')
-        ignore_schema_paths = []
-        while subfolders:
-            ignore_schema_paths.append(f"{cls.test_module}/tests/test_files/{'/'.join(subfolders)}/ignore_schema.xml")
-            subfolders.pop()
-        ignore_schema_paths.append(f"{cls.test_module}/tests/test_files/ignore_schema.xml")
+        if ignore_schema_bytes := cls._get_ignore_schema(subfolder, 'ignore_schema.xml'):
+            return etree.fromstring(ignore_schema_bytes)
 
-        for ignore_schema_path in ignore_schema_paths:
-            try:
-                with file_open(ignore_schema_path, 'rb') as f:
-                    return etree.fromstring(f.read())
-            except FileNotFoundError:
-                pass
+    @classmethod
+    def _get_json_ignore_schema(cls, subfolder: str) -> dict | list | None:
+        if ignore_schema_bytes := cls._get_ignore_schema(subfolder, 'ignore_schema.json'):
+            return json.loads(ignore_schema_bytes)
 
     @classmethod
     def _clear_xml_content(cls, xml_element: etree._Element, clean_namespaces=True):
@@ -1182,7 +1227,29 @@ class AccountTestInvoicingCommon(ProductCommon):
         optional_subfolder = f"{subfolder}/" if subfolder else ''
         return file_path(f"{self.test_module}/tests/test_files/{optional_subfolder}{file_name}")
 
-    def assert_json(self, content_to_assert: dict, test_name: str, subfolder=''):
+    @classmethod
+    def _apply_json_ignore_schema(cls, data, ignore_schema):
+        assert data.__class__ is ignore_schema.__class__, "Type of data and ignore_schema must match"
+
+        if isinstance(ignore_schema, dict):
+            for schema_key, schema_value in ignore_schema.items():
+                if schema_key in data:
+                    if schema_value == '___ignore___':
+                        data[schema_key] = '___ignore___'
+                    elif data[schema_key]:  # schema_value is a dict or a list, and the corresponding value is not None
+                        cls._apply_json_ignore_schema(data[schema_key], schema_value)
+        elif isinstance(ignore_schema, list):
+            if len(ignore_schema) == 1:
+                # if there's only one dictionary, apply it to every item in the `data` list
+                for data_child in data:
+                    cls._apply_json_ignore_schema(data_child, ignore_schema[0])
+            else:
+                # otherwise, the length of the schema must match the data, and go through them as pairs
+                assert len(ignore_schema) == len(data), "Length of list of ignore_schema and data must match"
+                for i in range(len(ignore_schema)):
+                    cls._apply_json_ignore_schema(data[i], ignore_schema[i])
+
+    def assert_json(self, content_to_assert: dict | list, test_name: str, subfolder=''):
         """
         Helper to save/assert a dictionary to a JSON file located in the corresponding module `test_files`.
         By default, this method will assert the dictionary with the JSON content.
@@ -1192,20 +1259,22 @@ class AccountTestInvoicingCommon(ProductCommon):
         Before asserting, the dictionary will first be serialized to ensure it is in the same format of the saved JSON.
         This means that for example: all tuples within the dictionary will be converted to list, etc.
 
-        :param content_to_assert: dictionary to save or assert to the corresponding test file
+        :param content_to_assert: dictionary | list to save or assert to the corresponding test file
         :param test_name: the test file name
         :param subfolder: the test file subfolder(s), separated by `/` if there is more than one
         """
         json_path = self._get_test_file_path(f"{test_name}.json", subfolder=subfolder)
+        content_to_assert = json.loads(json.dumps(content_to_assert))
+        if json_ignore_schema := self._get_json_ignore_schema(subfolder):
+            self._apply_json_ignore_schema(content_to_assert, json_ignore_schema)
 
         if 'SAVE_JSON' in config['test_tags']:
             with file_open(json_path, 'w') as f:
-                json.dump(content_to_assert, f, indent=4)
+                f.write(json.dumps(content_to_assert, indent=4))
+            _logger.info("Saved the generated JSON content to %s", json_path)
         else:
             with file_open(json_path, 'rb') as f:
                 expected_content = json.loads(f.read())
-
-            content_to_assert = json.loads(json.dumps(content_to_assert))
             self.assertDictEqual(content_to_assert, expected_content)
 
     def assert_xml(
@@ -1270,7 +1339,7 @@ class AccountTestInvoicingCommon(ProductCommon):
             # Save the xml_element content
             with file_open(test_file_path, 'wb') as f:
                 f.write(etree.tostring(xml_element, pretty_print=True, encoding='UTF-8'))
-                _logger.info("Saved the generated xml content to %s", file_name)
+                _logger.info("Saved the generated XML content to %s", file_name)
         else:
             with file_open(test_file_path, 'rb') as f:
                 expected_xml_str = f.read()

--- a/addons/l10n_ar/tests/common.py
+++ b/addons/l10n_ar/tests/common.py
@@ -9,7 +9,7 @@ import time
 _logger = logging.getLogger(__name__)
 
 
-class TestAr(AccountTestInvoicingCommon):
+class TestArCommon(AccountTestInvoicingCommon):
 
     @classmethod
     @AccountTestInvoicingCommon.setup_chart_template('ar_ri')
@@ -347,309 +347,269 @@ class TestAr(AccountTestInvoicingCommon):
         cls.demo_credit_notes = {}
         cls.demo_bills = {}
 
-    def _create_test_invoices_like_demo(self, use_current_date=True):
-        """ Create in the unit tests the same invoices created in demo data """
-        payment_term_id = self.env.ref("account.account_payment_term_end_following_month")
-        invoice_user_id = self.env.user
-        incoterm = self.env.ref("account.incoterm_EXW")
+    @classmethod
+    def _get_ar_multi_invoice_line_ids(cls):
+        return [
+            cls._prepare_invoice_line(product_id=cls.product_iva_105, price_unit=642.0, quantity=5),
+            cls._prepare_invoice_line(product_id=cls.service_iva_27, price_unit=250.0, quantity=1),
+            cls._prepare_invoice_line(product_id=cls.product_iva_105_perc, price_unit=3245.0, quantity=2),
+            cls._prepare_invoice_line(product_id=cls.product_no_gravado, price_unit=50.0, quantity=10),
+            cls._prepare_invoice_line(product_id=cls.product_iva_cero, price_unit=200.0, quantity=1),
+            cls._prepare_invoice_line(product_id=cls.product_iva_exento, price_unit=100.0, quantity=1),
+        ]
 
-        decimal_price = self.env.ref('product.decimal_price')
+    @classmethod
+    def _create_test_invoices_like_demo(cls, use_current_date=True):
+        """ Create in the unit tests the same invoices created in demo data """
+        payment_term = cls.env.ref("account.account_payment_term_end_following_month")
+        incoterm = cls.env.ref("account.incoterm_EXW")
+
+        decimal_price = cls.env.ref('product.decimal_price')
         decimal_price.digits = 4
 
-        invoices_to_create = {
+        test_invoices_map = {
             'test_invoice_1': {
                 "ref": "test_invoice_1: Invoice to gritti support service, vat 21",
-                "partner_id": self.res_partner_gritti_mono,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_gritti_mono,
+                "invoice_payment_term_id": payment_term,
                 "move_type": "out_invoice",
                 "invoice_date": "2021-03-01",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21}
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21),
                 ],
             },
             'test_invoice_2': {
                 "ref": "test_invoice_2: Invoice to Servicios Globales with vat 21, 27 and 10,5",
-                "partner_id": self.res_partner_servicios_globales,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_servicios_globales,
+                "invoice_payment_term_id": payment_term,
                 "move_type": "out_invoice",
                 "invoice_date": "2021-03-05",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
-                    {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
-                    {'product_id': self.product_iva_105_perc, 'price_unit': 3245.0, 'quantity': 2}
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105, price_unit=642.0, quantity=5),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_27, price_unit=250.0, quantity=1),
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105_perc, price_unit=3245.0, quantity=2),
                 ],
             },
             'test_invoice_3': {
                 "ref": "test_invoice_3: Invoice to ADHOC with vat cero and 21",
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-01",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
-                    {'product_id': self.product_iva_cero, 'price_unit': 200.0, 'quantity': 1}
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105, price_unit=642.0, quantity=5),
+                    cls._prepare_invoice_line(product_id=cls.product_iva_cero, price_unit=200.0, quantity=1),
                 ],
             },
             'test_invoice_4': {
                 'ref': 'test_invoice_4: Invoice to ADHOC with vat exempt and 21',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-01",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.1234, 'quantity': 5},
-                    {'product_id': self.product_iva_exento, 'price_unit': 100.5678, 'quantity': 1},
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105, price_unit=642.1234, quantity=5),
+                    cls._prepare_invoice_line(product_id=cls.product_iva_exento, price_unit=100.5678, quantity=1),
                 ],
             },
             'test_invoice_5': {
                 'ref': 'test_invoice_5: Invoice to ADHOC with all type of taxes',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
-                "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
-                    {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
-                    {'product_id': self.product_iva_105_perc, 'price_unit': 3245.0, 'quantity': 2},
-                    {'product_id': self.product_no_gravado, 'price_unit': 50.0, 'quantity': 10},
-                    {'product_id': self.product_iva_cero, 'price_unit': 200.0, 'quantity': 1},
-                    {'product_id': self.product_iva_exento, 'price_unit': 100.0, 'quantity': 1}
-                ],
+                "company_id": cls.company_ri,
+                "invoice_line_ids": cls._get_ar_multi_invoice_line_ids(),
             },
             'test_invoice_6': {
                 'ref': 'test_invoice_6: Invoice to Montana Sur, fiscal position changes taxes to exempt',
-                "partner_id": self.res_partner_montana_sur,
-                "journal_id": self.sale_expo_journal_ri,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_montana_sur,
+                "journal_id": cls.sale_expo_journal_ri,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-03",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_incoterm_id": incoterm,
-                "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
-                    {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
-                    {'product_id': self.product_iva_105_perc, 'price_unit': 3245.0, 'quantity': 2},
-                    {'product_id': self.product_no_gravado, 'price_unit': 50.0, 'quantity': 10},
-                    {'product_id': self.product_iva_cero, 'price_unit': 200.0, 'quantity': 1},
-                    {'product_id': self.product_iva_exento, 'price_unit': 100.0, 'quantity': 1},
-                ],
+                "invoice_line_ids": cls._get_ar_multi_invoice_line_ids(),
             },
             'test_invoice_7': {
                 'ref': 'test_invoice_7: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 4 because it have services)',
-                "partner_id": self.res_partner_barcelona_food,
-                "journal_id": self.sale_expo_journal_ri,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_barcelona_food,
+                "journal_id": cls.sale_expo_journal_ri,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-03",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_incoterm_id": incoterm,
-                "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
-                    {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
-                    {'product_id': self.product_iva_105_perc, 'price_unit': 3245.0, 'quantity': 2},
-                    {'product_id': self.product_no_gravado, 'price_unit': 50.0, 'quantity': 10},
-                    {'product_id': self.product_iva_cero, 'price_unit': 200.0, 'quantity': 1},
-                    {'product_id': self.product_iva_exento, 'price_unit': 100.0, 'quantity': 1},
-                ],
+                "invoice_line_ids": cls._get_ar_multi_invoice_line_ids(),
             },
             'test_invoice_8': {
                 'ref': 'test_invoice_8: Invoice to consumidor final',
-                "partner_id": self.partner_cf,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.partner_cf,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21, 'price_unit': 642.0, 'quantity': 1},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=642.0, quantity=1),
                 ],
             },
             'test_invoice_10': {
                 'ref': 'test_invoice_10; Invoice to ADHOC in USD and vat 21',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 1000.0, 'quantity': 5},
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105, price_unit=1000.0, quantity=5),
                 ],
-                "currency_id": self.env.ref("base.USD"),
+                "currency_id": cls.env.ref("base.USD"),
             },
             'test_invoice_11': {
                 'ref': 'test_invoice_11: Invoice to ADHOC with many lines in order to prove rounding error, with 4 decimals of precision for the currency and 2 decimals for the product the error apperar',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21, 'price_unit': 1.12, 'quantity': 1, 'name': 'Support Services 1'},
-                    {'product_id': self.service_iva_21, 'price_unit': 1.12, 'quantity': 1, 'name': 'Support Services 2'},
-                    {'product_id': self.service_iva_21, 'price_unit': 1.12, 'quantity': 1, 'name': 'Support Services 3'},
-                    {'product_id': self.service_iva_21, 'price_unit': 1.12, 'quantity': 1, 'name': 'Support Services 4'},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=1.12, quantity=1, name='Support Services 1'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=1.12, quantity=1, name='Support Services 2'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=1.12, quantity=1, name='Support Services 3'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=1.12, quantity=1, name='Support Services 4'),
                 ],
             },
             'test_invoice_12': {
                 'ref': 'test_invoice_12: Invoice to ADHOC with many lines in order to test rounding error, it is required to use a 4 decimal precision in prodct in order to the error occur',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21, 'price_unit': 15.7076, 'quantity': 1, 'name': 'Support Services 1'},
-                    {'product_id': self.service_iva_21, 'price_unit': 5.3076, 'quantity': 2, 'name': 'Support Services 2'},
-                    {'product_id': self.service_iva_21, 'price_unit': 3.5384, 'quantity': 2, 'name': 'Support Services 3'},
-                    {'product_id': self.service_iva_21, 'price_unit': 1.6376, 'quantity': 2, 'name': 'Support Services 4'},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=15.7076, quantity=1, name='Support Services 1'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=5.3076, quantity=2, name='Support Services 2'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=3.5384, quantity=2, name='Support Services 3'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=1.6376, quantity=2, name='Support Services 4'),
                 ],
             },
             'test_invoice_13': {
                 'ref': 'test_invoice_13: Invoice to ADHOC with many lines in order to test zero amount invoices y rounding error. it is required to set the product decimal precision to 4 and change 260.59 for 260.60 in order to reproduce the error',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21, 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 1'},
-                    {'product_id': self.service_iva_21, 'price_unit': 260.59, 'quantity': 1, 'name': 'Support Services 2'},
-                    {'product_id': self.service_iva_21, 'price_unit': 48.72, 'quantity': 1, 'name': 'Support Services 3'},
-                    {'product_id': self.service_iva_21, 'price_unit': 13.666, 'quantity': 1, 'name': 'Support Services 4'},
-                    {'product_id': self.service_iva_21, 'price_unit': 11.329, 'quantity': 2, 'name': 'Support Services 5'},
-                    {'product_id': self.service_iva_21, 'price_unit': 68.9408, 'quantity': 1, 'name': 'Support Services 6'},
-                    {'product_id': self.service_iva_21, 'price_unit': 4.7881, 'quantity': 2, 'name': 'Support Services 7'},
-                    {'product_id': self.service_iva_21, 'price_unit': 12.0625, 'quantity': 2, 'name': 'Support Services 8'},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=24.3, quantity=3, name='Support Services 1'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=260.59, quantity=1, name='Support Services 2'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=48.72, quantity=1, name='Support Services 3'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=13.666, quantity=1, name='Support Services 4'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=11.329, quantity=2, name='Support Services 5'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=68.9408, quantity=1, name='Support Services 6'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=4.7881, quantity=2, name='Support Services 7'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=12.0625, quantity=2, name='Support Services 8'),
                 ],
             },
             'test_invoice_14': {
                 'ref': 'test_invoice_14: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 1 because only products)',
-                "partner_id": self.res_partner_barcelona_food,
-                "journal_id": self.sale_expo_journal_ri,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_barcelona_food,
+                "journal_id": cls.sale_expo_journal_ri,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-20",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_incoterm_id": incoterm,
                 "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105, price_unit=642.0, quantity=5),
                 ],
             },
             'test_invoice_15': {
                 'ref': 'test_invoice_15: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 2 because only service)',
-                "partner_id": self.res_partner_barcelona_food,
-                "journal_id": self.sale_expo_journal_ri,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_barcelona_food,
+                "journal_id": cls.sale_expo_journal_ri,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-20",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_incoterm_id": incoterm,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_27, price_unit=250.0, quantity=1),
                 ],
             },
             'test_invoice_16': {
                 'ref': 'test_invoice_16: Export invoice to Barcelona food, fiscal position changes tax to exempt (type 1 because it have products only, used to test refund of expo)',
-                "partner_id": self.res_partner_barcelona_food,
-                "journal_id": self.sale_expo_journal_ri,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_barcelona_food,
+                "journal_id": cls.sale_expo_journal_ri,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-22",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_incoterm_id": incoterm,
                 "invoice_line_ids": [
-                    {'product_id': self.product_iva_105, 'price_unit': 642.0, 'quantity': 5},
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105, price_unit=642.0, quantity=5),
                 ],
             },
             'test_invoice_17': {
                 'ref': 'test_invoice_17: Invoice to ADHOC with 100%% of discount',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21, 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 8', 'discount': 100},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=24.3, quantity=3, name='Support Services 8', discount=100),
                 ],
             },
             'test_invoice_18': {
                 'ref': 'test_invoice_18: Invoice to ADHOC with 100%% of discount and with different VAT aliquots',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21, 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 8', 'discount': 100},
-                    {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1, 'discount': 100},
-                    {'product_id': self.product_iva_105_perc, 'price_unit': 3245.0, 'quantity': 1},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=24.3, quantity=3, name='Support Services 8', discount=100),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_27, price_unit=250.0, quantity=1, discount=100),
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105_perc, price_unit=3245.0, quantity=1),
                 ],
             },
             'test_invoice_19': {
                 'ref': 'test_invoice_19: Invoice to ADHOC with multiple taxes and perceptions',
-                "partner_id": self.res_partner_adhoc,
-                "invoice_payment_term_id": payment_term_id,
+                "partner_id": cls.res_partner_adhoc,
+                "invoice_payment_term_id": payment_term,
                 "move_type": 'out_invoice',
                 "invoice_date": "2021-03-13",
-                "company_id": self.company_ri,
+                "company_id": cls.company_ri,
                 "invoice_line_ids": [
-                    {'product_id': self.service_iva_21, 'price_unit': 24.3, 'quantity': 3, 'name': 'Support Services 8'},
-                    {'product_id': self.service_iva_27, 'price_unit': 250.0, 'quantity': 1},
-                    {'product_id': self.product_iva_105_perc, 'price_unit': 3245.0, 'quantity': 1},
+                    cls._prepare_invoice_line(product_id=cls.service_iva_21, price_unit=24.3, quantity=3, name='Support Services 8'),
+                    cls._prepare_invoice_line(product_id=cls.service_iva_27, price_unit=250.0, quantity=1),
+                    cls._prepare_invoice_line(product_id=cls.product_iva_105_perc, price_unit=3245.0, quantity=1),
                 ],
             }
         }
 
-        for key, values in invoices_to_create.items():
-            with Form(self.env['account.move'].with_context(default_move_type=values['move_type'])) as invoice_form:
-                invoice_form.ref = values['ref']
-                invoice_form.partner_id = values['partner_id']
-                invoice_form.invoice_payment_term_id = values['invoice_payment_term_id']
-                if not use_current_date:
-                    invoice_form.invoice_date = values['invoice_date']
-                if values.get('invoice_incoterm_id'):
-                    invoice_form.invoice_incoterm_id = values['invoice_incoterm_id']
-                for line in values['invoice_line_ids']:
-                    with invoice_form.invoice_line_ids.new() as line_form:
-                        line_form.product_id = line.get('product_id')
-                        line_form.price_unit = line.get('price_unit')
-                        line_form.quantity = line.get('quantity')
-                        if line.get('tax_ids'):
-                            line_form.tax_ids = line.get('tax_ids')
-                        line_form.name = 'xxxx'
-                        line_form.account_id = self.company_data['default_account_revenue']
-            invoice = invoice_form.save()
-            self.demo_invoices[key] = invoice
+        for invoice_key, invoice_values in test_invoices_map.items():
+            invoice_values.setdefault('invoice_payment_term_id', cls.env.ref("account.account_payment_term_end_following_month"))
+            if use_current_date:
+                invoice_values.pop('invoice_date')
+            cls.demo_invoices[invoice_key] = cls._create_invoice_ar(**invoice_values)
 
-    def _create_invoice_from_dict(self, values, use_current_date=True):
-        if not values.get('invoice_payment_term_id'):
-            values['invoice_payment_term_id'] = self.env.ref("account.account_payment_term_end_following_month")
-        if use_current_date:
-            values.pop('invoice_date', False)
-
-        for key, value in values.items():
-            if key.endswith("_id"):
-                values[key] = value.id
-
-        for line in values['invoice_line_ids']:
-            for key, value in line.items():
-                if key.endswith("_id"):
-                    line[key] = value.id
-
-        values['invoice_line_ids'] = [(0, 0, line_data) for line_data in values['invoice_line_ids']]
-        return self.env['account.move'].with_context(default_move_type=values['move_type']).create(values)
-
+    # -------------------------------------------------------------------------
     # Helpers
+    # -------------------------------------------------------------------------
 
     @classmethod
     def _get_afip_pos_system_real_name(cls):
         return {'PREPRINTED': 'II_IM'}
 
-    def _create_journal(self, afip_ws, data=None):
+    @classmethod
+    def _create_journal(cls, afip_ws, data=None):
         """ Create a journal of a given AFIP ws type.
         If there is a problem because we are using a AFIP certificate that is already been in use then change the certificate and try again """
         data = data or {}
@@ -660,90 +620,23 @@ class TestAr(AccountTestInvoicingCommon):
         values = {'name': '%s %s' % (afip_ws.replace('WS', ''), pos_number),
                   'type': 'sale',
                   'code': pos_number,
-                  'l10n_ar_afip_pos_system': self._get_afip_pos_system_real_name().get(afip_ws),
+                  'l10n_ar_afip_pos_system': cls._get_afip_pos_system_real_name().get(afip_ws),
                   'l10n_ar_afip_pos_number': pos_number,
                   'l10n_latam_use_documents': True,
-                  'company_id': self.env.company.id,
-                  'l10n_ar_afip_pos_partner_id': self.partner_ri.id,
+                  'company_id': cls.env.company.id,
+                  'l10n_ar_afip_pos_partner_id': cls.partner_ri.id,
                   'sequence': 1}
         values.update(data)
 
-        journal = self.env['account.journal'].create(values)
-        _logger.info('Created journal %s for company %s', journal.name, self.env.company.name)
+        journal = cls.env['account.journal'].create(values)
+        _logger.info('Created journal %s for company %s', journal.name, cls.env.company.name)
         return journal
 
-    def _create_invoice(self, data=None, invoice_type='out_invoice'):
-        data = data or {}
-        with Form(self.env['account.move'].with_context(default_move_type=invoice_type)) as invoice_form:
-            invoice_form.partner_id = data.get('partner', self.partner)
-            if 'in_' not in invoice_type:
-                invoice_form.journal_id = data.get('journal', self.journal)
-
-            if data.get('document_type'):
-                invoice_form.l10n_latam_document_type_id = data.get('document_type')
-            if data.get('document_number'):
-                invoice_form.l10n_latam_document_number = data.get('document_number')
-            if data.get('incoterm'):
-                invoice_form.invoice_incoterm_id = data.get('incoterm')
-            if data.get('currency'):
-                invoice_form.currency_id = data.get('currency')
-            for line in data.get('lines', [{}]):
-                with invoice_form.invoice_line_ids.new() as invoice_line_form:
-                    invoice_line_form.display_type = line.get('display_type', 'product')
-                    if line.get('display_type') in ('line_note', 'line_section'):
-                        invoice_line_form.name = line.get('name', 'not invoice line')
-                    else:
-                        invoice_line_form.product_id = line.get('product', self.product_iva_21)
-                        invoice_line_form.quantity = line.get('quantity', 1)
-                        invoice_line_form.price_unit = line.get('price_unit', 100)
-            invoice_form.invoice_date = invoice_form.date
-        invoice = invoice_form.save()
-        return invoice
-
-    def _create_invoice_product(self, data=None):
-        data = data or {}
-        return self._create_invoice(data)
-
-    def _create_invoice_service(self, data=None):
-        data = data or {}
-        newlines = []
-        for line in data.get('lines', [{}]):
-            line.update({'product': self.service_iva_27})
-            newlines.append(line)
-        data.update({'lines': newlines})
-        return self._create_invoice(data)
-
-    def _create_invoice_product_service(self, data=None):
-        data = data or {}
-        newlines = []
-        for line in data.get('lines', [{}]):
-            line.update({'product': self.product_iva_21})
-            newlines.append(line)
-        data.update({'lines': newlines + [{'product': self.service_iva_27}]})
-        return self._create_invoice(data)
-
-    def _create_credit_note(self, invoice, data=None):
-        data = data or {}
-        refund_wizard = self.env['account.move.reversal'].with_context({'active_ids': [invoice.id], 'active_model': 'account.move'}).create({
-            'reason': data.get('reason', 'Mercadería defectuosa'),
-            'journal_id': invoice.journal_id.id})
-
-        forced_document_type = data.get('document_type')
-        if forced_document_type:
-            refund_wizard.l10n_latam_document_type_id = forced_document_type.id
-
-        res = refund_wizard.refund_moves() if data.get('refund_method', 'refund') == 'refund' else refund_wizard.modify_moves()
-        refund = self.env['account.move'].browse(res['res_id'])
-        return refund
-
-    def _create_debit_note(self, invoice, data=None):
-        data = data or {}
-        debit_note_wizard = self.env['account.debit.note'].with_context(
-            {'active_ids': [invoice.id], 'active_model': 'account.move', 'default_copy_lines': True}).create({
-                'reason': data.get('reason', 'Mercadería defectuosa')})
-        res = debit_note_wizard.create_debit()
-        debit_note = self.env['account.move'].browse(res['res_id'])
-        return debit_note
+    @classmethod
+    def _create_invoice_ar(cls, **invoice_args):
+        invoice_args.setdefault('partner_id', cls.partner)
+        invoice_args.setdefault('invoice_line_ids', [cls._prepare_invoice_line(price_unit=100, product_id=cls.product_iva_21)])
+        return cls._create_invoice(**invoice_args)
 
     def _search_tax(self, tax_type, type_tax_use='sale'):
         res = self.env['account.tax'].with_context(active_test=False).search([

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -1,4 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from unittest import skip
+
 from . import common
 from odoo import Command
 from odoo.exceptions import ValidationError
@@ -7,14 +9,14 @@ from odoo.tools.float_utils import float_split_str
 
 
 @tagged('post_install_l10n', '-at_install', 'post_install')
-class TestManual(common.TestAr):
+class TestArManual(common.TestArCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestManual, cls).setUpClass()
-        cls.journal = cls._create_journal(cls, 'preprinted')
+        super().setUpClass()
+        cls.journal = cls._create_journal('preprinted')
         cls.partner = cls.res_partner_adhoc
-        cls._create_test_invoices_like_demo(cls)
+        cls._create_test_invoices_like_demo()
 
     def test_01_create_invoice(self):
         """ Create and validate an invoice for a Responsable Inscripto
@@ -23,7 +25,7 @@ class TestManual(common.TestAr):
         * Properly set the tax amount of the product / partner
         * Proper fiscal position (this case not fiscal position is selected)
         """
-        invoice = self._create_invoice()
+        invoice = self._create_invoice_ar()
         self.assertEqual(invoice.company_id, self.company_ri, 'created with wrong company')
         self.assertEqual(invoice.amount_tax, 21, 'invoice taxes are not properly set')
         self.assertEqual(invoice.amount_total, 121.0, 'invoice taxes has not been applied to the total')
@@ -36,19 +38,19 @@ class TestManual(common.TestAr):
 
     def test_02_fiscal_position(self):
         # ADHOC SA > IVA Responsable Inscripto > Without Fiscal Positon
-        invoice = self._create_invoice({'partner': self.partner})
+        invoice = self._create_invoice_ar(partner_id=self.partner)
         self.assertFalse(invoice.fiscal_position_id, 'Fiscal position should be set to empty')
 
         # Consumidor Final > IVA Responsable Inscripto > Without Fiscal Positon
-        invoice = self._create_invoice({'partner': self.partner_cf})
+        invoice = self._create_invoice_ar(partner_id=self.partner_cf)
         self.assertFalse(invoice.fiscal_position_id, 'Fiscal position should be set to empty')
 
         # Montana Sur > IVA Liberado - Ley Nº 19.640 > Compras / Ventas Zona Franca > IVA Exento
-        invoice = self._create_invoice({'partner': self.res_partner_montana_sur})
+        invoice = self._create_invoice_ar(partner_id=self.res_partner_montana_sur)
         self.assertEqual(invoice.fiscal_position_id, self._search_fp('Purchases / Sales Free Trade Zone'))
 
         # Barcelona food > Cliente / Proveedor del Exterior >  > IVA Exento
-        invoice = self._create_invoice({'partner': self.res_partner_barcelona_food})
+        invoice = self._create_invoice_ar(partner_id=self.res_partner_barcelona_food)
         self.assertEqual(invoice.fiscal_position_id, self._search_fp('Purchases / Sales abroad'))
 
     def test_03_corner_cases(self):
@@ -110,7 +112,7 @@ class TestManual(common.TestAr):
         self.assertTrue(self.journal.l10n_ar_is_pos)
 
         # If we create an invoice it will not use manual numbering
-        invoice = self._create_invoice({'partner': self.partner})
+        invoice = self._create_invoice_ar()
         self.assertFalse(invoice.l10n_latam_manual_document_number)
 
         # Create a new sale journal that is not AFIP POS
@@ -194,23 +196,18 @@ class TestManual(common.TestAr):
 
     def test_18_invoice_b_tax_breakdown_1(self):
         """ Display Both VAT and Other Taxes """
-        invoice = self._create_invoice_from_dict({
-            'ref': 'test_invoice_20:  Final Consumer Invoice B with multiple vat/perceptions/internal/other/national taxes',
-            "move_type": 'out_invoice',
-            "partner_id": self.partner_cf,
-            "company_id": self.company_ri,
-            "invoice_date": "2021-03-20",
-            "invoice_line_ids": [
-                {'product_id': self.service_iva_21, 'price_unit': 124.3, 'quantity': 3, 'name': 'Support Services 8',
-                 'tax_ids': [Command.set([self.tax_21.id, self.tax_perc_iibb.id])]},
-                {'product_id': self.service_iva_27, 'price_unit': 2250.0,
-                 'tax_ids': [Command.set([self.tax_27.id, self.tax_national.id])]},
-                {'product_id': self.product_iva_105_perc, 'price_unit': 1740.0,
-                 'tax_ids': [Command.set([self.tax_10_5.id, self.tax_internal.id])]},
-                {'product_id': self.product_iva_105_perc, 'price_unit': 10000.0,
-                 'tax_ids': [Command.set([self.tax_0.id, self.tax_other.id])]},
+        invoice = self._create_invoice_ar(
+            ref='test_invoice_20:  Final Consumer Invoice B with multiple vat/perceptions/internal/other/national taxes',
+            partner_id=self.partner_cf,
+            company_id=self.company_ri,
+            invoice_date="2021-03-20",
+            invoice_line_ids=[
+                self._prepare_invoice_line(product_id=self.service_iva_21, price_unit=124.3, quantity=3, name='Support Services 8', tax_ids=self.tax_21 + self.tax_perc_iibb),
+                self._prepare_invoice_line(product_id=self.service_iva_27, price_unit=2250.0, tax_ids=self.tax_27 + self.tax_national),
+                self._prepare_invoice_line(product_id=self.product_iva_105_perc, price_unit=1740.0, tax_ids=self.tax_10_5 + self.tax_internal),
+                self._prepare_invoice_line(product_id=self.product_iva_105_perc, price_unit=10000.0, tax_ids=self.tax_0 + self.tax_other),
             ],
-        })
+        )
         results = invoice._l10n_ar_get_invoice_custom_tax_summary_for_report()
         self.assertEqual(results, [
             {
@@ -255,17 +252,13 @@ class TestManual(common.TestAr):
 
     def test_19_invoice_b_tax_breakdown_2(self):
         """ Display only Other Taxes (VAT taxes are 0) """
-        invoice = self._create_invoice_from_dict({
-            'ref': 'test_invoice_21: Final Consumer Invoice B with 0 tax and internal tax',
-            "move_type": 'out_invoice',
-            "partner_id": self.partner_cf,
-            "company_id": self.company_ri,
-            "invoice_date": "2021-03-20",
-            "invoice_line_ids": [
-                {'product_id': self.product_iva_105_perc, 'price_unit': 10000.0,
-                 'tax_ids': [Command.set([self.tax_no_gravado.id, self.tax_internal.id])]},
-            ],
-        })
+        invoice = self._create_invoice_ar(
+            ref='test_invoice_21: Final Consumer Invoice B with 0 tax and internal tax',
+            partner_id=self.partner_cf,
+            company_id=self.company_ri,
+            invoice_date="2021-03-20",
+            invoice_line_ids=[self._prepare_invoice_line(product_id=self.product_iva_105_perc, price_unit=10000.0, tax_ids=self.tax_no_gravado + self.tax_internal)],
+        )
         results = invoice._l10n_ar_get_invoice_custom_tax_summary_for_report()
         self.assertEqual(results, [
             {
@@ -291,17 +284,13 @@ class TestManual(common.TestAr):
 
     def test_20_invoice_b_tax_breakdown_3(self):
         """ Display only Other Taxes (VAT taxes are 0 and non other taxes) """
-        invoice = self._create_invoice_from_dict({
-            'ref': 'test_invoice_22: Final Consumer Invoice B with only 0 tax',
-            "move_type": 'out_invoice',
-            "partner_id": self.partner_cf,
-            "company_id": self.company_ri,
-            "invoice_date": "2021-03-20",
-            "invoice_line_ids": [
-                {'product_id': self.product_iva_105_perc, 'price_unit': 10000.0, 'quantity': 1,
-                    'tax_ids': [(6, 0, [self.tax_no_gravado.id])]},
-            ],
-        })
+        invoice = self._create_invoice_ar(
+            ref='test_invoice_22: Final Consumer Invoice B with only 0 tax',
+            partner_id=self.partner_cf,
+            company_id=self.company_ri,
+            invoice_date="2021-03-20",
+            invoice_line_ids=[self._prepare_invoice_line(product_id=self.product_iva_105_perc, price_unit=10000.0, tax_ids=self.tax_no_gravado)],
+        )
         results = invoice._l10n_ar_get_invoice_custom_tax_summary_for_report()
         self.assertEqual(results, [
             {
@@ -382,3 +371,40 @@ class TestManual(common.TestAr):
         })
         debit_note_wizard.create_debit()
         self.assertTrue(invoice.reversal_move_ids.debit_note_ids)
+
+    @skip("TODO: failing test. 'Fix' the rounding error")
+    def test_l10n_ar_rounding_01(self):
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        currency_usd = self.env.ref('base.USD')
+        currency_usd.active = True
+
+        self.env['res.currency.rate'].create([{
+            'name': '2025-04-01',
+            'inverse_company_rate': 1066.50,
+            'currency_id': currency_usd.id,
+            'company_id': self.env.company.id,
+        }])
+        tax_02 = self.percent_tax(0.2)
+        invoice_a = self._create_invoice_ar(
+            invoice_date='2025-04-02',
+            currency_id=currency_usd,
+            invoice_line_ids=[self._prepare_invoice_line(price_unit=124, tax_ids=tax_02)],
+        )
+        self.assertEqual(invoice_a.amount_total, invoice_a.invoice_line_ids.price_total, 'The invoice total should match the line total since there is only one line.')
+
+        tax_lines_a = invoice_a.line_ids \
+            .filtered(lambda x: x.tax_line_id) \
+            .sorted(lambda x: (x.move_id.id, x.tax_line_id.id, x.tax_ids.ids, x.tax_repartition_line_id.id))
+        self.env.company.tax_calculation_rounding_method = 'round_per_line'
+        invoice_b = self._create_invoice_ar(
+            invoice_date='2025-04-02',
+            currency_id=currency_usd,
+            invoice_line_ids=[self._prepare_invoice_line(price_unit=124, tax_ids=tax_02)],
+        )
+        self.assertEqual(invoice_b.amount_total, invoice_b.invoice_line_ids.price_total, 'The invoice total should match the line total since there is only one line.')
+
+        tax_lines_b = invoice_b.line_ids \
+            .filtered(lambda x: x.tax_line_id) \
+            .sorted(lambda x: (x.move_id.id, x.tax_line_id.id, x.tax_ids.ids, x.tax_repartition_line_id.id))
+
+        self.assertEqual(tax_lines_a.balance, tax_lines_b.balance, 'Tax balances should be equal since both invoices have a single line and the total matches the line amount.')

--- a/addons/l10n_ar_website_sale/tests/test_invoice.py
+++ b/addons/l10n_ar_website_sale/tests/test_invoice.py
@@ -7,11 +7,11 @@ from freezegun import freeze_time
 
 from odoo.addons.account_payment.tests.common import AccountPaymentCommon
 from odoo.addons.sale.tests.common import SaleCommon
-from odoo.addons.l10n_ar.tests.common import TestAr
+from odoo.addons.l10n_ar.tests.common import TestArCommon
 
 
 @tagged('-at_install', 'post_install', 'post_install_l10n')
-class TestWebsiteSaleInvoice(AccountPaymentCommon, SaleCommon, TestAr):
+class TestArWebsiteSaleInvoice(AccountPaymentCommon, SaleCommon, TestArCommon):
 
     @classmethod
     def setUpClass(cls):

--- a/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
+++ b/addons/l10n_ar_withholding/tests/test_withholding_ar_ri.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-from odoo.addons.l10n_ar.tests.common import TestAr
+from odoo.addons.l10n_ar.tests.common import TestArCommon
 from odoo.tests import tagged
 from odoo import Command
 from datetime import datetime
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class TestL10nArWithholdingArRi(TestAr):
+class TestArWithholdingArRi(TestArCommon):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
- Implemented a working `assert_json` method on `AccountTestInvoicingCommon`, that also supports the ignore_schema system and quick save using the `SAVE_JSON` test tag.
- Refactors the whole test suite of `l10n_ar*` modules to use the new accounting test helpers properly.

task-4891206