### PR TITLE
[MOV] core: odoo.http.router.root.session_store to session

### DIFF
--- a/addons/auth_ldap/tests/test_auth_ldap.py
+++ b/addons/auth_ldap/tests/test_auth_ldap.py
@@ -1,7 +1,6 @@
 import re
 from unittest.mock import patch
 
-from odoo.http.router import root
 from odoo.tests.common import HttpCase, tagged
 
 
@@ -63,12 +62,10 @@ class TestAuthLDAP(HttpCase):
             )
             res.raise_for_status()
 
-        session = root.session_store.get(res.cookies["session_id"])
-        self.assertEqual(
-            session.sid, res.cookies["session_id"], "A session must exist at this point")
+        self.assertTrue(res.session, "A session must exist at this point")
 
         with self.registry.cursor() as cr:
             cr.execute(
                 "SELECT id FROM res_users WHERE login = %s and id = %s",
-                ("test_ldap_user", session.uid))
+                ("test_ldap_user", res.session.uid))
             self.assertTrue(cr.rowcount, "User should be present")

--- a/addons/auth_timeout/models/ir_http.py
+++ b/addons/auth_timeout/models/ir_http.py
@@ -2,7 +2,7 @@ import time
 
 from odoo import api, models
 from odoo.http import request
-from odoo.http.router import root
+from odoo.http.session import session_store
 
 
 class IrHttp(models.AbstractModel):
@@ -94,11 +94,11 @@ class IrHttp(models.AbstractModel):
             if not session.get("identity-check-next") or next_check < session["identity-check-next"]:
                 session["identity-check-next"] = next_check
                 # Save manually, websocket requests do not save the session automatically
-                root.session_store.save(session)
+                session_store().save(session)
         elif not inactive and (timestamp := session.get("identity-check-next")) and timestamp > time.time():
             session.pop("identity-check-next")
             # Save manually, websocket requests do not save the session automatically
-            root.session_store.save(session)
+            session_store().save(session)
 
     def _session_info_common_auth_timeout(self, session_info):
         """

--- a/addons/auth_timeout/models/ir_websocket.py
+++ b/addons/auth_timeout/models/ir_websocket.py
@@ -1,6 +1,6 @@
 from odoo import models
 from odoo.http import request
-from odoo.http.router import root
+from odoo.http.session import session_store
 
 from odoo.addons.bus.websocket import wsrequest
 
@@ -35,7 +35,7 @@ class IrWebsocket(models.AbstractModel):
         :return: None
         """
         if self.env.user:
-            session = root.session_store.get(cookies["session_id"])
+            session = session_store().get(cookies["session_id"])
             if not session.is_new:
                 # `is_new` is a mitigation to avoid calls with arbitrary `session_id`
                 # which would create a new session file in the session filestore with an arbitrary name

--- a/addons/auth_timeout/tests/test_auth_timeout.py
+++ b/addons/auth_timeout/tests/test_auth_timeout.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import lxml.html
 
-from odoo.http.router import root
+from odoo.http.session import session_store
 from odoo.tests import HttpCase, TransactionCase, new_test_user, tagged
 from odoo.tests.common import HOST
 
@@ -241,19 +241,19 @@ class TestAuthTimeoutHttp(HttpCase):
         ).json()
 
     def set_session_create_time(self, session_id, timestamp):
-        session = root.session_store.get(session_id)
+        session = session_store().get(session_id)
         session["create_time"] = timestamp
-        root.session_store.save(session)
+        session_store().save(session)
 
     def set_session_last_check_identity(self, session_id, timestamp):
-        session = root.session_store.get(session_id)
+        session = session_store().get(session_id)
         session["identity-check-last"] = timestamp
-        root.session_store.save(session)
+        session_store().save(session)
 
     def set_session_next_check_identity(self, session_id, timestamp):
-        session = root.session_store.get(session_id)
+        session = session_store().get(session_id)
         session["identity-check-next"] = timestamp
-        root.session_store.save(session)
+        session_store().save(session)
 
     def set_auth_totp_mail(self):
         config = self.env["res.config.settings"].create({})

--- a/addons/bus/session_helpers.py
+++ b/addons/bus/session_helpers.py
@@ -3,7 +3,7 @@ import hmac
 import time
 
 from odoo.api import Environment
-from odoo.http.session import delete_old_sessions, SessionExpiredException
+from odoo.http.session import SessionExpiredException, session_store
 from odoo.modules.registry import Registry
 from odoo.sql_db import SQL
 from odoo.tools.lru import LRU
