### PR TITLE
[IMP] web: offline: disable menus, view switchers and records

### DIFF
--- a/addons/calendar/static/src/views/calendar_form/calendar_form_model.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_form_model.js
@@ -4,7 +4,6 @@ import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { Record } from "@web/model/relational_model/record";
 
 class CalendarFormRecord extends Record {
-
     async setLocation() {
         const videoLocation = await this.model.discussVideocallLocation;
         this.update({
@@ -24,6 +23,7 @@ class CalendarFormRecord extends Record {
 
 export class CalendarFormModel extends RelationalModel {
     static Record = CalendarFormRecord;
+    static withCache = false;
 
     setup() {
         super.setup(...arguments);

--- a/addons/mail/static/src/views/web/activity/activity_model.js
+++ b/addons/mail/static/src/views/web/activity/activity_model.js
@@ -2,6 +2,7 @@ import { RelationalModel } from "@web/model/relational_model/relational_model";
 
 export class ActivityModel extends RelationalModel {
     static DEFAULT_LIMIT = 100;
+    static withCache = false;
 
     async load(params = {}) {
         this.originalDomain = params.domain ? [...params.domain] : [];

--- a/addons/web/models/ir_ui_view.py
+++ b/addons/web/models/ir_ui_view.py
@@ -13,7 +13,6 @@ class IrUiView(models.Model):
                 'display_name': display_name,
                 'icon': _view_info[type_]['icon'],
                 'multi_record': _view_info[type_].get('multi_record', True),
-                'available_offline': _view_info[type_].get('available_offline', False),
             }
             for (type_, display_name)
             in self.fields_get(['type'], ['selection'])['type']['selection']
@@ -22,11 +21,11 @@ class IrUiView(models.Model):
 
     def _get_view_info(self):
         return {
-            'list': {'icon': 'oi oi-view-list', 'available_offline': True},
-            'form': {'icon': 'fa fa-address-card', 'multi_record': False, 'available_offline': True},
+            'list': {'icon': 'oi oi-view-list'},
+            'form': {'icon': 'fa fa-address-card', 'multi_record': False},
             'graph': {'icon': 'fa fa-area-chart'},
             'pivot': {'icon': 'oi oi-view-pivot'},
-            'kanban': {'icon': 'oi oi-view-kanban', 'available_offline': True},
+            'kanban': {'icon': 'oi oi-view-kanban'},
             'calendar': {'icon': 'fa fa-calendar'},
             'search': {'icon': 'oi oi-search'},
         }

--- a/addons/web/static/src/core/offline/offline_error.js
+++ b/addons/web/static/src/core/offline/offline_error.js
@@ -19,7 +19,7 @@ export function lostConnectionHandler(env, error, originalError) {
         return false;
     }
     if (originalError instanceof ConnectionLostError) {
-        env.services.offline.status.offline = true;
+        env.services.offline.offline = true;
         return true;
     }
 }

--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -1,107 +1,215 @@
-import { reactive, useState } from "@odoo/owl";
+import { markRaw } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { ConnectionLostError, rpc, rpcBus } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
-import { useService } from "@web/core/utils/hooks";
+import { IndexedDB } from "@web/core/utils/indexed_db";
+import { Reactive } from "@web/core/utils/reactive";
+import { session } from "@web/session";
 
-const SELECTORS_TO_DISABLE = [
-    "button:not([data-available-offline]):not([disabled])",
-    "input[type='checkbox']:not([data-available-offline]):not([disabled])",
-];
+class OfflineManager extends Reactive {
+    static TABLE_NAME = "visited-ui-items";
+    static TABLE_NAME_DEBUG = "visited-ui-items-debug";
 
-function offlineUI() {
-    document.querySelectorAll(SELECTORS_TO_DISABLE.join(", ")).forEach((el) => {
-        el.setAttribute("disabled", "");
-        el.classList.add("o_disabled_offline");
-    });
-}
+    static SELECTORS_TO_DISABLE = [
+        "button:not([data-available-offline]):not([disabled])",
+        "input[type='checkbox']:not([data-available-offline]):not([disabled])",
+    ];
 
-function onlineUI() {
-    document.querySelectorAll(".o_disabled_offline").forEach((el) => {
-        el.removeAttribute("disabled");
-        el.classList.remove("o_disabled_offline");
-    });
-}
+    constructor(env) {
+        super(...arguments);
 
-export const offlineService = {
-    async start() {
-        let timeout;
-        let observer;
+        this.env = env;
+        this._idb = markRaw(new IndexedDB("offline", session.registry_hash));
+        this._idbTable = this.env.debug
+            ? OfflineManager.TABLE_NAME_DEBUG
+            : OfflineManager.TABLE_NAME;
+        this._visited = {}; // stores items that are available offline (only populated when offline)
+        this._timeout = null; // used to repeatedly ping the server when offline
+        this._observer = null; // used to detect DOM mutations and disable the UI when offline
+        this._offline = false;
 
-        async function checkConnection() {
-            try {
-                await rpc("/web/webclient/version_info", {});
-            } catch {
-                status.offline = true;
-                return;
-            }
-            status.offline = false;
-        }
-
-        const status = reactive(
-            {
-                offline: false,
-            },
-            () => {
-                if (status.offline) {
-                    // Disable everything in the UI that isn't marked as available offline
-                    offlineUI();
-                    // Create an observer instance linked to the callback function to keep disabling
-                    // buttons that would appear in the DOM while being offline
-                    observer = new MutationObserver((mutationList) => {
-                        if (status.offline && mutationList.find((m) => m.addedNodes.length > 0)) {
-                            offlineUI();
-                        }
-                    });
-                    observer.observe(document.body, {
-                        childList: true, // listen for direct children being added/removed
-                        subtree: true, // also observe descendants (not just direct children)
-                    });
-
-                    // Repeatedly check if connection is back
-                    let delay = 2000;
-                    const _checkConnection = async () => {
-                        if (status.offline) {
-                            await checkConnection();
-                            // exponential backoff, with some jitter
-                            delay = delay * 1.5 + 500 * Math.random();
-                            timeout = browser.setTimeout(_checkConnection, delay);
-                        }
-                    };
-                    timeout = browser.setTimeout(_checkConnection, delay);
-                } else {
-                    onlineUI();
-                    observer?.disconnect();
-                    browser.clearTimeout(timeout);
-                }
-            }
-        );
-        status.offline; // activate the reactivity!
-
-        rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
-            status.offline = ev.detail.error instanceof ConnectionLostError;
-        });
-
+        // Use "offline" and "online" events for instant detection of connection lost/restored.
         browser.addEventListener("offline", () => {
-            if (!status.offline) {
-                checkConnection();
+            if (!this.offline) {
+                this.checkConnection();
             }
         });
         browser.addEventListener("online", () => {
-            if (status.offline) {
-                checkConnection();
+            if (this.offline) {
+                this.checkConnection();
             }
         });
 
-        return {
-            status,
-            checkConnection,
-        };
+        // Use RPC:RESPONSE to validate the current offline status, which is more accurate than
+        // the "offline"/"online" events (e.g. server is down).
+        rpcBus.addEventListener("RPC:RESPONSE", async (ev) => {
+            this.offline = ev.detail.error instanceof ConnectionLostError;
+        });
+
+        // When the "CLEAR-CACHES" event is triggered, the rpc cache is wiped out, so we must also
+        // clear the information about elements that are available offline, as they aren't anymore.
+        rpcBus.addEventListener("CLEAR-CACHES", () => {
+            this._idb.invalidate([OfflineManager.TABLE_NAME, OfflineManager.TABLE_NAME_DEBUG]);
+            this._visited = {};
+        });
+    }
+
+    get offline() {
+        return this._offline;
+    }
+
+    /**
+     * Sets the offline status.
+     *
+     * If we're going offline, we must get the information about actions, views, records that
+     * are available offline before toggling the status, such that the rest of the UI can
+     * synchronously access the information when rendering offline. As reading from indexeddb
+     * is async, we read everything once, and store it in an plain object. We also ensure that
+     * buttons and inputs in the UI that haven't been tagged as "available-offline" are
+     * disabled while being offline. Finally, we repeatedly try to ping the server to detect if
+     * connection is back.
+     *
+     * If we're going online, we re-enable the UI and update the offline status.
+     *
+     * @param {boolean} offline
+     */
+    set offline(offline) {
+        if (offline === this._offline) {
+            return;
+        }
+        this._offline = offline;
+        this._visited = {};
+        if (offline) {
+            // Disable everything in the UI that isn't marked as available offline.
+            this._offlineUI();
+            // Create an observer instance linked to the callback function to keep disabling
+            // elements that would appear in the DOM while being offline.
+            this._observer = new MutationObserver((mutationList) => {
+                if (this._offline && mutationList.find((m) => m.addedNodes.length > 0)) {
+                    this._offlineUI();
+                }
+            });
+            this._observer.observe(document.body, {
+                childList: true, // listen for direct children being added/removed
+                subtree: true, // also observe descendants (not just direct children)
+            });
+
+            // Repeatedly check if connection is back.
+            let delay = 2000;
+            const _checkConnection = async () => {
+                if (this._offline) {
+                    await this.checkConnection();
+                    // exponential backoff, with some jitter
+                    delay = delay * 1.5 + 500 * Math.random();
+                    this._timeout = browser.setTimeout(_checkConnection, delay);
+                }
+            };
+            this._timeout = browser.setTimeout(_checkConnection, delay);
+
+            // Retrieve the information about visited items from indexeddb.
+            this._idb.getAllKeys(this._idbTable).then((result) => {
+                if (offline !== this._offline) {
+                    return; // status changed again meanwhile
+                }
+                for (const r of result) {
+                    const value = JSON.parse(r);
+                    this._visited[value.action] = this._visited[value.action] || { views: {} };
+                    if (value.viewType === "form") {
+                        this._visited[value.action].views.form =
+                            this._visited[value.action].views.form || [];
+                        this._visited[value.action].views.form.push(value.resId);
+                    } else {
+                        this._visited[value.action].views[value.viewType] = true;
+                    }
+                }
+            });
+        } else {
+            this._onlineUI();
+            this._observer?.disconnect();
+            browser.clearTimeout(this._timeout);
+        }
+    }
+
+    /**
+     * Pings the server to check if it is reachable.
+     */
+    async checkConnection() {
+        try {
+            await rpc("/web/webclient/version_info", {});
+        } catch {
+            // just catch the error, the offline status will be updated with RPC:RESPONSE
+        }
+    }
+
+    /**
+     * Returns a boolean indicating whether the requested element is available offline, i.e.
+     * if it has been visited online and stored in cache.
+     *
+     * @param {number} actionId
+     * @param {"kanban"|"list"|"form"} [viewType]
+     * @param {number} [resId]
+     * @returns boolean
+     */
+    isAvailableOffline(actionId, viewType, resId) {
+        const action = this._visited[actionId];
+        if (!viewType) {
+            return !!action;
+        }
+        const view = action?.views[viewType];
+        if (viewType !== "form") {
+            return !!view;
+        }
+        return view?.includes(resId);
+    }
+
+    /**
+     * Mark an action, view type and optionally record as available offline.
+     *
+     * @param {number} actionId
+     * @param {"kanban"|"list"|"form"} viewType
+     * @param {Object} params
+     * @param {number} [params.resId] the record id, when viewType is "form"
+     */
+    async setAvailableOffline(actionId, viewType, { resId }) {
+        if (!this.offline) {
+            const key = JSON.stringify({ action: actionId, viewType, resId });
+            this._idb.write(this._idbTable, key, true);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private
+    // -------------------------------------------------------------------------
+
+    /**
+     * Disables interactive elements (e.g. buttons) that haven't been tagged as "available-offline".
+     *
+     * @private
+     */
+    _offlineUI() {
+        document.querySelectorAll(OfflineManager.SELECTORS_TO_DISABLE.join(", ")).forEach((el) => {
+            el.setAttribute("disabled", "");
+            el.classList.add("o_disabled_offline");
+        });
+    }
+
+    /**
+     * Re-enables elements that have previously been disabled by @_offlineUI.
+     *
+     * @private
+     */
+    _onlineUI() {
+        document.querySelectorAll(".o_disabled_offline").forEach((el) => {
+            el.removeAttribute("disabled");
+            el.classList.remove("o_disabled_offline");
+        });
+    }
+}
+
+export const offlineService = {
+    async start(env) {
+        return new OfflineManager(env);
     },
 };
 
 registry.category("services").add("offline", offlineService);
-
-export function useOfflineStatus() {
-    return useState(useService("offline").status);
-}

--- a/addons/web/static/src/core/offline/offline_systray.js
+++ b/addons/web/static/src/core/offline/offline_systray.js
@@ -1,7 +1,6 @@
 import { Component, useEffect } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
-import { useOfflineStatus } from "./offline_service";
 
 class OfflineSystray extends Component {
     static template = "web.OfflineSystray";
@@ -9,8 +8,7 @@ class OfflineSystray extends Component {
 
     setup() {
         this.offlineService = useService("offline");
-        this.status = useOfflineStatus();
-        useEffect(this.env.redrawNavbar, () => [this.status.offline]);
+        useEffect(this.env.redrawNavbar, () => [this.offlineService.offline]);
     }
 }
 

--- a/addons/web/static/src/core/offline/offline_systray.xml
+++ b/addons/web/static/src/core/offline/offline_systray.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.OfflineSystray">
-        <div t-if="status.offline" t-on-click="() => this.offlineService.checkConnection()">
+        <div t-if="this.offlineService.offline" t-on-click="() => this.offlineService.checkConnection()">
             <i t-if="env.isSmall"
                 class="fa fa-chain-broken o_nav_entry text-danger"
                 role="img"

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -142,7 +142,7 @@ export class Record extends DataPoint {
     }
 
     get isInEdition() {
-        if (this.model.offline.status.offline) {
+        if (this.model.offline.offline) {
             return false;
         }
         if (this.config.mode === "readonly") {

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -290,7 +290,7 @@ export class RelationalModel extends Model {
         }
         if (
             !this.isReady || // first load of the model
-            this.offline.status.offline || // use the cache if we are offline
+            this.offline.offline || // use the cache if we are offline
             // monorecord, loading a different id, or creating a new record (onchange)
             (config.isMonoRecord && (this.root.config.resId !== config.resId || !config.resId))
         ) {
@@ -298,6 +298,16 @@ export class RelationalModel extends Model {
                 type: "disk",
                 update: "always",
                 callback: async (result, hasChanged) => {
+                    const { actionId, viewType } = this.env.config;
+                    // TODO?: maybe mark available whatever result.length is, but store the length
+                    // in the value, and when considering filters to display (other PR), filter out
+                    // queries where result.length is 0
+                    const markAsAvailableOffline =
+                        actionId && (config.isMonoRecord ? config.resId : result.length);
+                    if (markAsAvailableOffline) {
+                        const params = config.isMonoRecord ? { resId: config.resId } : {};
+                        this.offline.setAvailableOffline(actionId, viewType, params);
+                    }
                     if (!hasChanged) {
                         return;
                     }

--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -110,6 +110,7 @@ export class ControlPanel extends Component {
 
     setup() {
         this.actionService = useService("action");
+        this.offlineService = useService("offline");
         this.pagerProps = this.env.config.pagerProps
             ? useState(this.env.config.pagerProps)
             : undefined;
@@ -404,6 +405,13 @@ export class ControlPanel extends Component {
         }
 
         this.oldScrollTop = scrollTop;
+    }
+
+    isViewAvailable(view) {
+        return (
+            !this.offlineService.offline ||
+            this.offlineService.isAvailableOffline(this.env.config.actionId, view.type)
+        );
     }
 
     /**

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -97,9 +97,9 @@
                                     <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
                                         <DropdownItem 
                                             tag="'button'"
-                                            attrs="{ 'data-available-offline': view.availableOffline}"
+                                            attrs="{ 'data-available-offline': this.isViewAvailable(view)}"
                                             onSelected="() => this.switchView(view.type)"
-                                            class="view.active ? 'selected' : ''">
+                                            class="{ 'selected': view.active }">
                                                 <i class="oi-fw" t-att-class="view.icon"/>
                                                 <span class="ms-1" t-out="view.name"/>
                                         </DropdownItem>
@@ -110,8 +110,9 @@
                         <nav t-else="" class="o_cp_switch_buttons d-print-none d-inline-flex btn-group">
                             <t t-foreach="env.config.viewSwitcherEntries" t-as="view" t-key="view.type">
                                 <button class="btn btn-secondary o_switch_view "
-                                    t-attf-class="o_{{view.type}} {{view.active ? 'active' : ''}}"
-                                    t-att-data-available-offline="view.availableOffline"
+                                    t-att-class="{ 'active': view.active }"
+                                    t-attf-class="o_{{view.type}}"
+                                    t-att-data-available-offline="this.isViewAvailable(view)"
                                     t-att-data-tooltip="view.name"
                                     t-custom-click="(ev, isMiddleClick) => this.switchView(view.type, isMiddleClick)"
                                     t-att-aria-label="view.name + ' View'"

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -13,7 +13,6 @@ import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useNavigation } from "@web/core/navigation/navigation";
-import { useOfflineStatus } from "@web/core/offline/offline_service";
 
 const parsers = registry.category("parsers");
 
@@ -69,6 +68,7 @@ export class SearchBar extends Component {
 
     setup() {
         this.dialogService = useService("dialog");
+        this.offlineService = useService("offline");
         this.fields = this.env.searchModel.searchViewFields;
         this.searchItemsFields = this.env.searchModel.getSearchItems((f) => f.type === "field");
         this.root = useRef("root");
@@ -86,8 +86,6 @@ export class SearchBar extends Component {
         // derived state
         this.items = useState([]);
         this.subItems = {};
-
-        this.offlineStatus = useOfflineStatus();
 
         this.facetContainerRef = useRef("facetContainerRef");
         this.menuRef = useChildRef();

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -86,7 +86,7 @@
     </t>
 
     <t t-name="web.SearchBar">
-        <div t-if="visibilityState.showSearchBar and !offlineStatus.offline" class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
+        <div t-if="visibilityState.showSearchBar and !offlineService.offline" class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
             <Dropdown
                 state="inputDropdownState"
                 manual="true"

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -1,5 +1,4 @@
 import { Domain } from "@web/core/domain";
-import { useOfflineStatus } from "@web/core/offline/offline_service";
 import { evaluateBooleanExpr, evaluateExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { utils } from "@web/core/ui/ui_service";
@@ -9,6 +8,7 @@ import { X2M_TYPES, getClassNameFromDecoration } from "@web/views/utils";
 import { getTooltipInfo } from "./field_tooltip";
 
 import { Component, xml } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
 
 const isSmall = utils.isSmall;
 
@@ -356,7 +356,7 @@ export class Field extends Component {
     };
 
     setup() {
-        this.offlineStatus = useOfflineStatus();
+        this.offlineService = useService("offline");
         if (this.props.fieldInfo) {
             this.field = this.props.fieldInfo.field;
         } else {
@@ -412,7 +412,7 @@ export class Field extends Component {
     get fieldComponentProps() {
         const record = this.props.record;
         // disable edition in offline mode
-        let readonly = this.props.readonly || this.offlineStatus.offline || false;
+        let readonly = this.props.readonly || this.offlineService.offline || false;
 
         let propsFromNode = {};
         if (this.props.fieldInfo) {

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -165,6 +165,7 @@ export class FormController extends Component {
         this.orm = useService("orm");
         this.viewService = useService("view");
         this.ui = useService("ui");
+        this.offlineService = useService("offline");
         useBus(this.ui.bus, "resize", this.render);
 
         this.archInfo = this.props.archInfo;
@@ -295,7 +296,15 @@ export class FormController extends Component {
 
         usePager(() => {
             if (!this.model.root.isNew) {
-                const resIds = this.model.root.resIds;
+                let resIds = this.model.root.resIds;
+                if (this.offlineService.offline) {
+                    const actionId = this.env.config.actionId;
+                    resIds = resIds.filter(
+                        (resId) =>
+                            resId === this.model.root.resId ||
+                            this.offlineService.isAvailableOffline(actionId, "form", resId)
+                    );
+                }
                 return {
                     offset: resIds.indexOf(this.model.root.resId),
                     limit: 1,

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -72,6 +72,7 @@ export class KanbanController extends Component {
     setup() {
         this.actionService = useService("action");
         this.dialog = useService("dialog");
+        this.offlineService = useService("offline");
         const { Model, archInfo } = this.props;
 
         class KanbanSampleModel extends Model {

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -186,6 +186,7 @@ export class KanbanRecord extends Component {
         this.action = useService("action");
         this.dialog = useService("dialog");
         this.notification = useService("notification");
+        this.offlineService = useService("offline");
 
         const { Compiler, archInfo } = this.props;
         const ViewCompiler = Compiler || KanbanCompiler;
@@ -266,6 +267,12 @@ export class KanbanRecord extends Component {
         }
         if (this.props.record.selected) {
             classes.push("o_record_selected");
+        }
+        if (
+            this.offlineService.offline &&
+            !this.offlineService.isAvailableOffline(this.env.config.actionId, "form", record.resId)
+        ) {
+            classes.push("o_disabled_offline");
         }
         classes.push(archInfo.cardClassName);
         return classes.join(" ");

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -71,6 +71,7 @@ export class ListController extends Component {
         this.actionService = useService("action");
         this.dialogService = useService("dialog");
         this.orm = useService("orm");
+        this.offlineService = useService("offline");
         this.rootRef = useRef("root");
 
         this.archInfo = this.props.archInfo;

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -138,6 +138,7 @@ export class ListRenderer extends Component {
 
     setup() {
         this.uiService = useService("ui");
+        this.offlineService = useService("offline");
         this.notificationService = useService("notification");
         this.orm = useService("orm");
         const key = this.createViewKey();
@@ -902,6 +903,13 @@ export class ListRenderer extends Component {
         return ["float", "integer", "monetary"].includes(type);
     }
 
+    isRecordAvailable(record) {
+        return (
+            !this.offlineService.offline ||
+            this.offlineService.isAvailableOffline(this.env.config.actionId, "form", record.resId)
+        );
+    }
+
     isSortable(column) {
         const { hasLabel, name, options } = column;
         const { sortable } = this.fields[name];
@@ -946,6 +954,9 @@ export class ListRenderer extends Component {
         }
         if (this.canResequenceRows) {
             classNames.push("o_row_draggable");
+        }
+        if (!this.isRecordAvailable(record)) {
+            classNames.push("o_disabled_offline");
         }
         return classNames.join(" ");
     }
@@ -1008,7 +1019,7 @@ export class ListRenderer extends Component {
                 this.isCellReadonly(column, this.editedRecord)
             ) {
                 classNames.push("text-muted");
-            } else {
+            } else if (this.isRecordAvailable(record)) {
                 classNames.push("cursor-pointer");
             }
         }

--- a/addons/web/static/src/webclient/menus/menu_providers.js
+++ b/addons/web/static/src/webclient/menus/menu_providers.js
@@ -33,6 +33,12 @@ commandProviderRegistry.add("menu", {
         const result = [];
         const menuService = env.services.menu;
         let { apps, menuItems } = computeAppsAndMenuItems(menuService.getMenuAsTree("root"));
+        function isAvailable(menu) {
+            return (
+                env.services.offline.offline &&
+                !env.services.offline.isAvailableOffline(menu.actionID)
+            );
+        }
         if (options.searchValue !== "") {
             apps = fuzzyLookup(options.searchValue, apps, (menu) => menu.label);
 
@@ -44,6 +50,7 @@ commandProviderRegistry.add("menu", {
                         menuService.selectMenu(menu);
                     },
                     category: "menu_items",
+                    className: isAvailable(menu) ? "o_disabled_offline" : "",
                     name: menu.parents + " / " + menu.label,
                     href: menu.href || `#menu_id=${menu.id}&amp;action_id=${menu.actionID}`,
                 });
@@ -68,6 +75,7 @@ commandProviderRegistry.add("menu", {
                     menuService.selectMenu(menu);
                 },
                 category: "apps",
+                className: isAvailable(menu) ? "o_disabled_offline" : "",
                 name: menu.label,
                 href: menu.href || `#menu_id=${menu.id}&amp;action_id=${menu.actionID}`,
                 props,

--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -17,6 +17,7 @@ import {
     onWillUnmount,
     useChildSubEnv,
 } from "@odoo/owl";
+
 const systrayRegistry = registry.category("systray");
 
 const getBoundingClientRect = Element.prototype.getBoundingClientRect;
@@ -41,6 +42,7 @@ export class NavBar extends Component {
         this.currentAppSectionsExtra = [];
         this.actionService = useService("action");
         this.menuService = useService("menu");
+        this.offlineService = useService("offline");
         this.pwa = useService("pwa");
         this.root = useRef("root");
         this.appSubMenus = useRef("appSubMenus");
@@ -232,6 +234,15 @@ export class NavBar extends Component {
     _openAppMenuSidebar() {
         this.state.isAppMenuSidebarOpened = !this.state.isAppMenuSidebarOpened;
     }
+
+    _isAvailable(menu) {
+        return (
+            !this.offlineService.offline ||
+            !menu.actionID ||
+            this.offlineService.isAvailableOffline(menu.actionID)
+        );
+    }
+
     onAllAppsBtnClick() {
         this.state.isAllAppsMenuOpened = !this.state.isAllAppsMenuOpened;
     }

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -81,7 +81,7 @@
     <t t-else="">
       <div t-if="!isScopedApp" class="o_navbar_apps_menu">
         <Dropdown>
-          <button data-hotkey="h" title="Home Menu">
+          <button data-hotkey="h" title="Home Menu" data-available-offline="">
             <i class="oi oi-apps" />
           </button>
           <t t-set-slot="content">
@@ -89,7 +89,7 @@
               t-foreach="apps"
               t-as="app"
               t-key="app.id"
-              class="{ 'o_app': true, focus: menuService.getCurrentApp() === app }"
+              class="{ 'o_app': true, focus: menuService.getCurrentApp() === app, 'o_disabled_offline': !this._isAvailable(app) }"
               onSelected="() => this.onNavBarDropdownItemSelection(app)"
               t-esc="app.name"
               attrs="{ href: getMenuItemHref(app), 'data-menu-xmlid': app.xmlid, 'data-section': app.id }"
@@ -129,7 +129,7 @@
 
                     <t t-else="">
                       <t t-foreach="apps" t-as="app" t-key="app_index">
-                        <li t-att-data-menu-xmlid="app.xmlid" class="o_app fw-bolder py-2" t-att-class="{'bg-primary-subtle': menuService.getCurrentApp() === app}" t-on-click="() => {this.onNavBarDropdownItemSelection(app); this._closeAppMenuSidebar();}">
+                        <li t-att-data-menu-xmlid="app.xmlid" class="o_app fw-bolder py-2" t-att-class="{'bg-primary-subtle': menuService.getCurrentApp() === app, 'o_disabled_offline': !this._isAvailable(app)}" t-on-click="() => {this.onNavBarDropdownItemSelection(app); this._closeAppMenuSidebar();}">
                           <div class="d-flex align-items-center">
                             <img style="height: 3em;" t-if="app.webIconData" class="o_app_icon me-2" t-attf-src="{{app.webIconData}}"/>
                             <i t-elif="app.webIcon" t-att-class="app.webIcon.split(',')[0] + ' fa-3x me-2'" t-att-style="'color:' + app.webIcon.split(',')[1]"></i>
@@ -165,7 +165,10 @@
 
                     <t t-if="!section.childrenTree.length">
                         <DropdownItem
-                            class="'o_nav_entry'"
+                            class="{
+                                o_nav_entry: true,
+                                o_disabled_offline: !this._isAvailable(section)
+                            }"
                             onSelected="() => this.onNavBarDropdownItemSelection(section)"
                             t-esc="section.name"
                             attrs="{
@@ -215,6 +218,7 @@
         t-if="!item.childrenTree.length"
         class="{
           'dropdown-item': true,
+          o_disabled_offline: !this._isAvailable(item),
           o_dropdown_menu_group_entry: decalage gt 20
         }"
         t-esc="item.name"
@@ -243,7 +247,10 @@
           <t t-foreach="sections" t-as="section" t-key="section.id">
             <t t-if="!section.childrenTree.length">
               <DropdownItem
-                class="'o_more_dropdown_section'"
+                class="{
+                  'o_more_dropdown_section': true,
+                  o_disabled_offline: !this._isAvailable(item)
+                }"
                 onSelected="() => this.onNavBarDropdownItemSelection(section)"
                 t-esc="section.name"
                 attrs="{ href: getMenuItemHref(section), 'data-menu-xmlid': section.xmlid, 'data-section': section.id }"

--- a/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
+++ b/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
@@ -28,6 +28,10 @@ export function mockIndexedDB(_name, { fn }) {
                 return this.mockIndexedDB[table]?.[key];
             }
 
+            async getAllKeys(table) {
+                return Object.keys(this.mockIndexedDB[table] || {});
+            }
+
             async invalidate(tables = null) {
                 if (tables) {
                     tables = typeof tables === "string" ? [tables] : tables;

--- a/addons/web/static/tests/core/commands/menu_provider.test.js
+++ b/addons/web/static/tests/core/commands/menu_provider.test.js
@@ -8,6 +8,8 @@ import {
     defineMenus,
     getService,
     mountWithCleanup,
+    mockOffline,
+    mockService,
     useTestClientAction,
 } from "@web/../tests/web_test_helpers";
 
@@ -58,6 +60,29 @@ test("displays only apps if the search value is '/'", async () => {
     expect(".o_command_category").toHaveCount(1);
     expect(".o_command").toHaveCount(2);
     expect(queryAllTexts(".o_command_name")).toEqual(["Contact", "Sales"]);
+});
+
+test.tags("desktop");
+test(`[Offline] disable unavailable menus when offline`, async () => {
+    const setOffline = mockOffline();
+    mockService("offline", {
+        isAvailableOffline(actionId) {
+            return actionId === 1001;
+        },
+    });
+    await mountWithCleanup(WebClient);
+    await setOffline(true);
+
+    expect(".o_menu_brand").toHaveCount(0);
+
+    await press(["control", "k"]);
+    await animationFrame();
+    await contains(".o_command_palette_search input").edit("/", { confirm: false });
+    await animationFrame();
+    expect(".o_command").toHaveCount(2);
+    expect(queryAllTexts(".o_command_name")).toEqual(["Contact", "Sales"]);
+    expect(".o_command a.o_disabled_offline").toHaveCount(1);
+    expect(queryAllTexts(".o_command a.o_disabled_offline")).toEqual(["Sales"]);
 });
 
 test.tags("desktop");

--- a/addons/web/static/tests/core/offline/offline_error.test.js
+++ b/addons/web/static/tests/core/offline/offline_error.test.js
@@ -7,11 +7,11 @@ test("ConnectionLostError handler", async () => {
     expect.errors(1);
 
     const env = await makeMockEnv();
-    expect(env.services.offline.status.offline).toBe(false);
+    expect(env.services.offline.offline).toBe(false);
     const error = new ConnectionLostError("/fake_url");
     Promise.reject(error);
     await animationFrame();
-    expect(env.services.offline.status.offline).toBe(true);
+    expect(env.services.offline.offline).toBe(true);
     expect.verifyErrors([
         `Error: Connection to "/fake_url" couldn't be established or was interrupted`,
     ]);

--- a/addons/web/static/tests/core/offline/offline_systray.test.js
+++ b/addons/web/static/tests/core/offline/offline_systray.test.js
@@ -1,64 +1,70 @@
 import { WebClient } from "@web/webclient/webclient";
 
-import { animationFrame, expect, test } from "@odoo/hoot";
-import { contains, getService, mountWithCleanup, onRpc } from "@web/../tests/web_test_helpers";
+import { expect, test } from "@odoo/hoot";
+import {
+    contains,
+    getService,
+    mountWithCleanup,
+    mockOffline,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
 
 test.tags("desktop");
 test("offline systray item: basic rendering (desktop)", async () => {
+    const setOffline = mockOffline();
     await mountWithCleanup(WebClient);
     expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
-    getService("offline").status.offline = true;
+    await setOffline(true);
 
-    await animationFrame();
     expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(1);
     expect(`.o_menu_systray .o_nav_entry:first`).toHaveText("Working offline");
 
-    getService("offline").status.offline = false;
-    await animationFrame();
+    await setOffline(false);
     expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
 });
 
 test.tags("mobile");
 test("offline systray item: basic rendering (mobile)", async () => {
+    const setOffline = mockOffline();
     await mountWithCleanup(WebClient);
     expect(`.o_menu_systray .o_nav_entry.fa-chain-broken`).toHaveCount(0);
-    getService("offline").status.offline = true;
+    await setOffline(true);
 
-    await animationFrame();
     expect(`.o_menu_systray .o_nav_entry.fa-chain-broken`).toHaveCount(1);
     expect(`.o_menu_systray .o_nav_entry:first`).toHaveAttribute("data-tooltip", "Working offline");
 
-    getService("offline").status.offline = false;
-    await animationFrame();
+    await setOffline(false);
     expect(`.o_menu_systray .o_nav_entry.fa-chain-broken`).toHaveCount(0);
 });
 
 test.tags("desktop");
 test("offline systray item: click to check connection (desktop)", async () => {
+    const setOffline = mockOffline();
     onRpc("/web/webclient/version_info", async () => {
         expect.step("version_info");
         return true;
     });
     await mountWithCleanup(WebClient);
-    getService("offline").status.offline = true;
+    await setOffline(true);
 
     await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
     expect.verifySteps(["version_info"]);
-    expect(getService("offline").status.offline).toBe(false);
+    expect(getService("offline").offline).toBe(false);
     expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
 });
 
 test.tags("mobile");
 test("offline systray item: click to check connection (mobile)", async () => {
+    const setOffline = mockOffline();
     onRpc("/web/webclient/version_info", async () => {
         expect.step("version_info");
         return true;
     });
     await mountWithCleanup(WebClient);
-    getService("offline").status.offline = true;
+    await setOffline(true);
 
     await contains(`.o_menu_systray .o_nav_entry.fa-chain-broken`).click();
     expect.verifySteps(["version_info"]);
-    expect(getService("offline").status.offline).toBe(false);
+    expect(getService("offline").offline).toBe(false);
     expect(`.o_menu_systray .o_nav_entry .fa-chain-broken`).toHaveCount(0);
 });

--- a/addons/web/static/tests/core/utils/indexed_db.test.js
+++ b/addons/web/static/tests/core/utils/indexed_db.test.js
@@ -137,6 +137,28 @@ test("one cache, invalidate all tables", async () => {
     await ensureDbIsAbsent();
 });
 
+test("one table, call getAllKeys", async () => {
+    onError(() => deleteCacheDB());
+    await ensureDbIsAbsent();
+
+    const indexedDB = new IndexedDB(CACHE_NAME, 1);
+
+    // empty table
+    expect(await indexedDB.getAllKeys("mytable")).toEqual([]);
+
+    // populate and call getAllKeys
+    await indexedDB.write("mytable", "test", "value for 'test'");
+    await indexedDB.write("mytable", "test2", "value for 'test2'");
+    expect(await indexedDB.getAllKeys("mytable")).toEqual(["test", "test2"]);
+
+    // invalidate table and call getAllKeys
+    await indexedDB.invalidate("mytable");
+    expect(await indexedDB.getAllKeys("mytable")).toEqual([]);
+
+    await indexedDB.deleteDatabase();
+    await ensureDbIsAbsent();
+});
+
 test("invalidate all tables, empty cache", async () => {
     onError(() => deleteCacheDB());
     await ensureDbIsAbsent();

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -42,7 +42,7 @@ export {
     findComponent,
     getDropdownMenu,
     mountWithCleanup,
-    waitUntilIdle
+    waitUntilIdle,
 } from "./_framework/component_test_helpers";
 export { contains, defineStyle, editAce, sortableDrag } from "./_framework/dom_test_helpers";
 export {
@@ -52,7 +52,8 @@ export {
     makeDialogMockEnv,
     makeMockEnv,
     mockService,
-    restoreRegistry
+    restoreRegistry,
+    mockOffline,
 } from "./_framework/env_test_helpers";
 export {
     clickKanbanLoadMore,
@@ -74,7 +75,7 @@ export {
     toggleKanbanColumnActions,
     toggleKanbanRecordDropdown,
     validateKanbanColumn,
-    validateKanbanRecord
+    validateKanbanRecord,
 } from "./_framework/kanban_test_helpers";
 export { Command, registerInlineViewArchs } from "./_framework/mock_server/mock_model";
 export {
@@ -88,14 +89,14 @@ export {
     MockServer,
     onRpc,
     stepAllNetworkCalls,
-    withUser
+    withUser,
 } from "./_framework/mock_server/mock_server";
 export {
     getKwArgs,
     makeKwArgs,
     makeServerError,
     MockServerError,
-    unmakeKwArgs
+    unmakeKwArgs,
 } from "./_framework/mock_server/mock_server_utils";
 export { serverState } from "./_framework/mock_server_state.hoot";
 export { patchWithCleanup } from "./_framework/patch_test_helpers";
@@ -117,7 +118,10 @@ export {
     openAddCustomFilterDialog,
     pagerNext,
     pagerPrevious,
-    removeFacet, saveAndEditFavorite, saveFavorite, selectGroup,
+    removeFacet,
+    saveAndEditFavorite,
+    saveFavorite,
+    selectGroup,
     switchView,
     toggleActionMenu,
     toggleFavoriteMenu,
@@ -128,12 +132,13 @@ export {
     toggleMenuItemOption,
     toggleSaveFavorite,
     toggleSearchBarMenu,
-    validateSearch
+    validateSearch,
 } from "./_framework/search_test_helpers";
 export { swipeLeft, swipeRight } from "./_framework/touch_helpers";
 export {
-    allowTranslations, installLanguages,
-    patchTranslations
+    allowTranslations,
+    installLanguages,
+    patchTranslations,
 } from "./_framework/translation_test_helpers";
 export {
     clickButton,
@@ -142,13 +147,15 @@ export {
     clickFieldDropdownItem,
     clickModalButton,
     clickSave,
-    clickViewButton, editSelectMenu, expectMarkup,
+    clickViewButton,
+    editSelectMenu,
+    expectMarkup,
     fieldInput,
     hideTab,
     mountView,
     mountViewInDialog,
     parseViewProps,
-    selectFieldDropdownItem
+    selectFieldDropdownItem,
 } from "./_framework/view_test_helpers";
 export { mountWebClient, useTestClientAction } from "./_framework/webclient_test_helpers";
 


### PR DESCRIPTION
With this commit, when being offline, menus, view switchers and
records (in kanban and list views) that aren't available are
disabled (i.e. displayed with opacity and not-allowed cursor).
Those disabled elements are still clickable though, but it's highly
unlikely that clicking on them would lead to anything but an empty
screen (due to the lack of connection).

All such items aren't disabled though: we store in indexeddb the
list of visited items (actions, view types, records), s.t. we know
what is available in cache, and what is then accessible offline.

This commit also prepares the ground for the next task, which is
to have an offline search bar, allowing to select among previously
enabled filters, in kanban and list views.

Task~5424765