### PR TITLE
[18.0][FIX] account_edi_ubl_cii: search bank account with same partner instead of same company

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -487,7 +487,7 @@ class AccountEdiCommon(models.AbstractModel):
         acc_number_partner_bank_dict = {
             bank.sanitized_acc_number: bank
             for bank in ResPartnerBank.with_context(active_test=False).search(
-                [('company_id', 'in', [False, invoice.company_id.id]), ('acc_number', 'in', bank_details)]
+                [('partner_id', '=', partner.id), ('acc_number', 'in', bank_details)]
             )
         }
         for account_number in bank_details:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Imagine a situation where a vendor is defined on a parent company and its bank account already exists. When importing an electronic invoice for that vendor on a child company, the search for a bank account linked to the same company would not find that pre-existing bank account on the parent company. When later trying to create it, the unicity constraint on (sanitized_acc_number, partner_id) would trigger, failing the import.

Current behavior before PR:

The electronic invoice cannot be imported if the same IBAN account already exists on the partner but on another company than the invoice being created, even though we are going to create the invoice for a partner linked to that other company.

Desired behavior after PR is merged:

Banks account already linked to the partner are found irrespective of the company, provided the partner (account holder) is the same. This should be correct since the res.partner.bank company_id is a related on res.partner.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
