### PR TITLE
[FIX] stock_account,_*: show Return button only for done or linked pickings

### DIFF
--- a/addons/purchase_stock/views/stock_picking_views.xml
+++ b/addons/purchase_stock/views/stock_picking_views.xml
@@ -12,4 +12,15 @@
         </xpath>
     </template>
 
+    <record model="ir.ui.view" id="view_picking_form">
+        <field name="name">purchase.stock.view.picking.form</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"></field>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="attributes">
+                <attribute name="invisible" separator="and" add="not purchase_id"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/sale_stock/views/stock_picking_views.xml
+++ b/addons/sale_stock/views/stock_picking_views.xml
@@ -25,6 +25,9 @@
             <xpath expr="//field[@name='move_type']" position="before">
                 <field name="sale_id"/>
             </xpath>
+            <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="attributes">
+                <attribute name="invisible" separator="and" add="not sale_id"/>
+            </xpath>
         </field>
     </record>
 

--- a/addons/stock_account/views/stock_picking_views.xml
+++ b/addons/stock_account/views/stock_picking_views.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <!-- TODO remove in master -->
     <record model="ir.ui.view" id="view_picking_form">
         <field name="name">stock.account.view.picking.form</field>
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form"></field>
+        <field name="active" eval="False"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="attributes">
                 <attribute name="invisible">0</attribute>


### PR DESCRIPTION
_*= sale_stock, purchase_stock

Steps to Reproduce:
- Create a Helpdesk ticket.
- Click Replace, and the picking form opens.
- Add product lines to the picking to deliver to the customer.
- Observe that the Return button is visible and shows a warning when clicked, even though the picking is not in Done state.

Cause:
- When `stock_account` is installed, the Return button visibility is overridden to always show (`invisible=0`), ignoring the original condition (`state != 'done'`).

Solution:
- Restore the Return button visibility to its original condition so it’s only shown when the picking is Done or when picking is linked to any PO or SO.

task-5075584


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
