### PR TITLE
[IMP] hr_attendance: Public holiday ruleset

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -334,7 +334,7 @@ class HrAttendance(models.Model):
         for ruleset, ruleset_attendances in attendances_by_ruleset.items():
             attendances_dates = list(chain(*ruleset_attendances._get_dates().values()))
             overtime_vals_list.extend(
-                ruleset.rule_ids._generate_overtime_vals_v2(min(attendances_dates), max(attendances_dates), ruleset_attendances, schedules_intervals_by_employee)
+                ruleset.rule_ids._generate_overtime_vals(min(attendances_dates), max(attendances_dates), ruleset_attendances, schedules_intervals_by_employee)
             )
         self.env['hr.attendance.overtime.line'].create(overtime_vals_list)
         self.env.add_to_compute(self._fields['overtime_hours'], all_attendances)

--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -22,10 +22,6 @@ def _midnight(date):
     return datetime.combine(date, datetime.min.time())
 
 
-def _replace_interval_records(intervals, records):
-    return Intervals((start, end, records) for (start, end, _) in intervals)
-
-
 def _record_overlap_intervals(intervals):
     boundaries = sorted(_boundaries(intervals, 'start', 'stop'))
     counts = {}
@@ -48,25 +44,6 @@ def _record_overlap_intervals(intervals):
                 start = time
         ids = new_ids
     return Intervals(interval_vals, keep_distinct=True)
-
-
-def _time_delta_hours(td):
-    return td.total_seconds() / 3600
-
-
-def _last_hours_as_intervals(starting_intervals, hours):
-    last_hours_intervals = []
-    for (start, stop, record) in reversed(starting_intervals):
-        duration = _time_delta_hours(stop - start)
-        if hours >= duration:
-            last_hours_intervals.append((start, stop, record))
-            hours -= duration
-        elif hours > 0:
-            last_hours_intervals.append((stop - relativedelta(hours=hours), stop, record))
-            break
-        else:
-            break
-    return Intervals(last_hours_intervals)
 
 
 class HrAttendanceOvertimeRule(models.Model):
@@ -95,9 +72,6 @@ class HrAttendanceOvertimeRule(models.Model):
         ('leave', "When employee is off"),
         ('public_leave', "On a Public holiday"),
         ('schedule', "Outside of a specific schedule"),
-        # ('employee', "Outside the employee's working schedule"),
-        # ('off_time', "When employee is off"),  # TODO in ..._holidays
-        # ('public_leave', "On a holiday"), ......
     ], default='work_days')
     timing_start = fields.Float("From", default=0)
     timing_stop = fields.Float("To", default=24)
@@ -166,161 +140,6 @@ class HrAttendanceOvertimeRule(models.Model):
             ):
                 raise ValidationError(self.env._("Rule '%(name)s' is based off timing, but the work schedule is not specified", name=rule.name))
 
