### PR TITLE
[FIX] website_slides: fix html escaping in cached quiz description

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_service.js
+++ b/addons/website_slides/static/src/js/slides_course_service.js
@@ -49,6 +49,7 @@ const websiteSlidesService = {
                 karmaGain: undefined,
                 karmaWon: undefined,
                 karmaMax: undefined,
+                desciption: undefined,
                 descriptionSafe: undefined,
                 slideResources: [],
                 rankProgress: undefined,
@@ -137,9 +138,7 @@ const websiteSlidesService = {
                     });
                     Object.assign(data.quiz, {
                         sessionAnswers: quizData.session_answers || [],
-                        descriptionSafe: quizData.slide_description
-                            ? markup(quizData.slide_description)
-                            : "",
+                        description: quizData.description || "",
                         questions: quizData.slide_questions || [],
                         questionCount: quizData.slide_questions.length,
                         attemptsCount: quizData.quiz_attempts_count || 0,
@@ -149,6 +148,7 @@ const websiteSlidesService = {
                         slideResources: quizData.slide_resource_ids || [],
                     });
                 }
+                data.quiz.descriptionSafe = markup(data.quiz.description || "");
                 quizCache[data.slide.id] = structuredClone(data.quiz);
                 data.slide.hasQuestion = data.quiz.questionCount > 0;
             },


### PR DESCRIPTION
When a user navigates away from a course quiz page and comes back, the quiz data is retrieved from a local cache to avoid reloading it.

However, the caching mechanism stores the field as a String. As a result, when the data is restored from the cache, it escapes the HTML tags, displaying them to the user instead of rendering the formatting.

This commit ensures that the markup is re-applied to the description when retrieving the quiz from the cache.

Steps to reproduce:
1. Open a Course Slide that has a Quiz with a formatted description (e.g., bold text).
2. Navigate to the next Slide.
3. Navigate back to the previous Slide.
4. The description now displays raw HTML tags (e.g., `<b>text</b>`) instead of the formatted text.

Task-5452792

