### PR TITLE
[FIX] point_of_sale: ensure user role is set without pos_hr

### DIFF
--- a/addons/point_of_sale/models/res_users.py
+++ b/addons/point_of_sale/models/res_users.py
@@ -17,6 +17,6 @@ class ResUsers(models.Model):
     def _load_pos_data_read(self, records, config):
         read_records = super()._load_pos_data_read(records, config)
         if read_records:
-            read_records[0]['role'] = 'manager' if config.group_pos_manager_id.id in read_records[0]['all_group_ids'] else 'cashier'
+            read_records[0]['_role'] = 'manager' if config.group_pos_manager_id.id in read_records[0]['all_group_ids'] else 'cashier'
             del read_records[0]['all_group_ids']
         return read_records

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1233,9 +1233,6 @@ export class PosStore extends WithLazyGetterTrap {
      * @returns {name: string, id: int, role: string}
      */
     getCashier() {
-        if (!this.user.role) {
-            this.user._role = this.user.raw.role;
-        }
         return this.user;
     }
     getCashierUserId() {


### PR DESCRIPTION
When the pos_hr was not installed, the user role was not set, and if the role was accessed with cashier._role, it was undefined.

opw-5479742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
