### PR TITLE
18.0 ubl various fixes las

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -376,8 +376,8 @@ class AccountTestInvoicingCommon(ProductCommon):
     def group_of_taxes(self, taxes, **kwargs):
         self.tax_number += 1
         return self.env['account.tax'].create({
-            **kwargs,
             'name': f"group_({self.tax_number})",
+            **kwargs,
             'amount_type': 'group',
             'children_tax_ids': [Command.set(taxes.ids)],
         })
@@ -385,8 +385,8 @@ class AccountTestInvoicingCommon(ProductCommon):
     def percent_tax(self, amount, **kwargs):
         self.tax_number += 1
         return self.env['account.tax'].create({
-            **kwargs,
             'name': f"percent_{amount}_({self.tax_number})",
+            **kwargs,
             'amount_type': 'percent',
             'amount': amount,
         })
@@ -394,8 +394,8 @@ class AccountTestInvoicingCommon(ProductCommon):
     def division_tax(self, amount, **kwargs):
         self.tax_number += 1
         return self.env['account.tax'].create({
-            **kwargs,
             'name': f"division_{amount}_({self.tax_number})",
+            **kwargs,
             'amount_type': 'division',
             'amount': amount,
         })
@@ -403,8 +403,8 @@ class AccountTestInvoicingCommon(ProductCommon):
     def fixed_tax(self, amount, **kwargs):
         self.tax_number += 1
         return self.env['account.tax'].create({
-            **kwargs,
             'name': f"fixed_{amount}_({self.tax_number})",
+            **kwargs,
             'amount_type': 'fixed',
             'amount': amount,
         })
