### PR TITLE
[FIX] sale: fix quote view issue

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -137,7 +137,15 @@ class CustomerPortal(payment_portal.PaymentPortal):
                 download=download,
             )
 
-        if request.env.user.share and access_token:
+        if (
+            request.env.user.share
+            and access_token
+            # Ensure request is coming from UI when accessing this order
+            and (
+                request.session.uid
+                or 'Sec-Fetch-Site' in request.httprequest.headers
+            )
+        ):
             # If a public/portal user accesses the order with the access token
             # Log a note on the chatter.
             today = fields.Date.today().isoformat()


### PR DESCRIPTION
Steps:
- Install sales app.
- Copy portal of an SO.
- use it in editor link or somewhere where preview_url is used.

Issue:
- Quotation viewed log note adding on the SO.

Cause:
- `get_link_preview_from_url` method do request on the url that's why it calling it's
controller and adding log note.

Fix:
- Add check for uid in session or `Sec-Fetch-Site` in request header
to ensure request is actually coming from user not from some method.

opw-5409727
