### PR TITLE
[FIX] website_links: fix link tracker verification

### DIFF
--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -316,6 +316,7 @@ publicWidget.registry.websiteLinks = publicWidget.Widget.extend({
         }
         utmForm.classList.remove("d-none");
         document.querySelector("#generated_tracked_link").classList.add("d-none");
+        document.querySelector("input#url").disabled = "";
         document.querySelector("#btn_shorten_url").classList.remove("d-none");
         document.querySelector("input#url").value = '';
     },
@@ -370,6 +371,7 @@ publicWidget.registry.websiteLinks = publicWidget.Widget.extend({
                 var link = result[0];
 
                 document.querySelector("#generated_tracked_link").classList.remove("d-none");
+                document.querySelector("input#url").disabled = "disabled";
                 document.querySelector("#btn_shorten_url").classList.add("d-none");
 
                 document.querySelector(".copy-to-clipboard").dataset.clipboardText = link.short_url;

--- a/addons/website_links/static/src/js/website_links_code_editor.js
+++ b/addons/website_links/static/src/js/website_links_code_editor.js
@@ -67,16 +67,21 @@ publicWidget.registry.websiteLinksCodeEditor = publicWidget.Widget.extend({
      */
     _submitCode: function () {
         var initCode = $('#edit-code-form #init_code').val();
-        var newCode = $('#edit-code-form #new_code').val();
+        var newCode = $("#edit-code-form #new_code").val();
+        var formattedNewCode = newCode.replace(/[^a-zA-Z0-9_-]/g, "");
         var self = this;
+
+        if (formattedNewCode !== newCode) {
+            self.$('.o_website_links_code_error').text(_t("Only letters (A–Z, a–z), numbers (0–9), underscores (_) and hyphens (-) are allowed. No spaces."));
+            self.$('.o_website_links_code_error').show();
+            return;
+        }
 
         if (newCode === '') {
             self.$('.o_website_links_code_error').html(_t("The code cannot be left empty"));
             self.$('.o_website_links_code_error').show();
             return;
         }
-
-        this._showNewCode(newCode);
 
         if (initCode === newCode) {
             this._showNewCode(newCode);

--- a/addons/website_links/static/src/js/website_links_code_editor.js
+++ b/addons/website_links/static/src/js/website_links_code_editor.js
@@ -67,16 +67,21 @@ publicWidget.registry.websiteLinksCodeEditor = publicWidget.Widget.extend({
      */
     _submitCode: function () {
         var initCode = $('#edit-code-form #init_code').val();
-        var newCode = $('#edit-code-form #new_code').val();
+        var newCode = $("#edit-code-form #new_code").val();
+        var formattedNewCode = newCode.replace(/[^a-zA-Z0-9_-]/g, "");
         var self = this;
+
+        if (formattedNewCode !== newCode) {
+            self.$('.o_website_links_code_error').html(_t("Only letters (A–Z, a–z), numbers (0–9), underscores (_) and hyphens (-) are allowed. No spaces."));
+            self.$('.o_website_links_code_error').show();
+            return;
+        }
 
         if (newCode === '') {
             self.$('.o_website_links_code_error').html(_t("The code cannot be left empty"));
             self.$('.o_website_links_code_error').show();
             return;
         }
-
-        this._showNewCode(newCode);
 
         if (initCode === newCode) {
             this._showNewCode(newCode);


### PR DESCRIPTION
This commit removes the possibility to create link tracker with an empty code since they wouldn't work but would still appear in the list.

This commit also fixes the error message that would disappear even if the code is still not valid.

Steps:
- Go to the link tracker page
- Create a first tracker with the code "ABC"
- Create another tracker
- Edit the code to be "ABC". An error appears (duplicated code)
- Edit the code to be empty. An error appears (empty code)
- Edit the code to be "ABC". There is no error, yet the code cannot be submitted.

task-4531974