### PR TITLE
[FIX] pos_online_payment: correct order name in QR popup

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -123,7 +123,7 @@ patch(PaymentScreen.prototype, {
                         qrCode: qrCodeSrc(
                             `${this.pos.session._base_url}/pos/pay/${this.currentOrder.id}?access_token=${this.currentOrder.access_token}`
                         ),
-                        orderName: this.currentOrder.name,
+                        orderName: this.currentOrder.pos_reference,
                     };
                     this.currentOrder.onlinePaymentData = onlinePaymentData;
                     const qrCodePopupCloser = this.dialog.add(


### PR DESCRIPTION
The QR popup for Online Payments was showing "/" as the order reference
instead of the actual order name.

Technically, although `this.currentOrder.name` is a valid field in the 
Order model, it remains uninitialized or empty at the specific moment 
 the payment flow is triggered. 

By switching to `this.currentOrder.pos_reference`, we ensure the UI 
correctly displays the unique order string already generated by the 
POS session, allowing for proper identification in the payment 
provider's interface.

Steps to reproduce:
1. Configure a payment method as 'POS Online Payment'.
2. Start a POS session and add items to a sequence.
3. Go to the payment screen and trigger the QR code.
4. The QR title/reference displays "/" instead of the Order ID.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