-    def _get_local_time_start(self, date, tz):
-        self.ensure_one()
-        ret = _midnight(date) + relativedelta(hours=self.timing_start)
-        return _naive_utc(ret.replace(tzinfo=tz))
-
-    def _get_local_time_stop(self, date, tz):
-        self.ensure_one()
-        if self.timing_stop == 24:
-            ret = datetime.combine(date, datetime.max.time())
-            return _naive_utc(ret.replace(tzinfo=tz))
-        ret = _midnight(date) + relativedelta(hours=self.timing_stop)
-        return _naive_utc(ret.replace(tzinfo=tz))
-
-    def _get1_timing_overtime_intervals(self, attendances, version_map):
-        self.ensure_one()
-        attendances.employee_id.ensure_one()
-        assert self.base_off == 'timing'
-
-        employee = attendances.employee_id
-        start_dt = min(attendances.mapped('check_in'))
-        end_dt = max(attendances.mapped('check_out'))
-
-        if self.timing_type in ['work_days', 'non_work_days']:
-            company = self.company_id or employee.company_id
-            unusual_days = company.resource_calendar_id._get_unusual_days(start_dt, end_dt, company_id=company)
-
-            attendance_intervals = []
-            for date, day_attendances in attendances.filtered(
-                lambda att: unusual_days.get(att.date.strftime('%Y-%m-%d'), None) == (self.timing_type == 'non_work_days')
-            ).grouped('date').items():
-                tz = ZoneInfo(version_map[employee][date]._get_tz())
-                time_start = self._get_local_time_start(date, tz)
-                time_stop = self._get_local_time_stop(date, tz)
-
-                attendance_intervals.extend([(
-                        max(time_start, attendance.check_in),
-                        min(time_stop, attendance.check_out),
-                        attendance,
-                    ) for attendance in day_attendances
-                    if time_start <= attendance.check_out and attendance.check_in <= time_stop
-                ])
-
-            overtime_intervals = Intervals(attendance_intervals, keep_distinct=True)
-        else:
-            attendance_intervals = [
-                (att.check_in, att.check_out, att)
-                for att in attendances
-            ]
-            resource = attendances.employee_id.resource_id
-            resources_per_tz = attendances.employee_id._get_resources_per_tz(start_dt)
-            # Just use last version for now
-            last_version = version_map[employee][max(attendances.mapped('date'))]
-            tz = ZoneInfo(last_version._get_tz())
-            if self.timing_type == 'schedule':
-                work_schedule = self.resource_calendar_id
-                work_intervals = Intervals(
-                    (_naive_utc(start), _naive_utc(end), records)
-                    for (start, end, records)
-                    in work_schedule._attendance_intervals_batch(
-                        start_dt.replace(tzinfo=UTC),
-                        end_dt.replace(tzinfo=UTC),
-                        resources_per_tz,
-                    )[resource.id]
-                )
-                overtime_intervals = Intervals(attendance_intervals, keep_distinct=True) - work_intervals
-            elif self.timing_type == 'leave':
-                # TODO: completely untested
-                leave_intervals = last_version.resource_calendar_id._leave_intervals_batch(
-                    start_dt.replace(tzinfo=UTC),
-                    end_dt.replace(tzinfo=UTC),
-                    resources_per_tz,
-                )[resource.id]
-                overtime_intervals = Intervals(attendance_intervals, keep_distinct=True) & leave_intervals
-
-        if self.employer_tolerance:
-            overtime_intervals = Intervals((
-                    ot for ot in overtime_intervals
-                    if _time_delta_hours(ot[1] - ot[0]) >= self.employer_tolerance
-                ),
-                keep_distinct=True,
-            )
-        return overtime_intervals
-
-    @api.model
-    def _get_periods(self):
-        return [name for (name, _) in self._fields['quantity_period'].selection]
-
-    @api.model
-    def _get_period_keys(self, date):
-        return {
-            'day': date,
-            # use sunday as key for whole week;
-            # also determines which version we use for the whole week
-            'week': date + relativedelta(days=6 - date.weekday()),
-        }
-
-    def _get_expected_hours_from_contract(self, date, version, period='day'):
-        # todo : improve performance with batch on mapped versions
-        date_start = date
-        date_end = date
-        if period == 'week':
-            date_start = date_start - relativedelta(days=date_start.weekday())  # Set to Monday
-            date_end = date_start + relativedelta(days=6)  # Set to Sunday
-        date_start = datetime.combine(date_start, datetime.min.time())
-        date_end = datetime.combine(date_end, datetime.max.time())
-        expected_work_time = version.employee_id._get_expected_attendances(
-            date_start.replace(tzinfo=UTC),
-            date_end.replace(tzinfo=UTC)
-        )
-        delta = sum((i[1] - i[0]).total_seconds() for i in expected_work_time)
-        expected_hours = delta / 3600.0
-
-        return expected_hours
-
-    def _get_daterange_overtime_intervals_for_quantity_rule(self, start, stop, attendance_intervals, schedule):  # TODO: TO REMOVE IN MASTER
-        self.ensure_one()
-        expected_duration = self.expected_hours
-        attendances_interval = []
-        intervals_attendance_by_attendance = defaultdict(Intervals)
-        attendances = self.env['hr.attendance']
-        for (a_start, a_stop, attendance) in attendance_intervals:
-            attendances += attendance
-            intervals_attendance_by_attendance[attendance] = Intervals([(a_start, a_stop, self.env['resource.calendar'])]) &\
-                Intervals([(start, stop, self.env['resource.calendar'])])
-            attendances_interval.extend(intervals_attendance_by_attendance[attendance]._items)
-
-        if self.expected_hours_from_contract:
-            period_schedule = schedule & Intervals([(start, stop, self.env['resource.calendar'])])
-            expected_duration = sum_intervals(period_schedule)
-
-        overtime_amount = sum_intervals(Intervals(attendances_interval)) - expected_duration
-        if float_compare(overtime_amount, self.employer_tolerance, precision_digits=5) != 1:
-            return dict()
-
-        overtime_intervals = defaultdict(list)
-        remaining_duration = expected_duration
-        remanining_overtime_amount = overtime_amount
-        # Attendances are sorted by check_in asc
-        for attendance in attendances.sorted('check_in'):
-            for start, stop, _cal in intervals_attendance_by_attendance[attendance]:
-                interval_duration = (stop - start).total_seconds() / 3600
-                if remaining_duration >= interval_duration:
-                    remaining_duration -= interval_duration
-                    continue
-                interval_overtime_duration = interval_duration
-                if remaining_duration != 0:
-                    interval_overtime_duration = interval_duration - remaining_duration
-                new_start = stop - timedelta(hours=interval_overtime_duration)
-                remaining_duration = 0
-                overtime_intervals[attendance].append((new_start, stop, self))
-                remanining_overtime_amount = remanining_overtime_amount - interval_overtime_duration
-                if remanining_overtime_amount <= 0:
-                    return overtime_intervals
-        return overtime_intervals
-
     def _get_daterange_overtime_undertime_intervals_for_quantity_rule(self, start, stop, attendance_intervals, schedule):
         self.ensure_one()
         expected_duration = self.expected_hours
