### PR TITLE
[FIX] {,test_}mail: avoid marking unrelated notifications as bounced

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -823,13 +823,13 @@ class MailThread(models.AbstractModel):
                 bounced_record._message_receive_bounce(bounced_email, bounced_partner)
 
             if bounced_message and (bounced_email or bounced_partner):
-                self.env['mail.notification'].sudo().search(Domain(
-                    'mail_message_id', '=', bounced_message.id
-                ) & Domain.OR([
-                    Domain('res_partner_id', 'in', bounced_partner.ids) if bounced_partner else [],
-                    Domain('mail_email_address', '=', bounced_email) if bounced_email else [],
-                ]),
-                ).write({
+                domain = Domain('mail_message_id', '=', bounced_message.id)
+                sub_domains = []
+                if bounced_partner:
+                    sub_domains.append(Domain('res_partner_id', 'in', bounced_partner.ids))
+                if bounced_email:
+                    sub_domains.append(Domain('mail_email_address', '=', bounced_email))
+                self.env['mail.notification'].sudo().search(domain & Domain.OR(sub_domains)).write({
                     'failure_reason': html2plaintext(message_dict.get('body') or ''),
                     'failure_type': 'mail_bounce',
                     'notification_status': 'bounce',

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1332,6 +1332,49 @@ class TestMailgateway(MailGatewayCommon):
         self.assertEqual(self.partner_1.message_bounce, 1)
         self.assertEqual(self.test_record.message_bounce, 0)
 
+    @mute_logger('odoo.addons.mail.models.mail_thread')
+    def test_message_process_bounce_records_partner_multi(self):
+        """Bounce must only affect the notification matching the bounced email."""
+
+        bounce_email = 'specific.bounce.address@example.com'
+
+        message = self._create_gateway_message(
+            self.test_record,
+            'bounce_multi',
+            body='Test message',
+            message_type='email',
+            partner_ids=(self.partner_1 + self.partner_employee).ids,
+            subject='Test Multi Partner',
+        )
+
+        notif_partner, notif_employee = self.env['mail.notification'].create([
+            {
+                'mail_message_id': message.id,
+                'res_partner_id': self.partner_1.id,
+                'notification_type': 'email',
+                'notification_status': 'sent',
+                'mail_email_address': bounce_email,
+            },
+            {
+                'mail_message_id': message.id,
+                'res_partner_id': self.partner_employee.id,
+                'notification_type': 'email',
+                'notification_status': 'sent',
+            },
+        ])
+
+        with self.mock_mail_gateway():
+            self.format_and_process(
+                test_mail_data.MAIL_BOUNCE,
+                bounce_email,
+                f'groups@{self.alias_domain}',
+                subject='Undelivered Mail Returned to Sender',
+                extra=message.message_id,
+            )
+
+        self.assertEqual(notif_partner.notification_status, 'bounce')
+        self.assertEqual(notif_employee.notification_status, 'sent')
+
     # --------------------------------------------------
     # Thread formation
     # --------------------------------------------------


### PR DESCRIPTION
When a bounce is received for one recipient of a message sent to multiple partners, notifications for other recipients can be incorrectly marked as “bounced”.

Reproduction Steps:
1. Configure an incoming mail server with a bounce alias.
2. Create multiple contacts with different email addresses.
3. Send a message that notifies multiple contacts.
4. Process a bounce email related to only one recipient.
5. Observe that notifications for other recipients of the same message are also marked as “bounced”.

Root Cause:
During bounce processing, `MailThread._routing_handle_bounce` builds a search domain to identify which `mail.notification` records should be updated.

The original implementation constructed an `OR` domain that could include empty domain elements (`[]`) when some bounce identification data was missing. In Odoo’s domain logic, an empty domain represents a constant “match all” condition. When such a domain is included in an `OR`, the entire expression can match all notifications linked to the message, rather than only those related to the bounced recipient.

Fix:
The domain used to select bounced notifications is now built dynamically. Criteria are only added when the corresponding bounce identification data is present.

opw-5349170
