### PR TITLE
[FIX] html_editor: handle missing `key` in keydown events

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -183,13 +183,13 @@ export class ToolbarPlugin extends Plugin {
             // keyup. Opening is debounced to avoid open/close between
             // sequential keystrokes.
             this.addDomListener(this.editable, "keydown", (ev) => {
-                if (ev.key.startsWith("Arrow")) {
+                if (ev.key?.startsWith("Arrow")) {
                     this.overlay.close();
                     this.onSelectionChangeActive = false;
                 }
             });
             this.addDomListener(this.editable, "keyup", (ev) => {
-                if (ev.key.startsWith("Arrow")) {
+                if (ev.key?.startsWith("Arrow")) {
                     this.onSelectionChangeActive = true;
                     this.debouncedUpdateToolbar();
                 }


### PR DESCRIPTION
Problem:
When using Google Input Tool, typing Arabic numbers causes a traceback in HTML fields.

Cause:
The tool triggers a fake `keydown` event without the `key` attribute. This is failing before c10fd06320b013057831a6a46b2922b5386b71ef.

Solution:
Explicitly check that the `key` attribute exists on the event before using it.

Steps to reproduce:
- Install Google Input Tool in your browser.
- Open any HTML field.
- Add any character using the extension.
- Observe a traceback.

opw-5447680

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
