### PR TITLE
[FIX] account_edi_ubl_cii, l10n_hr_edi: remove outdated config param

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -712,7 +712,6 @@ class TestAccountEdiUblCii(TestUblCiiCommon, HttpCase):
         Test that invoice contacts without specific names use their parent partner's
         name in the XML output, avoiding the 'Invoice address' suffix from display_name.
         """
-        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True)
         partner = self.env['res.partner'].create({
             'parent_id': self.partner_a.id,
             'type': 'invoice'

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -107,7 +107,6 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
     ####################################################
 
     def test_export_import_invoice(self):
-        self.env['ir.config_parameter'].sudo().set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True)
         invoice = self._generate_move(
             self.partner_1,
             self.partner_2,
@@ -167,7 +166,6 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
         self._assert_imported_invoice_from_etree(invoice, attachment)
 
     def test_export_import_refund(self):
-        self.env['ir.config_parameter'].sudo().set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True)
         refund = self._generate_move(
             self.partner_1,
             self.partner_2,

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
@@ -79,7 +79,6 @@ class TestUBLDE(TestUBLCommon):
     ####################################################
 
     def test_export_import_invoice(self):
-        self.env['ir.config_parameter'].sudo().set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True)
         invoice = self._generate_move(
             self.partner_1,
             self.partner_2,
@@ -300,8 +299,6 @@ class TestUBLDE(TestUBLCommon):
         self.assertTrue(created_bill)
 
     def test_leitweg_id(self):
-        self.env['ir.config_parameter'].sudo().set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True)
-
         partner = self.partner_2
         partner.write({
             'peppol_eas': '0204',

--- a/addons/l10n_hr_edi/tests/test_hr_edi_common.py
+++ b/addons/l10n_hr_edi/tests/test_hr_edi_common.py
@@ -7,7 +7,6 @@ class TestL10nHrEdiCommon(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env['ir.config_parameter'].sudo().set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', True)
         cls.env.company.tax_calculation_rounding_method = 'round_globally'
         cls.partner_a.invoice_edi_format = 'ubl_hr'
         cls.product_a.product_tmpl_id.l10n_hr_kpd_category_id = cls.env['l10n_hr.kpd.category'].search([('name', '=', '01.11.11')])


### PR DESCRIPTION
The configuration parameter `account_edi_ubl_cii.use_new_dict_to_xml_helpers`
was removed in saas-18.4.

However, this parameter was still being set in various tests across
`account_edi_ubl_cii`, `l10n_account_edi_ubl_cii_tests`, `l10n_hr_edi`, and `l10n_co_dian`.

This commit removes these unnecessary configuration lines to clean up the tests.

Related PR : https://github.com/odoo/enterprise/pull/103766