### PR TITLE
[18.0][FIX] Product: fix compute display name depends context with lang

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -489,7 +489,7 @@ class ProductProduct(models.Model):
         return super()._search(domain, offset, limit, order)
 
     @api.depends('name', 'default_code', 'product_tmpl_id')
-    @api.depends_context('display_default_code', 'seller_id', 'company_id', 'partner_id')
+    @api.depends_context('display_default_code', 'seller_id', 'company_id', 'partner_id', 'lang')
     def _compute_display_name(self):
 
         def get_display_name(name, code):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Compute of display_name in different languages that can be returned incorrect

Current behavior before PR:

When accessing  two times in the same method the display_name of a configured product but the second time having a .with_context(lang=lang) other than the previous language, the returned display name will not be in the specified language as the cached value will be returned. 

Desired behavior after PR is merged:

_compute_display_name should always take into account a change of language in context when the value is accessed. 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
