### PR TITLE
[FIX] hr_expense: exclude archived journals in payment_method selection

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -219,6 +219,7 @@ class HrExpense(models.Model):
     selectable_payment_method_line_ids = fields.Many2many(
         comodel_name='account.payment.method.line',
         compute='_compute_selectable_payment_method_line_ids',
+        compute_sudo=True,
     )
     payment_method_line_id = fields.Many2one(
         comodel_name='account.payment.method.line',
@@ -660,6 +661,7 @@ class HrExpense(models.Model):
                     # The journal is the source of the payment method line company
                     *self.env['account.journal']._check_company_domain(expense.company_id),
                     ('payment_type', '=', 'outbound'),
+                    ('journal_id.active', '=', True),
                 ])
 
     @api.depends('product_id', 'company_id')


### PR DESCRIPTION
Steps to Reproduce:
1. Go to Accounting > Configuration > Journals
2. Archive a Journal with outgoing payment method
3. Go to Expenses > Create an Expense paid by company
4. Note that payment methods from archived journal are still visible and can be selected.

Issue:
- Archived journals with outbound payment methods were still selectable when creating company-paid expenses.
- Due to this [commit](https://github.com/odoo/odoo/commit/5c9a6704dd54bbbde1703850619ddcc1a3552547) The journals can be archived without system prevention as the action_archived method has been removed.

Solution:
- This occurred because selectable_payment_method_line_ids did not filter out inactive journals when falling back to a generic search. -Aligning the search domain with
[company_expense_allowed_payment_method_line_ids]
(https://github.com/odoo/odoo/blob/19.0/addons/hr_expense/models/res_company.py#L20) by excluding payment method lines linked to inactive journals.

Before Fix:
```py
In [1]: expense = self.env['hr.expense'].browse(1639)

In [2]: expense.selectable_payment_method_line_ids
Out[2]: account.payment.method.line(2, 4, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 166, 170, 172, 512, 516)

In [3]: archived_journal_ids = []

In [4]: payment_method_lines = self.env['account.payment.method.line'].search([
   ...:                     *self.env['account.journal']._check_company_domain(expense.company_id),
   ...:                     ('payment_type', '=', 'outbound'),
   ...:                 ])

In [5]: payment_method_lines
Out[5]: account.payment.method.line(2, 4, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 166, 170, 172, 512, 516)

In [6]: for payment_method_line in payment_method_lines:
   ...:     if not payment_method_line.journal_id.active:
   ...:         archived_journal_ids.append(payment_method_line.journal_id.id)
   ...:

In [7]: archived_journal_ids
Out[7]: [7, 8]
```

After Fix:
```py
In [8]: payment_method_lines_with_fix = self.env['account.payment.method.line'].search([
   ...:                     # The journal is the source of the payment method line company
   ...:                     *self.env['account.journal']._check_company_domain(expense.company_id),
   ...:                     ('payment_type', '=', 'outbound'),
   ...:                     ('journal_id.active', '=', True),
   ...:                 ])
In [9]: payment_method_lines_with_fix
Out[9]: account.payment.method.line(153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 166, 170, 172, 512, 516)

In [10]: archived_journal_ids_with_fix = []
In [11]: for payment_method_line in payment_method_lines_with_fix:
    ...:     if not payment_method_line.journal_id.active:
    ...:         archived_journal_ids_with_fix.append(payment_method_line.journal_id.id)

In [12]: archived_journal_ids_with_fix
Out[12]: []
```

OPW-5461359

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
