### PR TITLE
[IMP] l10n_es_edi_sii: Certificate scope

### DIFF
--- a/addons/l10n_es_edi_sii/views/l10n_es_edi_sii_certificate_views.xml
+++ b/addons/l10n_es_edi_sii/views/l10n_es_edi_sii_certificate_views.xml
@@ -28,7 +28,7 @@
         <field name="inherit_id" ref="certificate.certificate_certificate_view_form"/>
         <field name="arch" type="xml">
             <field name="scope" position="attributes">
-                <attribute name="invisible">False</attribute>
+                <attribute name="invisible" add="not (country_code == 'ES')" separator="or"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Will make it visible the scope fiel only if the company country is ES. The field will remain invisible as defined in the certificate module for other cases.

This way we avoid to show this field on certificates that use other localizations that can confuse to the user.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
