### PR TITLE
[IMP] hr_holidays: Improve UI

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -182,11 +182,13 @@ class HrLeave(models.Model):
     # details
     meeting_id = fields.Many2one('calendar.event', string='Meeting', copy=False)
     first_approver_id = fields.Many2one(
-        'hr.employee', string='First Approval', readonly=True, copy=False,
+        'hr.employee', string='First Approver', readonly=True, copy=False,
         help='This area is automatically filled by the user who validate the time off')
     second_approver_id = fields.Many2one(
-        'hr.employee', string='Second Approval', readonly=True, copy=False,
+        'hr.employee', string='Second Approver', readonly=True, copy=False,
         help='This area is automatically filled by the user who validate the time off with second level (If time off type need second validation)')
+    first_approve_date = fields.Datetime('First Approval Date', readonly=True, copy=False)
+    second_approver_date = fields.Datetime('Second Approval Date', readonly=True, copy=False)
 
     can_approve = fields.Boolean(compute='_compute_can_approve', export_string_translation=False)
     can_validate = fields.Boolean(compute='_compute_can_validate', export_string_translation=False)
@@ -1156,7 +1158,12 @@ class HrLeave(models.Model):
                 leave_to_approve += leave
             else:
                 raise UserError(self.env._('You cannot approve this leave.'))
-        leave_to_approve.write({'state': 'validate1', 'first_approver_id': current_employee.id})
+        leave_to_approve.write(
+            {
+                'state': 'validate1',
+                'first_approver_id': current_employee.id,
+                'first_approve_date': fields.Datetime.now(),
+            })
         leave_to_validate._action_validate(check_state)
         if not self.env.context.get('leave_fast_create'):
             self.activity_update()
@@ -1252,8 +1259,8 @@ class HrLeave(models.Model):
             else:
                 leaves_first_approver += leave
 
-        leaves_second_approver.write({'second_approver_id': current_employee.id})
-        leaves_first_approver.write({'first_approver_id': current_employee.id})
+        leaves_second_approver.write({'second_approver_id': current_employee.id, 'second_approver_date': fields.Datetime.now()})
+        leaves_first_approver.write({'first_approver_id': current_employee.id, 'first_approve_date': fields.Datetime.now()})
 
         self._validate_leave_request()
         if not self.env.context.get('leave_fast_create'):
@@ -1267,8 +1274,10 @@ class HrLeave(models.Model):
 
         self._notify_manager()
         validated_holidays = self.filtered(lambda hol: hol.state == 'validate1')
-        validated_holidays.write({'state': 'refuse', 'first_approver_id': current_employee.id})
-        (self - validated_holidays).write({'state': 'refuse', 'second_approver_id': current_employee.id})
+        validated_holidays.write(
+            {'state': 'refuse', 'first_approver_id': current_employee.id, 'first_approve_date': False}
+        )
+        (self - validated_holidays).write({'state': 'refuse', 'second_approver_id': current_employee.id, 'second_approver_date': False})
         # Delete the meeting
         self.mapped('meeting_id').write({'active': False})
         # Post a second message, more verbose than the tracking message

--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -96,7 +96,7 @@
 
     .ribbon {
         --Ribbon-wrapper-width: 6.77rem;
-        height: 5rem;
+        height: 100%;
         span {
             --Ribbon-left-position-default: 0.3rem;
         }
@@ -121,9 +121,10 @@
         @media only screen and (min-width:768px){
             .o_kanban_record:not(.o_kanban_ghost) {
                 width: 100%;
-                max-height: 5.1rem;
+                min-height: auto !important;
                 margin: 0px;
                 justify-content: center;
+                padding: 4px 8px !important;
             }
             .o_hr_holidays_kanban_mobile {
                 display: none;

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -419,7 +419,7 @@
                             <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate'"/>
                             <aside>
                                 <img t-att-src="'/web/image/hr.employee.public/' + record.employee_id.raw_value + '/avatar_128?unique=' + record.write_date.raw_value"
-                                    class="o_image_64_cover float-start mb-2 me-2" alt="Employee's image"/>
+                                    class="o_image_64_cover float-start me-2" alt="Employee's image"/>
                             </aside>
                             <main class="h-100">
                                 <div class="justify-content-center o_holidays_kanban_card">

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -49,8 +49,8 @@
                 <filter name="missing_document" string="Missing Document"
                     domain="['&amp;', ('holiday_status_id.support_document', '=', True), ('attachment_ids', '=', False)]"/>
                 <separator/>
-                <filter domain="[('state', '=', 'confirm')]" string="First Approval" name="approve"/>
-                <filter domain="[('state', '=', 'validate1')]" string="Second Approval" name="second_approval"/>
+                <filter domain="[('state', '=', 'confirm')]" string="First Approver" name="approve"/>
+                <filter domain="[('state', '=', 'validate1')]" string="Second Approver" name="second_approval"/>
                 <filter domain="[('state','in',('confirm','validate1'))]" string="To Approve" name="to_approve"/>
                 <filter string="Approved" domain="[('state', '=', 'validate')]" name="validated"/>
                 <filter name="cancelled_leaves" string="Cancelled" domain="[('state', '=', 'cancel')]"/>


### PR DESCRIPTION
Before this change, when we grouped by first approval and second approval, we could see who approved the leave, but we couldn’t see when it was approved.

With this update:
- Extra spacing in the kanban view has been removed.
- First approval date and second approval date are now shown, so it’s clear when the leave was approved.

Task-5472909

