### PR TITLE
[FIX] website_sale: add null check to prevent checkout JS traceback

### DIFF
--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -371,7 +371,7 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
 
         // When no dm is set and a price span is hidden, hide the message and show the price span.
         if (amountDelivery.classList.contains('d-none')) {
-            amountDelivery.querySelector('span[name="o_message_no_dm_set"]').classList.add('d-none');
+            amountDelivery.querySelector('span[name="o_message_no_dm_set"]')?.classList.add('d-none');
             amountDelivery.classList.remove('d-none');
         }
 


### PR DESCRIPTION
**Description:**

- This error occurs when the code attempts to access the classList of a DOM element that has not yet been rendered. Specifically, amountDelivery.querySelector(...) returns null during the first selection of the delivery method, and calling .classList on this null value triggers the traceback.
- The issue is observed only on the first interaction when selecting the delivery method. After refreshing the page, the required DOM element is available, and the checkout flow works as expected.
- To resolve this issue, a conditional check was added to ensure that the DOM element exists before accessing its classList.

- [Reference](https://github.com/odoo/odoo/pull/204358/files#diff-ecbd12f8bbcc7e08a87d7edba111301bb0ca5197137d193323d156809651fcb6R353) 

**Steps to reproduce:**

1) Create a fresh database on version saas-18.4.
2) Install the website_sale module.
3) Create a product and add it to the cart.
4) Proceed to the checkout page.
5) Add two delivery addresses for the customer.
6) Configure a delivery method for only one of the delivery addresses. 
7) During checkout, select the delivery address that has a delivery method configured.
8) When selecting the delivery method for the first time, a traceback occurs.

- Video [video.webm](https://github.com/user-attachments/assets/b9146fef-cef8-4d16-8556-bbeac9ef6119)


**Traceback:**

```.py
Odoo Client Error

UncaughtPromiseError > TypeError
Uncaught Promise > Cannot read properties of null (reading 'classList')

Occured on 51.test.upgrade.odoo.com on 2026-01-07 12:09:06 GMT

TypeError: Cannot read properties of null (reading 'classList')
    at Class._updateCartSummary (https://51.test.upgrade.odoo.com/web/assets/1/beaafe8/web.assets_frontend_lazy.min.js:11024:437)
    at https://51.test.upgrade.odoo.com/web/assets/1/beaafe8/web.assets_frontend_lazy.min.js:11025:355
    at NodeList.forEach (<anonymous>)
    at Class._updateCartSummaries (https://51.test.upgrade.odoo.com/web/assets/1/beaafe8/web.assets_frontend_lazy.min.js:11025:337)
    at Class._updateDeliveryMethod (https://51.test.upgrade.odoo.com/web/assets/1/beaafe8/web.assets_frontend_lazy.min.js:11022:2353)
    at async Class._selectDeliveryMethod (https://51.test.upgrade.odoo.com/web/assets/1/beaafe8/web.assets_frontend_lazy.min.js:11022:54)
```

- opw-5427215
- upg-3715707

