### PR TITLE
[FIX] mail: fix undeafen action in call settings and menu

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -36,15 +36,16 @@ export const muteAction = {
     badge: ({ owner, store }) =>
         !owner.env.inCallMenu && store.rtc.microphonePermission !== "granted",
     badgeIcon: "fa fa-exclamation",
-    condition: ({ thread }) => thread?.isSelfInCall,
+    condition: ({ owner, store, thread }) =>
+        thread?.isSelfInCall && (owner.env.inCallMenu || !store.rtc.selfSession?.is_deaf),
     name: ({ store }) => (store.rtc.selfSession.isMute ? _t("Unmute") : _t("Mute")),
     isActive: ({ store }) =>
         (store.rtc.selfSession?.isMute && store.rtc.microphonePermission === "granted") ||
         store.rtc.selfSession?.is_deaf,
     isTracked: true,
-    icon: ({ action, store }) =>
+    icon: ({ action, owner, store }) =>
         action.isActive
-            ? store.rtc.selfSession?.is_deaf
+            ? store.rtc.selfSession?.is_deaf && !owner.env.inCallMenu
                 ? CALL_ICON_DEAFEN
                 : CALL_ICON_MUTED
             : "fa fa-microphone",
@@ -77,7 +78,8 @@ export const quickActionSettings = {
 };
 registerCallAction("quick-voice-settings", quickActionSettings);
 registerCallAction("deafen", {
-    condition: ({ owner, thread }) => owner.env.inCallMenu && thread?.isSelfInCall,
+    condition: ({ owner, store, thread }) =>
+        thread?.isSelfInCall && (owner.env.inCallMenu || store.rtc.selfSession?.is_deaf),
     name: ({ store }) => (store.rtc.selfSession.is_deaf ? _t("Undeafen") : _t("Deafen")),
     isActive: ({ store }) => store.rtc.selfSession?.is_deaf,
     isTracked: true,
@@ -85,7 +87,7 @@ registerCallAction("deafen", {
     hotkey: "shift+d",
     onSelected: ({ store }) => store.rtc.toggleDeafen(),
     sequence: 10,
-    sequenceGroup: 110,
+    sequenceGroup: 100,
     tags: ({ action }) => (action.isActive ? ACTION_TAGS.DANGER : undefined),
 });
 export const cameraOnAction = {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -1127,6 +1127,7 @@ test("discuss sidebar call participant shows appropriate status icon", async () 
     await contains(
         ".o-mail-DiscussSidebarCallParticipants:contains('Mitchell Admin') .fa-microphone-slash"
     );
+    await contains("button[title='Unmute']");
     await click("button[title='Voice Settings']");
     await click(".dropdown-menu button:contains('Deafen')");
     await contains(".o-mail-DiscussSidebarCallParticipants:contains('Mitchell Admin') .fa-deaf");
@@ -1134,7 +1135,7 @@ test("discuss sidebar call participant shows appropriate status icon", async () 
         ".o-mail-DiscussSidebarCallParticipants:contains('Mitchell Admin') .fa-microphone-slash",
         { count: 0 }
     );
-    await click("button[title='Unmute']");
+    await click("button[title='Undeafen']");
     await contains(".o-mail-DiscussSidebarCallParticipants:contains('Mitchell Admin') .fa-deaf", {
         count: 0,
     });


### PR DESCRIPTION
Before this commit, the hint in the call settings was not taking into account if it was deafen or mute. On top of that the icon in the menu was showing the deafen icon but with the unmute label. When deafened, this was redundant with the undeafen button as well since unmute and undeafen are practically doing the same thing.

Now, when deafen is activated, only the undeafen button is shown in the call menu and the hint in the call actions is undeafen not unmute.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