@@ -367,28 +186,6 @@ class HrAttendanceOvertimeRule(models.Model):
                 if remanining_overtime_amount <= 0:
                     return overtime_intervals, {}
         return overtime_intervals, {}
-
-    def _get_all_overtime_intervals_for_quantity_rule(self, attendances_by_periods_by_employee, schedule_by_employee):  # TODO: TO REMOVE IN MASTER
-        def _merge_overtime_dict(d1, d2):
-            for attendance, overtime_list in d2.items():
-                d1[attendance].extend(overtime_list)
-
-        overtime_by_employee_by_attendance = defaultdict(lambda: defaultdict(list))
-        for employee, duration_and_amount_by_periods in attendances_by_periods_by_employee.items():
-            schedule = schedule_by_employee['schedule'][employee]
-            fully_flex_schedule = schedule_by_employee['fully_flexible'][employee]
-            for day, attendance_interval in duration_and_amount_by_periods.items():
-                for rule in self:
-                    start = datetime.combine(day, datetime.min.time())
-                    if rule.quantity_period == 'week':
-                        start -= relativedelta(days=6)
-                    stop = datetime.combine(day, datetime.max.time())
-                    if not (Intervals([(start, stop, self.env['resource.calendar'])]) - fully_flex_schedule):  # employee is fully flexible
-                        continue
-                    rule_overtime_list_by_attendance = rule._get_daterange_overtime_intervals_for_quantity_rule(
-                        start, stop, attendance_interval, schedule)
-                    _merge_overtime_dict(overtime_by_employee_by_attendance[employee], rule_overtime_list_by_attendance)
-        return overtime_by_employee_by_attendance
 
     def _get_all_overtime_undertime_intervals_for_quantity_rule(self, attendances_by_periods_by_employee, schedule_by_employee):
         def _merge_overtime_dict(d1, d2):
@@ -565,42 +362,6 @@ class HrAttendanceOvertimeRule(models.Model):
                     _fill_overtime(employees, rule, timing_intervals_by_employee, attendances_intervals_by_employee)
         return overtime_by_employee_by_attendance
 
-    def _get_overtime_intervals_by_employee_by_attendance(self, min_check_in, max_check_out, attendances, schedules_intervals_by_employee):  # TODO: TO REMOVE IN MASTER
-
-        def _merge_overtime_dict(d1, d2):
-            for employee, overtime_interval_list in d2.items():
-                for attendance, overtime_list in overtime_interval_list.items():
-                    d1[employee][attendance].extend(overtime_list)
-
-        overtime_by_employee_by_attendance = defaultdict(lambda: defaultdict(list))
-
-        quantity_rules = self.filtered_domain([('base_off', '=', 'quantity')])
-        if quantity_rules:
-            attendances_by_periods_by_employee = attendances._get_attendance_by_periods_by_employee()
-            quantity_rule_by_periods = quantity_rules.grouped('quantity_period')
-            for period, rules in quantity_rule_by_periods.items():
-                _merge_overtime_dict(
-                    overtime_by_employee_by_attendance,
-                    rules._get_all_overtime_intervals_for_quantity_rule(
-                        attendances_by_periods_by_employee[period], schedules_intervals_by_employee
-                    )
-                )
-
-        timing_rules = (self - quantity_rules)
-        if not timing_rules:
-            return overtime_by_employee_by_attendance
-
-        _merge_overtime_dict(
-            overtime_by_employee_by_attendance,
-            timing_rules._get_all_overtime_intervals_for_timing_rule(
-                min_check_in,
-                max_check_out,
-                attendances,
-                schedules_intervals_by_employee
-            )
-        )
-        return overtime_by_employee_by_attendance
-
     def _get_overtime_undertime_intervals_by_employee_by_attendance(self, min_check_in, max_check_out, attendances, schedules_intervals_by_employee):
 
         def _merge_overtime_dict(d1, d2):
@@ -635,135 +396,7 @@ class HrAttendanceOvertimeRule(models.Model):
         )
         return overtime_by_employee_by_attendance, undertime_by_employee_by_attendance
 
-    def _get_overtime_intervals_by_date(self, attendances, version_map):  # TO REMOVE IN MASTER
-        """ return all overtime over the attendances (all of the SAME employee)
-            as a list of `Intervals` sets with the rule as the recordset
-            generated by `timing` rules in self
-        """
-        attendances.employee_id.ensure_one()
-        employee = attendances.employee_id
-        if not attendances:
-            return [Intervals(keep_distinct=True)]
-
-        # Timing based
-        timing_intervals_by_date = defaultdict(list)
-        all_timing_overtime_intervals = Intervals(keep_distinct=True)
-        for rule in self.filtered(lambda r: r.base_off == 'timing'):
-            new_intervals = rule._get1_timing_overtime_intervals(attendances, version_map)
-            all_timing_overtime_intervals |= new_intervals
-            for start, end, attendance in new_intervals:
-                timing_intervals_by_date[attendance.date].append((start, end, rule))
-            # timing_intervals_list.append(
-            #     Intervals((start, end, (rule, attendance.date)) for (start, end, attendance) in intervals)
-            # )
-            # timing_intervals_list.append(
-            #     _replace_interval_records(new_intervals, rule)
-            # )
-
-        # Quantity Based
-        periods = self._get_periods()
-
-        work_hours_by = {period: defaultdict(lambda: 0) for period in periods}
-        attendances_by = {period: defaultdict(list) for period in periods}
-        overtime_hours_by = {period: defaultdict(lambda: 0) for period in periods}
-        overtimes_by = {period: defaultdict(list) for period in periods}
-        for attendance in attendances:
-            for period, key_date in self._get_period_keys(attendance.date).items():
-                work_hours_by[period][key_date] += attendance.worked_hours
-                attendances_by[period][key_date].append(
-                    (attendance.check_in, attendance.check_out, attendance)
-                )
-        for start, end, attendance in all_timing_overtime_intervals:
-            for period, key_date in self._get_period_keys(attendance.date).items():
-                overtime_hours_by[period][key_date] += _time_delta_hours(end - start)
-                overtimes_by[period][key_date].append((start, end, attendance))
-
-        # list -> Intervals
-        for period in periods:
-            overtimes_by[period] = defaultdict(
-                lambda: Intervals(keep_distinct=True),
-                {
-                    date: Intervals(ots, keep_distinct=True)
-                    for date, ots in overtimes_by[period].items()
-                }
-            )
-            # non overtime attendances
-            attendances_by[period] = defaultdict(
-                lambda: Intervals(keep_distinct=True),
-                {
-                    date: Intervals(atts, keep_distinct=True) - overtimes_by[period][date]
-                    for date, atts in attendances_by[period].items()
-                }
-            )
-
-        quantity_intervals_by_date = defaultdict(list)
-        for rule in self.filtered(lambda r: r.base_off == 'quantity').sorted(
-            lambda r: {p: i for i, p in enumerate(periods)}[r.quantity_period]
-        ):
-            period = rule.quantity_period
-            for date in attendances_by[period]:
-                if rule.expected_hours_from_contract:
-                    expected_hours = self._get_expected_hours_from_contract(date, version_map[employee][date], period)
-                else:
-                    expected_hours = rule.expected_hours
-
-                overtime_quantity = work_hours_by[period][date] - expected_hours
-                # if overtime_quantity <= -rule.employee_tolerance and rule.undertime: make negative adjustment
-                if overtime_quantity <= 0 or overtime_quantity <= rule.employer_tolerance:
-                    continue
-                if overtime_quantity < overtime_hours_by[period][date]:
-                    for start, end, attendance in _last_hours_as_intervals(
-                        starting_intervals=overtimes_by[period][date],
-                        hours=overtime_quantity,
-                    ):
-                        quantity_intervals_by_date[attendance.date].append((start, end, rule))
-                else:
-                    new_intervals = _last_hours_as_intervals(
-                        starting_intervals=attendances_by[period][date],
-                        hours=overtime_quantity - overtime_hours_by[period][date],
-                    )
-
-                    # Uncommenting this changes the logic of how rules for different periods will interact.
-                    # Would make it so weekly overtimes try to overlap daily overtimes as much as possible
-                    # for outer_period, key_date in self._get_period_keys(date).items():
-                    #     overtimes_by[outer_period][key_date] |= new_intervals
-                    #     attendances_by[outer_period][key_date] -= new_intervals
-                    #     overtime_hours_by[outer_period][key_date] += sum(
-                    #         (end - start).seconds / 3600
-                    #         for (start, end, _) in new_intervals
-                    #     )
-
-                    for start, end, attendance in (
-                        new_intervals | overtimes_by[period][date]
-                    ):
-                        date = attendance[0].date
-                        quantity_intervals_by_date[date].append((start, end, rule))
-        intervals_by_date = {}
-        for date in quantity_intervals_by_date.keys() | timing_intervals_by_date.keys():
-            intervals_by_date[date] = _record_overlap_intervals([
-                *timing_intervals_by_date[date],
-                *quantity_intervals_by_date[date],
-            ])
-        return intervals_by_date
-
-    def _generate_overtime_vals(self, employee, attendances, version_map):  # TO REMOVE IN MASTER
-        vals = []
-        for date, intervals in self._get_overtime_intervals_by_date(attendances, version_map).items():
-            vals.extend([
-                {
-                    'time_start': start,
-                    'time_stop': stop,
-                    'duration': _time_delta_hours(stop - start),
-                    'employee_id': employee.id,
-                    'date': date,
-                    'rule_ids': rules.ids,
-                    **rules._extra_overtime_vals(),
-                }
-                for start, stop, rules in intervals
-            ])
-        return vals
-
-    def _generate_overtime_vals_v2(self, min_check_in, max_check_out, attendances, schedules_intervals_by_employee):  # SHOULD BE RENAME IN MASTER
+    def _generate_overtime_vals(self, min_check_in, max_check_out, attendances, schedules_intervals_by_employee):
         vals = []
 
         def _add_overtime_val(attendance, duration_by_day_by_rules):

