### PR TITLE
[IMP] mrp: hide destination package column for MO components

### DIFF
--- a/addons/mrp/views/stock_move_views.xml
+++ b/addons/mrp/views/stock_move_views.xml
@@ -59,6 +59,9 @@
                         }
                     </attribute>
                 </xpath>
+                <xpath expr="//field[@name='result_package_id' and @widget='package_m2o']" position="attributes">
+                    <attribute name="column_invisible">parent.picking_code == 'mrp_operation'</attribute>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
Hide the `Destination Package` column in `Detailed Operations` for MO components
as they are always consumed unpacked. Keeping it visible can mislead users into
entering information that has no functional meaning.

Enterprise PR:- odoo/enterprise#107810
TaskID-4068485
