### PR TITLE
[FIX] payment: smoothly handle non-JSON request responses

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -802,7 +802,10 @@ class PaymentProvider(models.Model):
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError:
-            error_msg = self._parse_response_error(response)
+            try:
+                error_msg = self._parse_response_error(response)
+            except requests.exceptions.JSONDecodeError:  # The provider failed to parse plain text.
+                error_msg = response.text
             raise ValidationError(_("The payment provider rejected the request.\n%s", error_msg))
         return self._parse_response_content(response, **kwargs)
 

--- a/addons/payment/tests/test_payment_provider.py
+++ b/addons/payment/tests/test_payment_provider.py
@@ -2,8 +2,13 @@
 
 from unittest.mock import patch
 
+import requests
+from requests.exceptions import JSONDecodeError
+
+from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.tests import tagged
+from odoo.tools import mute_logger
 
 from odoo.addons.payment.const import REPORT_REASONS_MAPPING
 from odoo.addons.payment.tests.common import PaymentCommon
@@ -406,3 +411,23 @@ class TestPaymentProvider(PaymentCommon):
         )._get_validation_currency()
         self.assertIn(validation_currency, self.provider.available_currency_ids)
         self.assertIn(validation_currency, self.payment_method.supported_currency_ids)
+
+    @mute_logger('odoo.addons.payment.models.payment_provider')
+    def test_parsing_non_json_response_falls_back_to_text_response(self):
+        """Test that a non-JSON response is smoothly parsed as a text response."""
+        response = requests.Response()
+        response.status_code = 502
+        response._content = b"<html><body>Cloudflare Error</body></html>"
+        with (
+            patch('requests.request', return_value=response),
+            patch(
+                'odoo.addons.payment.models.payment_provider.PaymentProvider._parse_response_error',
+                new=lambda _self, _response: _response.json(),
+            ),
+        ):
+            try:
+                self.provider._send_api_request('GET', '/dummy')
+            except Exception as e:  # noqa: BLE001
+                self.assertNotIsInstance(e, JSONDecodeError)
+                self.assertIsInstance(e, ValidationError)
+                self.assertIn("Cloudflare Error", e.args[0])


### PR DESCRIPTION
Both Flutterwave and Worldline may respond with plain text rather than JSON-formatted responses when a Cloudflare outage occurs. This would lead to a traceback in Odoo when trying to extract the error message from the request response.

This commit introduces a fallback to the text content of the response when any provider fails to parse the response as a JSON content.

opw-5403982
