### PR TITLE
[IMP] account, mail: make activity systray redirection filters consistent

### DIFF
--- a/addons/account/views/account_account_views.xml
+++ b/addons/account/views/account_account_views.xml
@@ -175,6 +175,12 @@
                     <filter string="Inactive Accounts" name="inactiveacc" domain="[('active', '=', False)]"/>
                     <separator/>
                     <field name="account_type"/>
+                    <separator invisible="1"/>
+                    <filter string="My Activities" name="filter_activities_my" domain="[('activity_user_id', '=', uid)]" invisible="True"/>
+                    <separator invisible="1"/>
+                    <filter string="Late Activities" name="activities_overdue" domain="[('my_activity_date_deadline', '&lt;', 'today')]" invisible="True"/>
+                    <filter string="Today Activities" name="activities_today" domain="[('my_activity_date_deadline', '=', 'today')]" invisible="True"/>
+                    <filter string="Future Activities" name="activities_upcoming_all" domain="[('my_activity_date_deadline', '&gt;', 'today')]" invisible="True"/>
                     <group>
                         <filter string="Account Type" name="accounttype" domain="" context="{'group_by':'account_type'}"/>
                     </group>

--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -56,16 +56,6 @@ export class ActivityMenu extends Component {
             force_search_count: 1,
             search_default_filter_activities_my: 1,
         };
-        if (group.model === "mail.activity") {
-            this.action.doAction("mail.mail_activity_without_access_action", {
-                newWindow,
-                additionalContext: {
-                    active_ids: group.activity_ids,
-                    active_model: "mail.activity",
-                },
-            });
-            return;
-        }
 
         if (filter === "all") {
             context["search_default_activities_overdue"] = 1;
@@ -76,6 +66,18 @@ export class ActivityMenu extends Component {
             context["search_default_activities_today"] = 1;
         } else if (filter === "upcoming_all") {
             context["search_default_activities_upcoming_all"] = 1;
+        }
+
+        if (group.model === "mail.activity") {
+            this.action.doAction("mail.mail_activity_without_access_action", {
+                newWindow,
+                additionalContext: {
+                    ...context,
+                    active_ids: group.activity_ids,
+                    active_model: "mail.activity",
+                },
+            });
+            return;
         }
 
         let domain = [];

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -235,15 +235,15 @@
                 ]"/>
                 <field name="user_id"/>
                 <field name="activity_type_id"/>
-                <filter name="filter_user_id_uid" string="My Activities" domain="[('user_id', '=', uid)]"/>
+                <filter name="filter_activities_my" string="My Activities" domain="[('user_id', '=', uid)]"/>
                 <filter name="filter_user_id_no_user" string="Unassigned Activities" domain="[('user_id', '=', False)]"/>
                 <separator/>
                 <separator invisible="1"/>
                 <filter string="Done" name="filter_archived" domain="[('active', '=', False)]"/>
-                <filter string="Overdue" name="filter_date_deadline_past"
+                <filter string="Overdue" name="activities_overdue"
                         domain="[('date_deadline', '&lt;', 'today')]"
                         help="Show all records whose next activity date is past"/>
-                <filter string="Today" name="filter_date_deadline_today"
+                <filter string="Today" name="activities_today"
                         domain="[('date_deadline', '=', 'today')]"/>
                 <filter string="Tomorrow" name="filter_date_deadline_tomorrow"
                         help="Show all records whose next action date is tomorrow"
@@ -254,7 +254,7 @@
                             ('date_deadline', '&gt;=', '=week_start'),
                             ('date_deadline', '&lt;', '=week_start +1w')
                         ]"/>
-                <filter string="Future" name="filter_date_deadline_future"
+                <filter string="Future" name="activities_upcoming_all"
                         domain="[('date_deadline', '&gt;', 'today')
                         ]"/>
                 <separator />
@@ -455,9 +455,9 @@
         <!-- ensure pagination works even if _search removes records after fetching -->
         <field name="context">{
             'force_search_count': 1,
-            'search_default_filter_user_id_uid': 1,
-            'search_default_filter_date_deadline_past': 1,
-            'search_default_filter_date_deadline_today': 1,
+            'search_default_filter_activities_my': 1,
+            'search_default_activities_today': 1,
+            'search_default_activities_overdue': 1,
         }</field>
     </record>
 


### PR DESCRIPTION
Activity redirections from systray apply the default filters My Activities, Today Activities, and Late Activities.

However, Knowledge, Account, and 'Other activities' were missing these filters.

This commit fixes this so that the default activity filters are set in all models in the activity systray.

task-5424661
