### PR TITLE
[FIX] html_editor: code block hint visibility

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
@@ -7,7 +7,7 @@
             convertToParagraph="this.props.convertToParagraph"
         />
         <pre t-ref="pre"/>
-        <textarea t-ref="textarea" class="o_prism_source" contenteditable="true"
+        <textarea t-ref="textarea" class="o_prism_source" contenteditable="true" placeholder="Code"
             t-on-input="onInput"
             t-on-scroll="onScroll"
             t-on-keydown="onKeydown"

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
@@ -28,6 +28,13 @@
         background: transparent;
         resize: none;
         white-space: pre;
+
+        &::placeholder {
+            opacity: 0;
+        }
+        &:focus::placeholder {
+            opacity: 1;
+        }
     }
 
     .o_code_toolbar {

--- a/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
+++ b/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
@@ -194,7 +194,7 @@ export const highlightedPre = ({
             )}","languageId":"${language.toLowerCase()}"}'>
             ${TOOLBAR(LANGUAGES[language])}
             <pre>//PRE//</pre>${textareaRange === null ? "" : "[]"}
-            <textarea //TEXTAREA// class="o_prism_source" contenteditable="true"></textarea>
+            <textarea //TEXTAREA// class="o_prism_source" contenteditable="true"  placeholder="Code"></textarea>
         </div>`
     )
         // Do not trim spaces within the PRE and in the textarea data:


### PR DESCRIPTION
#### Description of the issue this PR addresses:

- After syntax highlighting was introduced, placing the cursor inside an empty code block no longer displayed the 'Code' hint.
- The hint logic gets the syntax-highlighing element instead of the `<pre>` element, and the `<pre>` is the child of syntax-highlighing node, and that is marked as data-oe-protected='true', so the`<pre>` is treated as a protected node and is not eligible for hint rendering.

#### Desired behavior after PR is merged:

- For code blocks, use the native placeholder attribute on the <textarea> and control its visibility based on focus.

task-5473682

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
