### PR TITLE
[FIX] website_sale: prevent auto-publishing products without category

### DIFF
--- a/addons/website_sale/static/src/js/systray_items/new_content.js
+++ b/addons/website_sale/static/src/js/systray_items/new_content.js
@@ -11,7 +11,7 @@ patch(NewContentModal.prototype, {
         newProductElement.createNewContent = () => this.onAddContent(
             'website_sale.product_product_action_add',
             true,
-            {default_is_published: true});
+        );
         newProductElement.status = MODULE_STATUS.INSTALLED;
         newProductElement.model = 'product.product';
     },

--- a/addons/website_sale/static/tests/tours/website_sale_product_publish.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_publish.js
@@ -1,0 +1,73 @@
+/** @odoo-module **/
+
+import { registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+
+registerWebsitePreviewTour(
+    'product_unpublished_without_category',
+    {
+        url: '/',
+    },
+    () => [
+        {
+            trigger: '.o_menu_systray .o_new_content_container > a',
+            run: 'click',
+        },
+        {
+            trigger: 'a[data-module-xml-id="base.module_website_sale"]',
+            run: 'click',
+        },
+        {
+            trigger: '.modal-dialog .o_field_widget[name="name"] input',
+            run: 'edit Product Without Category',
+        },
+        {
+            trigger: '.modal-footer button.btn-primary',
+            run: 'click',
+        },
+        {
+            trigger: 'body:not(:has(.modal))',
+        },
+        {
+            trigger: ':iframe body:has(h1:contains("Product Without Category"))',
+        },
+    ]
+);
+
+registerWebsitePreviewTour(
+    'product_published_with_category',
+    {
+        url: '/',
+    },
+    () => [
+        {
+            trigger: '.o_menu_systray .o_new_content_container > a',
+            run: 'click',
+        },
+        {
+            trigger: 'a[data-module-xml-id="base.module_website_sale"]',
+            run: 'click',
+        },
+        {
+            trigger: '.modal-dialog .o_field_widget[name="name"] input',
+            run: 'edit Product With Category',
+        },
+        {
+            trigger: '.modal-dialog .o_field_widget[name="public_categ_ids"] input',
+            run: 'edit Test',
+        },
+        {
+            trigger: '.ui-autocomplete a:contains("Test Category")',
+            run: 'click',
+        },
+        {
+            trigger: '.modal-footer button.btn-primary',
+            run: 'click',
+        },
+        {
+            trigger: 'body:not(:has(.modal))',
+        },
+        {
+            trigger: ':iframe body:has(h1:contains("Product With Category"))',
+        },
+    ]
+);

--- a/addons/website_sale/tests/test_website_sale_product_page.py
+++ b/addons/website_sale/tests/test_website_sale_product_page.py
@@ -52,3 +52,24 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
                 "message_id": message.id,
             },
         )
+
+    def test_product_unpublished_without_category(self):
+        """Test that products created from frontend are unpublished without category"""
+        self.start_tour("/", 'product_unpublished_without_category', login="admin")
+        product = self.env['product.product'].search(
+            [('name', '=', 'Product Without Category')],
+            limit=1,
+        )
+        self.assertTrue(product)
+        self.assertFalse(product.website_published)
+
+    def test_product_published_with_category(self):
+        """Test that products with category are published"""
+        self.env['product.public.category'].create({'name': 'Test Category'})
+        self.start_tour("/", 'product_published_with_category', login="admin")
+        product = self.env['product.product'].search(
+            [('name', '=', 'Product With Category')],
+            limit=1,
+        )
+        self.assertTrue(product)
+        self.assertTrue(product.website_published)

--- a/addons/website_sale/views/product_product_add.xml
+++ b/addons/website_sale/views/product_product_add.xml
@@ -32,7 +32,7 @@
         <field name="res_model">product.product</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
-        <field name="context" eval="{'dialog_size': 'medium', 'website_published': True}"/>
+        <field name="context" eval="{'dialog_size': 'medium'}"/>
         <field name="view_id" ref="product_product_view_form_normalized_website_sale"/>
     </record>
 


### PR DESCRIPTION
**Description:**
Products created from the website frontend were automatically published even without a category assigned, contradicting the "Unpublished" placeholder expectation.
The issue had three root causes:
1. JavaScript (new_content.js) forced default_is_published: true
2. XML action context contained website_published: True
3. Both caused products to be published regardless of category

**Fixed by:**
- Removed default_is_published from JS product creation handler
- Removed website_published from action context.

**After this PR:**
Now products remain unpublished until a category is assigned, matching the intended UX indicated by the placeholder text.
opw-5408903

SEE ALSO:
Enterprise PR:https://github.com/odoo/enterprise/pull/103778

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
