### PR TITLE
[FIX] pos_loyalty: prevent pdf generation for fully consumed gift cards in pos

### DIFF
--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -233,7 +233,7 @@ class PosOrder(models.Model):
                         'issued': coupon_vals['points'] if coupon_vals['points'] > 0 else 0,
                     })
 
-                if updated:
+                if updated and gift_card.points:
                     updated_gift_cards |= gift_card
 
                 coupon_key_to_remove.append(coupon_id)


### PR DESCRIPTION
**Steps to produce:**
- Install `pos_loyalty` module.
- Go to POS > select clothes > Load sample data > Buy one gift card.
- Now make another order > add product above 50 > use the gift card.
- Complete payment.

**Issue:**
- Even when the gift card is fully consumed (its points are reduced to 0), a gift card PDF is still generated after the POS payment.

**Root cause:**
- In `_process_existing_gift_cards` ([1]), when a gift card is updated, it is always added to `updated_gift_cards` and returned.
- Later, at [2], all gift cards in updated_gift_cards are used to generate and print PDFs, without checking whether the remaining points are 0.

**Solution:**
- Do not generate or print a PDF for gift cards whose points are 0 after being updated. Only gift cards with a positive remaining balance should be included for PDF generation.

[1]https://github.com/odoo/odoo/blob/57206cc4e3dd988382a063517546ca5dcd74da58/addons/pos_loyalty/models/pos_order.py#L236-L237
[2]https://github.com/odoo/odoo/blob/57206cc4e3dd988382a063517546ca5dcd74da58/addons/pos_loyalty/models/pos_order.py#L132-L133

opw-5474006
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
