### PR TITLE
[FIX] setup: missing `gatt` in IoT Box image

### DIFF
--- a/setup/iot_box_builder/configuration/requirements.txt
+++ b/setup/iot_box_builder/configuration/requirements.txt
@@ -1,5 +1,5 @@
 # The following requirements are needed only on Raspberry Pi IoT:
-gatt; sys_platform == "linux" and "rpi" in platform_release
+gatt; sys_platform == "linux"
 
 # The following requirements are needed only on Windows Virtual IoT:
 ghostscript==0.8.1; sys_platform == "win32"


### PR DESCRIPTION
As the image is built on a "non-RPI" linux machine, gatt isn't installed at build time.
It requires the image to update itself to get the package.

Even if the gatt package is only used for bluetooth caliper devices that are not widely used, this fix avoids a traceback.
