### PR TITLE
[FIX] l10n_*_pos: add missing super calls

### DIFF
--- a/addons/l10n_ar_pos/models/l10n_latam_identification_type.py
+++ b/addons/l10n_ar_pos/models/l10n_latam_identification_type.py
@@ -16,4 +16,7 @@ class L10n_LatamIdentificationType(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['name']
+        fields = super()._load_pos_data_fields(config)
+        if self.env.company.country_id.code == 'AR':
+            fields.append('name')
+        return fields

--- a/addons/l10n_pe_pos/models/l10n_latam_identification_type.py
+++ b/addons/l10n_pe_pos/models/l10n_latam_identification_type.py
@@ -16,4 +16,7 @@ class L10n_LatamIdentificationType(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['name']
+        fields = super()._load_pos_data_fields(config)
+        if self.env.company.country_id.code == 'PE':
+            fields.append('name')
+        return fields


### PR DESCRIPTION
Problem:
- In the `l10n_ar_pos` and `l10n_pe_pos` modules, the `_load_pos_data_fields` method of the `l10n_latam.identification.type` model was missing a `super()` call.
- Due to the missing `super()`, the method chain was broken, preventing other modules extending the same method from being executed.
- This issue affected `l10n_gt_edi_pos` when installed together with these modules (see related PR).

Context:
- The issue was not faced earlier because existing localizations extending this method were loading the same field `name`, so the missing `super()` did not cause functional differences and tests continued to pass.
- The problem became visible when `l10n_gt_edi_pos` needed to load an additional field `country_id`, which was skipped due to the broken method chain.

Solution:
- Added the missing `super()` calls in both modules to restore proper method chaining.

related PR https://github.com/odoo/enterprise/pull/103767

task-4393614

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
