### PR TITLE
[FIX] mail: fix current user not being owner of created channel

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -435,7 +435,7 @@ class DiscussChannel(models.Model):
                         "partner_id": pid,
                         "channel_role": (
                             "owner"
-                            if vals.get("channel_type") in ["channel", "group"]
+                            if vals.get("channel_type", "channel") in ["channel", "group"]
                             and pid == self.env.user.partner_id.id
                             and not self.env.user._is_public()
                             else None

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -49,6 +49,18 @@ class TestChannelInternals(MailCommon, HttpCase):
         with self.assertRaises(ValidationError):
             public_channel._add_members(users=user_public)
 
+    @users("employee")
+    def test_channel_creator_is_owner(self):
+        create_vals = [
+            {"name": "Channel Owner Test Channel default"},
+            {"name": "Channel Owner Test Group", "channel_type": "group"},
+            {"name": "Channel Owner Test Channel", "channel_type": "channel"},
+        ]
+        channels = self.env["discuss.channel"].create(create_vals)
+        self.assertEqual(
+            len(channels.filtered(lambda c: c.self_member_id.sudo().channel_role == "owner")), 3
+        )
+
     @users('employee')
     @freeze_time("2020-03-22 10:42:06")
     def test_channel_members(self):


### PR DESCRIPTION
Before this commit, when creating a channel from the form view, the current user is not set as the owner of that channel.

Since the channel_type is the default one, it is not sent by the form and therefore not in the create_vals. We should apply the default when the channel_type is not in those vals.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
