### PR TITLE
[FIX] web_tour: avoid logs in check_undeterminisms unit tests

### DIFF
--- a/addons/web_tour/static/src/js/tour_automatic/tour_automatic.js
+++ b/addons/web_tour/static/src/js/tour_automatic/tour_automatic.js
@@ -58,7 +58,7 @@ export class TourAutomatic {
                             ? 9999999
                             : step.timeout || this.timeout || 10000,
                     action: async (trigger) => {
-                        if (step.observe) {
+                        if (step.observe && this.debugMode) {
                             await step.checkForUndeterminisms(trigger, observeDelay);
                         }
                         this.allowUnload = false;

--- a/addons/web_tour/static/tests/check_undeterminisms.test.js
+++ b/addons/web_tour/static/tests/check_undeterminisms.test.js
@@ -72,6 +72,7 @@ beforeEach(async () => {
         },
     });
     patchWithCleanup(browser.console, {
+        groupCollapsed: () => {},
         log: () => {},
         error: () => {},
         warn: (s) => {


### PR DESCRIPTION
With this commit, we remove logs about hoot in check_undeterminisms unit tests by patching console.groupCollapsed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
