### PR TITLE
[IMP] l10n_dk_nemhandel: disallow 'DK' prefix for CVR number

### DIFF
--- a/addons/l10n_dk/models/res_partner.py
+++ b/addons/l10n_dk/models/res_partner.py
@@ -13,7 +13,7 @@ class ResPartner(models.Model):
         for partner in self.filtered(lambda p: p.country_id.code == 'DK' and p.vat):
             vat_country, vat_number = self._split_vat(partner.vat)
             if vat_country in ('DK', '') and self._check_vat_number('DK', vat_number):
-                partner.company_registry = vat_number
+                partner.company_registry = vat_number[2:] if vat_number.upper().startswith('DK') else vat_number
 
     @api.depends('country_id.code', 'ref_company_ids.account_fiscal_country_id.code')
     def _compute_company_registry_placeholder(self):

--- a/addons/l10n_dk_nemhandel/models/res_partner.py
+++ b/addons/l10n_dk_nemhandel/models/res_partner.py
@@ -96,6 +96,15 @@ class ResPartner(models.Model):
         if self.filtered(lambda partner: partner.invoice_edi_format != 'oioubl_21' and partner.invoice_sending_method == 'nemhandel'):
             raise ValidationError(_('On Nemhandel, only OIOUBL 2.1 is supported.'))
 
+    @api.constrains('nemhandel_identifier_type', 'nemhandel_identifier_value')
+    def _check_nemhandel_identifier_value(self):
+        for partner in self:
+            if (
+                partner.nemhandel_identifier_type == '0184' and
+                partner.nemhandel_identifier_value and
+                partner.nemhandel_identifier_value.upper().startswith('DK')
+            ):
+                raise ValidationError(_('The Nemhandel Identifier Value should not include the country code prefix "DK" when the Identifier Type is CVR.'))
     # -------------------------------------------------------------------------
     # OVERRIDE AND HELPERS
     # -------------------------------------------------------------------------

--- a/addons/l10n_dk_nemhandel/models/res_partner.py
+++ b/addons/l10n_dk_nemhandel/models/res_partner.py
@@ -74,7 +74,8 @@ class ResPartner(models.Model):
                 continue
             country_code = partner._deduce_country_code()
             if country_code == 'DK' and partner.nemhandel_identifier_type == '0184':
-                partner.nemhandel_identifier_value = partner.company_registry
+                vat_country, vat_number = partner._split_vat(partner.company_registry or '')
+                partner.nemhandel_identifier_value = vat_number if vat_country == 'DK' else partner.company_registry
             elif country_code == 'DK':
                 partner.nemhandel_identifier_value = partner.nemhandel_identifier_value
             else:


### PR DESCRIPTION
Before this PR:
- When a user enters a full VAT number with the 'DK' prefix in the company registry, the Nemhandel identifier becomes incorrect and results in a cryptic error being returned to the client.

After this PR:
- An error is raised if the CVR contains the 'DK' country code prefix, to ensure the correctness of the Nemhandel identifier.

Task: 5449059

