### PR TITLE
[FIX] delivery: default shipping method on so

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -128,8 +128,15 @@ class SaleOrder(models.Model):
         view_id = self.env.ref('delivery.choose_delivery_carrier_view_form').id
         if self.env.context.get('carrier_recompute'):
             name = _('Update shipping cost')
+            carrier = self.carrier_id
         else:
             name = _('Add a shipping method')
+            shipping_partner_id = self.with_company(self.company_id).partner_shipping_id
+            carrier_property = (
+                shipping_partner_id.property_delivery_carrier_id
+                or shipping_partner_id.commercial_partner_id.property_delivery_carrier_id
+            )
+            carrier = carrier_property.available_carriers(self.partner_shipping_id, self)
         return {
             'name': name,
             'type': 'ir.actions.act_window',
@@ -140,7 +147,7 @@ class SaleOrder(models.Model):
             'target': 'new',
             'context': {
                 'default_order_id': self.id,
-                'default_carrier_id': self.carrier_id,
+                'default_carrier_id': carrier.id,
                 'default_total_weight': self._get_estimated_weight()
             }
         }

--- a/addons/delivery/tests/test_delivery_availability.py
+++ b/addons/delivery/tests/test_delivery_availability.py
@@ -194,3 +194,40 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
         }))
         choose_delivery_carrier = delivery_wizard.save()
         self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier excluded tag is set on one product in the order")
+
+    def test_set_default_carrier_when_partner_delivery_method_is_available(self):
+        """The default carrier is set as property_delivery_carrier_id is in available_carriers."""
+        self.sale_order.partner_shipping_id.property_delivery_carrier_id = (
+            self.non_restricted_carrier
+        )
+        delivery_wizard = self.sale_order.action_open_delivery_wizard()
+        self.assertEqual(
+            delivery_wizard['context']['default_carrier_id'],
+            self.non_restricted_carrier.id,
+        )
+
+    def test_dont_set_default_carrier_when_partner_delivery_method_is_not_available(self):
+        """The default carrier is not set as property_delivery_carrier_id is not in
+        available_carriers."""
+        restricted_carrier = self._prepare_carrier(self.carrier.product_id, max_weight=0.1)
+        self.product.weight = 1.0
+        self.sale_order.partner_shipping_id.property_delivery_carrier_id = restricted_carrier
+        delivery_wizard = self.sale_order.action_open_delivery_wizard()
+        self.assertFalse(delivery_wizard['context']['default_carrier_id'])
+
+    def test_dont_set_default_carrier_when_partner_delivery_method_is_not_set(self):
+        """The default carrier is not set as property_delivery_carrier_id is not set on partner."""
+        self.sale_order.partner_shipping_id.property_delivery_carrier_id = False
+        delivery_wizard = self.sale_order.action_open_delivery_wizard()
+        self.assertFalse(delivery_wizard['context']['default_carrier_id'])
+
+    def test_set_default_carrier_when_sale_order_delivery_method_is_set(self):
+        """The default carrier is set as delivery_carrier_id is set on sale.order."""
+        self.sale_order.carrier_id = self.non_restricted_carrier
+        delivery_wizard = self.sale_order.with_context(
+            carrier_recompute=True
+        ).action_open_delivery_wizard()
+        self.assertEqual(
+            delivery_wizard['context']['default_carrier_id'],
+            self.non_restricted_carrier.id,
+        )


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/203955, by wanting to ensure no unallowed carrier was set as default, removed the possibility to set one. 
This PR puts back the possibility of having a default shipping method if part of the available carriers.

opw-5263540