### PR TITLE
[IMP] base: add access tokens API

### DIFF
--- a/addons/survey/tests/test_survey_controller.py
+++ b/addons/survey/tests/test_survey_controller.py
@@ -9,7 +9,7 @@ from odoo.tests.common import tagged, HttpCase
 from odoo.tools import mute_logger
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('-at_install', 'post_install')  # LEGACY at_install
 class TestSurveyController(common.TestSurveyCommon, HttpCase):
 
     def test_submit_route_scoring_after_page(self):
@@ -84,7 +84,8 @@ class TestSurveyController(common.TestSurveyCommon, HttpCase):
                     page0, _ = self.env['survey.question'].create(pages)
 
                 response = self._access_start(survey)
-                user_input = self.env['survey.user_input'].search([('access_token', '=', response.url.split('/')[-1])])
+                access_token = response.url.split('/')[-1]
+                user_input = self.env.user.use_access_token(access_token, 'access-survey-input')
                 answer_token = user_input.access_token
 
                 r = self._access_page(survey, answer_token)

--- a/addons/survey/tests/test_survey_performance.py
+++ b/addons/survey/tests/test_survey_performance.py
@@ -16,9 +16,9 @@ class SurveyPerformance(common.TestSurveyResultsCommon, HttpCase):
         """
         url = f'/survey/results/{self.survey.id}?filters=A,0,{self.gras_id}|L,0,{self.answer_pauline.id}'
         self.authenticate('survey_manager', 'survey_manager')
-        # cold orm/fields cache (only survey: 26, all module: 23)
+        # cold orm/fields cache (only survey: 30, all module: 23)
         #  the extra requests are `_get_default_lang` which is not called when website is installed
-        with self.assertQueryCount(default=26):
+        with self.assertQueryCount(default=30):
             self.url_open(url)
 
     @warmup
@@ -29,16 +29,16 @@ class SurveyPerformance(common.TestSurveyResultsCommon, HttpCase):
         """
         url = f'/survey/results/{self.survey.id}?filters=A,0,{self.gras_id}|A,0,{self.cat_id}'
         self.authenticate('survey_manager', 'survey_manager')
-        # cold orm/fields cache (only survey: 24, all module: 21)
+        # cold orm/fields cache (only survey: 28, all module: 21)
         #  the extra requests are `_get_default_lang` which is not called when website is installed
-        with self.assertQueryCount(default=24):
+        with self.assertQueryCount(default=28):
             self.url_open(url)
 
     @warmup
     def test_survey_results_with_one_filter(self):
         url = f'/survey/results/{self.survey.id}?filters=A,0,{self.cat_id}'
         self.authenticate('survey_manager', 'survey_manager')
-        # cold orm/fields cache (only survey: 24, all module: 21)
+        # cold orm/fields cache (only survey: 28, all module: 21)
         #  the extra requests are `_get_default_lang` which is not called when website is installed
-        with self.assertQueryCount(default=24):
+        with self.assertQueryCount(default=28):
             self.url_open(url)

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -27,6 +27,7 @@ The kernel of Odoo, needed for all installation.
         'views/decimal_precision_views.xml',
         'views/res_config_views.xml',
         'data/res.country.state.csv',
+        'views/ir_access_token_views.xml',
         'views/ir_actions_views.xml',
         'views/ir_asset_views.xml',
         'views/ir_config_parameter_views.xml',

--- a/odoo/addons/base/models/__init__.py
+++ b/odoo/addons/base/models/__init__.py
@@ -6,6 +6,7 @@ from . import ir_model
 from . import ir_sequence
 from . import ir_ui_menu
 from . import ir_ui_view
+from . import ir_access_token
 from . import ir_asset
 from . import ir_actions
 from . import ir_embedded_actions

