### PR TITLE
[FIX] point_of_sale, pos_iot: Remove use_type

### DIFF
--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -15,7 +15,6 @@
                     <group>
                         <group>
                             <field name="use_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
-                            <field name="printer_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
                             <field name="epson_printer_ip" invisible="printer_type != 'epson_epos'" placeholder="10.100.50.87" required="printer_type == 'epson_epos'"/>
                             <field name="use_lna" invisible="printer_type != 'epson_epos'"/>
                             <field name="product_categories_ids" invisible="use_type != 'preparation'" widget="many2many_tags"/>


### PR DESCRIPTION
When there is only one choice in the selection of `use_type` (IP address or IOT), we hide it in the form. But when there is two choice (so, when pos_iot is installed), we show the two options.

enterprise pr: https://github.com/odoo/enterprise/pull/103655

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
