### PR TITLE
[FIX] mrp: prevent reusing already unbuilt tracked components

### DIFF
--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -1117,3 +1117,72 @@ class TestUnbuild(TestMrpCommon):
                     {'product_id': self.product_2.id, 'quantity': 24, 'state': 'done'},  # Wood
                     {'product_id': self.product_1.id, 'quantity': 48, 'state': 'done'},  # Courage
                 ])
+
+    def test_unbuild_tracked_component_multiple_unbuilds_same_mo(self):
+        """
+        Create a Manufacturing Order producing 2 units of a serial-tracked finished product
+        from a serial-tracked component, and verify that during two successive unbuilds,
+        the correct component serial numbers are restored.
+
+        - The MO produces 2 units of P1, consuming serials SN1 and SN2 of C1
+        - Unbuild the first P1 → serial SN1 of C1 is restored
+        - Unbuild the second P1 → serial SN2 of C1 is restored (SN1 must not be reused)
+        """
+        (self.bom_4.product_id | self.bom_4.bom_line_ids.product_id).is_storable = True
+        (self.bom_4.product_id | self.bom_4.bom_line_ids.product_id).tracking = 'serial'
+        component = self.bom_4.bom_line_ids.product_id
+        # Serials for component
+        sn1 = self.env['stock.lot'].create({
+            'name': 'SN1',
+            'product_id': component.id,
+        })
+        sn2 = self.env['stock.lot'].create({
+            'name': 'SN2',
+            'product_id': component.id,
+        })
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=sn1)
+        self.env['stock.quant']._update_available_quantity(component, self.stock_location, 1, lot_id=sn2)
+        # Serials for finished product
+        fp_sn1 = self.env['stock.lot'].create({
+            'name': 'SN1-P1',
+            'product_id': self.bom_4.product_id.id,
+        })
+        fp_sn2 = self.env['stock.lot'].create({
+            'name': 'SN2-P1',
+            'product_id': self.bom_4.product_id.id,
+        })
+        mo = self.env['mrp.production'].create({
+            'product_id': self.bom_4.product_id.id,
+            'product_qty': 2.0,
+            'bom_id': self.bom_4.id,
+            'product_uom_id': self.bom_4.product_uom_id.id,
+        })
+        mo.action_confirm()
+        mo.lot_producing_ids = fp_sn1 + fp_sn2
+        mo._set_qty_producing()
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.move_raw_ids.move_line_ids.lot_id, sn1 + sn2)
+
+        unbuild_1 = self.env['mrp.unbuild'].create({
+            'mo_id': mo.id,
+            'product_id': self.bom_4.product_id.id,
+            'lot_id': fp_sn1.id,
+        })
+        unbuild_1.action_unbuild()
+        self.assertEqual(unbuild_1.state, 'done')
+        self.assertEqual(
+            self.env['stock.quant']._get_available_quantity(component, self.stock_location, lot_id=sn1),
+            1, 'SN1 should be restored after first unbuild'
+        )
+        unbuild_2 = self.env['mrp.unbuild'].create({
+            'mo_id': mo.id,
+            'product_id': self.bom_4.product_id.id,
+            'lot_id': fp_sn2.id,
+        })
+        unbuild_2.action_unbuild()
+        self.assertEqual(unbuild_2.state, 'done')
+        self.assertEqual(
+            self.env['stock.quant']._get_available_quantity(component, self.stock_location, lot_id=sn2),
+            1, 'SN2 should be restored after second unbuild'
+        )


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a storable product P1
    - Tracking: Serial Number
    - BoM: Component: 1 unit of C1, tracked by Serial Number

- Update the inventory of C1
    - 1 unit with SN1
    - 1 unit with SN2
- Create a Manufacturing Order to produce 2 units of P1
- Confirm and validate the MO using serials SN1-P1 and SN2-P1
- SN1 and SN2 of C1 are consumed
- Unbuild 1 unit of P1 with serial SN1-P1 Result: SN1 of C1 is correctly restored

- Unbuild 1 unit of P1 with serial SN2-P1
- Try to validate the unbuild

Problem:
 A user error is raised:
 "The serial number SN1 has already been assigned"
This happens because _action_unbuild attempts to reuse the same component serial number (SN1 of C1) without checking whether it has already been consumed by a previous unbuild operation on the same Manufacturing Order.

Solution:
This fix ensures that, when unbuilding tracked products, component serial numbers already used by previous unbuilds of the same MO are excluded from the candidate move lines.
This prevents reassigning the same serial number multiple times and avoids the validation error.

opw-5441256