--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -93,6 +93,7 @@ class HrAttendanceOvertimeRule(models.Model):
         ('work_days', "On any working day"),
         ('non_work_days', "On any non-working day"),
         ('leave', "When employee is off"),
+        ('public_leave', "On a Public holiday"),
         ('schedule', "Outside of a specific schedule"),
         # ('employee', "Outside the employee's working schedule"),
         # ('off_time', "When employee is off"),  # TODO in ..._holidays
@@ -463,7 +464,8 @@ class HrAttendanceOvertimeRule(models.Model):
             'leave': schedules_intervals_by_employee['leave'],
             'schedule': defaultdict(lambda: defaultdict(Intervals)),
             'work_days': defaultdict(),
-            'non_work_days': defaultdict()
+            'non_work_days': defaultdict(),
+            'public_leave': defaultdict(),
         }
 
         for employee in employees:
@@ -479,6 +481,9 @@ class HrAttendanceOvertimeRule(models.Model):
                         datetime.combine(max_check_out, datetime.max.time())
                     )
                 )
+            if 'public_leave' in timing_type_set:
+                intervals_by_timing_type['public_leave'][employee] = _generate_days_intervals(schedules_intervals_by_employee['public_leave'][employee])
+
         if 'schedule' in timing_type_set:
             for calendar in timing_rule_by_timing_type['schedule'].resource_calendar_id:
                 start_datetime = datetime.combine(min_check_in, datetime.min.time()).replace(tzinfo=UTC) - relativedelta(days=1)  # to avoid timezone shift

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -285,6 +285,7 @@ class HrEmployee(models.Model):
     def _get_schedules_by_employee_by_work_type(self, start, stop, version_periods_by_employee):
         employees_by_calendar = defaultdict(lambda: self.env['hr.employee'])
         leave_intervals_by_cal_by_resource = defaultdict(lambda: defaultdict(Intervals))
