### PR TITLE
[FIX] *: propagate stock move partner from procurement

### DIFF
--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -627,7 +627,7 @@ class TestProcurement(TestMrpCommon):
         create_run_procurement(product, 10, {
             'reference_ids': reference,
             'warehouse_id': self.warehouse_1,
-            'partner_id': vendor,
+            'partner_id': vendor.id,
         })
         customer_move = self.env['stock.move'].search([('reference_ids', 'in', reference.id), ('picking_type_id', '=', self.picking_type_out.id)])
         manufacturing_order = self.env['mrp.production'].search([('product_id', '=', product.id)])
@@ -640,7 +640,7 @@ class TestProcurement(TestMrpCommon):
         create_run_procurement(product, -5.00, {
             'reference_ids': reference,
             'warehouse_id': self.warehouse_1,
-            'partner_id': vendor,
+            'partner_id': vendor.id,
         })
         self.assertEqual(customer_move.product_uom_qty, 5, 'The demand on the initial move should have been decreased when merged with the procurement.')
         self.assertEqual(manufacturing_order.product_qty, 10, 'The demand on the manufacturing order should not have been decreased.')

--- a/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_rule.py
@@ -8,7 +8,7 @@ class StockRule(models.Model):
     _inherit = 'stock.rule'
 
     def _prepare_purchase_order(self, company_id, origins, values):
-        if 'partner_id' not in values[0] \
+        if not values[0].get('partner_id') \
             and (company_id.subcontracting_location_id.parent_path in self.location_dest_id.parent_path
                  or self.location_dest_id.is_subcontract()):
             move = values[0].get('move_dest_ids')
@@ -18,6 +18,6 @@ class StockRule(models.Model):
 
     def _make_po_get_domain(self, company_id, values, partner):
         domain = super()._make_po_get_domain(company_id, values, partner)
-        if values.get('partner_id', False):
+        if self.location_src_id.usage == 'supplier' and self.location_dest_id.is_subcontract() and values.get('partner_id', False):
             domain += (('dest_address_id', '=', values.get('partner_id')),)
         return domain

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1704,7 +1704,7 @@ class PosOrderLine(models.Model):
             'date_deadline': date_deadline,
             'route_ids': self.order_id.config_id.route_id,
             'warehouse_id': self.order_id.config_id.warehouse_id or False,
-            'partner': self.order_id.partner_id,
+            'partner_id': self.order_id.partner_id.id,
             'product_description_variants': self.full_product_name,
             'company_id': self.order_id.company_id,
             'reference_ids': self.order_id.stock_reference_ids,

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -397,7 +397,7 @@ class StockRule(models.Model):
         return res
 
     def _get_partner_id(self, values, rule):
-        return values.get("supplierinfo_name") or (values.get("force_uom") and values.get("partner"))
+        return values.get("supplierinfo_name") or (values.get("force_uom") and values.get("partner_id"))
 
 
 class StockRoute(models.Model):

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -637,7 +637,7 @@ class TestCreatePicking(ProductVariantsCommon):
         # Create initial procurement that will generate the initial move and its picking.
         create_run_procurement(product, 50, {
             'warehouse_id': picking_type_out.warehouse_id,
-            'partner_id': vendor
+            'partner_id': vendor.id
         })
         customer_move = self.env['stock.move'].search([('product_id', '=', product.id)])
         purchase_order = self.env['purchase.order'].search([('partner_id', '=', partner.id)])

--- a/addons/sale_purchase/models/purchase_order.py
+++ b/addons/sale_purchase/models/purchase_order.py
@@ -24,10 +24,10 @@ class PurchaseOrder(models.Model):
 
     @api.depends('order_line.sale_order_id.partner_shipping_id')
     def _compute_dest_address_id(self):
+        super()._compute_dest_address_id()
         po_with_address = self.filtered(lambda po: po.dest_address_id and len(po._get_sale_orders().partner_shipping_id) == 1)
         for order in po_with_address:
             order.dest_address_id = order._get_sale_orders().partner_shipping_id
-        super(PurchaseOrder, self - po_with_address)._compute_dest_address_id()
 
     def action_view_sale_orders(self):
         self.ensure_one()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1663,6 +1663,11 @@ Please change the quantity done or the rounding precision in your settings.""",
 
         return quantities
 
+    def _get_partner_id(self):
+        if self.location_id == self.env.company.internal_transit_location_id:
+            return False
+        return self.partner_id.id
+
     def _prepare_procurement_values(self):
         """ Prepare specific key for moves or other componenets that will be created from a stock rule
         comming from a stock move. This method could be override in order to add other custom key that could
@@ -1693,6 +1698,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             'date_order': dates_info.get('date_order'),
             'date_deadline': self.date_deadline,
             'move_dest_ids': move_dest_ids,
+            'partner_id': move_dest_ids._get_partner_id() if move_dest_ids else False,
             'route_ids': route,
             'warehouse_id': warehouse,
             'priority': self.priority,

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -329,7 +329,7 @@ class StockRule(models.Model):
             fields.Datetime.from_string(values['date_planned']) - relativedelta(days=self.delay or 0)
         )
         date_deadline = values.get('date_deadline') and (fields.Datetime.to_datetime(values['date_deadline']) - relativedelta(days=self.delay or 0)) or False
-        partner = self.partner_address_id or values.get('partner', False)
+        partner = self.partner_address_id.id or values.get('partner_id', False)
         # it is possible that we've already got some move done, so check for the done qty and create
         # a new move with the correct qty
         qty_left = product_qty
