### PR TITLE
[IMP] portal: add owl_props and owl_component helpers for OWL integra…

### DIFF
--- a/addons/portal/models/ir_qweb.py
+++ b/addons/portal/models/ir_qweb.py
@@ -1,8 +1,85 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from markupsafe import Markup
+
 from odoo import models
 from odoo.tools import is_html_empty, lazy
+from odoo.tools.json import scriptsafe, json_default
+
+
+def owl_props(value, fields=None, **extra):
+    """Serialize a value to JSON props for owl-component.
+
+    This helper function serializes Python objects (including ORM records) to
+    JSON format suitable for passing as props to OWL components via the
+    `<owl-component>` tag.
+
+    Usage in QWeb templates::
+
+        <owl-component name="my.component" t-att-props="owl_props({'key': value})"/>
+        <owl-component name="my.component" t-att-props="owl_props(record, fields=['name', 'email'])"/>
+        <owl-component name="my.component" t-att-props="owl_props(record, fields=['name'], extra_prop=True)"/>
+
+    :param value: dict, ORM record, or other JSON-serializable value
+    :param fields: For ORM records, optional list of field names to include.
+                   Defaults to ['display_name'] for safety.
+    :param extra: Additional key-value pairs to merge into props (for dict values)
+    :return: JSON string safe for HTML attribute embedding
+    """
+    def serialize(obj, flds=None):
+        from odoo.models import BaseModel
+        if isinstance(obj, BaseModel):
+            if not obj:
+                return None if len(obj) <= 1 else []
+            read_fields = flds or ['display_name']
+            if 'id' not in read_fields:
+                read_fields = ['id'] + list(read_fields)
+            return obj.read(read_fields)[0] if len(obj) == 1 else obj.read(read_fields)
+        elif isinstance(obj, dict):
+            return {k: serialize(v) for k, v in obj.items()}
+        elif isinstance(obj, (list, tuple)):
+            return [serialize(item) for item in obj]
+        return obj
+
+    serialized = serialize(value, fields)
+    if isinstance(serialized, dict):
+        serialized.update(extra)
+    elif extra:
+        serialized = {'value': serialized, **extra}
+    return scriptsafe.dumps(serialized, default=json_default)
+
+
+def owl_component(name, props=None, **attrs):
+    """Generate an <owl-component> tag with properly serialized props.
+
+    This helper generates complete owl-component markup that will be mounted
+    by the PublicComponentInteraction class on the client side.
+
+    Usage in QWeb templates::
+
+        <t t-out="owl_component('portal.signature_form', {'callUrl': call_url})"/>
+        <t t-out="owl_component('my.component', props, class_='my-class')"/>
+
+    :param name: The component name registered in the public_components registry
+    :param props: Dictionary of props to pass to the component
+    :param attrs: Additional HTML attributes for the owl-component tag.
+                  Trailing underscores are stripped (e.g., class_ -> class) and
+                  remaining underscores are converted to hyphens (e.g., data_test -> data-test).
+    :return: Markup-safe HTML string
+    """
+    attr_parts = [f'name="{Markup.escape(name)}"']
+    if props:
+        props_json = scriptsafe.dumps(props, default=json_default)
+        attr_parts.append(f'props="{Markup.escape(props_json)}"')
+    for attr_name, attr_value in attrs.items():
+        if attr_value is not None:
+            # Strip trailing underscore (Python convention to avoid reserved words like class_)
+            # then convert remaining underscores to hyphens (data_test -> data-test)
+            escaped_name = attr_name.rstrip("_").replace("_", "-")
+            escaped_value = Markup.escape(str(attr_value))
+            attr_parts.append(f'{escaped_name}="{escaped_value}"')
+    return Markup(f'<owl-component {" ".join(attr_parts)}></owl-component>')
 
 
 class IrQweb(models.AbstractModel):
@@ -15,7 +92,10 @@ class IrQweb(models.AbstractModel):
         irQweb = super()._prepare_frontend_environment(values)
         values.update(
             is_html_empty=is_html_empty,
-            frontend_languages=lazy(lambda: irQweb.env['res.lang']._get_frontend())
+            frontend_languages=lazy(lambda: irQweb.env['res.lang']._get_frontend()),
+            # OWL component helpers for embedding OWL components in server-rendered templates
+            owl_props=owl_props,
+            owl_component=owl_component,
         )
         for key in irQweb.env.context:
             if key not in values:

