### PR TITLE
[FIX] portal: message sent from chatter triggers page view

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -137,7 +137,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
                 download=download,
             )
 
-        if request.env.user.share and access_token:
+        if request.env.user.share and access_token and request.is_frontend:
             # If a public/portal user accesses the order with the access token
             # Log a note on the chatter.
             today = fields.Date.today().isoformat()


### PR DESCRIPTION
When a link to the portal is sent from the chatter via message or log note, the preview of the link triggers that the page was viewed by customer.

As a solution, now we will check if it was viewed from browser with request.is_frontend

opw-5237785



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
