### PR TITLE
[FIX] web: fix card background color inconsistencies

### DIFF
--- a/addons/web/static/lib/bootstrap/scss/_variables.scss
+++ b/addons/web/static/lib/bootstrap/scss/_variables.scss
@@ -1265,7 +1265,7 @@ $card-cap-bg:                       rgba($black, .03) !default;
 $card-cap-color:                    null !default;
 $card-height:                       null !default;
 $card-color:                        null !default;
-$card-bg:                           $white !default;
+$card-bg:                           $body-bg !default;
 $card-img-overlay-padding:          $spacer !default;
 $card-group-margin:                 $grid-gutter-width * .5 !default;
 // scss-docs-end card-variables


### PR DESCRIPTION
Steps:
- Switch the website background to a dark color
- Add a product to the cart
- Go to cart checkout page
- Switch to mobile view
- Observe the text next to amounts (Subtotal, Taxes, Total) inside cart summary card.
<img width="322" height="493" alt="image" src="https://github.com/user-attachments/assets/eb04ded2-bd5d-4b19-9707-be7ca8bd2953" />

Issue:
- Text next to amounts becomes unreadable on dark backgrounds in mobile view

Cause:
- The cart summary block is a card which was using a fixed background color, while text colors are dynamically adapted to the website theme colors, leading to contrast issues.

Fix:
- Update the card background color to rely on the website color palette to ensure proper  contrast and readability

opw-5386622
