### PR TITLE
[FIX] web: prevent automatic conversion of `B)` to 😎 emoji

### DIFF
--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -1060,7 +1060,6 @@ const emojisData1 = `{
     "category": "Smileys & Emotion",
     "codepoints": "😎",
     "emoticons": [
-        "B)",
         "8)",
         "B-)",
         "8-)"


### PR DESCRIPTION
Before this PR,
typing `B)` was automatically converted into a 😎 emoji, which could unintentionally alter user input.

This PR disables that conversion.

task-[5221032](https://www.odoo.com/odoo/project/1519/tasks/5221032)