### PR TITLE
[FIX] mail: fix reply behavior in HTML composer for notes

### DIFF
--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -1,11 +1,13 @@
 import { fields, OR, Record } from "@mail/core/common/record";
 import {
     convertBrToLineBreak,
+    generatePartnerMentionElement,
     getNonEditableMentions,
     prettifyMessageText,
 } from "@mail/utils/common/format";
 import { markup } from "@odoo/owl";
-import { isHtmlEmpty } from "@web/core/utils/html";
+import { createDocumentFragmentFromContent, isHtmlEmpty } from "@web/core/utils/html";
+import { nbsp } from "@web/core/utils/strings";
 
 export class Composer extends Record {
     static id = OR("thread", "message");
@@ -129,6 +131,31 @@ export class Composer extends Record {
 
     get targetThread() {
         return this.replyToMessage?.thread ?? this.thread ?? this.message?.thread ?? null;
+    }
+
+    /** @param {import("models").Message} message */
+    insertReplyFromNote(message) {
+        this.mentionedPartners.add(message.author);
+        if (!this.store.env.services["mail.composer"].htmlEnabled) {
+            const mentionText = `@${message.authorName} `;
+            if (!this.composerText.includes(mentionText)) {
+                this.insertText(mentionText, 0, { moveCursorToEnd: true });
+            }
+            return;
+        }
+        const composerBody = createDocumentFragmentFromContent(this.composerHtml).body;
+        if (
+            composerBody.querySelector(
+                `a.o_mail_redirect[data-oe-model="res.partner"][data-oe-id="${message.author.id}"]`
+            )
+        ) {
+            return;
+        }
+        composerBody.firstElementChild.prepend(
+            generatePartnerMentionElement(message.author, this.thread),
+            nbsp
+        );
+        this.composerHtml = markup(composerBody.innerHTML);
     }
 }
 

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -91,12 +91,8 @@ registerMessageAction("reply-to", {
         if (thread.model === "discuss.channel") {
             return;
         }
-        if (!message.isSelfAuthored && message.model !== "discuss.channel") {
-            const mentionText = `@${message.authorName} `;
-            if (!composer.composerText.includes(mentionText)) {
-                composer.mentionedPartners.add(message.author);
-                composer.insertText(mentionText, 0, { moveCursorToEnd: true });
-            }
+        if (!message.isSelfAuthored && message.model !== "discuss.channel" && message.author) {
+            composer.insertReplyFromNote(message);
         }
         owner.env.inChatter?.toggleComposer("note", { force: true });
         composer.restoredFromFullComposer = false;

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -1,4 +1,4 @@
-import { toRaw, useComponent, useState } from "@odoo/owl";
+import { markup, toRaw, useComponent, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
@@ -8,8 +8,11 @@ import { Deferred } from "@web/core/utils/concurrency";
 import { Action, ACTION_TAGS, UseActions } from "@mail/core/common/action";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { QuickReactionMenu } from "@mail/core/common/quick_reaction_menu";
+import { generatePartnerMentionElement } from "@mail/utils/common/format";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { useService } from "@web/core/utils/hooks";
+import { createDocumentFragmentFromContent } from "@web/core/utils/html";
+import { nbsp } from "@web/core/utils/strings";
 
 const { DateTime } = luxon;
 
@@ -92,10 +95,21 @@ registerMessageAction("reply-to", {
             return;
         }
         if (!message.isSelfAuthored && message.model !== "discuss.channel") {
-            const mentionText = `@${message.authorName} `;
-            if (!composer.composerText.includes(mentionText)) {
-                composer.mentionedPartners.add(message.author);
-                composer.insertText(mentionText, 0, { moveCursorToEnd: true });
+            composer.mentionedPartners.add(message.author);
+            const messageBody = createDocumentFragmentFromContent(composer.composerHtml).body;
+            if (
+                message.author &&
+                !messageBody.querySelector(`a.o_mail_redirect[data-oe-id="${message.author.id}"]`)
+            ) {
+                if (thread.store.env.services["mail.composer"].htmlEnabled) {
+                    messageBody.firstElementChild.prepend(
+                        generatePartnerMentionElement(message.author, thr),
+                        nbsp
+                    );
+                    composer.composerHtml = markup(messageBody.innerHTML);
+                } else {
+                    composer.insertText(`@${message.authorName} `, 0, { moveCursorToEnd: true });
+                }
             }
         }
         owner.env.inChatter?.toggleComposer("note", { force: true });

--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -95,7 +95,7 @@ export class MentionPlugin extends Plugin {
             // This will lead to issues where the mention cannot be deleted or edited properly.
             // In this case, we wrap the mention with a base container.
             if (el.parentElement === this.editable) {
-                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer("DIV");
                 baseContainer.appendChild(el.cloneNode(true));
                 this.editable.replaceChild(baseContainer, el);
                 this.dependencies.history.addStep();

--- a/addons/mail/static/tests/message/message_reply.test.js
+++ b/addons/mail/static/tests/message/message_reply.test.js
@@ -1,14 +1,17 @@
-import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
+import {
+    insertText as htmlInsertText,
+    pasteHtml,
+} from "@html_editor/../tests/_helpers/user_actions";
 import {
     click,
     contains,
     defineMailModels,
     openDiscuss,
+    openFormView,
     start,
     startServer,
-    openFormView,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import { queryFirst } from "@odoo/hoot-dom";
 import { disableAnimations } from "@odoo/hoot-mock";
 import { getService, serverState } from "@web/../tests/web_test_helpers";
@@ -295,4 +298,44 @@ test("click on message in reply in inbox navigates to the parent message", async
     await contains(
         ".o-mail-DiscussContent:has(.o-mail-DiscussContent-threadName[title='General']) .o-mail-Message.o-highlighted .o-mail-Message-content:has(:text('Parent message'))"
     );
+});
+
+test.tags("focus required", "html composer");
+test("Click reply to note again preserves composer content", async () => {
+    const pyEnv = await startServer();
+    pyEnv["mail.message"].create([
+        {
+            author_id: pyEnv["res.partner"].create({ name: "Batman" }),
+            body: "I am Justice",
+            model: "res.partner",
+            res_id: serverState.partnerId,
+            subtype_id: pyEnv["mail.message.subtype"].search([
+                ["subtype_xmlid", "=", "mail.mt_note"],
+            ])[0],
+        },
+    ]);
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click(".o-mail-Message:contains(I am Justice) [title='Reply']");
+    await contains(".o-mail-Composer.o-focused");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    pasteHtml(editor, "<strong>Strong Text</strong>");
+    await contains(
+        ".o-mail-Composer-html.odoo-editor-editable:text('@Batman Strong Text'):has(a.o_mail_redirect:text('@Batman')):has(strong:text('Strong Text'))"
+    );
+    // check the exact textContent because :text() validates the rendered text, not the NBSP separator.
+    expect(editor.editable.textContent).toBe("\uFEFF@Batman\uFEFF\u00A0Strong Text");
+    await click("button.active:text('Log note')");
+    await contains(".o-mail-Composer", { count: 0 });
+    await click(".o-mail-Message:contains(I am Justice) [title='Reply']");
+    await contains(".o-mail-Composer.o-focused");
+    await contains(
+        ".o-mail-Composer-html.odoo-editor-editable:text('@Batman Strong Text'):has(a.o_mail_redirect:text('@Batman')):has(strong:text('Strong Text'))"
+    );
+    expect(editor.editable.textContent).toBe("\uFEFF@Batman\uFEFF\u00A0Strong Text");
 });

--- a/addons/mail/static/tests/message/message_reply.test.js
+++ b/addons/mail/static/tests/message/message_reply.test.js
@@ -1,12 +1,15 @@
-import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
+import {
+    insertText as htmlInsertText,
+    pasteHtml,
+} from "@html_editor/../tests/_helpers/user_actions";
 import {
     click,
     contains,
     defineMailModels,
     openDiscuss,
+    openFormView,
     start,
     startServer,
-    openFormView,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { queryFirst } from "@odoo/hoot-dom";
@@ -295,4 +298,49 @@ test("click on message in reply in inbox navigates to the parent message", async
     await contains(
         ".o-mail-DiscussContent:has(.o-mail-DiscussContent-threadName[title='General']) .o-mail-Message.o-highlighted .o-mail-Message-content:has(:text('Parent message'))"
     );
+});
+
+test.tags("focus required", "html composer");
+test("replying again to a note preserves edited composer content with formatting", async () => {
+    const pyEnv = await startServer();
+    pyEnv["mail.message"].create([
+        {
+            author_id: pyEnv["res.partner"].create({ name: "Batman" }),
+            body: "I am Justice",
+            model: "res.partner",
+            res_id: serverState.partnerId,
+            subtype_id: pyEnv["mail.message.subtype"].search([
+                ["subtype_xmlid", "=", "mail.mt_note"],
+            ])[0],
+        },
+    ]);
+    await start();
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click(".o-mail-Message:contains(I am Justice) [title='Reply']");
+    await contains(".o-mail-Composer.o-focused");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    pasteHtml(editor, "<strong>Strong Text</strong>");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", {
+        text: "@Batman\uFEFF\u00A0Strong Text",
+        contains: [
+            ["a.o_mail_redirect[contenteditable=false]:text(@Batman)"],
+            ["strong:text(Strong Text)"],
+        ],
+    });
+    await click("button.active:text('Log note')");
+    await contains(".o-mail-Composer", { count: 0 });
+    await click(".o-mail-Message:contains(I am Justice) [title='Reply']");
+    await contains(".o-mail-Composer.o-focused");
+    await contains(".o-mail-Composer-html.odoo-editor-editable", {
+        text: "@Batman\uFEFF\u00A0Strong Text",
+        contains: [
+            ["a.o_mail_redirect[contenteditable=false]:text(@Batman)"],
+            ["strong:text(Strong Text)"],
+        ],
+    });
 });


### PR DESCRIPTION
Before this PR,
Replying to a note with the HTML composer enabled had several issues.
- The mention added did not include a trailing space.
- If the composer already contained formatted content, reply action discarded all formatting because the content was overwritten using composerText, which is not formatting-aware.
- the composer sometimes showed extra spacing between lines because the base container used a `<p>` tag instead of a `<div>`.

This PR fixes these issues by
- inserting the mention directly into composerHtml with an editable trailing space instead of mutating composerText. This preserves existing formatting, and correctly adds spacing after mentions.
- The base container always use a `<div>`, preventing unwanted line spacing

task-[5454785](https://www.odoo.com/odoo/project/1519/tasks/5454785)