### PR TITLE
[FIX] purchase_stock: avoid duplicate product description on receipt

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -51,7 +51,11 @@ class StockMove(models.Model):
                 vendor_reference = f'[{seller.product_code}]' if seller.product_code else ''
                 vendor_reference += f' {seller.product_name}' if seller.product_name else ''
                 no_variant_attributes = '\n'.join(f'{attribute.attribute_id.name}: {attribute.name}' for attribute in move.purchase_line_id.sudo().product_no_variant_attribute_value_ids)
-                move.description_picking = (no_variant_attributes + '\n' + vendor_reference + '\n' + move.description_picking).strip()
+                exiting_description = move.description_picking.splitlines()
+                if vendor_reference and (vendor_reference).strip() not in exiting_description:
+                    move.description_picking = vendor_reference + '\n' + move.description_picking
+                if no_variant_attributes and no_variant_attributes not in exiting_description:
+                    move.description_picking = no_variant_attributes + '\n' + move.description_picking
 
     def _get_description(self):
         return self.purchase_line_id.name if self.purchase_line_id else super()._get_description()

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -892,3 +892,22 @@ class TestCreatePicking(ProductVariantsCommon):
         po.order_line.name += '\nRandom purchase notes'
         po.button_confirm()
         self.assertEqual(po.picking_ids.move_ids.description_picking, ('No variant: extra\n' if product_matrix_installed else '') + '[123] ABC\nReceive with care')
+
+    def test_move_description_picking_supplier_product(self):
+        """Test receipt move description uses the product supplier name and code."""
+        self.product_id_1.seller_ids = [Command.create({
+            'partner_id': self.partner_id.id,
+            'product_name': 'Vendor_A',
+            'product_code': '001',
+            'min_qty': 1,
+            'price': 1,
+        })]
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': [Command.create({
+                'product_id': self.product_id_1.id,
+                'product_qty': 1,
+            })],
+        })
+        po.button_confirm()
+        self.assertEqual(po.picking_ids.move_ids.description_picking, '[001] Vendor_A')


### PR DESCRIPTION
**Steps to reproduce:**
* Install the `purchase_stock` module.
* Create a product and set a vendor with a vendor product name and code
* Create a Purchase Order with the same vendor.
* Add the product to the Purchase Order lines.
* Confirm the Purchase Order.
* Open the generated receipt.

**Observed behavior:**
* The stock move description on the receipt contains the product description twice.

**Cause**
`_compute_description_picking` in `purchase_stock` first calls super().
In this super() call, it executes `_get_description`.
However,` _get_description` is overridden in `purchase_stock` to return
the purchase order line name.

https://github.com/odoo/odoo/blob/57e265c482733029b33c75c1ec99b808c1b17055/addons/stock/models/stock_move.py#L711

https://github.com/odoo/odoo/blob/57e265c482733029b33c75c1ec99b808c1b17055/addons/purchase_stock/models/stock_move.py#L56-L57

The purchase order line name already includes the vendor product name and code.
So, after super() runs, `description_picking` already contains 
the vendor product details.
Then,` _compute_description_picking` in purchase_stock adds the supplier product
name and code again.

https://github.com/odoo/odoo/blob/57e265c482733029b33c75c1ec99b808c1b17055/addons/purchase_stock/models/stock_move.py#L46-L54

Because of this, the same vendor product details are added twice, which results
in a duplicated description in `description_picking`.

---

<details>
    <summary>Click here to see the results:</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/d52f74a0-933d-4ff0-9968-3df88d0b0959"/>
    After:
   <img src="https://github.com/user-attachments/assets/83e11c16-acda-45d0-bb01-1b794840cca0"/>

</details>

---

opw-5392864

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
