### PR TITLE
[IMP] stock: allow empty tracking value

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -167,7 +167,7 @@ class MrpUnbuild(models.Model):
         self._check_company()
         # remove the default_* keys that were only needed in the unbuild wizard
         self = self.with_env(self.env(context=clean_context(self.env)))  # noqa: PLW0642
-        if self.product_id.tracking != 'none' and not self.lot_id.id:
+        if self.product_id.tracking in ['lot', 'serial'] and not self.lot_id.id:
             raise UserError(_('You should provide a lot number for the final product.'))
 
         if self.mo_id and self.mo_id.state != 'done':
@@ -189,10 +189,10 @@ class MrpUnbuild(models.Model):
             "It will allow us to retrieve the lots/serial numbers of the correct components and/or byproducts."
         )
 
-        if any(produce_move.has_tracking != 'none' and not self.mo_id for produce_move in produce_moves):
+        if any(produce_move.product_id.tracking in ['lot', 'serial'] and not self.mo_id for produce_move in produce_moves):
             raise UserError(error_message)
 
-        if any(consume_move.has_tracking != 'none' and not self.mo_id for consume_move in consume_moves):
+        if any(consume_move.product_id.tracking in ['lot', 'serial'] and not self.mo_id for consume_move in consume_moves):
             raise UserError(error_message)
 
         for finished_move in finished_moves:

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -578,9 +578,6 @@ class MrpWorkorder(models.Model):
         for production in self.mapped("production_id"):
             production._link_workorders_and_moves()
 
