### PR TITLE
[FIX] crm: show stages with sales team in crm pipeline

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1157,7 +1157,8 @@
             <field name="domain">[('type','=','opportunity')]</field>
             <field name="context">{
                     'default_type': 'opportunity',
-                    'search_default_assigned_to_me': 1
+                    'search_default_assigned_to_me': 1,
+                    'show_user_team_stages': 1,
             }</field>
             <field name="search_view_id" ref="crm.view_crm_case_opportunities_filter"/>
         </record>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install `crm`
2. Assign a user to the sales team from  crm > sales team
3. Now, create a stage and add that team to this stage from crm > Stages

**Issue:**
- The stage assigned to a Sales Team is not visible in "My Pipeline" for users belonging to that team. The stage is only visible to admin users if they have records

**Cause:**
- The stage domain in the pipeline view only considers the `default_team_id` from the context. This ignores the Sales Teams of the current user, causing team-specific stages to be incorrectly filtered out for non-admin users.

**Solution:**
- Extend the stage domain to include all Sales Teams of the current user
when explicitly requested via context. like we did in v19 https://github.com/odoo/odoo/commit/0c0ccde96facfd6c4f823da33c52e3994b36a028

opw-5444009

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
