### PR TITLE
[FIX] website: fix mega menu nav item alignment

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -695,6 +695,10 @@
     <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
         <attribute name="_div_class.f">mt-2 text-center</attribute>
     </xpath>
+    <xpath expr="//t[@t-call='website.submenu']" position="attributes">
+        <attribute name="dropdown_toggler_classes.f"/>
+        <attribute name="dropdown_menu_classes.f" add="text-center" separator=" "/>
+    </xpath>
 </template>
 
 <template id="template_header_hamburger_mobile_align_right" inherit_id="website.template_header_hamburger" active="False">
@@ -706,6 +710,10 @@
     </xpath>
     <xpath expr="//t[@t-call='website.placeholder_header_social_links']" position="attributes">
         <attribute name="_div_class.f">mt-2 text-end</attribute>
+    </xpath>
+    <xpath expr="//t[@t-call='website.submenu']" position="attributes">
+        <attribute name="dropdown_toggler_classes.f"/>
+        <attribute name="dropdown_menu_classes.f" add="text-end" separator=" "/>
     </xpath>
 </template>
 


### PR DESCRIPTION
The PR [1] updated the templates for many headers to adapt the nav-item
positions in desktop/mobile views. However, the hamburger menu was not
updated correctly. In the desktop view, the mega menu toggle elements
were not aligned properly (unlike in the mobile view).

This commit fixes the PR by adding the necessary <xpath>.

Steps to reproduce the issue:
- Go to Website
- Add a Mega Menu (edit menu)
- Click on the header
- Set the template to "Hamburger"
- Set the text alignment to center for the desktop view
=> The mega menu toggle is not centered.

task-5416632

---------------------------------------------
[1]: https://github.com/odoo/odoo/pull/225672