### PR TITLE
[FIX] web: load inactive records for many2many filters

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -870,7 +870,8 @@ export class CalendarModel extends Model {
                 const records = await this.orm.searchRead(
                     field.relation,
                     [["id", "in", relatedIds]],
-                    fieldsToFetch
+                    fieldsToFetch,
+                    { context: { active_test: false } }
                 );
                 if (isX2Many) {
                     const nameById = Object.fromEntries(records.map((r) => [r.id, r.display_name]));

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -2204,6 +2204,51 @@ test(`set filter with many2many field on mobile`, async () => {
 });
 
 test.tags("desktop");
+test("many2many filter handles archived records without crashing on desktop", async () => {
+    CalendarPartner._fields.active = fields.Boolean({ default: true });
+    CalendarPartner._records.push({
+        id: 99,
+        name: "Joni",
+        active: false,
+    });
+    Event._records[0].attendee_ids = [99];
+
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start">
+                <field name="attendee_ids" filters="1"/>
+            </calendar>
+        `,
+    });
+    expect(`.o_calendar_filter_item`).toHaveCount(4);
+});
+
+test.tags("mobile");
+test("many2many filter handles archived records without crashing on mobile", async () => {
+    CalendarPartner._fields.active = fields.Boolean({ default: true });
+    CalendarPartner._records.push({
+        id: 99,
+        name: "Joni",
+        active: false,
+    });
+    Event._records[0].attendee_ids = [99];
+
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start">
+                <field name="attendee_ids" filters="1"/>
+            </calendar>
+        `,
+    });
+    await contains(`.o_filter`).click();
+    expect(`.o_calendar_filter_item`).toHaveCount(4);
+});
+
+test.tags("desktop");
 test(`set filter with one2many field on desktop`, async () => {
     Event._fields.attendee_ids = fields.One2many({
         relation: "calendar.partner",


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In fa56409 support was added for many2many filters in the calendar arch. Since X2many fields use the many2one formatter (see makeFilterDynamic) filters need to be passed in the following format [id, display_name]. Since x2many records are not automatically fetched in this format fa56409 added an additional step wherein colors and display names are fetched (by calling searchRead) and filters are properly formatted. An issue arises though if a record is archived and therefore not found by searchRead. In this case the filter will not be properly formatted and formatMany2one will raise an exception.

Current behavior before PR:

Using a x2many filter with an archived record raises an exception.

Desired behavior after PR is merged:

Using a x2many filter with an archived record will not raise an exception.

(ref: #241522)