### PR TITLE
[FIX] point_of_sale: include 'done' state in session sales statistics

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -376,7 +376,7 @@ class PosConfig(models.Model):
             },
         }
 
-        all_paid_orders = session.order_ids.filtered(lambda o: o.state == 'paid')
+        all_paid_orders = session.order_ids.filtered(lambda o: o.state in ['paid', 'done'])
         refund_orders = all_paid_orders.filtered(lambda o: o.is_refund)
         draft_orders = session.order_ids.filtered(lambda o: o.state == 'draft')
         non_refund_orders = all_paid_orders - refund_orders


### PR DESCRIPTION
When computing the sales statistics for a POS session, include invoiced orders (state 'done') along with paid orders (state 'paid'). This ensures that all completed transactions are accounted for in the session summary.

opw-5475876

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
