### PR TITLE
[FIX] website: preload translated elements to fix translation tests

### DIFF
--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -473,6 +473,13 @@ test("Ensure the contenteditable attributes have been set before the Translation
     });
 });
 
+test("sidebar is open when we setup builder for translation", async () => {
+    await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({ inWrap: "Hello" }),
+    });
+    expect(".o_builder_sidebar_open").toHaveCount(1);
+});
+
 function getTranslateEditable({
     inWrap,
     oeId = "526",

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -301,20 +301,21 @@ export async function setupWebsiteBuilder(
     resolveIframeLoaded(iframe);
     await animationFrame();
     if (openEditor) {
-        await openBuilderSidebar(editAssetsLoaded);
+        await openBuilderSidebar(editAssetsLoaded, translateMode);
     }
     return {
         getEditor: () => editor,
         getEditableContent: () => editableContent,
-        openBuilderSidebar: async () => await openBuilderSidebar(editAssetsLoaded),
+        openBuilderSidebar: async () => await openBuilderSidebar(editAssetsLoaded, translateMode),
         waitSidebarUpdated,
     };
 }
 
-async function openBuilderSidebar(editAssetsLoaded) {
+async function openBuilderSidebar(editAssetsLoaded, translateMode) {
     // The next line allow us to await asynchronous fetches and cache them before it is used
     await Promise.all([
         getWebsiteSnippets(),
+        translateMode ? getTranslatedElements() : Promise.resolve(),
         loadBundle("website.website_builder_assets"),
         loadBundle("html_editor.assets_image_cropper"),
     ]);


### PR DESCRIPTION
When opening the sidebar in translation mode, translated elements must be preloaded before the sidebar renders. Without preloading, the fetch requires an extra tick to complete, causing tests that immediately check sidebar content to fail because the sidebar isn't fully open yet.

runbot-237540

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
