### PR TITLE
[IMP] account: improve opening balance editing and add validate action

### DIFF
--- a/addons/account/models/onboarding_onboarding_step.py
+++ b/addons/account/models/onboarding_onboarding_step.py
@@ -101,6 +101,7 @@ class OnboardingOnboardingStep(models.Model):
             'search_view_id': [self.env.ref('account.view_account_search').id],
             'views': [[view_id, 'list'], [False, 'form']],
             'domain': domain,
+            'context': {'company_id': company.id},
         }
 
     # STEPS WITHOUT PANEL

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -87,6 +87,15 @@
             <field name="model">account.account</field>
             <field name="arch" type="xml">
                 <list editable="top" create="1" delete="1" decoration-muted="opening_debit == 0 and opening_credit == 0" open_form_view="True">
+                    <header>
+                        <button name="action_validate_opening_move"
+                                type="object"
+                                string="Validate and Post"
+                                display="always"
+                                confirm="This action is irreversible: the credit/debit cannot be modified again from this screen."
+                                confirm-label="Post"
+                                confirm-title="Post Entry?"/>
+                    </header>
                     <field name="code"/>
                     <field name="name"/>
                     <field name="company_ids" column_invisible="True"/>


### PR DESCRIPTION
When creating a new database, opening debit/credit amounts can be edited from Accounting > Dashboard > Review Chart of Accounts (Tax Return card). However, updating these values was buggy: changes were not reflected immediately and required a manual page refresh.

This commit fixes the issue by ensuring opening balances are updated and reflected instantly as soon as the user edits them.

Additionally, a `Validate and Post` button has been added in the view. Upon confirmation, the opening miscellaneous entry is posted directly.

task-5462685

Related Enterprise PR: https://github.com/odoo/enterprise/pull/103810