+        public_leave_intervals_by_cal_by_resource = defaultdict(lambda: defaultdict(Intervals))
         attendance_intervals_by_employee = defaultdict(Intervals)
 
         for employee, intervals in version_periods_by_employee.items():
@@ -302,6 +303,11 @@ class HrEmployee(models.Model):
                 stop,
                 resources_per_tz=resources_per_tz,
             )
+            cal_public_leave_intervals_by_resource = cal._public_leave_intervals_batch(
+                start,
+                stop,
+                resources_per_tz=resources_per_tz,
+            )
             for resource, leave_intervals in cal_leave_intervals_by_resource.items():
                 naive_leave_intervals = Intervals([(
                     i_start.replace(tzinfo=None),
@@ -309,6 +315,14 @@ class HrEmployee(models.Model):
                     i_model
                 ) for (i_start, i_stop, i_model) in leave_intervals])
                 leave_intervals_by_cal_by_resource[cal][resource] = naive_leave_intervals
+
+            for resource, public_leave_intervals in cal_public_leave_intervals_by_resource.items():
+                naive_public_leave_intervals = Intervals([(
+                    i_start.replace(tzinfo=None),
+                    i_stop.replace(tzinfo=None),
+                    i_model
+                ) for (i_start, i_stop, i_model) in public_leave_intervals])
+                public_leave_intervals_by_cal_by_resource[cal][resource] = naive_public_leave_intervals
 
             cal_attendance_intervals_by_resource = cal._attendance_intervals_batch(
                 start,
@@ -325,7 +339,8 @@ class HrEmployee(models.Model):
         full_schedule_by_employee = {
             'leave': defaultdict(Intervals),
             'schedule': defaultdict(Intervals),
-            'fully_flexible': defaultdict(Intervals)
+            'fully_flexible': defaultdict(Intervals),
+            'public_leave': defaultdict(Intervals),
         }
         for employee, intervals in version_periods_by_employee.items():
             employee_attendances = attendance_intervals_by_employee[employee]
@@ -336,6 +351,8 @@ class HrEmployee(models.Model):
                     continue
                 calendar = version.resource_calendar_id
                 employee_leaves = leave_intervals_by_cal_by_resource[calendar][employee.resource_id.id]
+                employee_public_leaves = public_leave_intervals_by_cal_by_resource[calendar][employee.resource_id.id]
+                full_schedule_by_employee['public_leave'][employee] |= employee_public_leaves & interval
                 full_schedule_by_employee['leave'][employee] |= employee_leaves & interval
                 full_schedule_by_employee['schedule'][employee] |= employee_attendances & interval
 

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -303,10 +303,11 @@ class HrEmployee(models.Model):
                 stop,
                 resources_per_tz=resources_per_tz,
             )
