### PR TITLE
[FIX] html_builder: avoid option list text in center

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -24,6 +24,7 @@
         }
         .hb-row-label {
             flex: 0 0 38%;
+            align-self: center;
         }
         .hb-row-content {
             flex: 0 0 62%;
@@ -55,7 +56,7 @@
         z-index: $_z-index;
         background-color: var(--o-hb-row-bg-color, #{$o-we-bg-lighter});
         padding: $o-hb-row-spacing 0 $o-hb-row-spacing $o-hb-row-padding-left;
-        align-self: center;
+        align-self: baseline;
     }
 
     .hb-row-content {


### PR DESCRIPTION
### Issue:
The `hb-row-label` class shows inconsistent behavior in the builder
sidebar. The 'Option List' label appears centered rather than following
the standard alignment. In addition, the alignment of nested options
within the builder sidebar is marginally misaligned.

### Steps to Reproduce:
- Open the website and switch to edit mode.
- Drop a Form snippet onto the page.
- Add a new field and set its type to 'Multiple Checkbox'.
- In the builder sidebar, notice that the 'Option List' label is
  centered.

### Reason:
This [commit](https://github.com/odoo/odoo/commit/2c90e135a30b5810be0e2796154d85a918fbe303) changed the `align-self` property of the `hb-row-label`
class from `baseline` to `center`. That change was intended to fix
alignment issues for nested options inside popovers. However, since
`hb-row-label` is also used globally, this caused misalignment in the
builder sidebar.

### Fix:
Apply a separate alignment rule for popover usage while keeping the
default `hb-row-label` alignment set to baseline. This restores the
correct label positioning in the builder sidebar (refer img 1) and
preserves the improved alignment inside popover (refer img 2).

### Visual Changes:
<img width="1866" height="622" alt="image" src="https://github.com/user-attachments/assets/b243fbf3-2f7f-4942-b1e4-7de7c5eafe0f" />

<img width="1843" height="688" alt="image" src="https://github.com/user-attachments/assets/562dfc33-43f9-45cd-b3ce-efec32e3cf45" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
