### PR TITLE
[IMP] {google_,microsoft_}calendar: improve the UX

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -2,7 +2,9 @@
 
 from datetime import timedelta
 
-from odoo import api, fields, models
+from markupsafe import Markup
+
+from odoo import _, api, fields, models
 from odoo.tools import plaintext2html
 from odoo.tools.sql import SQL
 
@@ -198,6 +200,7 @@ class CalendarAlarm_Manager(models.AbstractModel):
                 alarm.mail_template_id,
                 force_send=len(attendees) <= force_send_limit,
                 notify_author=True,
+                completion_log_message=_('The %s reminder was sent', Markup('<i>%s</i>') % alarm.name)
             )
 
         events._setup_event_recurrent_alarms(events_by_alarm)

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -215,6 +215,7 @@ class CalendarEvent(models.Model):
     alarm_ids = fields.Many2many(
         'calendar.alarm', 'calendar_alarm_calendar_event_rel',
         string='Reminders', ondelete="restrict",
+        default=lambda self: self.env.ref('calendar.alarm_notif_1', raise_if_not_found=False),
         help="Notifications sent to all attendees to remind of the meeting.")
     # RECURRENCE FIELD
     recurrency = fields.Boolean('Recurrent')

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -72,7 +72,7 @@ class CalendarEvent(models.Model):
     _name = 'calendar.event'
     _description = "Calendar Event"
     _order = "start desc"
-    _inherit = ["mail.thread"]
+    _inherit = ["mail.thread", "mail.activity.mixin"]
     _mail_post_access = 'read'
     _systray_view = 'calendar'
 
@@ -199,7 +199,7 @@ class CalendarEvent(models.Model):
         'Document Model Name', related='res_model_id.model', readonly=True, store=True)
     res_model_name = fields.Char(related='res_model_id.name')
     # messaging
-    activity_ids = fields.One2many('mail.activity', 'calendar_event_id', string='Activities')
+    meeting_activity_ids = fields.One2many('mail.activity', 'calendar_event_id', string='Meeting Activities')
     # attendees
     attendee_ids = fields.One2many(
         'calendar.attendee', 'event_id', 'Participant')
