### PR TITLE
[FIX] html_editor: avoid failing when no inserted content remains and when selection nodes are disconnected

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -441,18 +441,16 @@ export class DomPlugin extends Plugin {
                 candidateForRemoval.remove();
             }
         }
-        for (const insertedNode of allInsertedNodes.reverse()) {
-            if (insertedNode.isConnected) {
-                currentNode = insertedNode;
-                break;
-            }
+        const lastInsertedNode = allInsertedNodes.findLast((node) => node.isConnected);
+        if (!lastInsertedNode) {
+            return;
         }
         let lastPosition =
-            isParagraphRelatedElement(currentNode) ||
-            isListItemElement(currentNode) ||
-            isListElement(currentNode)
-                ? rightPos(lastLeaf(currentNode))
-                : rightPos(currentNode);
+            isParagraphRelatedElement(lastInsertedNode) ||
+            isListItemElement(lastInsertedNode) ||
+            isListElement(lastInsertedNode)
+                ? rightPos(lastLeaf(lastInsertedNode))
+                : rightPos(lastInsertedNode);
         lastPosition = normalizeCursorPosition(lastPosition[0], lastPosition[1], "right");
 
         if (!this.config.allowInlineAtRoot && this.isEditionBoundary(lastPosition[0])) {

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -432,6 +432,9 @@ export class FormatPlugin extends Plugin {
     removeEmptyInlineElement(selectionData) {
         const { anchorNode } = selectionData.editableSelection;
         const blockEl = closestBlock(anchorNode);
+        if (!blockEl) {
+            return;
+        }
         const inlineElement = findFurthest(
             closestElement(anchorNode),
             blockEl,

--- a/addons/html_editor/static/tests/utils/dom.test.js
+++ b/addons/html_editor/static/tests/utils/dom.test.js
@@ -397,3 +397,12 @@ describe("fillEmpty", () => {
         expect(el.innerHTML).toBe('<div data-oe-protected="true" contenteditable="false"></div>');
     });
 });
+
+describe("crash fixes", () => {
+    test("inserting a br should not crash", async () => {
+        const { el, editor } = await setupEditor("<p>a[]</p>");
+        const br = document.createElement("br");
+        editor.shared.dom.insert(br);
+        expect(getContent(el)).toBe("<p>a[]</p>");
+    });
+});


### PR DESCRIPTION
During an `DomPlugin.insert`, the inserted content is added.
Then some transformations are applied to clean up, including the
removal of some nodes which are inventoried into
`candidatesForRemoval`, and some specific `<br>` nodes.
Ultimately, the selection is set after the last inserted node.

In some cases, none of the inserted content remains after the clean up.
When this happens, the selection is being set after the last
inserted node, which is not part of the DOM anymore, and therefore
leads to an error.

This commit prevents this from happening by detecting when all inserted
content was actually already removed.

Steps to reproduce:
- In a plain web page, copy a <br> into the clipboard
- In an editor, put a character on a line
- Paste

=> An error popup was displayed

task-5429909

[FIX] html_editor: avoid failing when selection nodes are disconnected

This commit addresses a traceback that was spotted but for which the
actual scenario remains undetermined.
The only possible way this traceback may occur is if nodes inside a
selection are disconnected.

The test added by this commit produces the same traceback as the
observed one.

task-5429909