### PR TITLE
[IMP] account_edi_ubl_cii: check for 'LU' prefix in Luxembourg peppol endpoints

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -243,6 +243,13 @@ class ResPartner(models.Model):
             value = self.vat
             if value.isalnum():
                 value = value.removeprefix(country_code)
+        elif (
+            country_code == 'LU'
+            and field == 'vat'
+            and value
+            and not value.startswith('LU')
+        ):
+            value = 'LU' + value
 
         return sanitize_peppol_endpoint(value, eas)
 
@@ -296,6 +303,8 @@ class ResPartner(models.Model):
             return _("The Peppol endpoint is not valid. "
                      "It should contain exactly 10 digits (Company Registry number)."
                      "The expected format is: 1234567890")
+        if eas == '9938' and not re.match(r"^LU\d{8}$", endpoint):
+            return self.env._("The Peppol endpoint is not valid. The expected format is: LU15027442")
         if PEPPOL_ENDPOINT_INVALIDCHARS_RE.search(endpoint) or not 1 <= len(endpoint) <= 50:
             return _("The Peppol endpoint (%s) is not valid. It should contain only letters and digit.", endpoint)
 

--- a/addons/account_edi_ubl_cii/tests/common.py
+++ b/addons/account_edi_ubl_cii/tests/common.py
@@ -51,7 +51,7 @@ class TestUblCiiCommon(AccountTestInvoicingCommon):
             'company_id': cls.company_data['company'].id,
             'country_id': cls.env.ref('base.lu').id,
             'peppol_eas': '9938',
-            'peppol_endpoint': '00005000041',
+            'peppol_endpoint': 'LU05000041',
             **kwargs,
         })
 

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_luxembourg_dig.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_luxembourg_dig.xml
@@ -46,7 +46,7 @@
 	</cac:AccountingSupplierParty>
 	<cac:AccountingCustomerParty>
 		<cac:Party>
-			<cbc:EndpointID schemeID="9938">00005000041</cbc:EndpointID>
+			<cbc:EndpointID schemeID="9938">LU05000041</cbc:EndpointID>
 			<cac:PartyName>
 				<cbc:Name>Division informatique et gestion</cbc:Name>
 			</cac:PartyName>
@@ -59,14 +59,14 @@
 				</cac:Country>
 			</cac:PostalAddress>
 			<cac:PartyTaxScheme>
-				<cbc:CompanyID>00005000041</cbc:CompanyID>
+				<cbc:CompanyID>LU05000041</cbc:CompanyID>
 				<cac:TaxScheme>
 					<cbc:ID>9938</cbc:ID>
 				</cac:TaxScheme>
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>Division informatique et gestion</cbc:RegistrationName>
-				<cbc:CompanyID>00005000041</cbc:CompanyID>
+				<cbc:CompanyID>LU05000041</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>Division informatique et gestion</cbc:Name>


### PR DESCRIPTION
Before this PR:
- No validation for the 'LU' prefix in Luxembourg peppol endpoint IDs leads to registration with an incorrect vat number.

After this PR:
- Added a validation check to prevent registration without the prefix 'LU' in Luxembourg peppol endpoint IDs.

Task: 5441651