### PR TITLE
[FIX] account_tax_python: fix _check_formula because it doesn't consu…

### DIFF
--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -124,7 +124,11 @@ class AccountTaxPython(models.Model):
                 continue
 
             continue_needed = False
-            for token in allowed_tokens:
+            # Token consumption should be greedy, so the set of allowed tokens should be
+            # sorted from longer to shorter. Otherwise, if the set has '>' before '>=',
+            # the '>=' token will raise an error. This is because the '>' is consumed and
+            # then it leaves the '=' character next, wich is not in the allowed_tokens.
+            for token in sorted(allowed_tokens, key=len, reverse=True):
                 if formula[i:i + len(token)] == token:
                     i += len(token)
                     continue_needed = True

--- a/doc/cla/individual/rocketgithub.md
+++ b/doc/cla/individual/rocketgithub.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Rodrigo Fernandez rodrigo@solucionesprisma.com https://github.com/rocketgithub
+Rodrigo Fernandez rodrigo@aquih.com https://github.com/rocketgithub


### PR DESCRIPTION
…me tokens greedily.

Fixes issue #241004 and is a cleaned up version of a previous PR https://github.com/odoo/odoo/pull/241033

This is a hard to reproduce bug because it depends in what order the FORMULA_ALLOWED_TOKENS set is iterated. Since the set is an unordered structure, this bug will happen just sometimes. The issue is this:

There might be taxes that do a different calculation depending on the base. So for example, we might need to do a formula like this:

(base >= 100) and (base * 0.05) or (base * 0.07)

<img width="1302" height="651" alt="Captura de pantalla 2025-12-26 a la(s) 11 17 02" src="https://github.com/user-attachments/assets/7ce16272-56a4-452b-8eba-e797442f68c2" />

This formula multiplies the base by a certain value depending on whether the base is greater or equal than 100.

This formula will work sometimes, but sometimes, it will fail with this error.

<img width="1302" height="615" alt="Captura de pantalla 2025-12-26 a la(s) 11 18 48" src="https://github.com/user-attachments/assets/5527ff5d-6747-4221-b54f-085e0603aa5a" />

The position of the error is the '=', because the '=' is not a valid token in this list:

https://github.com/odoo/odoo/blob/18.0/addons/account_tax_python/models/account_tax.py#L10.

The formula is not using just the '=' token in this formula. The formula is using the '>=' token and '>=' is an allowed token. So why this error  appears sometimes?

So here is the important thing and why this bug appears only sometimes: FORMULA_ALLOWED_TOKENS is not a tuple. It is a set. And sets iterate randomly (it is an unordered list). So the loop in this line:

https://github.com/odoo/odoo/blob/18.0/addons/account_tax_python/models/account_tax.py#L127

sometimes sees the token '>=' first, and sometimes sees the token '>' first in its cycle.

When the '>=' is first in the set of allowed tokens, the loop goes through the formula, trying to match substrings to each token in the set. It matches the '>=' first so it advances 2 positions. In this scenario, the validation does not fail.

But when the '>' is first in the set of allowed tokens, the loop goes through the formula, trying to match substrings to each token in the set. It matches the '>' first so it advances 1 position. It has consumed only the '>' of '>='. Now, it will try to match the lone '=' to any of it tokens in the set of allowed tokens, but this '=' will not match any of the allowed tokens, so it will fail.

You can reproduce this bug using the above formula, and restarting Odoo if the error does not appear. Eventually, after restarting, the FORMULA_ALLOWED_TOKENS will have the '>' first and trigger the error.

The important part to understand here is that FORMULA_ALLOWED_TOKENS is unordered, so, the order of the loop is not guaranteed and sometimes this error is triggered and sometimes it is not, depending on the order the loop is done.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
