### PR TITLE
[FIX] pos_self_order: traceback order from kiosk

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1256,7 +1256,7 @@ class PosOrder(models.Model):
         account_moves = self.sudo().account_move | self.sudo().payment_ids.account_move_id
         return {
             'pos.order': self._load_pos_data_read(self, config) if config else [],
-            'pos.session': self.env['pos.session']._load_pos_data_read(self.session_id, config) if config else [],
+            'pos.session': [],
             'pos.payment': self.env['pos.payment']._load_pos_data_read(self.payment_ids, config) if config else [],
             'pos.order.line': self.env['pos.order.line']._load_pos_data_read(self.lines, config) if config else [],
             'pos.pack.operation.lot': self.env['pos.pack.operation.lot']._load_pos_data_read(self.lines.pack_lot_ids, config) if config else [],


### PR DESCRIPTION
When loading orders from a different session inside the POS (such as loading kiosk orders to pay inside the main POS), the session data is loaded together with the orders. The POS assumes that if there are multiple pos.session models in the data, it means that one of them is a recovery session, so it will try to delete the old one and replace it with the recovery session.

Because the self order session is loaded in the data, it will delete the main POS session, which will then cause the POS to crash any time it needs session data, as that will be undefined. If we don't load the session data together with the order, this will be avoided.

Task-[547989](https://www.odoo.com/odoo/project/1737/tasks/5473989)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
