### PR TITLE
[FIX] account: Do not convert source_amount_currency to company currency in payment wizard

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -531,12 +531,7 @@ class AccountPaymentRegister(models.TransientModel):
             return self._get_total_amount_using_same_currency(batch_result, early_payment_discount=early_payment_discount)
         elif self.source_currency_id != comp_curr and self.currency_id == comp_curr:
             # Foreign currency on source line but the company currency one on the opposite line.
-            return self.source_currency_id._convert(
-                self.source_amount_currency,
-                comp_curr,
-                self.company_id,
-                self.payment_date,
-            ), False
+            return self.source_amount, False
         elif self.source_currency_id == comp_curr and self.currency_id != comp_curr:
             # Company currency on source line but a foreign currency one on the opposite line.
             residual_amount = 0.0


### PR DESCRIPTION
The model `account.payment.register` allows payments in any active currency. If a payment in the company currency is issued for an invoice in some other currency, the current code will convert `source_amount_currency` back into the main currency.

The values used to calculate `source_amount_currency` were already converted from the values used to calculate `source_amount`. Additional currency conversions may introduce rounding errors for large values and small exchange rates.

[opw-5378634
](https://www.odoo.com/odoo/all-tasks/5378634)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr