### PR TITLE
[IMP] purchase: display RFQ billing status as tag

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -630,7 +630,7 @@
                     <field name="company_currency_id" column_invisible="True"/>
                     <field name="state" optional="show" widget="badge" decoration-success="state == 'purchase'"
                         decoration-warning="state == 'to approve'" decoration-info="state == 'draft' or state == 'sent'"/>
-                    <field name="invoice_status" optional="hide"/>
+                    <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" decoration-info="invoice_status == 'to invoice'" optional="hide"/>
                 </list>
             </field>
         </record>


### PR DESCRIPTION
Currently, the billing status of RFQs is displayed as text. In order to improve user experience and make the UI more consistent, it should be displayed as a tag.

Task: 5429434

New UI:

<img width="417" height="122" alt="Screenshot from 2026-01-07 19-27-09" src="https://github.com/user-attachments/assets/c682548f-13b5-4b0b-8b14-1ef4272eaf10" />


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
