### PR TITLE
[IMP] mail: Use partner-id for messages card popover.

### DIFF
--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -55,7 +55,7 @@ patch(Message.prototype, {
         };
     },
     hasAuthorClickable() {
-        return this.message.author_id?.main_user_id;
+        return this.message.author_id;
     },
     onClickAuthor(ev) {
         if (this.hasAuthorClickable()) {
@@ -63,7 +63,8 @@ patch(Message.prototype, {
             const target = ev.currentTarget;
             if (!this.avatarCard.isOpen) {
                 this.avatarCard.open(target, {
-                    id: this.message.author_id.main_user_id.id,
+                    id: this.message.author_id.id,
+                    model: "res.partner"
                 });
             }
         }


### PR DESCRIPTION
Description:
In order to unify the UI for all communication modes in the Discuss app, we have updated the setup of message popover cards to use the res_partner ID.

Previously, the Discuss app specifically required a res_user ID for these cards, which meant messages from partners without a linked user account did not display a popover. By switching to the partner ID, we ensure that all participants—regardless of user status—have functional popover cards and consistent access to their partner pages.

task-5333399