### PR TITLE
[FIX] iot_drivers: remove tailscale ip from status

### DIFF
--- a/addons/iot_drivers/controllers/homepage.py
+++ b/addons/iot_drivers/controllers/homepage.py
@@ -126,8 +126,8 @@ class IotBoxOwlHomePage(http.Controller):
         if IS_RPI:
             ssid = wifi.get_current() or wifi.get_access_point_ssid()
             for iface_id in netifaces.interfaces():
-                if iface_id == 'lo':
-                    continue  # Skip loopback interface (127.0.0.1)
+                if iface_id == 'lo' or 'tailscale' in iface_id:
+                    continue  # Skip loopback interface (127.0.0.1) and Tailscale interfaces
 
                 is_wifi = 'wlan' in iface_id
                 network_interfaces.extend([{


### PR DESCRIPTION
This PR removes tailscale ip address from iot box status screen.

```
>>> netifaces.interfaces()
['lo', 'eth0', 'wlan0', 'tailscale0']
```

The 'tailscale0' interface will now be ignored

