### PR TITLE
[IMP] mail: add a few spinner in discuss app

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -3,7 +3,8 @@
 
 <t t-name="mail.Thread">
     <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto o-scrollbar-thin bg-inherit" t-att-class="{ 'pb-5': env.inChatter?.aside, 'o-pb-3_5': !env.inChatter?.aside, 'ps-2 pe-3': env.inDiscussApp and !ui.isSmall, 'o-focused': state.isFocused }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1" t-on-focusin="onFocusin" t-on-focusout="onFocusout">
-        <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
+        <div t-if="!props.thread.isLoaded" class="h-100 w-100 d-flex align-items-center justify-content-center"><i class="fa fa-circle-o-notch fa-spin opacity-50"/></div>
+        <t t-elif="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1 bg-inherit" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>
                 <t t-set="currentDay" t-value="0"/>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -7,7 +7,8 @@
                 <div class="flex-grow-1" t-att-class="{
                     'd-flex justify-content-center align-items-center': props.channel.attachments.length === 0,
                 }">
-                    <p t-if="props.channel.attachments.length === 0" class="text-center fst-italic text-500">
+                    <div t-if="props.channel.isLoadingAttachments" class="d-flex align-items-center justify-content-center"><i class="fa fa-circle-o-notch fa-spin opacity-50" title="Loading attachments..."/></div>
+                    <p t-if="!props.channel.isLoadingAttachments and props.channel.attachments.length === 0" class="text-center fst-italic text-500">
                         <t t-if="props.channel.channel_type === 'channel'">This channel doesn't have any attachments.</t>
                         <t t-else="">This conversation doesn't have any attachments.</t>
                     </p>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -32,6 +32,7 @@ export class ChannelInvitation extends Component {
         this.inputRef = useRef("input");
         this.sequential = useSequential();
         this.state = useState({
+            fetching: false,
             searchResultCount: 0,
             searchStr: "",
             selectableEmails: [],
@@ -118,12 +119,14 @@ export class ChannelInvitation extends Component {
     }
 
     async fetchPartnersToInvite() {
+        this.state.fetching = true;
         const results = await this.sequential(() =>
             this.orm.call("res.partner", "search_for_channel_invite", [
                 this.searchStr,
                 this.props.channel?.id ?? false,
             ])
         );
+        this.state.fetching = false;
         if (!results) {
             return;
         }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -12,7 +12,8 @@
         <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.channel }">
             <t t-if="store.self_user">
                 <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
-                <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 and state.selectableEmails.length === 0 }">
+                <span t-if="state.fetching" class="d-flex align-items-center justify-content-center mt-3"><i class="fa fa-circle-o-notch fa-spin opacity-50"/></span>
+                <ul t-else="" class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 and state.selectableEmails.length === 0 }">
                     <div t-if="selectablePartners.length === 0 and state.selectableEmails.length === 0" class="smaller text-muted mx-1 opacity-50">
                         <t t-if="props.channel">No people found to invite.</t>
                         <t t-else="">No user found.</t>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.scss
@@ -1,0 +1,3 @@
+.o-discuss-ChannelMemberList-loading {
+    z-index: $o-mail-NavigableList-zIndex;
+}

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -4,6 +4,7 @@
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
             <button name="inviteButton" t-on-click="() => props.openChannelInvitePanel({ keepPrevious: env.inChatWindow })" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3"><i class="oi oi-user-plus"/><span>Invite a User</span></button>
+            <div t-if="props.channel.fetchMembersState === 'pending'" class="o-discuss-ChannelMemberList-loading d-flex align-items-center justify-content-center my-2 position-absolute top-0 end-0 m-2 me-3"><i class="fa fa-circle-o-notch fa-spin opacity-50"/></div>
             <t t-if="props.channel.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="onlineSectionText"/>

--- a/addons/mail/static/src/discuss/core/common/pinned_messages_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/pinned_messages_panel.xml
@@ -2,7 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="discuss.PinnedMessagesPanel">
         <ActionPanel title.translate="Pinned Messages" minWidth="200" initialWidth="400" icon="'fa fa-thumb-tack'">
-            <MessageCardList emptyText="emptyText" messages="props.channel.pinnedMessages" thread="props.channel.thread" mode="'pin'"/>
+            <div t-if="props.channel.pinnedMessagesState === 'loading'" class="d-flex w-100 h-100 align-items-center justify-content-center mt-3"><i class="fa fa-circle-o-notch fa-spin opacity-50"/></div>
+            <MessageCardList t-else="" emptyText="emptyText" messages="props.channel.pinnedMessages" thread="props.channel.thread" mode="'pin'"/>
         </ActionPanel>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -19,7 +19,8 @@
                 </div>
             </t>
             <div class="o-mail-SubChannelList o-mail-Discuss-threadActionPopover mw-100 w-100 h-100" t-att-class="{ 'align-items-center justify-content-center': state.subChannels.length === 0 }">
-                <div t-if="state.subChannels.length === 0" class="flex-grow-1 d-flex flex-column justify-content-center align-items-center">
+                <div t-if="state.loading or !props.channel.loadSubChannelsDone" class="o-discuss-ChannelMemberList-loading d-flex align-items-center justify-content-center my-2 position-absolute top-0 end-0 m-2 me-3"><i class="fa fa-circle-o-notch fa-spin opacity-50"/></div>
+                <div t-if="state.subChannels.length === 0 and !state.loading and props.channel.loadSubChannelsDone" class="flex-grow-1 d-flex flex-column justify-content-center align-items-center">
                     <p class="my-1 text-center fst-italic text-500">
                         <t t-if="state.searching" t-esc="NO_THREAD_FOUND"/>
                         <t t-else="">This channel has no thread yet.</t>


### PR DESCRIPTION
- Show spinner when loading message list for the 1st time, instead of just being empty.
- Show spinner in channel invitation and attachment list instead of "No search found" / "No attachments in conversation" wrong hint.
- Show spinner in top-right of member list and sub-threads when loading data

These RPCs are not silent so the web-client shows "Loading", however the panels were misleading with emptiness or wrong hint, and also eyes of self user are on these UI panels therefore some hint that data is loading is expected over there.