### PR TITLE
[FIX] pos_event: sync all event registration answers

### DIFF
--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -7,11 +7,32 @@ import * as EventTourUtils from "@pos_event/../tests/tours/utils/event_tour_util
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("SellingEventInPos", {
+registry.category("web_tour.tours").add("SellingEventInPosWithTextAnswers", {
     steps: () =>
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            // Buy a VIP Ticket
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            Dialog.confirm(),
+            EventTourUtils.answerGlobalTextQuestion("Text Box 1", "TB1-Answer"),
+            EventTourUtils.answerTicketQuestion("1", "Text Box 2", "T1-TB2-Answer"),
+            EventTourUtils.answerTicketQuestion("2", "Text Box 2", "T2-TB2-Answer"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("400.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("SellingEventInPosWithChoiceAnswers", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
             // Confirm popup - There isn't enough tickets available
             ProductScreen.clickDisplayedProduct("My Awesome Event"),
             EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),

--- a/addons/pos_event/static/tests/tours/utils/event_tour_utils.js
+++ b/addons/pos_event/static/tests/tours/utils/event_tour_utils.js
@@ -39,6 +39,16 @@ export function answerGlobalSelectQuestion(question, answer) {
     ];
 }
 
+export function answerTicketQuestion(ticketNumber, question, answer) {
+    return [
+        {
+            content: `Answer question ${question} with ${answer} for ticket ${ticketNumber}`,
+            trigger: `.ticket_question:contains('Ticket #${ticketNumber}') .input-group:contains('${question}') input`,
+            run: `edit ${answer}`,
+        },
+    ];
+}
+
 export function answerGlobalTextQuestion(question, answer) {
     return [
         {

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -106,6 +106,20 @@ class TestUi(TestPointOfSaleHttpCommon):
             "iface_available_categ_ids": [(6, 0, [self.event_category.id])],
         })
         self.test_event.write({
+            'seats_max': 4,
+            'event_ticket_ids': [(1, self.test_event.event_ticket_ids[1].id, {'seats_max': 3})],
+            'question_ids': [
+                Command.create({'title': 'Text Box 1', 'question_type': 'text_box', 'once_per_order': True}),
+                Command.create({'title': 'Text Box 2', 'question_type': 'text_box'})
+            ]
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('SellingEventInPosWithTextAnswers')
+        order = self.main_pos_config.session_ids.order_ids[:1]
+        event_registration = order.lines[0].event_registration_ids
+        self.assertEqual(len(event_registration.registration_answer_ids), 4)
+        self.assertEqual(event_registration.registration_answer_ids.mapped("value_text_box"), ['TB1-Answer', 'T2-TB2-Answer', 'TB1-Answer', 'T1-TB2-Answer'])
+        self.test_event.write({
             'question_ids': [Command.create({
                 'title': 'Question3',
                 'question_type': 'simple_choice',
@@ -118,7 +132,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })]
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'SellingEventInPos', login="pos_user")
+        self.start_pos_tour('SellingEventInPosWithChoiceAnswers')
 
         order = self.env['pos.order'].search([], order='id desc', limit=1)
         event_registration = order.lines[0].event_registration_ids


### PR DESCRIPTION
## Steps to reproduce:

- Configure event registration with only free-text fields (no selection field).
- Open the POS, add an event ticket product, and fill in the registration form.
- Click Payment and validate the order.

## Issue:

- Registration answers were only sent to the backend when at least one selection-type question was filled.
- When no selection field was present, free-text answers were not synced at all.

## Reason:

- The `registration_answer_ids` and `registration_answer_choice_ids` One2many fields on EventRegistration both point to the same `registration_id` Many2one field on EventRegistrationAnswer.
https://github.com/odoo/odoo/blob/c738d049fe09101bd14dce0710c2659a4a6eca39/addons/event/models/event_registration.py#L83-L85

- This caused data loss during the POS model synchronization, as entries were overwritten in the `inverseMap`.
https://github.com/odoo/odoo/blob/c738d049fe09101bd14dce0710c2659a4a6eca39/addons/point_of_sale/static/src/app/models/related_models/model_defs.js#L59-L75

## Fix:

- Send all registration answers (free-text and selection-based) exclusively via `registration_answer_choice_ids`.


task-5438565

