### PR TITLE
[FIX] point_of_sale: fix some xml printer fields

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -206,6 +206,12 @@ class PosConfig(models.Model):
 
     pos_snooze_ids = fields.One2many('pos.product.template.snooze', 'pos_config_id', string='Snoozed Products')
 
+    @api.onchange('receipt_printer_ids')
+    def _onchange_receipt_printer_ids(self):
+        """Clear default_receipt_printer_id if it's removed from receipt_printer_ids"""
+        if self.default_receipt_printer_id.id not in self.receipt_printer_ids.ids:
+            self.default_receipt_printer_id = False
+
     def _get_next_order_refs(self, device_identifier='0'):
         next_number = self.order_backend_seq_id._next()
         year_2_digits = str(datetime.now().year)[-2:]

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -310,3 +310,9 @@ class ResConfigSettings(models.TransientModel):
                     old._add_trusted_config_id(config.pos_config_id)
                 if old.id in removed_trusted_configs:
                     old._remove_trusted_config_id(config.pos_config_id)
+
+    @api.onchange('pos_receipt_printer_ids')
+    def _onchange_pos_receipt_printer_ids(self):
+        """Clear pos_default_receipt_printer_id if it's removed from pos_receipt_printer_ids"""
+        if self.pos_default_receipt_printer_id.id not in self.pos_receipt_printer_ids.ids:
+            self.pos_default_receipt_printer_id = False

--- a/addons/point_of_sale/views/pos_config_view.xml
+++ b/addons/point_of_sale/views/pos_config_view.xml
@@ -59,7 +59,8 @@
                                     <div class="col-lg-5">
                                         <field name="receipt_printer_ids"
                                             class="w-100 pt-1"
-                                            widget="many2many_tags"/>
+                                            widget="many2many_tags"
+                                            context="{'default_use_type': 'receipt'}"/>
                                     </div>
                                     <div class="col-lg-5">
                                         <widget name="point_of_sale_test_epos"/>
@@ -89,7 +90,8 @@
                                     <div class="col-lg-5">
                                         <field name="preparation_printer_ids"
                                             class="w-100 pt-1"
-                                            widget="many2many_tags"/>
+                                            widget="many2many_tags"
+                                            context="{'default_use_type': 'preparation'}"/>
                                     </div>
                                 </div>
                             </div>

--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -18,7 +18,7 @@
                             <field name="printer_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
                             <field name="epson_printer_ip" invisible="printer_type != 'epson_epos'" placeholder="10.100.50.87" required="printer_type == 'epson_epos'"/>
                             <field name="use_lna" invisible="printer_type != 'epson_epos'"/>
-                            <field name="product_categories_ids" invisible="use_type != 'preparation'" widget="many2many_tags"/>
+                            <field name="product_categories_ids" invisible="use_type != 'preparation'" widget="many2many_tags" required="use_type == 'preparation'"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -402,11 +402,11 @@
                                     <div class="content-group" invisible="not pos_other_devices">
                                         <div class="mt16 mb-1">
                                             <label string="Printers" for="pos_receipt_printer_ids" class="o_light_label me-2"/>
-                                            <field name="pos_receipt_printer_ids" widget="many2many_tags"/>
+                                            <field name="pos_receipt_printer_ids" widget="many2many_tags" context="{'default_use_type': 'receipt'}"/>
                                         </div>
                                         <div class="mt16 mb-1">
                                             <label string="Default" for="pos_default_receipt_printer_id" class="o_light_label me-2"/>
-                                            <field name="pos_default_receipt_printer_id" domain="[('id', 'in', pos_receipt_printer_ids)]"/>
+                                            <field name="pos_default_receipt_printer_id" domain="[('id', 'in', pos_receipt_printer_ids)]" required="pos_other_devices"/>
                                         </div>
                                         <div class="mt16 mb-1">
                                             <label string="Link Cashdrawer" for="pos_iface_cashdrawer" class="o_light_label me-2"/>
@@ -437,7 +437,8 @@
                                             <div class="col-lg-5">
                                                 <field name="pos_preparation_printer_ids"
                                                     class="w-100 pt-1"
-                                                    widget="many2many_tags"/>
+                                                    widget="many2many_tags"
+                                                    context="{'default_use_type': 'preparation'}"/>
                                             </div>
                                             <div>
                                                 <button name="action_pos_printer_dialog"


### PR DESCRIPTION
The goal of this pr was to set the printer type by default as `receipt` when a quick create was done from the "Receipt Printers" category and as `preparation` when it's done in the "Preparation Printers" category, both in `pos.config` and in `res.config`.

Also, in the `pos.printer` form view, for a preparation printer, products categories are now required when creating a printer to avoid user oversights.

And, a quick fix to make the default receipt printer as required, under the "Receipt Printers" category in the `res.config`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
