### PR TITLE
[FIX] website: image edit tests due to async sidebar updates

### DIFF
--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -15,7 +15,7 @@ import {
     getSnippetView,
 } from "@html_builder/../tests/helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
-import { animationFrame, Deferred, queryText, tick, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, Deferred, queryText, tick } from "@odoo/hoot-dom";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
@@ -40,7 +40,7 @@ const dummySnippet = `
 `;
 
 test("Use the sidebar 'remove' buttons", async () => {
-    await setupWebsiteBuilder(dummySnippet);
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(dummySnippet);
 
     const removeSectionSelector =
         ".o_customize_tab .options-container > div:contains('Dummy Section') button.oe_snippet_remove";
@@ -50,7 +50,7 @@ test("Use the sidebar 'remove' buttons", async () => {
         ".o_customize_tab .options-container > div:contains('Image') button.oe_snippet_remove";
 
     await contains(":iframe .col-lg-7 img").click();
-    await waitFor(".options-container");
+    await waitSidebarUpdated();
     expect(removeSectionSelector).toHaveCount(1);
     expect(removeColumnSelector).toHaveCount(1);
     expect(removeImageSelector).toHaveCount(1);

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -514,6 +514,7 @@ test("Should have the correct active shape in the image shape selector", async (
     `);
 
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/geometric/geo_tetris']").click();
     await waitSidebarUpdated();

--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -1,6 +1,6 @@
 import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
-import { describe, expect, test } from "@odoo/hoot";
-import { queryFirst, queryOne, waitFor } from "@odoo/hoot-dom";
+import { describe, expect, test, waitFor } from "@odoo/hoot";
+import { queryFirst, queryOne } from "@odoo/hoot-dom";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
@@ -24,14 +24,13 @@ const styleContent = `
 `;
 
 test("visibility of animation animation=none", async () => {
-    await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
     await contains(":iframe .test-options-target img").click();
-
-    await waitFor(".options-container");
+    await waitSidebarUpdated();
     expect(".options-container [data-label='Effect']").not.toBeVisible();
     expect(".options-container [data-label='Direction']").not.toHaveCount();
     expect(".options-container [data-label='Trigger']").not.toBeVisible();
@@ -50,6 +49,7 @@ describe("onAppearance", () => {
             { styleContent }
         );
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
         await contains(".o-dropdown--menu [data-action-value='onAppearance']").click();
@@ -78,6 +78,7 @@ describe("onAppearance", () => {
             { styleContent }
         );
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
         await contains(".o-dropdown--menu [data-action-value='onAppearance']").click();
@@ -106,6 +107,7 @@ describe("onAppearance", () => {
             { styleContent }
         );
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
         await contains(".o-dropdown--menu [data-action-value='onAppearance']").click();
@@ -134,6 +136,7 @@ describe("onAppearance", () => {
             { styleContent }
         );
         await contains(":iframe .test-options-target img").click();
+        await waitSidebarUpdated();
 
         await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
         await contains(".o-dropdown--menu [data-action-value='onAppearance']").click();
@@ -160,6 +163,7 @@ test("visibility of animation animation=onScroll", async () => {
         </div>
     `);
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     await contains(".o-dropdown--menu [data-action-value='onScroll']").click();
@@ -186,6 +190,7 @@ test("animation=onScroll should not be visible when the animation is limited", a
         { styleContent }
     );
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     await contains(".o-dropdown--menu [data-action-value='onAppearance']").click();
@@ -233,6 +238,7 @@ test("visibility of animation animation=onHover", async () => {
         </div>
     `);
     await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
 
     // NOTE: we use waitSidebarUpdated because setting the hover effect may
     // take some time (and setting "On Hover" sets a default)
@@ -269,29 +275,29 @@ test("visibility of animation animation=onHover", async () => {
     expectOnHoverOptions({ Effect: "Mirror Blur", Intensity: 1 });
 });
 test("animation=onHover should not be visible when the image is a device shape", async () => {
-    await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             <img data-shape="html_builder/devices/iphone_front_portrait" src='${base64Img}'>
         </div>
     `);
     await contains(":iframe .test-options-target img").click();
-
+    await waitSidebarUpdated();
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     expect(".o-dropdown--menu [data-action-value='onHover']").not.toHaveCount();
 });
 test("animation=onHover should not be visible when the image has a wrong mimetype", async () => {
-    await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             <img data-original-id="1" data-mimetype="foo/bar" src='${base64Img}'>
         </div>
     `);
     await contains(":iframe .test-options-target img").click();
-
+    await waitSidebarUpdated();
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     expect(".o-dropdown--menu [data-action-value='onHover']").not.toHaveCount();
 });
 test("animation=onHover should not be visible when the image has a cors protected image", async () => {
-    await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             <img data-original-id="1" src='/web/image/0-redirect/foo.jpg'>
         </div>
@@ -323,30 +329,28 @@ test("animation=onHover should not be visible when the image has a cors protecte
         { pure: true }
     );
     await contains(":iframe .test-options-target img").click();
-
+    await waitSidebarUpdated();
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     expect.verifySteps(["/web/image/0-redirect/foo.jpg"]);
     expect(".o-dropdown--menu [data-action-value='onHover']").not.toHaveCount();
 });
 
 test("image should not be lazy onAppearance", async () => {
-    await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testImg}
         </div>
     `);
     await contains(":iframe .test-options-target img").click();
-
+    await waitSidebarUpdated();
     expect(":iframe .test-options-target img").toHaveProperty("loading", "auto");
 
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     await contains(".o-dropdown--menu [data-action-value='onAppearance']").click();
-
     expect(":iframe .test-options-target img").toHaveProperty("loading", "eager");
 
     await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
     await contains(".o-dropdown--menu [data-action-value='']").click();
-
     expect(":iframe .test-options-target img").toHaveProperty("loading", "auto");
 });
 
@@ -358,9 +362,9 @@ test("should not show the animation options if the image has a parent [data-oe-t
     `);
     const editor = getEditor();
     await contains(":iframe .test-options-target img").click();
-
-    await waitFor(".options-container");
+    await waitSidebarUpdated();
     expect(".options-container [data-label='Animation'] .dropdown-toggle").toBeVisible();
+
     const optionTarget = queryFirst(":iframe .test-options-target");
     optionTarget.setAttribute("data-oe-type", "image");
     editor.shared.history.addStep();
@@ -376,12 +380,12 @@ test("should not show the animation options if the image has is [data-oe-xpath]"
     `);
     const editor = getEditor();
     await contains(":iframe .test-options-target img").click();
-
-    await waitFor(".options-container");
+    await waitSidebarUpdated();
     expect(".options-container [data-label='Animation'] .dropdown-toggle").toBeVisible();
     const optionTarget = queryFirst(":iframe .test-options-target img");
     optionTarget.setAttribute("data-oe-xpath", "/foo/bar");
     editor.shared.history.addStep();
+
     await waitSidebarUpdated();
     expect(".options-container [data-label='Animation'] .dropdown-toggle").not.toHaveCount();
 });

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -339,7 +339,7 @@ async function dragAndDropBgImage() {
 }
 
 test("change the main color of a background image of type '/html_editor/shape'", async () => {
-    await setupWebsiteBuilder(
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
         `
             <section style="background-image: url('/web_editor/shape/http_routing/404.svg?c2=o-color-2');">
                 AAAA
@@ -350,6 +350,7 @@ test("change the main color of a background image of type '/html_editor/shape'",
         }
     );
     await contains(":iframe section").click();
+    await waitSidebarUpdated();
     await contains("[data-label='Main Color'] .o_we_color_preview").click();
     await contains(
         ".o-main-components-container .o_colorpicker_section [data-color='o-color-5']"
@@ -385,6 +386,7 @@ test("remove the background image of a snippet", async () => {
             </div>
         </section>`);
     await contains(":iframe section").click();
+    await waitSidebarUpdated();
     expect(":iframe section").toHaveStyle("backgroundImage");
     await contains("[data-action-id='toggleBgImage']").click();
     await waitSidebarUpdated();
@@ -392,7 +394,7 @@ test("remove the background image of a snippet", async () => {
 });
 
 test("changing shape's background color doesn't hide the shape itself", async () => {
-    await setupWebsiteBuilder(
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
         `<section style="background-image: url('/web_editor/shape/http_routing/404.svg?c2=o-color-2');">
             AAAA
         </section>`,
@@ -401,6 +403,7 @@ test("changing shape's background color doesn't hide the shape itself", async ()
         }
     );
     await contains(":iframe section").click();
+    await waitSidebarUpdated();
     await contains("button[data-action-id='toggleBgShape']").click();
     await contains(
         ".o_pager_container .o-hb-bg-shape-btn [data-action-value='web_editor/Connections/01'][data-action-id='setBackgroundShape']"

--- a/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
+++ b/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
@@ -89,7 +89,7 @@ test("Drag and drop a column toggles the grid mode", async () => {
 });
 
 test("Drag and drop an image should drag the closest draggable element but not if it is a section", async () => {
-    const { getEditableContent } = await setupWebsiteBuilderWithSnippet(
+    const { getEditableContent, waitSidebarUpdated } = await setupWebsiteBuilderWithSnippet(
         ["s_text_image", "s_three_columns"],
         { loadIframeBundles: true }
     );
@@ -102,6 +102,7 @@ test("Drag and drop an image should drag the closest draggable element but not i
     expect(":iframe section.s_text_image").not.toHaveClass("o_draggable");
 
     await contains(":iframe section.s_text_image img").click();
+    await waitSidebarUpdated();
     expect(".overlay .o_overlay_options .o_move_handle").toHaveClass("o_draggable");
     expect(":iframe section.s_text_image .row > div:nth-child(2)").toHaveClass("o_draggable");
 

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -112,10 +112,10 @@ test.skip("Remove all images in gallery", async () => {
 });
 
 test("Change gallery layout", async () => {
-    await setupWbsiteBuilderWithImageWall();
+    const { waitSidebarUpdated } = await setupWbsiteBuilderWithImageWall();
 
     await contains(":iframe img").click();
-    await waitFor("[data-label='Mode']");
+    await waitSidebarUpdated();
     expect("[data-label='Mode']").toHaveCount(1);
     expect(queryOne("[data-label='Mode'] .dropdown-toggle").textContent).toBe("Masonry");
     await contains("[data-label='Mode'] .dropdown-toggle").click();


### PR DESCRIPTION
Image edit tests using the builder sidebar were failing intermittently because image elements rely on async actions with non-deterministic timing, causing the sidebar options to be unavailable sometimes.

Use `waitSidebarUpdated` to ensure the sidebar is fully updated before asserting on its content.

Here is an example of an error:
error-234951

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