-    def _get_byproduct_move_to_update(self):
-        return self.production_id.move_finished_ids.filtered(lambda x: (x.product_id.id != self.production_id.product_id.id) and (x.state not in ('done', 'cancel')))
-
     def _plan_workorders(self, from_date=False, alternative=True):
         """Plan or replan a set of manufacturing workorders
 

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -213,7 +213,8 @@ class StockMove(models.Model):
 
     @api.onchange('product_uom_qty', 'uom_id')
     def _onchange_product_uom_qty(self):
-        if self.uom_id and self.raw_material_production_id and self.has_tracking == 'none'\
+        if self.uom_id and self.raw_material_production_id \
+            and (self.has_tracking not in ['lot', 'serial']) \
             and self.state not in ('draft', 'cancel', 'done'):
             mo = self.raw_material_production_id
             new_qty = self.uom_id.round((mo.qty_producing - mo.qty_produced) * self.unit_factor)

--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -183,7 +183,7 @@
                                             <span t-field="move_line.uom_id" groups="uom.group_uom">UOM id</span>
                                         </div>
                                     </div>
-                                    <t t-if="move_line.product_id.tracking != 'none' and (move_line.lot_name or move_line.lot_id)">
+                                    <t t-if="move_line.product_id.tracking in ['lot', 'serial'] and (move_line.lot_name or move_line.lot_id)">
                                         <div t-field="move_line.lot_name or move_line.lot_id.name" t-options="{'widget': 'barcode', 'img_style': 'width:100%;height:35%'}"/>
                                         <div class="o_label_4x12 text-center"><span t-out="move_line.lot_name or move_line.lot_id.name">Demo Barcode</span></div>
                                     </t>

--- a/addons/mrp/report/mrp_zebra_production_templates.xml
+++ b/addons/mrp/report/mrp_zebra_production_templates.xml
@@ -24,7 +24,7 @@
 ^BCN,100,Y,N,N
 ^FD<t t-out="move_line.lot_id.name"/>^FS
 </t>
-<t t-elif="move_line.product_id.tracking == 'none' and move_line.product_id.barcode">
+<t t-elif="(move_line.product_id.tracking not in ['lot', 'serial']) and move_line.product_id.barcode">
 ^FO100,100^BY3
 ^BCN,100,Y,N,N
 ^FD<t t-out="move_line.product_id.barcode"/>^FS

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -136,7 +136,7 @@ class TestConsumeComponentCommon(common.TransactionCase):
                 'inventory_quantity': qty,
             }
 
-            if product.tracking != 'none':
+            if product.tracking in ['lot', 'serial']:
                 qDict['lot_id'] = cls.env['stock.lot'].create({
                     'name': name + str(offset + x),
                     'product_id': product.id,
@@ -186,7 +186,6 @@ class TestConsumeComponentCommon(common.TransactionCase):
 
         isSerial = tracking == 'serial'
         isAvailable = all(move.state == 'assigned' for move in mrp_productions.move_raw_ids)
-        isComponentTracking = any(move.has_tracking != 'none' for move in mrp_productions.move_raw_ids)
 
         countOk = True
         length = len(mrp_productions)
@@ -276,7 +275,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         self.executeConsumptionTriggers(mo_lot)
 
         for mov in mo_all.move_raw_ids:
-            if mov.has_tracking == 'none':
+            if mov.has_tracking not in ['lot', 'serial']:
                 self.assertTrue(mov.picked, "components should be picked even without no quantity reserved")
             else:
                 self.assertEqual(mov.product_qty, mov.quantity, "Done quantity shall be equal to To Consume quantity.")
@@ -308,7 +307,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
             #  are partially reserved (stock.move state is partially_available)
             mo.action_assign()
             for mov in mo.move_raw_ids:
-                if mov.has_tracking == "none":
+                if mov.has_tracking not in ['lot', 'serial']:
                     self.assertEqual(raw_none_qty, mov.quantity, "Reserved quantity shall be equal to " + str(raw_none_qty) + ".")
                 else:
                     self.assertEqual(raw_tracked_qty, mov.quantity, "Reserved quantity shall be equal to " + str(raw_tracked_qty) + ".")
@@ -322,7 +321,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
                 mo.action_generate_serial()
 
             for mov in mo.move_raw_ids:
-                if mov.has_tracking == "none":
+                if mov.has_tracking not in ['lot', 'serial']:
                     self.assertTrue(mov.picked, "non tracked components should be picked")
                 else:
                     self.assertEqual(mov.product_qty, mov.quantity, "Done quantity shall be equal to To Consume quantity.")

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1277,10 +1277,7 @@ class TestMrpOrder(TestMrpCommon):
         mo_form.qty_producing = 1
         mo2 = mo_form.save()
         move_byproduct = mo2.move_finished_ids.filtered(lambda m: m.product_id != mo.product_id)
-        details_operation_form = Form(move_byproduct, view=self.env.ref('stock.view_stock_move_operations'))
-        with details_operation_form.move_line_ids.new() as ml:
-            ml.lot_id = sn
-        details_operation_form.save()
+        move_byproduct.move_line_ids = [Command.create({'product_id': byproduct.id, 'lot_id': sn.id, 'quantity': 1})]
         with self.assertRaises(UserError):
             mo2.button_mark_done()
 

--- a/addons/mrp/tests/test_performance.py
+++ b/addons/mrp/tests/test_performance.py
@@ -78,7 +78,7 @@ class TestMrpSerialMassProducePerformance(common.TransactionCase):
                         'lot_id': lot.id,
                     })._apply_inventory()
                     qty -= 10
-            else:
+            elif raw_materials[i].tracking == 'serial':
                 for _ in range(total_quantity):
                     lot = self.env['stock.lot'].create({
                         'product_id': raw_materials[i].id,

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -278,7 +278,7 @@ class TestWarehouseMrp(common.TestMrpCommon):
         """ Test that movement of pack in backorder is correctly handled. """
         self.warehouse_1.manufacture_steps = 'pbm'
 
-        self.product_1.is_storable = True
+        self.product_1.tracking = 'none'
         self.env['stock.quant']._update_available_quantity(self.product_1, self.stock_location, 100)
 
         mo_form = Form(self.env['mrp.production'])
@@ -353,10 +353,10 @@ class TestKitPicking(common.TestMrpCommon):
         super().setUpClass()
 
         def create_product(name):
-            p = Form(cls.env['product.product'])
-            p.name = name
-            p.is_storable = True
-            return p.save()
+            return cls.env['product.product'].create({
+                'name': name,
+                'tracking': 'none',
+            })
 
         # Create a kit 'kit_parent' :
         # ---------------------------

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -94,7 +94,7 @@ class TestTraceability(TestMrpCommon):
 
             # Start MO production
             mo_form = Form(mo)
-            if finished_product.tracking != 'none':
+            if finished_product.tracking in ['lot', 'serial']:
                 mo_form.lot_producing_ids.set(self.env['stock.lot'].create({'name': 'Serial or Lot finished', 'product_id': finished_product.id}))
             mo = mo_form.save()
 
@@ -134,7 +134,7 @@ class TestTraceability(TestMrpCommon):
                 self.assertEqual(
                     line['columns'][-1], "1.00 Units", 'Part with tracking type "%s", should have quantity = 1' % (tracking)
                 )
-                unfoldable = False if tracking == 'none' else True
+                unfoldable = tracking in ['lot', 'serial']
                 self.assertEqual(
                     line['unfoldable'],
                     unfoldable,

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -170,7 +170,7 @@ class TestUnbuild(TestMrpCommon):
         self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 5)
         mo.action_assign()
         for ml in mo.move_raw_ids.mapped('move_line_ids'):
-            if ml.product_id.tracking != 'none':
+            if ml.product_id.tracking in ['lot', 'serial']:
                 self.assertEqual(ml.lot_id, lot, 'Wrong reserved lot.')
 
         # FIXME sle: behavior change

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -23,7 +23,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Stick'
         product_form.uom_id = cls.uom_unit
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.route_ids.clear()
         product_form.route_ids.add(cls.route_mto)
         cls.finished_product = product_form.save()
@@ -31,7 +31,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         # Create raw product for manufactured product
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Raw Stick'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.uom_id = cls.uom_unit
         cls.raw_product = product_form.save()
 
@@ -419,7 +419,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         # Create an additional BoM for component
         product_form = Form(self.env['product.product'])
         product_form.name = 'Wood'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.uom_id = self.uom_unit
         self.wood_product = product_form.save()
 

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -504,8 +504,8 @@
                                         create="parent.use_create_components_lots"
                                         context="{'default_product_id': product_id}"
                                         domain="[('product_id','=',product_id)]"/>
-                                    <button name="action_show_details" type="object" title="Show Details" string="Details" context="{'default_product_uom_qty': 0}" invisible="not show_details_visible or has_tracking == 'none'"/>
-                                    <button class="o_optional_button btn" name="action_show_details" type="object" title="Show Details" string="Details" context="{'default_product_uom_qty': 0}" invisible="has_tracking != 'none' or not show_details_visible"/>
+                                    <button name="action_show_details" type="object" title="Show Details" string="Details" context="{'default_product_uom_qty': 0}" invisible="not show_details_visible or has_tracking not in ['lot', 'serial']"/>
+                                    <button class="o_optional_button btn" name="action_show_details" type="object" title="Show Details" string="Details" context="{'default_product_uom_qty': 0}" invisible="(has_tracking in ['lot', 'serial']) or not show_details_visible"/>
                                 </list>
                             </field>
                         </page>
@@ -544,7 +544,7 @@
                                     <field name="move_lines_count" column_invisible="True"/>
                                     <field name="state" column_invisible="True" force_save="1"/>
                                     <field name="product_uom_qty" string="To Produce" force_save="1" readonly="parent.state != 'draft' and ((parent.state not in ('confirmed', 'progress', 'to_close') and not parent.is_planned) or parent.is_locked)"/>
-                                    <field name="quantity" column_invisible="parent.state == 'draft'" readonly="has_tracking != 'none'"/>
+                                    <field name="quantity" column_invisible="parent.state == 'draft'" readonly="has_tracking in ['lot', 'serial']"/>
                                     <field name="picked" string="Produced" column_invisible="parent.state == 'draft'" optional="show"/>
                                     <field name="uom_id" groups="uom.group_uom" widget="many2one_uom"/>
                                     <field name="cost_share" optional="hide"/>
@@ -560,8 +560,8 @@
                                         create="parent.use_create_components_lots"
                                         context="{'default_product_id': product_id}"
                                         domain="[('product_id','=',product_id)]"/>
-                                    <button name="action_show_details" type="object" title="Show Details" icon="fa-list" invisible="has_tracking == 'none' or not show_details_visible"/>
-                                    <button class="o_optional_button btn btn-light" name="action_show_details" type="object" title="Show Details" icon="fa-list" invisible="has_tracking != 'none' or not show_details_visible"/>
+                                    <button name="action_show_details" type="object" title="Show Details" icon="fa-list" invisible="has_tracking not in ['lot', 'serial'] or not show_details_visible"/>
+                                    <button class="o_optional_button btn btn-light" name="action_show_details" type="object" title="Show Details" icon="fa-list" invisible="has_tracking in ['lot', 'serial'] or not show_details_visible"/>
                                 </list>
                             </field>
                         </page>

--- a/addons/mrp/views/mrp_unbuild_views.xml
+++ b/addons/mrp/views/mrp_unbuild_views.xml
@@ -107,7 +107,7 @@
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" readonly="state == 'done'"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" readonly="state == 'done'"/>
                                 <field name="has_tracking" invisible="1"/>
-                                <field name="lot_id" invisible="has_tracking == 'none'" readonly="state == 'done'" required="has_tracking != 'none'" groups="stock.group_production_lot" force_save="1"/>
+                                <field name="lot_id" invisible="has_tracking not in ['lot', 'serial']" readonly="state == 'done'" required="has_tracking in ['lot', 'serial']" groups="stock.group_production_lot" force_save="1"/>
                                 <field name="company_id" groups="base.group_multi_company" readonly="state == 'done'"/>
                             </group>
                         </group>
@@ -142,7 +142,7 @@
                                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" readonly="state == 'done'"/>
                                 <field name="location_dest_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations" readonly="state == 'done'"/>
                                 <field name="has_tracking" invisible="1"/>
-                                <field name="lot_id" invisible="has_tracking == 'none'" required="has_tracking != 'none'" groups="stock.group_production_lot"/>
+                                <field name="lot_id" invisible="has_tracking not in ['lot', 'serial']" required="has_tracking in ['lot', 'serial']" groups="stock.group_production_lot"/>
                                 <field name="company_id" groups="base.group_multi_company" readonly="1"/>
                             </group>
                         </group>

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -41,7 +41,7 @@ class StockMove(models.Model):
         done_moves = self.env['stock.move']
         for move in self:
             if move.is_subcontract:
-                move.is_quantity_done_editable = move.has_tracking == 'none'
+                move.is_quantity_done_editable = move.has_tracking not in ['lot', 'serial']
                 done_moves |= move
         return super(StockMove, self - done_moves)._compute_is_quantity_done_editable()
 
@@ -239,7 +239,7 @@ class StockMove(models.Model):
             productions = move._get_subcontract_production()
             if not productions:
                 continue
-            if move.has_tracking == 'none':
+            if move.has_tracking not in ['lot', 'serial']:
                 if productions.uom_id.compare(productions.product_qty, move.quantity) != 0:
                     self.sudo().env['change.production.qty'].with_context(skip_activity=True).create([{
                         'mo_id': productions.id,

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -36,7 +36,7 @@ class StockPicking(models.Model):
     def _compute_show_lots_text(self):
         super()._compute_show_lots_text()
         for picking in self:
-            if any(move.is_subcontract and move.has_tracking != 'none' for move in picking.move_ids):
+            if any(move.is_subcontract and move.product_id.tracking in ['lot', 'serial'] for move in picking.move_ids):
                 picking.show_lots_text = False
 
     # -------------------------------------------------------------------------

--- a/addons/point_of_sale/models/pos_order_line.py
+++ b/addons/point_of_sale/models/pos_order_line.py
@@ -298,7 +298,7 @@ class PosOrderLine(models.Model):
             pickings_to_confirm = order.picking_ids
             if pickings_to_confirm:
                 # Trigger the Scheduler for Pickings
-                tracked_lines = order.lines.filtered(lambda l: l.product_id.tracking != 'none')
+                tracked_lines = order.lines.filtered(lambda l: l.product_id.tracking in ['lot', 'serial'])
                 lines_by_tracked_product = groupby(sorted(tracked_lines, key=lambda l: l.product_id.id), key=lambda l: l.product_id.id)
                 pickings_to_confirm.action_confirm()
                 for product_id, lines in lines_by_tracked_product:

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -214,7 +214,7 @@ class StockMove(models.Model):
     def _add_mls_related_to_order(self, related_order_lines, are_qties_done=True):
         lines_data = self._prepare_lines_data_dict(related_order_lines)
         # Moves with product_id not in related_order_lines. This can happend e.g. when product_id has a phantom-type bom.
-        moves_to_assign = self.filtered(lambda m: m.product_id.id not in lines_data or m.product_id.tracking == 'none'
+        moves_to_assign = self.filtered(lambda m: m.product_id.id not in lines_data or m.product_id.tracking not in ['lot', 'serial']
                                                   or (not m.picking_type_id.use_existing_lots and not m.picking_type_id.use_create_lots))
 
         # Check for any conversion issues in the moves before setting quantities

--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.js
@@ -119,7 +119,8 @@ export class Orderline extends Component {
             productImage: this.props.showImage && imageUrl,
             taxGroup: this.props.showTaxGroup && taxGroup,
             price: this.line.currencyDisplayPrice,
-            lotLines: line.product_id.tracking !== "none" && (line.packLotLines || []),
+            lotLines:
+                ["lot", "serial"].includes(line.product_id.tracking) && (line.packLotLines || []),
         };
     }
 }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1638,7 +1638,9 @@ export class PosStore extends WithLazyGetterTrap {
 
         if (
             currentOrder.lines.some(
-                (line) => line.getProduct().tracking !== "none" && !line.hasValidProductLot()
+                (line) =>
+                    ["lot", "serial"].includes(line.getProduct().tracking) &&
+                    !line.hasValidProductLot()
             ) &&
             (this.pickingType.use_create_lots || this.pickingType.use_existing_lots)
         ) {

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -179,7 +179,7 @@ class SaleOrderLine(models.Model):
                 product_uom = sale_line.product_id.uom_id
                 sale_line_uom = sale_line.product_uom_id
                 item = sale_line.read(field_names, load=False)[0]
-                if sale_line.product_id.tracking != 'none':
+                if sale_line.product_id.tracking in ['lot', 'serial']:
                     move_lines = sale_line.move_ids.move_line_ids.filtered(lambda ml: ml.product_id.id == sale_line.product_id.id)
                     item['lot_names'] = move_lines.lot_id.mapped('name')
                     item['lot_qty_by_name'] = {line.lot_id.name: line.quantity for line in move_lines}

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -145,7 +145,7 @@ patch(PosStore.prototype, {
 
             const converted_line = converted_lines.find((l) => l.id === line.id);
             if (
-                newLine.getProduct().tracking !== "none" &&
+                ["lot", "serial"].includes(newLine.getProduct().tracking) &&
                 (this.pickingType.use_create_lots || this.pickingType.use_existing_lots) &&
                 converted_line.lot_names.length > 0
             ) {

--- a/addons/product_expiry/views/product_template_views.xml
+++ b/addons/product_expiry/views/product_template_views.xml
@@ -6,11 +6,11 @@
             <field name="inherit_id" ref="stock.view_template_property_form" />
             <field name="arch" type="xml">
                 <group name="traceability" position="inside">
-                    <field name="use_expiration_date" string="Expiration Date" invisible="tracking == 'none'"/>
+                    <field name="use_expiration_date" string="Expiration Date" invisible="tracking not in ['lot', 'serial']"/>
                 </group>
                 <group name="stock_property" position="after">
                     <group string="Dates" name="expiry_and_lots" groups="stock.group_production_lot"
-                        invisible="tracking == 'none' or not use_expiration_date">
+                        invisible="tracking not in ['lot', 'serial'] or not use_expiration_date">
                         <label for="expiration_time"/>
                         <div>
                             <field name="expiration_time" class="oe_inline"/>

--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -42,8 +42,8 @@
                 <field name="tracking" column_invisible="True"/>
                 <field name="expiration_date" decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
                  decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
-                 force_save="1" readonly="picking_type_use_existing_lots" invisible="tracking == 'none'"/>
-                <field name="removal_date" force_save="1" readonly="1" invisible="tracking == 'none'"
+                 force_save="1" readonly="picking_type_use_existing_lots" invisible="tracking not in ['lot', 'serial']"/>
+                <field name="removal_date" force_save="1" readonly="1" invisible="tracking not in ['lot', 'serial']"
                  decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')" decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
             <xpath expr="//field[@name='lot_id']" position="after">

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -30,7 +30,7 @@ class TestReorderingRule(TransactionCase):
         # create product and set the vendor
         product_form = Form(cls.env['product.product'])
         product_form.name = 'Product A'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.description = 'Internal Notes'
         with product_form.seller_ids.new() as seller:
             seller.partner_id = cls.partner
@@ -371,7 +371,7 @@ class TestReorderingRule(TransactionCase):
 
         product_form = Form(self.env['product.product'])
         product_form.name = 'Simple Product'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         with product_form.seller_ids.new() as s:
             s.partner_id = partner
             s.uom_id = product_form.uom_id
@@ -379,7 +379,7 @@ class TestReorderingRule(TransactionCase):
 
         product_form = Form(self.env['product.product'])
         product_form.name = 'Product BUY + MTO'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.route_ids.add(route_buy)
         product_form.route_ids.add(route_mto)
         with product_form.seller_ids.new() as s:
@@ -471,7 +471,7 @@ class TestReorderingRule(TransactionCase):
 
         product_form = Form(self.env['product.product'])
         product_form.name = 'Simple Product'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         with product_form.seller_ids.new() as s:
             s.partner_id = partner
             s.uom_id = product_form.uom_id
@@ -479,7 +479,7 @@ class TestReorderingRule(TransactionCase):
 
         product_form = Form(self.env['product.product'])
         product_form.name = 'Product BUY + MTO'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.route_ids.add(route_buy)
         product_form.route_ids.add(route_mto)
         with product_form.seller_ids.new() as s:

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -569,7 +569,7 @@ class RepairOrder(models.Model):
             if not repair.product_id:
                 continue
 
-            if repair.product_id.product_tmpl_id.tracking != 'none' and not repair.lot_id:
+            if repair.product_id.tracking in ['lot', 'serial'] and not repair.lot_id:
                 raise ValidationError(_(
                     "Serial number is required for product to repair : %s",
                     repair.product_id.display_name

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -154,7 +154,7 @@ class TestRepairCommon(common.TransactionCase):
                 'inventory_quantity': qty,
             }
 
-            if product.tracking != 'none':
+            if product.tracking in ['lot', 'serial']:
                 qDict['lot_id'] = cls.env['stock.lot'].create({
                     'name': name + str(offset + x),
                     'product_id': product.id,

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -146,7 +146,7 @@ class TestSaleMrpFlowCommon(ValuationReconciliationTestCommon, TestSaleCommon):
     def _cls_create_product(cls, name, uom_id, routes=()):
         p = Form(cls.env['product.product'])
         p.name = name
-        p.is_storable = True
+        p.tracking = 'none'
         p.uom_id = uom_id
         p.route_ids.clear()
         for r in routes:

--- a/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_lead_time.py
@@ -20,7 +20,7 @@ class TestSaleMrpLeadTime(TestStockCommon):
         with Form(cls.product_1) as p1:
             # `type` is invisible in the view,
             # and it's a compute field based on `type` which is the field visible in the view
-            p1.is_storable = True
+            p1.tracking = 'none'
             p1.sale_delay = 5.0
             p1.route_ids.clear()
             p1.route_ids.add(cls.warehouse_1.manufacture_pull_id.route_id)

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -41,7 +41,7 @@ class TestSaleMrpProcurement(TransactionCase):
         product.categ_id = product_category_allproductssellable0
         product.list_price = 200.0
         product.name = 'Slider Mobile'
-        product.is_storable = True
+        product.tracking = 'none'
         product.uom_id = uom_unit
         product.route_ids.clear()
         product.route_ids.add(warehouse0.manufacture_pull_id.route_id)
@@ -102,7 +102,7 @@ class TestSaleMrpProcurement(TransactionCase):
         # Create raw product for manufactured product
         product_form = Form(self.env['product.product'])
         product_form.name = 'Raw Stick'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.uom_id = self.uom_unit
         self.raw_product = product_form.save()
 
@@ -110,7 +110,7 @@ class TestSaleMrpProcurement(TransactionCase):
         product_form = Form(self.env['product.product'])
         product_form.name = 'Stick'
         product_form.uom_id = self.uom_unit
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.route_ids.clear()
         product_form.route_ids.add(self.warehouse.manufacture_pull_id.route_id)
         product_form.route_ids.add(self.warehouse.mto_pull_id.route_id)
@@ -119,7 +119,7 @@ class TestSaleMrpProcurement(TransactionCase):
         # Create manifactured product which uses another manifactured
         product_form = Form(self.env['product.product'])
         product_form.name = 'Arrow'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.route_ids.clear()
         product_form.route_ids.add(self.warehouse.manufacture_pull_id.route_id)
         product_form.route_ids.add(self.warehouse.mto_pull_id.route_id)
@@ -128,7 +128,7 @@ class TestSaleMrpProcurement(TransactionCase):
         ## Create raw product for manufactured product
         product_form = Form(self.env['product.product'])
         product_form.name = 'Raw Iron'
-        product_form.is_storable = True
+        product_form.tracking = 'none'
         product_form.uom_id = self.uom_unit
         self.raw_product_2 = product_form.save()
 

--- a/addons/stock/models/res_config_settings.py
+++ b/addons/stock/models/res_config_settings.py
@@ -152,7 +152,7 @@ class ResConfigSettings(models.TransientModel):
                     view.active = True
 
         if not self.group_stock_production_lot and previous_group.get('group_stock_production_lot'):
-            if self.env['product.product'].search_count([('tracking', '!=', 'none')], limit=1):
+            if self.env['product.product'].search_count([('tracking', 'in', ['lot', 'serial'])], limit=1):
                 raise UserError(_("You have product(s) in stock that have lot/serial number tracking enabled. \nSwitch off tracking on all the products before switching off this setting."))
 
         return

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -115,10 +115,10 @@ class StockMoveLine(models.Model):
     def _compute_lots_visible(self):
         for line in self:
             picking = line.picking_id
-            if picking.picking_type_id and line.product_id.tracking != 'none':  # TDE FIXME: not sure correctly migrated
+            if picking.picking_type_id and line.product_id.tracking in ['lot', 'serial']:
                 line.lots_visible = picking.picking_type_id.use_existing_lots or picking.picking_type_id.use_create_lots
             else:
-                line.lots_visible = line.product_id.tracking != 'none'
+                line.lots_visible = line.product_id.tracking in ['lot', 'serial']
 
     @api.depends('state')
     def _compute_picked(self):
@@ -187,7 +187,7 @@ class StockMoveLine(models.Model):
     @api.onchange('product_id', 'uom_id')
     def _onchange_product_id(self):
         if self.product_id:
-            self.lots_visible = self.product_id.tracking != 'none'
+            self.lots_visible = self.product_id.tracking in ['lot', 'serial']
 
     @api.onchange('lot_name', 'lot_id')
     def _onchange_serial_number(self):
@@ -618,7 +618,7 @@ class StockMoveLine(models.Model):
 
             qty_done_float_compared = ml.uom_id.compare(ml.quantity, 0)
             if qty_done_float_compared > 0:
-                if ml.product_id.tracking == 'none':
+                if ml.tracking not in ['lot', 'serial']:
                     continue
                 picking_type_id = ml.move_id.picking_type_id
                 if not ml._exclude_requiring_lot():

--- a/addons/stock/report/picking_templates.xml
+++ b/addons/stock/report/picking_templates.xml
@@ -25,13 +25,13 @@
 ^FO100,50
 ^A0N,44,33^FD<t t-out="move_line.product_id.display_name"/>^FS
 ^FO100,100
-<t t-if="move_line.product_id.tracking != 'none' and (move_line.lot_id or move_line.lot_name)">
+<t t-if="move_line.product_id.tracking in ['lot', 'serial'] and (move_line.lot_id or move_line.lot_name)">
 ^A0N,44,33^FDLN/SN: <t t-out="move_line.lot_id.name or move_line.lot_name"/>^FS
 ^FO100,150^BY3
 ^BCN,100,Y,N,N
 ^FD<t t-out="move_line.lot_id.name or move_line.lot_name"/>^FS
 </t>
-<t t-if="move_line.product_id.tracking == 'none' and move_line.product_id.barcode">
+<t t-if="(move_line.product_id.tracking not in ['lot', 'serial']) and move_line.product_id.barcode">
 ^BCN,100,Y,N,N
 ^FD<t t-out="move_line.product_id.barcode"/>^FS
 </t>
@@ -71,7 +71,7 @@
                                                         <span t-out="move.product_id.display_name"/>
                                                     </th>
                                                 </tr>
-                                                <t t-if="move_line.product_id.tracking != 'none'">
+                                                <t t-if="move_line.product_id.tracking in ['lot', 'serial']">
                                                     <tr>
                                                         <td class="text-center align-middle">
                                                             <t t-if="move_line.lot_name or move_line.lot_id">
@@ -84,7 +84,7 @@
                                                         </td>
                                                     </tr>
                                                 </t>
-                                                <t t-if="move_line.product_id.tracking == 'none'">
+                                                <t t-if="move_line.product_id.tracking not in ['lot', 'serial']">
                                                     <tr>
                                                         <td class="text-center align-middle" style="height: 6rem;">
                                                             <t t-if="move_line.product_id.barcode">

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -328,7 +328,7 @@ class TestVirtualAvailable(TestStockCommon):
         product_form = Form(product)
         product_form.type = 'service'
         product = product_form.save()
-        self.assertEqual(product.tracking, 'none')
+        self.assertEqual(product.tracking, False)
 
         product.is_storable = True
         product.tracking = 'serial'
@@ -337,7 +337,7 @@ class TestVirtualAvailable(TestStockCommon):
         product_form = Form(product.product_variant_id)
         product_form.type = 'service'
         product = product_form.save()
-        self.assertEqual(product.tracking, 'none')
+        self.assertEqual(product.tracking, False)
 
     def test_domain_locations_only_considers_selected_companies(self):
         product = self.env['product.product'].create({'name': 'Product', 'is_storable': True})

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -33,11 +33,11 @@ class TestReportsCommon(TransactionCase):
             'tracking': 'serial',
         })
 
-        product_form = Form(cls.env['product.product'])
-        product_form.is_storable = True
-        product_form.name = 'Product'
-        product_form.categ_id = cls.env.ref('product.product_category_goods')
-        cls.product = product_form.save()
+        cls.product = cls.env['product.product'].create({
+            'name': 'Product',
+            'categ_id': cls.env.ref('product.product_category_goods').id,
+            'tracking': 'none',
+        })
         cls.product_template = cls.product.product_tmpl_id
         cls.wh_2 = cls.env['stock.warehouse'].create({
             'name': 'Evil Twin Warehouse',

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -180,15 +180,16 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
+                <xpath expr="//label[@for='is_storable']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
                 <xpath expr="//div[@name='tracking_and_qty_no_stock']" position="replace">
                     <!-- Replace the single line tacking + qty without stock with 2 individual lines with stock (tracking + tracking method // qty) -->
-                    <div name="tracking_with_stock" class="o_row w-100" invisible="type != 'consu'">
-                        <field name="is_storable"/>
-                    </div>
-                    <field name="tracking" invisible="not is_storable" groups="stock.group_production_lot"/>
+                    <field name="is_storable" groups="!stock.group_production_lot"/>
+                    <field name="tracking" placeholder="None" invisible="type != 'consu'" groups="stock.group_production_lot"/>
                     <!-- Qty line if storable -->
-                    <label for="qty_available" class="oe_inline" invisible="not is_storable" groups="stock.group_stock_user"/>
-                    <div name="qty_available_with_stock" class="o_row" invisible="not is_storable" groups="stock.group_stock_user">
+                    <label for="qty_available" class="oe_inline" invisible="not is_storable or not tracking" groups="stock.group_stock_user"/>
+                    <div name="qty_available_with_stock" class="o_row" invisible="not is_storable or not tracking" groups="stock.group_stock_user">
                         <a type="object" name="action_open_quants"
                            invisible="not show_qty_update_button" groups="stock.group_stock_manager">
                             <field name="qty_available" readonly="True"/>
@@ -219,9 +220,9 @@
                     </group>
                 </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="after">
-                    <group string="Traceability" name="traceability" groups="stock.group_production_lot" invisible="tracking == 'none'">
-                        <label for="serial_prefix_format" string="Custom Lot/Serial" invisible="tracking == 'none'"/>
-                        <div class="d-flex" invisible="tracking == 'none'">
+                    <group string="Traceability" name="traceability" groups="stock.group_production_lot" invisible="tracking not in ['lot', 'serial']">
+                        <label for="serial_prefix_format" string="Custom Lot/Serial" invisible="tracking not in ['lot', 'serial']"/>
+                        <div class="d-flex" invisible="tracking not in ['lot', 'serial']">
                             <field name="serial_prefix_format" style="max-width: 150px;"/>
                             <field name="next_serial" style="max-width: 150px;"/>
                         </div>
@@ -391,7 +392,7 @@
                             </button>
                             <button type="object"
                                 name="action_open_product_lot"
-                                invisible="tracking == 'none'"
+                                invisible="tracking not in ['lot', 'serial']"
                                 class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot">
                                 <div class="o_stat_info">
                                     <span class="o_stat_text">Lot/Serial Numbers</span>
@@ -514,7 +515,7 @@
                             </button>
                             <button type="object"
                                 name="action_open_product_lot"
-                                invisible="tracking == 'none'"
+                                invisible="tracking not in ['lot', 'serial']"
                                 class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot">
                                 <div class="o_stat_info">
                                     <span class="o_stat_text">Lot/Serial Numbers</span>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -96,9 +96,9 @@
                                 <field name="uom_id" options="{'no_create': True}" widget="many2one_uom" groups="uom.group_uom"/>
                             </div>
                             <field name="lot_id" groups="stock.group_production_lot" context="{'default_product_id': product_id, 'active_picking_id': picking_id}"
-                                   invisible="tracking == 'none' or not lot_id and lot_name"/>
+                                   invisible="tracking not in ['lot', 'serial'] or not lot_id and lot_name"/>
                             <field name="lot_name" groups="stock.group_production_lot"
-                                   invisible="tracking == 'none' or lot_id or not lot_name"/>
+                                   invisible="tracking not in ['lot', 'serial'] or lot_id or not lot_name"/>
                             <field name="package_id" string="Source Package" groups="stock.group_tracking_lot"/>
                             <field name="result_package_id" string="Destination Package" groups="stock.group_tracking_lot"/>
                             <field name="owner_id" string="Owner" groups="stock.group_tracking_owner"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -187,7 +187,7 @@
                         column_invisible="not parent.show_quant"
                         options="{'no_create': True, 'no_open': True}"/>
                     <field name="lot_id" groups="stock.group_production_lot"
-                        column_invisible="parent.show_quant or parent.has_tracking == 'none' or not parent.show_lots_m2o"
+                        column_invisible="parent.show_quant or parent.has_tracking not in ['lot', 'serial'] or not parent.show_lots_m2o"
                         domain="[('product_id', '=', parent.product_id), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
                         context="{
                             'active_picking_id': picking_id,
@@ -195,7 +195,7 @@
                         }"/>
                     <field name="lot_name" string="Lot/Serial Number" groups="stock.group_production_lot"
                         placeholder="e.g. SN000001"
-                        column_invisible="parent.has_tracking == 'none' or not parent.show_lots_text"/>
+                        column_invisible="parent.has_tracking not in ['lot', 'serial'] or not parent.show_lots_text"/>
                     <field name="location_dest_id" string="Store To"
                         column_invisible="parent.show_quant and parent.picking_code != 'internal'"
                         domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -311,7 +311,7 @@
                                     <field name="lot_ids" widget="many2many_tags"
                                         column_invisible="parent.state == 'draft'"
                                         groups="stock.group_production_lot"
-                                        invisible="not show_details_visible or has_tracking == 'none'"
+                                        invisible="not show_details_visible or has_tracking not in ['serial', 'lot']"
                                         optional="hide"
                                         create="parent.use_create_lots == True"
                                         context="{'default_company_id': company_id, 'default_product_id': product_id, 'active_picking_id': parent.id}"

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -74,7 +74,7 @@
                             <field name="location_id" readonly="0" options="{'no_create': True}"/>
                             <field name="lot_id" groups="stock.group_production_lot"
                                 readonly="tracking not in ['serial', 'lot']"
-                                required="tracking != 'none'"
+                                required="tracking in ['serial', 'lot']"
                                 context="{'default_product_id': product_id}"/>
                             <field name="package_id" readonly="0" groups="stock.group_tracking_lot" context="{'show_src_package': 1}"/>
                             <field name="owner_id" readonly="0" groups="stock.group_tracking_owner" options="{'no_create': True}"/>

--- a/addons/stock/wizard/stock_inventory_conflict.xml
+++ b/addons/stock/wizard/stock_inventory_conflict.xml
@@ -27,7 +27,7 @@
                             <field name="company_id" column_invisible="True"/>
                             <field name="product_id" readonly="context.get('single_product', False) or id" column_invisible="context.get('single_product', False)" force_save="1" options="{'no_create': True}"/>
                             <field name="location_id" column_invisible="context.get('hide_location', False)" readonly="id" options="{'no_create': True}"/>
-                            <field name="lot_id" groups="stock.group_production_lot" column_invisible="context.get('hide_lot', False)" readonly="id or tracking not in ['serial', 'lot']" required="tracking != 'none'" context="{'default_product_id': product_id}"/>
+                            <field name="lot_id" groups="stock.group_production_lot" column_invisible="context.get('hide_lot', False)" readonly="id or tracking not in ['serial', 'lot']" required="tracking in ['serial', 'lot']" context="{'default_product_id': product_id}"/>
                             <field name="package_id" groups="stock.group_tracking_lot" readonly="id"/>
                             <field name="owner_id" groups="stock.group_tracking_owner" readonly="id" options="{'no_create': True}"/>
                             <field name="quantity" string="Quantity"/>

--- a/addons/stock/wizard/stock_request_count.py
+++ b/addons/stock/wizard/stock_request_count.py
@@ -32,7 +32,7 @@ class StockRequestCount(models.TransientModel):
     def _get_quants_to_count(self):
         self.ensure_one()
         quants_to_count = self.quant_ids
-        tracked_quants = self.quant_ids.filtered(lambda q: q.product_id.tracking != 'none')
+        tracked_quants = self.quant_ids.filtered(lambda q: q.product_id.tracking in ['lot', 'serial'])
         if not self.env.user.has_group('stock.group_production_lot') or not tracked_quants:
             return quants_to_count
         # Searches sibling quants for tracked product.

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -49,10 +49,10 @@ class ProductTemplate(models.Model):
         domain_company = Domain(['|', ('categ_id.property_valuation', '=', False), ('categ_id', '=', False), ('company_id.inventory_valuation', operator, value)])
         return domain_company | domain_categ
 
-    @api.depends('tracking')
+    @api.depends('tracking', 'is_storable')
     def _compute_lot_valuated(self):
         for product in self:
-            if product.tracking == 'none':
+            if product.tracking not in ['lot', 'serial']:
                 product.lot_valuated = False
 
     @api.depends_context('company')

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -46,7 +46,7 @@
             <field name="inherit_id" ref="stock.view_template_property_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//label[@for='serial_prefix_format']" position="before">
-                    <field name="lot_valuated" widget="confirm_boolean" invisible="tracking == 'none'"/>
+                    <field name="lot_valuated" widget="confirm_boolean" invisible="tracking not in ['lot', 'serial']"/>
                 </xpath>
             </field>
         </record>

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -108,7 +108,17 @@ class TestStockMoveInvoice(TestSaleCommon):
         serial_numbers = self.env['stock.lot'].create([{
             'name': str(x),
             'product_id': self.product_cable_management_box.id,
-        } for x in range(5)])
+        } for x in range(2)])
+
+        # Add stock for the serial numbers
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        for lot in serial_numbers:
+            self.env['stock.quant']._update_available_quantity(
+                self.product_cable_management_box,
+                warehouse.lot_stock_id,
+                1,
+                lot_id=lot
+            )
 
         self.sale_prepaid = self.SaleOrder.create({
             'partner_id': self.partner_18.id,

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -59,10 +59,12 @@ registry.category("web_tour.tours").add('main_flow_tour', {
     tooltipPosition: 'left',
     run: "edit the_flow.product",
 }, {
-    trigger: ".o_field_widget[name=is_storable] input",
-    content: _t("Let's enter the product type"),
+    trigger: ".o_field_widget[name=tracking] input",
+    content: _t("Un-set product tracking"),
     tooltipPosition: 'right',
-    run: "click",
+    run: function({ anchor }) {
+        anchor.value = "";
+    },
 }, {
     trigger: '.o_notebook .nav-link:contains("Inventory")',
     content: _t('Go to inventory tab'),


### PR DESCRIPTION
This commit allows the value of `tracking` field on `product.product` to
be false. The main purpose of this, is that currently on the form of
`product.product` there are two fields that represent the same fact in a
way or another, which are `tracking` and `is_storable`. Since this may
be confusing, we remove `is_storable` field from the view if `stock` is
installed, and only leave `tracking`. If the user wants a product to be
not tracked, they just leave the field empty.

Task-5446456
