### PR TITLE
[FIX] html_editor: hint text wrapping

### DIFF
--- a/addons/html_editor/static/src/main/hint.scss
+++ b/addons/html_editor/static/src/main/hint.scss
@@ -12,5 +12,8 @@
         pointer-events: none;
         text-align: inherit;
         width: 100%;
+        overflow: hidden;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
     }
 }


### PR DESCRIPTION
Description of the issue this PR addresses:

- The placeholder hint text wraps onto multiple lines when the cell width is reduced.
- When there is insufficient horizontal space, the text should be truncated rather than wrapped.

task-5480080

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
