### PR TITLE
[FIX] l10n_dk_nemhandel: fix traceback on timeout

### DIFF
--- a/addons/l10n_dk_nemhandel/models/account_move_send.py
+++ b/addons/l10n_dk_nemhandel/models/account_move_send.py
@@ -112,7 +112,7 @@ class AccountMoveSend(models.AbstractModel):
         except UserError as e:
             for invoice, invoice_data in invoices_data_nemhandel.items():
                 invoice.nemhandel_move_state = 'error'
-                invoice_data['error'] = e.message
+                invoice_data['error'] = str(e)
         else:
             if response.get('error'):
                 # at the moment the only error that can happen here is ParticipantNotReady error


### PR DESCRIPTION
In case of timeout when sending an invoice there is a traceback due to the following error.
```
AttributeError: 'UserError' object has no attribute 'message'
```

It is fixed in this commit.

task-None