### PR TITLE
[FIX] project, project_todo: restrict stages and tags for employees

### DIFF
--- a/addons/project/tests/__init__.py
+++ b/addons/project/tests/__init__.py
@@ -15,6 +15,7 @@ from . import test_project_sharing_portal_access
 from . import test_project_sharing_ui
 from . import test_project_stage_multicompany
 from . import test_project_subtasks
+from . import test_project_tags
 from . import test_project_tags_filter
 from . import test_project_task_type
 from . import test_project_template

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -44,6 +44,12 @@ class TestProjectCommon(TransactionCase):
             'signature': 'SignChell',
             'notification_type': 'email',
             'group_ids': [(6, 0, [cls.env.ref('base.group_portal').id])]})
+        cls.user_employee = Users.create({
+            'name': 'Eustache Employee',
+            'login': 'eustache',
+            'password': 'eustache',
+            'email': 'eustache.projectuser@example.com',
+            'group_ids': [(6, 0, [user_group_employee.id])]})
         cls.user_projectuser = Users.create({
             'name': 'Armande ProjectUser',
             'login': 'armandel',

--- a/addons/project/tests/test_project_tags.py
+++ b/addons/project/tests/test_project_tags.py
@@ -1,0 +1,107 @@
+import logging
+
+from odoo.exceptions import AccessError
+from odoo.tests import tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.project.tests.test_project_base import TestProjectCommon
+
+_logger = logging.getLogger(__name__)
+
+
+# `at_install` on purpose, the security of `project` is tested without the ACLs and rules of `project_todo`
+@tagged("at_install", "-post_install")
+class TestProjectTagsSecurity(TestProjectCommon):
+    @classmethod
+    @mute_logger("odoo.models.unlink")
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tag_project, cls.tag_admin = cls.env["project.tags"].create(
+            [
+                {"name": "project tag", "project_ids": [cls.project_goats.id]},
+                {"name": "admin tag"},
+            ]
+        )
+
+    def _assert_access_portal(self):
+        """Assert the access to `project.tags` for `base.group_portal`"""
+
+        _logger.info("Testing access for portal")
+        # Can read any tag
+        (self.tag_project | self.tag_admin).with_user(self.user_portal).read(["name"])
+
+        # Cannot create/write/unlink tags
+        with self.assertRaises(AccessError):
+            self.env["project.tags"].with_user(self.user_portal).create({"name": "Foo"})
+        # Force create a tag with as create_uid `self.user_portal`
+        tag = self.env["project.tags"].with_user(self.user_portal).sudo().create({"name": "Portal tag"}).sudo(False)
+        with self.assertRaises(AccessError):
+            tag.with_user(self.user_portal).write({"name": "Foo"})
+        with self.assertRaises(AccessError):
+            tag.with_user(self.user_portal).unlink()
+
+    def _assert_access_employee(self):
+        """Assert the access to `project.tags` for `base.group_user`"""
+
+        _logger.info("Testing access for employee")
+        # Can read any tag
+        (self.tag_project | self.tag_admin).with_user(self.user_employee).read(["name"])
+
+        # Cannot create/write/unlink tags
+        with self.assertRaises(AccessError):
+            self.env["project.tags"].with_user(self.user_employee).create({"name": "Foo"})
+        # Force create a tag with as create_uid `self.user_employee`
+        tag = self.env["project.tags"].with_user(self.user_employee).sudo().create({"name": "Employee tag"}).sudo(False)
+        with self.assertRaises(AccessError):
+            tag.with_user(self.user_employee).write({"name": "Foo"})
+        with self.assertRaises(AccessError):
+            tag.with_user(self.user_employee).unlink()
+
+    def _assert_access_project_user(self):
+        """Assert the access to `project.tags` for `project.group_project_user`"""
+
+        _logger.info("Testing access for project user")
+        # Can read any tag
+        (self.tag_project | self.tag_admin).with_user(self.user_projectuser).read(["name"])
+
+        # Cannot create/write/unlink tags
+        with self.assertRaises(AccessError):
+            self.env["project.tags"].with_user(self.user_projectuser).create({"name": "Foo"})
+        # Force create a tag with as create_uid `self.user_employee`
+        tag = (
+            self.env["project.tags"]
+            .with_user(self.user_projectuser)
+            .sudo()
+            .create({"name": "Project user tag"})
+            .sudo(False)
+        )
+        with self.assertRaises(AccessError):
+            tag.with_user(self.user_projectuser).write({"name": "Foo"})
+        with self.assertRaises(AccessError):
+            tag.with_user(self.user_projectuser).unlink()
+
+    def _assert_access_project_manager(self):
+        """Assert the access to `project.tags` for `project.group_project_manager`"""
+
+        _logger.info("Testing access for project manager")
+        # Can read any tag
+        (self.tag_project | self.tag_admin).with_user(self.user_projectmanager).read(["name"])
+
+        # Can create/write/unlink tags, whether associated to projects or not
+        self.env["project.tags"].with_user(self.user_projectmanager).create(
+            [
+                {"name": "Manager tag"},
+                {"name": "Project tag", "project_ids": [self.project_goats.id]},
+            ]
+        )
+        (self.tag_project | self.tag_admin).with_user(self.user_projectmanager).write({"color": 1})
+        (self.tag_project | self.tag_admin).with_user(self.user_projectmanager).unlink()
+
+    @mute_logger("odoo.addons.base.models.ir_model", "odoo.addons.base.models.ir_rule", "odoo.models.unlink")
+    def test_security(self):
+        """Tests the access to `project.tags` for the different user groups"""
+
+        self._assert_access_portal()
+        self._assert_access_employee()
+        self._assert_access_project_user()
+        self._assert_access_project_manager()

--- a/addons/project/tests/test_project_task_type.py
+++ b/addons/project/tests/test_project_task_type.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
 
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 from odoo.tests import tagged
+from odoo.tools import mute_logger
 
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
+
+_logger = logging.getLogger(__name__)
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
@@ -12,7 +16,7 @@ class TestProjectTaskType(TestProjectCommon):
 
     @classmethod
     def setUpClass(cls):
-        super(TestProjectTaskType, cls).setUpClass()
+        super().setUpClass()
 
         cls.stage_created = cls.env['project.task.type'].create({
             'name': 'Stage Already Created',
@@ -82,3 +86,182 @@ class TestProjectTaskType(TestProjectCommon):
             self.stage_created.user_id,
             "user_id should be reset if a project is set on the current stage",
         )
+
+
+# `at_install` on purpose, the security of `project` is tested without the ACLs and rules of `project_todo`
+@tagged("at_install", "-post_install")
+class TestProjectTaskTypeSecurity(TestProjectCommon):
+    @classmethod
+    @mute_logger("odoo.models.unlink")
+    def setUpClass(cls):
+        super().setUpClass()
+        (cls.stage_project, cls.stage_manager, cls.stage_user, cls.stage_employee, cls.stage_portal) = cls.env[
+            "project.task.type"
+        ].create(
+            [
+                {"name": "project stage", "project_ids": [cls.project_goats.id]},
+                {"name": "manager stage", "user_id": cls.user_projectmanager.id},
+                {"name": "user stage", "user_id": cls.user_projectuser.id},
+                {"name": "employee stage", "user_id": cls.user_employee.id},
+                {"name": "portal stage", "user_id": cls.user_portal.id},
+            ]
+        )
+
+    def _assert_access_portal(self):
+        """Assert the access to `project.task.type` for `base.group_portal`"""
+
+        _logger.info("Testing access for portal")
+        # Can read a project stage
+        self.stage_project.with_user(self.user_portal).read(["name"])
+
+        # Can read own stage
+        self.stage_portal.with_user(self.user_portal).read(["name"])
+
+        # Cannot read another people's stage
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_portal).read(["name"])
+
+        # Cannot create/write/unlink project stage
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_portal).create(
+                {
+                    "name": "foo",
+                    "project_ids": [self.project_goats.id],
+                }
+            )
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_portal).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_portal).unlink()
+
+        # Cannot create/write/unlink personal stages, even own
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_portal).create({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_portal.with_user(self.user_portal).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_portal.with_user(self.user_portal).unlink()
+
+    def _assert_access_employee(self):
+        """Assert the access to `project.task.type` for `base.group_user`"""
+
+        _logger.info("Testing access for employee")
+        # Can read a project stage
+        self.stage_project.with_user(self.user_employee).read(["name"])
+
+        # Can read own stage
+        self.stage_employee.with_user(self.user_employee).read(["name"])
+
+        # Cannot read another people's stage
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_employee).read(["name"])
+
+        # Cannot create/write/unlink project stage
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_employee).create(
+                {
+                    "name": "foo",
+                    "project_ids": [self.project_goats.id],
+                }
+            )
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_employee).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_employee).unlink()
+
+        # Cannot create/write/unlink personal stages, even own
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_employee).create({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_employee.with_user(self.user_employee).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_employee.with_user(self.user_employee).unlink()
+
+    def _assert_access_project_user(self):
+        """Assert the access to `project.task.type` for `project.group_project_user`"""
+
+        _logger.info("Testing access for project user")
+        # Can read a project stage
+        self.stage_project.with_user(self.user_projectuser).read(["name"])
+        # but not create/write/unlink a project stage
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_projectuser).create(
+                {
+                    "name": "foo",
+                    "project_ids": [self.project_goats.id],
+                }
+            )
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_projectuser).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_projectuser).unlink()
+
+        # Cannot do anything on a stage from another user
+        with self.assertRaises(AccessError):
+            self.stage_manager.with_user(self.user_projectuser).read(["name"])
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_projectuser).create(
+                {
+                    "name": "foo",
+                    "user_id": self.user_projectmanager.id,
+                }
+            )
+        with self.assertRaises(AccessError):
+            self.stage_manager.with_user(self.user_projectuser).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_manager.with_user(self.user_projectuser).unlink()
+
+        # Can do everything on his own stage
+        self.stage_user.with_user(self.user_projectuser).read(["name"])
+        stage_user_new = (
+            self.env["project.task.type"]
+            .with_user(self.user_projectuser)
+            .create({"name": "foo", "user_id": self.user_projectuser.id})
+        )
+        self.stage_user.with_user(self.user_projectuser).write({"name": "foo"})
+        stage_user_new.with_user(self.user_projectuser).unlink()
+
+    def _assert_access_project_manager(self):
+        """Assert the access to `project.tags` for `project.group_project_manager`"""
+
+        _logger.info("Testing access for project manager")
+        # Can do everything on project stages
+        self.stage_project.with_user(self.user_projectmanager).read(["name"])
+        self.env["project.task.type"].with_user(self.user_projectmanager).create(
+            {
+                "name": "foo",
+                "project_ids": [self.project_goats.id],
+            }
+        )
+        self.stage_project.with_user(self.user_projectmanager).write({"name": "foo"})
+        self.stage_project.with_user(self.user_projectmanager).unlink()
+
+        # Cannot do anything on a stage from another user
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_projectmanager).read(["name"])
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_projectmanager).create(
+                {
+                    "name": "foo",
+                    "user_id": self.user_projectuser.id,
+                }
+            )
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_projectmanager).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_projectmanager).unlink()
+
+        # Can do everything on his own stage
+        self.stage_manager.with_user(self.user_projectmanager).read(["name"])
+        self.env["project.task.type"].with_user(self.user_projectmanager).create(
+            {"name": "foo", "user_id": self.user_projectmanager.id}
+        )
+        self.stage_manager.with_user(self.user_projectmanager).write({"name": "foo"})
+        self.stage_manager.with_user(self.user_projectmanager).unlink()
+
+    @mute_logger("odoo.addons.base.models.ir_model", "odoo.addons.base.models.ir_rule", "odoo.models.unlink")
+    def test_security(self):
+        self._assert_access_portal()
+        self._assert_access_employee()
+        self._assert_access_project_user()
+        self._assert_access_project_manager()

