### PR TITLE
[FIX] html_editor: restore list marker when changing list type

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -430,6 +430,9 @@ export class ListPlugin extends Plugin {
             if (li.style.listStyle !== "none") {
                 li.style.listStyle = null;
             }
+            if (!isListElement(li.firstChild)) {
+                li.classList.remove("oe-nested");
+            }
         }
         removeClass(newList, "o_checklist");
         if (newMode === "CL") {

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -47,6 +47,22 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a ordered list without marker into a checklist", async () => {
+            await testEditor({
+                contentBefore: '<ol><li class="oe-nested">ab[]cd</li></ol>',
+                stepFunction: toggleCheckList,
+                contentAfter: '<ul class="o_checklist"><li>ab[]cd</li></ul>',
+            });
+        });
+
+        test("should turn a unordered list without marker into a checklist", async () => {
+            await testEditor({
+                contentBefore: '<ul><li class="oe-nested">ab[]cd</li></ul>',
+                stepFunction: toggleCheckList,
+                contentAfter: '<ul class="o_checklist"><li>ab[]cd</li></ul>',
+            });
+        });
+
         test("should turn an empty heading into a checklist and display the right hint", async () => {
             const { el, editor } = await setupEditor("<h1>[]</h1>");
             expect(getContent(el)).toBe(`<h1 placeholder="Heading 1" class="o-we-hint">[]</h1>`);

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -39,6 +39,22 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a unordered list without marker into a ordered list", async () => {
+            await testEditor({
+                contentBefore: '<ul><li class="oe-nested">ab[]cd</li></ul>',
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>ab[]cd</li></ol>",
+            });
+        });
+
+        test("should turn a checklist without marker into a ordered list", async () => {
+            await testEditor({
+                contentBefore: '<ul class="o_checklist"><li class="oe-nested">ab[]cd</li></ul>',
+                stepFunction: toggleOrderedList,
+                contentAfter: "<ol><li>ab[]cd</li></ol>",
+            });
+        });
+
         test("should turn a heading into a list", async () => {
             await testEditor({
                 contentBefore: "<h1>ab[]cd</h1>",

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -39,6 +39,22 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should turn a ordered list without marker into an unordered list", async () => {
+            await testEditor({
+                contentBefore: '<ol><li class="oe-nested">ab[]cd</li></ol>',
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>ab[]cd</li></ul>",
+            });
+        });
+
+        test("should turn a checklist without marker into a unordered list", async () => {
+            await testEditor({
+                contentBefore: '<ul class="o_checklist"><li class="oe-nested">ab[]cd</li></ul>',
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<ul><li>ab[]cd</li></ul>",
+            });
+        });
+
         test("should turn a heading into a list", async () => {
             await testEditor({
                 contentBefore: "<h1>ab[]cd</h1>",


### PR DESCRIPTION
Steps to reproduce:

- Create a numbered list
- Press Backspace to remove the list marker
- Change the list type to bullet or checklist using the powerbox.

Current behavior before PR:

- The list type is changed to bullet or checklist, but the marker is not visible

Cause:

- When a list marker is removed using Backspace, the `oe-nested` class is added to the `<li>` element, which hides the marker.
- When switching the list to another list type, the `oe-nested` class is not removed.
- As a result, even though the list type changes, the marker remains hidden.

Solution:

- When changing the list type, remove the `oe-nested` class from `<li>` elements that do not contain any list elements as children.
- This ensures the marker is correctly restored for the new list type.

task-5468384
