### PR TITLE
[FIX] html_editor,mail,web_editor: fix color css breaking inline style in mails

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing_mail.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing_mail.scss
@@ -66,3 +66,9 @@
         display: none;
     }
 }
+
+// Redeclare CSS values that use color-mix()
+// to avoid issues with mail rendering engines
+:root {
+    --o-border-color: #{o-color('300')};
+}


### PR DESCRIPTION
**Steps to reproduce:**
- Install Mass Mailing and Website apps
- Create a new mailing
- Add Columns block with different content size
- In "Vert. Alignment" field > Select the "Stretch to Equal Height" option
- Columns are properly aligned in Odoo
- Save the record and send test mail
- The columns are not aligned anymore in the received mail

**Issue:**
Inline styling breaks in mail engines due to `website.scss` file. The `color-mix` css function is used and cast as a `color()` functional notation in the columns `border-color`. The inline styling is then removed by the mail engine (with all siblings attributes) as it is not compatible with this notation.
(e.g. `border-color: color(srgb 0.129412 0.145098 0.160784 / 0.15);`)
The color normalization step doesn't take this into account as it only checks for rgb patterns.

**Fix:**
Overwrite the css with the color notation by a default value for mailing.

opw-5225248