@@ -600,14 +600,14 @@ class CalendarEvent(models.Model):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
         defaults = self.browse().default_get([
-            'activity_ids', 'allday', 'description', 'name', 'partner_ids',
+            'meeting_activity_ids', 'allday', 'description', 'name', 'partner_ids',
             'res_model_id', 'res_id', 'start', 'user_id',
         ])
 
         vals_list = [  # Else bug with quick_create when we are filter on an other user
             {
                 **vals,
-                'activity_ids': vals.get('activity_ids', defaults.get('activity_ids')),
+                'meeting_activity_ids': vals.get('meeting_activity_ids', defaults.get('meeting_activity_ids')),
                 'allday': vals.get('allday', defaults.get('allday')),
                 'description': vals.get('description', defaults.get('description')),
                 'name': vals.get('name', defaults.get('name')),
@@ -638,7 +638,7 @@ class CalendarEvent(models.Model):
         if meeting_activity_types:
             for values in vals_list:
                 # created from calendar: try to create an activity on the related record
-                if values['activity_ids'] and not existing_event:
+                if values['meeting_activity_ids'] and not existing_event:
                     continue
                 res_model = all_models.filtered(lambda m: m.id == values['res_model_id'])
                 res_id = values['res_id']
@@ -668,7 +668,7 @@ class CalendarEvent(models.Model):
                     activity_vals['date_deadline'] = self._get_activity_deadline_from_start(fields.Datetime.from_string(values['start']), values['allday'])
                 if values['user_id']:
                     activity_vals['user_id'] = values['user_id']
-                values['activity_ids'] = [(0, 0, activity_vals)]
+                values['meeting_activity_ids'] = [(0, 0, activity_vals)]
 
         self._set_videocall_location(vals_list)
 
@@ -733,7 +733,7 @@ class CalendarEvent(models.Model):
         # complete
         to_sync_activities = self.browse()
         for event, event_values in zip(events, vals_list):
-            if any(command[0] != 0 for command in event_values.get('activity_ids') or []):
+            if any(command[0] != 0 for command in event_values.get('meeting_activity_ids') or []):
                 to_sync_activities += event
         to_sync_activities._sync_activities(fields={f for vals in vals_list for f in vals})
 
@@ -1233,7 +1233,7 @@ class CalendarEvent(models.Model):
     def _sync_activities(self, fields):
         # update activities
         for event in self:
-            if event.activity_ids:
+            if event.meeting_activity_ids:
                 activity_values = {}
                 if 'name' in fields:
                     activity_values['summary'] = event.name
@@ -1245,7 +1245,7 @@ class CalendarEvent(models.Model):
                 if 'user_id' in fields:
                     activity_values['user_id'] = event.user_id.id
                 if activity_values.keys():
-                    event.activity_ids.write(activity_values)
+                    event.meeting_activity_ids.write(activity_values)
 
     @api.model
     def _get_activity_deadline_from_start(self, start, allday):

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -104,7 +104,7 @@ class CalendarRecurrence(models.Model):
     rrule = fields.Char(compute='_compute_rrule', inverse='_inverse_rrule', store=True)
     dtstart = fields.Datetime(compute='_compute_dtstart')
     rrule_type = fields.Selection(RRULE_TYPE_SELECTION, default='weekly')
-    end_type = fields.Selection(END_TYPE_SELECTION, default='count')
+    end_type = fields.Selection(END_TYPE_SELECTION, default='forever')
     interval = fields.Integer(default=1)
     count = fields.Integer(default=1)
     mon = fields.Boolean()

--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -41,7 +41,7 @@ class MailActivity(models.Model):
             'default_res_model': self.env.context.get('default_res_model'),
             'default_name': self.res_name,
             'default_description': self.note if not is_html_empty(self.note) else '',
-            'default_activity_ids': [(6, 0, self.ids)],
+            'default_meeting_activity_ids': [(6, 0, self.ids)],
             'default_partner_ids': self.user_id.partner_id.ids,
             'default_user_id': self.user_id.id,
             'initial_date': self.date_deadline,

--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -160,6 +160,7 @@ class ResUsers(models.Model):
                 'id': self.env['ir.model']._get('calendar.event').id,
                 'type': 'meeting',
                 'name': meeting_label,
+                'is_today_meetings': True,
                 'model': 'calendar.event',
                 'icon': modules.module.get_module_icon(EventModel._original_module),
                 'domain': [('active', 'in', [True, False])],

--- a/addons/calendar/static/src/core/web/activity_menu_patch.js
+++ b/addons/calendar/static/src/core/web/activity_menu_patch.js
@@ -2,8 +2,20 @@ import { ActivityMenu } from "@mail/core/web/activity_menu";
 import { patch } from "@web/core/utils/patch";
 
 patch(ActivityMenu.prototype, {
+    availableViews(group) {
+        if (group.model === "calendar.event" && !group.is_today_meetings) {
+            return [
+                [false, "list"],
+                [false, "kanban"],
+                [false, "form"],
+                [false, "activity"],
+            ];
+        }
+        return super.availableViews(...arguments);
+    },
+
     openActivityGroup(group, filter, newWindow) {
-        if (group.model === "calendar.event") {
+        if (group.is_today_meetings) {
             this.dropdown.close();
             this.action.doAction("calendar.action_calendar_event", {
                 newWindow,

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
@@ -3,7 +3,7 @@
     <t t-name="calendar.AttendeeCalendarController" t-inherit="web.CalendarController" t-inherit-mode="primary">
         <xpath expr="//Layout" position="inside">
             <t t-set-slot="control-panel-buttons">
-                <button class="btn btn-primary o-calendar-button-new" t-on-click="onClickAddButton">New</button>
+                <button class="btn btn-primary o-calendar-button-new" t-on-click="onClickAddButton" data-hotkey="c">New</button>
             </t>
         </xpath>
         <!-- Add header div to be filled with synchronization buttons in synchronization modules. -->

--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.xml
@@ -24,7 +24,7 @@
         </xpath>
         <xpath expr="//t[@t-if='isEventDeletable']" position="before">
             <t t-if="displayAttendeeAnswerChoice">
-                <div class="btn-group w-100 w-lg-auto ms-lg-auto order-first order-lg-0 px-2 px-lg-0">
+                <div class="btn-group w-100 w-auto me-auto me-lg-0 ms-lg-auto order-first order-lg-0 px-2 px-lg-0">
                     <button class="btn"
                             t-attf-class="#{selectedStatusInfo.text === 'Yes' ? 'btn-secondary active' : 'btn-outline-secondary'}"
                             t-on-click="() => this.changeAttendeeStatus('accepted')">Yes</button>

--- a/addons/calendar/static/tests/activity_menu.test.js
+++ b/addons/calendar/static/tests/activity_menu.test.js
@@ -39,6 +39,6 @@ test("activity menu widget:today meetings", async () => {
     await contains(".o-mail-ActivityGroup .o-calendar-meeting", { count: 2 });
     await contains(".o-calendar-meeting span.fw-bold", { text: "meeting1" });
     await contains(".o-calendar-meeting span:not(.fw-bold)", { text: "meeting2" });
-    await click(".o-mail-ActivityMenu .o-mail-ActivityGroup");
+    await click(".o-mail-ActivityGroup div[name='activityTitle']", { text: "Today's Meetings" });
     await expect.waitForSteps(["calendar.action_calendar_event"]);
 });

--- a/addons/calendar/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/calendar/static/tests/mock_server/mock_models/res_users.js
@@ -59,6 +59,7 @@ export class ResUsers extends mailModels.ResUsers {
                 meetings: meetingsLines,
                 model: "calendar.event",
                 name: "Today's Meetings",
+                is_today_meetings: true,
                 type: "meeting",
             });
         }

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -362,7 +362,6 @@ class TestAccessRights(TransactionCase):
             event_form.stop = datetime(2024, 1, 15, 10, 0)
             event_form.recurrency = True
             event_form.rrule_type_ui = 'yearly'
-            event_form.count = 3
             event_form.alarm_ids.add(alarm)
             event_form.partner_ids.add(self.john.partner_id)
             recurring_event = event_form.save()

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -117,6 +117,7 @@ class TestCalendar(SavepointCaseWithUserDemo):
         f.name = 'test'
         f.start = '2022-07-07 01:00:00'  # This is in UTC. In NY, it corresponds to the 6th of july at 9pm.
         f.recurrency = True
+        f.end_type = 'count'
         self.assertEqual(f.weekday, 'WED')
         self.assertEqual(f.event_tz, 'America/New_York', "The value should correspond to the user tz")
         self.assertEqual(f.count, 1, "The default value should be displayed")

--- a/addons/calendar/tests/test_calendar_activity.py
+++ b/addons/calendar/tests/test_calendar_activity.py
@@ -97,21 +97,21 @@ class TestCalendarActivity(ActivityScheduleCase):
         })
 
         # default usage in successive create
-        event_1_1 = self.env['calendar.event'].with_context(default_activity_ids=[(6, 0, activity_1.ids)]).create({
+        event_1_1 = self.env['calendar.event'].with_context(default_meeting_activity_ids=[(6, 0, activity_1.ids)]).create({
             'name': 'Meeting 1',
             'start': datetime(2025, 3, 10, 17),
             'stop': datetime(2025, 3, 10, 22),
         })
-        self.assertEqual(event_1_1.activity_ids, activity_1)
+        self.assertEqual(event_1_1.meeting_activity_ids, activity_1)
         self.assertEqual(activity_1.calendar_event_id, event_1_1)
         self.assertEqual(activity_1.date_deadline, date(2025, 3, 10))
-        event_1_2 = self.env['calendar.event'].with_context(default_activity_ids=[(6, 0, activity_1.ids)]).create({
+        event_1_2 = self.env['calendar.event'].with_context(default_meeting_activity_ids=[(6, 0, activity_1.ids)]).create({
             'name': 'Meeting 2',
             'start': datetime(2025, 3, 12, 17),
             'stop': datetime(2025, 3, 12, 22),
         })
-        self.assertFalse(event_1_1.activity_ids, 'Changes activity ownership')
-        self.assertEqual(event_1_2.activity_ids, activity_1, 'Changes activity ownership')
+        self.assertFalse(event_1_1.meeting_activity_ids, 'Changes activity ownership')
+        self.assertEqual(event_1_2.meeting_activity_ids, activity_1, 'Changes activity ownership')
         self.assertEqual(activity_1.calendar_event_id, event_1_2)
         self.assertEqual(activity_1.date_deadline, date(2025, 3, 12))
 
@@ -130,7 +130,7 @@ class TestCalendarActivity(ActivityScheduleCase):
             'start': datetime(2025, 4, 10, 17),
             'stop': datetime(2025, 4, 10, 22),
         })
-        self.assertEqual(event_2_1.activity_ids, activity_2)
+        self.assertEqual(event_2_1.meeting_activity_ids, activity_2)
         self.assertEqual(activity_2.calendar_event_id, event_2_1)
         self.assertEqual(activity_2.date_deadline, date(2025, 4, 10))
 
@@ -141,12 +141,12 @@ class TestCalendarActivity(ActivityScheduleCase):
         })
         new_existing_activities = self.env['mail.activity'].search([])
         new_activity = new_existing_activities - existing_activities
-        self.assertEqual(event_2_1.activity_ids, activity_2, "Event 1's activity should still be the first activity")
+        self.assertEqual(event_2_1.meeting_activity_ids, activity_2, "Event 1's activity should still be the first activity")
         self.assertEqual(activity_2.calendar_event_id, event_2_1, "The first activity's event should still be event 1")
 
         self.assertEqual(len(new_activity), 1, "1 more activity record should have been created (by event 2)")
-        self.assertEqual(event_2_2.activity_ids, new_activity, "Event 2's activity should not be the first activity")
-        self.assertEqual(event_2_2.activity_ids.activity_type_id, activity_2.activity_type_id, "Event 2's activity should be the same activity type as the first activity")
+        self.assertEqual(event_2_2.meeting_activity_ids, new_activity, "Event 2's activity should not be the first activity")
+        self.assertEqual(event_2_2.meeting_activity_ids.activity_type_id, activity_2.activity_type_id, "Event 2's activity should be the same activity type as the first activity")
         self.assertEqual(test_record.activity_ids, activity_1 + activity_2 + new_activity, "Resource record should now have all activities")
 
     def test_event_activity_user_sync(self):
@@ -190,7 +190,7 @@ class TestCalendarActivity(ActivityScheduleCase):
 
         with freeze_time(datetime(2025, 6, 19, 12, 44, 00)):
             calendar_event = self.env['calendar.event'].create({
-                'activity_ids': [(6, 0, activity.ids)],
+                'meeting_activity_ids': [(6, 0, activity.ids)],
                 'name': 'Meeting with partner',
                 'start': datetime(2025, 6, 21, 21, 0, 0),
                 'stop': datetime(2025, 6, 22, 0, 0, 0),
@@ -228,7 +228,7 @@ class TestCalendarActivity(ActivityScheduleCase):
 
         with freeze_time(datetime(2025, 6, 19, 12, 44, 00)):
             calendar_event = self.env['calendar.event'].create({
-                'activity_ids': [(6, False, activity.ids)],
+                'meeting_activity_ids': [(6, False, activity.ids)],
                 'allday': True,
                 'name': 'All Day',
                 'start': datetime(2025, 6, 21, 0, 0, 0),

--- a/addons/calendar/tests/test_calendar_recurrent_event_case2.py
+++ b/addons/calendar/tests/test_calendar_recurrent_event_case2.py
@@ -15,6 +15,7 @@ class TestRecurrentEvent(common.TransactionCase):
         # In order to test recurrent meetings in Odoo, I create meetings with different recurrence using different test cases.
         # I create a recurrent meeting with daily recurrence and fixed amount of time.
         self.CalendarEvent.create({
+            'end_type': 'count',
             'count': 5,
             'start': '2011-04-13 11:04:00',
             'stop': '2011-04-13 12:04:00',

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -305,7 +305,7 @@ class TestEventNotifications(CalendarMailCommon):
                     'start': now + relativedelta(minutes=50),
                     'stop': now + relativedelta(minutes=55),
                     'partner_ids': [(4, self.partner.id)],
-                    'alarm_ids': [(4, alarm.id)]
+                    'alarm_ids': [(6, 0, alarm.ids)]
                 })
 
     def test_email_alarm(self):
@@ -615,7 +615,7 @@ class TestEventNotifications(CalendarMailCommon):
                     'start': now + relativedelta(minutes=50),
                     'stop': now + relativedelta(minutes=55),
                     'partner_ids': [(4, self.partner.id)],
-                    'alarm_ids': [(4, alarm.id)]
+                    'alarm_ids': [(6, 0, alarm.ids)]
                 })
 
     def test_calendar_recurring_event_delete_notification(self):

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -45,6 +45,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'rrule_type': 'weekly',
             'tue': True,
             'interval': 1,
+            'end_type': 'count',
             'count': 3,
             'event_tz': 'UTC',
         })
@@ -64,6 +65,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'interval': 2,
             'rrule_type': 'weekly',
             'tue': True,
+            'end_type': 'count',
             'count': 2,
             'event_tz': 'UTC',
         })
@@ -82,6 +84,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'interval': 2,
             'rrule_type': 'weekly',
             'tue': True,
+            'end_type': 'count',
             'count': 2,
             'event_tz': 'UTC',
         })
@@ -196,6 +199,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
         self.event._apply_recurrence_values({
             'interval': 2,
             'rrule_type': 'yearly',
+            'end_type': 'count',
             'count': 2,
             'event_tz': 'UTC',
         })
@@ -214,6 +218,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'interval': 2,
             'rrule_type': 'weekly',
             'mon': True,
+            'end_type': 'count',
             'count': '2',
             'event_tz': 'America/New_York',  # DST change on 2002/10/27
         })
