### PR TITLE
[FIX] pos_loyalty: increase barcode width

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -52,7 +52,7 @@
                                 </t>
                             </div>
                             <div>
-                                <img t-att-src="'/report/barcode/Code128/'+coupon_info['code']" style="width:200px;height:50px" alt="Barcode"/>
+                                <img t-att-src="'/report/barcode/Code128/'+coupon_info['code']" style="width:250px;height:62px" alt="Barcode"/>
                             </div>
                             <div>
                                 <t t-esc="coupon_info['code']"/>


### PR DESCRIPTION
Step to reproduce;
- install pos_loyalty
- create a loyalty program of type "next order coupon" with minimum spend of 1$.
- open pos and settle a order, see receipt.

Issue:
- currently bar-code is too narrow, making it difficult for to be scanned

Fix:
- increase the width of barcode, so it can be easily scanned.

<table>
<tr>
<td>
<b>Before</b>
</td>
<td>
<b>After</b>
</td>
</tr>
<tr>
<td>
<img width="451" height="508" alt="image" src="https://github.com/user-attachments/assets/a0d1e95e-0a9d-4552-977a-0ad9686867b8" />

</td>
<td>
<img width="456" height="517" alt="image" src="https://github.com/user-attachments/assets/40d04ac4-9ffc-4f81-a063-31b3ea26b4e1" />
</td>
</tr>
</table>

opw-5363916

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
