### PR TITLE
[FIX] account: allow salesman to access invoice

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -853,6 +853,7 @@
                                     </div>
                             </button>
                             <button name="open_payments"
+                                    groups="account.group_account_invoice,account.group_account_readonly"
                                     class="oe_stat_button"
                                     icon="fa-bars"
                                     type="object"

--- a/addons/sale/tests/test_access_rights.py
+++ b/addons/sale/tests/test_access_rights.py
@@ -2,7 +2,7 @@
 
 from odoo import Command
 from odoo.exceptions import AccessError, UserError
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.mail.tests.common import MailCommon
@@ -109,6 +109,9 @@ class TestAccessRights(SaleCommon, MailCommon):
         # Salesperson can send & print
         with self.mock_mail_gateway(mail_unlink_sent=False):
             composer.action_send_and_print()
+
+        # Salesperson should be able to create an invoice form
+        Form(move_as_salesperson)
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.addons.base.models.ir_rule')
     def test_access_portal_user(self):


### PR DESCRIPTION
### Issue:
User with sale access group cannot access invoices.

#### Steps to reproduce:
- Install demo data
- In user setting, `Access Rights` tab, remove `Accounting` access and set `Sale` access to Administrator for user Demo.
- Log in using Demo user.
- Create a SO, and after confirming, create an invoice.
- As you see, you will get access rights error.

### Cause:
Group salesman doesn't have `read` access on `account.payment`.

`_compute_payment_count` causes `_compute_reconciled_payment_ids` to be called:
https://github.com/odoo/odoo/blob/25542ed259deb722ced921906c7171961ab44c6a/addons/account/models/account_move.py#L1348-L1351

And then in the `_compute_reconciled_payment_ids`:
https://github.com/odoo/odoo/blob/25542ed259deb722ced921906c7171961ab44c6a/addons/account/models/account_move.py#L2368-L2369

Enterprise PR: odoo/enterprise#103477

Ticket [link](https://www.odoo.com/odoo/project.task/5461135)
opw-5461135
