### PR TITLE
[FIX] pos_event: populate registration user fields from global questions

### DIFF
--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -23,6 +23,7 @@ registry.category("web_tour.tours").add("SellingEventInPos", {
             ProductScreen.clickDisplayedProduct("My Awesome Event"),
             EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
             Dialog.confirm(),
+            EventTourUtils.answerGlobalTextQuestion("Name", "Tony Stark"),
             EventTourUtils.answerTicketSelectQuestion("1", "Question1", "Q1-Answer1"),
             EventTourUtils.answerGlobalSelectQuestion("Question2", "Q2-Answer1"),
             Dialog.confirm(),

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -44,6 +44,11 @@ class TestUi(TestPointOfSaleHttpCommon):
             })],
             'question_ids': [
                 (0, 0, {
+                    'title': 'Name',
+                    'question_type': 'name',
+                    'once_per_order': True,
+                }),
+                (0, 0, {
                     'title': 'Question1',
                     'question_type': 'simple_choice',
                     'once_per_order': False,
@@ -112,9 +117,14 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         order = self.env['pos.order'].search([], order='id desc', limit=1)
         event_registration = order.lines[0].event_registration_ids
-        event_answer_name = event_registration.registration_answer_ids.value_answer_id.mapped('name')
-        self.assertEqual(len(event_registration.registration_answer_ids), 3)
-        self.assertEqual(event_answer_name, ['Q1-Answer1', 'Q2-Answer1', 'Q3-Answer1'])
+        event_selection_value = event_registration.registration_answer_ids.value_answer_id.mapped('name')
+        event_answer_name = event_registration.registration_answer_ids.filtered(
+            lambda answer: answer.question_id.question_type == 'name'
+        ).value_text_box
+        self.assertEqual(event_registration.name, 'Tony Stark')  # Global (once per order) Questions should also populate the user fields.
+        self.assertEqual(len(event_registration.registration_answer_ids), 4)
+        self.assertEqual(event_answer_name, 'Tony Stark')  # Global (once per order) Questions of user field types should also be avaialable at event registarion answers.
+        self.assertEqual(event_selection_value, ['Q1-Answer1', 'Q2-Answer1', 'Q3-Answer1'])
 
     def test_pos_event_registration_not_mandatory(self):
         self.pos_user.write({


### PR DESCRIPTION
Before this commit:
===================
- When an event uses a user's fields (name, email, phone, company_name) as a global questions (once per order), these values were not saved on the event registration record.

After this commit:
==================
- User fields defined as global questions are now correctly populated on the event registration record.

Task: 5462923




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
