### PR TITLE
[IMP] account: hide portal preview button in vendor bill email notifcations

### DIFF
--- a/addons/account/data/mail_template_data.xml
+++ b/addons/account/data/mail_template_data.xml
@@ -496,7 +496,7 @@
                                 <strong style="color:#2c2431;">Files included:</strong> the original document(s) are attached for your convenience.
                             </div>
 
-                            <div style="margin-top:32px; text-align:center;">
+                            <div style="margin-top:32px; text-align:center;" t-if="object.move_type != 'in_invoice'">
                                 <a t-if="portal_url" t-attf-href="{{ portal_url }}"
                                    style="display:inline-block; margin:0 10px 14px; padding:13px 30px; min-width:210px; background:linear-gradient(135deg,#714B67 0%,#9b77a3 100%); color:#FFFFFF; text-decoration:none; border-radius:12px; font-weight:600; font-size:14px;"
                                    target="_blank">

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -174,8 +174,7 @@
                                             <field name="alias_domain_id" placeholder="e.g. mycompany.com" options="{'no_create': True, 'no_open': True}"/>
                                         </div>
                                         <field name="incoming_einvoice_notification_email"
-                                               widget="CopyClipboardChar"
-                                               placeholder="e.g. finance@example.com; billing@example.com"
+                                               placeholder="e.g. finance@example.com; accountant@example.com"
                                                class="w-100"/>
                                     </group>
                                     <!-- edi -->


### PR DESCRIPTION
Vendor bill emails are meant to include the vendor’s original PDF rather than an Odoo-generated invoice. The "Preview on Portal" button was hidden to avoid facing errors in the portal payment page.

Additionally, remove the CopyClipboardChar widget from the "incoming_einvoice_notification_email" field to make the input placeholder visible.

task-5438315

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
