### PR TITLE
[FIX] sale_management: fix indeterministic sign tour

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -1,5 +1,6 @@
 import { registry } from "@web/core/registry";
 import { redirect } from "@web/core/utils/urls";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 // This tour relies on data created on the Python test.
 registry.category("web_tour.tours").add('sale_signature', {
@@ -61,6 +62,7 @@ registry.category("web_tour.tours").add('sale_signature', {
 
 registry.category("web_tour.tours").add("sale_signature_without_name", {
     steps: () => [
+        stepUtils.waitIframeIsReady(),
         {
             content: "Sign & Pay",
             trigger:


### PR DESCRIPTION
This commit fixes the flaky quotation signing tour in sale_management by adding an explicit step to wait for interactions to fully load before proceeding with the next steps.

runbot error-224021



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
