### PR TITLE
[IMP] iot_drivers: register even on duplicate action

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -49,6 +49,7 @@ class Driver(Thread):
         :return: the result of the action method
         """
         if self._check_if_action_is_duplicate(data.get('action_unique_id')):
+            event_manager.device_changed(self, {'status': 'duplicate'})
             return
 
         action = data.get('action', '')


### PR DESCRIPTION
In order to inform the user if an action has already been processed we now send an event for duplicated actions.

see odoo/enterprise#103682