### PR TITLE
[IMP] fleet: split contract and service types configuration

### DIFF
--- a/addons/fleet/models/fleet_service_type.py
+++ b/addons/fleet/models/fleet_service_type.py
@@ -14,3 +14,8 @@ class FleetServiceType(models.Model):
         ('contract', 'Contract'),
         ('service', 'Service')
         ], 'Category', required=True, help='Choose whether the service refer to contracts, vehicle services or both')
+    company_id = fields.Many2one(
+        'res.company',
+        string='Company',
+        default=lambda self: self.env.company,
+    )

--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -18,7 +18,7 @@ class FleetVehicleLogContract(models.Model):
         return fields.Date.to_string(start_date + oneyear)
 
     vehicle_id = fields.Many2one('fleet.vehicle', 'Vehicle', required=True, check_company=True, tracking=True, index=True)
-    cost_subtype_id = fields.Many2one('fleet.service.type', 'Type', help='Cost type purchased with this cost', domain=[('category', '=', 'contract')])
+    cost_subtype_id = fields.Many2one('fleet.service.type', 'Contract Type', help='Cost type purchased with this cost', domain=[('category', '=', 'contract')])
     amount = fields.Monetary('Cost', tracking=True)
     date = fields.Date(help='Date when the cost has been executed')
     company_id = fields.Many2one('res.company', 'Company', default=lambda self: self.env.company)
@@ -62,7 +62,7 @@ class FleetVehicleLogContract(models.Model):
         ('monthly', 'Monthly'),
         ('yearly', 'Yearly')
         ], 'Recurring Cost Frequency', default='monthly', required=True, tracking=True)
-    service_ids = fields.Many2many('fleet.service.type', string="Included Services")
+    service_ids = fields.Many2many('fleet.service.type', string="Included Services", domain=[('category', '=', 'service')])
 
     @api.depends('vehicle_id.name', 'cost_subtype_id')
     def _compute_contract_name(self):

--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -73,5 +73,11 @@
             <field name="global" eval="True"/>
             <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
+        <record id="ir_rule_fleet_service_type" model="ir.rule">
+            <field name="name">Fleet service type: Multi Company</field>
+            <field name="model_id" ref="model_fleet_service_type"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        </record>
     </data>
 </odoo>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -23,9 +23,19 @@
                     <group string="Information" col="2">
                         <group col="1">
                             <field name="ins_ref"/>
-                            <field name="cost_subtype_id"/>
+                            <field name="cost_subtype_id" domain="[('category', '=', 'contract')]"
+                                   context="{
+                                       'default_category': 'contract',
+                                       'list_view_ref': 'fleet.fleet_vehicle_service_types_view_tree',
+                                       'form_view_ref': 'fleet.fleet_service_type_view_form_shared'
+                                   }"/>
                             <field name="insurer_id" widget="many2one_avatar_user"/>
-                            <field name="service_ids" widget="many2many_tags"/>
+                            <field name="service_ids" widget="many2many_tags" domain="[('category', '=', 'service')]"
+                                   context="{
+                                       'default_category': 'service',
+                                       'list_view_ref': 'fleet.fleet_vehicle_service_types_view_tree',
+                                       'form_view_ref': 'fleet.fleet_service_type_view_form_shared'
+                                   }"/>
                             <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
                         </group>
                         <group col="2">
@@ -78,14 +88,14 @@
                 sample="1">
                 <field name="active" column_invisible="True"/>
                 <field name="expires_today" column_invisible="True"/>
-                <field name="name" class="fw-bold" />
-                <field name="cost_subtype_id" />
+                <field name="name" class="fw-bold"/>
+                <field name="cost_subtype_id"/>
                 <field name="start_date" />
                 <field name="expiration_date" widget="remaining_days"
                     options="{'classes': {'danger': 'record.days_left==0 and not record.expires_today and not record.has_open_contract'}}"/>
                 <field name="days_left" column_invisible="True"/>
                 <field name="vehicle_id"/>
-                <field name="insurer_id" />
+                <field name="insurer_id"/>
                 <field name="purchaser_id" widget="many2one_avatar_user"/>
                 <field name="cost_generated" widget="monetary"/>
                 <field name="currency_id" column_invisible="True"/>
@@ -225,7 +235,12 @@
                     <group col="2">
                         <group>
                             <field name="description" />
