### PR TITLE
[18.0][FIX] stock: stock_warehouse_orderpoint unlink method domain #1324

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -609,7 +609,7 @@ class StockWarehouseOrderpoint(models.Model):
             ('trigger', '=', 'manual'),
         ]
         if self.ids:
-            expression.AND([domain, [('ids', 'in', self.ids)]])
+            domain = expression.AND([domain, [('id', 'in', self.ids)]])
         manual_orderpoints = self.env['stock.warehouse.orderpoint'].with_context(active_test=False).search(domain)
         orderpoints_to_remove = manual_orderpoints.filtered(lambda o: o.qty_to_order <= 0.0)
         # Remove previous automatically created orderpoint that has been refilled.

--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -56,3 +56,4 @@ Ricardo Almeida Soares ricardo.almeidasoares@camptocamp.com https://github.com/r
 Italo Lopes italo.lopes@camptocamp.com https://github.com/imlopes
 Luca Policastro luca.policastro@camptocamp.com https://github.com/Luca-Policastro
 Tomasz Walter tomasz.walter@camptocamp.com https://github.com/twalter-c2c
+Paolo Yammouni paolo.yammouni@camptocamp.com https://github.com/paoloyam


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR fixes an incorrect domain construction when restricting records to the current recordset.
The existing code attempted to combine domains using expression.AND() but did not apply the result, and referenced an invalid domain field.

Current behavior before PR:

- expression.AND() was called without assigning its return value, so the combined domain was never applied.
- The domain condition used ('ids', 'in', self.ids), which is not a valid searchable field.
- As a result, the intended filtering by the current recordset was silently ignored.

Desired behavior after PR is merged:

- The domain is correctly rebuilt and assigned using expression.AND().
- The filter uses the valid field instead of ids
- Records are properly restricted to the current recordset

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
