### PR TITLE
[FIX] html_builder: remove image shape option for dynamic svg

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.js
@@ -3,6 +3,7 @@ import { ImageShapeOption } from "@html_builder/plugins/image/image_shape_option
 import { ImageFilterOption } from "@html_builder/plugins/image/image_filter_option";
 import { ImageFormatOption } from "@html_builder/plugins/image/image_format_option";
 import { ImageTransformOption } from "./image_transform_option";
+import { dynamicSVGSelector } from "../utils";
 
 export class ImageToolOption extends BaseOptionComponent {
     static template = "html_builder.ImageToolOption";
@@ -19,6 +20,7 @@ export class ImageToolOption extends BaseOptionComponent {
         super.setup();
         this.state = useDomState((editingElement) => ({
             isImageAnimated: editingElement.classList.contains("o_animate"),
+            isDynamicSVG: editingElement.matches(dynamicSVGSelector),
         }));
     }
 }

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -2,7 +2,9 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.ImageToolOption">
-    <ImageShapeOption />
+    <t t-if="!state.isDynamicSVG">
+        <ImageShapeOption />
+    </t>
     <BuilderRow label.translate="Description"
         tooltip.translate="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...).">
         <BuilderTextInput

--- a/addons/html_builder/static/src/plugins/utils.js
+++ b/addons/html_builder/static/src/plugins/utils.js
@@ -1,3 +1,5 @@
+export const dynamicSVGSelector = "img[src^='/html_editor/shape/'], img[src^='/web_editor/shape/']";
+
 export function applyFunDependOnSelectorAndExclude(fn, rootEl, selectorParams) {
     const editingEls = getEditingEls(rootEl, selectorParams);
     if (!editingEls.length) {

--- a/addons/website/static/src/builder/plugins/dynamic_svg_option.js
+++ b/addons/website/static/src/builder/plugins/dynamic_svg_option.js
@@ -1,8 +1,9 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { dynamicSVGSelector } from "@html_builder/plugins/utils";
 
 export class DynamicSvgOption extends BaseOptionComponent {
     static template = "website.DynamicSvgOption";
-    static selector = "img[src^='/html_editor/shape/'], img[src^='/web_editor/shape/']";
+    static selector = dynamicSVGSelector;
 
     setup() {
         super.setup();


### PR DESCRIPTION
The image shape option was added for dynamic SVG with the new builder in saas-18.4. However, this seems to be an error since shapes are not supported with dynamic SVG.
The image shape option will not appear anymore in such cases to avoid tracebacks for the user.

task-5451405
