### PR TITLE
[FIX] orm: error message for custom field access rules

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3557,6 +3557,8 @@ class BaseModel(metaclass=MetaModel):
         if self.env.user._has_group('base.group_no_one'):
             if field.groups == NO_ACCESS:
                 allowed_groups_msg = _("always forbidden")
+            elif not field.groups:
+                allowed_groups_msg = _("custom field access rules")
             else:
                 groups_list = [self.env.ref(g) for g in field.groups.split(',')]
                 groups = self.env['res.groups'].union(*groups_list).sorted('id')


### PR DESCRIPTION
Method `_check_field_access` may raise for fields that have no groups, in case there are custom field access rules.  Simply make the details of the error message less confusing.

backport of https://github.com/odoo/odoo/pull/231159

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
