### PR TITLE
[IMP] account: update accounting firms mode

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -648,6 +648,8 @@ class AccountMove(models.Model):
              'Odoo will automatically create one invoice line with default values to match it.',
     )
     quick_encoding_vals = fields.Json(compute='_compute_quick_encoding_vals', exportable=False)
+    document_sequence_editable = fields.Boolean(related='company_id.document_sequence_editable')
+    set_to_review_documents = fields.Boolean(related='company_id.set_to_review_documents')
 
     # === Misc Information === #
     narration = fields.Html(
@@ -2067,7 +2069,9 @@ class AccountMove(models.Model):
 
     @api.depends('journal_id.type', 'company_id')
     def _compute_quick_edit_mode(self):
-        for move in self:
+        move_with_quick_edit_enabled = self.filtered('company_id.quick_edit_mode_enabled')
+        (self - move_with_quick_edit_enabled).quick_edit_mode = False
+        for move in move_with_quick_edit_enabled:
             quick_edit_mode = move.company_id.quick_edit_mode
             if move.journal_id.type == 'sale':
                 move.quick_edit_mode = quick_edit_mode in ('out_invoices', 'out_and_in_invoices')
@@ -2670,7 +2674,7 @@ class AccountMove(models.Model):
 
     @api.onchange('name', 'highest_name')
     def _onchange_name_warning(self):
-        if self.name and self.name != '/' and self.name <= (self.highest_name or '') and not self.quick_edit_mode:
+        if self.name and self.name != '/' and self.name <= (self.highest_name or '') and not self.document_sequence_editable:
             self.show_name_warning = True
         else:
             self.show_name_warning = False
@@ -2738,7 +2742,7 @@ class AccountMove(models.Model):
 
     @api.onchange('journal_id')
     def _onchange_journal_id(self):
-        if not self.quick_edit_mode:
+        if not self.document_sequence_editable:
             self.name = False
             self._compute_name()
 
@@ -3899,9 +3903,9 @@ class AccountMove(models.Model):
                 if is_user_able_to_review:
                     if move.review_state:
                         move_ids_review_done.append(move.id)
-                else:
+                elif move.set_to_review_documents:
                     move_ids_review_todo.append(move.id)
-            if not is_user_able_to_review and move.review_state in ('reviewed', 'supervised') and modified_accounting_fields:
+            if not is_user_able_to_review and move.review_state in ('reviewed', 'supervised') and modified_accounting_fields and move.set_to_review_documents:
                 move_ids_review_todo.append(move.id)
 
             violated_fields = set(vals).intersection(move._get_integrity_hash_fields() + ['inalterable_hash'])
@@ -3921,7 +3925,7 @@ class AccountMove(models.Model):
                     move.name and move.name != '/'
                     and move.sequence_number not in (0, 1)
                     and 'journal_id' in vals and move.journal_id.id != vals['journal_id']
-                    and not move.quick_edit_mode
+                    and not move.document_sequence_editable
                     and not ('name' in vals and (vals['name'] == '/' or not vals['name']))
             ):
                 raise UserError(_('You cannot edit the journal of a journal entry with a sequence number assigned, unless the name is removed or set to "/". This might create a gap in the sequence.'))
@@ -4053,7 +4057,7 @@ class AccountMove(models.Model):
         """
         if not (
             self.env.user.has_group('account.group_account_manager')
-            or any(self.company_id.mapped('quick_edit_mode'))
+            or any(self.company_id.mapped('document_sequence_editable'))
             or self.env.context.get('force_delete')
             or self.check_move_sequence_chain()
         ):
@@ -4193,7 +4197,7 @@ class AccountMove(models.Model):
 
     def _must_check_constrains_date_sequence(self):
         # OVERRIDES sequence.mixin
-        return self.state == 'posted' and not self.quick_edit_mode
+        return self.state == 'posted' and not self.document_sequence_editable
 
     def _get_last_sequence_domain(self, relaxed=False):
         #pylint: disable=sql-injection
@@ -4563,9 +4567,9 @@ class AccountMove(models.Model):
 
     def _check_total_amount(self, amount_total):
         """
-        Verifies that the total amount corresponds to the quick total amount chosen as some
+        Verifies that the total amount corresponds to the expected total amount chosen as some
         rounding errors may appear. In such a case, we round up the tax such that the total
