### PR TITLE
[FIX] point_of_sale: catch error when loading POS

### DIFF
--- a/addons/point_of_sale/static/src/app/components/loader/critical_pos_error/critical_pos_error.js
+++ b/addons/point_of_sale/static/src/app/components/loader/critical_pos_error/critical_pos_error.js
@@ -1,0 +1,64 @@
+import { Component, useState } from "@odoo/owl";
+
+export class CriticalPOSError extends Component {
+    static template = "point_of_sale.CriticalPOSError";
+    static props = { error: Object };
+
+    setup() {
+        this.state = useState({ expanded: false });
+    }
+    async fullReset() {
+        // Storage
+        localStorage.clear();
+        sessionStorage.clear();
+
+        try {
+            // Unregister service workers
+            if ("serviceWorker" in navigator) {
+                const regs = await navigator.serviceWorker.getRegistrations();
+                await Promise.all(regs.map((r) => r.unregister()));
+            }
+
+            // Clear Cache Storage (important for PWAs)
+            if ("caches" in window) {
+                const keys = await caches.keys();
+                await Promise.all(keys.map((k) => caches.delete(k)));
+            }
+
+            // Delete IndexedDB databases (if supported)
+            if ("indexedDB" in window && typeof indexedDB.databases === "function") {
+                const dbs = await indexedDB.databases();
+                const names = dbs.map((db) => db?.name).filter(Boolean);
+                await Promise.all(
+                    names.map(
+                        (name) =>
+                            new Promise((resolve, reject) => {
+                                const req = indexedDB.deleteDatabase(name);
+                                req.onsuccess = () => resolve();
+                                req.onerror = () => reject(req.error);
+                                req.onblocked = () => resolve();
+                            })
+                    )
+                );
+            }
+        } finally {
+            // Reload
+            location.reload();
+        }
+    }
+    async copyToClipboard() {
+        const text = this.state.expanded ? this.props.error.stack : this.props.error;
+        if (!text) {
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(text);
+        } catch (err) {
+            console.error("Could not copy text: ", err);
+        }
+    }
+    back() {
+        window.history.back();
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/loader/critical_pos_error/critical_pos_error.xml
+++ b/addons/point_of_sale/static/src/app/components/loader/critical_pos_error/critical_pos_error.xml
@@ -1,0 +1,33 @@
+<templates>
+    <t t-name="point_of_sale.CriticalPOSError">
+        <div class="card pos-error rounded">
+            <div class="o_error_dialog p-0">
+                <div role="alert">
+                    <div class="card-header">
+                        <h1> Oops! </h1>
+                    </div>
+                    <div class="card-body">
+                        <p>Something went wrong... If you really are stuck, share the report with your friendly support service</p>
+                        <button class="btn btn-link p-0" t-on-click="() => this.state.expanded = !this.state.expanded" >
+                            <t t-if="this.state.expanded">Hide details</t>
+                            <t t-if="!this.state.expanded">Show details</t>
+                        </button>
+                        <div t-if="state.expanded" class="bg-100 mb-0 clearfix mt-3 position-relative o_error_detail">
+                            <button class="btn position-absolute bg-100" t-ref="copyButton" t-on-click="copyToClipboard">
+                                <i class="fa fa-clipboard" />
+                            </button>
+                            <div class="ps-3 pt-3">
+                                <pre t-esc="props.error.stack"/>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="m-2 p-2">
+                        <div class="flex align-self-center">
+                            <button class="btn btn-primary" t-on-click="fullReset">Reload data</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/src/app/components/loader/loader.js
+++ b/addons/point_of_sale/static/src/app/components/loader/loader.js
@@ -1,8 +1,11 @@
 import { Component, useEffect } from "@odoo/owl";
+import { CriticalPOSError } from "./critical_pos_error/critical_pos_error";
 
 export class Loader extends Component {
     static template = "point_of_sale.Loader";
-    static props = { loader: { type: Object, shape: { isShown: Boolean } } };
+    static props = { loader: { type: Object, shape: { isShown: Boolean, error: Object } } };
+    static components = { CriticalPOSError };
+
     setup() {
         useEffect(
             (isShown) => {

--- a/addons/point_of_sale/static/src/app/components/loader/loader.scss
+++ b/addons/point_of_sale/static/src/app/components/loader/loader.scss
@@ -11,6 +11,15 @@
     color: $gray-700;
     transition: opacity 0.8s;
 
+    .pos-error {
+      text-align: left;
+      width: 80%;
+      align-self: center;
+      position: absolute;
+      left: 10%;
+      top: 20%;
+    }
+
     .loader-feedback {
         width: 400px;
         height: 160px;

--- a/addons/point_of_sale/static/src/app/components/loader/loader.xml
+++ b/addons/point_of_sale/static/src/app/components/loader/loader.xml
@@ -1,13 +1,10 @@
 <templates>
     <t t-name="point_of_sale.Loader">
         <div class="pos-loader" t-att-style="props.loader.isShown ? '' : 'opacity: 0'">
+            <CriticalPOSError t-if="props.loader.error" error="props.loader.error"/>
             <div class="loader-feedback">
                 <!-- spinner from https://loading.io/css/ -->
-                <div class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
-                <!-- FIXME POSREF restore skip button? -->
-                <!-- <t t-if="false and pos.loadingSkipButtonIsShown">
-                    <h1 class="message">Connecting to devices</h1>
-                </t> -->
+                <div t-if="!props.loader.error" class="lds-ellipsis"><div></div><div></div><div></div><div></div></div>
             </div>
         </div>
     </t>

--- a/addons/point_of_sale/static/src/app/main.js
+++ b/addons/point_of_sale/static/src/app/main.js
@@ -10,18 +10,16 @@ import { mountComponent } from "@web/env";
 import { Chrome } from "@point_of_sale/app/pos_app";
 import { jsToPyLocale } from "@web/core/l10n/utils";
 
-const loader = reactive({ isShown: true });
+const loader = reactive({ isShown: true, error: false });
 whenReady(() => {
-    // Show loader as soon as the page is ready, do not wait for services to be started
-    // as some services load data over RPC and this is why we want to show a loader.
     mount(Loader, document.body, {
         getTemplate,
         props: { loader },
         translatableAttributes: ["data-tooltip"],
-        translateFn: _t,
+        translateFn: (s) => s,
     });
 });
-// The following is mostly a copy of startWebclient but without any of the legacy stuff
+
 (async function startPosApp() {
     odoo.info = {
         db: session.db,
@@ -30,36 +28,41 @@ whenReady(() => {
         isEnterprise: session.server_version_info.slice(-1)[0] === "e",
     };
     await whenReady();
-    const app = await mountComponent(Chrome, document.body, {
-        name: "Odoo Point of Sale",
-        props: { disableLoader: () => (loader.isShown = false) },
-    });
-    window.addEventListener("beforeunload", function (event) {
-        if (app.env.services.pos_data.network.offline) {
-            var confirmationMessage = _t(
-                "You are currently offline. Reloading the page may cause you to lose unsaved data."
-            );
-            event.returnValue = confirmationMessage;
-            return confirmationMessage;
+    try {
+        const app = await mountComponent(Chrome, document.body, {
+            name: "Odoo Point of Sale",
+            props: { disableLoader: () => (loader.isShown = false) },
+        });
+        window.addEventListener("beforeunload", function (event) {
+            if (app.env.services.pos_data.network.offline) {
+                var confirmationMessage = _t(
+                    "You are currently offline. Reloading the page may cause you to lose unsaved data."
+                );
+                event.returnValue = confirmationMessage;
+                return confirmationMessage;
+            }
+        });
+        const classList = document.body.classList;
+        if (localization.direction === "rtl") {
+            classList.add("o_rtl");
         }
-    });
-    const classList = document.body.classList;
-    if (localization.direction === "rtl") {
-        classList.add("o_rtl");
-    }
-    if (user.userId === 1) {
-        classList.add("o_is_superuser");
-    }
-    if (app.env.debug) {
-        classList.add("o_debug");
-    }
-    if (hasTouch()) {
-        classList.add("o_touch_device");
-        classList.add("o_mobile_overscroll");
-        document.documentElement.classList.add("o_mobile_overscroll");
-    }
+        if (user.userId === 1) {
+            classList.add("o_is_superuser");
+        }
+        if (app.env.debug) {
+            classList.add("o_debug");
+        }
+        if (hasTouch()) {
+            classList.add("o_touch_device");
+            classList.add("o_mobile_overscroll");
+            document.documentElement.classList.add("o_mobile_overscroll");
+        }
 
-    registerServiceWorker();
+        registerServiceWorker();
+    } catch (e) {
+        loader.error = e;
+        throw e;
+    }
 })();
 
 function registerServiceWorker() {


### PR DESCRIPTION
Inconsistent data in the localDB or local storage can cause the POS to fail before it can get initialized. When this happens the page just stays showing the loading screen forever.

Now when an error happens while initializing the POS the loader will disappear and the app will give the user the option to clear all local data and refresh the page. This should be especially useful for users on mobile where it's a pain to refresh the local data manually.

Task-[5420544](https://www.odoo.com/odoo/project/1737/tasks/5420544)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
