### PR TITLE
[FIX] mail: ondelete operations during module uninstallation

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -12,6 +12,7 @@ from odoo.tools import frozendict, float_compare, groupby, SQL, OrderedSet
 from odoo.addons.web.controllers.utils import clean_action
 
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 
 _logger = logging.getLogger(__name__)
@@ -1939,6 +1940,8 @@ class AccountMoveLine(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_posted(self):
+        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+            return
         # Prevent deleting lines on posted entries
         if not self.env.context.get('force_delete') and any(m.state == 'posted' for m in self.move_id):
             raise UserError(_("You can't delete a posted journal item. Don’t play games with your accounting records; reset the journal entry to draft before deleting it."))

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -12,7 +12,6 @@ from odoo.tools import frozendict, float_compare, groupby, SQL, OrderedSet
 from odoo.addons.web.controllers.utils import clean_action
 
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 
 _logger = logging.getLogger(__name__)
@@ -1940,8 +1939,6 @@ class AccountMoveLine(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_posted(self):
-        if self.env.context.get(MODULE_UNINSTALL_FLAG):
-            return
         # Prevent deleting lines on posted entries
         if not self.env.context.get('force_delete') and any(m.state == 'posted' for m in self.move_id):
             raise UserError(_("You can't delete a posted journal item. Don’t play games with your accounting records; reset the journal entry to draft before deleting it."))

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -11,7 +11,6 @@ import logging
 import re
 
 from odoo import Command, api, models
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import AccessError, UserError
 from odoo.modules import get_resource_from_path
 from odoo.tools import file_open, float_compare, get_lang, groupby, SQL
@@ -230,7 +229,7 @@ class AccountChartTemplate(models.AbstractModel):
                         records -= records_to_keep
                         for records_for_companies in records_to_keep.grouped('company_ids').values():
                             records_for_companies.company_ids -= children_companies
-                    records.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
+                    records.with_context(force_delete=True).unlink()
 
         data = self._get_chart_template_data(template_code)
         template_data = data.pop('template_data')

--- a/addons/account_payment/models/account_journal.py
+++ b/addons/account_payment/models/account_journal.py
@@ -1,8 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, models
 from odoo.exceptions import UserError
+
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 
 class AccountJournal(models.Model):
@@ -15,6 +16,8 @@ class AccountJournal(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_to_payment_provider(self):
+        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+            return
         linked_providers = self.env['payment.provider'].sudo().search([]).filtered(
             lambda p: p.journal_id.id in self.ids and p.state != 'disabled'
         )

--- a/addons/account_payment/models/account_journal.py
+++ b/addons/account_payment/models/account_journal.py
@@ -3,8 +3,6 @@
 from odoo import _, api, models
 from odoo.exceptions import UserError
 
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
-
 
 class AccountJournal(models.Model):
     _inherit = "account.journal"
@@ -16,7 +14,7 @@ class AccountJournal(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_to_payment_provider(self):
-        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if self.env.context.get('force_delete'):
             return
         linked_providers = self.env['payment.provider'].sudo().search([]).filtered(
             lambda p: p.journal_id.id in self.ids and p.state != 'disabled'

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -8,8 +8,6 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import ormcache, make_index_name, create_index
 
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
-
 
 class AccountAnalyticPlan(models.Model):
     _name = 'account.analytic.plan'
@@ -319,7 +317,7 @@ class AccountAnalyticPlan(models.Model):
                 # If there is a parent, we just need to make sure there is a field to group by the hierarchy level
                 # of this plan, allowing to group by sub plan
                 if prev_stored:
-                    prev_stored.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
+                    prev_stored.with_context(force_delete=True).unlink()
                 description = f"{plan.root_id.name} ({depth})"
                 if not prev_related:
                     self.env['ir.model.fields'].with_context(update_custom_fields=True).sudo().create({
@@ -339,7 +337,7 @@ class AccountAnalyticPlan(models.Model):
             else:
                 # If there is no parent, then we need to create a new stored field as this is the root plan
                 if prev_related:
-                    prev_related.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()
+                    prev_related.with_context(force_delete=True).unlink()
                 description = plan.name
                 if not prev_stored:
                     column = plan._strict_column_name()

--- a/addons/crm/models/ir_config_parameter.py
+++ b/addons/crm/models/ir_config_parameter.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 
 class IrConfig_Parameter(models.Model):
@@ -26,7 +25,7 @@ class IrConfig_Parameter(models.Model):
     def unlink(self):
         pls_emptied = any(record.key == "crm.pls_fields" for record in self)
         result = super().unlink()
-        if pls_emptied and not self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if pls_emptied and not self.pool.uninstalling_modules:
             self.env.flush_all()
             self.env.registry._setup_models__(self.env.cr, ['crm.lead'])
         return result

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -9,11 +9,9 @@ from dateutil.relativedelta import relativedelta
 from math import ceil
 from markupsafe import Markup
 
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
-from odoo.addons.resource.models.utils import HOURS_PER_DAY
-
 from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
+from odoo.addons.resource.models.utils import HOURS_PER_DAY
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools.date_utils import float_to_time
 from odoo.fields import Command, Date, Domain
@@ -1281,7 +1279,7 @@ class HrLeave(models.Model):
         self._force_cancel(reason, 'mail.mt_note')
 
     def _force_cancel(self, reason=None, msg_subtype='mail.mt_comment', notify_responsibles=True):
-        leaves = self.browse() if self.env.context.get(MODULE_UNINSTALL_FLAG) else self
+        leaves = self.browse() if self.env.context.get('force_delete') else self
         if reason:
             model_description = self.env['ir.model']._get('hr.holidays').display_name
             for leave in leaves:

--- a/addons/hr_holidays/tests/test_uninstall.py
+++ b/addons/hr_holidays/tests/test_uninstall.py
@@ -2,8 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
-from odoo.tests import tagged, TransactionCase
+
+from odoo.tests import TransactionCase, tagged
 
 
 @tagged('-at_install', 'post_install')
@@ -34,7 +34,7 @@ class TestHrLeaveUninstall(TransactionCase):
         self.assertTrue(activity_type)
         self.assertIn('hr.leave', activity_type.mapped('res_model'))
 
-        model.sudo().with_context(**{MODULE_UNINSTALL_FLAG: True}).unlink()
+        model.sudo().with_context(force_delete=True).unlink()
         self.assertFalse(model.exists())
 
         domain = [('res_model', '=', 'hr.leave')]

--- a/addons/mail/models/ir_model_fields.py
+++ b/addons/mail/models/ir_model_fields.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.tools import groupby
 
 
@@ -32,7 +32,8 @@ class IrModelFields(models.Model):
             attrs['tracking'] = field_data['tracking']
         return attrs
 
-    def unlink(self):
+    @api.ondelete(at_uninstall=False)
+    def _unlink_tracking(self):
         """ When unlinking fields populate tracking value table with relevant
         information. That way if a field is removed (custom tracked, migration
         or any other reason) we keep the tracking and its relevant information.
@@ -56,4 +57,3 @@ class IrModelFields(models.Model):
                         'type': field.ttype,
                     }
                 })
-        return super().unlink()

--- a/addons/purchase_stock/tests/test_uninstall.py
+++ b/addons/purchase_stock/tests/test_uninstall.py
@@ -3,7 +3,6 @@
 from unittest.mock import patch
 
 from odoo import fields
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.addons.purchase_stock.models.purchase_order_line import PurchaseOrderLine
 from odoo.tests.common import tagged
 
@@ -46,9 +45,7 @@ class TestUninstallPurchaseStock(PurchaseTestCommon):
                 records.flush_recordset()
 
         with patch.object(PurchaseOrderLine, '_compute_qty_received', _compute_qty_received):
-            stock_moves_option.sudo().with_context(**{
-                MODULE_UNINSTALL_FLAG: True
-            }).unlink()
+            stock_moves_option.sudo().with_context(force_delete=True).unlink()
 
         self.assertEqual(order_line.qty_received_method, 'manual')
         self.assertEqual(order_line.qty_received, 1)

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -1029,7 +1029,7 @@ class TestTrackingInternals(MailCommon):
         # update a module with the model code removed
         model = self.env.registry.models.pop('mail.test.ticket')
         try:
-            fields_to_remove.with_context(_force_unlink=True).unlink()
+            fields_to_remove.with_context(force_delete=True).unlink()
         finally:
             # Restore model to prevent registry errors after test
             self.env.registry.models['mail.test.ticket'] = model
@@ -1117,7 +1117,7 @@ class TestTrackingInternals(MailCommon):
             ('model', '=', 'mail.test.ticket'),
             ('name', 'in', ('email_from', 'user_id', 'datetime'))  # also include a non tracked field
         ])
-        fields_toremove.with_context(_force_unlink=True).unlink()
+        fields_toremove.with_context(force_delete=True).unlink()
         self.assertEqual(len(trackings_all.exists()), 5)
 
         # check display / format, even if field is removed

--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -13,7 +13,7 @@ def uninstall_hook(env):
     # TODO: This should be an Odoo generic fix, not a website specific one
     website_domain = [('website_id', '!=', False)]
     env['ir.asset'].search(website_domain).unlink()
-    env['ir.ui.view'].search(website_domain).with_context(active_test=False, _force_unlink=True).unlink()
+    env['ir.ui.view'].search(website_domain).with_context(active_test=False, force_delete=True).unlink()
 
     # Cleanup records which are related to websites and will not be autocleaned
     # by the uninstall operation. This must be done here in the uninstall_hook

--- a/addons/website/models/ir_model_data.py
+++ b/addons/website/models/ir_model_data.py
@@ -17,11 +17,7 @@ class IrModelData(models.Model):
             theme_records = self.env['ir.module.module']._theme_model_names.values()
             if record._name in theme_records:
                 # use active_test to also unlink archived models
-                # and use MODULE_UNINSTALL_FLAG to also unlink inherited models
-                copy_ids = record.with_context({
-                    'active_test': False,
-                    'MODULE_UNINSTALL_FLAG': True
-                }).copy_ids
+                copy_ids = record.with_context(active_test=False).copy_ids
                 if request:
                     # we are in a website context, see `write()` override of
                     # ir.module.module in website

--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -9,8 +9,6 @@ from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 from odoo.http import request
 
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
-
 
 class Website(models.Model):
     _inherit = 'website'
@@ -153,7 +151,7 @@ class IrModelFields(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _check_if_used_in_website_form(self):
-        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if self.env.context.get('force_delete'):
             return
         """Prevent field deletion if used in a website form."""
         for field in self:

--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -9,6 +9,8 @@ from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 from odoo.http import request
 
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+
 
 class Website(models.Model):
     _inherit = 'website'
@@ -151,6 +153,8 @@ class IrModelFields(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _check_if_used_in_website_form(self):
+        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+            return
         """Prevent field deletion if used in a website form."""
         for field in self:
             for model_name, field_name in self.env['website']._get_html_fields():

--- a/addons/website/tests/test_views_inherit_module_update.py
+++ b/addons/website/tests/test_views_inherit_module_update.py
@@ -23,12 +23,12 @@ def test_01_cow_views_inherit_on_module_update(env):
 
     # 1. Setup hierarchy as comment above
     View = env['ir.ui.view']
-    View.with_context(_force_unlink=True, active_test=False).search([('website_id', '=', 1)]).unlink()
+    View.with_context(force_delete=True, active_test=False).search([('website_id', '=', 1)]).unlink()
     child_view = env.ref('portal.footer_language_selector')
     parent_view = env.ref('portal.portal_back_in_edit_mode')
     # Remove any possibly existing COW view (another theme etc)
-    parent_view.with_context(_force_unlink=True, active_test=False)._get_specific_views().unlink()
-    child_view.with_context(_force_unlink=True, active_test=False)._get_specific_views().unlink()
+    parent_view.with_context(force_delete=True, active_test=False)._get_specific_views().unlink()
+    child_view.with_context(force_delete=True, active_test=False)._get_specific_views().unlink()
     # Change `inherit_id` so the module update will set it back to the XML value
     child_view.write({'inherit_id': parent_view.id, 'arch': child_view.arch_db.replace('o_footer_copyright_name', 'text-center')})
     # Trigger COW on view
@@ -58,7 +58,7 @@ def test_02_cow_views_inherit_on_module_update(env):
 
     # 1. Setup hierarchy as comment above
     View = env['ir.ui.view']
-    View.with_context(_force_unlink=True, active_test=False).search([('website_id', '=', 1)]).unlink()
+    View.with_context(force_delete=True, active_test=False).search([('website_id', '=', 1)]).unlink()
     view_D = env.ref('portal.my_account_link')
     view_A = env.ref('portal.message_thread')
     # Change `inherit_id` so the module update will set it back to the XML value

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -27,7 +27,7 @@ class TestWebsiteSaleComparison(TransactionCase):
 
         # Create a generic inherited view, with a key not starting with
         # `website_sale_comparison` otherwise the unlink will work just based on
-        # the key, but we want to test also for `MODULE_UNINSTALL_FLAG`.
+        # the key, but we want to test also for `force_delete`.
         product_attributes_body = Website0.viewref('website_sale_comparison.product_attributes_body')
         test_view_key = 'my_test.my_key'
         self.env['ir.ui.view'].with_context(website_id=None).create({

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2525,6 +2525,10 @@ class IrModelData(models.Model):
             except Exception:
                 if len(records) <= 1:
                     undeletable_ids.extend(ref_data._ids)
+                    if records._name in 'ir.model':
+                        _logger.warning("Could not delete model %s", records.model, exc_info=True)
+                    elif records._name == 'ir.model.fields':
+                        _logger.warning("Could not delete field %s.%s", records.model, records.name, exc_info=True)
                 else:
                     # divide the batch in two, and recursively delete them
                     half_size = len(records) // 2

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -347,6 +347,8 @@ class IrModel(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_manual(self):
+        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+            return
         # Prevent manual deletion of module tables
         for model in self:
             if model.state != 'manual':
@@ -376,7 +378,7 @@ class IrModel(models.Model):
 
         # Reload registry for normal unlink only. For module uninstall, the
         # reload is done independently in odoo.modules.loading.
-        if not self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if not self.pool.uninstalling_modules:
             # setup models; this automatically removes model from registry
             self.env.flush_all()
             self.pool._setup_models__(self.env.cr)
@@ -959,7 +961,7 @@ class IrModelFields(models.Model):
                     ", ".join(str(f) for f in fields),
                     view.name)
         finally:
-            if not uninstalling:
+            if not self.pool.uninstalling_modules:
                 # the registry has been modified, restore it
                 self.pool._setup_models__(self.env.cr)
 
@@ -994,7 +996,7 @@ class IrModelFields(models.Model):
 
         # The field we just deleted might be inherited, and the registry is
         # inconsistent in this case; therefore we reload the registry.
-        if not self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if not self.pool.uninstalling_modules:
             # setup models; this re-initializes models in registry
             self.env.flush_all()
             self.pool._setup_models__(self.env.cr, model_names)
@@ -1706,6 +1708,8 @@ class IrModelFieldsSelection(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_manual(self):
+        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+            return
         # Prevent manual deletion of module columns
         if (
             self.pool.ready
@@ -1722,7 +1726,7 @@ class IrModelFieldsSelection(models.Model):
 
         # Reload registry for normal unlink only. For module uninstall, the
         # reload is done independently in odoo.modules.loading.
-        if not self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if not self.pool.uninstalling_modules:
             # setup models; this re-initializes model in registry
             self.env.flush_all()
             self.pool._setup_models__(self.env.cr, model_names)

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -33,7 +33,9 @@ ACCESS_ERROR_GROUPS = _lt("This operation is allowed for the following groups:\n
 ACCESS_ERROR_NOGROUP = _lt("No group currently allows this operation.")
 ACCESS_ERROR_RESOLUTION = _lt("Contact your administrator to request access if necessary.")
 
-MODULE_UNINSTALL_FLAG = '_force_unlink'
+# constant MODULE_UNINSTALL_FLAG is kept for backward compatibility only;
+# use 'force_delete' explicitly in your code to add/detect it
+MODULE_UNINSTALL_FLAG = 'force_delete'
 RE_ORDER_FIELDS = re.compile(r'"?(\w+)"?\s*(?:asc|desc)?', flags=re.I)
 
 # base environment for doing a safe_eval
@@ -347,7 +349,7 @@ class IrModel(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_manual(self):
-        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if self.env.context.get('force_delete'):
             return
         # Prevent manual deletion of module tables
         for model in self:
@@ -885,8 +887,8 @@ class IrModelFields(models.Model):
         """
         from odoo.orm.model_classes import pop_field
 
-        uninstalling = self.env.context.get(MODULE_UNINSTALL_FLAG)
-        if not uninstalling and any(record.state != 'manual' for record in self):
+        force_delete = self.env.context.get('force_delete')
+        if not force_delete and any(record.state != 'manual' for record in self):
             raise UserError(_("This column contains module data and cannot be removed!"))
 
         records = self              # all the records to delete
@@ -916,7 +918,7 @@ class IrModelFields(models.Model):
         self = records
 
         if failed_dependencies:
-            if not uninstalling:
+            if not force_delete:
                 field, dep = failed_dependencies[0]
                 raise UserError(_(
                     "The field '%(field)s' cannot be removed because the field '%(other_field)s' depends on it.",
@@ -948,7 +950,7 @@ class IrModelFields(models.Model):
             for view in views:
                 view._check_xml()
         except Exception:
-            if not uninstalling:
+            if not force_delete:
                 raise UserError(_(
                     "Cannot rename/delete fields that are still present in views:\nFields: %(fields)s\nView: %(view)s",
                     fields=fields,
@@ -1708,7 +1710,7 @@ class IrModelFieldsSelection(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_manual(self):
-        if self.env.context.get(MODULE_UNINSTALL_FLAG):
+        if self.env.context.get('force_delete'):
             return
         # Prevent manual deletion of module columns
         if (
@@ -2437,7 +2439,7 @@ class IrModelData(models.Model):
 
         # enable model/field deletion
         # we deactivate prefetching to not try to read a column that has been deleted
-        self = self.with_context(**{MODULE_UNINSTALL_FLAG: True, 'prefetch_fields': False})
+        self = self.with_context(force_delete=True, prefetch_fields=False)  # noqa: PLW0642
 
         # determine records to unlink
         records_items = []              # [(model, id)]
@@ -2611,7 +2613,7 @@ class IrModelData(models.Model):
             return True
 
         bad_imd_ids = []
-        self = self.with_context({MODULE_UNINSTALL_FLAG: True})
+        self = self.with_context({'force_delete': True})  # noqa: PLW0642
         loaded_xmlids = self.pool.loaded_xmlids
 
         query = """ SELECT id, module || '.' || name, model, res_id FROM ir_model_data

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -1,32 +1,35 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
 import functools
-from collections import defaultdict, OrderedDict
-from textwrap import dedent
 import logging
 import os
 import platform
 import shutil
 import typing
+from collections import OrderedDict, defaultdict
+from textwrap import dedent
 
+import lxml.html
+import psycopg2
 from docutils import nodes
 from docutils.core import publish_string
 from docutils.transforms import Transform, writer_aux
 from docutils.writers.html4css1 import Writer
-import lxml.html
-import psycopg2
 
 import odoo
-from odoo import api, fields, models, modules, tools, _
-from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+from odoo import _, api, fields, models, modules, tools
 from odoo.exceptions import AccessDenied, UserError, ValidationError
 from odoo.fields import Domain
-from odoo.tools import config
-from odoo.tools.parse_version import parse_version
-from odoo.tools.misc import topological_sort, get_flag
-from odoo.tools.translate import TranslationImporter, get_po_paths, get_datafile_translation_path
 from odoo.http import request
 from odoo.modules.module import Manifest, MissingDependency
+from odoo.tools import config
+from odoo.tools.misc import get_flag, topological_sort
+from odoo.tools.parse_version import parse_version
+from odoo.tools.translate import (
+    TranslationImporter,
+    get_datafile_translation_path,
+    get_po_paths,
+)
 
 T = typing.TypeVar('T')
 _logger = logging.getLogger(__name__)
@@ -515,7 +518,7 @@ class IrModuleModule(models.Model):
         they rely on data that don't exist anymore if the module is removed.
         """
         domain = Domain.OR(Domain('key', '=like', m.name + '.%') for m in self)
-        orphans = self.env['ir.ui.view'].with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search(domain)
+        orphans = self.env['ir.ui.view'].with_context(active_test=False, force_delete=True).search(domain)
         orphans.unlink()
 
     def downstream_dependencies(self, known_deps=None,

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -665,7 +665,7 @@ actual arch.
 
     def unlink(self):
         # if in uninstall mode and has children views, emulate an ondelete cascade
-        if self.env.context.get('_force_unlink', False) and self.inherit_children_ids:
+        if self.env.context.get('force_delete') and self.inherit_children_ids:
             self.inherit_children_ids.unlink()
         return super().unlink()
 

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -1,25 +1,26 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date
 import json
-from markupsafe import Markup
-from psycopg2 import IntegrityError, ProgrammingError
-import requests
+from datetime import date
 from unittest.mock import patch
 
+import requests
+from markupsafe import Markup
+from psycopg2 import IntegrityError
+
 import odoo
-from odoo.exceptions import UserError, ValidationError, AccessError
-from odoo.tools import mute_logger
-from odoo.tests import common, tagged
-from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo import Command
+from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.tests import common, tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 
 
 class TestServerActionsBase(TransactionCaseWithUserDemo):
 
     def setUp(self):
-        super(TestServerActionsBase, self).setUp()
+        super().setUp()
 
         # Data on which we will run the server action
         self.test_country = self.env['res.country'].create({
@@ -726,7 +727,7 @@ class TestCustomFields(TestCommonCustomFields):
             field.unlink()
 
         # but it works in the context of uninstalling a module
-        field.with_context(_force_unlink=True).unlink()
+        field.with_context(force_delete=True).unlink()
 
     def test_unlink_with_inverse(self):
         """ create a custom o2m and then delete its m2o inverse """
@@ -755,7 +756,7 @@ class TestCustomFields(TestCommonCustomFields):
             m2o_field.unlink()
 
         # uninstall mode: unlink dependant fields
-        m2o_field.with_context(_force_unlink=True).unlink()
+        m2o_field.with_context(force_delete=True).unlink()
         self.assertFalse(o2m_field.exists())
 
     def test_unlink_with_dependant(self):
@@ -778,7 +779,7 @@ class TestCustomFields(TestCommonCustomFields):
             field.unlink()
 
         # uninstall mode: unlink dependant fields
-        field.with_context(_force_unlink=True).unlink()
+        field.with_context(force_delete=True).unlink()
         self.assertFalse(dependant.exists())
 
     def test_unlink_inherited_custom(self):

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -4896,39 +4896,33 @@ class TestUnlinkConstraints(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         MODEL = cls.env['test_orm.model_constrained_unlinks']
-
-        cls.deletable_bar = MODEL.create({'bar': 5})
-        cls.undeletable_bar = MODEL.create({'bar': 6})
         cls.deletable_foo = MODEL.create({'foo': 'formaggio'})
         cls.undeletable_foo = MODEL.create({'foo': 'prosciutto'})
+        cls.deletable_bar = MODEL.create({'bar': 5})
+        cls.undeletable_bar = MODEL.create({'bar': 6})
 
-        from odoo.addons.base.models.ir_model import (  # noqa: PLC0415
-            MODULE_UNINSTALL_FLAG,
-        )
-        uninstall = {MODULE_UNINSTALL_FLAG: True}
-        cls.undeletable_bar_uninstall = cls.undeletable_bar.with_context(**uninstall)
-        cls.undeletable_foo_uninstall = cls.undeletable_foo.with_context(**uninstall)
-
-    def test_unlink_constraint_manual_bar(self):
+    def test_unlink_manual(self):
+        self.assertTrue(self.deletable_foo.unlink())
         self.assertTrue(self.deletable_bar.unlink())
+
+        # should both fail because of ondelete method
+        with self.assertRaises(ValueError, msg="You didn't say if you wanted it crudo or cotto..."):
+            self.undeletable_foo.unlink()
         with self.assertRaises(ValueError, msg="Nooooooooo bar can't be greater than five!!"):
             self.undeletable_bar.unlink()
 
-    def test_unlink_constraint_uninstall_bar(self):
-        self.assertTrue(self.deletable_bar.unlink())
-        # should succeed since it's at_uninstall=False
-        self.assertTrue(self.undeletable_bar_uninstall.unlink())
+    def test_unlink_uninstall(self):
+        self.patch(self.registry, 'uninstalling_modules', {'test_orm'})
 
-    def test_unlink_constraint_manual_foo(self):
         self.assertTrue(self.deletable_foo.unlink())
+        self.assertTrue(self.deletable_bar.unlink())
+
+        # should fail since it's at_uninstall=True
         with self.assertRaises(ValueError, msg="You didn't say if you wanted it crudo or cotto..."):
             self.undeletable_foo.unlink()
 
-    def test_unlink_constraint_uninstall_foo(self):
-        self.assertTrue(self.deletable_foo)
-        # should fail since it's at_uninstall=True
-        with self.assertRaises(ValueError, msg="You didn't say if you wanted it crudo or cotto..."):
-            self.undeletable_foo_uninstall.unlink()
+        # should succeed since it's at_uninstall=False
+        self.assertTrue(self.undeletable_bar.unlink())
 
 
 @tagged('wrong_related_path')

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -529,6 +529,7 @@ def load_modules(
             cr.execute("SELECT name, id FROM ir_module_module WHERE state=%s", ('to remove',))
             modules_to_remove = dict(cr.fetchall())
             if modules_to_remove:
+                registry.uninstalling_modules = set(modules_to_remove)
                 pkgs = reversed([p for p in graph if p.name in modules_to_remove])
                 for pkg in pkgs:
                     uninstall_hook = pkg.manifest.get('uninstall_hook')

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3497,7 +3497,6 @@ class BaseModel(metaclass=MetaModel):
 
         self.check_access('unlink')
 
-        from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
         for func in self._ondelete_methods:
             # func._ondelete is True => should be called during uninstallation
             # func._ondelete is False => should be called unless its module is being uninstalled
@@ -3558,8 +3557,8 @@ class BaseModel(metaclass=MetaModel):
             ir_attachment_unlink |= Attachment.browse(row[0] for row in cr.fetchall())
 
             # don't allow fallback value in ir.default for many2one company dependent fields to be deleted
-            # Exception: when MODULE_UNINSTALL_FLAG, these fallbacks can be deleted by Defaults.discard_records(records)
-            if (many2one_fields := self.env.registry.many2one_company_dependents[self._name]) and not self.env.context.get(MODULE_UNINSTALL_FLAG):
+            # Exception: when 'force_delete', these fallbacks can be deleted by Defaults.discard_records(records)
+            if (many2one_fields := self.env.registry.many2one_company_dependents[self._name]) and not self.env.context.get('force_delete'):
                 IrModelFields = self.env["ir.model.fields"]
                 field_ids = tuple(IrModelFields._get_ids(field.model_name).get(field.name) for field in many2one_fields)
                 sub_ids_json_text = tuple(json.dumps(id_) for id_ in sub_ids)
@@ -3572,7 +3571,7 @@ class BaseModel(metaclass=MetaModel):
             # on delete set null/restrict for jsonb company dependent many2one
             for field in many2one_fields:
                 model = self.env[field.model_name]
-                if field.ondelete == 'restrict' and not self.env.context.get(MODULE_UNINSTALL_FLAG):
+                if field.ondelete == 'restrict' and not self.env.context.get('force_delete'):
                     if res := self.env.execute_query(SQL(
                         """
                         SELECT id, %(field)s

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3499,8 +3499,13 @@ class BaseModel(metaclass=MetaModel):
 
         from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
         for func in self._ondelete_methods:
-            # func._ondelete is True if it should be called during uninstallation
-            if func._ondelete or not self.env.context.get(MODULE_UNINSTALL_FLAG):
+            # func._ondelete is True => should be called during uninstallation
+            # func._ondelete is False => should be called unless its module is being uninstalled
+            if (
+                func._ondelete
+                or not self.pool.uninstalling_modules
+                or func.__module__.split('.')[2] not in self.pool.uninstalling_modules
+            ):
                 func(self)
 
         # TOFIX: this avoids an infinite loop when trying to recompute a

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -256,8 +256,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
         self._reinit_modules: set[str] = set()  # modules to reinitialize
 
         # modules fully loaded (maintained during init phase by `loading` module)
-        self._init_modules: set[str] = set()       # modules have been initialized
-        self.updated_modules: list[str] = []       # installed/updated modules
+        self._init_modules: set[str] = set()         # modules have been initialized
+        self.updated_modules: list[str] = []         # installed/updated modules
+        self.uninstalling_modules: set[str] = set()  # modules being uninstalled
         self.loaded_xmlids: set[str] = set()
 
         self.db_name = db_name


### PR DESCRIPTION
This fixes two overrides of `unlink()` that break when module `mail` is being uninstalled.
It also fixes the uninstalling system to comply to the spec of the `ondelete` decorator.

### Add warnings when some model/field could not be deleted

The uninstallation process tries to delete all the records created by the modules being uninstalled.  It uses a best-effort strategy, i.e., it skips the records that cannot be deleted, whatever the reason.  But some records are very likely to cause problems, namely `ir.model` and `ir.model.fields` records, because skipping them implies not cleaning up their corresponding table's schema.

For instance, if a column is not dropped, reinstalling the corresponding module will possibly cause inconsistencies, because
 - the column contains old values for existing records, which won't be recomputed (if the field is computed);
 - the column contains NULLs for records created between the uninstallation and the reinstallation of the module.

We therefore add a warning in those cases, in order to detect and fix those potential issues as soon as possible.

### Make ondelete decorator work as documented

A method decorated with `@api.ondelete(at_uninstall=False)` should be called except when the method's module is being uninstalled.  Currently the method is skipped when *any* module is uninstalled.

The fix consists in adding the set of modules being uninstalled in the attribute `registry.uninstalling_modules`, which may be used to detect uninstallation and determine which modules are being uninstalled.

### Replace MODULE_UNINSTALL_FLAG by new conventional flag 'force_delete'

We turn constant `MODULE_UNINSTALL_FLAG` into an explicit conventional flag, and rename it `force_delete` for the sake of simplicity.  The idea is to decouple the flag from uninstallation.  The caller simply uses
```py
records.with_context(force_delete=True).unlink()
```
to bypass some deletion hooks, which typically prevent deletion by raising some exception, in order to avoid data inconsistencies.  On the callee's side, one has to explicitly detect the flag and skip the checks, like in:
```py
@api.ondelete(at_uninstall=False)
def _prevent_deleting_confirmed(self):
    if self.env.context.get('force_delete'):
        return
    if any(record.state == 'confirm' for record in self):
        raise UserError(_("You cannot delete confirmed records!"))
```
Note that the uninstallation process uses the convention by automatically adding `force_delete=True` in the `context` for deleting records.

### Fix issue module mail uninstallation

Two overrides of `unlink()` on models `ir.model` and `ir.model.fields` fail when uninstalling module "mail", because their code relies on some columns and those columns have been dropped already.  This causes some table and column to remain after uninstallation.  When reinstalling module "mail", errors like follows are logged:
```
column "mail_message_id" of relation "mail_tracking_value" contains null values
```
The fix consists in turning the overrides in proper "ondelete" methods, which are skipped when module "mail" is uninstalled.


https://github.com/odoo/enterprise/pull/103651