-        is equal to the quick total amount set
+        is equal to the provided total amount.
         E.g.: 100€ including 21% tax: base = 82.64, tax = 17.35, total = 99.99
         The tax will be set to 17.36 in order to have a total of 100.00
         """

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -251,12 +251,16 @@ class ResCompany(models.Model):
     )
 
     # Fiduciary mode
+    quick_edit_mode_enabled = fields.Boolean(string="Quick encoding")
     quick_edit_mode = fields.Selection(
         selection=[
             ('out_invoices', 'Customer Invoices'),
             ('in_invoices', 'Vendor Bills'),
             ('out_and_in_invoices', 'Customer Invoices and Vendor Bills')],
-        string="Quick encoding")
+        default='out_and_in_invoices',
+    )
+    document_sequence_editable = fields.Boolean(string="Document's sequence editable")
+    set_to_review_documents = fields.Boolean(string="Review data")
 
     # Separate account for allocation of discounts
     account_discount_income_allocation_id = fields.Many2one(comodel_name='account.account', string='Separate account for income discount')

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -156,7 +156,10 @@ class ResConfigSettings(models.TransientModel):
     group_sale_delivery_address = fields.Boolean("Customer Addresses", implied_group='account.group_delivery_invoice_address')
 
     # Quick encoding (fiduciary mode)
-    quick_edit_mode = fields.Selection(string="Quick encoding", readonly=False, related='company_id.quick_edit_mode')
+    quick_edit_mode_enabled = fields.Boolean(string="Quick encoding", readonly=False, related='company_id.quick_edit_mode_enabled')
+    quick_edit_mode = fields.Selection(readonly=False, related='company_id.quick_edit_mode')
+    document_sequence_editable = fields.Boolean(string="Document's sequence editable", readonly=False, related='company_id.document_sequence_editable')
+    set_to_review_documents = fields.Boolean(string="Review data", readonly=False, related='company_id.set_to_review_documents')
 
     account_journal_early_pay_discount_loss_account_id = fields.Many2one(
         comodel_name='account.account',

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2288,7 +2288,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertFalse(move_form.invoice_date)
 
         # Fiduciary mode enabled, date suggestion
-        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.quick_edit_mode_enabled = True
 
         # We are June 17th. No Lock date. Bill Date of the most recent Vendor Bill : March 15th
         # ==> Default New Vendor Bill date = March 31st (last day of March)

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -3759,7 +3759,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertEqual(len(invoice.invoice_line_ids), 0)
 
         # Quick edit total amount activated
-        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.quick_edit_mode_enabled = True
         self.env.company.account_sale_tax_id = self.env['account.tax'].create({
             'name': '21%',
             'amount': 21,
@@ -3797,7 +3797,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         move_form.invoice_date = fields.Date.from_string('2022-01-01')
 
         # Quick edit total amount activated
-        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.quick_edit_mode_enabled = True
         # 21% sale tax
         self.env.company.account_sale_tax_id = self.env['account.tax'].create({
             'name': '21%',
@@ -3856,7 +3856,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
                 Command.create({'repartition_type': 'tax', 'factor_percent': -100.0}),
             ],
         })
-        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.quick_edit_mode_enabled = True
         self.env.company.account_sale_tax_id = tax
 
         move_form = Form(self.env['account.move'].with_context(default_move_type='out_invoice'))
@@ -4372,7 +4372,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
     def test_on_quick_encoding_non_accounting_lines(self):
         """ Ensure that quick encoding values are only applied to accounting lines) """
 
-        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.quick_edit_mode_enabled = True
         move_form = Form(
             self.env['account.move'].with_context(default_move_type='out_invoice')
         )

--- a/addons/account/tests/test_account_to_check.py
+++ b/addons/account/tests/test_account_to_check.py
@@ -16,6 +16,8 @@ class TestCheckAccountMoves(AccountTestInvoicingCommon):
         super().setUpClass()
         cls.simple_accountman.group_ids = cls.env.ref('account.group_account_invoice')
         cls.bank_journal = cls.env['account.journal'].search([('type', '=', 'bank'), ('company_id', '=', cls.company.id)], limit=1)
+        # As the user has only invoicing right, the move shouldn't be checked if review documents is activated in Accounting Firms mode
+        cls.company.set_to_review_documents = True
 
     def test_try_check_move_with_invoicing_user(self):
         invoice = self._create_invoice(review_state='todo')
@@ -49,10 +51,16 @@ class TestCheckAccountMoves(AccountTestInvoicingCommon):
         # As the user has admin right, the move doesn't need to be checked
         self.assertFalse(invoice_admin.review_state)
 
+        # As the user has only invoicing right and review documents setting enabled from Accounting Firms mode, the move needs to be reviewed
         invoice_invoicing = self._create_invoice(user_id=self.simple_accountman.id)
         invoice_invoicing.with_user(self.simple_accountman).action_post()
-        # As the user has only invoicing right, the move shouldn't be checked
         self.assertEqual(invoice_invoicing.review_state, 'todo')
+
+        # Disable the review documents from Accounting Firms mode, the move doesn't need to review
+        self.company.set_to_review_documents = False
+        invoice_invoicing_1 = self._create_invoice(user_id=self.simple_accountman.id)
+        invoice_invoicing_1.with_user(self.simple_accountman).action_post()
+        self.assertFalse(invoice_invoicing_1.review_state)
 
     def test_post_move_auto_check_with_auto_post_at_date_accountant(self):
         invoice = self._create_invoice(date=fields.Date.today())

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -92,7 +92,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         Test the sequence update behavior when changing the date of a move in quick edit mode.
         The sequence should only be recalculated if a value (year or month) utilized in the sequence is modified.
         """
