### PR TITLE
[FIX] website: avoid switching away from customize tab in translate

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -158,7 +158,7 @@ export class Builder extends Component {
                     },
                     change_current_options_containers_listeners: (currentOptionsContainers) => {
                         this.state.currentOptionsContainers = currentOptionsContainers;
-                        if (!currentOptionsContainers.length) {
+                        if (!currentOptionsContainers.length && !this.displayOnlyCustomizeTab) {
                             // If there is no option, fallback on the current
                             // fallback tab.
                             this.setTab(this.noSelectionTab);

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -68,6 +68,22 @@ test("show invisible elements in translate mode", async () => {
     expect(":iframe .o_snippet_invisible").not.toHaveAttribute("data-invisible");
 });
 
+test("show+hide invisible elements in translate mode do not switch away from customize tab", async () => {
+    await setupSidebarBuilderForTranslation({ websiteContent: invisibleEl });
+    expect(".o_customize_tab").toHaveCount(1);
+    expect(":iframe .o_snippet_invisible").toHaveAttribute("data-invisible", "1");
+    await contains(
+        ".o_we_invisible_el_panel  .o_we_invisible_entry:contains('Invisible Element') i.fa-eye-slash"
+    ).click();
+    expect(".o_customize_tab").toHaveCount(1);
+    expect(":iframe .o_snippet_invisible").not.toHaveAttribute("data-invisible");
+    await contains(
+        ".o_we_invisible_el_panel  .o_we_invisible_entry:contains('Invisible Element') i.fa-eye"
+    ).click();
+    expect(".o_customize_tab").toHaveCount(1);
+    expect(":iframe .o_snippet_invisible").toHaveAttribute("data-invisible", "1");
+});
+
 test("translate text", async () => {
     const resultSave = [];
     onRpc("/website/field/translation/update", async (data) => {


### PR DESCRIPTION
With commit 3a80ac79c5b0193911e8ddab442660b315562639, the builder option plugin is not a custom one in translate. And the builder option plugin automatically switches to a fallback tab (instead of customize tab) when containers are de-activated. This happens when the user hides an invisible element.

This commit fixes it by skipping swithing to fallback tab if the builder is in translation mode.

Steps to reproduce:
- Open website builder
- Drop a section
- Make it invisible on desktop
- Add a language to the website
- Open builder in translate mode
- Click on the eye of invisible elements to show the invisible section
- Click again to hide it
- Bug: the sidebar left the "customize" tab and switched to "block" tab

task-5475107
