### PR TITLE
[FIX] mass_mailing: fix assets loading test

### DIFF
--- a/addons/html_editor/static/src/utils/blocks.js
+++ b/addons/html_editor/static/src/utils/blocks.js
@@ -72,7 +72,7 @@ export function isBlock(node) {
     // We won't call `getComputedStyle(node).display` more than once per node.
     let display = computedStyleDisplayCache.get(node);
     if (display === undefined) {
-        const style = node.ownerDocument.defaultView.getComputedStyle(node);
+        const style = (node.ownerDocument.defaultView ?? window).getComputedStyle(node);
         display = style.display;
         computedStyleDisplayCache.set(node, display);
     }

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -314,6 +314,7 @@ describe("field HTML", () => {
             resId: 1,
             arch: mailViewArch,
         });
+        await waitFor(".o_mass_mailing_theme_selector_iframe_container iframe:not([hidden])", { timeout: 3000 });
         await click(waitFor(":iframe .o_mailing_template_preview_wrapper [data-name='default']"));
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass(
@@ -327,8 +328,8 @@ describe("field HTML", () => {
         await waitFor(".hb-row .hb-row-label span:contains(Domain)");
         expect(queryOne(".hb-row span.fa-filter + span").textContent.toLowerCase()).toBe("id = 1");
         await clickSave();
-        await waitFor("table[t-if]");
-        expect(queryOne("table[t-if]")).toHaveAttribute(
+        await waitFor(".o_mail_body_inline table[t-if]");
+        expect(queryOne(".o_mail_body_inline table[t-if]")).toHaveAttribute(
             "t-if",
             'object.filtered_domain([("id", "=", 1)])'
         );
@@ -392,6 +393,7 @@ describe("field HTML: with loaded assets", () => {
             resId: 1,
             arch: mailViewArch,
         });
+        await waitFor(".o_mass_mailing_theme_selector_iframe_container iframe:not([hidden])", { timeout: 3000 });
         await click(waitFor(":iframe .o_mailing_template_preview_wrapper [data-name='default']"));
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         const { bundleControls } = await htmlField.ensureIframeLoaded();


### PR DESCRIPTION
This commit fixes an undeterministic issue with the theme selector iframe's
loading. It could take a bit longer for it to be properly displayed.

When [1] was merged it introduced some non-determinism as we now needed to load
an iframe that could contain shadow roots. This iframe needs to load some more
assets, which leads to loading wait times. This change wasn't taken into account
for the fixed test in this commit. Now we properly await for the iframe to be
loaded before querying elements inside it.

[1]: https://github.com/odoo/odoo/commit/0f7ee1764e8b59029003c6ad7269e185b30c6b43

runbot-234965

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