@@ -34,7 +34,7 @@ def _get_session_token_query_params(cr, session):
 
 
 def check_session(cr, session):
-    delete_old_sessions(session)
+    session_store().delete_old_sessions(session)
     if 'deletion_time' in session and session['deletion_time'] <= time.time():
         e = "session is too old"
         raise SessionExpiredException(e)

--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -12,7 +12,6 @@ from weakref import WeakSet
 from freezegun import freeze_time
 
 from odoo.api import Environment
-from odoo.http.router import root
 from odoo.tests import common, new_test_user
 from odoo.tools import mute_logger
 
@@ -208,8 +207,7 @@ class TestWebsocketCaryall(WebsocketCase):
         # preferred language), this could be a unknown language (ex. territorial
         # specific) or a known language that is uninstalled; in all cases this
         # should not crash the notif. dispatching.
-        self.session.context['lang'] = 'fr_LU'
-        root.session_store.save(self.session)
+        self.update_session_context(lang='fr_LU')
         self.subscribe(websocket, ['my_channel'], self.env['bus.bus']._bus_last_id())
         self.env['bus.bus']._sendone('my_channel', 'notif_type', 'message')
         self.trigger_notification_dispatching(["my_channel"])

--- a/addons/test_website/tests/test_session.py
+++ b/addons/test_website/tests/test_session.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from unittest.mock import patch
 
 from lxml import html
 
 import odoo.tests
-from odoo.http.router import root
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website.models.website import Website
@@ -18,10 +16,8 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
         self.start_tour('/', 'test_json_auth')
 
     def test_02_inactive_session_lang(self):
-        session = self.authenticate(None, None)
+        self.authenticate(None, None, session_extra={'context': {'lang': 'fr_FR'}})
         self.env.ref('base.lang_fr').active = False
-        session.context['lang'] = 'fr_FR'
-        root.session_store.save(session)
 
         # ensure that _get_current_website_id will be able to match a website
         current_website_id = self.env["website"]._get_current_website_id(odoo.tests.HOST)
@@ -31,10 +27,8 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
         res.raise_for_status()
 
     def test_03_totp_login_with_inactive_session_lang(self):
-        session = self.authenticate(None, None)
+        self.authenticate(None, None, session_extra={'context': {'lang': 'fr_FR'}})
         self.env.ref('base.lang_fr').active = False
-        session.context['lang'] = 'fr_FR'
-        root.session_store.save(session)
 
         # ensure that _get_current_website_id will be able to match a website
         current_website_id = self.env["website"]._get_current_website_id(odoo.tests.HOST)
@@ -51,11 +45,7 @@ class TestWebsiteSession(HttpCaseWithUserDemo):
         self.assertTrue(res.next.path_url.startswith("/web/login/totp"))
 
     def test_04_ensure_website_cached_data_can_be_called(self):
-        session = self.authenticate('admin', 'admin')
-
-        # Force a browser language that is not installed
-        session.context['lang'] = 'fr_MC'
-        root.session_store.save(session)
+        self.authenticate('admin', 'admin', session_extra={'context': {'lang': 'fr_MC'}})
 
         # Disable cache in order to make sure that values would be fetched at any time
         get_cached_values_without_cache = Website._cached_data.__cache__.method

--- a/addons/web/controllers/utils.py
+++ b/addons/web/controllers/utils.py
@@ -9,7 +9,7 @@ import werkzeug.exceptions
 from werkzeug.urls import iri_to_uri
 
 from odoo.http import request, router
-from odoo.http.session import get_default_session
+from odoo.http.session import get_default_session, session_store
 from odoo.tools.misc import file_open
 from odoo.tools.translate import JAVASCRIPT_TRANSLATION_COMMENT
 
@@ -91,7 +91,7 @@ def ensure_db(redirect='/web/database/selector', db=None):
 
     # always switch the session to the computed db
     if db != request.session.db:
-        request.session = router.root.session_store.new()
+        request.session = session_store().new()
         request.session.update(get_default_session(), db=db)
         request.session.context['lang'] = request.default_lang()
         werkzeug.exceptions.abort(request.redirect(request.httprequest.url, 302))

--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import odoo.tests
 from odoo.exceptions import UserError
-from odoo.http.router import root
+from odoo.http.session import session_store
 from odoo.tests import tagged
 from odoo.tools import mute_logger
 