-            cal_public_leave_intervals_by_resource = cal._public_leave_intervals_batch(
+            cal_public_leave_intervals_by_resource = cal._leave_intervals_batch(
                 start,
                 stop,
                 resources_per_tz=resources_per_tz,
+                domain=[('resource_id', '=', False)]
             )
             for resource, leave_intervals in cal_leave_intervals_by_resource.items():
                 naive_leave_intervals = Intervals([(

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1077,6 +1077,74 @@ class TestHrAttendanceOvertime(HttpCase):
         self.assertEqual(response.get('overtime_today'), 10)
         self.assertEqual(response.get('total_overtime'), 10)
 
+    def test_overtime_with_public_leave_timing_type(self):
+        """
+        Validate that a public leave timing type is correctly applied.
+        Comapny 1 has a public holiday, while Company 2 does not.
+        Employee from Company 2 should not get overtime for working that day.
+        Also Employee from Company 1 should not get overtime for working on a weekend.
+        """
+
+        with freeze_time("2025-11-11 12:00:00"):
+            self.env.user.tz = 'UTC'  # to avoid to shift the public holidays hours
+            company_be = self.env['res.company'].create({'name': 'Odoo BE'})
+            company_de = self.env['res.company'].create({'name': 'Odoo DE'})
+
+            with Form(self.env['resource.calendar.leaves'].with_company(company_be)) as holiday_form:
+                holiday_form.name = 'Armistice Day'
+                holiday_form.date_from = datetime(2025, 11, 11, 0, 0)
+                holiday_form.save()
+
+            ruleset_be = self.env['hr.attendance.overtime.ruleset'].with_company(company_be).create({
+                'name': 'Ruleset schedule timing',
+                'rule_ids': [Command.create({
+                        'name': 'Rule schedule timing',
+                        'base_off': 'timing',
+                        'timing_type': 'public_leave',
+                        'timing_start': 0,
+                        'timing_stop': 24,
+                    })],
+            })
+            ruleset_de = self.env['hr.attendance.overtime.ruleset'].with_company(company_de).create({
+                'name': 'Ruleset schedule timing',
+                'rule_ids': [Command.create({
+                        'name': 'Rule schedule timing',
+                        'base_off': 'timing',
+                        'timing_type': 'public_leave',
+                        'timing_start': 0,
+                        'timing_stop': 24,
+                    })],
+            })
+
+            employee_be = self.env['hr.employee'].with_company(company_be).create({
+                'name': 'Hans Belgian',
+                'ruleset_id': ruleset_be.id,
+            })
+            employee_de = self.env['hr.employee'].with_company(company_de).create({
+                'name': 'Henry German',
+                'ruleset_id': ruleset_de.id,
+            })
+
+            attendance_company_be = self.env['hr.attendance'].create({
+                'employee_id': employee_be.id,
+                'check_in': datetime(2025, 11, 11, 8, 0),
+                'check_out': datetime(2025, 11, 11, 17, 0),
+            })
+            attendance_company_de = self.env['hr.attendance'].create({
+                'employee_id': employee_de.id,
+                'check_in': datetime(2025, 11, 11, 8, 0),
+                'check_out': datetime(2025, 11, 11, 17, 0),
+            })
+            attendance_saturday_be = self.env['hr.attendance'].create({
+                'employee_id': employee_be.id,
+                'check_in': datetime(2025, 11, 15, 8, 0),  # Saturday
+                'check_out': datetime(2025, 11, 15, 17, 0),
+            })
+
+            self.assertAlmostEqual(attendance_company_be.overtime_hours, 9, 2, "Employee from Company 1 should have overtime for working on a public holiday.")
+            self.assertAlmostEqual(attendance_company_de.overtime_hours, 0, 2, "Employee from Company 2 should not have overtime for working on a non-holiday day.")
+            self.assertAlmostEqual(attendance_saturday_be.overtime_hours, 0, 2, "Shouldn't have overtime for working on a public holiday.")
+
     def test_overtime_with_public_holidays(self):
         """ Comapny 1 has a public holiday, while Company 2 does not.
             Employee from Company 2 should not get overtime for working that day.

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -420,6 +420,67 @@ class ResourceCalendar(models.Model):
         resources_per_tz = resource._get_resources_per_tz()
         return self._leave_intervals_batch(start_dt, end_dt, resources_per_tz=resources_per_tz, domain=domain)[resource.id]
 
+    def _public_leave_intervals_batch(self, start_dt, end_dt, resources_per_tz=None, domain=None):
+        """ Return only the global/public leave intervals in the given datetime range.
+            These are leaves where resource_id is False.
+        """
+        assert start_dt.tzinfo and end_dt.tzinfo
+
+        # Force the domain to only look for global leaves (resource_id = False)
+        if domain is None:
+            domain = [('time_type', '=', 'leave')]
+
+        domain = domain + [('resource_id', '=', False)]
+
+        if self:
+            domain = domain + [('calendar_id', 'in', [False] + self.ids)]
+
+        # 2. Identify all resources to be processed
+        all_resources = set()
+        if not resources_per_tz or self:
+            all_resources.add(self.env['resource.resource'])
+            resources_per_tz = resources_per_tz or {start_dt.tzinfo: self.env['resource.resource']}
+
+        if resources_per_tz:
+            for _, resources in resources_per_tz.items():
+                all_resources |= set(resources)
+
+        domain = domain + [
+            ('date_from', '<=', end_dt.astimezone(UTC).replace(tzinfo=None)),
+            ('date_to', '>=', start_dt.astimezone(UTC).replace(tzinfo=None)),
+            ('company_id', 'in',
+             [False] + ([r.company_id.id for r in all_resources if r.company_id] or [self.company_id.id])),
+        ]
+
+        result = defaultdict(list)
+        tz_dates = {}
+        all_leaves = self.env['resource.calendar.leaves'].search(domain)
+
+        for leave in all_leaves:
+            leave_company = leave.company_id
+            leave_date_from = leave.date_from
+            leave_date_to = leave.date_to
+
+            for tz, resources in resources_per_tz.items():
+                # Standardize the boundary dates for this timezone
+                if (tz, start_dt) not in tz_dates:
+                    tz_dates[tz, start_dt] = start_dt.astimezone(tz)
+                if (tz, end_dt) not in tz_dates:
+                    tz_dates[tz, end_dt] = end_dt.astimezone(tz)
+
+                start = tz_dates[tz, start_dt]
+                end = tz_dates[tz, end_dt]
+
+                dt0 = leave_date_from.astimezone(tz)
+                dt1 = leave_date_to.astimezone(tz)
+
+                for resource in resources:
+                    # Only apply if the company matches (or leave has no company)
+                    if not leave_company or (resource.company_id == leave_company):
+                        result[resource.id].append((max(start, dt0), min(end, dt1), leave))
+
+        return {r.id: Intervals(result[r.id]) for r in all_resources}
+
     def _leave_intervals_batch(self, start_dt, end_dt, resources_per_tz=None, domain=None):
         """ Return the leave intervals in the given datetime range.
             The returned intervals are expressed in specified tz or in the calendar's timezone.

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -420,67 +420,6 @@ class ResourceCalendar(models.Model):
         resources_per_tz = resource._get_resources_per_tz()
         return self._leave_intervals_batch(start_dt, end_dt, resources_per_tz=resources_per_tz, domain=domain)[resource.id]
 
-    def _public_leave_intervals_batch(self, start_dt, end_dt, resources_per_tz=None, domain=None):
-        """ Return only the global/public leave intervals in the given datetime range.
-            These are leaves where resource_id is False.
-        """
-        assert start_dt.tzinfo and end_dt.tzinfo
-
-        # Force the domain to only look for global leaves (resource_id = False)
-        if domain is None:
-            domain = [('time_type', '=', 'leave')]
-
-        domain = domain + [('resource_id', '=', False)]
-
-        if self:
-            domain = domain + [('calendar_id', 'in', [False] + self.ids)]
-
-        # 2. Identify all resources to be processed
-        all_resources = set()
-        if not resources_per_tz or self:
-            all_resources.add(self.env['resource.resource'])
-            resources_per_tz = resources_per_tz or {start_dt.tzinfo: self.env['resource.resource']}
-
-        if resources_per_tz:
-            for _, resources in resources_per_tz.items():
-                all_resources |= set(resources)
-
-        domain = domain + [
-            ('date_from', '<=', end_dt.astimezone(UTC).replace(tzinfo=None)),
-            ('date_to', '>=', start_dt.astimezone(UTC).replace(tzinfo=None)),
-            ('company_id', 'in',
-             [False] + ([r.company_id.id for r in all_resources if r.company_id] or [self.company_id.id])),
-        ]
-
-        result = defaultdict(list)
-        tz_dates = {}
-        all_leaves = self.env['resource.calendar.leaves'].search(domain)
-
-        for leave in all_leaves:
-            leave_company = leave.company_id
-            leave_date_from = leave.date_from
-            leave_date_to = leave.date_to
-
-            for tz, resources in resources_per_tz.items():
-                # Standardize the boundary dates for this timezone
-                if (tz, start_dt) not in tz_dates:
-                    tz_dates[tz, start_dt] = start_dt.astimezone(tz)
-                if (tz, end_dt) not in tz_dates:
-                    tz_dates[tz, end_dt] = end_dt.astimezone(tz)
-
-                start = tz_dates[tz, start_dt]
-                end = tz_dates[tz, end_dt]
-
-                dt0 = leave_date_from.astimezone(tz)
-                dt1 = leave_date_to.astimezone(tz)
-
-                for resource in resources:
-                    # Only apply if the company matches (or leave has no company)
-                    if not leave_company or (resource.company_id == leave_company):
-                        result[resource.id].append((max(start, dt0), min(end, dt1), leave))
-
-        return {r.id: Intervals(result[r.id]) for r in all_resources}
-
     def _leave_intervals_batch(self, start_dt, end_dt, resources_per_tz=None, domain=None):
         """ Return the leave intervals in the given datetime range.
             The returned intervals are expressed in specified tz or in the calendar's timezone.


### PR DESCRIPTION
This commit aims to create a new timing type called "Public leaves". Before, we only had 'work_days' and 'non_work_days' , thus there was no distinction between public leaves, and normal non working days like weekends. Some companies use differant rates depending if it's a public holiday or just a normal weekend. So it's relevant to seperate Public holidays from normal leaves.

task - 5427597
