### PR TITLE
[FIX] iot_drivers: provide `session_id` in response

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -54,11 +54,12 @@ class Driver(Thread):
         self.data['owner'] = data.get('session_id')
         action = data.get('action', '')
 
+        base_response = {'action_args': {**data}, 'session_id': data.get('session_id')}
         try:
-            response = {'status': 'success', 'result': self._actions[action](data), 'action_args': {**data}}
+            response = {'status': 'success', 'result': self._actions[action](data), **base_response}
         except Exception as e:
             _logger.exception("Error while executing action %s with params %s", action, data)
-            response = {'status': 'error', 'result': str(e), 'action_args': {**data}}
+            response = {'status': 'error', 'result': str(e), **base_response}
 
         # Make response available to /event route or websocket
         # printers handle their own events (low on paper, etc.)

--- a/addons/iot_drivers/event_manager.py
+++ b/addons/iot_drivers/event_manager.py
@@ -51,7 +51,7 @@ class EventManager:
         :param Driver device: actual device class
         :param dict data: data returned by the device (optional)
         """
-        data = data or request.params.get('data', {}) if request else {}
+        data = data or (request.params.get('data', {}) if request else {})
 
         # Make notification available to longpolling event route
         event = {
@@ -62,9 +62,7 @@ class EventManager:
         }
         send_to_controller({
             **event,
-            'session_id': data.get('action_args', {}).get('session_id', ''),
             'iot_box_identifier': helpers.get_identifier(),
-            **data,
         })
         self.events.append(event)
         for session in self.sessions:


### PR DESCRIPTION
Instead of passing `session_id` in the device class parameters, we provide it directly in the response dictionary, in order to allow concurrent actions on the device.

Before this commit:
- send an action from a PoS: `session_id` is set to `1`,
- before the end of the execution, send a second action from the same PoS on the same device (e.g. on another browser): `session_id` is updated to `2`,
- you get only one confirmation in the PoS.

After this commit: we get both confirmations.
