### PR TITLE
[FIX] portal: link preview triggering page view

### DIFF
--- a/addons/mail/tools/link_preview.py
+++ b/addons/mail/tools/link_preview.py
@@ -21,12 +21,15 @@ def get_link_preview_from_url(url, request_session=None):
     (e.g. a lot of url could have the same domain).
     """
     # Some websites are blocking non browser user agent.
-    user_agent = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0'}
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0',
+        'Odoo-Link-Preview': 'True',  # Used to identify coming from the link previewer
+    }
     try:
         if request_session:
-            response = request_session.get(url, timeout=3, headers=user_agent, allow_redirects=True, stream=True)
+            response = request_session.get(url, timeout=3, headers=headers, allow_redirects=True, stream=True)
         else:
-            response = requests.get(url, timeout=3, headers=user_agent, allow_redirects=True, stream=True)
+            response = requests.get(url, timeout=3, headers=headers, allow_redirects=True, stream=True)
     except requests.exceptions.RequestException:
         return False
     except LocationParseError:

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -132,7 +132,9 @@ class CustomerPortal(payment_portal.PaymentPortal):
                 download=download,
             )
 
-        if request.env.user.share and access_token:
+        # If the route is fetched from the link previewer avoid triggering that quotation is viewed.
+        is_link_preview = request.httprequest.headers.get('Odoo-Link-Preview')
+        if request.env.user.share and access_token and is_link_preview != 'True':
             # If a public/portal user accesses the order with the access token
             # Log a note on the chatter.
             today = fields.Date.today().isoformat()


### PR DESCRIPTION
When a link to the portal is sent from the chatter via message or log note, the preview of the link triggers that the page was viewed by customer.

As a solution a variable was added to the request headers coming from the previewer.

opw-5237785


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