@@ -235,6 +240,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'interval': 1,
             'rrule_type': 'weekly',
             'sun': True,
+            'end_type': 'count',
             'count': '2',
             'event_tz': 'America/New_York'  # DST change on 2002/4/7
         })
@@ -257,6 +263,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'interval': 1,
             'rrule_type': 'weekly',
             'sun': True,
+            'end_type': 'count',
             'count': '2',
             'event_tz': 'America/New_York'  # DST change on 2002/4/7
         })
@@ -279,6 +286,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'interval': 1,
             'rrule_type': 'weekly',
             'mon': True,
+            'end_type': 'count',
             'count': 2,
             'event_tz': 'Europe/Brussels'  # DST change on 2020/3/23
         })
@@ -368,6 +376,7 @@ class TestCreateRecurrentEvents(TestRecurrentEvents):
             'rrule_type': 'weekly',
             'tue': True,
             'interval': 1,
+            'end_type': 'count',
             'count': 2,
             'event_tz': 'UTC',
             'allday': True,
@@ -421,6 +430,7 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
             'rrule_type': 'weekly',
             'tue': True,
             'interval': 1,
+            'end_type': 'count',
             'count': 3,
             'event_tz': 'Etc/GMT-4',
         })
@@ -684,6 +694,7 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
             'rrule_type': 'weekly',
             'tue': True,
             'interval': 1,
