### PR TITLE
[FIX] website_sale_collect: fix shop add to cart

### DIFF
--- a/addons/website_sale_collect/models/website.py
+++ b/addons/website_sale_collect/models/website.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.http import request
 
 
 class Website(models.Model):
@@ -24,13 +25,22 @@ class Website(models.Model):
 
     def _get_product_available_qty(self, product, **kwargs):
         """ Override of `website_sale_stock` to include free quantities of the product in warehouses
-         of in-store delivery method and return maximum possible for one order. Needed only if a
-         warehouse is set on website, otherwise free quantity is already calculated from all
-         warehouses."""
+        of in-store delivery method.
+        If Click and Collect is enabled, and a warehouse is set on the website:
+        - If a in-store pickup location is selected: return the stock at that specific warehouse.
+        - If no delivery method is selected: return the maximum between the website's warehouse
+        stock and the best stock available among all in-store warehouses.
+         """
         free_qty = super()._get_product_available_qty(product, **kwargs)
         if self.warehouse_id and self.sudo().in_store_dm_id:  # If warehouse is set on website.
-            # Check free quantities in the in-store warehouses.
-            free_qty = max(free_qty, self._get_max_in_store_product_available_qty(product))
+            order = request and request.cart
+            if not order or not order.carrier_id:
+                # Check free quantities in the in-store warehouses.
+                free_qty = max(free_qty, self._get_max_in_store_product_available_qty(product))
+            elif order.carrier_id.delivery_type == 'in_store' and order.pickup_location_data:
+                # Get free_qty from the selected location's wh.
+                free_qty = product.with_context(warehouse_id=order.warehouse_id.id).free_qty
+
         return free_qty
 
     def _get_max_in_store_product_available_qty(self, product):

--- a/addons/website_sale_collect/tests/test_website.py
+++ b/addons/website_sale_collect/tests/test_website.py
@@ -3,6 +3,7 @@
 from odoo.fields import Command
 from odoo.tests import tagged
 
+from odoo.addons.website_sale.tests.common import MockRequest
 from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
 
 
@@ -23,6 +24,45 @@ class TestWebsite(ClickAndCollectCommon):
         self.in_store_dm.is_published = False
         self.website.warehouse_id = self.warehouse_2
         free_qty = self.website._get_product_available_qty(self.storable_product)
+        self.assertEqual(free_qty, 0)
+
+    def test_product_available_qty_with_no_carrier(self):
+        """
+        Test that when no carrier is set on the cart, the available quantity is the
+        maximum between the website warehouse and the max available in in-store warehouses.
+        """
+        self.website.warehouse_id = self.warehouse_2
+        order = self._create_so()
+        with MockRequest(self.env, website=self.website, sale_order_id=order.id):
+            free_qty = self.website._get_product_available_qty(self.storable_product)
+        # Should be max(0, 10) -> 10
+        self.assertEqual(free_qty, 10)
+
+    def test_product_available_qty_with_in_store_carrier(self):
+        """
+        Test that when an in-store carrier is selected, the available quantity is strictly
+        limited to the stock at the selected pickup warehouse (warehouse_id on the cart).
+        """
+        self.website.warehouse_id = self.warehouse_2
+        self._add_product_qty_to_wh(self.storable_product.id, 5, self.warehouse_2.lot_stock_id.id)
+        order = self._create_in_store_delivery_order(
+            pickup_location_data={'id': self.warehouse_2.id, 'name': 'WH1'}
+        )
+        with MockRequest(self.env, website=self.website, sale_order_id=order.id):
+            free_qty = self.website._get_product_available_qty(self.storable_product, order=order)
+        # Should be exactly 5 (specific warehouse stock), ignoring the 10 in WH1
+        self.assertEqual(free_qty, 5)
+
+    def test_product_available_qty_with_standard_carrier(self):
+        """
+        Test that when a standard (non-in-store) carrier is selected, the system behaves
+        standardly (ignoring other in-store stocks), returning only the website warehouse stock.
+        """
+        self.website.warehouse_id = self.warehouse_2
+        order = self._create_so(carrier_id=self.free_delivery.id)
+        with MockRequest(self.env, website=self.website, sale_order_id=order.id):
+            free_qty = self.website._get_product_available_qty(self.storable_product)
+        # Should be 0 (website warehouse stock), ignoring the 10 in WH1
         self.assertEqual(free_qty, 0)
 
     def test_in_store_product_available_qty_for_order(self):


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Enable click and collect
2. Add a product with tracked inventory
3. Set the quantity on hand
4. Uncheck "Sell when Out-of-stock"
5. Try to add to cart more than the quantity on hand on the product page
    - note that you are only allowed to add up to the quantity on hand
6. Try to add to cart more than the quantity on hand from the shop page by hovering over the product and clicking the cart icon
    - note that you can add to cart more than the quantity on hand
7. Try to go to the cart page and adjust the quantity of the product
    - note that it is reset to the quantity on hand and you're prevented from exceeding it

Issue
-----
You shouldn't be able to add to cart more than the quantity on hand of a product when you have "Sell when Out-of-stock" disabled. Especially since you can't do that from the product or cart page, and adjusting the extra quantity from the cart page leads it to reset.

Cause
-----
When you enable click and collect, it disables the check for quantity when adding items to cart. This was originally done because otherwise you had no way of adding items to cart in case there was a quantity available for pickup from shop but not available for delivery. This has changed since the introduction of the widget on the product page that allows you to select a store to pickup from in that case.

Solution
--------
Remove the code that disables checking for quantity when adding to cart when click to collect is installed.

opw-5449451