-        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.quick_edit_mode_enabled = True
         self.env.company.fiscalyear_last_day = 30
         self.env.company.fiscalyear_last_month = '12'
 
@@ -140,9 +140,9 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             invoice_form.date = '2017-01-01'
             self.assertMoveName(invoice_form, 'INV/16-17/0001')
 
-    def test_sequence_empty_editable_with_quick_edit_mode(self):
+    def test_sequence_empty_editable_with_document_sequence_editable(self):
         """ Ensure the names of all but the first moves in a period are empty and editable in quick edit mode """
-        self.env.company.quick_edit_mode = 'in_invoices'
+        self.env.company.document_sequence_editable = True
 
         bill_1 = self.env['account.move'].create({
             'partner_id': self.ref('base.partner_root'),
@@ -599,7 +599,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
 
     def test_sequence_staggered_year(self):
         """The sequence is correctly computed when the year is staggered."""
-        self.env.company.quick_edit_mode = "out_and_in_invoices"
+        self.env.company.document_sequence_editable = True
         self.env.company.fiscalyear_last_day = 15
         self.env.company.fiscalyear_last_month = '4'
 

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1045,9 +1045,9 @@
                             <div class="text-warning" invisible="not show_name_warning">The current highest number is <field class="oe_inline" name="highest_name"/>. You might want to put a higher number here.</div>
 
                             <h1>
-                                <field name="name" invisible="not (name or name_placeholder or quick_edit_mode)" readonly="state != 'draft'" options="{'placeholder_field': 'name_placeholder'}"/>
+                                <field name="name" invisible="not (name or name_placeholder or document_sequence_editable)" readonly="state != 'draft'" options="{'placeholder_field': 'name_placeholder'}"/>
 
-                                <span invisible="name or name_placeholder or quick_edit_mode">Draft</span>
+                                <span invisible="name or name_placeholder or document_sequence_editable">Draft</span>
                             </h1>
                         </div>
                         <group>

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -373,14 +373,16 @@
                                 <field name="account_storno"/>
                             </setting>
                         </block>
-                        <block title="Accounting Firms mode" id="quick_edit_mode">
-                            <div class="text-muted">
-                                <p style="margin-bottom: 0">Accounting firm mode will change invoice/bill encoding:</p>
-                                <p style="margin-bottom: 0"> - The document's sequence becomes editable on all documents.</p>
-                                <p style="margin-bottom: 0"> - A new field « Total (tax inc.) » to speed up and control the encoding by automating line creation with the right account &amp; tax.</p>
-                            </div>
-                            <setting company_dependent="1">
-                                <field name="quick_edit_mode" placeholder="Disabled"/>
+                        <block title="Accounting Firms mode">
+                            <setting  id="quick_edit_mode_enabled" company_dependent="1" help="A new field 'Total (tax inc.)' to speed up and control the encoding by automating line creation with the right account and tax.">
+                                <field name="quick_edit_mode_enabled"/>
+                                <field name="quick_edit_mode" required="quick_edit_mode_enabled" invisible="not quick_edit_mode_enabled"/>
+                            </setting>
+                            <setting  id="document_sequence_editable" company_dependent="1" help="The document's sequence becomes editable on all documents.">
+                                <field name="document_sequence_editable"/>
+                            </setting>
+                            <setting  id="set_to_review_documents" company_dependent="1" help="Review all the modification done by the user with right under bookkeeper.">
+                                <field name="set_to_review_documents"/>
                             </setting>
                         </block>
                     </app>

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1141,7 +1141,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
 
         # ==== ref, invoice_origin, narration, payment_reference ====
         ref = tree.findtext('./{*}ID')
-        if ref and invoice.is_sale_document(include_receipts=True) and invoice.quick_edit_mode:
+        if ref and invoice.is_sale_document(include_receipts=True) and invoice.document_sequence_editable:
             invoice_values['name'] = ref
         elif ref:
             invoice_values['ref'] = ref


### PR DESCRIPTION
Previously, in Accounting Firms mode, users had to select the invoice types on which all settings(document sequence editable, total amount (tax-included), and date suggestion) would apply.

With this commit, this behavior is now split into two parts. Quick Encoding controls the total amount and date suggestion features and applies only to the selected invoice types. Document Sequence Editable is no longer invoice-type
specific and, when enabled, applies to all invoice types.

Additionally, journal entries created by standard accounting users (non-bookkeepers) were previously always marked as To Review. They are now marked as To Review only when the Review Data setting is enabled in Accounting Firms mode.

task-5418617

Related:
https://github.com/odoo/enterprise/pull/103443
https://github.com/odoo/upgrade/pull/9203