### PR TITLE
[FIX][WIP] sale: discount value when compute triggers from subscription

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -768,14 +768,13 @@ class SaleOrderLine(models.Model):
                 line.discount = line._get_linked_line().discount
                 continue
 
-            line.discount = 0.0
-
             if not line.pricelist_item_id._show_discount():
-                # No pricelist rule was found for the product
-                # therefore, the pricelist didn't apply any discount/change
-                # to the existing sales price.
+                # No pricelist rule found: reset discount only if pricelist has rules
+                if line.order_id.pricelist_id.item_ids:
+                    line.discount = 0.0
                 continue
 
+            line.discount = 0.0
             line = line.with_company(line.company_id)
             pricelist_price = line._get_pricelist_price()
             base_price = line._get_pricelist_price_before_discount()


### PR DESCRIPTION
Steps to reproduce:
-----------------------------------
1. Install `sale_subscription` module.
2. Go to Settings and enable Pricelists
3. Create a new Subscription, set a pricelist & add a recurring plan
4. Add a non-subscription product to the order line
5. Manually set the Discount field to any non-zero value
6. Save the subscription
7. Open the Other Info tab, set the Start Date, and save again

Observation:
-----------------------------------
After saving the start date, the Discount value on the order line is reset to 0.00

Issue:
-----------------------------------
https://github.com/odoo/odoo/blob/55f34fa471316406f4ace442cb962545fa47bca1/addons/sale/models/sale_order_line.py#L771-L777
For regular products, In the discount recomputation logic, the discount is
explicitly set to 0 before checking for a pricelist. When a pricelist is present
the computation continues to the next iteration, leaving the discount already
reset

This issue only affected non-subscription products because subscription
products have their own discount computation logic in `sale_subscription`
https://github.com/odoo/enterprise/blob/00e2e658312eda2d3dae04eb966fd538972e5243/sale_subscription/models/sale_order_line.py#L80-L97
This implementation preserves discounts during temporal computations
(start_date) and doesn't rely on pricelist rules

Solution:
-----------------------------------
Reset discount to 0 only when pricelist has rules but none apply, preserving manual discounts when pricelist contains no rules at all

Related Enterprise PR: https://github.com/odoo/enterprise/pull/103639

opw-5428077