### PR TITLE
[FIX] pos_sale: prevent spliting by lots when product is kit

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -75,8 +75,9 @@ class SaleOrderLine(models.Model):
                 sale_line_uom = sale_line.product_uom
                 item = sale_line.read(field_names)[0]
                 if sale_line.product_id.tracking != 'none':
-                    item['lot_names'] = sale_line.move_ids.move_line_ids.lot_id.mapped('name')
-                    item['lot_qty_by_name'] = {line.lot_id.name: line.quantity for line in sale_line.move_ids.move_line_ids}
+                    move_lines = sale_line.move_ids.move_line_ids.filtered(lambda ml: ml.product_id.id == sale_line.product_id.id)
+                    item['lot_names'] = move_lines.lot_id.mapped('name')
+                    item['lot_qty_by_name'] = {line.lot_id.name: line.quantity for line in move_lines}
                 if product_uom == sale_line_uom:
                     results.append(item)
                     continue


### PR DESCRIPTION
When a kit product with tracked components is sold, and if the kit is tracked by lots, the imported sale order lines were being split by lots causing issues in the POS session.

Although kits are not supposed to be tracked by lots, this commit prevents the splitting of sale order lines by lots when the product is a kit.

opw-5423833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
