### PR TITLE
[FIX] sale_subscription: prevent archiving guest partners on subscriptions

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -916,7 +916,7 @@ class SaleOrder(models.Model):
     def _archive_partner_if_no_user(self):
         partners_to_archive = self.env['res.partner']
         for order in self:
-            if not (commercial_partner := order.partner_id).user_ids:
+            if not (commercial_partner := order.partner_id).user_ids and not order.is_subscription:
                 partners_to_archive |= commercial_partner + commercial_partner.child_ids
 
         partners_to_archive.active = False


### PR DESCRIPTION
When purchasing a subscription from the eCommerce as a guest user,
the payment fails because Odoo attempts to archive the subscription
customer, which causes issues.

To fix this, guest customers are no longer archived when they are
linked to a subscription.

ticket-5475479
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