+            'end_type': 'count',
             'count': 3,
             'event_tz': 'Etc/GMT-4',
             'allday': True,
@@ -815,6 +826,7 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
             'wed': True,
             'fri': True,
             'interval': 1,
+            'end_type': 'count',
             'count': 3,
             'event_tz': 'Etc/GMT-4',
         })
@@ -859,6 +871,7 @@ class TestUpdateMultiDayWeeklyRecurrentEvents(TestRecurrentEvents):
             'tue': True,
             'fri': True,
             'interval': 1,
+            'end_type': 'count',
             'count': 3,
             'event_tz': 'Etc/GMT-4',
         })
@@ -932,6 +945,7 @@ class TestUpdateMonthlyByDay(TestRecurrentEvents):
             'recurrency': True,
             'rrule_type': 'monthly',
             'interval': 1,
+            'end_type': 'count',
             'count': 3,
             'month_by': 'day',
             'weekday': 'TUE',
@@ -972,6 +986,7 @@ class TestUpdateMonthlyByDate(TestRecurrentEvents):
             'recurrency': True,
             'rrule_type': 'monthly',
             'interval': 1,
+            'end_type': 'count',
             'count': 3,
             'month_by': 'date',
             'day': 22,
@@ -1016,6 +1031,7 @@ class TestUpdateMonthlyByDate(TestRecurrentEvents):
             calendar_form.name = 'test recurrence daily'
             calendar_form.recurrency = True
             calendar_form.rrule_type_ui = 'daily'
