### PR TITLE
[FIX] base_import_module: mark if module was imported with demo

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -127,6 +127,8 @@ class IrModuleModule(models.Model):
         values['latest_version'] = terp.version
         if self.env.context.get('data_module'):
             values['module_type'] = 'industries'
+        if with_demo:
+            values['demo'] = True
 
         unmet_dependencies = set(terp.get('depends', [])).difference(installed_mods)
 


### PR DESCRIPTION
Currently even if an imported module was imported with demo data, the 'demo' field is not set to True.

Setting this field properly will allow to have a better handling of demo data in industry tests.
