### PR TITLE
[FIX] hr_expense: prioritize employee bank account in payment register

### DIFF
--- a/addons/hr_expense/wizard/__init__.py
+++ b/addons/hr_expense/wizard/__init__.py
@@ -1,3 +1,4 @@
+from . import account_payment_register
 from . import hr_expense_refuse_reason
 from . import hr_expense_post_wizard
 from . import hr_expense_approve_duplicate


### PR DESCRIPTION
**Steps to reproduce:**
* Create an **employee** with a bank account.
* Link the employee’s contact to the current company as a **child partner**.
* Create an expense for that employee with payment mode **Paid by Employee**.
* Submit, approve, and post the expense.
* Open the **payment register** to reimburse the employee.

**Observed behavior:**
* The payment register defaults to the **company bank account** instead of the employee’s bank account.

**Cause:**
* The `account_payment_registered` file was removed in this commit: https://github.com/odoo/odoo/commit/704a5a19499469e5a14461bb81d33c832ce00d70#diff-f8829ed273c0ec8838636b1709ac4f895857992dddada6dbcbca3c62a2cbce81
* As a result, the payment register no longer prioritizes the employee’s bank account when the employee contact is linked to the company.

**Fix:**
* Added `account_register_payment` back to the `__init__` file.

opw-5414133