+            calendar_form.end_type = 'count'
             calendar_form.count = 2
             calendar_form.start = datetime(2019, 6, 23, 16)
             calendar_form.stop = datetime(2019, 6, 23, 17)
@@ -1032,6 +1048,7 @@ class TestUpdateMonthlyByDate(TestRecurrentEvents):
             calendar_form.name = 'test recurrence monthly'
             calendar_form.recurrency = True
             calendar_form.rrule_type_ui = 'monthly'
+            calendar_form.end_type = 'count'
             calendar_form.count = 2
             calendar_form.start = datetime(2019, 6, 11, 16)
             calendar_form.stop = datetime(2019, 6, 11, 17)
@@ -1049,6 +1066,7 @@ class TestUpdateMonthlyByDate(TestRecurrentEvents):
             calendar_form.name = 'test recurrence yearly'
             calendar_form.recurrency = True
             calendar_form.rrule_type_ui = 'yearly'
+            calendar_form.end_type = 'count'
             calendar_form.count = 2
             calendar_form.start = datetime(2019, 6, 11, 16)
             calendar_form.stop = datetime(2019, 6, 11, 17)

--- a/addons/calendar/tests/test_recurrence_rule.py
+++ b/addons/calendar/tests/test_recurrence_rule.py
@@ -12,6 +12,7 @@ class TestRecurrenceRule(TransactionCase):
         recurrence = self.env['calendar.recurrence'].create({
             'rrule_type': 'daily',
             'interval': 2,
+            'end_type': 'count',
             'count': 3,
             'event_tz': 'UTC',
         })
@@ -42,6 +43,7 @@ class TestRecurrenceRule(TransactionCase):
             'rrule_type': 'weekly',
             'tue': True,
             'wed': True,
+            'end_type': 'count',
             'interval': 2,
             'count': 3,
             'event_tz': 'UTC',
@@ -153,6 +155,7 @@ class TestRecurrenceRule(TransactionCase):
         recurrence = self.env['calendar.recurrence'].create({
             'rrule_type': 'yearly',
             'interval': 2,
+            'end_type': 'count',
             'count': 3,
             'event_tz': 'UTC',
         })

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -107,8 +107,8 @@
                     <button name="action_open_composer" class="btn btn-primary" type="object" string="Send email" invisible="not user_can_edit"/>
                 </header>
                 <div invisible="not recurrence_id" class="alert alert-info oe_edit_only" role="status">
-                    <p>Edit recurring event</p>
-                    <field name="recurrence_update" widget="radio"/>
+                    <label for="recurrence_update" class="me-2">Edit recurring event</label>
+                    <field name="recurrence_update" widget="radio" options="{'horizontal': True}"/>
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -183,7 +183,8 @@
                             <label for="privacy" string="Status"/>
                             <div class="d-flex">
                                 <field name="show_as" class="oe_inline me-2" readonly="not user_can_edit" nolabel="1"/>
-                                <field name="privacy" class="oe_inline me-2" readonly="not user_can_edit" nolabel="1" placeholder="User default"
+                                <field name="privacy_placeholder" invisible="1"/> <!-- Used to generate the privacy field's placeholder. -->
+                                <field name="privacy" class="oe_inline me-2" readonly="not user_can_edit" nolabel="1" options="{'placeholder_field': 'privacy_placeholder'}"
                                     help="Set whether you're available for other simultaneous events and the privacy of this event to others. Manage your default privacy in your user preferences."/>
                             </div>
                             <field name="should_show_status" invisible="1"/>
@@ -244,7 +245,7 @@
                                     />
                                 </group>
                                 <group>
-                                    <field name="alarm_ids" widget="many2many_tags" options="{'no_quick_create': True}" readonly="not user_can_edit"/>
+                                    <field name="alarm_ids" widget="many2many_tags" options="{'no_quick_create': True, 'on_tag_click': 'open_form'}" readonly="not user_can_edit"/>
                                     <field name="recurrence_id" invisible="1" />
                                     <field name="rrule_type" invisible="1" />
                                     <label for="recurrency" string="Recurrent"/>
@@ -284,7 +285,7 @@
                                         <field name="count" class="oe_inline w-auto" nolabel="1" invisible="end_type != 'count'" required="recurrency" readonly="not user_can_edit"/>
                                         <field name="until" class="oe_inline w-auto" nolabel="1" invisible="end_type != 'end_date'" readonly="not user_can_edit"
                                             required="recurrency and end_type == 'end_date'"