--- a/addons/project_todo/security/project_todo_security.xml
+++ b/addons/project_todo/security/project_todo_security.xml
@@ -10,5 +10,34 @@
         <field name="groups" eval="[(4,ref('base.group_user'))]"/>
     </record>
 
+    <record model="ir.rule" id="task_type_own_write_rule">
+        <field name="name">Project/Task Type: write own stages</field>
+        <field name="model_id" ref="project.model_project_task_type"/>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+        <field name="groups" eval="[(4,ref('base.group_user'))]"/>
+    </record>
+
+    <record model="ir.rule" id="tags_own_write_rule">
+        <field name="name">Project/tags employees: Full access to own tags only</field>
+        <field name="model_id" ref="project.model_project_tags"/>
+        <field name="domain_force">[('create_uid', '=', user.id),('project_ids', '=', False)]</field>
+        <field name="groups" eval="[(4,ref('base.group_user'))]"/>
+        <field name="perm_read" eval="False"/>
+        <field name="perm_write" eval="True"/>
+        <field name="perm_create" eval="True"/>
+        <field name="perm_unlink" eval="True"/>
+    </record>
+
+    <record model="ir.rule" id="tags_manager_rule">
+        <field name="name">Project/tags: manager sees all</field>
+        <field name="model_id" ref="project.model_project_tags"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+    </record>
+
 </data>
 </odoo>

