### PR TITLE
[FIX] point_of_sale: sync all event registration answers

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models/model_defs.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/model_defs.js
@@ -60,6 +60,11 @@ export function processModelDefs(modelDefs) {
                 let inverseField = Object.values(relationModel).find(
                     (f) => f.relation === model && f.name === field.inverse_name
                 );
+                if (inverseMap.has(inverseField)) {
+                    throw new Error(
+                        `Invalid relational field definition: many2one '${field.relation}.${field.inverse_name}' has multiple one2many inverses. Only one inverse one2many field is allowed.`
+                    );
+                }
                 if (!inverseField) {
                     const backRefName = getBackRef(model, field.name);
                     inverseField = {

--- a/addons/pos_event/models/event_registration.py
+++ b/addons/pos_event/models/event_registration.py
@@ -35,7 +35,7 @@ class EventRegistration(models.Model):
     @api.model
     def _load_pos_data_fields(self, config):
         return ['id', 'event_id', 'event_ticket_id', 'event_slot_id', 'pos_order_line_id', 'pos_order_id', 'phone',
-                'company_name', 'email', 'name', 'registration_answer_ids', 'registration_answer_choice_ids', 'write_date']
+                'company_name', 'email', 'name', 'registration_answer_ids', 'write_date']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -7,12 +7,11 @@ import * as EventTourUtils from "@pos_event/../tests/tours/utils/event_tour_util
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("SellingEventInPos", {
+registry.category("web_tour.tours").add("SellingEventInPosWithChoiceAnswers", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
             // Confirm popup - There isn't enough tickets available
             ProductScreen.clickDisplayedProduct("My Awesome Event"),
             EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
@@ -39,6 +38,28 @@ registry.category("web_tour.tours").add("SellingEventInPos", {
             FeedbackScreen.printTicket("Full Page"),
             FeedbackScreen.printTicket("Badge"),
             FeedbackScreen.clickNextOrder(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("SellingEventInPosWithTextAnswers", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            // Buy a VIP Ticket
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            Dialog.confirm(),
+            EventTourUtils.answerGlobalTextQuestion("Text Box 1", "TB1-Answer"),
+            EventTourUtils.answerTicketQuestion("1", "Text Box 2", "T1-TB2-Answer"),
+            EventTourUtils.answerTicketQuestion("2", "Text Box 2", "T2-TB2-Answer"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("400.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.00" }),
+            PaymentScreen.clickValidate(),
+            FeedbackScreen.isShown(),
         ].flat(),
 });
 

--- a/addons/pos_event/static/tests/tours/utils/event_tour_utils.js
+++ b/addons/pos_event/static/tests/tours/utils/event_tour_utils.js
@@ -39,6 +39,16 @@ export function answerGlobalSelectQuestion(question, answer) {
     ];
 }
 
+export function answerTicketQuestion(ticketNumber, question, answer) {
+    return [
+        {
+            content: `Answer question ${question} with ${answer} for ticket ${ticketNumber}`,
+            trigger: `.ticket_question:contains('Ticket #${ticketNumber}') .input-group:contains('${question}') input`,
+            run: `edit ${answer}`,
+        },
+    ];
+}
+
 export function answerGlobalTextQuestion(question, answer) {
     return [
         {

--- a/addons/pos_event/static/tests/unit/data/event_registration.data.js
+++ b/addons/pos_event/static/tests/unit/data/event_registration.data.js
@@ -17,7 +17,6 @@ export class EventRegistration extends models.ServerModel {
             "email",
             "name",
             "registration_answer_ids",
-            "registration_answer_choice_ids",
             "write_date",
         ];
     }

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -106,6 +106,20 @@ class TestUi(TestPointOfSaleHttpCommon):
             "iface_available_categ_ids": [(6, 0, [self.event_category.id])],
         })
         self.test_event.write({
+            'seats_max': 4,
+            'event_ticket_ids': [(1, self.test_event.event_ticket_ids[1].id, {'seats_max': 3})],
+            'question_ids': [
+                Command.create({'title': 'Text Box 1', 'question_type': 'text_box', 'once_per_order': True}),
+                Command.create({'title': 'Text Box 2', 'question_type': 'text_box'}),
+            ],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('SellingEventInPosWithTextAnswers')
+        order = self.main_pos_config.session_ids.order_ids[:1]
+        event_registration = order.lines[0].event_registration_ids
+        self.assertEqual(len(event_registration.registration_answer_ids), 4)
+        self.assertEqual(event_registration.registration_answer_ids.mapped("value_text_box"), ['TB1-Answer', 'T2-TB2-Answer', 'TB1-Answer', 'T1-TB2-Answer'])
+        self.test_event.write({
             'question_ids': [Command.create({
                 'title': 'Question3',
                 'question_type': 'simple_choice',
@@ -118,7 +132,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             })]
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui/%d" % self.main_pos_config.id, 'SellingEventInPos', login="pos_user")
+        self.start_pos_tour('SellingEventInPosWithChoiceAnswers')
 
         order = self.env['pos.order'].search([], order='id desc', limit=1)
         event_registration = order.lines[0].event_registration_ids

--- a/addons/pos_self_order_event/static/src/app/pages/event_page/event_page.js
+++ b/addons/pos_self_order_event/static/src/app/pages/event_page/event_page.js
@@ -406,8 +406,10 @@ export class EventPage extends Component {
                 event_slot_id: this.event.is_multi_slots ? this.state.selectedSlot : null,
                 pos_order_line_id: line,
                 partner_id: this.selfOrder.currentOrder.partner_id,
-                registration_answer_ids: this.formatTextAnswers(textAnswer),
-                registration_answer_choice_ids: this.formatChoiceAnswers(simpleChoice),
+                registration_answer_ids: [
+                    ...this.formatTextAnswers(textAnswer),
+                    ...this.formatChoiceAnswers(simpleChoice),
+                ],
             });
         }
     }
@@ -427,8 +429,7 @@ export class EventPage extends Component {
             }
             if (question.question_type === "simple_choice") {
                 simpleChoice[questionId] = value;
-            }
-            if (value) {
+            } else if (value) {
                 textAnswer[questionId] = value;
             }
         }


### PR DESCRIPTION
## Steps to reproduce:
- Configure event registration with only free-text fields (no selection field).
- Open the POS, add an event ticket product, and fill in the registration form.
- Click Payment and validate the order.

## Issue:
- Registration answers were sent to the backend only if at least one selection-type question was filled.
- If no selection field was present, free-text answers were not sent at all.

## Cause:
- The `registration_answer_ids` and `registration_answer_choice_ids` One2many fields on EventRegistration both point to the same `registration_id` Many2one field on EventRegistrationAnswer.
https://github.com/odoo/odoo/blob/c738d049fe09101bd14dce0710c2659a4a6eca39/addons/event/models/event_registration.py#L83-L85
- This caused data loss during the POS model synchronization, as entries were overwritten in the `inverseMap`.
https://github.com/odoo/odoo/blob/c738d049fe09101bd14dce0710c2659a4a6eca39/addons/point_of_sale/static/src/app/models/related_models/model_defs.js#L59-L75

## Fix:
-  Send all free-text and selection answers through `registration_answer_ids` and  stop using `registration_answer_choice_ids` in POS to avoid inverse ambiguity.
- Add a safeguard to enforce POS constraints by raising an error when a  One2many relation has more than one inverse, preventing silent data loss.

task-5438565

