### PR TITLE
[FIX] mail: fix incorrect avatar display

### DIFF
--- a/addons/mail/static/src/core/web/activity.scss
+++ b/addons/mail/static/src/core/web/activity.scss
@@ -10,3 +10,7 @@
 .o-mail-Activity-iconContainer {
     box-shadow: 0 0 0 2px $o-view-background-color;
 }
+
+.o-mail-Activity-avatar {
+    --Avatar-size: #{$o-mail-Avatar-size};
+}

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -5,7 +5,7 @@
     <t t-set="activity" t-value="props.data"/>
     <div class="o-mail-Activity d-flex px-3 py-1 mb-2" t-on-click="onClick">
         <div class="o-mail-Activity-sidebar flex-shrink-0 position-relative">
-            <img class="w-100 h-100 rounded cursor-pointer" t-attf-src="/web/image/res.users/{{activity.user_id[0]}}/avatar_128" t-on-click.stop.prevent="onClickAvatar"/>
+            <img class="o-mail-Activity-avatar o_avatar rounded cursor-pointer" t-attf-src="/web/image/res.users/{{activity.user_id[0]}}/avatar_128" t-on-click.stop.prevent="onClickAvatar"/>
                 <div
                     class="o-mail-Activity-iconContainer position-absolute top-100 start-100 translate-middle d-flex align-items-center justify-content-center mt-n1 ms-n1 rounded-circle w-50 h-50"
                     t-att-class="{


### PR DESCRIPTION
Before this commit, user avatars in the Chater UI were not displayed using the object-fit: cover style, causing distorted or improperly scaled images.

Current behavior before PR:

<img width="671" height="380" alt="image" src="https://github.com/user-attachments/assets/a4b7ef3a-0c69-4fec-bf2a-70c9bd89236e" />

Desired behavior after PR is merged:

<img width="663" height="384" alt="image" src="https://github.com/user-attachments/assets/479586c8-a01c-45fb-9e46-9246616e1329" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
