### PR TITLE
[ADD] l10n_tr_nilvera_einvoice: import invoice/bill from UBL TR 1.2

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/__init__.py
@@ -13,3 +13,4 @@ from . import res_config_settings
 from . import res_partner
 from . import res_partner_category
 from . import template_tr
+from . import res_partner_bank

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -1,15 +1,19 @@
+import logging
 import math
 from collections import defaultdict
 
 from lxml import etree
 from num2words import num2words
 
-from odoo import api, models
+from odoo import _, api, models
 from odoo.exceptions import UserError
 from odoo.tools import float_compare, frozendict, html2plaintext
 
+from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
 from odoo.addons.l10n_tr_nilvera_einvoice.tools.clean_node_dict import clean_node_dict
 from odoo.addons.l10n_tr_nilvera_einvoice.tools.ubl_tr_invoice import TrInvoice
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountEdiXmlUblTr(models.AbstractModel):
@@ -976,21 +980,305 @@ class AccountEdiXmlUblTr(models.AbstractModel):
     # -------------------------------------------------------------------------
     # IMPORT
     # -------------------------------------------------------------------------
+    @api.model
+    def _l10n_tr_import_profile_id(self, tree):
+        return self._find_value(".//cbc:ProfileID", tree)
+
+    @api.model
+    def _l10n_tr_import_party_role(self, tree, move_category='sale'):
+        profile_id = self._l10n_tr_import_profile_id(tree)
+        suffix = 'Customer' if move_category == 'sale' else 'Supplier'
+        if profile_id == "IHRACAT":
+            return "Buyer" + suffix
+        return "Accounting" + suffix
+
+    @api.model
+    def _l10n_tr_import_invoice_type_code(self, tree):
+        return self._find_value(".//cbc:InvoiceTypeCode", tree)
 
     def _import_retrieve_partner_vals(self, tree, role):
