### PR TITLE
[IMP] base,http,web: detect untrusted devices

### DIFF
--- a/addons/auth_timeout/models/ir_http.py
+++ b/addons/auth_timeout/models/ir_http.py
@@ -51,7 +51,7 @@ class IrHttp(models.AbstractModel):
                         if first_fa:
                             timestamp_1fa, auth_method_1fa = first_fa
                             if timestamp_1fa > threshold:
-                                reauth_requirements["1fa_method"] = auth_method_1fa
+                                reauth_requirements["first_fa_method"] = auth_method_1fa
                     break
         return reauth_requirements
 

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -92,8 +92,16 @@ class IrHttp(models.AbstractModel):
             DEFAULT_MAX_CONTENT_LENGTH,
         )
         is_internal_user = user._is_internal()
+
+        device_salt = (
+            request.session.get('_device_salt', False)  # TODO (v20): remove backward compatibility
+            if IrConfigSudo.get_bool('base.session_check_device') and session_uid
+            else False
+        )
+
         session_info = {
             "uid": session_uid,
+            "device_salt": device_salt,
             "is_system": user._is_system() if session_uid else False,
             "is_admin": user._is_admin() if session_uid else False,
             "is_public": user._is_public(),


### PR DESCRIPTION
The session cookie allows the user to be authenticated and interact as such. If a user's session cookie is stolen by an attacker, the latter gains full control over the user's account.

Currently, a session rotation mechanism ensures that a session cookie expires after a certain amount of time. However, if a session cookie is stolen and used immediately, the session remains active and if rotation occurs, the attacker will continue to have a valid session cookie.

This commit introduces a mechanism that acts immediately if a session cookie is stolen and used.

The strategy is to maintain the devices using the session in the session data. From a technical point of view, a device is determined by the IP address-user agent pair. If a new device is detected for a session, it is potentially another physical machine using the session cookie. In this case, the user must re-authenticate[^1].

As mentioned, since a device depends on the IP address, re-authentication would be required for each new IP address detected. This would block the user too frequently, so it is not a viable solution.

When re-authentication is required, we will first attempt to re-authenticate the user automatically (without blocking from a UX perspective). To do this, we use the fingerprint specific to the physical machine[^2]. If the fingerprint matches the machine that created the session, we do not explicitly ask the user to re-authenticate. This is because a session is only supposed to be used by a single physical machine. If implicit re-authentication with the fingerprint fails (due to a change in machine or other reasons), we display a re-authentication window in the UX interface.

When re-authentication is requested, it blocks the current request. Even if we resolve re-authentication automatically, the request must be replayed (from a UX perspective, we have to click again if necessary). To avoid this "issue" during the login, the first device detected for a session will always be trusted. However, it is necessary to send the fingerprint of this trusted machine to the server. This is done when the backend webclient is loaded (which is the case after login). If a trusted machine sends a different fingerprint (due to variable parameters), the fingerprint in the session data is updated. Consequently, a session used from a trusted machine (the one who created the session) will never be blocked with a re-authentication window.

Since it detects changes in user-agents, automatic validation of the same physical machine means that developers who switch between desktop and mobile views for development are not affected (will only need to replay the action when the user agent changes the first time).

Regarding anti-fingerprinting techniques, some browsers have the feature of modifying the fingerprint in order to avoid being tracked. Regardless of the fingerprint generated, if the user proves their identity, the device will be accepted. Since the fingerprint is stored in RAM, the user will not experience any disruption after verification. Re-authentication will be required for each new browser process (which is acceptable).

This feature can be activated with the config parameter: `base.session_check_device`.
This mechanism applies only to internal users.
This mechanism only works when the request uses a route with `'user'` authentication.

This commit was made possible thanks to:
- https://github.com/odoo/odoo/commit/87592b98d631a07563dda5e51c0b0f4102ca2a9b
- https://github.com/odoo/odoo/commit/b6c2aafae2112ef98edca8a7f027716d9c15be11

Source:
[Canvas Fingerprint (further reading)](https://browserleaks.com/canvas)

[^1]: Re-authentication is different from authentication. Re-authentication does not modify the current session (the cookie and data). If re-authentication fails, the user is logged out.

[^2]: The fingerprint used is the canvas fingerprint. This technique uses the way a browser draws images or text on an HTML5 `<canvas>` element. Rendering differences occur depending on the system and hardware, which makes it possible to obtain a "unique" identifier for a physical machine. The fingerprint is stored in the client's RAM and in the session data in the filesystem. It is very difficult to steal it. In addition, it will be unique for each machine-session pair thanks to a random number used in the rendering. _This fingerprint is used solely for the purpose of preventing users from having their accounts stolen, and not for any other purpose._

Task-4281529