### PR TITLE
[FIX] mass_mailing: prevent crash on iframe removed

### DIFF
--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.js
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.js
@@ -137,6 +137,9 @@ export class ThemeSelectorIframe extends Component {
             loadCSSPromises.push(...cssLibs.map((url) => this.loadCSSSheets(url)));
         }
         const cssTexts = await Promise.all(loadCSSPromises);
+        if (status(this) === "destroyed") {
+            return [];
+        }
         const sheetPromises = [];
         for (const cssText of cssTexts) {
             const sheet = new this.iframeRef.el.contentDocument.defaultView.CSSStyleSheet();


### PR DESCRIPTION
Prior to this commit, if the `ThemeSelectorIframe` component was destroyed in
the time it took to get its bundle and load its CSSSheets, there could be a
crash because the iframe would not be in the dom anymore and it would
not be possible to use the `iframeRef.el`.