--- a/addons/portal/tests/__init__.py
+++ b/addons/portal/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import test_addresses
 from . import test_login
 from . import test_message_format_portal
+from . import test_owl_component_helpers
 from . import test_pager
 from . import test_portal
 from . import test_portal_wizard

--- a/addons/portal/tests/test_owl_component_helpers.py
+++ b/addons/portal/tests/test_owl_component_helpers.py
@@ -1,0 +1,266 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+from lxml import etree
+from markupsafe import Markup
+
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.portal.models.ir_qweb import owl_props, owl_component
+
+
+class TestOwlComponentHelpers(TransactionCase):
+    """Test the owl_props and owl_component helper functions.
+
+    These helpers simplify embedding OWL components in server-rendered QWeb
+    templates by providing easy serialization of Python objects to JSON props.
+    """
+
+    def test_owl_props_simple_dict(self):
+        """Test owl_props with a simple dictionary."""
+        result = owl_props({'key': 'value', 'number': 42})
+        # Result should be a valid JSON string
+        parsed = json.loads(str(result))
+        self.assertEqual(parsed, {'key': 'value', 'number': 42})
+
+    def test_owl_props_nested_dict(self):
+        """Test owl_props with nested dictionaries."""
+        result = owl_props({
+            'outer': {
+                'inner': 'value',
+                'list': [1, 2, 3]
+            }
+        })
+        parsed = json.loads(str(result))
+        self.assertEqual(parsed['outer']['inner'], 'value')
+        self.assertEqual(parsed['outer']['list'], [1, 2, 3])
+
+    def test_owl_props_with_extra_kwargs(self):
+        """Test owl_props merges extra keyword arguments."""
+        result = owl_props({'key': 'value'}, extra_key='extra_value', another=123)
+        parsed = json.loads(str(result))
+        self.assertEqual(parsed['key'], 'value')
+        self.assertEqual(parsed['extra_key'], 'extra_value')
+        self.assertEqual(parsed['another'], 123)
+
+    def test_owl_props_single_record(self):
+        """Test owl_props with a single ORM record."""
+        partner = self.env['res.partner'].create({
+            'name': 'Test Partner',
+            'email': 'test@example.com',
+        })
+        result = owl_props(partner, fields=['name', 'email'])
+        parsed = json.loads(str(result))
+
+        # Should include id (always added) plus requested fields
+        self.assertEqual(parsed['id'], partner.id)
+        self.assertEqual(parsed['name'], 'Test Partner')
+        self.assertEqual(parsed['email'], 'test@example.com')
+
+    def test_owl_props_record_default_fields(self):
+        """Test owl_props with a record using default fields."""
+        partner = self.env['res.partner'].create({
+            'name': 'Default Fields Partner',
+        })
+        result = owl_props(partner)
+        parsed = json.loads(str(result))
+
+        # Default should include id and display_name
+        self.assertEqual(parsed['id'], partner.id)
+        self.assertEqual(parsed['display_name'], 'Default Fields Partner')
+
+    def test_owl_props_multiple_records(self):
+        """Test owl_props with multiple ORM records."""
+        partners = self.env['res.partner'].create([
+            {'name': 'Partner 1'},
+            {'name': 'Partner 2'},
+        ])
+        result = owl_props(partners, fields=['name'])
+        parsed = json.loads(str(result))
+
+        self.assertIsInstance(parsed, list)
+        self.assertEqual(len(parsed), 2)
+        self.assertEqual(parsed[0]['name'], 'Partner 1')
+        self.assertEqual(parsed[1]['name'], 'Partner 2')
+
+    def test_owl_props_empty_recordset(self):
+        """Test owl_props with an empty recordset."""
+        empty_partners = self.env['res.partner'].browse([])
+        result = owl_props(empty_partners)
+        parsed = json.loads(str(result))
+        self.assertEqual(parsed, [])
+
+    def test_owl_props_record_in_dict(self):
+        """Test owl_props with a record nested in a dictionary."""
+        partner = self.env['res.partner'].create({'name': 'Nested Partner'})
+        result = owl_props({
+            'partner': partner,
+            'extra': 'value'
+        }, fields=['name'])
+        parsed = json.loads(str(result))
+
+        self.assertEqual(parsed['extra'], 'value')
+        self.assertEqual(parsed['partner']['name'], 'Nested Partner')
+
+    def test_owl_props_xss_safety(self):
+        """Test owl_props escapes potentially dangerous characters."""
+        result = owl_props({'script': '</script><script>alert("xss")</script>'})
+        # The result should escape < and > for safety when embedded in HTML
+        result_str = str(result)
+        self.assertNotIn('</script>', result_str)
+        # Should use unicode escapes
+        self.assertIn('\\u003c', result_str)  # <
+        self.assertIn('\\u003e', result_str)  # >
+
+    def test_owl_component_simple(self):
+        """Test owl_component generates correct markup."""
+        result = owl_component('my.component')
+
+        self.assertIsInstance(result, Markup)
+        tree = etree.fromstring(str(result))
+        self.assertEqual(tree.tag, 'owl-component')
+        self.assertEqual(tree.get('name'), 'my.component')
+
+    def test_owl_component_with_props(self):
+        """Test owl_component with props."""
+        result = owl_component('my.component', {'key': 'value', 'num': 42})
+
+        tree = etree.fromstring(str(result))
+        self.assertEqual(tree.get('name'), 'my.component')
+
+        props_json = tree.get('props')
+        self.assertIsNotNone(props_json)
+        parsed_props = json.loads(props_json)
+        self.assertEqual(parsed_props['key'], 'value')
+        self.assertEqual(parsed_props['num'], 42)
+
+    def test_owl_component_with_attrs(self):
+        """Test owl_component with additional attributes."""
+        result = owl_component('my.component', {'key': 'value'}, class_='my-class', id='my-id')
+
+        tree = etree.fromstring(str(result))
+        self.assertEqual(tree.get('name'), 'my.component')
+        self.assertEqual(tree.get('class'), 'my-class')
+        self.assertEqual(tree.get('id'), 'my-id')
+
+    def test_owl_component_underscore_to_hyphen(self):
+        """Test owl_component handles underscores in attribute names correctly.
+
+        - Trailing underscores are stripped (class_ -> class)
+        - Internal underscores are converted to hyphens (data_test -> data-test)
+        """
+        result = owl_component('my.component', None, data_test='value', aria_label='label', class_='my-class')
+
+        tree = etree.fromstring(str(result))
+        self.assertEqual(tree.get('data-test'), 'value')
+        self.assertEqual(tree.get('aria-label'), 'label')
+        self.assertEqual(tree.get('class'), 'my-class')  # trailing underscore stripped
+
+    def test_owl_component_escapes_name(self):
+        """Test owl_component escapes special characters in name."""
+        result = owl_component('my.component<script>')
+
+        # Should not contain unescaped script tag
+        self.assertNotIn('<script>', str(result))
+        self.assertIn('&lt;script&gt;', str(result))
+
+    def test_owl_component_none_attrs_ignored(self):
+        """Test owl_component ignores None attribute values."""
+        result = owl_component('my.component', None, class_='visible', hidden=None)
+
+        tree = etree.fromstring(str(result))
+        self.assertEqual(tree.get('class'), 'visible')
+        self.assertIsNone(tree.get('hidden'))
+
+
+class TestOwlHelpersInEnvironment(TransactionCase):
+    """Test that owl helpers are available in the frontend template environment."""
+
+    def test_helpers_in_frontend_environment(self):
+        """Test that owl_props and owl_component are available in templates."""
+        irQweb = self.env['ir.qweb']
+        values = {}
+        irQweb._prepare_frontend_environment(values)
+
+        self.assertIn('owl_props', values)
+        self.assertIn('owl_component', values)
+        self.assertEqual(values['owl_props'], owl_props)
+        self.assertEqual(values['owl_component'], owl_component)
+
+    def test_render_template_with_owl_props(self):
+        """Test rendering a template using owl_props helper."""
+        view = self.env['ir.ui.view'].create({
+            'key': 'portal.test_owl_props',
+            'type': 'qweb',
+            'arch': '''<t t-name="test_owl_props">
+                <owl-component name="test.component" t-att-props="owl_props({'key': value})"/>
+            </t>'''
+        })
+
+        # Render with frontend environment to have owl_props available
+        irQweb = self.env['ir.qweb']
+        values = {'value': 'test_value'}
+        irQweb._prepare_frontend_environment(values)
+
+        html = view._render_template(view.id, values)
+        tree = etree.fromstring(f'<root>{html}</root>')
+        owl_comp = tree.find('.//owl-component')
+
+        self.assertIsNotNone(owl_comp)
+        self.assertEqual(owl_comp.get('name'), 'test.component')
+
+        props = json.loads(owl_comp.get('props'))
+        self.assertEqual(props['key'], 'test_value')
+
+    def test_render_template_with_owl_component(self):
+        """Test rendering a template using owl_component helper."""
+        view = self.env['ir.ui.view'].create({
+            'key': 'portal.test_owl_component',
+            'type': 'qweb',
+            'arch': '''<t t-name="test_owl_component">
+                <t t-out="owl_component('test.component', {'data': data}, class_='my-class')"/>
+            </t>'''
+        })
+
+        irQweb = self.env['ir.qweb']
+        values = {'data': 'test_data'}
+        irQweb._prepare_frontend_environment(values)
+
+        html = view._render_template(view.id, values)
+        tree = etree.fromstring(f'<root>{html}</root>')
+        owl_comp = tree.find('.//owl-component')
+
+        self.assertIsNotNone(owl_comp)
+        self.assertEqual(owl_comp.get('name'), 'test.component')
+        self.assertEqual(owl_comp.get('class'), 'my-class')
+
+        props = json.loads(owl_comp.get('props'))
+        self.assertEqual(props['data'], 'test_data')
+
+    def test_render_template_with_record_props(self):
+        """Test rendering a template with ORM record as props."""
+        partner = self.env['res.partner'].create({
+            'name': 'Template Test Partner',
+            'email': 'template@test.com',
+        })
+
+        view = self.env['ir.ui.view'].create({
+            'key': 'portal.test_owl_record',
+            'type': 'qweb',
+            'arch': '''<t t-name="test_owl_record">
+                <owl-component name="partner.card" t-att-props="owl_props(partner, fields=['name', 'email'])"/>
+            </t>'''
+        })
+
+        irQweb = self.env['ir.qweb']
+        values = {'partner': partner}
+        irQweb._prepare_frontend_environment(values)
+
+        html = view._render_template(view.id, values)
+        tree = etree.fromstring(f'<root>{html}</root>')
+        owl_comp = tree.find('.//owl-component')
+
+        props = json.loads(owl_comp.get('props'))
+        self.assertEqual(props['id'], partner.id)
+        self.assertEqual(props['name'], 'Template Test Partner')
+        self.assertEqual(props['email'], 'template@test.com')

--- a/doc/cla/individual/calm329.md
+++ b/doc/cla/individual/calm329.md
@@ -1,0 +1,11 @@
+United States, 2026-01-09
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Oliver Anderson calmdev0329@gmail.com https://github.com/calm329


### PR DESCRIPTION
Fixes #241406

Current behavior before PR:

Developers must manually serialize Python objects to JSON and handle HTML escaping when passing props to OWL components in QWeb templates, leading to boilerplate code and potential XSS vulnerabilities if not done correctly.

Desired behavior after PR is merged:

Two new helper functions are available in all frontend templates via _prepare_frontend_environment():

- owl_props(value, fields, **extra): Serializes Python objects (including ORM records) to JSON props safe for HTML embedding
- owl_component(name, props, **attrs): Generates complete <owl-component> markup with properly escaped props and attributes

Usage:
```
<owl-component name="my.comp" t-att-props="owl_props(record, fields=['name'])"/>
<t t-out="owl_component('my.comp', {'key': value}, class_='my-class')"/>
```
---

I confirm I have signed the CLA and read the PR guidelines at http://www.odoo.com/submit-pr

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=148254234