### PR TITLE
[IMP] web: allow horizontal arrows to close autocomplete and focus tags

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -443,6 +443,15 @@ export class AutoComplete extends Component {
                 }
                 this.scroll();
                 break;
+            case "arrowleft":
+            case "arrowright":
+                if (!this.isOpened || this.inputRef.el.value.length) {
+                    return;
+                }
+                this.cancel();
+                // Let ArrowLeft/ArrowRight propagate to ensure focus transition
+                // from the options dropdown to the neighbor element
+                return;
             default:
                 return;
         }

--- a/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
+++ b/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
@@ -35,9 +35,7 @@ export function useTagNavigation(refName, options = {}) {
     const canNavigateFromInput = (navigator, navNext) => {
         const el = navigator.activeItem.el;
         if (el.classList.contains("o-autocomplete--input")) {
-            const menu = tagsContainerRef.el.querySelector(".o-autocomplete--dropdown-menu");
-            const index = navNext ? el.value.length : 0;
-            if (el.selectionStart !== index || menu) {
+            if (el.value.length) {
                 return false;
             }
         }


### PR DESCRIPTION
### This PR addresses:

Allow horizontal arrows to close autocomplete and focus tags. It makes it easier to move from typing a tag to selecting the tags you already added.

### Current behavior before PR:

When the search dropdown is open, you can't use the **LEFT/RIGHT** arrows to jump back to your existing tags. You have to close the menu first or use the mouse.

### Desired behavior after PR is merged:

* **Auto-Close:** Pressing **LEFT/RIGHT** closes the dropdown if the input is empty.
* **Smart Focus:** It automatically moves your focus from the input to the tags list.
* **Better Flow:** I allowed the keys to "bubble up" so they trigger the tag navigation naturally without breaking anything.
* **Fast Editing:** It makes it way faster to jump back and delete or change tags using only the keyboard.

#### Task-5162888
