### PR TITLE
[FIX] website: comparison bar overlapped by banner categories snippet

### DIFF
--- a/addons/website/views/snippets/s_banner_categories.xml
+++ b/addons/website/views/snippets/s_banner_categories.xml
@@ -12,7 +12,7 @@
             <div class="o_grid_mode row" data-row-count="13" style="gap: 16px;">
                 <div data-name="Intro"
                         class="o_grid_item o_colored_level g-height-6 g-col-lg-8 col-lg-8 justify-content-start"
-                        style="z-index: 1; --grid-item-padding-y: 72px; grid-area: 2 / 3 / 8 / 11;">
+                        style="--grid-item-padding-y: 72px; grid-area: 2 / 3 / 8 / 11;">
                     <h1 style="text-align: center;">Explore Our New Collection</h1>
                     <p class="lead" style="text-align: center;">
                         Each item in our collection is grouped by category to make your browsing experience effortless. Take a look and dive into the different worlds we’ve curated for you.
@@ -26,7 +26,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_colored_level o_cc o_cc5 o_bg_img_center oe_img_bg justify-content-end g-col-lg-4 g-height-6 col-lg-4 col-10 offset-1 offset-lg-0"
-                        style="grid-area: 8 / 1 / 14 / 5; z-index: 2;background-image: url('/web/image/website.shop_category_1_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
+                        style="grid-area: 8 / 1 / 14 / 5; background-image: url('/web/image/website.shop_category_1_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
                     <h2 class="h3-fs">Sofas</h2>
@@ -35,7 +35,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 col-10 offset-1 offset-lg-0"
-                        style="grid-area: 8 / 5 / 14 / 9; z-index: 3;background-image: url('/web/image/website.shop_category_2_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
+                        style="grid-area: 8 / 5 / 14 / 9; background-image: url('/web/image/website.shop_category_2_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
                     <h2 class="h3-fs">Desks</h2>
@@ -44,7 +44,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 offset-1 offset-lg-0 col-10"
-                        style="grid-area: 8 / 9 / 14 / 13; z-index: 4;background-image: url('/web/image/website.shop_category_3_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
+                        style="grid-area: 8 / 9 / 14 / 13; background-image: url('/web/image/website.shop_category_3_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
                     <h2 class="h3-fs">Drawers</h2>


### PR DESCRIPTION
Description of the issue:
The banner categories snippet (s_banner_categories) had hardcoded z-index values (1, 2, 3, 4) on its grid items. This caused a stacking context issue where grid items with z-index 3 and 4 would overlap the product comparison bottom bar, which uses z-index 3 (default) and 4 (when expanded).

Solution in the PR:
The z-index values on the grid items were unnecessary since they are positioned using CSS Grid and don't overlap with each other. Removing these inline z-index declarations allow the comparison bar to properly display above all snippet content.

After this PR:
The comparison bar now consistently appears on top, ensuring users can interact with it without visual interference from page snippets.

opw-5426163

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