-                                            placeholder="e.g: 12/31/2023"
+                                            placeholder="e.g: 12/31/2030"
                                         />
                                     </div>
                                     <field name="event_tz" invisible="not recurrency" readonly="not user_can_edit"/>
@@ -333,9 +334,9 @@
         <field name="priority" eval="2"/>
         <field name="arch" type="xml">
             <form string="Meetings" class="o_calendar_event_form_quick_create" js_class="calendar_quick_create_form_view">
-                <div class="o_unavailable_attendees_alert alert alert-warning border-0 d-flex flex-wrap m-0 mb-3" role="alert"
+                <div class="o_unavailability_alert alert alert-warning border-0 d-flex flex-wrap m-0 mb-3" role="alert"
                     invisible="not unavailable_partner_ids or allday">
-                    <span class="me-1">The following attendees are not available at the selected time</span>
+                    <span class="me-1">Not available at the selected time:</span>
                     <field name="unavailable_partner_ids" widget="many2many_tags"/>
                 </div>
                 <field name="invalid_email_partner_ids" invisible="1"/> <!--used in many2many_attendees widget-->
@@ -372,18 +373,17 @@
                     </span>
                     <field name="stop" invisible="1"/>
                 </div>
-                <div class="d-flex pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-user mt-1 text-600 me-2" title="Participants"/>
+                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-user text-600 me-2" title="Participants"/>
                     <field name="partner_ids" nolabel="1"
                         widget="many2many_tags"
                         placeholder="Participants"
-                        class="w-75 mb-0"
                     />
                 </div>
                 <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
                     <i class="fa fa-fw flex-shrink-0 fa-map text-600 me-2" title="Location"/>
                     <field name="location" nolabel="1"
-                        placeholder="Location"
+                        placeholder="Room or Location"
                         class="w-100 mb-0"
                     />
                     <!--fields set via the fake front-end only actions must be force saved (see calendar_form)-->
@@ -393,7 +393,7 @@
                     <field name="videocall_source" force_save="1" invisible="1"/>
                     <button name="set_discuss_videocall_location" type="object" class="ms-1 pe-0 btn-link text-nowrap"
                         invisible="videocall_location" context="{'recurrence_update': recurrence_update}">
-                        <span class="fa fa-plus me-1"/>Video
+                        <span class="fa fa-plus me-1"/>Video conference
                     </button>
                 </div>
                 <div class="d-flex align-items-center pt-1 pb-2" colspan="2" invisible="not videocall_location">
@@ -406,7 +406,12 @@
                 </div>
                 <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
                     <i class="fa fa-fw flex-shrink-0 fa-lock text-600 me-2" title="Visibility"/>
-                    <field name="privacy" nolabel="1" class="w-100 mb-0" placeholder="Visibility"/>
+                    <field name="privacy_placeholder" invisible="1"/> <!-- Used to generate the privacy field's placeholder. -->
+                    <field name="privacy" nolabel="1" class="w-100 mb-0" options="{'placeholder_field': 'privacy_placeholder'}"/>
+                </div>
+                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
+                    <i class="fa fa-fw flex-shrink-0 fa-circle text-600 me-2" title="Show as"/>
+                    <field name="show_as" nolabel="1" class="w-100 mb-0"/>
                 </div>
                 <div class="d-flex pt-1 pb-2" colspan="2">
                     <i class="fa fa-fw flex-shrink-0 fa-sticky-note mt-2 text-600 me-2" title="Notes"/>

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -492,6 +492,17 @@
                     <separator/>
                     <filter string="Date" name="group_by_start" domain="[]" context="{'group_by': 'start'}"/>
                 </group>
+                <separator/>
+                <filter invisible="1" string="My Activities" name="filter_activities_my"
+                    domain="[('activity_user_id', '=', uid)]"/>
+                <separator/>
+                <filter invisible="1" string="Late Activities" name="activities_overdue"
+                    domain="[('my_activity_date_deadline', '&lt;', 'today')]"
+                    help="Show all opportunities for which the next action date is before today"/>
+                <filter invisible="1" string="Today Activities" name="activities_today"
+                    domain="[('my_activity_date_deadline', '=', 'today')]"/>
+                <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
+                    domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
             </search>
         </field>
     </record>
@@ -500,7 +511,7 @@
         <field name="name">Meetings</field>
         <field name="path">calendar</field>
         <field name="res_model">calendar.event</field>
-        <field name="view_mode">calendar,list,form</field>
+        <field name="view_mode">calendar,list,form,activity</field>
         <field name="view_id" ref="view_calendar_event_calendar"/>
         <field name="search_view_id" ref="view_calendar_event_search"/>
         <field name="help" type="html">

--- a/addons/crm/models/calendar.py
+++ b/addons/crm/models/calendar.py
@@ -39,7 +39,7 @@ class CalendarEvent(models.Model):
     def create(self, vals_list):
         events = super().create(vals_list)
         for event in events:
-            if event.opportunity_id and not event.activity_ids:
+            if event.opportunity_id and not event.meeting_activity_ids:
                 event.opportunity_id.log_meeting(event)
         return events
 

