### PR TITLE
[FIX] account_peppol: if alias is given, change identifier

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -314,3 +314,12 @@ class AccountEdiProxyClientUser(models.Model):
                 edi_user.company_id.account_peppol_proxy_state = local_state
             else:
                 _logger.warning("Received unknown Peppol state '%s' for EDI proxy user id=%s", proxy_user.get('peppol_state'), edi_user.id)
+
+            new_alias = proxy_user.get('main_alias')
+            if new_alias:
+                scheme, endpoint = new_alias.split(':')
+                edi_user.company_id.write({
+                    'peppol_eas': scheme,
+                    'peppol_endpoint': endpoint
+                })
+                edi_user.edi_identification = new_alias

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -44,6 +44,7 @@ class TestPeppolParticipant(TransactionCase):
             '/api/peppol/1/participant_status': {
                 'result': {
                     'peppol_state': peppol_state,
+                    'main_alias': '0208:0000000388'
                 }
             },
             '/api/peppol/1/activate_participant': {'result': {}},
@@ -564,3 +565,16 @@ class TestPeppolParticipant(TransactionCase):
 
         # Should successfully deregister despite client_gone error
         self.assertEqual(self.env.company.account_peppol_proxy_state, 'not_registered')
+
+    def test_participant_status_update_alias(self):
+        """ a main alias in the participant_status should change the identifier """
+        company = self.env.company
+        settings = self.env['res.config.settings'].create(self._get_participant_vals())
+        settings.button_create_peppol_proxy_user()
+        self.assertEqual(company.peppol_endpoint, '0000000000')
+        self.assertEqual(company.peppol_eas, '9925')
+        self.assertEqual(company.account_edi_proxy_client_ids.edi_identification, '9925:0000000000')
+        self.env['account_edi_proxy_client.user']._cron_peppol_get_participant_status()
+        self.assertEqual(company.peppol_endpoint, '0000000388')
+        self.assertEqual(company.peppol_eas, '0208')
+        self.assertEqual(company.account_edi_proxy_client_ids.edi_identification, '0208:0000000388')


### PR DESCRIPTION
Some users were registered with the wrong EAS.
If we have an alias for the right one, change the identifier to it.

task-5463018

Related: https://github.com/odoo/iap-apps/pull/1360




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
