### PR TITLE
[FIX] stock_account: use actual unit price to calculate COGS with FIFO goods

### DIFF
--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -69,7 +69,7 @@ class AccountMoveLine(models.Model):
         # FIFO
         moves = self._get_stock_moves().filtered(lambda m: m.state == 'done')
         if not moves:
-            return self.product_id._run_fifo(self.quantity)
+            return self.product_id._run_fifo(1)
 
         price_unit = moves._get_price_unit()
         valuation_account = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=self.move_id.fiscal_position_id)['stock_valuation']

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2956,3 +2956,19 @@ class TestStockValuation(TestStockValuationCommon):
         product_value_form = Form(product_value)
 
         self.assertFalse(product_value_form.current_value_details)
+
+    def test_valuation_of_fifo_goods_before_delivery(self):
+        """
+        Test that COGS is correctly calculated when invoicing FIFO goods before delivery.
+        """
+        invoice = self._create_invoice(self.product_fifo_auto, quantity=5, price_unit=20)
+        # Sale price: $20 | Cost: $10
+        self.assertRecordValues(
+            invoice.journal_line_ids,
+            [
+                {'account_id': self.category_fifo_auto.property_account_income_categ_id.id, 'credit': 100.0, 'debit': 0.0},  # 5 * $20
+                {'account_id': self.account_receivable.id, 'credit': 0.0, 'debit': 100.0},
+                {'account_id': self.account_stock_valuation.id, 'credit': 50.0, 'debit': 0.0},  # 5 * $10
+                {'account_id': self.account_expense.id, 'credit': 0.0, 'debit': 50.0},
+            ]
+        )


### PR DESCRIPTION
## Issue
When performing a sale order with a product using the FIFO costing method and the *Perpetual* inventory valuation and confirming the invoice before delivering the products, the evaluated COGS (cost of goods sold) would be incorrectly calculated: The unit cost of the good would be multiplied by the quantity sold twice.

## Steps to reproduce
1. Install `stock_account`, *Sales* (`sale_management`) and *Accounting* (`accountant`);
2. Create a product:
    - Tracked Inventory
    - Cost: $100.00
    - Category > Costing Method: *First In First Out (FIFO)*
    - Category > Inventory Valuation: *Perpetual (at invoicing)*
3. Create a Quotation for the product:
    - Quantity: 5 (the expected cost would then be 5 * 100 = $500)
4. **Do not deliver the products.** Instead, confirm the quotation, then create and confirm the invoice;
5. On the invoice, click the *Journal Items* tab: the *Stock Valuation* and *Expenses* account lines are incorrect. The value should $500, but it is instead $2500.

## Cause
In the `AccountMoveLine._get_cogs_value` method, the `ProductProduct._run_fifo` method is used incorrectly. The `_get_cogs_value` method should return the **unit price** of the product, but when there's no stock move related to that `account_move_line` (e.g.: no delivery), it returns the total cost instead. In fact, `_run_fifo(self.quantity)` returns the total cost for the given quantity, not a unit price.

https://github.com/odoo/odoo/blob/0c6e40fcb2896b3ad6d219240b737fa0c9c29a99/addons/stock_account/models/account_move_line.py#L69-L72

The value returned by the `_get_cogs_value` method is used as a unit price by the `AccountMove._stock_account_prepare_realtime_out_lines_vals` method, incorrectly setting the `price_unit` variable to the total cost of the move.

https://github.com/odoo/odoo/blob/0c6e40fcb2896b3ad6d219240b737fa0c9c29a99/addons/stock_account/models/account_move.py#L122

opw-5452511