### PR TITLE
[FIX] point_of_sale: show accurate price in product configurator

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -223,9 +223,7 @@ export class ProductConfiguratorPopup extends Component {
                     acc[selected.id] = custom_value;
                     return acc;
                 }, []),
-            price_extra: this.selectedValues
-                .filter((value) => value.attribute_id.create_variant === "no_variant")
-                .reduce((acc, val) => acc + val.price_extra, 0),
+            price_extra: this.priceExtra,
         };
     }
 
@@ -246,13 +244,31 @@ export class ProductConfiguratorPopup extends Component {
     }
 
     get title() {
-        const info = this.props.productTemplate.getTaxDetails();
-        const name = this.props.productTemplate.display_name;
+        const overridedValues = {};
+        const order = this.pos.getOrder();
+        if (order) {
+            if (order.pricelist_id) {
+                overridedValues.pricelist = order.pricelist_id;
+            }
+            if (order.fiscal_position_id) {
+                overridedValues.fiscalPosition = order.fiscal_position_id;
+            }
+        }
+
+        overridedValues.priceExtra = this.priceExtra;
+
+        const product = this.product || this.props.productTemplate;
+        const info = product.getTaxDetails({ overridedValues });
         const total = this.env.utils.formatCurrency(info?.raw_total_included_currency || 0.0);
-        return `${name} | ${total}`;
+        return `${this.props.productTemplate.display_name} | ${total}`;
     }
     get showInfoBanner() {
         return this.props.productTemplate.is_storable;
+    }
+    get priceExtra() {
+        return this.selectedValues
+            .filter((value) => value.attribute_id.create_variant === "no_variant")
+            .reduce((acc, val) => acc + val.price_extra, 0);
     }
 
     confirm() {

--- a/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
@@ -8,11 +8,17 @@ export class ProductTemplateAccounting extends Base {
     static pythonModel = "product.template";
 
     prepareProductBaseLineForTaxesComputationExtraValues(opts = {}) {
-        const { price = false, pricelist = false, fiscalPosition = false } = opts;
+        const { price = false, pricelist = false, fiscalPosition = false, priceExtra = 0 } = opts;
         const isVariant = Boolean(this?.product_tmpl_id);
         const config = this.models["pos.config"].getFirst();
         const productTemplate = isVariant ? this.product_tmpl_id : this;
-        const baseP = productTemplate.getPrice(pricelist, 1, 0, false, isVariant ? this : false);
+        const baseP = productTemplate.getPrice(
+            pricelist,
+            1,
+            priceExtra,
+            false,
+            isVariant ? this : false
+        );
         const priceUnit = price || price === 0 ? price : baseP;
         const currency = config.currency_id;
 
@@ -139,7 +145,7 @@ export class ProductTemplateAccounting extends Base {
 
     getBaseLine(opts = {}) {
         const vals = opts.overridedValues || {};
-        const { price = false, pricelist = false, fiscalPosition = false } = vals;
+        const { price = false, pricelist = false, fiscalPosition = false, priceExtra = 0 } = vals;
 
         return accountTaxHelpers.prepare_base_line_for_taxes_computation(
             {},
@@ -147,6 +153,7 @@ export class ProductTemplateAccounting extends Base {
                 price,
                 pricelist,
                 fiscalPosition,
+                priceExtra,
                 ...vals,
             })
         );

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -211,3 +211,38 @@ registry.category("web_tour.tours").add("test_custom_attribute_alone_displayed",
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_product_configurator_price", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Configurable Product"),
+            ProductConfigurator.priceIs("13.20"), // 10 (Small) + 2 (Red) + 1.2 (10% tax)
+            ProductConfigurator.pickRadio("Large"),
+            ProductConfigurator.priceIs("14.30"), // 10 + 1 (Large) + 2 (Red) + 1.3 (10% tax)
+            ProductConfigurator.pickRadio("Blue"),
+            ProductConfigurator.priceIs("15.40"), // 10 + 1 (Large) + 3 (Blue) + 1.4 (10% tax)
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("15.40"),
+            ProductScreen.clickPriceList("Pricelist 2"),
+            ProductScreen.totalAmountIs("22.00"),
+            ProductScreen.clickDisplayedProduct("Configurable Product"),
+            ProductConfigurator.priceIs("22.00"), // 20 (pricelist 2) + 2 (10% tax)
+            ProductConfigurator.pickRadio("Blue"),
+            ProductConfigurator.priceIs("22.00"), // 20 (pricelist 2) + 2 (10% tax)
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("44.00"),
+            Chrome.createFloatingOrder(),
+            ProductScreen.clickFiscalPosition("Include to Exclude"),
+            ProductScreen.clickDisplayedProduct("Configurable Product"),
+            ProductConfigurator.priceIs("12.00"), // 10 (Small) + 2 (Red)
+            ProductConfigurator.pickRadio("Large"),
+            ProductConfigurator.priceIs("13.00"), // 10 + 1 (Large) + 2 (Red)
+            ProductConfigurator.pickRadio("Blue"),
+            ProductConfigurator.priceIs("14.00"), // 10 + 1 (Large) + 3 (Blue)
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("14.00"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_configurator_util.js
@@ -207,3 +207,12 @@ export function isRadioDisabled(name) {
         },
     ];
 }
+
+export function priceIs(price) {
+    return [
+        {
+            content: `checking that total price is ${price}`,
+            trigger: `.modal .modal-title:contains('${price}')`,
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3340,6 +3340,92 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_orderline_merge_with_higher_price_precision', login="pos_user")
 
+    def test_product_configurator_price(self):
+        """ Test that the product configurator displays the correct price when selecting attributes that impact the price. """
+        self.env['product.template'].search([('available_in_pos', '=', True)]).active = False
+        tax_10 = self.env['account.tax'].create({
+            'name': 'Tax 10%',
+            'amount': 10,
+        })
+        fiscal_position = self.env['account.fiscal.position'].create({
+            'name': 'Include to Exclude',
+        })
+        tax_10 = self.env['account.tax'].create({
+            'name': 'Tax 10 Excluded',
+            'amount': 10,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+            'price_include_override': 'tax_excluded',
+        })
+        self.env['account.tax'].create({
+            'name': 'Tax 10 Included',
+            'amount': 10,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+            'price_include_override': 'tax_included',
+            'fiscal_position_ids': fiscal_position,
+            'original_tax_ids': tax_10,
+        })
+        product = self.env['product.template'].create({
+            'name': 'Configurable Product',
+            'available_in_pos': True,
+            'list_price': 10.0,
+            'taxes_id': [(6, 0, [tax_10.id])],
+        })
+        size_attribute = self.env['product.attribute'].create({
+            'name': 'Size',
+            'create_variant': 'always',
+        })
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'create_variant': 'no_variant',
+        })
+        small_size_value, large_size_value = self.env['product.attribute.value'].create([{
+            'name': 'Small',
+            'attribute_id': size_attribute.id,
+        }, {
+            'name': 'Large',
+            'attribute_id': size_attribute.id,
+        }])
+        red_color_value, blue_color_value = self.env['product.attribute.value'].create([{
+            'name': 'Red',
+            'attribute_id': color_attribute.id,
+        }, {
+            'name': 'Blue',
+            'attribute_id': color_attribute.id,
+        }])
+        size_line = self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product.id,
+            'attribute_id': size_attribute.id,
+            'value_ids': [(6, 0, [small_size_value.id, large_size_value.id])],
+        })
+        size_line.product_template_value_ids[1].price_extra = 1
+        color_line = self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product.id,
+            'attribute_id': color_attribute.id,
+            'value_ids': [(6, 0, [red_color_value.id, blue_color_value.id])],
+        })
+        color_line.product_template_value_ids[0].price_extra = 2
+        color_line.product_template_value_ids[1].price_extra = 3
+
+        pricelist_1, pricelist_2 = self.env['product.pricelist'].create([{
+            'name': 'Pricelist 1',
+        }, {
+            'name': 'Pricelist 2',
+            'item_ids': [(0, 0, {
+                'applied_on': '1_product',
+                'product_tmpl_id': product.id,
+                'fixed_price': 20.0,
+            })],
+        }])
+        self.main_pos_config.write({
+            'available_pricelist_ids': [(6, 0, [pricelist_1.id, pricelist_2.id])],
+            'pricelist_id': pricelist_1.id,
+            'tax_regime_selection': True,
+            'fiscal_position_ids': [(6, 0, [fiscal_position.id])],
+        })
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_product_configurator_price', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Before this commit, product configurator popup did not consider selected attributes, and pricelist or fiscal position of the current order when displaying the price of the product being configured. This could lead to confusion for the user.

opw-5472946

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
