### PR TITLE
[FIX] hr_attendance: prevent error when creating an attendance for employee

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -525,9 +525,11 @@ class HrAttendanceOvertimeRule(models.Model):
                     stop_datetime = datetime.combine(interval[0].date(), float_to_time(stop))
                     timing_intervals = Intervals([(start_datetime, stop_datetime, self.env['resource.calendar'])])
                     if rule.timing_start > rule.timing_stop:
+                        day_start = datetime.combine(interval[0].date(), datetime.min.time())
+                        day_end = datetime.combine(interval[0].date(), datetime.max.time())
                         timing_intervals = Intervals([
                             (i_start, i_stop, self.env['resource.calendar'])
-                        for i_start, i_stop in invert_intervals([(start_datetime, stop_datetime)], 0, 23.99)])
+                        for i_start, i_stop in invert_intervals([(start_datetime, stop_datetime)], day_start, day_end)])
                     timing_intervals_by_employee[employee] |= timing_intervals
             return timing_intervals_by_employee
 

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1096,3 +1096,18 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2021, 1, 4, 20, 0)
         })
         self.assertTrue(attendance.with_user(user1).linked_overtime_ids.rule_ids.has_access("read"))
+
+    def test_attendance_overtime_with_timing_rule_cross_midnight(self):
+        """Test attendance creation when the overtime timing rule crosses midnight."""
+        self.employee.ruleset_id.rule_ids.base_off = 'timing'
+        self.employee.ruleset_id.rule_ids.timing_start = 14
+        self.employee.ruleset_id.rule_ids.timing_stop = 5
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2021, 1, 4, 8, 0),
+            'check_out': datetime(2021, 1, 4, 18, 0)
+        })
+
+        self.assertEqual(attendance.worked_hours, 9.0)
+        self.assertEqual(attendance.overtime_hours, 4.0)
+        self.assertEqual(attendance.expected_hours, 5.0)


### PR DESCRIPTION
Currently, an error occurs when a user creates an attendance for an employee.

**Steps to Reproduce ([Video](https://drive.google.com/file/d/1vm89hHBOVcliYwZjP7fwNOzwC68V3B1l/view)):**
 - Install the `hr_attendance` module.
 - Go to `Overtime Rulesets` and create a `new overtime ruleset` by adding an `overtime rule`. 
    Set Based on to `Timing`. 
    Set the `Start time greater than the Stop time` (ex, Start = 10 and Stop = 5).
 - Go to `Employees`, open `any employee record`, and assign this `Overtime Ruleset` to the employee.
 - Now go to `Attendances` and `create an attendance` for that employee.

`TypeError: '>' not supported between instances of 'datetime.datetime' and 'int'`

**Cause:**
This error occurs when a user sets the overtime rule on an employee and then creates an attendance. At that point, the system tries to calculate the overtime intervals based on the timing rule. Because the rule’s start time is greater than the stop time, it attempts to calculate the interval for the remaining working period of the day. However, the start date and end date are calculated in datetime format [1], while integer and float values are passed as arguments [2] for day in interval calulation. Since the interval expects values of the same data type, than it raise the error [3].

**Fix:**
This commit ensures that the day start and day end values are passed in datetime format.

[1]: https://github.com/odoo/odoo/blob/67191cf0915081df352331a698be47b7e3ecd505/addons/hr_attendance/models/hr_attendance_overtime_rule.py#L524

[2]- https://github.com/odoo/odoo/blob/67191cf0915081df352331a698be47b7e3ecd505/addons/hr_attendance/models/hr_attendance_overtime_rule.py#L530

[3]: https://github.com/odoo/odoo/blob/67191cf0915081df352331a698be47b7e3ecd505/odoo/tools/intervals.py#L138-L154

sentry-7166788786

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
