### PR TITLE
[FIX] mail: prevent hiding channel during an active call

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -244,6 +244,7 @@ registerThreadAction("hide", {
     condition: ({ channel, owner }) =>
         (channel?.canHide ||
             channel?.sub_channel_ids.some((subThread) => subThread.channel.canHide)) &&
+        !channel?.isSelfInCall &&
         !owner.isDiscussContent,
     icon: "fa fa-fw fa-eye-slash",
     /**

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -847,6 +847,38 @@ test("Can unpin chat channel", async () => {
     await contains(".o-mail-DiscussSidebar button:has(:text('View hidden conversations'))");
 });
 
+test("No 'Hide Until New Message' on conversation with self in call", async () => {
+    const pyEnv = await startServer();
+    onRpc("/mail/rtc/session/notify_call_members", () => true);
+    const partnerId = pyEnv["res.partner"].create({ name: "Partner1" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "chat",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+    });
+    const [memberId] = pyEnv["discuss.channel.member"].search([
+        ["partner_id", "=", partnerId],
+        ["channel_id", "=", channelId],
+    ]);
+    pyEnv["discuss.channel.rtc.session"].create({
+        channel_id: channelId,
+        channel_member_id: memberId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await click("button[title='Join Call']");
+    await contains(".o-discuss-Call.o-selfInCall");
+    await click("[title='Chat Actions']");
+    await contains(".o-dropdown-item:text('Invite People')");
+    await contains(".o-dropdown-item:text('Hide Until New Message')", { count: 0 });
+    await click("button[title='Disconnect']");
+    await contains(".o-discuss-Call.o-selfInCall", { count: 0 });
+    await click("[title='Chat Actions']");
+    await contains(".o-dropdown-item:text('Hide Until New Message')");
+});
+
 test("opening a hidden channel re-pins it", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create([


### PR DESCRIPTION
Purpose:
When a call is active in a channel, the “Hide until new message” action is still available, 
which does not make sense since the channel should remain visible throughout the call.

This commit hides the “Hide until new message” action from the action list when an active 
call is ongoing, preventing users from hiding the channel mid-call.

task-5469844