@@ -342,7 +342,7 @@ class StockRule(models.Model):
             if location_dest_id == company_id.internal_transit_location_id:
                 partners = move_dest.location_dest_id.warehouse_id.partner_id
                 if len(partners) == 1:
-                    partner = partners
+                    partner = partners.id
                 move_dest.partner_id = self.location_src_id.warehouse_id.partner_id or self.company_id.partner_id
 
         # If the quantity is negative the move should be considered as a refund
@@ -354,7 +354,7 @@ class StockRule(models.Model):
             'product_id': product_id.id,
             'product_uom': product_uom.id,
             'product_uom_qty': qty_left,
-            'partner_id': partner.id if partner else False,
+            'partner_id': partner,
             'location_id': self.location_src_id.id,
             'location_final_id': location_dest_id.id,
             'move_dest_ids': move_dest_ids,


### PR DESCRIPTION
*mrp{,_subcontracting_dropshipping}, point_of_sale, sale_purchase, {purchase_,sale_,}stock

### Issue: 

The partner_id (contact field) of stock move is no longer propagated in pull chain since the procurement/reference refactoring of 19.0 see 2713876dbc70d3984e584a9037a2206dcda4e84a

#### Steps to reproduce:
- In the settings enable Multi-Steps routes
- Inventory > Configuration > Warehouse Management > Warehouses
- Set your warehouse in two step deliveries
- Modify the routes to have two pull rules: Stock -> Out -> Customer
- Create and confirm an SO, 1 unit of a storable product for a customer
#### > While the customer is set on the ship move and picking it is not on the pick move and picking.

### Cause of the issue:

Due to the configuration, the ship move is created by the `action_launch_stock_rule` and linked to the customer via the procurement created from the sale order line:
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/sale_stock/models/sale_order_line.py#L295 Then, the confirmation of the ship move generates a second procurement for the pick move creation. Prior to 19.0, the partner_id of this second procurement was set to the customer via the procurement group: https://github.com/odoo/odoo/blob/712cd806c38e193acdb966e4d3b339ab780f158e/addons/stock/models/stock_rule.py#L333 However, since procurement groups have been removed by the reference refactor 2713876dbc70d3984e584a9037a2206dcda4e84a, the partner id is now expected to be set from the procurement values:
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/stock/models/stock_rule.py#L332 As it is not set by any mean in this procurement values it will therefore not be propagated.

### Additional changes:

1. The `partner_id` of the procurement values needs to be harmonized are some methods set a recordset and others a record id:
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/point_of_sale/models/pos_order.py#L1707
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/mrp_subcontracting_dropshipping/models/stock_orderpoint.py#L10-L13
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/sale_stock/models/sale_order_line.py#L295
The correct behavior is to set an id since the `partner_id` value of the procurement group is used in the `_get_stock_move_values` and written in its "raw state" as the `partner_id` values for the stock move for creation (when sale_stock is installed):
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/sale_stock/models/stock.py#L171-L174
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/stock/models/stock_rule.py#L378-L381

2. The `partner` key of the procurement values is set by to `partner_id` in every overrides but since 2713876dbc70d3984e584a9037a2206dcda4e84 was incorrectly cahnged to `partner`:
https://github.com/odoo/odoo/blob/4466a2684fd36ef3c9e1e7f7437ae48ff51f1941/addons/stock/models/stock_rule.py#L332
We change back this key to the expected `partner_id` and revert the associated pos  fix 203f807a2b764821ec4673515dd29f392ec37b3a using the changed `_get_partner_id` method.

3. In certain use cases, such as inter-warehouse transfer the the `partner_id` should not be propagated by the pull chain as it is expected to be set by the `_get_stock_move_values`:
https://github.com/odoo/odoo/blob/df01277bc053218dda6157f2f0657432e91e1d58/addons/stock/models/stock_rule.py#L339-L346

4. Since the `partner_id` is used to set the `dest_address_id` here:
https://github.com/odoo/odoo/blob/92486bab9b73f4370629452c454c25371d5063ac/addons/purchase_stock/models/stock_rule.py#L350
But is suppose to be reset for non dropshipping use case:
https://github.com/odoo/odoo/blob/df01277bc053218dda6157f2f0657432e91e1d58/addons/purchase_stock/models/purchase_order.py#L80-L82
We need to modify the fix of 3fb81df557553d471ff72998200097b3a0ea666f in order for the value set by th epartner_id to be reset in case we are not in a dropshipping use case.
Similarly, we should only add the `partner_id` of the procurement value as a possible `dest_address_id` in the dropship use case:
https://github.com/odoo/odoo/blob/2c0c26e6cc61f70c91617617ef77f23cfaa1dde6/addons/mrp_subcontracting_dropshipping/models/stock_rule.py#L19-L23

5. Since we are setting a default falsy 'partner_id' values in the `_prepare_procurement_values` of stock moves (e.g.`self.partner_id.id`) we needed to slightly alter the `_prepare_purchase_order` of the `mrp_subcontracting_dropshipping` module so that it sets the partner of the subcontractor when the move sets it to `False` rather than unset:
https://github.com/odoo/odoo/blob/1ac7834a9b9d07760700f6d7c73dfe270a247752/addons/mrp_subcontracting_dropshipping/models/stock_rule.py#L10-L11

opw-5428063
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