-        # EXTENDS account.edi.xml.ubl_20
-        partner_vals = super()._import_retrieve_partner_vals(tree, role)
-        partner_vals.update({
-            'vat': self._find_value(f'.//cac:Accounting{role}Party/cac:Party//cac:PartyIdentification//cbc:ID[string-length(text()) > 5]', tree),
+        # EXTENDS account_edi_ubl_cii
+        if not self.env.context.get('parse_for_ubl_tr'):
+            return super()._import_retrieve_partner_vals(tree, role)
+
+        role = self.env.context.get('ubl_tr_role', role)
+        res = super()._import_retrieve_partner_vals(tree, role)
+        res.update({
+            "vat": (
+                self._find_value(f".//cac:{role}Party//cac:PartyLegalEntity//cbc:CompanyID[string-length(text()) > 5]", tree)
+                or self._find_value(f'.//cac:{role}Party//cac:PartyIdentification//cbc:ID[@schemeID="VKN"][string-length(text()) > 5]', tree)
+            ),
+            "name": (
+                self._find_value(f".//cac:{role}Party//cac:PartyName//cbc:Name", tree)
+                or self._find_value(f".//cac:{role}Party//cbc:RegistrationName", tree)
+            ),
         })
-        return partner_vals
+        return res
 
-    def _import_fill_invoice_form(self, invoice, tree, qty_factor):
-        # EXTENDS account.edi.xml.ubl_20
-        logs = super()._import_fill_invoice_form(invoice, tree, qty_factor)
+    def _get_postal_address(self, tree, role):
+        # EXTENDS account_edi_ubl_cii
+        res = super()._get_postal_address(tree, role)
+        res.update({
+                "city": self._find_value(f".//cac:{role}Party//cac:PostalAddress/cbc:CitySubdivisionName", tree),
+                "state_name": self._find_value(f".//cac:{role}Party//cac:PostalAddress/cbc:CityName", tree),
+                'country_name': self._find_value(f'.//cac:{role}Party//cac:PostalAddress/cac:Country/cbc:Name', tree),
+            })
+        return res
 
+    def _import_partner(self, company_id, name, phone, email, vat, *, peppol_eas=False, peppol_endpoint=False, postal_address={}, **kwargs):
+        # Override account_edi_ubl_cii
+        # For UBL TR we only match partner with VKN, not name or email or phone
+        # Some Nilvera document have country name instead of code
+        # Instead of state code, nilvera has state name
+        # So many cases will complicate extension, thus overriding
+
+        if not self.env.context.get('parse_for_ubl_tr'):
+            return super()._import_partner(company_id, name, phone, email, vat, peppol_eas=peppol_eas, peppol_endpoint=peppol_endpoint, postal_address=postal_address, **kwargs)
+        logs = []
+        partner = self.env["res.partner"]._retrieve_partner(vat=vat, company=company_id)
+
+        country = self.env["res.country"]
+        if country_code := postal_address.get("country_code"):
+            country = country.search([("code", "=", country_code)], limit=1)
+        elif country_name := postal_address.get("country_name"):
+            country = country.search([("name", "=", country_name)], limit=1)
+
+        state = self.env["res.country.state"]
+        if country and (state_name := postal_address.get("state_name")):
+            state = state.search([("country_id", "=", country.id), ("name", "=", state_name)], limit=1)
+        if not partner and name and vat:
+            partner_vals = {'name': name, 'vat': vat, 'email': email, 'phone': phone, 'is_company': True}
+            partner = self.env['res.partner'].create(partner_vals)
+            partner.l10n_tr_check_nilvera_customer()
+            logs.append(_("Could not retrieve a partner corresponding to '%s'. A new partner was created.", name))
+        elif not partner and not logs:
+            logs.append(_("Could not retrieve partner with details: Name: %(name)s, Vat: %(vat)s, Phone: %(phone)s, Email: %(email)s",
+                  name=name, vat=vat, phone=phone, email=email))
+        if not partner.country_id and not partner.street and not partner.street2 and not partner.city and not partner.zip and not partner.state_id:
+            partner.write({
+                'country_id': country.id,
+                'street': postal_address.get('street'),
+                'street2': postal_address.get('additional_street'),
+                'city': postal_address.get('city'),
+                'zip': postal_address.get('zip'),
+                'state_id': state.id,
+            })
+        return partner, logs
+
+    @api.model
+    def _l10n_tr_resolve_delivery_details(self, tree, invoice_values):
+        delivery_tree = tree.find(".//cac:InvoiceLine/cac:Delivery", UBL_NAMESPACES)
+        if delivery_tree is None:
+            return
+
+        delivery_terms_id = self._find_value("cac:DeliveryTerms/cbc:ID", delivery_tree)
+        transport_mode_code = self._find_value("cac:Shipment/cac:ShipmentStage/cbc:TransportModeCode", delivery_tree)
+
+        invoice_values["l10n_tr_shipping_type"] = transport_mode_code
+        invoice_values["invoice_incoterm_id"] = (
+            self.env["account.incoterms"].search([("code", "=", delivery_terms_id)], limit=1).id
+        )
+
+    @api.model
+    def _l10n_tr_resolve_export_exemption(self, tree, invoice_values, logs):
+        invoice_type_code = self._l10n_tr_import_invoice_type_code(tree)
+        if invoice_type_code not in ["ISTISNA", "IHRACKAYITLI"]:
+            return
+        tax_category_node = tree.find("./cac:TaxTotal/cac:TaxSubtotal/cac:TaxCategory", UBL_NAMESPACES)
+        if tax_category_node is not None:
+            tax_exemption_reason_code = self._find_value("cbc:TaxExemptionReasonCode", tax_category_node)
+            tax_exemption_id = self.env["l10n_tr_nilvera_einvoice.account.tax.code"].search(
+                [("code", "=", tax_exemption_reason_code)],
+                limit=1,
+            )
+
+            if tax_exemption_id:
+                invoice_values["l10n_tr_exemption_code_id"] = tax_exemption_id.id
+            else:
+                logs.append(_("Could not find exemption code with reason '%s'", tax_exemption_reason_code))
+
+    @api.model
+    def _l10n_tr_resolve_basic_fields(self, tree, invoice_values, logs):
+        profile_id = self._l10n_tr_import_profile_id(tree)
+        if profile_id == "IHRACAT":
+            invoice_values["l10n_tr_is_export_invoice"] = True
+        elif profile_id in ["TEMELFATURA", "KAMU"]:
+            # EARSIVFATURA is ignored as it's not in the l10n_tr_gib_invoice_scenario field
+            invoice_values["l10n_tr_gib_invoice_scenario"] = profile_id
+
+        invoice_values["l10n_tr_gib_invoice_type"] = self._find_value(".//cbc:InvoiceTypeCode", tree)
+        invoice_values["currency_id"], currency_logs = self._import_currency(tree, ".//{*}DocumentCurrencyCode")
+        logs.extend(currency_logs)
+
+        invoice_values["invoice_date"] = self._find_value(".//cbc:IssueDate", tree)
+        invoice_values["invoice_date_due"] = self._find_value(".//cac:PaymentMeans/cbc:PaymentDueDate", tree)
+        invoice_values["ref"] = (
+            self._find_value("./cac:OrderReference/cbc:ID", tree)
+            or self._find_value("./cbc:ID", tree)
+        )
+        invoice_values["narration"] = self._import_description(tree, xpaths=["./{*}Note", "./{*}PaymentTerms/{*}Note"])
+
+    def _get_line_xpaths(self, document_type=False, qty_factor=1):
+        # EXTENDS account_edi_ubl_cii
+        res = super()._get_line_xpaths(document_type=document_type, qty_factor=qty_factor)
+        if self.env.context.get("parse_for_ubl_tr"):
+            res['product']["ctsp_number"] = ".//cac:Shipment//cbc:RequiredCustomsID"
+        return res
+
+    @api.model
+    def _l10n_tr_find_tax_id_by_percentage(self, amount, move_type):
+        return (
+            self.env["account.tax"]
+            .search(
+                [
+                    ("country_id.code", "=", "TR"),
+                    ("amount", "=", amount),
+                    ("amount_type", "=", "percent"),
+                    ("type_tax_use", "=", move_type),
+                ],
+                limit=1,
+                order="sequence",
+            )
+        )
+
+    @api.model
+    def _l10n_tr_find_tax_id_by_reason_code(self, withholding_code, move_type):
+        # There must be only one tax for each withholding code in Nilvera
+        # But based on model structure there can be multiple parent tax for each withholding code
+        return (
+            self.env["account.tax"]
+            .search(
+                [
+                    ("children_tax_ids.l10n_tr_tax_withholding_code_id.code", "=", withholding_code),
+                    ("country_id.code", "=", "TR"),
+                    ("type_tax_use", "=", move_type),
+                ],
+                order="sequence",
+                limit=1,
+            )
+        )
+
+    @api.model
+    def _l10n_tr_find_tax_id_by_tax_details(
+        self,
+        tax_details_list,
+        profile_id,
+        invoice_type,
+        move_type,
+    ):
+        """
+        Retrieve tax IDs for a list of tax details based on profile ID, invoice type, and account move type.
+
+        :param list[dict] tax_details_list: List of tax detail dictionaries.
+        :param str profile_id: ``ProfileID`` value from the XML.
+        :param str invoice_type: ``InvoiceTypeCode`` value from the XML.
+        :param str move_type: Account move type (``sale`` or ``purchase``).
+        :return list[list[int]]: Tax IDs grouped per tax detail entry.
+        """
+
+        result = []
+        for tax_details in tax_details_list:
+            if profile_id == "IHRACAT":
+                # this is a tax-exempt export
+                tax_id = self._l10n_tr_find_tax_id_by_percentage(0, move_type=move_type)
+            elif invoice_type == "TEVKIFAT":
+                tax_id = self._l10n_tr_find_tax_id_by_reason_code(
+                    tax_details["withholding_reason_code"],
+                    move_type=move_type,
+                )
+            else:
+                tax_id = self._l10n_tr_find_tax_id_by_percentage(
+                    tax_details["tax_percentage"],
+                    move_type=move_type,
+                )
+            if tax_id:
+                result.append(tax_id)
+        return result
+
+    @api.model
+    def _l10n_tr_import_tax_details(self, line_tree):
+        tax_percentage = self._find_value(".//cac:TaxTotal//cac:TaxSubtotal//cbc:Percent", line_tree)
+        return {
+            "withholding_reason_code": self._find_value(
+                ".//cac:WithholdingTaxTotal//cac:TaxSubtotal//cac:TaxCategory//cbc:TaxTypeCode", line_tree,
+            ),
+            "tax_percentage": float(tax_percentage) if tax_percentage else 0.0,
+        }
+
+    def _get_tax_nodes(self, tree):
+        # Extends account_edi_ubl_cii
+        if not self.env.context.get("parse_for_ubl_tr"):
+            return super()._get_tax_nodes(tree)
+        return tree
+
+    def _retrieve_taxes(self, record, line_values, tax_type, tax_exigibility=False):
+        # EXTENDS account_edi_ubl_cii
+        if not self.env.context.get("parse_for_ubl_tr"):
+            return super()._retrieve_taxes(record, line_values, tax_type, tax_exigibility)
+
+        logs = []
+        taxes = []
+
+        profile_id = self.env.context.get("ubl_tr_profile_id")
+        invoice_type_code = self.env.context.get("ubl_tr_invoice_type_code")
+        tax_data = self._l10n_tr_import_tax_details(line_values.pop("tax_nodes"))
+
+        tax_ids = self._l10n_tr_find_tax_id_by_tax_details(
+            [tax_data],
+            profile_id,
+            invoice_type_code,
+            "sale" if record.is_inbound() else "purchase",
+        )
+        if not tax_ids:
+            logs.append(_("Could not retrieve the tax for line '%(line)s'.", line=line_values["name"]))
+        else:
+            taxes.append(tax_ids[0].id)
+            if tax_ids[0].price_include:
+                line_values["price_unit"] *= 1 + tax_ids[0].amount / 100
+        return taxes, logs
+
+    def _import_fill_invoice(self, invoice, tree, qty_factor):
+        # EXTENDS account_edi_ubl_cii
+        # Adding custom decoder for Nilvera's TR1.2 UBL format
+
+        is_ubl_tr = self._find_value(".//cbc:CustomizationID", tree) == "TR1.2"
+
+        self_with_context = self
+        if is_ubl_tr:
+            if qty_factor == -1:
+                # TODO: Support credit note for UBL TR1.2
+                return [_("Invoice/Bill return creation from XML is not supported for TR1.2 UBL format yet.")]
+
+            profile_id = self._l10n_tr_import_profile_id(tree)
+            invoice_type_code = self._l10n_tr_import_invoice_type_code(tree)
+            ubl_tr_role = self._l10n_tr_import_party_role(tree, 'sale' if invoice.is_inbound() else 'purchase')
+
+            self_with_context = self.with_context(
+                parse_for_ubl_tr=True,
+                ubl_tr_profile_id=profile_id,
+                ubl_tr_invoice_type_code=invoice_type_code,
+                ubl_tr_role=ubl_tr_role,
+            )
+
+        logs = super(AccountEdiXmlUblTr, self_with_context)._import_fill_invoice(invoice, tree, qty_factor)
+
+        if not is_ubl_tr:
+            return logs
+
+        invoice_values = {}
         # ==== Nilvera UUID ====
-        if uuid_node := tree.findtext('./{*}UUID'):
-            invoice.l10n_tr_nilvera_uuid = uuid_node
+        if uuid_node := self._find_value(".//cbc:UUID", tree):
+            invoice_values["l10n_tr_nilvera_uuid"] = uuid_node
 
+        self._l10n_tr_resolve_basic_fields(tree, invoice_values, logs)
+
+        self._l10n_tr_resolve_delivery_details(tree, invoice_values)
+
+        self._l10n_tr_resolve_export_exemption(tree, invoice_values, logs)
+
+        invoice.write(invoice_values)
+
+        if not invoice.currency_id.active:
+            invoice.currency_id.active = True
+            logs.append(_("The currency %s has been reactivated.", invoice.currency_id.name))
         return logs

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -622,3 +622,19 @@ class AccountMove(models.Model):
             )
 
         return super()._reverse_moves(default_values_list, cancel=cancel)
+
+    def _compute_partner_bank_id(self):
+        # Extend account
+        # On currency change partner_bank_id is recomputed
+        # For UBL TR imports we want to keep the one in the xml
+
+        ubl_tr_moves_with_bank = self.filtered(lambda move: move.country_code == 'TR' and move.partner_bank_id and move.l10n_tr_nilvera_uuid)
+        # Don't want to block recompute as there might be other logics related to it. So will reassign it after super.
+        ubl_tr_move_bank_map = {
+            move.id: move.partner_bank_id
+            for move in ubl_tr_moves_with_bank
+        }
+        res = super()._compute_partner_bank_id()
+        for move in ubl_tr_moves_with_bank:
+            move.partner_bank_id = ubl_tr_move_bank_map[move.id]
+        return res

--- a/addons/l10n_tr_nilvera_einvoice/models/product_product.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/product_product.py
@@ -1,6 +1,7 @@
 from odoo import _, api, fields, models
 
 from odoo.exceptions import ValidationError
+from odoo.fields import Domain
 
 
 class ProductProduct(models.Model):
@@ -32,3 +33,13 @@ class ProductProduct(models.Model):
         for record in self:
             if record.l10n_tr_ctsp_number and len(record.l10n_tr_ctsp_number) > 12:
                 raise ValidationError(_("CTSP Number must be 12 digits or fewer."))
+
+    def _get_product_domain_search_order(self, **vals):
+        # Extend _get_product_domain_search_order
+        # UBL TR requires searching with CTSP Number too
+
+        sorted_domains = super()._get_product_domain_search_order(**vals)
+        if self.env.context.get("parse_for_ubl_tr"):
+            if ctsp_number := vals.get("ctsp_number"):
+                sorted_domains.append((13, Domain("l10n_tr_ctsp_number", "=", ctsp_number)))
+        return sorted_domains

--- a/addons/l10n_tr_nilvera_einvoice/models/res_partner_bank.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/res_partner_bank.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class ResPartnerBank(models.Model):
+    _inherit = "res.partner.bank"
+
+    def _find_or_create_bank_account(self, account_number, partner, company, *, allow_company_account_creation=False, extra_create_vals=None):
+        if self.env.context.get("parse_for_ubl_tr"):
+            allow_company_account_creation = True
+        return super()._find_or_create_bank_account(
+            account_number,
+            partner,
+            company,
+            allow_company_account_creation=allow_company_account_creation,
+            extra_create_vals=extra_create_vals,
+        )

--- a/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_account_move_send
 from . import test_xml_ubl_tr
 from . import test_xml_ubl_tr_common
 from . import test_tr_nilvera_mocked_requests
+from . import test_ubl_tr_xml_decode

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/ihracat_istisna.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/ihracat_istisna.xml
@@ -1,0 +1,203 @@
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:udt="urn:un:unece:uncefact:data:specification:UnqualifiedDataTypesSchemaModule:2"
+         xmlns:ccts="urn:un:unece:uncefact:documentation:2"
+         xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2"
+         xmlns:qdt="urn:oasis:names:specification:ubl:schema:xsd:QualifiedDatatypes-2"
+         xmlns:ubltr="urn:oasis:names:specification:ubl:schema:xsd:TurkishCustomizationExtensionComponents"
+         xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xades="http://uri.etsi.org/01903/v1.3.2#"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 UBL-Invoice-2.1.xsd"
+         xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+    <cbc:ProfileID>IHRACAT</cbc:ProfileID>
+    <cbc:ID>101</cbc:ID>
+    <cbc:CopyIndicator>false</cbc:CopyIndicator>
+    <cbc:UUID>0c50f933-89cf-44c8-ae97-78a2df3ba695</cbc:UUID>
+    <cbc:IssueDate>2026-02-11</cbc:IssueDate>
+    <cbc:IssueTime>10:28:24</cbc:IssueTime>
+    <cbc:InvoiceTypeCode>ISTISNA</cbc:InvoiceTypeCode>
+    <cbc:Note>YALNIZ : BİR TL SIFIR Kr.</cbc:Note>
+    <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+    <cbc:LineCountNumeric>1</cbc:LineCountNumeric>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>309fddea-e8e1-4717-be44-c6f46974c864</cbc:ID>
+        <cbc:IssueDate>2026-02-11</cbc:IssueDate>
+        <cbc:DocumentType>XSLT</cbc:DocumentType>
+        <cbc:DocumentDescription>E-Fatura stil dosyası.</cbc:DocumentDescription>
+    </cac:AdditionalDocumentReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>3281. Cadde</cbc:StreetName>
+                <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+                <cbc:CityName>Düzce</cbc:CityName>
+                <cbc:PostalZone>06810</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID>3297552117</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+                <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">1460415308</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>Gümrük ve Ticaret Bakanlığı Gümrükler Genel Müdürlüğü- Bilgi İşlem Dairesi Başkanlığı
+                </cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:CitySubdivisionName>Ulus</cbc:CitySubdivisionName>
+                <cbc:CityName>Ankara</cbc:CityName>
+                <cac:Country>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Ulus</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:BuyerCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="PARTYTYPE">EXPORT</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>earchive_partner</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+                <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+                <cbc:CityName>Ankara</cbc:CityName>
+                <cbc:PostalZone>06934</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>earchive_partner</cbc:RegistrationName>
+                <cbc:CompanyID>17291716060</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+                <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+            </cac:Contact>
+            <cac:Person>
+                <cbc:FirstName>earchive_partner</cbc:FirstName>
+                <cbc:FamilyName>___ignore___</cbc:FamilyName>
+            </cac:Person>
+        </cac:Party>
+    </cac:BuyerCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>1</cbc:PaymentMeansCode>
+        <cbc:PaymentChannelCode>2</cbc:PaymentChannelCode>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>TR231313211111111111111111</cbc:ID>
+            <cbc:CurrencyCode>TRY</cbc:CurrencyCode>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="TRY">0</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="TRY">1</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="TRY">0</cbc:TaxAmount>
+            <cbc:CalculationSequenceNumeric>1</cbc:CalculationSequenceNumeric>
+            <cac:TaxCategory>
+                <cbc:TaxExemptionReasonCode>301</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>11/1-a Mal ihracatı</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:Name>KDV</cbc:Name>
+                    <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="TRY">1</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="TRY">1</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="TRY">1</cbc:TaxInclusiveAmount>
+        <cbc:AllowanceTotalAmount currencyID="TRY">0</cbc:AllowanceTotalAmount>
+        <cbc:PayableAmount currencyID="TRY">1</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="NIU">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="TRY">1</cbc:LineExtensionAmount>
+        <cac:Delivery>
+            <cac:DeliveryAddress>
+                <cbc:StreetName>AAAAAAAAAAAAAAAAAAA</cbc:StreetName>
+                <cbc:CitySubdivisionName>AAAA</cbc:CitySubdivisionName>
+                <cbc:CityName>sdasd</cbc:CityName>
+                <cac:Country>
+                    <cbc:Name>TERES</cbc:Name>
+                </cac:Country>
+            </cac:DeliveryAddress>
+            <cac:DeliveryTerms>
+                <cbc:ID schemeID="INCOTERMS">CFR</cbc:ID>
+            </cac:DeliveryTerms>
+            <cac:Shipment>
+                <cbc:ID></cbc:ID>
+                <cac:GoodsItem>
+                    <cbc:RequiredCustomsID>111111111111</cbc:RequiredCustomsID>
+                </cac:GoodsItem>
+                <cac:ShipmentStage>
+                    <cbc:TransportModeCode>2</cbc:TransportModeCode>
+                </cac:ShipmentStage>
+            </cac:Shipment>
+        </cac:Delivery>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="TRY">0</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="TRY">1</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="TRY">0</cbc:TaxAmount>
+                <cbc:CalculationSequenceNumeric>1</cbc:CalculationSequenceNumeric>
+                <cac:TaxCategory>
+                    <cac:TaxScheme>
+                        <cbc:Name>KDV</cbc:Name>
+                        <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>STOK TEST</cbc:Description>
+            <cbc:Name>STOK TEST</cbc:Name>
+            <cac:SellersItemIdentification>
+                <cbc:ID>CTK 4001</cbc:ID>
+            </cac:SellersItemIdentification>
+            <cac:ItemInstance>
+                <cbc:ProductTraceID/>
+            </cac:ItemInstance>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="TRY">1</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_ubl_tr_xml_decode.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_ubl_tr_xml_decode.py
@@ -1,0 +1,388 @@
+import copy
+from unittest.mock import patch
+
+from lxml import etree
+
+from odoo import api
+from odoo.tests import tagged
+from odoo.tools import file_open
+
+from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
+from odoo.addons.l10n_tr_nilvera_einvoice.tests.test_xml_ubl_tr_common import (
+    TestUBLTRCommon,
+)
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLTRXMLDecode(TestUBLTRCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.account_edi_xml_ubl_tr = cls.env['account.edi.xml.ubl.tr']
+
+        # Preload all XMLs
+        cls.xml_templates = {
+            'satis': 'l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_sale_einvoice.xml',
+            'ihracat': 'l10n_tr_nilvera_einvoice/tests/expected_xmls/ihracat_istisna.xml',
+            'tevkifat': 'l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_withholding_einvoice.xml',
+            'ihrackayitli': 'l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_export_registered_einvoice.xml',
+            'istisna': 'l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_tax_exempt_einvoice.xml',
+            'usd_currency': 'l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml',
+        }
+
+        cls.invoice_basic_sale_einvoice_tree = cls._load_xml_tree(cls.xml_templates['satis'])
+
+        # ==== Partner ====
+        cls.partner_tr_customer = cls.env['res.partner'].create({
+            'name': 'TR Customer',
+            'country_id': cls.env.ref('base.tr').id,
+            'vat': '1729171602',
+        })
+
+        # ==== Bank Account ====
+        cls.partner_tr_bank_account = cls.env['res.partner.bank'].create({
+            'partner_id': cls.partner_tr_customer.id,
+            'account_number': 'TESTIBAN1234',
+        })
+
+        # ==== Products ====
+        cls.product_with_ctsp = cls.env['product.product'].create({
+            'name': 'CTSP Product',
+            'type': 'consu',
+            'l10n_tr_ctsp_number': "_CTSP_TEST",
+        })
+
+        cls.product_with_default_code = cls.env['product.product'].create({
+            'name': 'Default Code Product',
+            'type': 'consu',
+            'default_code': "_DEF_CODE_5678",
+        })
+
+    # =====================================================================
+    # Helper: Load XML once
+    # =====================================================================
+    @classmethod
+    def _load_xml_tree(cls, path):
+        with file_open(path, 'rb') as xml_file:
+            return etree.fromstring(xml_file.read())
+
+    # =====================================================================
+    # Helper: Return cloned tree w/ nodes removed
+    # =====================================================================
+    @staticmethod
+    def _xml_remove_nodes(tree, xpath):
+        new_tree = copy.deepcopy(tree)
+        for node in new_tree.xpath(xpath, namespaces=UBL_NAMESPACES):
+            parent = node.getparent()
+            if parent is not None:
+                parent.remove(node)
+        return new_tree
+
+    @staticmethod
+    def _update_xpath_text(tree, xpath, new_value):
+        new_tree = copy.deepcopy(tree)
+        for node in new_tree.xpath(xpath, namespaces=UBL_NAMESPACES):
+            node.text = new_value
+        return new_tree
+
+    # =====================================================================
+    # Helper: Create invoice template
+    # =====================================================================
+    @api.model
+    def _create_invoice(self, move_type='out_invoice'):
+        return self.env['account.move'].create({
+            'move_type': move_type,
+        })
+
+    # =====================================================================
+    # BASIC PROVIDED TESTS
+    # =====================================================================
+
+    def test_l10n_tr_nilvera_uuid_field_is_set(self):
+        invoice = self._create_invoice()
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree, './/cbc:UUID', 'UUID_TEST_VALUE')
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertEqual(
+            invoice.l10n_tr_nilvera_uuid,
+            'UUID_TEST_VALUE',
+            'The UUID field was not set correctly from the XML.',
+        )
+
+    def test_node_name_mapping_is_correct(self):
+        tree = copy.deepcopy(self.invoice_basic_sale_einvoice_tree)
+        profile_id_node = tree.find('.//cbc:ProfileID', namespaces=UBL_NAMESPACES)
+
+        # IHRACAT → BuyerCustomer
+        profile_id_node.text = 'IHRACAT'
+        node_name = self.account_edi_xml_ubl_tr._l10n_tr_import_party_role(tree)
+        self.assertEqual(node_name, 'BuyerCustomer', 'IHRACAT profile should map to BuyerCustomer node.')
+
+        # Sale
+        # Other → AccountingCustomer
+        profile_id_node.text = 'random'
+        node_name = self.account_edi_xml_ubl_tr._l10n_tr_import_party_role(tree, 'sale')
+        self.assertEqual(node_name, 'AccountingCustomer', 'Other profiles should map to AccountingCustomer node for sale.')
+
+        profile_id_node.text = ''
+        node_name = self.account_edi_xml_ubl_tr._l10n_tr_import_party_role(tree, 'sale')
+        self.assertEqual(node_name, 'AccountingCustomer', 'Empty profile should map to AccountingCustomer node for sale.')
+
+        # Purchase
+        # Other → AccountingCustomer
+        profile_id_node.text = 'random'
+        node_name = self.account_edi_xml_ubl_tr._l10n_tr_import_party_role(tree, 'purchase')
+        self.assertEqual(node_name, 'AccountingSupplier', 'Other profiles should map to AccountingCustomer node for purchase.')
+
+        profile_id_node.text = ''
+        node_name = self.account_edi_xml_ubl_tr._l10n_tr_import_party_role(tree, 'purchase')
+        self.assertEqual(node_name, 'AccountingSupplier', 'Empty profile should map to AccountingCustomer node for purchase.')
+
+    def test_fetch_existing_partner_by_vkn(self):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PartyLegalEntity//cbc:CompanyID', self.partner_tr_customer.vat)
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertEqual(invoice.partner_id.id, self.partner_tr_customer.id, 'Should fetch existing partner by VAT/VKN.')
+
+    @patch('odoo.addons.l10n_tr_nilvera.models.res_partner.ResPartner.l10n_tr_check_nilvera_customer')
+    @patch('odoo.addons.base_vat.models.res_partner.ResPartner._inverse_vat', new=lambda self: None)
+    def test_create_new_partner_and_verify_when_not_existing_vkn(self, l10n_tr_check_nilvera_customer_mocked):
+        new_vat = '0123456789000'
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PartyLegalEntity//cbc:CompanyID', new_vat)
+
+        non_existing_partner = self.env['res.partner'].search([('vat', '=', new_vat)])
+        self.assertFalse(non_existing_partner, 'Partner with new VAT should not exist before test.')
+
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        new_created_partner = self.env['res.partner'].search([('vat', '=', new_vat)])
+
+        self.assertEqual(invoice.partner_id.id, new_created_partner.id,
+                         'Should create and set new partner based on VAT/VKN.')
+
+        l10n_tr_check_nilvera_customer_mocked.assert_called_once()
+
+    def test_existing_bank_account_detected_by_account_number(self):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PaymentMeans//cac:PayeeFinancialAccount//cbc:ID',
+                                       self.partner_tr_bank_account.account_number)
+        tree = self._update_xpath_text(tree, './/cac:PartyLegalEntity//cbc:CompanyID', self.partner_tr_customer.vat)
+        invoice = self._create_invoice()
+        invoice.move_type = 'in_invoice'
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertEqual(invoice.partner_bank_id.id, self.partner_tr_bank_account.id,
+                         'Should fetch existing bank account based on account no.')
+
+    def test_new_bank_account_created_if_not_existing(self):
+        new_iban = 'NEW-IBAN-5678'
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree,
+                                       './/cac:PaymentMeans//cac:PayeeFinancialAccount//cbc:ID',
+                                       new_iban)
+        tree = self._update_xpath_text(tree, ".//cac:PartyLegalEntity//cbc:CompanyID", self.partner_tr_customer.vat)
+
+        non_existing_bank_account = self.env['res.partner.bank'].search([
+            ('partner_id', '=', self.partner_tr_customer.id),
+            ('account_number', '=', new_iban),
+        ])
+        self.assertFalse(non_existing_bank_account, 'Bank account with new IBAN should not exist before test.')
+
+        invoice = self._create_invoice()
+        invoice.move_type = "in_invoice"
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        new_created_bank_account = self.env['res.partner.bank'].search([
+            ('partner_id', '=', self.partner_tr_customer.id),
+            ('account_number', '=', new_iban),
+        ])
+
+        self.assertEqual(invoice.partner_bank_id.id, new_created_bank_account.id,
+                         'Should create and set new bank account based on IBAN.')
+        self.assertEqual(new_created_bank_account.partner_id.id, self.partner_tr_customer.id,
+                         'New bank account should be linked to the correct partner.')
+
+    def test_product_resolution_by_ctsp_number(self):
+        ihracat_tree = self._load_xml_tree(self.xml_templates['ihracat'])
+        tree = self._update_xpath_text(ihracat_tree,
+                                       './/cac:InvoiceLine//cac:Delivery//cac:Shipment//cbc:RequiredCustomsID',
+                                       self.product_with_ctsp.l10n_tr_ctsp_number)
+
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        product_lines = invoice.invoice_line_ids.filtered(lambda l: not l.display_name.endswith('Discount'))
+        self.assertEqual(product_lines[:1].product_id.id, self.product_with_ctsp.id,
+                         'Product should be resolved by CTSP number.')
+
+    def test_product_resolution_by_default_code(self):
+        ihracat_tree = self._load_xml_tree(self.xml_templates['ihracat'])
+        tree = self._update_xpath_text(ihracat_tree,
+                                       './/cac:InvoiceLine//cac:Item//cac:SellersItemIdentification//cbc:ID',
+                                       self.product_with_default_code.default_code)
+
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        product_lines = invoice.invoice_line_ids.filtered(lambda l: not l.display_name.endswith("Discount"))
+        self.assertEqual(product_lines[:1].product_id.id, self.product_with_default_code.id,
+                         'Product should be resolved by default code.')
+
+    def test_product_resolution_fallback_to_name(self):
+        ihracat_tree = self._load_xml_tree(self.xml_templates['ihracat'])
+        tree = self._update_xpath_text(ihracat_tree,
+                                       './/cac:InvoiceLine//cac:Item//cbc:Description',
+                                       'Fallback Product Name')
+
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        product_lines = invoice.invoice_line_ids.filtered(lambda l: not l.display_name.endswith("Discount"))
+        self.assertFalse(product_lines[:1].product_id, 'Product should not be resolved')
+        self.assertTrue(product_lines[:1].display_name, 'Fallback Product Name should be set as line description.')
+
+    def test_multi_currency_is_set_from_xml(self):
+        tree = self._load_xml_tree(self.xml_templates['usd_currency'])
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+        self.assertEqual(invoice.currency_id.name, 'USD', 'Invoice currency should be set to USD from XML.')
+
+    def test_innactive_invoice_currency_is_set_active(self):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree, './/cbc:DocumentCurrencyCode', 'BDT')
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+        self.assertTrue(invoice.currency_id.active, 'Inactive currency should be set active when used in invoice.')
+
+    # =====================================================================
+    # Invoice Scenarios
+    # =====================================================================
+
+    # SATIS(Sale)
+    # =====================================================================
+    def test_import_satis(self):
+        invoice = self._create_invoice()
+        tree = copy.deepcopy(self.invoice_basic_sale_einvoice_tree)
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'satis should not be marked as export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'SATIS', 'Invoice type should be SATIS.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        non_discount_lines = invoice.invoice_line_ids.filtered(
+            lambda l: not l.display_name.endswith("Discount")
+        )
+        first_line = non_discount_lines[:1]
+
+        # tax should not be zero
+        self.assertTrue(first_line.tax_ids, 'There should be taxes on the line.')
+        self.assertNotEqual(first_line.tax_ids.amount, 0.0, 'temelfatura_satis should have non-zero tax.')
+
+        # Discount field is set
+        # Not mandatory, but xml has it. So, check if it's set.
+        self.assertGreaterEqual(first_line.discount, 1, 'Discount field should be set on the line.')
+
+    # TEVKIFAT (WITHHOLDING)
+    # =====================================================================
+    def test_import_tevkifat(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['tevkifat'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'Should not be an export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'TEVKIFAT', 'Invoice type should be TEVKIFAT.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        non_discount_lines = invoice.invoice_line_ids.filtered(
+            lambda l: not l.display_name.endswith("Discount")
+        )
+        first_line = non_discount_lines[:1]
+
+        self.assertTrue(first_line.tax_ids)
+        self.assertTrue(first_line.tax_ids.children_tax_ids, 'There should be child taxes for withholding.')
+
+        withholding_taxes = first_line.tax_ids.children_tax_ids.filtered('l10n_tr_tax_withholding_code_id')
+        self.assertTrue(withholding_taxes, 'tevkifat should be a tax with withholding reason')
+
+    # IHRACKAYITLI (Registered for Export)
+    # =====================================================================
+    def test_import_ihrackayitli(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['ihrackayitli'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'Should not be an export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'IHRACKAYITLI', 'Invoice type should be IHRACKAYITLI.')
+        self.assertTrue(invoice.l10n_tr_exemption_code_id, 'ihrackayitli should have an exemption code set.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        non_discount_lines = invoice.invoice_line_ids.filtered(lambda l: not l.display_name.endswith('Discount'))
+        first_line = non_discount_lines[:1]
+
+        self.assertTrue(first_line.tax_ids)
+
+    # ISTISNA (Tax Exempt)
+    # =====================================================================
+    def test_import_istisna(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['istisna'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertFalse(invoice.l10n_tr_is_export_invoice, 'Should not be an export invoice.')
+        self.assertEqual(invoice.l10n_tr_gib_invoice_type, 'ISTISNA', 'Invoice type should be ISTISNA.')
+        self.assertTrue(invoice.l10n_tr_exemption_code_id, 'istisna should have an exemption code set.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        non_discount_lines = invoice.invoice_line_ids.filtered(lambda l: not l.display_name.endswith('Discount'))
+        first_line = non_discount_lines[:1]
+
+        self.assertTrue(first_line.tax_ids)
+
+    # IHRACAT (EXPORT)
+    # =====================================================================
+    def test_import_ihracat_export_invoice(self):
+        invoice = self._create_invoice()
+        tree = self._load_xml_tree(self.xml_templates['ihracat'])
+
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+
+        self.assertEqual(invoice.partner_id.name, 'earchive_partner', 'Partner name is not correctly imported')
+        self.assertTrue(invoice.l10n_tr_is_export_invoice, 'ihracat should be marked as export invoice.')
+        self.assertTrue(invoice.l10n_tr_exemption_code_id, 'ihracat should have an exemption code set.')
+        self.assertTrue(invoice.l10n_tr_shipping_type, 'ihracat should have a shipping type set.')
+        self.assertTrue(invoice.invoice_incoterm_id, 'Incoterm should be set for export invoice.')
+
+        self.assertTrue(invoice.invoice_line_ids, 'There should be invoice lines.')
+        for line in invoice.invoice_line_ids:
+            if line.tax_ids:
+                self.assertEqual(line.tax_ids.amount, 0.0, 'Export invoice lines should have 0% tax.')
+
+    def test_credit_note_not_supported_logs_error(self):
+        invoice = self._create_invoice()
+        tree = copy.deepcopy(self.invoice_basic_sale_einvoice_tree)
+
+        logs = self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, qty_factor=-1)
+
+        self.assertTrue(any(
+            'invoice/bill return creation from xml is not supported for tr1.2 ubl format yet.' in log.lower() for log in
+            logs))
+
+    # =====================================================================
+    # FALLBACK → IF CustomizationID != TR1.2
+    # =====================================================================
+
+    @patch('odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20.AccountEdiXmlUBL20._import_fill_invoice')
+    def test_fallback_to_super_when_not_ubl_tr(self, _import_fill_invoice_mocked):
+        tree = self._update_xpath_text(self.invoice_basic_sale_einvoice_tree, './/cbc:CustomizationID',
+                                       'OTHER-VERSION')
+        invoice = self._create_invoice()
+        self.account_edi_xml_ubl_tr._import_fill_invoice(invoice, tree, 1)
+        _import_fill_invoice_mocked.assert_called_once()


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

Nilvera uses a customized Turkish UBL format (UBL TR 1.2).

The existing Turkish UBL decoder in Odoo does not fully support TR 1.2 (CustomizationID="TR1.2"). As a result, importing such XML documents often creates invoices with missing or incomplete data because some business fields cannot be properly extracted.

# Current behavior before PR:

- Importing a TR 1.2 invoice frequently results in partially populated or empty invoices.

- The decoder lacks support for several TR 1.2-specific structures used in Nilvera electronic invoicing.

# Desired behavior after PR is merged:

- Extend the existing Turkish UBL decoder (AccountEdiXMLUblTr) to properly support UBL TR 1.2 documents.

- Reuse and enhance existing parsing logic to handle TR 1.2 specific elements while preserving compatibility with the standard UBL import flow.

- The import process now correctly extracts key invoice information, including:

  - Override Partner resolution using VKN

  - Extended postal address parsing and completion

  - Bank account prioritization from the XML document

  - Delivery details and export exemption handling

  - Product identification using default code or CTSP number

  - Tax computation for percentages, exemptions, and withholding

  - Invoice line pricing and discount extraction

- Supported scenarios are limited to:

  - ProfileID: TEMELFATURA, IHRACAT, KAMU

  - InvoiceTypeCode: SATIS, TEVKIFAT, ISTISNA, IHRACKAYITLI

  - Customer invoices and vendor bills

- Credit notes remain unsupported.

- Additional test cases ensure correct behavior for successful imports and relevant edge cases.

task-5079559

I confirm I have signed the CLA and read the PR guidelines at
https://www.odoo.com/submit-pr