### PR TITLE
[IMP] mail, web: add size expand/collapse button to full message composer dialog

### DIFF
--- a/addons/mail/static/src/core/web/action_dialog_patch.js
+++ b/addons/mail/static/src/core/web/action_dialog_patch.js
@@ -1,0 +1,29 @@
+import { useState } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+import { ActionDialog } from "@web/webclient/actions/action_dialog";
+
+patch(ActionDialog.prototype, {
+    setup() {
+        super.setup();
+        this.expanded = useState({ value: false });
+    },
+
+    get canExpand() {
+        const actionProps = this.props.actionProps || {};
+        return actionProps.resModel === "mail.compose.message" && actionProps.type === "form";
+    },
+
+    get size() {
+        return this.expanded.value ? "fs" : super.size;
+    },
+
+    get toggleSizeTitle() {
+        return this.expanded.value ? _t("Compress") : _t("Expand");
+    },
+
+    toggleExpand() {
+        this.expanded.value = !this.expanded.value;
+    },
+});

--- a/addons/mail/static/src/core/web/action_dialog_patch.xml
+++ b/addons/mail/static/src/core/web/action_dialog_patch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="web.ActionDialog.header" t-inherit-mode="extension">
+        <xpath expr="//h4[hasclass('modal-title')]" position="after">
+            <button t-if="canExpand and !props.onExpand" type="button" class="fa btn me-2 opacity-50 opacity-100-hover" t-att-class="expanded.value ? 'fa-compress' : 'fa-expand'" t-att-title="toggleSizeTitle" t-on-click="toggleExpand" />
+        </xpath>
+    </t>
+</templates>

--- a/addons/mail/static/tests/chatter/web/chatter_topbar.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter_topbar.test.js
@@ -226,3 +226,17 @@ test("composer state conserved when clicking on another topbar button", async ()
     await contains("button.active:text('Log note')");
     await contains("button:not(.active):text('Send message')");
 });
+
+test("full message composer dialog size expand/collapse", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({});
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click("button:text('Log note')");
+    await click("button[aria-label='Open Full Composer']");
+    await contains("div.modal-lg");
+    await click("button[title='Expand']");
+    await contains("div.modal-fs");
+    await click("button[title='Compress']");
+    await contains("div.modal-lg");
+});

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -116,12 +116,16 @@ export class Dialog extends Component {
         });
     }
 
+    get size() {
+        return this.props.size;
+    }
+
     get isFullscreen() {
         return this.props.fullscreen || (this.env.isSmall && this.design !== "minimal");
     }
 
     get design() {
-        return ["sm", "md"].includes(this.props.size) ? "minimal" : "default";
+        return ["sm", "md"].includes(this.size) ? "minimal" : "default";
     }
 
     get contentStyle() {

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -9,7 +9,7 @@
                 t-attf-class="o_modal_design_{{ design }} {{ !props.withBodyPadding ? 'o_modal_no_body_padding': 'o_modal_body_padding' }}"
                 t-ref="modalRef"
                 >
-                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" t-attf-class="modal-{{props.size}}">
+                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" t-attf-class="modal-{{ size }}">
                     <div class="modal-content" t-att-class="props.contentClass" t-att-style="contentStyle">
                         <header t-if="props.header" class="modal-header">
                             <t t-slot="header" close="data.close" isFullscreen="isFullscreen">


### PR DESCRIPTION
**Current behavior before PR:**
The full message composer (`mail.compose.message` form view) opens with a large dialog size by default, which is still too small for comfortably writing long messages.

**Desired behavior after PR is merged:**
The full message composer provides a size expand / collapse button, allowing users to toggle the dialog size between its default size and `fs` size while composing a message, making it more comfortable to write longer content.

Before
<img width="1916" height="962" alt="image" src="https://github.com/user-attachments/assets/26a99bb9-b462-4492-a373-25b795a67112" />


After
![after](https://github.com/user-attachments/assets/aaad6c86-7818-45b9-a18a-1484411315a2)



task-[5163977](https://www.odoo.com/odoo/project/1519/tasks/5163977)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
