### PR TITLE
[FIX] iot_drivers: get_mac_address from system

### DIFF
--- a/addons/iot_drivers/main.py
+++ b/addons/iot_drivers/main.py
@@ -82,7 +82,7 @@ class Manager(Thread):
         """
         iot_box = {
             'identifier': self.identifier,
-            'mac': helpers.get_mac_address(),
+            'mac': system.get_mac_address(),
             'ip': self.domain,
             'token': helpers.get_token(),
             'version': self.version,


### PR DESCRIPTION
odoo/odoo#242356 fw port introduced an issue where the iot tries to get the mac address from `helpers` instead of `system`.