### PR TITLE
[FIX] website: prevent removal of last avatar from `s_avatars`

### DIFF
--- a/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
+++ b/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
@@ -40,8 +40,10 @@ export class CarouselItemHeaderMiddleButtons extends Component {
     }
 
     removeSlide() {
-        this.callOperation(async () => {
-            await this.props.removeSlide(this.env.getEditingElement());
-        });
+        if (this.state.hasMultiItems) {
+            this.callOperation(async () => {
+                await this.props.removeSlide(this.env.getEditingElement());
+            });
+        }
     }
 }

--- a/addons/website/static/src/builder/plugins/options/avatars_header_buttons.js
+++ b/addons/website/static/src/builder/plugins/options/avatars_header_buttons.js
@@ -26,8 +26,10 @@ export class AvatarsHeaderMiddleButtons extends Component {
     }
 
     removeAvatar() {
-        this.callOperation(() => {
-            this.props.removeAvatar(this.env.getEditingElement());
-        });
+        if (!this.state.disableRemoveButton) {
+            this.callOperation(() => {
+                this.props.removeAvatar(this.env.getEditingElement());
+            });
+        }
     }
 }

--- a/addons/website/static/src/builder/plugins/options/navtabs_header_buttons.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_header_buttons.js
@@ -27,8 +27,10 @@ export class NavTabsHeaderMiddleButtons extends Component {
     }
 
     removeItem() {
-        this.callOperation(() => {
-            this.props.removeItem(this.env.getEditingElement());
-        });
+        if (this.state.tabEls.length > 2) {
+            this.callOperation(() => {
+                this.props.removeItem(this.env.getEditingElement());
+            });
+        }
     }
 }

--- a/addons/website/static/tests/builder/options/avatars_option.test.js
+++ b/addons/website/static/tests/builder/options/avatars_option.test.js
@@ -69,4 +69,11 @@ test("Add/remove avatars", async () => {
     expect(":iframe .s_avatars .s_avatars_avatar.o_avatar:first").toHaveStyle("z-index: 3");
     expect(":iframe .s_avatars .s_avatars_avatar.o_avatar:last").toHaveStyle("z-index: 2");
     expect(removeButtonSelector).not.toHaveAttribute("disabled");
+
+    // Check that the last avatar is never removed, even if the user clicks fast
+    // on the "remove" button. For this test, we simulate a double click when
+    // only two avatars are present.
+    await contains(removeButtonSelector).dblclick();
+    expect(":iframe .s_avatars .s_avatars_avatar.o_avatar").toHaveCount(1);
+    expect(removeButtonSelector).toHaveAttribute("disabled");
 });


### PR DESCRIPTION
**Problem**
Users could remove all avatars from the `s_avatars` snippet by clicking the "Remove avatar"
button rapidly. This also causes an error when attempting to add a new avatar afterward.

**Reproduction**
1. Drop the `s_avatars` snippet.
2. Click very quickly on the "Remove avatar" button multiple times.

**Cause**
The code relied on preventing the removal of the last element by disabling the "Remove
avatar" button based on DOM state. Because rendering is asynchronous, rapid clicks could be
registered before the button was disabled, allowing the last avatar to be removed.

**Fix**
Add a check in `AvatarsHeaderMiddleButtons.removeAvatar` to prevent removal when only one
avatar remains, covering cases where clicks occur before the UI updates. The components
`CarouselItemHeaderMiddleButtons` and `NavTabsHeaderMiddleButtons` use the same logic of
`AvatarsHeaderMiddleButtons` and could fail similarly, thus they have been fixed too, even
if the bug is not currently reproducible on them.

task-5462816