### PR TITLE
[FIX] payment_razorpay: fix callback_url issue 

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -42,18 +42,20 @@ class PaymentTransaction(models.Model):
 
         customer_id = self._razorpay_create_customer()['id']
         order_id = self._razorpay_create_order(customer_id)['id']
-        return {
+        processing_values = {
             'razorpay_key_id': self.provider_id.razorpay_key_id,
             'razorpay_public_token': self.provider_id.razorpay_public_token,
             'razorpay_customer_id': customer_id,
             'is_tokenize_request': self.tokenize,
             'razorpay_order_id': order_id,
-            'callback_url': url_join(
+        }
+        if self.payment_method_id.code in const.REDIRECT_PAYMENT_METHOD_CODES:
+            processing_values['callback_url'] = url_join(
                 self.provider_id.get_base_url(),
                 f'{RazorpayController._return_url}?{url_encode({"reference": self.reference})}'
-            ),
-            'redirect': self.payment_method_id.code in const.REDIRECT_PAYMENT_METHOD_CODES,
-        }
+            )
+
+        return processing_values
 
     def _razorpay_create_customer(self):
         """ Create and return a Customer object.


### PR DESCRIPTION
Steps:
- Install Razorpay and sales app.
- Create a SO and try to pay with UPI pm in IOS mobile.

Issue:
- After payment compilation it is trying to redirect to `callback_url` which should
only trigger when `redirect` is `True`.

Cause:
- In Razorpay documentation it's not clearly mention it will only trigger `callback_url`
when `redirect` is `True`, so in some cases it redirect to `callback_url` even `redirect` is
`False` which is cause issue during signature verification as it try to verify signature
according to `is_redirect` with `razorpay_secret` but in oAuth `razorpay_secret` is not
set.

Razorpay doc link:
https://razorpay.com/docs/payments/payment-gateway/web-integration/standard/integration-steps/#123-checkout-options

<img width="670" height="537" alt="image" src="https://github.com/user-attachments/assets/81c855c0-aaca-4953-bcff-942bc11a32d2" />


Fix:
- Only set `callback_url` for `REDIRECT_PAYMENT_METHOD_CODES` PMs
where we expect it to redirect to `return_url` and not in the oAuth flow, Instead
relying on the `redirect` option of the Razorpay.

opw-5389499