### PR TITLE
[FIX] calendar,marketing_automation: set mail recipients using attendees on calendar event

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1634,3 +1634,12 @@ class Meeting(models.Model):
         res = res or ir_default_get('calendar.event', 'duration', company_id=True)
         res = res or ir_default_get('calendar.event', 'duration')
         return res or 1
+
+    def _message_get_default_recipients(self):
+        return {
+            e.id: {
+                'partner_ids': e.attendee_ids.mapped('partner_id.id'),
+                'email_to': False,
+                'email_cc': False,
+            } for e in self
+        }


### PR DESCRIPTION
**Steps to reproduce:**
- Install Calendar and Marketing Automation apps
- Go to Calendar
- Add an event with multiple attendees
- Go to Marketing Automation
- Create the marketing automation campaign
- Select `Calendar Event` as target
- Filter to only get your event
- Add an activity with a template
- Launch a test or start the campaign
- Mail is only sent to the owner of the event, not all the participants

Fixed in 19.0 as the attendees also receive the mail

Could also be reproduced with a more useful flow using appointment:
- Add appointment type
- Create meeting on it with a name, attendees, and status set to checked-in
- Create a mail automation campaign for Calendar Event
- Filter on [("appointment_status", "=", "attended")]

**Issue:**
Goal was to set a feedback mail which triggers after a calendar meeting was done. But the recipients are set using the `partner_id` of the record in: 
`default_recipients = RecordsModel.browse(res_ids)._message_get_default_recipients()`

**Fix:**
Override `_message_get_default_recipients` to get the `partner_ids` of all the attendees.

opw-5266543