--- a/addons/crm/tests/test_crm_lead_merge.py
+++ b/addons/crm/tests/test_crm_lead_merge.py
@@ -451,7 +451,7 @@ class TestLeadMerge(TestLeadMergeCommon):
         activity = lead_1.activity_schedule('crm.lead_test_activity_1', user_id=self.user_sales_manager.id)
         calendar_event = self.env['calendar.event'].create({
             'name': 'Meeting with partner',
-            'activity_ids': [(4, activity.id)],
+            'meeting_activity_ids': [(4, activity.id)],
             'start': '2021-06-12 21:00:00',
             'stop': '2021-06-13 00:00:00',
             'res_model_id': self.env['ir.model']._get('crm.crm_lead').id,

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -331,7 +331,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'end': {'date': str(event.stop_date + relativedelta(days=1)), 'dateTime': None},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'declined'}],
             'extendedProperties': {'private': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
         })
 
     @patch_api
@@ -1412,7 +1412,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
                           {'email': 'odoobot@example.com', 'responseStatus': 'accepted'},],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id,
                                               '%s_owner_id' % self.env.cr.dbname: other_user.id}},
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'transparency': 'opaque',
         }, timeout=3)
 

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -166,7 +166,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'location': '',
             'visibility': 'private',
             'guestsCanModify': True,
-            'reminders': {'useDefault': False, 'overrides': []},
+            'reminders': {'useDefault': False, 'overrides': [{'method': 'popup', 'minutes': 15}]},
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'jean-luc@opoo.com', 'responseStatus': 'needsAction'},
                           {'email': 'phineas@opoo.com', 'responseStatus': 'needsAction'}],
@@ -192,7 +192,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'description': '',
             'location': '',
             'guestsCanModify': True,
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
@@ -253,7 +253,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'description': '',
             'location': '',
             'guestsCanModify': True,
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'recurrence': ['RRULE:FREQ=WEEKLY;COUNT=2;BYDAY=WE'],
@@ -288,7 +288,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'description': '',
             'location': '',
             'guestsCanModify': True,
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'recurrence': ['RRULE:FREQ=WEEKLY;COUNT=2;BYDAY=WE'],
@@ -339,7 +339,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.recurrence_id.id}},
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=1;BYDAY=WE'],
             'transparency': 'opaque',
         }, timeout=3)
@@ -387,7 +387,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'description': event.description,
             'location': '',
             'guestsCanModify': True,
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': 'jean-luc@opoo.com', 'self': True},
             'attendees': [{'email': 'jean-luc@opoo.com', 'responseStatus': 'accepted'}],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
@@ -428,7 +428,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=2;BYDAY=WE'],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: new_recurrence.id}},
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'transparency': 'opaque',
         }, timeout=3)
 
@@ -557,7 +557,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'jean-luc@opoo.com', 'responseStatus': 'declined'}],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'transparency': 'opaque',
         })
 
@@ -595,7 +595,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'recurrence': ['RRULE:FREQ=WEEKLY;WKST=SU;COUNT=2;BYDAY=WE'],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: new_recurrence.id}},
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'transparency': 'opaque',
         }, timeout=3)
 
@@ -638,7 +638,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event_1.id}},
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'status': 'cancelled',
             'transparency': 'opaque',
         }, timeout=3)
@@ -770,7 +770,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'description': '',
             'location': '',
             'guestsCanModify': True,
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
@@ -796,7 +796,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'description': '',
             'location': '',
             'guestsCanModify': True,
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': 'odoobot@example.com', 'self': True},
             'attendees': [{'email': 'odoobot@example.com', 'responseStatus': 'accepted'}],
             'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: event.id}},
@@ -843,7 +843,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'location': '',
             'guestsCanModify': True,
             'transparency': 'opaque',
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': self.organizer_user.email, 'self': True},
             'attendees': [
                             {'email': self.attendee_user.email, 'responseStatus': 'needsAction'},
@@ -884,7 +884,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'description': event.description,
             'location': '',
             'guestsCanModify': True,
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'organizer': {'email': self.organizer_user.email, 'self': True},
             'attendees': [{'email': self.organizer_user.email, 'responseStatus': 'accepted'}],
             'recurrence': ['RRULE:FREQ=WEEKLY;COUNT=1;BYDAY=WE'],
@@ -940,7 +940,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                 'location': '',
                 'guestsCanModify': True,
                 'transparency': 'opaque',
-                'reminders': {'overrides': [], 'useDefault': False},
+                'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
                 'organizer': {'email': self.organizer_user.email, 'self': True},
                 'attendees': [
                                 {'email': self.attendee_user.email, 'responseStatus': 'needsAction'},
@@ -973,7 +973,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                             {'email': self.attendee_user.email, 'responseStatus': 'needsAction'},
                             {'email': self.organizer_user.email, 'responseStatus': 'accepted'}
                          ],
-            'reminders': {'overrides': [], 'useDefault': False},
+            'reminders': {'overrides': [{'method': 'popup', 'minutes': 15}], 'useDefault': False},
             'transparency': 'opaque',
         }
         self.assertGoogleEventInsertedMultiTime({

--- a/addons/google_calendar/tests/test_sync_odoo2google_mail.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google_mail.py
@@ -49,7 +49,7 @@ class TestSyncOdoo2GoogleMail(TestTokenAccess, TestSyncGoogle, MailCommon):
                         'guestsCanModify': is_public,
                         'organizer': {'email': organizer.email, 'self': False} if organizer else False,
                         'summary': 'Event',
-                        'reminders': {'useDefault': False, 'overrides': []},
+                        'reminders': {'useDefault': False, 'overrides': [{'method': 'popup', 'minutes': 15}]},
                     }, timeout=3)
                 else:
                     self.assertGoogleEventNotInserted()

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1126,7 +1126,7 @@ class HrLeave(models.Model):
                 'allday': allday_value,
                 'privacy': 'confidential',
                 'event_tz': user.tz,
