### PR TITLE
[FIX] hr: fix trailing zeros in other input count

### DIFF
--- a/addons/hr/static/src/components/float_without_trailing_zeros/float_without_trailing_zeros.js
+++ b/addons/hr/static/src/components/float_without_trailing_zeros/float_without_trailing_zeros.js
@@ -5,7 +5,7 @@ const fieldRegistry = registry.category("fields");
 
 class FloatWithoutTrailingZeros extends FloatField {
     get formattedValue() {
-        return super.formattedValue.replace(/^([\d,]+)$|^([\d,]+)\.0*$|^([\d,]+\.\d*?)0*$/, "$1$2$3");
+        return super.formattedValue.replace(/(\.\d*?[1-9])0+$/ , "$1").replace(/\.0+$/, "");
     }
 }
 


### PR DESCRIPTION
Steps to Reproduce:
- install Payroll app
- create an employee and create a salary attachment.
- check the negative value for salary attachment
- generate a payslip

Issue:
- In "Other Input" section, salary attachment count displays value with trailing decimal zeros for negative amounts.

Reason:
- The field is using the widget float_without_trailing_zeros which should remove the extra decimal zeros but it doesn't work when the value is negative.

Solution:
- Fix the regular expression in the float_without_trailing_zeros widget to handle negative values and properly remove trailing decimal zeros.

task-5477466
