### PR TITLE
[IMP] product: make is_in_selected_section_of_order non-stored

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -137,7 +137,10 @@ class ProductProduct(models.Model):
 
     is_favorite = fields.Boolean(related='product_tmpl_id.is_favorite', readonly=False, store=True)
     _is_favorite_index = models.Index("(is_favorite) WHERE is_favorite IS TRUE")
-    is_in_selected_section_of_order = fields.Boolean(search='_search_is_in_selected_section_of_order')
+    is_in_selected_section_of_order = fields.Boolean(
+        search='_search_is_in_selected_section_of_order',
+        store=False,
+    )
 
     @api.depends('image_variant_1920', 'image_variant_1024')
     def _compute_can_image_variant_1024_be_zoomed(self):


### PR DESCRIPTION
`is_in_selected_section_of_order` field is only evaluated at search time in the product catalog and is never meant to be read or relied upon as stored data. Since it is not meant to be persisted or reused outside of search domains, storing it is unnecessary and misleading.

See also:
- https://github.com/odoo/upgrade/pull/9223

task-5477995