-                            <field name="service_type_id" />
+                            <field name="service_type_id" domain="[('category', '=', 'service')]"
+                                   context="{
+                                       'default_category': 'service',
+                                       'list_view_ref': 'fleet.fleet_vehicle_service_types_view_tree',
+                                       'form_view_ref': 'fleet.fleet_service_type_view_form_shared'
+                                   }"/>
                             <field name="date_from" string="Date" widget="daterange"
                                 options="{'end_date_field': 'date_to'}"/>
                             <field name="amount" widget="monetary"/>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -451,8 +451,9 @@
         <field name="model">fleet.service.type</field>
         <field name="arch" type="xml">
             <list string="Service Types" editable="bottom">
-                <field name="name" />
-                <field name="category"/>
+                <field name="name"/>
+                <field name="company_id" options="{'no_create': True}"/>
+                <field name="category" column_invisible="True"/>
             </list>
         </field>
     </record>
@@ -470,21 +471,58 @@
         </field>
     </record>
 
-    <record id='fleet_vehicle_service_types_action' model='ir.actions.act_window'>
-        <field name="name">Types</field>
+    <record id="fleet_service_type_view_form_shared" model="ir.ui.view">
+        <field name="name">fleet.service.type.form.shared</field>
+        <field name="model">fleet.service.type</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="company_id"
+                                   options="{'no_create': True}"
+                                   domain="[('id', 'in', allowed_company_ids)]"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id='fleet_vehicle_contract_types_action' model='ir.actions.act_window'>
+        <field name="name">Contract Types</field>
         <field name="res_model">fleet.service.type</field>
         <field name="view_mode">list,form</field>
-        <field name="context">{"search_default_groupby_category" : True}</field>
+        <field name="domain">[('category', '=', 'contract')]</field>
+        <field name="context">{"default_category" : 'contract'}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            Create a new type of contract
+          </p><p>
+            Contract types define the kinds of vehicle agreements you can track.
+          </p>
+        </field>
+    </record>
+    <menuitem name="Contracts" parent="fleet_configuration" id="fleet_contracts_configuration" sequence="20" groups="fleet.fleet_group_manager"/>
+    <menuitem action="fleet_vehicle_contract_types_action" parent="fleet_contracts_configuration" name="Contract Types"
+        id="fleet_vehicle_contract_types_menu" sequence="1" groups="fleet.fleet_group_manager"/>
+
+    <record id='fleet_vehicle_service_types_action' model='ir.actions.act_window'>
+        <field name="name">Service Types</field>
+        <field name="res_model">fleet.service.type</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('category', '=', 'service')]</field>
+        <field name="context">{"default_category" : 'service'}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             Create a new type of service
           </p><p>
-            Each service can used in contracts, as a standalone service or both.
+            Service types define categories of vehicle maintenance and servicing.
           </p>
         </field>
     </record>
-    <menuitem name="Services" parent="fleet_configuration" id="fleet_services_configuration" sequence="20" groups="fleet.fleet_group_manager"/>
-    <menuitem action="fleet_vehicle_service_types_action" parent="fleet_services_configuration" name="Types"
+    <menuitem name="Services" parent="fleet_configuration" id="fleet_services_configuration" sequence="21" groups="fleet.fleet_group_manager"/>
+    <menuitem action="fleet_vehicle_service_types_action" parent="fleet_services_configuration" name="Service Types"
         id="fleet_vehicle_service_types_menu" sequence="1" groups="fleet.fleet_group_manager"/>
 
     <record id='fleet_vehicle_state_view_tree' model='ir.ui.view'>


### PR DESCRIPTION
Currently, Contracts and Services are configured through a single menu item "Service Types". This creates ambiguity for users as these items are used in different functional contexts.

This commit separates the configuration into two distinct menu items to improve clarity and usability, while preserving the existing `fleet.service.type` model.

Changes implemented:
- Added `company_id` field to `fleet.service.type` model to support multi-company configuration in list views.
- Created two separate window actions for "Contract Types" and "Service Types" using domain filters on the `category` field.
- Defined a shared Form View where the `category` field is:
    1. Pre-filled via the action's context (default_category).
    2. Set to `readonly` and `force_save` to prevent user error.
- Implemented a non-editable List View to force the "New" button to open the specific Form View instead of inline editing.
- Replaced the original "Service Types" menu with the two new specific menus.

task-5456150

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
