### PR TITLE
[FIX] l10n_th: make branch name translatable according to language set on partner.

### DIFF
--- a/addons/l10n_th/models/res_partner.py
+++ b/addons/l10n_th/models/res_partner.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, fields
 
+
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
@@ -13,4 +14,5 @@ class ResPartner(models.Model):
                 partner.l10n_th_branch_name = ""
             else:
                 code = partner.company_registry
-                partner.l10n_th_branch_name = f"Branch {code}" if code else "Headquarter"
+                partner.l10n_th_branch_name = partner.env._("Branch %(code)s", code=code) if code else partner.env._(
+                    "Headquarter")


### PR DESCRIPTION
Currently, l10n_th_branch_name is not translatable. Regardless of the language setting, it is printed in English on the tax invoice. This PR addresses that.

Task-5438534

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
