### PR TITLE
[FIX] website_sale: fix wrong kwargs in price computation

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -160,7 +160,7 @@ class ProductProduct(models.Model):
         self.ensure_one()
 
         product_price = request.pricelist._get_product_price(
-            self, quantity=1, target_currency=website.currency_id
+            self, quantity=1, currency=website.currency_id
         )
         # Use sudo to access cross-company taxes.
         product_taxes_sudo = self.sudo().taxes_id._filter_taxes_by_company(self.env.company)

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -487,7 +487,7 @@ class ProductTemplate(models.Model):
         pricelist_price, pricelist_rule_id = pricelist._get_product_price_rule(
             product=product_or_template,
             quantity=quantity,
-            target_currency=currency,
+            currency=currency,
         )
 
         price_before_discount = pricelist_price

--- a/addons/website_sale/tests/test_website_sale_product_template.py
+++ b/addons/website_sale/tests/test_website_sale_product_template.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from odoo.fields import Command
+from odoo.fields import Command, Date
 from odoo.tests import tagged
 
 from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
@@ -85,6 +85,23 @@ class TestWebsiteSaleProductTemplate(WebsiteSaleCommon):
                 ),
             )
 
+    def test_markup_data_converts_price_to_website_currency(self):
+        company_currency = self.env.company.currency_id
+        # Find a currency different from the company currency.
+        self.website.currency_id = self.env['res.currency'].with_context(active_test=False).search([
+            ('name', '!=', company_currency.name)
+        ], limit=1)
+        with MockRequest(self.env, website=self.website):
+            markup = self.product._to_markup_data(self.website)
+        # Expected converted price
+        expected_price = company_currency._convert(
+            self.product.list_price,
+            self.website.currency_id,
+            company=self.env.company,
+            date=Date.from_string('2020-01-01'),
+        )
+        self.assertAlmostEqual(markup['offers']['price'], expected_price, places=2)
+
     def test_remove_archived_products_from_cart(self):
         """Archived products shouldn't appear in carts"""
         self.product.action_archive()
@@ -97,3 +114,22 @@ class TestWebsiteSaleProductTemplate(WebsiteSaleCommon):
             self.service_product, self.cart.order_line.product_id,
             "All products from archived product templates should be removed from the cart.",
         )
+
+    def test_get_additionnal_combination_info_converts_price_to_website_currency(self):
+        company_currency = self.env.company.currency_id
+        # Find a currency different from the company currency.
+        self.website.currency_id = self.env['res.currency'].with_context(active_test=False).search([
+            ('name', '!=', company_currency.name)
+        ], limit=1)
+        with MockRequest(self.env, website=self.website):
+            result = self.env['product.template']._get_additionnal_combination_info(
+                self.product, 1.0, Date.from_string('2020-01-01'), self.website
+            )
+        # Expected converted price
+        expected_price = company_currency._convert(
+            self.product.list_price,
+            self.website.currency_id,
+            company=self.env.company,
+            date=Date.from_string('2020-01-01'),
+        )
+        self.assertAlmostEqual(result['price'], expected_price, places=2)


### PR DESCRIPTION
In website_sale product price computation in [_to_markup_data](https://github.com/odoo/odoo/blob/saas-18.2/addons/website_sale/models/product_product.py#L163) and [_get_additionnal_combination_info](https://github.com/odoo/odoo/blob/saas-18.2/addons/website_sale/models/product_template.py#L490), the target_currency is passed but it is unused parameter.

The product_pricelist price computation logic relies on the [currency](https://github.com/odoo/odoo/blob/saas-18.2/addons/product/models/product_pricelist.py#L162)  and target_currency is not used anywhere in the pricing flow. As a result, passing target_currency adds confusion without affecting the outcome.

The target_currency parameter was unused in the method call flow and, due to this, it was always being passed as NULL. This made the parameter ineffective and confusing, while the actual logic expects a valid currency value.

This commit replaces target_currency with currency to avoid unused / misleading parameter.

Traceback
```py
2026-01-22 12:50:48,564 48232 ERROR currency_19 odoo.addons.website_sale.tests.test_website_sale_product_template: ERROR: TestWebsiteSaleProductTemplate.test_markup_data_uses_taxes_included_price_when_configured_on_website
Traceback (most recent call last):
  File "/home/odoo/odoo/odoo/addons/website_sale/tests/test_website_sale_product_template.py", line 81, in test_markup_data_uses_taxes_included_price_when_configured_on_website
    markup_data = self.product._to_markup_data(self.website)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/addons/website_sale/models/product_product.py", line 162, in _to_markup_data
    product_price = request.pricelist._get_product_price(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/addons/product/models/product_pricelist.py", line 121, in _get_product_price
    return self._compute_price_rule(product, *args, **kwargs)[product.id][0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/odoo/odoo/addons/product/models/product_pricelist.py", line 220, in _compute_price_rule
    price = suitable_rule._compute_price(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ProductPricelistItem._compute_price() got an unexpected keyword argument 'target_currency'
 
```
Before fix, 
```py
(Pdb) > /home/odoo/odoo/saas~18.2/odoo/addons/product/models/product_pricelist.py(166)_compute_price_rule()
(Pdb) args
self = product.pricelist(2,)
products = product.product(4,)
quantity = 1
currency = None
uom = None
date = False
compute_price = True
kwargs = {'target_currency': res.currency(20,)}

> /home/odoo/odoo/saas~18.2/odoo/addons/product/models/product_pricelist.py(186)_compute_price_rule()
(Pdb) currency
(Pdb) self.currency_id
res.currency(20,)
(Pdb) self.env.company.currency_id
res.currency(1,)
(Pdb) 
```
After fix,
```py
(Pdb) > /home/odoo/odoo/saas~18.2/odoo/addons/product/models/product_pricelist.py(166)_compute_price_rule()
(Pdb) args
self = product.pricelist(2,)
products = product.product(4,)
quantity = 1
currency = res.currency(20,)
uom = None
date = False
compute_price = True
kwargs = {}

> /home/odoo/odoo/saas~18.2/odoo/addons/product/models/product_pricelist.py(186)_compute_price_rule()
(Pdb) currency
res.currency(20,)
(Pdb) self.currency_id
res.currency(20,)
(Pdb) self.env.company.currency_id
res.currency(1,)
```

- opw - [5447980](https://www.odoo.com/odoo/project/70/tasks/5447980)
- upg - [3782135](https://upgrade.odoo.com/odoo/upgrade.request/3782135)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