--- a/odoo/addons/base/models/ir_access_token.py
+++ b/odoo/addons/base/models/ir_access_token.py
@@ -1,0 +1,99 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError, MissingError, UserError, ValidationError
+from odoo.models import BaseModel
+from odoo.tools.misc import consteq, hash_sign, verify_hash_signed
+
+
+class IrAccessToken(models.Model):
+    _name = 'ir.access.token'
+    _description = 'Access Token'
+
+    res_model = fields.Char('Resource Model', required=True)
+    res_id = fields.Integer('Resource ID', required=True)
+    scope = fields.Char('Scope', required=True)
+    expiration = fields.Datetime('Expiration')
+    owner_id = fields.Many2one('res.users')
+    # Tokens are not stored.
+    # However, it is necessary to maintain existing tokens as valid
+    # and retain the ability to force the value of a token.
+    manual_token = fields.Char('Manual Token', groups=fields.NO_ACCESS, index='btree_not_null')
+    token = fields.Char('Token', compute='_compute_token', groups=fields.NO_ACCESS)
+
+    _res_record_idx = models.Index('(res_model, res_id)')
+
+    @api.autovacuum
+    def _gc_access_token(self):
+        self.search([('expiration', '<', fields.Datetime.now())]).unlink()
+
+    @api.constrains('expiration')
+    def _constraint_expiration(self):
+        for access_token in self:
+            if access_token.expiration and access_token.expiration < fields.Datetime.now():
+                raise ValidationError(_('Expiration cannot be in the past'))
+
+    @api.depends_context('uid')  # Invalidate the cache if the user changes
+    @api.depends('manual_token')
+    def _compute_token(self):
+        # A ``MissingError`` will be raised if access token doesn't exist
+        for access_token in self:
+            if access_token.manual_token:
+                access_token.token = access_token.manual_token
+                continue
+            # It is necessary to embedded the access token id in the payload.
+            # Indeed, if there are two tokens that can grant access to the same
+            # record, it must be possible to invalidate only one of the two.
+            payload = (access_token.id, access_token.res_model, access_token.res_id, access_token.owner_id.id)
+            access_token.token = hash_sign(
+                self.env, access_token.scope, payload,
+                expiration=access_token.expiration,
+            )
+
+    def write(self, vals):
+        # To update an access token invalidate it
+        raise UserError(_('Cannot update access tokens'))
+
+    @api.model
+    @api.private
+    def use(self, token: str, scope: str) -> BaseModel:
+        """ Use the token and get the referenced record (sudoed).
+
+        :raises AccessError: If the token is invalid, expired, or does not match
+                             the expected scope or payload.
+                             If the owner of the token is not correct.
+        """
+        try:
+            payload = verify_hash_signed(self.env, scope, token)  # Expiration is verified
+        except ValueError:
+            # The token is not in the correct format (maybe manually entered token)
+            access_token = self.search_fetch([
+                ('manual_token', '=', token),
+                ('scope', '=', scope),
+                ('owner_id', 'in', (False, self.env.uid)),
+                '|',
+                    ('expiration', '>=', fields.Datetime.now()),
+                    ('expiration', '=', False),
+            ], limit=1)
+        else:
+            if payload is None:  # Expired token
+                raise AccessError(_('Invalid token'))
+            access_token_id, *_rest, owner_id = payload
+            access_token = self.browse(access_token_id)
+            # Ensure correct owner
+            if owner_id and owner_id != self.env.uid:
+                raise AccessError(_('Invalid token'))
+            # Ensure the access_token record exists (+ fetch)
+            try:
+                access_token.res_model
+            except MissingError:
+                raise AccessError(_('Invalid token'))
+
+        # Recompute token and assert with the token used ensures the integrity
+        # of values in the database. This ensures that if the data in the
+        # database is altered, it does not change the intended behaviour of the
+        # token.
+        if not consteq(access_token.token or '', token):
+            raise AccessError(_('Invalid token'))
+
+        # Return the referenced record in sudo
+        return self.env[access_token.res_model].browse(access_token.res_id).sudo()

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -125,3 +125,4 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_res_device",access_res_device,base.model_res_device,base.group_user,1,0,0,0
 "access_res_device_log",access_res_device_log,base.model_res_device_log,base.group_user,1,0,0,0
 "access_properties_base_definition_group_system",access_properties_base_definition,base.model_properties_base_definition,base.group_system,1,1,1,1
+"access_ir_access_token",access_ir_access_token,base.model_ir_access_token,base.group_system,1,0,1,1

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -23,6 +23,7 @@ from . import test_image
 from . import test_install
 from . import test_avatar_mixin
 from . import test_init
+from . import test_ir_access_token
 from . import test_ir_actions
 from . import test_ir_asset
 from . import test_ir_attachment

