### PR TITLE
[REF] mail, *: clean deprecate code (ResPartner.displayName)

### DIFF
--- a/addons/im_livechat/static/src/core/common/res_partner_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/res_partner_model_patch.js
@@ -9,8 +9,8 @@ const resPartnerPatch = {
         /** @type {String[]} */
         this.livechat_languages = [];
     },
-    _computeDisplayName() {
-        return super._computeDisplayName() || this.user_livechat_username;
+    get displayName() {
+        return super.displayName || this.user_livechat_username;
     },
 };
 patch(ResPartner.prototype, resPartnerPatch);

--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -94,20 +94,6 @@ export class ResPartner extends Record {
     user_ids = fields.Many("res.users", { inverse: "partner_id" });
     write_date = fields.Datetime();
 
-    /**
-     * @deprecated
-     *
-     * `store.menuThreads` uses this field to filter threads based on search
-     * terms. For each computation, the `menuThread` field is marked as needing a
-     * recompute, which can lead to excessive recursion—sometimes even exceeding the
-     * call stack size. This computation is simple enough that it doesn’t need a
-     * compute and has been replaced by a getter. To override the display name
-     * computation, override the displayName getter.
-     */
-    _computeDisplayName() {
-        return this.name || this.display_name;
-    }
-
     get avatarUrl() {
         const accessTokenParam = {};
         if (this.store.self_user?.share !== false) {
@@ -119,8 +105,17 @@ export class ResPartner extends Record {
         });
     }
 
+    /**
+     * ⚠️ This is intentionally a getter and not a field!
+     *
+     * `store.menuThreads` uses this field to filter threads based on search
+     * terms. For each computation, the `menuThread` field is marked as needing a
+     * recompute, which can lead to excessive recursion—sometimes even exceeding the
+     * call stack size. This computation is simple enough that it doesn’t need a
+     * compute and has been replaced by a getter.
+     */
     get displayName() {
-        return this._computeDisplayName();
+        return this.name || this.display_name;
     }
 
     searchChat() {


### PR DESCRIPTION
*: im_livechat

Method `ResPartner._computeDisplayName` has been flagged as deprecated.

This is not really "deprecated", but more like an important consideration of previously a `field.Attr()` that has been intentionally turned into a getter.

This commit removes the deprecated function and moves all relevant code in the getter `ResPartner.displayName`. The docstring of getter has been tweaked to clarify the intention of getter instead of a record field.