### PR TITLE
[FIX] calendar: render video call links correctly in emails

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -87,7 +87,7 @@
                     <t t-else="">Join</t>
                 </td>
                 <td style="padding-top: 6px;">
-                    <a t-attf-href="object.event_id.videocall_location" target="_blank" style="color: #008f8c;">
+                    <a t-att-href="object.event_id.videocall_location" target="_blank" style="color: #008f8c;">
                         <t t-if="object.get_base_url() in object.event_id.videocall_location">Odoo Discuss</t>
                         <t t-else="">Video meeting</t>
                     </a>
@@ -217,7 +217,7 @@
                     <t t-else="">Join</t>
                 </td>
                 <td style="padding-top: 6px;">
-                    <a t-attf-href="object.event_id.videocall_location" target="_blank" style="color: #008f8c;">
+                    <a t-att-href="object.event_id.videocall_location" target="_blank" style="color: #008f8c;">
                         <t t-if="object.event_id.videocall_source == 'discuss'">Odoo Discuss</t>
                         <t t-else="">Video meeting</t>
                     </a>
@@ -328,7 +328,7 @@
                     <t t-else="">Join</t>
                 </td>
                 <td style="padding-top: 6px;">
-                    <a t-attf-href="object.event_id.videocall_location" target="_blank" style="color: #008f8c;">
+                    <a t-att-href="object.event_id.videocall_location" target="_blank" style="color: #008f8c;">
                         <t t-if="object.get_base_url() in object.event_id.videocall_location">Odoo Discuss</t>
                         <t t-else="">Video meeting</t>
                     </a>
@@ -424,7 +424,7 @@
                     <t t-else="">Join</t>
                 </td>
                 <td style="padding-top: 6px;">
-                    <a t-attf-href="object.videocall_location" target="_blank" style="color: #008f8c;">
+                    <a t-att-href="object.videocall_location" target="_blank" style="color: #008f8c;">
                         <t t-if="object.videocall_source == 'discuss'">Odoo Discuss</t>
                         <t t-else="">Video meeting</t>
                     </a>


### PR DESCRIPTION
Video call links in calendar invitations were displayed as literal strings due to using `t-attf-href` instead of `t-att-href` in the email templates.

### Steps to reproduce

1. Schedule a meeting with a video call URL.
2. Send the invitation email.
3. Click the link; it incorrectly points to `http://object.videocall_location/`.

opw-5436011