### PR TITLE
[FIX] mail: avoid duplicated group ids when updating user groups

### DIFF
--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -21,7 +21,7 @@ class ResUsers(models.Model):
             # form: {'group_ids': [(3, 10), (3, 3), (4, 10), (4, 3)]} or {'group_ids': [(6, 0, [ids]}
             user_group_ids = [command[1] for command in vals["group_ids"] if command[0] == 4]
             user_group_ids += [id for command in vals["group_ids"] if command[0] == 6 for id in command[2]]
-            user_group_ids += self.env['res.groups'].browse(user_group_ids).all_implied_ids._ids
+            user_group_ids = self.env['res.groups'].browse(user_group_ids).all_implied_ids._ids
             self.env["discuss.channel"].search([("group_ids", "in", user_group_ids)])._subscribe_users_automatically()
         return res
 


### PR DESCRIPTION
When updating group(s) of a user, we search discuss channels with the same group for auto-subscription.

To do this, we need to pass a list of groups of the user to match against channels.

Previously, we extracted the new groups from the commands, added them to a list, and then appended their implied groups to it. This caused duplication because the implied groups already include the original groups.

This commit fixes the issue by overwriting the list instead of appending to it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
