### PR TITLE
[IMP] account: add help text for subformula field

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -555,7 +555,15 @@ class AccountReportExpression(models.Model):
         required=True
     )
     formula = fields.Char(string="Formula", required=True)
-    subformula = fields.Char(string="Subformula")
+    subformula = fields.Char(
+        string="Subformula",
+        help=(
+            "Defines how the result of the formula is computed, depending on the "
+            "selected computation engine (e.g. sum, sum_if_pos, count_rows). \n"
+            "Use 'ignore_zero_division' to return '0' instead of raising an error "
+            "when a division by zero occurs."
+        ),
+    )
     date_scope = fields.Selection(
         string="Date Scope",
         selection=[


### PR DESCRIPTION
Currently, the `Subformula` field in the `Create Expressions` wizard 
does not provide any `help` text.

**Steps to reproduce:**
- Install the `account_reports` module and enable `developer mode`.
- Navigate to Accounting > Configuration > Accounting Reports.
- Open any record, click `Add a line` > `Add a line`.
- Observe the `Subformula` field.

**Observation:**
The `Subformula` field is displayed without any help message.

**Root Cause:**
At [1], the `subformula` field is defined without a `help` attribute.

**Fix:**
This commit adds a help text to the `Subformula` field explaining the 
use of `ignore_zero_division`, improving usability when configuring 
accounting report formulas.

[1]:
https://github.com/odoo/odoo/blob/57c0a78536fa38779d981482aee6ae73c132c2bc/addons/account/models/account_report.py#L558

Related enterprise PR: https://github.com/odoo/enterprise/pull/103773

opw-5475146