--- a/addons/project_todo/tests/__init__.py
+++ b/addons/project_todo/tests/__init__.py
@@ -4,5 +4,7 @@ from . import test_access_rights
 from . import test_mail_activity_todo_create
 from . import test_todo_onboarding_for_users
 from . import test_mail_activity_systray_counter
+from . import test_project_tags
+from . import test_project_task_type
 from . import test_todo_ui
 from . import test_todo_quick_create

--- a/addons/project_todo/tests/test_project_tags.py
+++ b/addons/project_todo/tests/test_project_tags.py
@@ -1,0 +1,67 @@
+import logging
+
+from odoo.exceptions import AccessError
+
+from odoo.addons.project.tests.test_project_tags import TestProjectTagsSecurity
+
+_logger = logging.getLogger(__name__)
+
+
+class TestProjectTodoTagsSecurity(TestProjectTagsSecurity):
+    def _assert_access_common_employee_project_user(self, user):
+        """Assert the access to `project.tags` for `base.group_user` and `project.group_project_user`
+        which become common with this module"""
+
+        # Can read any tag
+        (self.tag_project | self.tag_admin).with_user(user).read(["name"])
+
+        # Can create/write/unlink own tags
+        tag = self.env["project.tags"].with_user(user).create({"name": "Employee tag"})
+        tag.with_user(user).write({"name": "Foo"})
+        tag.with_user(user).unlink()
+
+        # Cannot create/write/unlink tags associated to projects
+        with self.assertRaises(AccessError):
+            tag = (
+                self.env["project.tags"]
+                .with_user(user)
+                .create(
+                    {
+                        "name": "Project tag",
+                        "project_ids": [self.project_goats.id],
+                    }
+                )
+            )
+        with self.assertRaises(AccessError):
+            self.tag_project.with_user(user).write({"name": "Foo"})
+        with self.assertRaises(AccessError):
+            self.tag_project.with_user(user).unlink()
+
+        # Cannot create/write/unlink tags not their own
+        with self.assertRaises(AccessError):
+            self.tag_admin.with_user(user).write({"name": "Foo"})
+        with self.assertRaises(AccessError):
+            self.tag_admin.with_user(user).unlink()
+
+    def _assert_access_employee(self):
+        """Override: assert the access to `project.tags` for `base.group_user`
+        with the new expectations of the module `project_todo`"""
+
+        _logger.info("Testing access for employee specific to project_todo")
+        self._assert_access_common_employee_project_user(self.user_employee)
+
+    def _assert_access_project_user(self):
+        """Override: assert the access to `project.tags` for `project.group_project_user`
+        with the new expectations of the module `project_todo`"""
+
+        _logger.info("Testing access for project user specific to project_todo")
+        self._assert_access_common_employee_project_user(self.user_projectuser)
+
+    def test_security(self):
+        """Override: force this unit test to be re-executed for the module `project_todo`"""
+
+        # Force to call `test_security` from the base class, to ensure the call of all methods `_assert_access_`
+        # The goal of the class inheritance and the call to `super`
+        # is to re-test the expected access for `project.group_project_user` and `project.group_project_manager`
+        # despite the new ACLs and rules of this module
+        super().test_security()

