### PR TITLE
Gracefully exit the gevent server

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -1041,9 +1041,17 @@ class WebsocketConnectionHandler:
 
 def _kick_all():
     """ Disconnect all the websocket instances. """
+    _logger.info('disconnecting %s websockets', len(_websocket_instances))
+    count = 0
+    wait_threshold = max(odoo.sql_db._Pool._maxconn // 8, 8) if odoo.sql_db._Pool else 32
     for websocket in _websocket_instances:
         if websocket.state is ConnectionState.OPEN:
             websocket.disconnect(CloseCode.GOING_AWAY)
+            count += 1
+            if count % wait_threshold == 0:
+                time.sleep(0.5)
+                _logger.debug('kicking websockets %s/%s ...', count, len(_websocket_instances))
+    _logger.debug('kicking websockets %s/%s done', count, len(_websocket_instances))
 
 
 CommonServer.on_stop(_kick_all)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -67,6 +67,7 @@ from odoo.tools import stripped_sys_argv, dumpstacks, log_ormcache_stats
 _logger = logging.getLogger(__name__)
 
 SLEEP_INTERVAL = 60     # 1 min
+GEVENT_STOP_TIMEOUT = 60
 
 def memory_info(process):
     """
@@ -696,6 +697,10 @@ class GeventServer(CommonServer):
         self.port = config['gevent_port']
         self.httpd = None
 
+    def sigint_handler(self, sig, frame):
+        if self.httpd:
+            self.httpd._stop_event.set()
+
     def process_limits(self):
         restart = False
         if self.ppid != os.getppid():
@@ -718,6 +723,7 @@ class GeventServer(CommonServer):
 
     def start(self):
         import gevent
+        import gevent.pool
         try:
             from gevent.pywsgi import WSGIServer, WSGIHandler
         except ImportError:
@@ -770,9 +776,10 @@ class GeventServer(CommonServer):
                     environ['wsgi.input_terminated'] = False
                 return environ
 
+        # Set process memory limit as an extra safeguard
         set_limit_memory_hard()
         if os.name == 'posix':
-            # Set process memory limit as an extra safeguard
+            signal.signal(signal.SIGINT, self.sigint_handler)
             signal.signal(signal.SIGQUIT, dumpstacks)
             signal.signal(signal.SIGUSR1, log_ormcache_stats)
             gevent.spawn(self.watchdog)
@@ -782,23 +789,39 @@ class GeventServer(CommonServer):
             log=logging.getLogger('longpolling'),
             error_log=logging.getLogger('longpolling'),
             handler_class=ProxyHandler,
+            spawn=gevent.pool.Pool(),
         )
+        self.httpd.stop_timeout = 15  # websocket timeout
+
+        # override gevent.WSGIServer's `close` to end websocket connections
+        # before we wait for all greenlets to finish & kill remaining.
+        original_httpd_close = self.httpd.close
+        super_stop = super().stop
+
+        def httpd_close_override():
+            original_httpd_close()
+            super_stop()
+
+        self.httpd.close = httpd_close_override
+
         _logger.info('Evented Service (longpolling) running on %s:%s', self.interface, self.port)
         try:
-            self.httpd.serve_forever()
+            self.httpd.serve_forever(stop_timeout=GEVENT_STOP_TIMEOUT)
         except:
             _logger.exception("Evented Service (longpolling): uncaught error during main loop")
             raise
 
     def stop(self):
-        import gevent
-        self.httpd.stop()
-        super().stop()
-        gevent.shutdown()
+        if self.httpd:
+            self.httpd._stop_event.set()
+            # will call super().stop() in WSGIServer.close
+        else:
+            super().stop()
 
     def run(self, preload, stop):
         self.start()
         self.stop()
+        _logger.info('Gevent server stopped')
 
 class PreforkServer(CommonServer):
     """ Multiprocessing inspired by (g)unicorn.


### PR DESCRIPTION
Upon receiving a SIGINT signal. Allowing for sysadmins to spawn a new gevent server and SIGINT the old one, close websocket connections batch by batch so their client doesn't flood a potentially newly spawned gevent server.

Also enable socket activation for the gevent server.