### PR TITLE
[IMP] stock: Improve UX for delivery methods and shipping connectors

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -88,6 +88,7 @@
         'views/stock_reference_views.xml',
         'views/uom_uom_views.xml',
         'views/digest_digest_views.xml',
+        'views/ir_module_module_views.xml',
     ],
     'application': True,
     'pre_init_hook': 'pre_init_hook',

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -31,16 +31,6 @@ class ResConfigSettings(models.TransientModel):
     stock_move_email_validation = fields.Boolean(related='company_id.stock_move_email_validation', readonly=False)
     module_stock_sms = fields.Boolean("SMS Confirmation")
     module_delivery = fields.Boolean("Delivery Methods")
-    module_delivery_dhl = fields.Boolean("DHL Express Connector")
-    module_delivery_fedex_rest = fields.Boolean("FedEx Connector")
-    module_delivery_ups_rest = fields.Boolean("UPS Connector")
-    module_delivery_usps_rest = fields.Boolean("USPS Connector")
-    module_delivery_bpost = fields.Boolean("bpost Connector")
-    module_delivery_easypost = fields.Boolean("Easypost Connector")
-    module_delivery_sendcloud = fields.Boolean("Sendcloud Connector")
-    module_delivery_shiprocket = fields.Boolean("Shiprocket Connector")
-    module_delivery_starshipit = fields.Boolean("Starshipit Connector")
-    module_delivery_envia = fields.Boolean("Envia.com Connector")
     module_quality_control = fields.Boolean("Quality")
     module_quality_control_worksheet = fields.Boolean("Quality Worksheet")
     group_stock_multi_locations = fields.Boolean('Storage Locations', implied_group='stock.group_stock_multi_locations',
@@ -155,4 +145,9 @@ class ResConfigSettings(models.TransientModel):
             if self.env['product.product'].search_count([('tracking', 'in', ['lot', 'serial'])], limit=1):
                 raise UserError(_("You have product(s) in stock that have lot/serial number tracking enabled. \nSwitch off tracking on all the products before switching off this setting."))
 
+        return
+
+    def action_view_delivery_methods(self):
+        if action := self.env.ref('delivery.action_delivery_carrier_form', raise_if_not_found=False):
+            return action._get_action_dict()
         return

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -31,16 +31,7 @@ class ResConfigSettings(models.TransientModel):
     stock_move_email_validation = fields.Boolean(related='company_id.stock_move_email_validation', readonly=False)
     module_stock_sms = fields.Boolean("SMS Confirmation")
     module_delivery = fields.Boolean("Delivery Methods")
-    module_delivery_dhl = fields.Boolean("DHL Express Connector")
-    module_delivery_fedex_rest = fields.Boolean("FedEx Connector")
-    module_delivery_ups_rest = fields.Boolean("UPS Connector")
-    module_delivery_usps_rest = fields.Boolean("USPS Connector")
-    module_delivery_bpost = fields.Boolean("bpost Connector")
-    module_delivery_easypost = fields.Boolean("Easypost Connector")
-    module_delivery_sendcloud = fields.Boolean("Sendcloud Connector")
-    module_delivery_shiprocket = fields.Boolean("Shiprocket Connector")
-    module_delivery_starshipit = fields.Boolean("Starshipit Connector")
-    module_delivery_envia = fields.Boolean("Envia.com Connector")
+    is_delivery_module_installed = fields.Boolean(compute='_compute_is_delivery_module_installed')
     module_quality_control = fields.Boolean("Quality")
     module_quality_control_worksheet = fields.Boolean("Quality Worksheet")
     group_stock_multi_locations = fields.Boolean('Storage Locations', implied_group='stock.group_stock_multi_locations',
@@ -63,6 +54,10 @@ class ResConfigSettings(models.TransientModel):
         route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)
         if route:
             self.replenish_on_order = route.active
+
+    @api.depends('module_delivery')
+    def _compute_is_delivery_module_installed(self):
+        self.is_delivery_module_installed = self.module_delivery and 'delivery' in self.env['ir.module.module']._installed()
 
     def _inverse_replenish_on_order(self):
         route = self.env.ref('stock.route_warehouse0_mto', raise_if_not_found=False)
@@ -156,3 +151,21 @@ class ResConfigSettings(models.TransientModel):
                 raise UserError(_("You have product(s) in stock that have lot/serial number tracking enabled. \nSwitch off tracking on all the products before switching off this setting."))
 
         return
+
+    def action_view_delivery_methods(self):
+        return self.env['ir.actions.actions']._for_xml_id('delivery.action_delivery_carrier_form')
+
+    def action_view_delivery_provider_modules(self):
+        return {
+            'name': self.env._("All Delivery Providers"),
+            'res_model': 'ir.module.module',
+            'view_mode': 'kanban,list',
+            'views': [
+                (self.env.ref('stock.module_view_kanban').id, 'kanban'),
+                (self.env.ref('stock.module_tree').id, 'list'),
+            ],
+            'search_view_id': [self.env.ref('stock.view_module_filter').id, 'search'],
+            'domain': [['name', '=like', 'delivery_%'], ['name', 'not in', ['delivery_stock_picking_batch', 'delivery_iot']]],
+            'type': 'ir.actions.act_window',
+            'help': self.env._('''<p class="o_view_nocontent">Buy Odoo Enterprise now to get more providers.</p>'''),
+        }

--- a/addons/stock/views/ir_module_module_views.xml
+++ b/addons/stock/views/ir_module_module_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="stock.module_tree" model="ir.ui.view">
+        <field name="name">ir.module.module.view.list.stock</field>
+        <field name="model">ir.module.module</field>
+        <field name="inherit_id" ref="base.module_tree"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="name" position="attributes">
+                <attribute name="column_invisible">1</attribute>
+            </field>
+            <field name="author" position="attributes">
+                <attribute name="column_invisible">1</attribute>
+            </field>
+            <field name="website" position="attributes">
+                <attribute name="column_invisible">1</attribute>
+            </field>
+            <field name="installed_version" position="attributes">
+                <attribute name="column_invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record id="stock.module_view_kanban" model="ir.ui.view">
+        <field name="name">ir.module.module.view.kanban.stock</field>
+        <field name="model">ir.module.module</field>
+        <field name="inherit_id" ref="base.module_view_kanban"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <a id="module_info" position="replace"/>
+        </field>
+    </record>
+
+    <record id="stock.view_module_filter" model="ir.ui.view">
+        <field name="name">ir.module.module.view.search.stock</field>
+        <field name="model">ir.module.module</field>
+        <field name="inherit_id" ref="base.view_module_filter"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//searchpanel" position="replace"/>
+        </field>
+    </record>
+</odoo>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <record id="ir_module_module_action_delivery_provider_modules" model="ir.actions.act_window">
+            <field name="name">All Delivery Providers</field>
+            <field name="res_model">ir.module.module</field>
+            <field name="view_mode">kanban,list</field>
+            <field name="domain">
+                [('name', '=like', 'delivery_%'),
+                ('name', 'not in', ['delivery_stock_picking_batch', 'delivery_iot'])]
+            </field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Buy Odoo Enterprise now to get more providers.
+                </p>
+            </field>
+        </record>
+
         <record id="res_config_settings_view_form" model="ir.ui.view">
             <field name="name">res.config.settings.view.form.inherit.stock</field>
             <field name="model">res.config.settings</field>
@@ -58,8 +73,23 @@
                             </setting>
                         </block>
                         <block title="Shipping" name="shipping_setting_container">
-                            <setting id="delivery" help="Compute shipping costs" title="Shipping connectors allow to compute accurate shipping costs, print shipping labels and request carrier picking at your warehouse to ship to the customer. Apply shipping connector from delivery methods.">
+                            <setting id="delivery" help="Compute shipping costs" title="Shipping connectors allow to compute accurate shipping costs, print shipping labels and request carrier picking at your warehouse to ship to the customer. Apply shipping connector from delivery methods."
+                                documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
                                 <field name="module_delivery"/>
+                                <button
+                                    string="Configure Methods"
+                                    type="object"
+                                    name="action_view_delivery_methods"
+                                    class="btn btn-primary"
+                                    invisible="not module_delivery"
+                                />
+                                <button
+                                    string="Find a Delivery Provider"
+                                    type="action"
+                                    name="%(stock.ir_module_module_action_delivery_provider_modules)d"
+                                    class="btn btn-link"
+                                    icon="oi-arrow-right"
+                                />
                             </setting>
                             <setting id="stock_fleet" help="Transport management: organize packs in your fleet, or carriers.">
                                 <field name="module_stock_fleet"/>
@@ -79,59 +109,6 @@
                             </setting>
                             <setting id="signature_delivery_orders" help="Require a signature on your delivery orders">
                                 <field name="group_stock_sign_delivery"/>
-                            </setting>
-                        </block>
-                        <block title="Shipping Connectors" name="shipping_connectors_setting_container">
-                            <setting id="compute_shipping_costs_ups" help="Compute shipping costs and ship with UPS">
-                                <div class="o_form_label">UPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with UPS<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_dhl" help=" Compute shipping costs and ship with DHL">
-                                <div class="o_form_label">DHL Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with DHL<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_fedex" help="Compute shipping costs and ship with FedEx">
-                                <div class="o_form_label">FedEx Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with FedEx<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_usps" help="Compute shipping costs and ship with USPS">
-                                <div class="o_form_label">USPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with USPS<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_bpost" help="Compute shipping costs and ship with bpost" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_bpost" widget="upgrade_boolean"/>
-                            </setting>
-
-                            <setting id="compute_shipping_costs_easypost" help="Compute shipping costs and ship with Easypost" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_easypost" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_sendcloud" help="Compute shipping costs and ship with Sendcloud" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_sendcloud" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_shiprocket" help="Compute shipping costs and ship with Shiprocket" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_shiprocket" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_starshipit" help="Compute shipping costs and ship with Starshipit" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_starshipit" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_envia" help="Compute shipping costs and ship with Envia.com" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_envia" widget="upgrade_boolean"/>
                             </setting>
                         </block>
                         <block title="Products" name="product_setting_container">

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -58,8 +58,24 @@
                             </setting>
                         </block>
                         <block title="Shipping" name="shipping_setting_container">
-                            <setting id="delivery" help="Compute shipping costs" title="Shipping connectors allow to compute accurate shipping costs, print shipping labels and request carrier picking at your warehouse to ship to the customer. Apply shipping connector from delivery methods.">
+                            <setting id="delivery" help="Compute shipping costs" title="Shipping connectors allow to compute accurate shipping costs, print shipping labels and request carrier picking at your warehouse to ship to the customer. Apply shipping connector from delivery methods."
+                                documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
                                 <field name="module_delivery"/>
+                                <field name="is_delivery_module_installed" invisible="1"/>
+                                <button
+                                    string="Configure Methods"
+                                    type="object"
+                                    name="action_view_delivery_methods"
+                                    class="btn btn-primary"
+                                    invisible="not is_delivery_module_installed"
+                                />
+                                <button
+                                    string="Find a Delivery Provider"
+                                    type="object"
+                                    name="action_view_delivery_provider_modules"
+                                    class="btn btn-link"
+                                    icon="oi-arrow-right"
+                                />
                             </setting>
                             <setting id="stock_fleet" help="Transport management: organize packs in your fleet, or carriers.">
                                 <field name="module_stock_fleet"/>
@@ -79,59 +95,6 @@
                             </setting>
                             <setting id="signature_delivery_orders" help="Require a signature on your delivery orders">
                                 <field name="group_stock_sign_delivery"/>
-                            </setting>
-                        </block>
-                        <block title="Shipping Connectors" name="shipping_connectors_setting_container">
-                            <setting id="compute_shipping_costs_ups" help="Compute shipping costs and ship with UPS">
-                                <div class="o_form_label">UPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with UPS<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_dhl" help=" Compute shipping costs and ship with DHL">
-                                <div class="o_form_label">DHL Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with DHL<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_fedex" help="Compute shipping costs and ship with FedEx">
-                                <div class="o_form_label">FedEx Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with FedEx<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_usps" help="Compute shipping costs and ship with USPS">
-                                <div class="o_form_label">USPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with USPS<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                            </setting>
-                            <setting id="compute_shipping_costs_bpost" help="Compute shipping costs and ship with bpost" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_bpost" widget="upgrade_boolean"/>
-                            </setting>
-
-                            <setting id="compute_shipping_costs_easypost" help="Compute shipping costs and ship with Easypost" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_easypost" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_sendcloud" help="Compute shipping costs and ship with Sendcloud" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_sendcloud" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_shiprocket" help="Compute shipping costs and ship with Shiprocket" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_shiprocket" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_starshipit" help="Compute shipping costs and ship with Starshipit" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_starshipit" widget="upgrade_boolean"/>
-                            </setting>
-                            <setting id="compute_shipping_costs_envia" help="Compute shipping costs and ship with Envia.com" documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                                <field name="module_delivery_envia" widget="upgrade_boolean"/>
                             </setting>
                         </block>
                         <block title="Products" name="product_setting_container">


### PR DESCRIPTION
Delivery methods and shipping connectors were split across different sections
in Inventory, creating a disconnected and confusing experience. The
dedicated Shipping Connectors section also took up significant
space while offering limited contextual value.

This change unifies all delivery methods into a single view and
groups all shipping connector modules in dedicated list and kanban views.
It improves clarity, reduces unnecessary navigation, groups all connectors 
in one place, and streamlines the overall configuration experience.

Enterprise PR:- https://github.com/odoo/enterprise/pull/103467
Upgrade PR:- https://github.com/odoo/upgrade/pull/9208

Task - 5380595