### PR TITLE
[FIX] base: correct GMT +/- offsets for Etc/GMT timezone

### DIFF
--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -421,6 +421,13 @@ class TestUsers2(TransactionCase):
             UserForm.email = "foo@bar.com"
         self.assertEqual(my_user.email, "foo@bar.com")
 
+    def test_etc_gmt_offsets(self):
+        """Etc/GMT±n should produce the correct GMT offset."""
+        for tz, expected in (('Etc/GMT+2', '+0200'), ('Etc/GMT-2', '-0200')):
+            with self.subTest(tz=tz):
+                self.user_employee.tz = tz
+                self.assertEqual(self.user_employee.tz_offset, expected)
+
 
 @tagged('post_install', '-at_install', 'res_groups')
 class TestUsersGroupWarning(TransactionCase):


### PR DESCRIPTION
Currently, an incorrect time offset is applied when selecting `Etc/GMT+` or 
`Etc/GMT-` timezones in user preferences, resulting in `reversed GMT` offsets.

**Steps to reproduce:**
- Open `User Preferences`.
- Select `Etc/GMT` as the `timezone` and note the displayed time.
- Change the timezone to `Etc/GMT+2` or `Etc/GMT-2`.
- Observe the displayed time.

**Observation:**
`Etc/GMT+2` behaves like `GMT−2`, resulting in the time being shown 2 hours 
earlier rather than 2 hours ahead (and vice versa for `Etc/GMT−2`).

**Root Cause:**
The `IANA timezone database` follows `POSIX sign` conventions [1], where 
the signs for `Etc/GMT±n` timezones are reversed compared to common 
usage. Python’s timezone handling relies on this database [2], leading to 
incorrect offsets being applied when the timezone is used directly.

**Fix:**
This commit normalizes `Etc/GMT±n` timezones by inverting their sign before computing 
the offset, ensuring the correct GMT offset is applied to the user interface.

[1]:
https://www.php.net/manual/en/timezones.others.php

[2]:
https://docs.python.org/3/library/zoneinfo.html#data-sources

opw-5441814