@@ -413,8 +413,8 @@ class AccountTestInvoicingCommon(ProductCommon):
         self.ensure_installed('account_tax_python')
         self.tax_number += 1
         return self.env['account.tax'].create({
-            **kwargs,
             'name': f"code_({self.tax_number})",
+            **kwargs,
             'amount_type': 'code',
             'amount': 0.0,
             'formula': formula,

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -721,10 +721,14 @@ class AccountEdiUBL(models.AbstractModel):
         currency = recycling_contribution_values['currency']
         amount = recycling_contribution_values['amount']
         tax = recycling_contribution_values['tax']
+        if 'bebat' in tax.name.lower():
+            charge_reason_code = 'CAV'
+        else:
+            charge_reason_code = 'AEO'
         return {
             '_currency': currency,
             'cbc:ChargeIndicator': {'_text': 'true' if amount > 0.0 else 'false'},
-            'cbc:AllowanceChargeReasonCode': {'_text': 'AEO'},
+            'cbc:AllowanceChargeReasonCode': {'_text': charge_reason_code},
             'cbc:AllowanceChargeReason': {'_text': tax.name},
             'cbc:Amount': {
                 '_text': FloatFmt(abs(amount), max_dp=currency.decimal_places),

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -774,7 +774,7 @@ class AccountEdiUBL(models.AbstractModel):
         return {
             '_currency': currency,
             'cbc:ChargeIndicator': {'_text': 'true' if is_charge else 'false'},
-            'cbc:AllowanceChargeReasonCode': {'_text': 'ZZZ' if is_charge else '66'},
+            'cbc:AllowanceChargeReasonCode': {'_text': 'ZZZ' if is_charge else '64'},
             'cbc:AllowanceChargeReason': {'_text': _("Conditional cash/payment discount")},
             'cbc:Amount': {
                 '_text': currency.round(abs(amount)),

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_custom_tax_recycling_contribution.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_custom_tax_recycling_contribution.xml
@@ -124,7 +124,7 @@
 		<cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
 		<cac:AllowanceCharge>
 			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
-			<cbc:AllowanceChargeReason>code_(1)</cbc:AllowanceChargeReason>
+			<cbc:AllowanceChargeReason>RECUPEL</cbc:AllowanceChargeReason>
 			<cbc:Amount currencyID="EUR">1.00</cbc:Amount>
 		</cac:AllowanceCharge>
 		<cac:Item>
@@ -156,7 +156,7 @@
 		</cac:AllowanceCharge>
 		<cac:AllowanceCharge>
 			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
-			<cbc:AllowanceChargeReason>code_(2)</cbc:AllowanceChargeReason>
+			<cbc:AllowanceChargeReason>AUVIBEL</cbc:AllowanceChargeReason>
 			<cbc:Amount currencyID="EUR">8.00</cbc:Amount>
 		</cac:AllowanceCharge>
 		<cac:Item>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_fixed_tax_recycling_contribution.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_fixed_tax_recycling_contribution.xml
@@ -98,10 +98,10 @@
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
 	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="EUR">84.42</cbc:TaxAmount>
+		<cbc:TaxAmount currencyID="EUR">105.42</cbc:TaxAmount>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">402.00</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">84.42</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">502.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">105.42</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>21.0</cbc:Percent>
@@ -112,11 +112,11 @@
 		</cac:TaxSubtotal>
 	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
-		<cbc:LineExtensionAmount currencyID="EUR">402.00</cbc:LineExtensionAmount>
-		<cbc:TaxExclusiveAmount currencyID="EUR">402.00</cbc:TaxExclusiveAmount>
-		<cbc:TaxInclusiveAmount currencyID="EUR">486.42</cbc:TaxInclusiveAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">502.00</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">502.00</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">607.42</cbc:TaxInclusiveAmount>
 		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-		<cbc:PayableAmount currencyID="EUR">486.42</cbc:PayableAmount>
+		<cbc:PayableAmount currencyID="EUR">607.42</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
@@ -125,7 +125,7 @@
 		<cac:AllowanceCharge>
 			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
 			<cbc:AllowanceChargeReasonCode>AEO</cbc:AllowanceChargeReasonCode>
-			<cbc:AllowanceChargeReason>fixed_1.0_(1)</cbc:AllowanceChargeReason>
+			<cbc:AllowanceChargeReason>RECUPEL</cbc:AllowanceChargeReason>
 			<cbc:Amount currencyID="EUR">1.00</cbc:Amount>
 		</cac:AllowanceCharge>
 		<cac:Item>
@@ -158,7 +158,7 @@
 		<cac:AllowanceCharge>
 			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
 			<cbc:AllowanceChargeReasonCode>AEO</cbc:AllowanceChargeReasonCode>
-			<cbc:AllowanceChargeReason>fixed_2.0_(2)</cbc:AllowanceChargeReason>
+			<cbc:AllowanceChargeReason>AUVIBEL</cbc:AllowanceChargeReason>
 			<cbc:Amount currencyID="EUR">8.00</cbc:Amount>
 		</cac:AllowanceCharge>
 		<cac:Item>
@@ -174,6 +174,31 @@
 		</cac:Item>
 		<cac:Price>
 			<cbc:PriceAmount currencyID="EUR">98.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
+		<cac:AllowanceCharge>
+			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+			<cbc:AllowanceChargeReasonCode>CAV</cbc:AllowanceChargeReasonCode>
+			<cbc:AllowanceChargeReason>BEBAT</cbc:AllowanceChargeReason>
+			<cbc:Amount currencyID="EUR">3.00</cbc:Amount>
+		</cac:AllowanceCharge>
+		<cac:Item>
+			<cbc:Description>product_a</cbc:Description>
+			<cbc:Name>product_a</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">97.0</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 </Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -171,8 +171,8 @@
 		<cbc:InvoicedQuantity unitCode="C62">5.0</cbc:InvoicedQuantity>
 		<cbc:LineExtensionAmount currencyID="EUR">0.50</cbc:LineExtensionAmount>
 		<cac:Item>
-			<cbc:Description>code_(1)</cbc:Description>
-			<cbc:Name>code_(1)</cbc:Name>
+			<cbc:Description>Vidange</cbc:Description>
+			<cbc:Name>Vidange</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0.0</cbc:Percent>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_multiple_taxes.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_multiple_taxes.xml
@@ -102,7 +102,7 @@
 	</cac:PaymentTerms>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-		<cbc:AllowanceChargeReasonCode>66</cbc:AllowanceChargeReasonCode>
+		<cbc:AllowanceChargeReasonCode>64</cbc:AllowanceChargeReasonCode>
 		<cbc:AllowanceChargeReason>Conditional cash/payment discount</cbc:AllowanceChargeReason>
 		<cbc:Amount currencyID="EUR">4.0</cbc:Amount>
 		<cac:TaxCategory>
@@ -128,7 +128,7 @@
 	</cac:AllowanceCharge>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-		<cbc:AllowanceChargeReasonCode>66</cbc:AllowanceChargeReasonCode>
+		<cbc:AllowanceChargeReasonCode>64</cbc:AllowanceChargeReasonCode>
 		<cbc:AllowanceChargeReason>Conditional cash/payment discount</cbc:AllowanceChargeReason>
 		<cbc:Amount currencyID="EUR">48.0</cbc:Amount>
 		<cac:TaxCategory>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_discount_on_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_discount_on_lines.xml
@@ -102,7 +102,7 @@
 	</cac:PaymentTerms>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-		<cbc:AllowanceChargeReasonCode>66</cbc:AllowanceChargeReasonCode>
+		<cbc:AllowanceChargeReasonCode>64</cbc:AllowanceChargeReasonCode>
 		<cbc:AllowanceChargeReason>Conditional cash/payment discount</cbc:AllowanceChargeReason>
 		<cbc:Amount currencyID="EUR">355.71</cbc:Amount>
 		<cac:TaxCategory>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_recycling_contribution_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_recycling_contribution_tax.xml
@@ -102,7 +102,7 @@
 	</cac:PaymentTerms>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-		<cbc:AllowanceChargeReasonCode>66</cbc:AllowanceChargeReasonCode>
+		<cbc:AllowanceChargeReasonCode>64</cbc:AllowanceChargeReasonCode>
 		<cbc:AllowanceChargeReason>Conditional cash/payment discount</cbc:AllowanceChargeReason>
 		<cbc:Amount currencyID="EUR">1.98</cbc:Amount>
 		<cac:TaxCategory>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_recycling_contribution_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_recycling_contribution_tax.xml
@@ -168,7 +168,7 @@
 		<cac:AllowanceCharge>
 			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
 			<cbc:AllowanceChargeReasonCode>AEO</cbc:AllowanceChargeReasonCode>
-			<cbc:AllowanceChargeReason>fixed_1.0_(1)</cbc:AllowanceChargeReason>
+			<cbc:AllowanceChargeReason>RECUPEL</cbc:AllowanceChargeReason>
 			<cbc:Amount currencyID="EUR">1.00</cbc:Amount>
 		</cac:AllowanceCharge>
 		<cac:Item>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -171,8 +171,8 @@
 		<cbc:InvoicedQuantity unitCode="C62">5.0</cbc:InvoicedQuantity>
 		<cbc:LineExtensionAmount currencyID="EUR">0.50</cbc:LineExtensionAmount>
 		<cac:Item>
-			<cbc:Description>fixed_0.1_(1)</cbc:Description>
-			<cbc:Name>fixed_0.1_(1)</cbc:Name>
+			<cbc:Description>Vidange</cbc:Description>
+			<cbc:Name>Vidange</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0.0</cbc:Percent>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_partner_with_gln.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_partner_with_gln.xml
@@ -75,7 +75,7 @@
 	</cac:AccountingCustomerParty>
 	<cac:Delivery>
 		<cac:DeliveryLocation>
-            <cbc:ID schemeID="0088">222222222222</cbc:ID>
+			<cbc:ID schemeID="0088">222222222222</cbc:ID>
 			<cac:Address>
 				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
 				<cbc:CityName>Ramillies</cbc:CityName>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -141,6 +141,7 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         """ Ensure the recycling contribution taxes are turned into allowance/charges at the document line level. """
         tax_recupel = self.fixed_tax(1.0, name="RECUPEL", include_base_amount=True)
         tax_auvibel = self.fixed_tax(2.0, name="AUVIBEL", include_base_amount=True)
+        tax_bebat = self.fixed_tax(3.0, name="BEBAT", include_base_amount=True)
         tax_21 = self.percent_tax(21.0)
         invoice = self._create_invoice(
             partner_id=self.partner_be,
@@ -156,6 +157,11 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
                     quantity=4.0,
                     discount=25.0,
                     tax_ids=tax_auvibel + tax_21,
+                ),
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    price_unit=97.0,
+                    tax_ids=tax_bebat + tax_21,
                 ),
             ],
             post=True,

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -411,12 +411,10 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_sent_to_luxembourg_dig')
 
-    def test_export_gln(self):
-        """ GLN was added in a fixup module account_add_gln. """
-        # TODO master: clean that skiptest, when the module account_add_gln is merged with account
-        if 'global_location_number' not in self.partner_be._fields:
-            self.skipTest("Fixup module with GLN not installed.")
+    def test_invoice_sent_to_partner_with_gln(self):
+        self.ensure_installed('account_add_gln')
         self.partner_be.global_location_number = "222222222222"
+
         tax_21 = self.percent_tax(21.0)
         product = self._create_product(
             lst_price=100.0,
@@ -429,7 +427,7 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         )
 
         self._generate_invoice_ubl_file(invoice)
-        self._assert_invoice_ubl_file(invoice, 'test_invoice_with_gln')
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_sent_to_partner_with_gln')
 
     def test_invoice_send_and_print_additional_documents(self):
         """ Ensure an additional document is added to the UBL under AdditionalDocumentReference. """


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: EPD allowance/charge code should be 64, not 66

64 stands for "Special agreement"
66 stands for "New outlet discount"

opw-5478324

[FIX] account_edi_ubl_cii: Bebat allowanceChargeReasonCode should be CAV

Bebat is a non-profit organization in Belgium that collects, sorts, and recycles used batteries.

Currently, whatever the recycling tax applied, we report is as AEO for
"Collection and recycling - The service of collection and recycling products."

However, since Bebat is about recycling batteries, we have to use CAV instead for
"Battery collection and recycling - The service of collecting and recycling batteries."

opw-5474752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
