### PR TITLE
[FIX] mail: discuss app same header height for all conversations

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -75,6 +75,13 @@ export class DiscussContent extends Component {
         return this.props.thread || this.store.discuss.thread;
     }
 
+    get showsChatLocalDateTime() {
+        return (
+            this.thread.channel?.channel_type === "chat" &&
+            this.state.correspondentLocalDateTimeFormatted
+        );
+    }
+
     get showThreadAvatar() {
         return ["channel", "group", "chat"].includes(this.thread.channel?.channel_type);
     }

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -20,14 +20,14 @@
                 <t t-else="">
                     <ThreadIcon className="'align-self-center fs-3 my-2 opacity-75'" size="'large'" thread="thread"/>
                 </t>
-                <div class="flex-grow-1 align-self-center align-items-center h-100 py-1">
+                <div class="flex-grow-1 align-self-center align-items-center h-100 py-1" t-att-class="{ 'lh-sm': showsChatLocalDateTime }">
                     <div class="d-flex">
                         <div t-if="thread.channel?.parent_channel_id" class="d-flex align-items-center gap-1 ms-1">
                             <span class="fw-bolder cursor-pointer opacity-75 opacity-100-hover o-hover-text-underline" t-esc="thread.channel.parent_channel_id.displayName" t-on-click="() => this.thread?.channel?.parent_channel_id?.open({ focus: true })"/>
                             <i class="oi oi-chevron-right o-xsmaller mx-1"/>
                         </div>
                         <AutoresizeInput
-                            className="'o-mail-DiscussContent-threadName fw-bold flex-shrink-1 py-0 fs-4'"
+                            className="'o-mail-DiscussContent-threadName fw-bold flex-shrink-1 py-0 ' + (showsChatLocalDateTime ? 'fs-5' : 'fs-4')"
                             enabled="thread.is_editable or thread.channel?.channel_type === 'chat'"
                             onValidate.bind="renameThread"
                             value="thread.displayName || ''"
@@ -44,7 +44,7 @@
                             />
                         </t>
                     </div>
-                    <div t-if="thread.channel?.channel_type === 'chat' and state.correspondentLocalDateTimeFormatted" class="text-muted small ms-1" t-out="state.correspondentLocalDateTimeFormatted"/>
+                    <div t-if="showsChatLocalDateTime" class="text-muted smaller ms-1" t-out="state.correspondentLocalDateTimeFormatted"/>
                 </div>
                 <div class="pe-3">
                     <ActionList actions="[partitionedActions.quick, partitionedActions.other, ...partitionedActions.group.slice().reverse()]" inline="true" odooControlPanelSwitchStyle="true"/>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/issues/210094

PR above add a new feature to show the local timezone of correspondent of chat when it differs from current user.

The conversation name, in addition to local timezone, increases the height of discuss header, which didn't look great.

This commit fixes the issue by:
- reducing the conversation name slightly when local timezone is shown
- reduce line-height when local timezone is shown
- reduce slightly font size of timezone

These changes preserves the height of discuss header for all conversations, and makes text content more balanced between each item relative to header, including the avatar size.

<img width="1164" height="490" alt="Screenshot 2026-01-07 at 20 39 07" src="https://github.com/user-attachments/assets/21a8dc59-c3c3-4fe4-9c54-f74f7156c00c" />
