### PR TITLE
[FIX] html_editor: text color classes on list items

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -351,7 +351,10 @@ export class ColorPlugin extends Plugin {
                         '[style*="color"]:not(li), [style*="background-color"]:not(li), [style*="background-image"]:not(li)'
                     ) ||
                     closestElement(node, "span") ||
-                    closestElement(node, (node) => hasTextColorClass(node, mode));
+                    closestElement(
+                        node,
+                        (node) => node.nodeName !== "LI" && hasTextColorClass(node, mode)
+                    );
 
                 const faNodes = font?.querySelectorAll(".fa");
                 if (faNodes && Array.from(faNodes).some((faNode) => faNode.contains(node))) {

--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -16,6 +16,14 @@ test("should apply color to completely selected list item", async () => {
     });
 });
 
+test("should apply text color class to completely selected list item", async () => {
+    await testEditor({
+        contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
+        stepFunction: setColor("text-o-color-1", "color"),
+        contentAfter: '<ol><li class="text-o-color-1">[abc]</li><li>def</li></ol>',
+    });
+});
+
 test("should apply color to completely selected multiple list items", async () => {
     await testEditor({
         contentBefore: "<ul><li>[abc</li><li>def]</li></ul>",
@@ -25,12 +33,30 @@ test("should apply color to completely selected multiple list items", async () =
     });
 });
 
+test("should apply text color class to fully selected multiple list items", async () => {
+    await testEditor({
+        contentBefore: "<ul><li>[abc</li><li>def]</li></ul>",
+        stepFunction: setColor("text-o-color-1", "color"),
+        contentAfter:
+            '<ul><li class="text-o-color-1">[abc</li><li class="text-o-color-1">def]</li></ul>',
+    });
+});
+
 test("should apply color to completely selected and partially selected list items", async () => {
     await testEditor({
         contentBefore: "<ol><li>[abc</li><li>def</li><li>gh]i</li></ol>",
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfter:
             '<ol><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(255, 0, 0);">def</li><li><font style="color: rgb(255, 0, 0);">gh]</font>i</li></ol>',
+    });
+});
+
+test("should apply text color class to completely selected and partially selected list items", async () => {
+    await testEditor({
+        contentBefore: "<ol><li>[abc</li><li>def</li><li>gh]i</li></ol>",
+        stepFunction: setColor("text-o-color-1", "color"),
+        contentAfter:
+            '<ol><li class="text-o-color-1">[abc</li><li class="text-o-color-1">def</li><li><font class="text-o-color-1">gh]</font>i</li></ol>',
     });
 });
 


### PR DESCRIPTION
### Steps to reproduce:

- Create a list and type some text.
- Press Ctrl + A and apply a text color from the toolbar.
- Observe that the list marker is not colored.

### Description of the issue/feature this PR addresses:

- `getFonts` looked for the closest element with a text color class, and this also matched `<li>` elements. When a `<li>` was selected, its text color class was removed and moved to a new <font> element created inside the `<li>`.
- As a result, the color class was removed from the list item itself, which broke list marker coloring.

### Desired behavior after PR is merged:

- Text color classes remain on list item, so list markers are colored correctly.

task-5454639

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