--- a/addons/project_todo/tests/test_project_task_type.py
+++ b/addons/project_todo/tests/test_project_task_type.py
@@ -1,0 +1,52 @@
+import logging
+
+from odoo.exceptions import AccessError
+from odoo.addons.project.tests.test_project_task_type import TestProjectTaskTypeSecurity
+
+_logger = logging.getLogger(__name__)
+
+
+class TestProjectTodoTaskTypeSecurity(TestProjectTaskTypeSecurity):
+    def _assert_access_employee(self):
+        """Override: assert the access to `project.task.type` for `base.group_user`
+        with the new expectations of the module `project_todo`"""
+
+        _logger.info("Testing access for employee specific to project_todo")
+        # Can read/create/write/unlink personal stage
+        stage = self.env["project.task.type"].with_user(self.user_employee).create({"name": "foo"})
+        stage.with_user(self.user_employee).read(["name"])
+        stage.with_user(self.user_employee).write({"name": "foo"})
+        stage.with_user(self.user_employee).unlink()
+
+        # Can read a project stage
+        self.stage_project.with_user(self.user_employee).read(["name"])
+        # Cannot create/write/unlink project stage
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_employee).create(
+                {"name": "foo", "project_ids": [self.project_goats.id]}
+            )
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_employee).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_project.with_user(self.user_employee).unlink()
+
+        # Cannot read/create/write/unlink other user stages
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_employee).read(["name"])
+        with self.assertRaises(AccessError):
+            self.env["project.task.type"].with_user(self.user_employee).create(
+                {"name": "foo", "user_id": self.user_projectuser.id}
+            )
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_employee).write({"name": "foo"})
+        with self.assertRaises(AccessError):
+            self.stage_user.with_user(self.user_employee).unlink()
+
+    def test_security(self):
+        """Override: force this unit test to be re-executed for the module `project_todo`"""
+
+        # Force to call `test_security` from the base class, to ensure the call of all methods `_assert_access_`
+        # The goal of the class inheritance and the call to `super`
+        # is to re-test the expected access for `base.group_user`, `project.group_project_user`,
+        # `project.group_project_manager` despite the new ACLs and rules of this module
+        super().test_security()


### PR DESCRIPTION
The project user is restricted to create/write/unlink its own stages only:
- He is not allowed to read other people stage
- He is not allowed to create/write/unlink other people stages neither project stages

There is no reason the employee should be able to create/write/unlink project stages.

It's an oversight from the `project_todo` module,
which is granting ACL (`ir.model.access`) to the `base.group_user` without adding a record rule (`ir.rule`) to restrict the access of employees to some records of the models and not all records.

There is the same issue for the tags.

task-5449945
