### PR TITLE
[FIX] l10n_th:  Remove trailing space in tax report formula

### DIFF
--- a/addons/l10n_th/data/account_tax_report_data.xml
+++ b/addons/l10n_th/data/account_tax_report_data.xml
@@ -34,14 +34,14 @@
                         </field>
                     </record>
                     <record id="tax_report_out_tax_less_sales_0_rate" model="account.report.line">
-                        <field name="name">2. Less sales subject to 0% tax rate </field>
-                        <field name="name@th">2. หักยอดขายโดยคิดอัตราภาษี 0% </field>
+                        <field name="name">2. Less sales subject to 0% tax rate</field>
+                        <field name="name@th">2. หักยอดขายโดยคิดอัตราภาษี 0%</field>
                         <field name="code">OUTPUTTAX_SALE_ZERO</field>
                         <field name="expression_ids">
                             <record id="tax_report_out_tax_less_sales_0_rate_tag" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">-2. Less sales subject to 0% tax rate </field>
+                                <field name="formula">-2. Less sales subject to 0% tax rate</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
-Report line formula was converted from Char to Text, which no longer strips
 trailing spaces.
-The fix removes the trailing space from "formula" to restore correct behavior.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/104405

task-5468804