### PR TITLE
[FIX] sale*: make quotation payment fail if a promotion is expired

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -2,7 +2,7 @@
 
 import binascii
 
-from odoo import fields, http, _
+from odoo import _, fields, http
 from odoo.exceptions import AccessError, MissingError, ValidationError
 from odoo.fields import Command
 from odoo.http import request
@@ -367,6 +367,13 @@ class CustomerPortal(payment_portal.PaymentPortal):
 
 class PaymentPortal(payment_portal.PaymentPortal):
 
+    def _validate_transaction_for_order(self, transaction, sale_order):
+        """
+        Perform final checks against the transaction & sale_order.
+        Override me to apply payment unrelated checks & processing
+        """
+        return
+
     @http.route('/my/orders/<int:order_id>/transaction', type='json', auth='public')
     def portal_order_transaction(self, order_id, access_token, **kwargs):
         """ Create a draft transaction and return its processing values.
@@ -397,6 +404,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         tx_sudo = self._create_transaction(
             custom_create_values={'sale_order_ids': [Command.set([order_id])]}, **kwargs,
         )
+        self._validate_transaction_for_order(tx_sudo, order_sudo)
 
         return tx_sudo._get_processing_values()
 

--- a/addons/sale_loyalty/__init__.py
+++ b/addons/sale_loyalty/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import controllers
 from . import models
 from . import wizard
 

--- a/addons/sale_loyalty/controllers/__init__.py
+++ b/addons/sale_loyalty/controllers/__init__.py
@@ -1,4 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import delivery
-from . import main
+from . import payment

--- a/addons/sale_loyalty/controllers/payment.py
+++ b/addons/sale_loyalty/controllers/payment.py
@@ -3,16 +3,16 @@
 from odoo import _
 from odoo.exceptions import ValidationError
 
-from odoo.addons.website_sale.controllers import payment
+from odoo.addons.sale.controllers import portal as payment_portal
 
 
-class PaymentPortal(payment.PaymentPortal):
+class PaymentPortal(payment_portal.PaymentPortal):
 
     def _validate_transaction_for_order(self, transaction, sale_order):
         """Update programs & rewards before finalizing transaction.
 
         :param payment.transaction transaction: The payment transaction
-        :param int order_id: The id of the sale order to pay
+        :param sale.order sale_order: The sale order to pay
         :raise: ValidationError if the order amount changed after updating rewards
         """
         super()._validate_transaction_for_order(transaction, sale_order)
@@ -23,6 +23,6 @@ class PaymentPortal(payment.PaymentPortal):
                 raise ValidationError(
                     _(
                         "Cannot process payment: applied reward was changed or has expired.\n"
-                        "Please refresh the page and try again."
+                        "Please try again."
                     )
                 )

--- a/addons/website_sale/controllers/payment.py
+++ b/addons/website_sale/controllers/payment.py
@@ -8,18 +8,11 @@ from odoo.fields import Command
 from odoo.http import request, route
 from odoo.tools import SQL
 
-from odoo.addons.payment.controllers import portal as payment_portal
+from odoo.addons.sale.controllers import portal as payment_portal
 
 # TODO ANVFE part of payment routes ? /shop/payment ? express_checkout ?
 
 class PaymentPortal(payment_portal.PaymentPortal):
-
-    def _validate_transaction_for_order(self, transaction, sale_order):
-        """
-        Perform final checks against the transaction & sale_order.
-        Override me to apply payment unrelated checks & processing
-        """
-        return
 
     @route('/shop/payment/transaction/<int:order_id>', type='json', auth='public', website=True)
     def shop_payment_transaction(self, order_id, access_token, **kwargs):


### PR DESCRIPTION
Paying for a quotation in the portal should fail if a quotation contains expired promotions. This also applies to payment links.

opw-5150616