### PR TITLE
[FIX] pos_self_order: Center preset when only one

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
@@ -5,14 +5,19 @@
             <div class="d-flex flex-column flex-grow-1 overflow-y-auto" t-ref="scrollContainer">
                <div class="container o_self_container my-auto">
                    <h1 class="text-center mt-4">Where do you want to eat?</h1>
-                   <div class="grid py-3 py-lg-4 gap-3 gap-sm-4 ">
+                   <div class="grid py-3 py-lg-4 gap-3 gap-sm-4" t-att-class="{'d-flex justify-content-center': presets.length === 1}">
                        <article
                             t-foreach="presets"
                             t-as="preset" t-key="preset.id"
                             t-on-click="() => this.selectPreset(preset)"
                             role="button"
-                            class="preset_btn fs-2 fw-medium g-col-12 g-col-sm-6 d-flex flex-row-inverse flex-sm-column  align-items-center w-100 border border-light shadow-sm overflow-hidden bg-white rounded cursor-pointer rounded-4"
-                            t-att-class="{'justify-content-center': !preset.has_image, 'g-col-md-6': presets.length &lt; 3, 'g-col-md-4': presets.length &gt; 2 }">
+                            class="preset_btn fs-2 fw-medium g-col-12 g-col-sm-6 d-flex flex-row-inverse flex-sm-column align-items-center border border-light shadow-sm overflow-hidden bg-white rounded cursor-pointer rounded-4"
+                            t-att-class="{
+                                'justify-content-center': !preset.has_image,
+                                'g-col-md-6': presets.length &lt; 3,
+                                'g-col-md-4': presets.length &gt; 2,
+                                'w-50': presets.length === 1
+                            }">
                             <t t-if="preset.has_image">
                                 <div class="img_container flex-shrink-0 w-25 w-sm-100 ratio ratio-1x1">
                                     <img class="object-fit-cover" t-attf-src="/web/image/pos.preset/#{preset.id}/image_512?unique=#{preset.write_date} "/>


### PR DESCRIPTION
On the eating location page, when there is only one preset, we would like to center it. Before, when there is only one preset available, it was aligned on the left.

This occurs when there is two presets for a pos config and the default one is not available in self o

task:5478651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
