### PR TITLE
[FIX] pos_{loyalty,discount}: ensure loyalty is calculated after discount

### DIFF
--- a/addons/pos_discount/static/src/app/services/pos_store.js
+++ b/addons/pos_discount/static/src/app/services/pos_store.js
@@ -55,7 +55,7 @@ patch(PosStore.prototype, {
         for (const baseLine of globalDiscountBaseLines) {
             const extra_tax_data = accountTaxHelpers.export_base_line_extra_tax_data(baseLine);
             extra_tax_data.discount_percentage = percent;
-            const line = await this.addLineToOrder(
+            const line = await this.addLineToCurrentOrder(
                 {
                     product_id: baseLine.product_id,
                     price_unit: baseLine.price_unit,
@@ -64,7 +64,6 @@ patch(PosStore.prototype, {
                     product_tmpl_id: baseLine.product_id.product_tmpl_id,
                     extra_tax_data: extra_tax_data,
                 },
-                order,
                 { merge: false }
             );
             if (line) {

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -213,10 +213,15 @@ registry.category("web_tour.tours").add("PosCouponTour5", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAAA"),
             ProductScreen.addOrderline("Test Product 1", "1", "100"),
+            PosLoyalty.pointsAwardedAre("115"),
             PosLoyalty.clickDiscountButton(),
             Dialog.confirm(),
             ProductScreen.totalAmountIs("92.00"),
+            PosLoyalty.pointsAwardedAre("92"),
+            Chrome.endTour(),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -752,6 +752,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         - Create a product with no taxes
         - Enable the global discount feature, and make sure the Discount product
             has a tax set on it.
+        - Test that customer get correct loyalty points after discount
         """
 
         if not self.env["ir.module.module"].search([("name", "=", "pos_discount"), ("state", "=", "installed")]):
@@ -811,6 +812,13 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'discount_mode': 'percent',
                 'discount_applicability': 'order',
             })],
+        })
+        loyalty_program2 = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        partner = self.env['res.partner'].create({'name': 'AAAA'})
+        self.env['loyalty.card'].create({
+            'program_id': loyalty_program2.id,
+            'partner_id': partner.id,
+            'points': 0,
         })
 
         self.product = self.env["product.product"].create(


### PR DESCRIPTION
Step To Reproduce:
- create a loyalty of type "loyalty card", that grants 1 point  per $ spent
- configure pos for global discounts
- start pos, select a product (say price_with tax is 100)
- select a customer
- apply a discount of 10%, price should be 90

refer image 
<img width="1367" height="687" alt="image" src="https://github.com/user-attachments/assets/37709299-b377-4eee-95af-e857b19c7671" />

Observation:
- the loyalty gained stays 100, even after we applied discount, it should be 90

<img width="257" height="587" alt="pos loyalty issue" src="https://github.com/user-attachments/assets/772821c2-dc06-4dfc-8d4c-ab00de209ce8" />


Cause:
- the recent commit [1], `applyDiscount` uses `addLineToOrder`, which bypasses `addLineToCurrentOrder`.
- This skips `updateRewards` and other module-level extensions defined on `addLineToCurrentOrder`

[1] https://github.com/odoo/odoo/commit/b63c7c28cfe6d59888982d58b8e9d99ea62281f4

https://github.com/odoo/odoo/blob/5d91798f0f5f712bf5210edd0bf6788f32d0c316/addons/pos_loyalty/static/src/app/services/pos_store.js#L439-L448

Fix:
- Replace `addLineToOrder` with `addLineToCurrentOrder` to ensure rewards and programs are properly updated

opw-5437844

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
