### PR TITLE
[FIX] sale: Hide zero amount in Down Payments section on order report

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -147,6 +147,16 @@
                                 t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                             >
                                 <t
+                                    t-set="show_section_total"
+                                    t-value="(
+                                        (
+                                            is_section
+                                            or not line.parent_id.collapse_prices
+                                        )
+                                        and not line.is_downpayment
+                                    )"
+                                />
+                                <t
                                     t-set="section_name_colspan"
                                     t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
                                 />
@@ -239,8 +249,8 @@
                                 <td t-if="display_taxes" name="td_product_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>
-                                <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end o_price_total">
-                                    <t t-if="not collapse_prices">
+                                <td name="td_product_subtotal" class="text-end o_price_total">
+                                    <t t-if="not line.is_downpayment and not collapse_prices">
                                         <span
                                             t-if="price_field == 'price_subtotal'"
                                             t-field="line.price_subtotal"

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -782,6 +782,16 @@
                                         t-att-class="'fw-bolder o_line_section' if is_section else 'fw-bold o_line_subsection'"
                                     >
                                         <t
+                                            t-set="show_section_total"
+                                            t-value="(
+                                                (
+                                                    is_section
+                                                    or not line.parent_id.collapse_prices
+                                                )
+                                                and not line.is_downpayment
+                                            )"
+                                        />
+                                        <t
                                             t-set="section_name_colspan"
                                             t-value="3 + (1 if display_discount else 0) + (1 if display_taxes else 0)"
                                         />
@@ -919,8 +929,8 @@
                                         <td t-if="display_taxes" name="td_product_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                             <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
-                                        <td t-if="not line.is_downpayment" name="td_product_subtotal" class="text-end">
-                                            <t t-if="not collapse_prices">
+                                        <td name="td_product_subtotal" class="text-end">
+                                            <t t-if="not line.is_downpayment and not collapse_prices">
                                                 <span
                                                     t-if="price_field == 'price_subtotal'"
                                                     t-field="line.price_subtotal"


### PR DESCRIPTION
When creating an order with a down payment, the printed order report incorrectly shows a zero amount on the “Down Payments” line. This line acts as a section header and should not display any amount.

opw-5446875
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