@@ -116,7 +116,7 @@ class TestReports(odoo.tests.HttpCase):
 
         with (MockRequest(report.env) as mock_request,
             patch('subprocess.run') as mock_popen,
-            patch.object(root.session_store, 'delete') as mock_delete,
+            patch.object(session_store(), 'delete') as mock_delete,
             patch.object(os, 'unlink') as mock_unlink):
 
             mock_request.session = self.authenticate(admin.login, admin.login)

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from lxml import html
 
 from odoo.fields import Command
-from odoo.http.router import root
+from odoo.http.session import session_store
 from odoo.tests import HttpCase, common, tagged
 from odoo.tools import mute_logger
 
@@ -16,7 +16,7 @@ from odoo.addons.website.controllers.main import Website
 @tagged('-at_install', 'post_install')
 class TestPage(common.TransactionCase):
     def setUp(self):
-        super(TestPage, self).setUp()
+        super().setUp()
         View = self.env['ir.ui.view']
         Page = self.env['website.page']
         Menu = self.env['website.menu']
@@ -279,7 +279,7 @@ class WithContext(HttpCase):
             self.assertIn('ZeroDivisionError: division by zero', r.text, "Error should be shown in debug.")
 
     def test_04_visitor_no_session(self):
-        with patch.object(root.session_store, 'save') as session_save,\
+        with patch.object(session_store(), 'save') as session_save,\
              MockRequest(self.env, website=self.env['website'].browse(1)):
             # no session should be saved for website visitor
             self.url_open(self.page.url).raise_for_status()

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-from odoo.http.router import root
 from odoo.tests import HttpCase, common, tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
@@ -197,7 +196,7 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
             'password': pwd,
             'csrf_token': res.text.partition(csrf_anchor)[2].partition('"')[0],
         })
-        self.session = root.session_store.get(res.cookies["session_id"])
+        self.session = res.session
 
 
 class WebsiteVisitorTests(WebsiteVisitorTestsCommon):

--- a/addons/website_sale/tests/test_express_checkout_flows.py
+++ b/addons/website_sale/tests/test_express_checkout_flows.py
@@ -2,13 +2,14 @@
 
 from unittest.mock import Mock, patch
 
-from odoo.http.router import root
 from odoo.tests import HttpCase, tagged
 from odoo.tools import urls
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.website_sale.controllers.cart import Cart
-from odoo.addons.website_sale.controllers.delivery import Delivery as WebsiteSaleDeliveryController
+from odoo.addons.website_sale.controllers.delivery import (
+    Delivery as WebsiteSaleDeliveryController,
+)
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
@@ -124,9 +125,7 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
 
     def test_express_checkout_public_user(self):
         """Test that when using express checkout as a public user, a new partner is created."""
