### PR TITLE
[FIX] purchase_stock: change move value after invoice

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -177,6 +177,8 @@ class StockMove(models.Model):
 
         other_candidates_qty = 0
         for move in self.purchase_line_id.move_ids:
+            if move == self:
+                continue
             if move.product_id != self.product_id:
                 continue
             if move.date > self.date or (move.date == self.date and move.id > self.id):


### PR DESCRIPTION
**Problem:**
move value does not take invoice into account

**Steps to reproduce:**
- storable product
- buy 1 at 10 and validate transfer
- invoice at 12

**Current behavior:**
move value is still at 10

**Expected behavior:**
it should be 12

**Cause of the issue:**
when other_candidates_qty is computed
the quantity from self is taken into account
https://github.com/odoo/odoo/blob/3832793e3ce61aff0c7cf4673de84645a3469b3a/addons/purchase_stock/models/stock_move.py#L179-L187 so in our case it will be 1 and the product_uom.compare will return 0.
https://github.com/odoo/odoo/blob/3832793e3ce61aff0c7cf4673de84645a3469b3a/addons/purchase_stock/models/stock_move.py#L189-L190 So we will return valuation_data before
changing its 'value' and 'quantity' from 0 to the correct values.

**fix**
we should not take self into accound when computing other_candiates_qty

opw-5261825