-                'activity_ids': [(5, 0, 0)],
+                'meeting_activity_ids': [(5, 0, 0)],
                 'res_id': holiday.id,
             }
             # Add the partner_id (if exist) as an attendee

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -352,6 +352,8 @@ class TestCreateEvents(TestCommon):
         self.assertEqual(self.organizer_user.microsoft_last_sync_date, False,
                          "Variable last_sync_date must be False due to sync stop.")
 
+        # Avoid default alarm for the test event as self.call_post_commit_hooks never clear self.env.cr.postcommit._funcs.
+        self.simple_event_values.update(alarm_ids=False)
         # Create a not synced event (local).
         simple_event_values_updated = self.simple_event_values
         for date_field in ['start', 'stop']:

--- a/addons/microsoft_calendar/tests/test_sync_odoo2microsoft_mail.py
+++ b/addons/microsoft_calendar/tests/test_sync_odoo2microsoft_mail.py
@@ -77,6 +77,8 @@ class TestSyncOdoo2MicrosoftMail(TestCommon, MailCase):
                 if not mail_notified_partners:
                     self.assertNotSentEmail()
                     mock_insert.assert_called_once()
+                    self.assertTrue(mock_insert.call_args[0][0]['isReminderOn'])
+                    self.assertEqual(mock_insert.call_args[0][0]['reminderMinutesBeforeStart'], 15)
                     self.assert_dict_equal(mock_insert.call_args[0][0]['organizer'], {
                         'emailAddress': {'address': organizer.email if organizer else '', 'name': organizer.name if organizer else ''}
                     })

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -78,7 +78,6 @@
         </t>
         <t t-if="isEventDeletable">
             <a href="#" class="btn btn-danger o_cw_popover_delete" t-on-click="onDeleteEvent">
-                <i class="fa fa-trash" role="presentation"/>
                 Delete
             </a>
         </t>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -119,8 +119,6 @@ export class CalendarCommonRenderer extends Component {
             eventDragStart: this.onEventDragStart,
             eventDragStop: this.onEventDragStop,
             eventDrop: this.onEventDrop,
-            eventMouseEnter: this.onEventMouseEnter,
-            eventMouseLeave: this.onEventMouseLeave,
             eventClassNames: this.eventClassNames,
             eventDidMount: this.onEventDidMount,
             eventContent: this.onEventContent,
@@ -254,11 +252,6 @@ export class CalendarCommonRenderer extends Component {
             el.classList.add(className);
         }
     }
-    unhighlightEvent(event, className) {
-        for (const el of this.fc.api.el.querySelectorAll(this.computeEventSelector(event))) {
-            el.classList.remove(className);
-        }
-    }
     mapRecordsToEvents() {
         const { records } = this.props.model.data;
         return Object.values(records).map((r) => this.convertRecordToEvent(r));
@@ -286,7 +279,6 @@ export class CalendarCommonRenderer extends Component {
 
     onClick(info) {
         this.openPopover(info.el, this.props.model.records[info.event.id]);
-        this.highlightEvent(info.event, "o_cw_custom_highlight");
     }
     onDateClick(info) {
         this.props.createRecord(this.fcEventToRecord(info));
@@ -461,15 +453,6 @@ export class CalendarCommonRenderer extends Component {
             res.id = existingRecord.id;
         }
         return res;
-    }
-    onEventMouseEnter(info) {
-        this.highlightEvent(info.event, "o_cw_custom_highlight");
-    }
-    onEventMouseLeave(info) {
-        if (!info.event.id) {
-            return;
-        }
-        this.unhighlightEvent(info.event, "o_cw_custom_highlight");
     }
     onEventDragStart(info) {
         this.props.cleanSquareSelection();


### PR DESCRIPTION
This PR improves the calendar's UX with multiple commits:

- Commit 1 improves the UX of the calendar.event forms by computing some placeholders, fixing the display of a field, changing a default value and allowing modifications of reminders when clicking on their tag.
- Commit 2 improves the UX of the calendar view by adding a hotkey on the "New" button, fixing the display of the popover and removing the shadow displayed when the user clicks or hovers over an event.
- Commit 3 set a default alarm for calendar.event.
- Commit 4 adds a message in the log's calendar.event when email reminders are sent.  
- Commit 5 allows calendar events to have activities.

Enterprise PR: https://github.com/odoo/enterprise/pull/103469
Upgrade PR: https://github.com/odoo/upgrade/pull/9344

Task-5429852