### PR TITLE
[IMP] mail: can see and edit thread description in chat window

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.js
@@ -17,4 +17,18 @@ patch(ChatWindow.prototype, {
         this.props.chatWindow.actionsDisabled = false;
         this.props.chatWindow.livechatStep = CW_LIVECHAT_STEP.NONE;
     },
+    get editingDescriptionTextAttClass() {
+        return {
+            ...super.editingDescriptionTextAttClass,
+            "text-warning":
+                this.channel.livechat_status === "need_help" && this.channel.description,
+        };
+    },
+    get editingDescriptionTextareaAttClass() {
+        return {
+            ...super.editingDescriptionTextareaAttClass,
+            "text-warning":
+                this.channel.livechat_status === "need_help" && this.channel.description,
+        };
+    },
 });

--- a/addons/mail/static/src/core/common/chat_window.dark.scss
+++ b/addons/mail/static/src/core/common/chat_window.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-ChatWindow {
+    --mail-ChatWindow-descriptionButtonActiveOpacity: 100%;
+}
+
 .o-mail-ChatWindow-moreActions {
     --mail-ChatWindow-moreActionsHoverColor: white;
 }

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -36,6 +36,22 @@
     width: 24px;
 }
 
+.o-mail-ChatWindow-descriptionButton {
+    opacity: 25%;
+    &:hover, &.o-showDescriptionDialog {
+        opacity: var(--mail-ChatWindow-descriptionButtonActiveOpacity, 75%);
+    }
+}
+
+.o-mail-ChatWindow-descriptionDialog {
+    min-width: 75%;
+}
+
+.o-mail-ChatWindow-descriptionDialogBackground {
+    z-index: $o-mail-NavigableList-zIndex - 1;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
 .o-mail-ChatWindow-header {
     .o-mail-ActionList-group {
         gap: map-get($spacers, 3);

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -50,6 +50,7 @@
                 <t t-out="channel.importantCounter"/>
             </div>
             <div class="ms-1 flex-grow-1"/>
+            <i t-if="channel.allowDescription and channel.description" class="o-mail-ChatWindow-descriptionButton fa fa-fw fa-lg fa-info-circle o-p-0_5 me-2" t-att-class="{ 'o-showDescriptionDialog': state.showDescriptionDialog }" t-att-data-tooltip="channelDescriptionText" data-tooltip-delay="0" data-tooltip-position="top" t-on-click.stop="() => this.toggleShowDescriptionDialog()"/>
             <div class="d-flex flex-shrink-0 me-1">
                 <ActionList actions="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" inline="true"/>
             </div>
@@ -76,6 +77,27 @@
                     <t t-call="mail.ChatWindow.memberTyping"/>
                     <Composer composer="channel.composer" autofocus="isMobileOS ? undefined : props.chatWindow.autofocus" mode="'compact'" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType" disabled="channel.composerDisabled"/>
                 </t>
+            </t>
+            <t t-if="state.showDescriptionDialog">
+                <div class="o-mail-ChatWindow-descriptionDialogBackground position-absolute w-100 h-100 d-flex justify-content-center align-items-center" t-on-click.stop="() => this.onClickDescriptionDialogBackground()">
+                    <div class="o-mail-ChatWindow-descriptionDialog rounded bg-view bg-opacity-100 p-3 m-3 d-flex flex-column position-relative" t-att-class="{ 'w-100': state.editingDescription }" t-on-click.stop="">
+                        <div class="d-flex align-items-center me-n2 mt-n2">
+                            <span class="text-muted small">Description:</span>
+                            <button class="ms-auto btn-close o-xsmaller p-1" t-on-click.stop="() => this.closeDescriptionDialog()"/>
+                        </div>
+                        <t t-if="state.editingDescription">
+                            <textarea t-att-class="editingDescriptionTextareaAttClass" autofocus="true" row="3" placeholder="Add a description" t-model="state.editingDescriptionText" t-on-keydown="onKeydownDescriptionTextarea"/>
+                            <div class="btn-group">
+                                <button class="btn btn-primary p-2" t-on-click.stop="() => this.updateThreadDescription()"><i class="fa fa-fw fa-save me-1"/><span>Save</span></button>
+                                <button class="btn btn-secondary p-2" t-on-click.stop="() => this.state.editingDescription = false"><i class="oi fa-fw oi-close me-1"/><span>Cancel</span></button>
+                            </div>
+                        </t>
+                        <t t-else="">
+                            <span t-att-class="editingDescriptionTextAttClass" t-esc="channel.description or ''"/>
+                            <button t-if="channel.is_editable" class="btn btn-primary p-2" t-on-click.stop="() => this.state.editingDescription = true"><i class="fa fa-fw fa-pencil me-1"/><span>Edit</span></button>
+                        </t>
+                    </div>
+                </div>
             </t>
         </div>
     </div>

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -65,9 +65,7 @@ test("Thread description update", async () => {
     await insertText(
         `${env1.selector} .o-mail-DiscussContent-threadDescription`,
         "The very best channel",
-        {
-            replace: true,
-        }
+        { replace: true }
     );
     triggerHotkey("Enter");
     await contains(

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -161,7 +161,7 @@ test("can active change thread from messaging menu", async () => {
 });
 
 test.tags("focus required");
-test("can change the thread description of #general", async () => {
+test("can change the thread description of #general (discuss app)", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "general",
@@ -1882,9 +1882,7 @@ test("Do not trigger channel description server update when channel has no descr
         create_uid: serverState.userId,
         name: "General",
     });
-
     onRpc("discuss.channel", "channel_change_description", ({ method }) => expect.step(method));
-
     await start();
     await openDiscuss(channelId);
     await insertText("input.o-mail-DiscussContent-threadDescription", "");


### PR DESCRIPTION
Before this commit, thread description feature was not visible nor editable in chat window.

This commit adds a small icon next to conversation name in header that can be mouse-hovered to see description at a glance. Click on button opens an in-chat-window dialog with description with "edit" button.

Editing and showing of thread description in discuss app has been kept unchanged.

Task-5470223

<img width="480" height="670" alt="Screenshot 2026-01-13 at 15 56 29" src="https://github.com/user-attachments/assets/27c27311-2b16-4dfc-a739-97688de5127f" />