### PR TITLE
Master imp background shape color bis dery test

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -25,12 +25,13 @@ declare module "plugins" {
     import { snippet_preview_dialog_bundles, snippet_preview_dialog_stylesheets_handlers } from "@html_builder/snippets/add_snippet_dialog";
     import { background_shape_groups_providers, background_shape_target_providers } from "@html_builder/plugins/background_option/background_shape_option_plugin";
     import { mark_color_level_selector_params } from "@html_builder/plugins/background_option/background_option_plugin";
-    import { is_movable_selector } from "@html_builder/core/move_plugin";
+    import { is_movable_selector, on_element_arrow_moved_handlers } from "@html_builder/core/move_plugin";
     import { content_editable_selectors, content_not_editable_selectors } from "@html_builder/core/builder_content_editable_plugin";
     import { builder_actions, BuilderActionsShared } from "@html_builder/core/builder_actions_plugin";
     import { so_content_addition_selector, so_snippet_addition_selector } from "@html_builder/core/dropzone_selector_plugin";
     import { fontCssVariables } from "@html_builder/plugins/font/font_plugin";
     import { apply_custom_css_style } from "@html_builder/core/core_builder_action_plugin";
+    import { on_bg_color_updated_handlers } from "@html_builder/core/color_style_plugin";
 
     interface SharedMethods {
         // Main
@@ -71,8 +72,10 @@ declare module "plugins" {
         change_current_options_containers_listeners: change_current_options_containers_listeners;
         default_shape_handlers: default_shape_handlers;
         image_shape_groups_providers: image_shape_groups_providers;
+        on_bg_color_updated_handlers: on_bg_color_updated_handlers;
         on_bg_image_hide_handlers: on_bg_image_hide_handlers;
         on_cloned_handlers: on_cloned_handlers;
+        on_element_arrow_moved_handlers: on_element_arrow_moved_handlers;
         on_element_dragged_handlers: on_element_dragged_handlers;
         on_element_dropped_handlers: on_element_dropped_handlers;
         on_element_dropped_near_handlers: on_element_dropped_near_handlers;

--- a/addons/html_builder/static/src/core/color_style_plugin.js
+++ b/addons/html_builder/static/src/core/color_style_plugin.js
@@ -3,6 +3,10 @@ import { registry } from "@web/core/registry";
 import { applyNeededCss } from "@html_builder/utils/utils_css";
 import { withSequence } from "@html_editor/utils/resource";
 
+/**
+ * @typedef {((editingElement: HTMLElement) => void)[]} on_bg_color_updated_handlers
+ */
+
 class ColorStylePlugin extends Plugin {
     static id = "colorStyle";
     static dependencies = ["color"];
@@ -21,6 +25,7 @@ class ColorStylePlugin extends Plugin {
                 value = `bg-${match[1]}`;
             }
             this.dependencies.color.colorElement(editingElement, value, "backgroundColor");
+            this.dispatchTo("on_bg_color_updated_handlers", editingElement);
             return true;
         } else if (styleName === "color") {
             const match = value.match(/var\(--([a-zA-Z0-9-_]+)\)/);

--- a/addons/html_builder/static/src/core/drag_and_drop_plugin.js
+++ b/addons/html_builder/static/src/core/drag_and_drop_plugin.js
@@ -22,6 +22,8 @@ import { selectElements } from "@html_editor/utils/dom_traversal";
  *     marginToAdd: string[];
  *     mousePositionYOnElement: number;
  *     mousePositionXOnElement: number;
+ *     originNextEl: HTMLElement | undefined;
+ *     originPreviousEl: HTMLElement | undefined;
  *     overFirstDropzone: boolean;
  *     overGrid: boolean;
  *     restoreCallbacks?: ReturnType<on_prepare_drag_handlers[0]>[] | null;
@@ -247,6 +249,8 @@ export class DragAndDropPlugin extends Plugin {
                 );
                 this.dragState.mousePositionYOnElement = boundedYMousePosition - targetRect.y;
                 this.dragState.mousePositionXOnElement = (x - targetRect.x) * (this.isRtl ? -1 : 1);
+                this.dragState.originPreviousEl = this.overlayTarget.previousElementSibling;
+                this.dragState.originNextEl = this.overlayTarget.nextElementSibling;
 
                 // Stop marking the elements with mutations as dirty and make
                 // some changes on the page to ease the drag and drop.

--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -10,7 +10,10 @@ import { isElementInViewport } from "@html_builder/utils/utils";
 import { scrollTo } from "@html_builder/utils/scrolling";
 import { localization } from "@web/core/l10n/localization";
 
-/** @typedef {import("plugins").CSSSelector} CSSSelector */
+/**
+ * @typedef {import("plugins").CSSSelector} CSSSelector
+ * @typedef {import("@html_builder/core/drag_and_drop_plugin").DragState} DragState
+ */
 /**
  * @typedef {{
  *     selector: CSSSelector;
@@ -18,6 +21,10 @@ import { localization } from "@web/core/l10n/localization";
  *     direction: "horizontal" | "vertical";
  *     noScroll?: boolean;
  * }[]} is_movable_selector
+ * @typedef {((arg: {
+ *      movedEl: HTMLElement,
+ *      dragState: DragState,
+ * }) => void)[]} on_element_arrow_moved_handlers
  */
 export class MovePlugin extends Plugin {
     static id = "move";
@@ -245,6 +252,9 @@ export class MovePlugin extends Plugin {
      * @param {String} direction "prev" or "next"
      */
     onMoveClick(direction) {
+        const dragState = {};
+        dragState.originPreviousEl = this.overlayTarget.previousElementSibling;
+        dragState.originNextEl = this.overlayTarget.nextElementSibling;
         const isMobile = this.config.isMobileView(this.overlayTarget);
         let hasMobileOrder = !!this.overlayTarget.style.order;
         const parentEl = this.overlayTarget.parentNode;
@@ -279,6 +289,10 @@ export class MovePlugin extends Plugin {
                 this.overlayTarget
             );
         }
+        this.dispatchTo("on_element_arrow_moved_handlers", {
+            movedEl: this.overlayTarget,
+            dragState,
+        });
 
         // Scroll to the element.
         if (!this.noScroll && !isElementInViewport(this.overlayTarget)) {

--- a/addons/html_builder/static/src/core/remove_plugin.js
+++ b/addons/html_builder/static/src/core/remove_plugin.js
@@ -14,7 +14,12 @@ import { closestElement, selectElements } from "@html_editor/utils/dom_traversal
  */
 
 /**
- * @typedef {((arg: { removedEl: HTMLElement, nextTargetEl: HTMLElement }) => void)[]} on_removed_handlers
+ * @typedef {((arg: {
+ *      removedEl: HTMLElement,
+ *      nextTargetEl: HTMLElement,
+ *      originPreviousEl: HTMLElement | undefined,
+ *      originNextEl: HTMLElement | undefined
+ * }) => void)[]} on_removed_handlers
  * @typedef {((toRemoveEl: HTMLElement) => void)[]} on_will_remove_handlers
  *
  * @typedef {((el: HTMLElement) => boolean)[]} empty_node_predicates
@@ -107,8 +112,15 @@ export class RemovePlugin extends Plugin {
         const optionTargetEls = this.getOptionsContainersElements().filter((targetEl) =>
             targetEl.contains(toRemoveEl)
         );
+        const originPreviousEl = toRemoveEl.previousElementSibling;
+        const originNextEl = toRemoveEl.nextElementSibling;
         const nextTargetEl = this.removeCurrentTarget(toRemoveEl, optionTargetEls);
-        this.dispatchTo("on_removed_handlers", { removedEl: toRemoveEl, nextTargetEl });
+        this.dispatchTo("on_removed_handlers", {
+            removedEl: toRemoveEl,
+            nextTargetEl,
+            originPreviousEl,
+            originNextEl,
+        });
         if (updateContainers) {
             this.dependencies.builderOptions.setNextTarget(nextTargetEl);
         }

--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -8,6 +8,7 @@ import { withSequence } from "@html_editor/utils/resource";
  * @property { VisibilityPlugin['toggleTargetVisibility'] } toggleTargetVisibility
  * @property { VisibilityPlugin['onOptionVisibilityUpdate'] } onOptionVisibilityUpdate
  * @property { VisibilityPlugin['hideElement'] } hideElement
+ * @property { VisibilityPlugin['getInvisibleElements'] } getInvisibleElements
  */
 
 /**
@@ -27,6 +28,7 @@ export class VisibilityPlugin extends Plugin {
         "toggleTargetVisibility",
         "onOptionVisibilityUpdate",
         "hideElement",
+        "getInvisibleElements",
     ];
     /** @type {import("plugins").BuilderResources} */
     resources = {
@@ -209,6 +211,14 @@ export class VisibilityPlugin extends Plugin {
         this.dependencies.builderOptions.deactivateContainers();
         this.config.updateInvisibleElementsPanel();
         this.dependencies.disableSnippets.disableUndroppableSnippets();
+    }
+    getInvisibleElements() {
+        const invisibleSelector = `.o_snippet_invisible, ${
+            this.config.isMobileView(this.editable)
+                ? ".o_snippet_mobile_invisible"
+                : ".o_snippet_desktop_invisible"
+        }`;
+        return [...this.editable.querySelectorAll(invisibleSelector)];
     }
 }
 

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
@@ -2,12 +2,12 @@ import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { toRatio } from "@html_builder/utils/utils";
 import { getBgImageURLFromEl } from "@html_builder/utils/utils_css";
 import { _t } from "@web/core/l10n/translation";
-import { ShapeSelector } from "@html_builder/plugins/shape/shape_selector";
+import { BackgroundShapeSelector } from "./background_shape_selector";
 
 export class BackgroundShapeOption extends BaseOptionComponent {
     static template = "html_builder.BackgroundShapeOption";
     static dependencies = ["backgroundShapeOption"];
-    static components = { ShapeSelector };
+    static components = { BackgroundShapeSelector };
     setup() {
         super.setup();
         this.backgroundShapePlugin = this.dependencies.backgroundShapeOption;

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
@@ -10,7 +10,7 @@
                 fullHeight="true"
                 darkBackground="true"
                 textContent="state.shapeName">
-                <ShapeSelector
+                <BackgroundShapeSelector
                     onClose="panel.close"
                     shapeActionId="'setBackgroundShape'"
                     buttonWrapperClassName="'o-hb-bg-shape-btn'"

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_selector.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_selector.js
@@ -1,0 +1,54 @@
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { ShapeSelector } from "@html_builder/plugins/shape/shape_selector";
+
+export class BackgroundShapeSelector extends BaseOptionComponent {
+    static template = "html_builder.BackgroundShapeSelector";
+    static dependencies = ["backgroundShapeOption"];
+    static components = { ShapeSelector };
+    static props = {
+        ...ShapeSelector.props,
+    };
+    setup() {
+        super.setup();
+        this.backgroundShapePlugin = this.dependencies.backgroundShapeOption;
+        this.state = useDomState((editingElement) => ({
+            shapeStyle: this.getShapeStyleDomUpdated(editingElement),
+        }));
+    }
+    get shapeSelectorProps() {
+        return { ...this.props, getShapeStyle: this.getShapeStyle.bind(this) };
+    }
+    getShapeStyle(shapePath) {
+        return this.state.shapeStyle[shapePath];
+    }
+    getShapeStyleDomUpdated(editingEl) {
+        const shapeStyleMap = {};
+        for (const group of Object.values(this.props.shapeGroups)) {
+            for (const subgroup of Object.values(group.subgroups)) {
+                for (const [shapePath] of Object.entries(subgroup.shapes)) {
+                    const shapeData = this.backgroundShapePlugin.getShapeData(editingEl);
+                    shapeData.shape = shapePath;
+                    shapeData.colors = this.backgroundShapePlugin.getImplicitColors(
+                        editingEl,
+                        shapePath,
+                        shapeData.colors
+                    );
+                    let backgroundPosition = "";
+                    if (shapeData.flip) {
+                        const [xPos, yPos] = this.backgroundShapePlugin.getShapeStylePosition(
+                            shapeData.shape,
+                            shapeData.flip
+                        );
+
+                        backgroundPosition = `background-position: ${xPos}% ${yPos}%`;
+                    }
+                    const shapeStyle = `background-image: url(${this.backgroundShapePlugin.getShapeSrc(
+                        shapeData
+                    )}); ${backgroundPosition}`;
+                    shapeStyleMap[shapePath] = shapeStyle;
+                }
+            }
+        }
+        return shapeStyleMap;
+    }
+}

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_selector.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_selector.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.BackgroundShapeSelector">
+    <ShapeSelector t-props="this.shapeSelectorProps"/>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.js
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.js
@@ -15,6 +15,7 @@ export class ShapeSelector extends BaseOptionComponent {
         buttonWrapperClassName: { type: String, optional: true },
         imgThroughDiv: { type: Boolean, optional: true },
         getShapeUrl: { type: Function, optional: true },
+        getShapeStyle: { type: Function, optional: true },
     };
     static components = { ImgGroup };
 

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.scss
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.scss
@@ -60,6 +60,9 @@
         button, div {
             height: 50px;
         }
+        .o_we_shape {
+            background-color: rgba(27, 27, 27, 0.2);
+        }
     }
 
     .o-hb-img-shape-btn {

--- a/addons/html_builder/static/src/plugins/shape/shape_selector.xml
+++ b/addons/html_builder/static/src/plugins/shape/shape_selector.xml
@@ -23,7 +23,7 @@
                                     <BuilderButton type="''" action="this.props.shapeActionId" actionValue="shape[0]">
                                         <div t-att-class="props.imgThroughDiv ? 'o_we_shape_btn_content' : ''">
                                             <t t-if="props.imgThroughDiv">
-                                                <div class="o_we_shape" t-att-class="this.getShapeClass(shape[0])"/>
+                                                <div class="o_we_shape" t-att-class="this.getShapeClass(shape[0])" t-att-style="this.props.getShapeStyle(shape[0])"/>
                                             </t>
                                             <t t-else="" >
                                                 <Image src="this.getShapeUrl(shape[0])" svgCheck="false"/>

--- a/addons/html_builder/static/tests/background_shape_color.test.js
+++ b/addons/html_builder/static/tests/background_shape_color.test.js
@@ -1,0 +1,430 @@
+import {
+    addBuilderOption,
+    confirmAddSnippet,
+    getSnippetStructure,
+    setupHTMLBuilder,
+} from "@html_builder/../tests/helpers";
+import { BackgroundOption } from "@html_builder/plugins/background_option/background_option";
+import { expect, test, describe, beforeEach } from "@odoo/hoot";
+import { queryOne } from "@odoo/hoot-dom";
+import { contains } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+
+const RGB_RED = "rgb(255, 0, 0)";
+const RGB_BLUE = "rgb(0, 0, 255)";
+const RGB_GREEN = "rgb(0, 255, 0)";
+const HEX_BLUE = "#0000ff";
+const HEX_GREEN = "#00ff00";
+const HEX_O_CC_4 = "#383e45";
+const HEX_O_CC_5 = "#f0f0f0";
+
+function getShapeTestCSS() {
+    return `
+        /* CSS Variables for theme colors */
+        :root {
+            --o-color-1: #3aadaa;
+            --o-color-2: #7c6576;
+            --o-color-3: #dd7777;
+            --o-color-4: ${HEX_O_CC_4};
+            --o-color-5: ${HEX_O_CC_5};
+
+            --o-cc1-bg: #3aadaa;
+            --o-cc2-bg: #7c6576;
+            --o-cc3-bg: #dd7777;
+            --o-cc4-bg: ${HEX_O_CC_4};
+            --o-cc5-bg: ${HEX_O_CC_5};
+        }
+
+        .o_cc4 {
+            background-color: var(--o-cc4-bg);
+        }
+
+        .o_cc5 {
+            background-color: var(--o-cc5-bg);
+        }
+
+        /* Base shape styles - required for positioning and layout */
+        .o_we_shape {
+            position: absolute !important;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            display: block;
+            overflow: hidden;
+            pointer-events: none;
+        }
+
+        /* Connections shapes */
+        .o_we_shape.o_html_builder_Connections_01 {
+            background-image: url("/html_editor/shape/html_builder/Connections/01.svg?c5=%23383e45");
+            background-position: center bottom;
+        }
+
+        /* Non-connection shapes used in tests */
+        .o_we_shape.o_html_builder_Blobs_02 {
+            background-image: url("/html_editor/shape/html_builder/Blobs/02.svg?c1=%23383e45");
+            background-position: center bottom;
+        }
+    `;
+}
+
+async function clickOnSnippetAndApplyShape(snippetSelector, waitSidebarUpdated) {
+    await contains(`:iframe ${snippetSelector}`).click();
+    await contains("[data-label='Shape'] button").click();
+    await waitSidebarUpdated();
+    await contains(
+        "button[data-action-id='setBackgroundShape'][data-action-value='html_builder/Connections/01']"
+    ).click();
+    await waitSidebarUpdated();
+}
+
+function getNoBgShapeSection1(bgColor) {
+    return `
+        <section id="section1" style="background-color: ${bgColor};" data-snippet="s_snippet">
+            Section 1
+        </section>
+    `;
+}
+function getNoBgShapeSection2(bgColor) {
+    return `
+        <section id="section2" style="background-color: ${bgColor};" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `;
+}
+async function updateBgColor(selector, bgColor, waitSidebarUpdated) {
+    await contains(selector).click();
+    await contains(".o_we_color_preview").click();
+    await contains(`[data-color='${bgColor}']`).click();
+    await waitSidebarUpdated();
+}
+
+beforeEach(async () => {
+    addBuilderOption(
+        class TestBackgroundOption extends BackgroundOption {
+            static selector = "section";
+            static props = {
+                ...BackgroundOption.props,
+                withColors: { type: Boolean, optional: true },
+                withImages: { type: Boolean, optional: true },
+                withColorCombinations: { type: Boolean, optional: true },
+            };
+            static defaultProps = {
+                withColors: true,
+                withImages: true,
+                withShapes: true,
+                withColorCombinations: false,
+            };
+        }
+    );
+});
+
+test("Connections shape takes neighbor element's background color", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        ${getNoBgShapeSection1(RGB_RED)}
+        ${getNoBgShapeSection2(RGB_BLUE)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await clickOnSnippetAndApplyShape("#section1", waitSidebarUpdated);
+    expect(":iframe #section1 .o_we_shape").toHaveCount(1);
+    const shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shapeData.shape).toBe("html_builder/Connections/01");
+    expect(shapeData.colors.c5).toBe(HEX_BLUE);
+});
+
+test("Flipped Connections shape takes previous element's background color", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        ${getNoBgShapeSection1(RGB_BLUE)}
+        <section id="section2" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_O_CC_4}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 2
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await contains(":iframe #section2").click();
+    await contains("button[data-action-id='flipShape'][data-action-param='y']").click();
+    await waitSidebarUpdated();
+    const shapeData = JSON.parse(queryOne(":iframe #section2").dataset.oeShapeData);
+    expect(shapeData.colors.c5).toBe(HEX_BLUE);
+    expect(shapeData.flip.includes("y")).toBe(true);
+});
+
+test("Connections shape uses contrasting color when neighbor has same background", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        ${getNoBgShapeSection1(RGB_RED)}
+        ${getNoBgShapeSection2(RGB_RED)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await clickOnSnippetAndApplyShape("#section1", waitSidebarUpdated);
+    expect(":iframe #section1 .o_we_shape").toHaveCount(1);
+    const shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shapeData.shape).toBe("html_builder/Connections/01");
+    expect(shapeData.colors.c5).toBe(HEX_O_CC_5);
+});
+
+test("Non-Connections shapes are not affected by neighbor color changes", async () => {
+    const hexYellow = "#ffff00";
+    const checkBgShapeSection1 = () => {
+        const section1 = queryOne(":iframe #section1");
+        const shapeData = JSON.parse(section1.dataset.oeShapeData);
+        expect(shapeData.shape).toBe("html_builder/Blobs/02");
+        expect(shapeData.colors.c1).toBe(hexYellow);
+    };
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Blobs/02","colors":{"c1":"${hexYellow}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Blobs_02"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_BLUE)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    checkBgShapeSection1();
+    await updateBgColor(":iframe #section2", "o_cc3", waitSidebarUpdated);
+    checkBgShapeSection1();
+});
+
+test("Connections shape color updates when neighbor background color changes", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_BLUE}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_BLUE)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await updateBgColor(":iframe #section2", "o_cc5", waitSidebarUpdated);
+    const shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shapeData.shape).toBe("html_builder/Connections/01");
+    expect(shapeData.colors.c5).toBe(HEX_O_CC_5);
+});
+
+test("User set connections shape color don't update when neighbor background color changes", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_BLUE}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":true}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_GREEN)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await updateBgColor(":iframe #section2", "o_cc5", waitSidebarUpdated);
+    const shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shapeData.colors.c5).toBe(HEX_BLUE);
+});
+
+test("Connections shape color updates when snippet is dropped next to it", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_O_CC_4}"},"flip":["y"],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01" style='background-image: url("/html_editor/shape/html_builder/Connections/01.svg?c5=%230000ff")'></div>
+            Section 1
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+            snippets: {
+                snippet_groups: [
+                    '<div name="A" data-oe-thumbnail="a.svg" data-oe-snippet-id="123" data-o-snippet-group="a"><section data-snippet="s_snippet_group"></section></div>',
+                ],
+                snippet_structure: [
+                    getSnippetStructure({
+                        name: "Test",
+                        groupName: "a",
+                        content: `<section class="s_test" data-snippet="s_test" data-name="Test" style ="background-color: ${RGB_BLUE}; height: 19px;">
+                <div class="test_a"></div>
+                </section>`,
+                    }),
+                ],
+            },
+        }
+    );
+    await contains("#blocks-tab").click();
+    const section1 = queryOne(":iframe #section1");
+    const { moveTo, drop } = await contains(
+        ".o-snippets-menu #snippet_groups .o_snippet_thumbnail"
+    ).drag();
+    await moveTo(section1);
+    await drop();
+    await confirmAddSnippet();
+    await waitSidebarUpdated();
+    const updatedShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(updatedShapeData.shape).toBe("html_builder/Connections/01");
+    expect(updatedShapeData.colors.c5).toBe(HEX_BLUE);
+});
+
+test("Connections shape color updates when adjacent snippet is removed", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_GREEN}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_GREEN)}
+        <section id="section3" style="background-color: ${RGB_BLUE}" data-snippet="s_snippet">
+            Section 3
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    const initialShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(initialShapeData.shape).toBe("html_builder/Connections/01");
+    expect(initialShapeData.colors.c5).toBe(HEX_GREEN);
+    await contains(":iframe #section2").click();
+    await contains(".oe_snippet_remove").click();
+    await waitSidebarUpdated();
+    const updatedShapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(updatedShapeData.shape).toBe("html_builder/Connections/01");
+    expect(updatedShapeData.colors.c5).toBe(HEX_BLUE);
+});
+
+test("Multiple Connections shapes update when middle section color changes", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"#00ff00"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_GREEN)}
+        <section id="section3" style="background-color: ${RGB_BLUE}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"#00ff00"},"flip":["y"],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 3
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await updateBgColor(":iframe #section2", "o_cc5", waitSidebarUpdated);
+    const updatedShape1Data = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    const updatedShape3Data = JSON.parse(queryOne(":iframe #section3").dataset.oeShapeData);
+    expect(updatedShape1Data.shape).toBe("html_builder/Connections/01");
+    expect(updatedShape3Data.shape).toBe("html_builder/Connections/01");
+    expect(updatedShape1Data.colors.c5).toBe(HEX_O_CC_5);
+    expect(updatedShape3Data.colors.c5).toBe(HEX_O_CC_5);
+});
+
+test("Connections shapes don't update for old bg shape", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_BLUE}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_GREEN)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+
+    await updateBgColor(":iframe #section2", "o_cc5", waitSidebarUpdated);
+    const updatedShape1Data = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(updatedShape1Data.shape).toBe("html_builder/Connections/01");
+    expect(updatedShape1Data.colors.c5).toBe(HEX_BLUE);
+});
+
+test("Connection shape updates when snippet background color updates", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_O_CC_4}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+    await updateBgColor(":iframe #section1", "o_cc4", waitSidebarUpdated);
+    const shape1Data = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shape1Data.colors.c5).not.toBe(HEX_O_CC_4);
+});
+
+test("Connection shape updates to default color when neighbor snippet background color updates to a custom color", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_O_CC_4}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_GREEN)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+    await contains(":iframe #section2").click();
+    await contains(".o_we_color_preview").click();
+    await contains(".o_font_color_selector button:contains(Gradient)").click();
+    await contains(".o_gradient_color_button").click();
+    await waitSidebarUpdated();
+    const shape1Data = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shape1Data.colors).toBe(undefined);
+});
+
+test("Connection shape color updates if background shape color and neighbor background color are resynchronized", async () => {
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_RED}" data-snippet="s_snippet"
+                 data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${HEX_O_CC_4}"},"flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":true}'>
+            <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 1
+        </section>
+        ${getNoBgShapeSection2(RGB_GREEN)}
+    `,
+        {
+            styleContent: getShapeTestCSS(),
+        }
+    );
+    await updateBgColor(":iframe #section2", "o_cc4", waitSidebarUpdated);
+    await updateBgColor(":iframe #section2", "o_cc5", waitSidebarUpdated);
+    const shape1Data = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
+    expect(shape1Data.colors.c5).toBe(HEX_O_CC_5);
+});

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -3,6 +3,7 @@ import { CORE_PLUGINS } from "@html_builder/core/core_plugins";
 import { Image } from "@html_builder/core/img";
 import { SetupEditorPlugin } from "@html_builder/core/setup_editor_plugin";
 import { revertPreview } from "@html_builder/core/utils";
+import { BackgroundShapeOptionPlugin } from "@html_builder/plugins/background_option/background_shape_option_plugin";
 import { unformat } from "@html_editor/../tests/_helpers/format";
 import { setContent } from "@html_editor/../tests/_helpers/selection";
 import { insertText } from "@html_editor/../tests/_helpers/user_actions";
@@ -286,6 +287,23 @@ export async function setupHTMLBuilder(
             editableContent = this.editable.querySelector(
                 '.o_savable.oe_structure.oe_empty, .o_savable[data-oe-type="html"]'
             );
+        },
+    });
+
+    // Remove as soon as the background shape are not always instantiated when
+    // entering in edit mode.
+    patchWithCleanup(BackgroundShapeOptionPlugin.prototype, {
+        getShapeStylePosition(shapeId, flip) {
+            if (!this.shapeStyles[this.convertShapeIdForStyleSearch(shapeId)]) {
+                return [50, 50];
+            }
+            return super.getShapeStylePosition(shapeId, flip);
+        },
+        getShapeStyleUrl(shapeId) {
+            if (!this.shapeStyles[this.convertShapeIdForStyleSearch(shapeId)]) {
+                return "";
+            }
+            return super.getShapeStyleUrl(shapeId);
         },
     });
 

--- a/addons/website/static/src/@types/plugins.d.ts
+++ b/addons/website/static/src/@types/plugins.d.ts
@@ -25,7 +25,7 @@ declare module "plugins" {
     import { WebsiteParallaxShared } from "@website/builder/plugins/options/parallax_option_plugin";
     import { searchbar_option_display_items, searchbar_option_order_by_items } from "@website/builder/plugins/options/searchbar_option_plugin";
     import { SocialMediaOptionShared } from "@website/builder/plugins/options/social_media_option_plugin";
-    import { visibility_selector_parameters } from "@website/builder/plugins/options/visibility_option_plugin";
+    import { on_visibility_toggled_handlers, visibility_selector_parameters } from "@website/builder/plugins/options/visibility_option_plugin";
     import { WebsitePageConfigOptionShared } from "@website/builder/plugins/options/website_page_config_option_plugin";
     import { PopupVisibilityShared } from "@website/builder/plugins/popup_visibility_plugin";
     import { SwitchableViewsShared } from "@website/builder/plugins/switchable_views_plugin";
@@ -77,6 +77,7 @@ declare module "plugins" {
         dynamic_snippet_template_updated: dynamic_snippet_template_updated;
         get_gallery_items_handlers: get_gallery_items_handlers;
         mark_translatable_nodes: mark_translatable_nodes;
+        on_visibility_toggled_handlers: on_visibility_toggled_handlers;
         remove_hover_effect_handlers: remove_hover_effect_handlers;
         reorder_items_handlers: reorder_items_handlers;
         set_hover_effect_handlers: set_hover_effect_handlers;

--- a/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
@@ -15,6 +15,10 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
  *      callWith: "code" | "name" | "value" | "id";
  * }[]} visibility_selector_parameters
  */
+
+/**
+ * @typedef {((editingElement: HTMLElement) => void)[]} on_visibility_toggled_handlers
+ */
 export const DEVICE_VISIBILITY_OPTION_SELECTOR = "section .row > div";
 
 export class DeviceVisibilityOption extends BaseOptionComponent {
@@ -210,6 +214,7 @@ export class ToggleDeviceVisibilityAction extends BuilderAction {
                 editingElement.classList.remove("o_snippet_override_invisible");
             },
         });
+        this.dispatchTo("on_visibility_toggled_handlers", editingElement);
     }
     clean({ editingElement }) {
         editingElement.classList.remove(
@@ -228,6 +233,7 @@ export class ToggleDeviceVisibilityAction extends BuilderAction {
             },
             revert: () => {},
         });
+        this.dispatchTo("on_visibility_toggled_handlers", editingElement);
     }
     isApplied({ editingElement, params: { mainParam: visibilityParam } }) {
         const classList = [...editingElement.classList];

--- a/addons/website/static/src/builder/plugins/options/website_background_shape_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_background_shape_option_plugin.js
@@ -1,0 +1,17 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+class WebsiteBackgroundShapeOptionPlugin extends Plugin {
+    static id = "websiteBackgroundShapeOption";
+    static dependencies = ["backgroundShapeOption"];
+    resources = {
+        on_visibility_toggled_handlers: this.visibilityToggledHandler.bind(this),
+    };
+    visibilityToggledHandler(editingElement) {
+        this.dependencies.backgroundShapeOption.handleBgColorUpdated(editingElement);
+    }
+}
+
+registry
+    .category("website-plugins")
+    .add(WebsiteBackgroundShapeOptionPlugin.id, WebsiteBackgroundShapeOptionPlugin);

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -620,3 +620,51 @@ test("Connections shape do not update if it is inside an invisible element", asy
     shapeData = JSON.parse(queryOne(":iframe #section1").dataset.oeShapeData);
     expect(shapeData.colors.c5).toBe(HEX_GREEN);
 });
+
+test("Previewed shape has the correct color when no shape is applied", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `
+        <section id="section1" data-snippet="s_snippet">
+            Section 1
+        </section>
+        <section id="section2" style="background-color: ${RGB_BLUE};" data-snippet="s_snippet">
+            Section 2
+        </section>
+    `,
+        {
+            loadIframeBundles: true,
+        }
+    );
+    await contains(":iframe #section1").click();
+    await contains("[data-label='Shape'] button").click();
+    await waitSidebarUpdated();
+    expect(getComputedStyle(queryOne(".o_html_builder_Connections_01")).backgroundImage).toInclude(
+        encodeURIComponent(HEX_BLUE)
+    );
+});
+
+test("Previewed shape has the correct color and flip when a shape is applied", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `
+        <section id="section1" style="background-color: ${RGB_BLUE};" data-snippet="s_snippet">
+                Section 1
+            </section>
+        <section id="section2" data-snippet="s_snippet"
+                    data-oe-shape-data='{"shape":"html_builder/Connections/01","colors":{"c5":"${RGB_BLUE}"},"flip":["x", "y"],"showOnMobile":false,"shapeAnimationSpeed":"0", "selectedColor":false}'>
+                <div class="o_we_shape o_html_builder_Connections_01"></div>
+            Section 2
+        </section>
+    `,
+        {
+            loadIframeBundles: true,
+        }
+    );
+    await contains(":iframe #section2").click();
+    await contains("[data-label='Shape'] button").click();
+    await waitSidebarUpdated();
+    const shapePreviewStyle = getComputedStyle(
+        queryOne(".o_html_builder_Connections_01")
+    ).backgroundImage;
+    expect(shapePreviewStyle).toInclude(encodeURIComponent(HEX_BLUE));
+    expect(shapePreviewStyle).toInclude("flip=xy");
+});

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -39,6 +39,7 @@ import { BorderConfigurator } from "@html_builder/plugins/border_configurator_op
 import { WebsiteBuilder } from "@website/builder/website_builder";
 import { session } from "@web/session";
 import { getTranslatedElements } from "./translated_elements_getter.hoot";
+import { BackgroundShapeOptionPlugin } from "@html_builder/plugins/background_option/background_shape_option_plugin";
 
 class Website extends models.Model {
     _name = "website";
@@ -268,6 +269,23 @@ export async function setupWebsiteBuilder(
     patchWithCleanup(WebsiteSessionPlugin.prototype, {
         getSession() {
             return {};
+        },
+    });
+
+    // Remove as soon as the background shape are not always instantiated when
+    // entering in edit mode.
+    patchWithCleanup(BackgroundShapeOptionPlugin.prototype, {
+        getShapeStylePosition(shapeId, flip) {
+            if (!this.shapeStyles[this.convertShapeIdForStyleSearch(shapeId)]) {
+                return [50, 50];
+            }
+            return super.getShapeStylePosition(shapeId, flip);
+        },
+        getShapeStyleUrl(shapeId) {
+            if (!this.shapeStyles[this.convertShapeIdForStyleSearch(shapeId)]) {
+                return "";
+            }
+            return super.getShapeStyleUrl(shapeId);
         },
     });
 


### PR DESCRIPTION
[IMP] html_builder, website: apply bg-color on 'connections' shape

This commit enhances the "Connections" background shapes by
automatically applying the background color of adjacent snippets to
ensure seamless transitions. Note that this is only done if the user has
not set a specific color.

When a "Connections" shape is added, its background color is determined
by the following snippet's background, ensuring visual continuity. If
the shape is flipped upside down, its background color is then
determined by the previous snippet background. Note that if the computed
color of the background shape of a snippet is the same than its current
background color, we apply the theme color that contrasts the most with
the current snippet backround color.

Connections background shapes also automatically update their colors
when the background color of adjacent snippets changes.

task-4280426


---------------------------------------------------------------------------------------------------------------------------------------

[IMP] html_builder, website: render dynamic preview of background shapes

Previously, the background shape preview in the selector always
displayed the default color, which did not reflect the real color
applied when the shape was selected.

This commit updates the shape preview to reflect the actual color and
flip state.

task-4280426