-        session = self.authenticate(None, None)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(None, None, session_extra={'sale_order_id': self.sale_order.id})
 
         self.make_jsonrpc_request(
             urls.urljoin(
@@ -149,9 +148,11 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         partner and reuse the existing one.
         """
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
 
         self.make_jsonrpc_request(
             urls.urljoin(
@@ -167,8 +168,8 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
                     'zip': self.user_demo.partner_id.zip,
                     'country': self.user_demo.partner_id.country_id.code,
                     'state': self.user_demo.partner_id.state_id.code,
-                }
-            }
+                },
+            },
         )
 
         self.assertEqual(self.sale_order.partner_id.id, self.user_demo.partner_id.id)
@@ -197,16 +198,18 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         ))
 
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
 
         self.make_jsonrpc_request(
             urls.urljoin(
                 self.base_url(), WebsiteSale._express_checkout_route
             ), params={
                 'billing_address': dict(self.express_checkout_billing_values)
-            }
+            },
         )
 
         self.assertEqual(self.sale_order.partner_id.id, self.user_demo.partner_id.id)
@@ -218,16 +221,18 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         odoo, we create a new partner.
         """
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
 
         self.make_jsonrpc_request(
             urls.urljoin(
-                self.base_url(), WebsiteSale._express_checkout_route
+                self.base_url(), WebsiteSale._express_checkout_route,
             ), params={
-                'billing_address': dict(self.express_checkout_billing_values)
-            }
+                'billing_address': dict(self.express_checkout_billing_values),
+            },
         )
 
         self.assertEqual(self.sale_order.partner_id.id, self.user_demo.partner_id.id)
@@ -242,12 +247,11 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         """Test that when using express checkout as a public user and selecting a shipping address,
         a new partner is created if the partner of the SO is the public partner.
         """
-        session = self.authenticate(None, None)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(None, None, session_extra={'sale_order_id': self.sale_order.id})
+
         with patch(
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
-            return_value=self.rate_shipment_result
+            return_value=self.rate_shipment_result,
         ):
             self.make_jsonrpc_request(
                 urls.urljoin(
@@ -273,9 +277,8 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         more than once, a new partner is created if the partner of the SO is the public partner
         (only creates one new partner that is updated).
         """
-        session = self.authenticate(None, None)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(None, None, session_extra={'sale_order_id': self.sale_order.id})
+
         with patch(
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
@@ -314,9 +317,12 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         shipping address, the existing partner (the one of the SO) is reused.
         """
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
+
         with patch(
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
@@ -340,9 +346,12 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         from the delivery information received.
         """
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
+
         with patch(
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
@@ -373,9 +382,12 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         the public partner (only creates one new partner that is updated).
         """
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
+
         with patch(
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
@@ -432,9 +444,12 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         to this user in Odoo, we do not create a new partner and reuse the existing one.
         """
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
+
         with patch(
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
@@ -471,9 +486,12 @@ class TestWebsiteSaleExpressCheckoutFlows(WebsiteSaleCommon, HttpCase):
         partner.
         """
         self.sale_order.partner_id = self.user_demo.partner_id.id
-        session = self.authenticate(self.user_demo.login, self.user_demo.login)
-        session['sale_order_id'] = self.sale_order.id
-        root.session_store.save(session)
+        self.authenticate(
+            self.user_demo.login,
+            self.user_demo.login,
+            session_extra={'sale_order_id': self.sale_order.id},
+        )
+
         with patch(
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -25,8 +25,7 @@ from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import AccessError, RedirectWarning, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.http.router import root
-from odoo.http.session import update_session_token
+from odoo.http.session import session_store, update_session_token
 from odoo.tools import config, is_html_empty, parse_version, split_every
 from odoo.tools.barcode import (
     check_barcode_encoding,
@@ -560,7 +559,7 @@ class IrActionsReport(models.Model):
             # Passing the cookie to wkhtmltopdf in order to resolve internal links.
             if request and request.db:
                 # Create a temporary session which will not create device logs
-                temp_session = root.session_store.new()
+                temp_session = session_store().new()
                 temp_session.update({
                     **request.session,
                     'debug': '',
@@ -568,8 +567,8 @@ class IrActionsReport(models.Model):
                 })
                 if temp_session.uid:
                     update_session_token(temp_session, self.env)
-                root.session_store.save(temp_session)
-                stack.callback(root.session_store.delete, temp_session)
+                session_store().save(temp_session)
+                stack.callback(session_store().delete, temp_session)
 
                 base_url = self._get_report_url()
                 domain = urlparse(base_url).hostname

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -35,13 +35,13 @@ from odoo.exceptions import AccessDenied
 from odoo.http import Response, request
 from odoo.http.dispatcher import SAFE_HTTP_METHODS
 from odoo.http.requestlib import is_cors_preflight
-from odoo.http.router import root
 from odoo.http.routing_map import ROUTING_KEYS
 from odoo.http.session import (
     check,
     CheckIdentityException,
     SessionExpiredException,
     get_session_max_inactivity,
+    session_store,
 )
 from odoo.modules.registry import Registry
 from odoo.tools.json import json_default
@@ -428,7 +428,7 @@ class IrHttp(models.AbstractModel):
     def _gc_sessions(self):
         if os.getenv("ODOO_SKIP_GC_SESSIONS"):
             return
-        root.session_store.vacuum(max_lifetime=get_session_max_inactivity(self.env))
+        session_store().vacuum(max_lifetime=get_session_max_inactivity(self.env))
 
     @api.model
     def _get_translations_for_webclient(self, modules, lang):

--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -5,8 +5,13 @@ from datetime import datetime, timedelta
 
 from odoo import api, fields, models, tools
 from odoo.http import request
-from odoo.http.router import root
-from odoo.http.session import STORED_SESSION_BYTES, get_session_max_inactivity, logout, update_device
+from odoo.http.session import (
+    STORED_SESSION_BYTES,
+    get_session_max_inactivity,
+    logout,
+    session_store,
+    update_device,
+)
 from odoo.tools import SQL
 from odoo.tools._vendor.useragents import UserAgent
 from odoo.tools.translate import _
@@ -78,7 +83,7 @@ class ResDeviceLog(models.Model):
                 revoked=False,
             ))
             _logger.info('User %d inserts device log (%s)', user_id, session_identifier)
-            root.session_store.save(request.session)
+            session_store().save(request.session)
 
     @api.autovacuum
     def _gc_device_log(self):
@@ -120,7 +125,7 @@ class ResDeviceLog(models.Model):
             if not candidate_device_log_ids:
                 break
             offset += batch_size
-            revoked_session_identifiers = root.session_store.get_missing_session_identifiers(
+            revoked_session_identifiers = session_store().get_missing_session_identifiers(
                 set(candidate_device_log_ids.mapped('session_identifier')),
             )
             if not revoked_session_identifiers:
@@ -290,7 +295,7 @@ class ResSession(models.Model):
     def _revoke(self):
         ResDeviceLog = self.env['res.device.log']
         session_identifiers = list(set(self.mapped('session_identifier')))
-        root.session_store.delete_from_identifiers(session_identifiers)
+        session_store().delete_from_identifiers(session_identifiers)
         revoked_devices = ResDeviceLog.sudo().search([
             ('session_identifier', 'in', session_identifiers),
             ('revoked', '=', False),

--- a/odoo/addons/test_http/tests/test_common.py
+++ b/odoo/addons/test_http/tests/test_common.py
@@ -7,12 +7,11 @@ from werkzeug.datastructures import ResponseCacheControl
 from werkzeug.http import parse_cache_control_header
 
 import odoo.http.geoip
-from odoo.http.router import Application, root
-from odoo.http.session import Session
+from odoo.http.router import root
 from odoo.tools import config, reset_cached_properties
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.addons.test_http.utils import MemoryGeoipResolver, MemorySessionStore
+from odoo.addons.test_http.utils import MemoryGeoipResolver
 
 HTTP_DATETIME_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
 
@@ -22,20 +21,14 @@ class TestHttpBase(HttpCaseWithUserDemo):
     def setUpClass(cls):
         super().setUpClass()
         geoip_resolver = MemoryGeoipResolver()
-        session_store = MemorySessionStore(session_cls=Session)
 
         reset_cached_properties(root)
         cls.addClassCleanup(reset_cached_properties, root)
         cls.classPatch(config, 'options', config.options.new_child({
             'server_wide_modules': ['base', 'web', 'rpc', 'test_http'],
         }))
-        cls.classPatch(Application, 'session_store', session_store)
         cls.classPatch(odoo.http.geoip, '_geoip_city_db', lambda: geoip_resolver)
         cls.classPatch(odoo.http.geoip, '_geoip_country_db', lambda: geoip_resolver)
-
-    def setUp(self):
-        super().setUp()
-        root.session_store.store.clear()
 
     def db_url_open(self, url, *args, allow_redirects=False, **kwargs):
         return self.url_open(url, *args, allow_redirects=allow_redirects, **kwargs)

--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -4,7 +4,6 @@ import json
 import time
 from http import HTTPStatus
 
-from odoo.http.router import root
 from odoo.http.session import SESSION_ROTATION_INTERVAL
 from odoo.tests import Like, new_test_user, tagged
 from odoo.tools import mute_logger
@@ -39,7 +38,6 @@ class TestHttpEchoReplyHttpNoDB(TestHttpBase):
         res = self.nodb_url_open('/test_http/echo-http-post', data=payload, headers=CT_JSON)
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.text, '{}')
-
 
     def test_echohttp5_post_csrf(self):
         res = self.nodb_url_open('/test_http/echo-http-csrf?race=Asgard', data={'commander': 'Thor'})
@@ -158,8 +156,7 @@ class TestHttpEchoReplyHttpWithDB(TestHttpBase):
         sid_before_rotation = self.opener.cookies['session_id']
 
         # Force a rotation by changing the create date of the session
-        self.session['create_time'] = time.time() - SESSION_ROTATION_INTERVAL
-        root.session_store.save(self.session)
+        self.update_session(create_time=time.time() - SESSION_ROTATION_INTERVAL)
 
         # Trigger session rotation by calling another endpoint
         res = self.db_url_open('/test_http/echo-http-get')

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -11,7 +11,6 @@ from urllib.parse import urlsplit
 from freezegun import freeze_time
 
 from odoo import api
-from odoo.http.router import root
 from odoo.tests import RecordCapturer, new_test_user, tagged
 from odoo.tools import config, file_open
 from odoo.tools.image import image_process
@@ -85,15 +84,12 @@ class TestHttpStatic(TestHttpStaticCommon):
             self.assertCacheControl(res, 'public, max-age=604800')
 
     def test_static01_debug_assets(self):
-        session = self.authenticate(None, None)
-        session.debug = 'assets'
-
+        self.authenticate(None, None, session_extra={'debug': 'assets'})
         res = self.assertDownloadGizeh('/test_http/static/src/img/gizeh.png')
         self.assertCacheControl(res, 'no-cache, max-age=0')
 
     def test_static02_not_found(self):
-        session = self.authenticate(None, None)
-        session.db = None
+        self.authenticate(None, None, session_extra={'db': None})
         res = self.nodb_url_open("/test_http/static/i-dont-exist")
         self.assertEqual(res.status_code, 404)
 
@@ -432,10 +428,9 @@ class TestHttpStatic(TestHttpStaticCommon):
             self.assertEqual(res.headers['Content-Security-Policy'], "default-src 'none'")
 
     def test_static23_remove_cache_control_wkhmtltopdf(self):
-        session = self.authenticate(None, None)
+        self.authenticate(None, None)
         for debug in ('', 'assets'):
-            session.debug = debug
-            root.session_store.save(self.session)
+            self.update_session(debug=debug)
             with self.subTest(debug=debug):
                 res = self.db_url_open('/test_http/static/src/img/gizeh.png', headers={
                     'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) '

--- a/odoo/http/dispatcher.py
+++ b/odoo/http/dispatcher.py
@@ -228,7 +228,7 @@ class HttpDispatcher(Dispatcher):
             response = self.request.redirect_query('/web/login', {
                 'redirect': self.request.httprequest.full_path})
             if was_connected:
-                root.session_store.rotate(session, self.request.env)
+                session_store().rotate(session, self.request.env)
                 response.set_cookie(
                     'session_id',
                     session.sid,
@@ -413,4 +413,5 @@ from .session import (
     SessionExpiredException,
     get_session_max_inactivity,
     logout,
+    session_store,
 )

--- a/odoo/http/requestlib.py
+++ b/odoo/http/requestlib.py
@@ -114,7 +114,7 @@ class Request:
 
     def _get_session_and_dbname(self) -> tuple[Session, str | None]:
         sid = self.httprequest._session_id__
-        session = root.session_store.get(sid, keep_sid=True)
+        session = session_store().get(sid, keep_sid=True)
 
         for key, val in get_default_session().items():
             session.setdefault(key, val)
@@ -479,11 +479,11 @@ class Request:
             return
 
         if sess.should_rotate:
-            root.session_store.rotate(sess, env)  # it saves
+            session_store().rotate(sess, env)  # it saves
         elif sess.uid and time.time() >= sess['create_time'] + SESSION_ROTATION_INTERVAL:
-            root.session_store.rotate(sess, env, soft=True)
+            session_store().rotate(sess, env, soft=True)
         elif sess.is_dirty:
-            root.session_store.save(sess)
+            session_store().save(sess)
 
         cookie_sid = self.cookies.get('session_id')
         if sess.is_dirty or cookie_sid != sess.sid:
@@ -707,6 +707,7 @@ from .session import (
     get_default_session,
     get_session_max_inactivity,
     logout,
+    session_store,
 )
 from .stream import STATIC_CACHE, Stream
 

--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -192,12 +192,6 @@ class Application:
 
         return nodb_routing_map
 
-    @functools.cached_property
-    def session_store(self):
-        path = config.session_dir
-        _logger.debug('HTTP sessions stored in: %s', path)
-        return SessionStore(path=path)
-
     def get_db_router(self, db: str | None) -> werkzeug.routing.Map:
         if not db:
             return self.nodb_routing_map
@@ -317,4 +311,4 @@ from .requestlib import (
     request,
 )
 from .routing_map import ROUTING_KEYS, _generate_routing_rules
-from .session import SessionExpiredException, SessionStore, logout
+from .session import SessionExpiredException, logout


### PR DESCRIPTION
The session store is a global-ish variable that was set as a lazy
property on the Application singleton. Now that http.py is split, it
really doesn't make sense to have the session store inside Application
inside router.py. It should be inside session.py, that's what this PR
does.

Changing the `@lazy` for a `@functools.lru_cache(1)` makes the decorated
function better typing-wise, but makes it impossible to monkey-patch. As
it was only monkey-patched inside `test_http`, we just adapted that
module to use the real session store.