### PR TITLE
[FIX] im_livechat: checking response time ends at live chat end

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -112,6 +112,12 @@ class Im_LivechatReportChannel(models.Model):
                 EXTRACT(dow from C.create_date)::text AS day_number,
                 EXTRACT('epoch' FROM COALESCE(C.livechat_end_dt, NOW() AT TIME ZONE 'utc') - C.create_date)/60 AS duration,
                 CASE
+                    WHEN C.livechat_end_dt IS NOT NULL
+                         AND channel_member_history.has_agent
+                         AND message_vals.first_agent_message_dt > C.livechat_end_dt THEN NULL
+                    WHEN C.livechat_end_dt IS NOT NULL
+                         AND NOT channel_member_history.has_agent
+                         AND message_vals.first_agent_message_dt_legacy > C.livechat_end_dt THEN NULL
                     WHEN channel_member_history.has_agent AND channel_member_history.has_bot THEN
                         EXTRACT('epoch' FROM message_vals.first_agent_message_dt - message_vals.last_bot_message_dt)
                     WHEN channel_member_history.has_agent THEN


### PR DESCRIPTION
Before this commit, the response time for a live chat conversation did not stop until the operator leaves the conversation, even if the customer had already closed it.
This leads to response times that are longer than the conversation duration.

The reason for this behavior is that the response time is indiscriminately checking for the first agent message. If the live chat gets closed by the customer without answer, the first message will be "Agent left the channel", posted upon the agent leaving the conversation.

Once the conversations is closed the response time should stop as it can be expected that an operator does not pay attention to already closed chats

This commit fixes the issue by setting the `time_to_answer` to NULL if the first message is posted after the live chat is closed.

task-5117556