### PR TITLE
[FIX] website: refresh gray swatches in color picker

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -281,6 +281,7 @@ export class CustomizeGrayAction extends BuilderAction {
                 colorType: "gray",
             }
         );
+        setBuilderCSSVariables(getHtmlStyle(this.document));
     }
 }
 export class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {


### PR DESCRIPTION
Steps to reproduce:
- Open Website Builder.
- Go to Theme > Advanced.
- Change the grays hue or saturation.
- Open a color picker and check the gray swatches.

Before this commit, gray swatches kept using the default palette after changing the grays hue or saturation.

After this commit, gray swatches reflect the customized grays.