### PR TITLE
[FIX] html_editor: column structure gets broken

### DIFF
--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -6,7 +6,7 @@ import { closestElement, firstLeaf } from "@html_editor/utils/dom_traversal";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
-const REGEX_BOOTSTRAP_COLUMN = /(?:^| )col(-[a-zA-Z]+)?(-\d+)?(?= |$)/;
+const REGEX_BOOTSTRAP_COLUMN = /(^| )col(-[a-zA-Z]+)?(-\d+)?(?= |$)/;
 
 function isUnremovableColumn(node, root) {
     const isColumnInnerStructure =
@@ -182,7 +182,7 @@ export class ColumnPlugin extends Plugin {
         for (const column of columns) {
             column.className = column.className.replace(
                 REGEX_BOOTSTRAP_COLUMN,
-                `col$1-${columnSize}`
+                `$1col$2-${columnSize}`
             );
         }
         if (diff > 0) {

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -81,8 +81,8 @@ export class ColumnPlugin extends Plugin {
         ],
         hints: [
             {
-                selector: `.odoo-editor-editable .o_text_columns div[class^='col-'],
-                            .odoo-editor-editable .o_text_columns div[class^='col-']>${baseContainerGlobalSelector}:first-child`,
+                selector: `.odoo-editor-editable .o_text_columns div[class*='col-'],
+                            .odoo-editor-editable .o_text_columns div[class*='col-']>${baseContainerGlobalSelector}:first-child`,
                 text: _t("Empty column"),
             },
         ],
@@ -100,9 +100,9 @@ export class ColumnPlugin extends Plugin {
             if (!columnContainer) {
                 return [];
             }
-            const closestColumn = closestElement(anchorNode, "div[class^='col-']");
+            const closestColumn = closestElement(anchorNode, "div[class*='col-']");
             const closestBlockEl = closestBlock(anchorNode);
-            return [...columnContainer.querySelectorAll("div[class^='col-']")]
+            return [...columnContainer.querySelectorAll("div[class*='col-']")]
                 .map((column) => {
                     const block = closestBlock(firstLeaf(column));
                     return column === closestColumn && block !== closestBlockEl ? null : block;

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -588,4 +588,33 @@ describe("helper hint", () => {
             /* eslint-enable */
         });
     });
+
+    test("should display hint in first block of each column after an undo operation", async () => {
+        await testEditor({
+            contentBefore: columnsContainer(
+                column(4, "<p>[]<br></p>") + column(4, "<p><br></p>") + column(4, "<p><br></p>")
+            ),
+            stepFunction: async (editor) => {
+                columnize(4)(editor);
+                undo(editor);
+            },
+            contentAfterEdit: unformat(
+                `<p data-selection-placeholder=""><br></p>
+                <div class="container o_text_columns o-contenteditable-false" contenteditable="false">
+                    <div class="row">
+                        <div class="o-contenteditable-true col-4" contenteditable="true">
+                            <p o-we-hint-text="Empty column" class="o-we-hint">[]<br></p>
+                        </div>
+                        <div class="o-contenteditable-true col-4" contenteditable="true">
+                            <p o-we-hint-text="Empty column" class="o-we-hint"><br></p>
+                        </div>
+                        <div class="o-contenteditable-true col-4" contenteditable="true">
+                            <p o-we-hint-text="Empty column" class="o-we-hint"><br></p>
+                        </div>
+                    </div>
+                </div>
+                <p data-selection-placeholder=""><br></p>`
+            ),
+        });
+    });
 });

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -6,6 +6,7 @@ import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, redo, undo } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 import { nodeSize } from "@html_editor/utils/position";
+import { unformat } from "./_helpers/format";
 
 function columnsContainer(contents) {
     return `<div class="container o_text_columns o-contenteditable-false"><div class="row">${contents}</div></div>`;
@@ -452,6 +453,36 @@ describe("undo", () => {
                 await insertText(editor, "x");
             },
             contentAfter: columnsContainer(column(6, "<p>x[]</p>") + column(6, "<p><br></p>")),
+        });
+    });
+    test("should create columns after undo", async () => {
+        await testEditor({
+            contentBefore: columnsContainer(
+                column(4, "<p>a</p>") + column(4, "<p>b</p>") + column(4, "<p>c[]</p>")
+            ),
+            stepFunction: async (editor) => {
+                columnize(4)(editor);
+                undo(editor);
+                columnize(4)(editor);
+            },
+            contentAfter: unformat(
+                `<div class="container o_text_columns o-contenteditable-false">
+                    <div class="row">
+                        <div class="o-contenteditable-true col-3">
+                            <p>a</p>
+                        </div>
+                        <div class="o-contenteditable-true col-3">
+                            <p>b</p>
+                        </div>
+                        <div class="o-contenteditable-true col-3">
+                            <p>c[]</p>
+                        </div>
+                        <div class="col-3 o-contenteditable-true">
+                            <p><br></p>
+                        </div>
+                    </div>
+                </div>`
+            ),
         });
     });
 });


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- Create 3 columns using powerbox
- Convert it into 4 columns
- Press ctrl + z to make it 3 columns
- Convert it into 4 columns again using powerbox

Notice that column structure is broken. This happens because after undo operation, in `changeColumnsNumber` the regex replaces column div className incorrectly leading to invalid colund structure.

**Desired behavior after PR is merged:**

This PR ensures that column structure doesn't break.

task-5468578





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
