### PR TITLE
[FIX] payment: onboarding provider button on payment page

### DIFF
--- a/addons/payment/data/ir_actions_server_data.xml
+++ b/addons/payment/data/ir_actions_server_data.xml
@@ -6,7 +6,10 @@
         <field name="model_id" ref="payment.model_payment_provider"/>
         <field name="state">code</field>
         <field name="code">
-action = env.company._start_payment_onboarding()
+if not env.company._get_onboarding_payment_provider():
+    action = env.company._start_payment_onboarding()
+else:
+    action = env.company.action_view_onboarding_payment_provider()
         </field>
     </record>
 

--- a/addons/payment/models/res_company.py
+++ b/addons/payment/models/res_company.py
@@ -77,3 +77,19 @@ class ResCompany(models.Model):
             return False
 
         return provider.action_start_onboarding(menu_id=menu_id)
+
+    def action_view_onboarding_payment_provider(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'payment.provider',
+            'views': [[False, 'form']],
+            'res_id': self._get_onboarding_payment_provider().id,
+        }
+
+    def _get_onboarding_payment_provider(self):
+        return self.env['payment.provider'].search([
+            ('code', '=', self.onboarding_payment_module),
+            ('state', '!=', 'disabled'),
+            *self.env['payment.provider']._check_company_domain(self),
+        ], limit=1)

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -410,7 +410,9 @@
                     role="button"
                     class="btn btn-primary me-2"
                 >
-                    CONNECT <t t-out="onboarding_provider.upper()"/>
+                    <t t-if="request.env.company._get_onboarding_payment_provider()">CONFIGURE</t>
+                    <t t-else="">CONNECT</t>
+                    <t t-out="onboarding_provider.upper()"/>
                 </a>
                 <a
                     t-if="availability_report"


### PR DESCRIPTION
Steps:
- Install Stripe and restrict it to Belgium.
- Set the provider to Test or Enabled and configure credentials.
- Place an order on a US company’s website.
- On the payment page, the 'Connect Stripe' button is displayed.

Issue:
- When the provider is already installed and in Test or Enabled state, the button should display 'Configure Stripe' and open the provider’s form view. Instead, it still displays 'Connect Stripe” and starts the onboarding flow.

Cause:
- The button logic does not check whether the provider is already in Test or Enabled state.

Fix:
- Add a condition to handle provider already in Test or Enabled state.
- Show 'Configure <provider>' and redirect to the provider’s form view instead of starting onboarding process.

opw-5473376