### PR TITLE
[FIX] repair: handle missing inventory loss location

### DIFF
--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -27,14 +27,20 @@ class StockWarehouse(models.Model):
     def _get_picking_type_create_values(self, max_sequence):
         data, next_sequence = super(StockWarehouse, self)._get_picking_type_create_values(max_sequence)
         prod_location = self._get_production_location()
-        scrap_location_id = self.env['stock.location'].search_read([('usage', '=', 'inventory'), ('company_id', 'in', [self.company_id.id, False])], fields=['id'], limit=1)[0].get('id')
+        scrap_location = self.env['stock.location'].search([
+            ('usage', '=', 'inventory'),
+            ('company_id', 'in', [self.company_id.id, False]),
+        ], limit=1)
+        if not scrap_location:
+            raise UserError(_("No location of type Inventory Loss found"))
+
         data.update({
             'repair_type_id': {
                 'name': _('Repairs'),
                 'code': 'repair_operation',
                 'default_location_src_id': self.lot_stock_id.id,
                 'default_location_dest_id': prod_location.id,
-                'default_remove_location_dest_id': scrap_location_id,
+                'default_remove_location_dest_id': scrap_location.id,
                 'default_recycle_location_dest_id': self.lot_stock_id.id,
                 'sequence': next_sequence + 1,
                 'sequence_code': 'RO',

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -906,6 +906,22 @@ class TestRepair(TestRepairCommon):
                 'company_id': company.id,
             })
 
+    def test_missing_inventory_loss_location_raises_user_error(self):
+        """
+        Test that a missing inventory loss location raises a UserError when creating a warehouse.
+        """
+        inv_locations = self.env['stock.location'].search([
+            ('usage', '=', 'inventory'),
+            ('company_id', '=', self.env.company.id),
+        ])
+        if inv_locations:
+            inv_locations.write({'usage': "internal"})
+        with self.assertRaises(UserError):
+            self.env['stock.warehouse'].create({
+                'name': 'ELCT',
+                'code': 'ET',
+            })
+
     def test_add_product_from_catalog(self):
         """Check that only consumable products are available in the catalog."""
         catalog_action = self.repair0.action_add_from_catalog()


### PR DESCRIPTION
Currently, an error occurs when user tries to create a new warehouse when Inventory loss stock location is not present.

Steps to replicate:
- Install repairs and enable Storage Locations in settings.  
- Go to `Inventory > Configuration > Locations`, open `Inventory Adjustment`.
- Change the `Location Type` to `Internal` (anything other than `Inventory Loss`).
- Navigate to Warehouses and try to create a new one.

Error:
```
  File /home/odoo/src/odoo/19.0/addons/stock/models/stock_warehouse.py, line 142, in create
    new_vals = warehouse._create_or_update_sequences_and_picking_types()
  File /home/odoo/src/odoo/19.0/addons/stock/models/stock_warehouse.py, line 373, in _create_or_update_sequences_and_picking_types
    create_data, max_sequence = self._get_picking_type_create_values(max_sequence)
  File /home/odoo/src/odoo/19.0/addons/repair/models/stock_warehouse.py, line 30, in _get_picking_type_create_values
    scrap_location_id = self.env['stock.location'].search_read([('usage', '=', 'inventory'), ('company_id', 'in', [self.company_id.id, False])], fields=['id'], limit=1)[0].get('id')
IndexError: list index out of range
```

Cause:
- Since the user changed the location type of `Inventory adjustment`, the `search_read()` [1] returned no results and attempting to access its first element causes the error.

Solution:
- Raised a UserError when no Inventory Loss location is found while warehouse creation.

    


[1]: https://github.com/odoo/odoo/blob/62b9f7a81e8d742508d6c80434bb4caf78f9dc65/addons/repair/models/stock_warehouse.py#L30

sentry-7169389190
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
