### PR TITLE
[FIX] purchase: fix multi-company error msg for RFQ

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -200,7 +200,7 @@ class PurchaseOrder(models.Model):
                     lambda p: p.company_id and p.company_id in invalid_companies
                 )
                 raise ValidationError(_(
-                    "Your quotation contains products from company %(product_company)s whereas your quotation belongs to company %(quote_company)s. \n Please change the company of your quotation or remove the products from other companies (%(bad_products)s).",
+                    "Your RFQ contains products from company %(product_company)s whereas your RFQ belongs to company %(quote_company)s. \n Please change the company of your RFQ or remove the products from other companies (%(bad_products)s).",
                     product_company=', '.join(invalid_companies.sudo().mapped('display_name')),
                     quote_company=order.company_id.display_name,
                     bad_products=', '.join(bad_products.mapped('display_name')),


### PR DESCRIPTION
Steps:
- Add a POL with product belonging to company A.
- Update RFQ company to company B.
- Try to save RFQ.

Issue:
- Getting error stating quotation and related products belongs to different company whereas
error is actually coming from RFQ multi-company issue.

Fix:
- Update string from quotation to RFQ.

opw-5391818