### PR TITLE
[IMP] payment: Add _rec_name_search to prevent display_name search warning

### DIFF
--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -11,6 +11,7 @@ class PaymentToken(models.Model):
     _order = 'partner_id, id desc'
     _description = 'Payment Token'
     _check_company_auto = True
+    _rec_names_search = ['payment_details', 'partner_id', 'provider_id']
 
     provider_id = fields.Many2one(string="Provider", comodel_name='payment.provider', required=True)
     provider_code = fields.Selection(string="Provider Code", related='provider_id.code')


### PR DESCRIPTION
address this warning:
`2026-01-07 04:53:23,985 3407309 WARNING v18c_... odoo.models: Cannot search on display_name, no _rec_name or _rec_names_search defined on payment.token`