### PR TITLE
[FIX] web: allow keyboard navigation to leave search bar

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -490,6 +490,12 @@ export class SearchBar extends Component {
                 return [];
             },
             hotkeys: {
+                tab: {
+                    isAvailable: () => false,
+                },
+                "shift+tab": {
+                    isAvailable: () => false,
+                },
                 enter: {
                     isAvailable: () => !this.inputDropdownState.isOpen,
                     callback: () => this.env.searchModel.search() /** @todo keep this thing ?*/,

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -51,6 +51,7 @@
                         aria-label="Remove"
                         title="Remove"
                         t-on-click="() => this.onFacetRemove(facet)"
+                        tabindex="-1"
                     />
                 </div>
             </div>

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -215,6 +215,45 @@ test("navigation with facets (2)", async () => {
     expect(queryFirst`.o_searchview .o_searchview_facet:nth-child(1)`).toBeFocused();
 });
 
+test.tags("desktop");
+test("navigation should move forward from search bar filter", async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: ["groupBy"],
+        searchViewId: false,
+        context: { search_default_date_group_by: 1 },
+    });
+
+    expect(`.o_searchview .o_searchview_facet`).toHaveCount(1);
+    expect(queryFirst`.o_searchview input`).toBeFocused();
+
+    // press tab to navigate forward to the toggler
+    await keyDown("Tab");
+    await animationFrame();
+    expect(queryFirst`.o_searchview_dropdown_toggler`).toBeFocused();
+});
+
+test.tags("desktop");
+test("navigation should move backward from search bar filter", async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: ["groupBy"],
+        searchViewId: false,
+        context: { search_default_date_group_by: 1 },
+    });
+
+    expect(`.o_searchview .o_searchview_facet`).toHaveCount(1);
+    expect(queryFirst`.o_searchview input`).toBeFocused();
+
+    // press shift+tab to navigate backward to the search icon button
+    await keyDown("Shift");
+    await press("Tab");
+    await animationFrame();
+    await press("Tab");
+    await animationFrame();
+    expect(queryFirst`.d-print-none.btn`).toBeFocused();
+});
+
 test.tags("mobile");
 test("search input is focused when being toggled", async () => {
     class Parent extends Component {


### PR DESCRIPTION
When navigating any view using keyboard navigation, 
the focus gets stuck on the search bar filter and cannot 
move forward.

After this commit keyboard navigation will move
forward from the search bar filter.

Issue introduced by https://github.com/odoo/odoo/pull/208862

Task-5421313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
