### PR TITLE
[FIX] point_of_sale: no printing receipt when pos confirm order

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/render_service.js
+++ b/addons/point_of_sale/static/src/app/printer/render_service.js
@@ -1,11 +1,11 @@
 /** @odoo-module **/
 
 import { registry } from "@web/core/registry";
-import { Component, onMounted, reactive, useRef, xml } from "@odoo/owl";
+import { Component, onRendered, reactive, useRef, xml } from "@odoo/owl";
 import { toCanvas } from "@point_of_sale/app/utils/html-to-image";
 
 class ComponentRenderer extends Component {
-    static props = ["comp", "onMounted"];
+    static props = ["comp", "onRendered"];
     static template = xml`
         <div t-ref="ref">
             <t t-component="props.comp.component" t-props="props.comp.props"/>
@@ -13,8 +13,9 @@ class ComponentRenderer extends Component {
     `;
     setup() {
         this.ref = useRef("ref");
-        onMounted(() => {
-            this.props.onMounted(this.ref?.el?.firstElementChild);
+        onRendered(async () => {
+            await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+            this.props.onRendered(this.ref?.el?.firstElementChild);
         });
     }
 }
@@ -28,7 +29,7 @@ export class RenderContainer extends Component {
     static template = xml`
         <div class="render-container-parent" style="left: -1000px; position: fixed;">
             <t t-if="props.comp.component">
-                <ComponentRenderer comp="props.comp" onMounted="props.onRendered" />
+                <ComponentRenderer comp="props.comp" onRendered="props.onRendered" />
             </t>
             <div class="render-container" />
         </div>`;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR fixes #241781

In the original flow, the component is supposed to mount in a "hidden" primary div and then be cloned or moved into the .render-container for processing, however, the content was staying stuck in the primary rendering div and was never successfully transported to the target container.

My modification ensures the component is correctly captured by switching to the onRendered hook and introducing a synchronization delay via requestAnimationFrame. This guarantees the element is fully rendered and the DOM is stable before the service attempts to move it. By synchronizing these steps, the code ensures the component is actually present in the expected DOM location when the canvas generation starts.

Current behavior before PR: 

The printing service fails to trigger when confirming a PoS order, causing the process to hang.

Desired behavior after PR is merged: 

The receipt prints correctly after order confirmation, including when the "auto print" setting is enabled.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
