### PR TITLE
[FIX] l10n_fr: wrong aggregation

### DIFF
--- a/addons/l10n_fr/data/tax_report_data.xml
+++ b/addons/l10n_fr/data/tax_report_data.xml
@@ -1968,7 +1968,7 @@
                                             <record id="tax_report_15_1_balance_rounded" model="account.report.expression">
                                                 <field name="label">balance_rounded</field>
                                                 <field name="engine">aggregation</field>
-                                                <field name="formula">15_1</field>
+                                                <field name="formula">box_15_1.balance_from_tags</field>
                                                 <field name="subformula">round(0)</field>
                                             </record>
                                             <record id="tax_report_15_1_balance_from_tags" model="account.report.expression">


### PR DESCRIPTION
During this commit: https://github.com/odoo/odoo/commit/869f80b466ec2246f27e11fa823eb32ac664fb01 we made a mistake in the box 15_1.

no task id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