--- a/odoo/addons/base/tests/test_ir_access_token.py
+++ b/odoo/addons/base/tests/test_ir_access_token.py
@@ -1,0 +1,224 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
+from freezegun import freeze_time
+
+from odoo.exceptions import AccessError, ValidationError
+from odoo.tests.common import new_test_user, TransactionCase
+
+
+class TestIrAccessToken(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.IrAccessToken = cls.env['ir.access.token']
+
+        cls.admin = new_test_user(cls.env, 'Test Admin', groups='base.group_erp_manager')
+        cls.user_1 = new_test_user(cls.env, 'Test User 1')
+        cls.user_2 = new_test_user(cls.env, 'Test User 2')
+        cls.record = cls.partner = cls.env['res.partner'].create({'name': 'Test Partner'})
+
+        cls.admin_user = cls.env.user.with_user(cls.admin)
+        cls.user_1_user = cls.env.user.with_user(cls.user_1)
+        cls.user_2_user = cls.env.user.with_user(cls.user_2)
+
+    def setUp(self):
+        super().setUp()
+        self.IrAccessToken.search([]).unlink()
+
+    def test_grant_access_to_record(self):
+        with self.assertRaises(AccessError):  # Only administrators can grant access tokens
+            self.user_1_user.grant_access_token(self.record, 'access-record')
+
+        token = self.admin_user.grant_access_token(self.record, 'access-record')
+        self.assertTrue(token, 'An access token must be generated and returned')
+
+        record = self.user_1_user.use_access_token(token, 'access-record')
+        self.assertEqual(record, self.record, 'The record must be found')
+
+    def test_grant_access_to_record_with_value(self):
+        token = self.admin_user.grant_access_token(self.record, 'access-record', value='123456789')
+        self.assertEqual(token, '123456789', 'The raw access token must be returned')
+
+        record = self.user_1_user.use_access_token('123456789', 'access-record')
+        self.assertEqual(record, self.record, 'The record must be found')
+
+    @freeze_time('2026-01-01')
+    def test_grant_access_to_record_with_expiration(self):
+        expiration = datetime(2026, 1, 10)
+        token = self.admin_user.grant_access_token(self.record, 'access-record', expiration=expiration)
+
+        with freeze_time('2026-01-9'):
+            record = self.user_1_user.use_access_token(token, 'access-record')
+            self.assertEqual(record, self.record, 'Token must be valid')
+
+        with freeze_time('2026-01-11'), self.assertRaises(AccessError):  # The token is invalid
+            self.user_1_user.use_access_token(token, 'access-record')
+
+    @freeze_time('2026-01-01')
+    def test_grant_access_to_record_with_expiration_in_past(self):
+        expiration = datetime(2025, 1, 1)
+        with self.assertRaises(ValidationError):
+            self.admin_user.grant_access_token(self.record, 'access-record', expiration=expiration)
+
+    def test_grant_access_to_record_with_owner(self):
+        token = self.admin_user.grant_access_token(self.record, 'access-record', owner=self.user_1)
+
+        with self.assertRaises(AccessError):  # With user 2, the token is invalid
+            self.user_2_user.use_access_token(token, 'access-record')
+
+        record = self.user_1_user.use_access_token(token, 'access-record')
+        self.assertTrue(record, 'Token is valid for the owner user_1')
+
+    def test_grant_access_to_record_with_scope(self):
+        token_read = self.admin_user.grant_access_token(self.record, 'access-read')
+        token_write = self.admin_user.grant_access_token(self.record, 'access-write')
+
+        with self.assertRaises(AccessError):  # Token incorrect for the scope
+            self.user_1_user.use_access_token(token_read, 'access-write')
+        with self.assertRaises(AccessError):  # Token incorrect for the scope
+            self.user_1_user.use_access_token(token_write, 'access-read')
+
+        record = self.user_1_user.use_access_token(token_write, 'access-write')
+        self.assertTrue(record, self.record)
+        record = self.user_1_user.use_access_token(token_read, 'access-read')
+        self.assertTrue(record, self.record)
+
+    def test_revoke_access_to_record(self):
+        token = self.admin_user.grant_access_token(self.record, 'access-record')
+        record = self.user_1_user.use_access_token(token, 'access-record')
+        self.assertEqual(record, self.record)
+
+        with self.assertRaises(AccessError):  # Only administrators can revoke access tokens
+            self.user_1_user.revoke_access_token(self.record, 'access-record')
+        self.admin_user.revoke_access_token(self.record, 'access-record')
+
+        with self.assertRaises(AccessError):  # The token is invalid
+            self.user_1_user.use_access_token(token, 'access-record')
+
+    @freeze_time('2026-01-01')
+    def test_ensure_database_integrity_expiration(self):
+        expiration = datetime(2026, 1, 10)
+        token = self.admin_user.grant_access_token(self.record, 'access-record', expiration=expiration)
+
+        with freeze_time('2026-01-9'):
+            record = self.user_1_user.use_access_token(token, 'access-record')
+            self.assertEqual(record, self.record, 'Token must be valid')
+            # Alter DB - Attempting to extend a token
+            access_token = self.IrAccessToken.search([], limit=1)
+            self.env.registry['base'].write(access_token, {'expiration': datetime(2026, 1, 20)})  # Bypass write override
+            with self.assertRaises(AccessError):  # We detect a modification in the expiration
+                self.user_1_user.use_access_token(token, 'access-record')
+
+    def test_ensure_database_integrity_owner(self):
+        token = self.admin_user.grant_access_token(self.record, 'access-record', owner=self.user_1)
+        record = self.user_1_user.use_access_token(token, 'access-record')
+        self.assertEqual(record, self.record, 'Token must be valid')
+        # Alter DB - Attempting to change user
+        access_token = self.IrAccessToken.search([], limit=1)
+        self.env.registry['base'].write(access_token, {'owner_id': self.user_2})  # Bypass write override
+        with self.assertRaises(AccessError):  # We detect a modification in the user
+            self.user_1_user.use_access_token(token, 'access-record')
+        with self.assertRaises(AccessError):  # Token completly invalid (even if we use the updated user)
+            self.user_2_user.use_access_token(token, 'access-record')
+
+    def test_ensure_database_integrity_scope(self):
+        token = self.admin_user.grant_access_token(self.record, 'access-read')
+        record = self.user_1_user.use_access_token(token, 'access-read')
+        self.assertEqual(record, self.record, 'Token must be valid')
+        # Alter DB - Attempting to change scope
+        access_token = self.IrAccessToken.search([], limit=1)
+        self.env.registry['base'].write(access_token, {'scope': 'access-write'})  # Bypass write override
+        with self.assertRaises(AccessError):  # We detect a modification in the scope
+            self.user_1_user.use_access_token(token, 'access-read')
+        with self.assertRaises(AccessError):  # Token completly invalid (even if we use the updated scope)
+            self.user_1_user.use_access_token(token, 'access-write')
+
+    def test_revoke_concurrent_tokens(self):
+        token_1 = self.admin_user.grant_access_token(self.record, 'access-record')
+        token_2 = self.admin_user.grant_access_token(self.record, 'access-record')
+        record = self.user_1_user.use_access_token(token_1, 'access-record')
+        self.assertEqual(record, self.record, 'Token must be valid')
+        record = self.user_1_user.use_access_token(token_2, 'access-record')
+        self.assertEqual(record, self.record, 'Token must be valid')
+
+        self.admin_user.revoke_access_token(self.record, 'access-record')
+        with self.assertRaises(AccessError):
+            self.user_1_user.use_access_token(token_1, 'access-record')
+        with self.assertRaises(AccessError):
+            self.user_1_user.use_access_token(token_2, 'access-record')
+
+    def test_revoke_concurrent_tokens_according_user(self):
+        token_1 = self.admin_user.grant_access_token(self.record, 'access-record', owner=self.user_1)
+        token_2 = self.admin_user.grant_access_token(self.record, 'access-record', owner=self.user_2)
+        record = self.user_1_user.use_access_token(token_1, 'access-record')
+        self.assertEqual(record, self.record, 'Token must be valid')
+        record = self.user_2_user.use_access_token(token_2, 'access-record')
+        self.assertEqual(record, self.record, 'Token must be valid')
+
+        self.admin_user.revoke_access_token(self.record, 'access-record', owners=self.user_1)
+        with self.assertRaises(AccessError):
+            self.user_1_user.use_access_token(token_1, 'access-record')
+        record = self.user_2_user.use_access_token(token_2, 'access-record')
+        self.assertEqual(record, self.record, 'Token must always be valid')
+
+    @freeze_time('2026-01-01')
+    def test_invalidate_concurrent_tokens_according_expiration(self):
+        expiration_1 = datetime(2026, 1, 10)
+        token_1 = self.admin_user.grant_access_token(self.record, 'access-record', expiration=expiration_1)
+        expiration_1 = datetime(2026, 1, 20)
+        token_2 = self.admin_user.grant_access_token(self.record, 'access-record', expiration=expiration_1)
+
+        with freeze_time('2026-01-05'):
+            record = self.user_1_user.use_access_token(token_1, 'access-record')
+            self.assertEqual(record, self.record, 'Token must be valid')
+            record = self.user_1_user.use_access_token(token_2, 'access-record')
+            self.assertEqual(record, self.record, 'Token must be valid')
+
+        with freeze_time('2026-01-15'):
+            with self.assertRaises(AccessError):
+                self.user_1_user.use_access_token(token_1, 'access-record')
+            record = self.user_1_user.use_access_token(token_2, 'access-record')
+            self.assertEqual(record, self.record, 'Token must be valid')
+
+        with freeze_time('2026-01-25'):
+            with self.assertRaises(AccessError):
+                self.user_1_user.use_access_token(token_1, 'access-record')
+            with self.assertRaises(AccessError):
+                self.user_1_user.use_access_token(token_2, 'access-record')
+
+    @freeze_time('2026-01-01')
+    def test_retrieve_token_from_record(self):
+        token = self.admin_user.grant_access_token(self.record, 'access-record')
+
+        with self.assertRaises(AccessError):  # Only administrators can retrieve access tokens
+            self.user_1_user.retrieve_access_token(self.record, 'access-record')
+        retrieved_token = self.admin_user.retrieve_access_token(self.record, 'access-record')
+        self.assertEqual(token, retrieved_token)
+
+        self.assertFalse(self.admin_user.retrieve_access_token(self.record, 'access-random-scope'))
+
+        expiration_1 = datetime(2026, 1, 10)
+        token_1 = self.admin_user.grant_access_token(self.record, 'access-record', expiration=expiration_1)
+        expiration_1 = datetime(2026, 1, 20)
+        token_2 = self.admin_user.grant_access_token(self.record, 'access-record', expiration=expiration_1)
+
+        with freeze_time('2026-01-05'):
+            retrieved_token = self.admin_user.retrieve_access_token(self.record, 'access-record')
+            self.assertEqual(token, retrieved_token, 'Expiration null must be retrieve first')
+            # Invalidate the token with the null expiration
+            self.IrAccessToken.search([('expiration', '=', False)]).unlink()
+            retrieved_token = self.admin_user.retrieve_access_token(self.record, 'access-record')
+            self.assertEqual(token_2, retrieved_token, 'Latest expiration be retrieve first')
+            # Invalidate the token with the latest expiry date
+            self.IrAccessToken.search([], order='expiration desc', limit=1).unlink()
+            retrieved_token = self.admin_user.retrieve_access_token(self.record, 'access-record')
+            self.assertEqual(token_1, retrieved_token)
+
+        with freeze_time('2026-01-15'):
+            self.assertFalse(self.admin_user.retrieve_access_token(self.record, 'access-record'))
+
+    def test_retrieve_token_from_record_create(self):
+        retrieved_token = self.admin_user.retrieve_access_token(self.record, 'access-record', create=True)
+        record = self.admin_user.use_access_token(retrieved_token, 'access-record')
+        self.assertEqual(record, self.record)

--- a/odoo/addons/base/views/ir_access_token_views.xml
+++ b/odoo/addons/base/views/ir_access_token_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record model="ir.ui.view" id="ir_access_token_view_tree">
+            <field name="name">ir.access.token.list</field>
+            <field name="model">ir.access.token</field>
+            <field name="arch" type="xml">
+                <list>
+                    <field name="res_model"/>
+                    <field name="res_id"/>
+                    <field name="scope"/>
+                    <field name="owner_id"/>
+                    <field name="expiration"/>
+                </list>
+            </field>
+        </record>
+
+        <record id="action_access_token" model="ir.actions.act_window">
+            <field name="name">Access Tokens</field>
+            <field name="res_model">ir.access.token</field>
+            <field name="path">access-token</field>
+            <field name="view_mode">list</field>
+        </record>
+        <menuitem action="action_access_token" id="menu_action_access_token" parent="base.menu_security" sequence="10"/>
+
+    </data>
+</odoo>


### PR DESCRIPTION
Currently, when a user does not have sufficient access rights to one or
more records, we grant elevated privileges to access the record(s) if a
verified access token is presented.

However, each module that requires the use of an access token implements
the logic for these tokens independently. The result is that there are
many differences in how access tokens are managed.

This commit introduces an API that maintains a standard for access token
management, thereby avoiding disparities and bad practices.
From a design perspective, it is much simpler to have all access tokens
centralised.

From a technical point of view, all access tokens will be managed in the
`ir.access.token` model.

In order to provide a simple API for developers, the best compromise is
to expose the token management methods directly on the `res.users` model.

A token is linked to a scope. This allows for greater granularity in
granting privileges following token verification. An expiry date can be
provided to force a token to expire. Furthermore, a token can be
specific to a particular user.

Tokens generated with this API are not stored in the database. However,
in order to avoid invalidating existing tokens and to maintain
compatibility, a `manual_token` column is provided for this purpose.

Task-4518427