### PR TITLE
[IMP] payment_*: switch communication protocol from JSON-RPC to HTTP

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import uuid
 from pprint import pformat
 
 import requests
@@ -968,32 +967,6 @@ class PaymentProvider(models.Model):
         :rtype: str
         """
         return response.text
-
-    def _prepare_json_rpc_payload(self, data):
-        """Prepare a JSON-RPC 2.0 formatted payload for proxy requests.
-
-        :param dict data: The data to include in the JSON-RPC request.
-        :return: The JSON-RPC 2.0 formatted proxy payload.
-        :rtype: dict
-        """
-        return {"jsonrpc": "2.0", "id": uuid.uuid4().hex, "method": "call", "params": data}
-
-    def _parse_proxy_response(self, response):
-        """Retrieve JSON-RPC 2.0 formatted response content of a proxy request.
-
-        Note: Proxies always respond with HTTP 200 as they implement JSON-RPC 2.0.
-
-        :param requests.Response response: The JSON-RPC 2.0 formatted proxy response.
-        :return: The response content.
-        :rtype: dict
-        """
-        response_content = response.json()
-        if response_content.get("error"):  # An exception was raised on the proxy.
-            error_data = response_content["error"]["data"]
-            raise ValidationError(
-                _("The payment provider rejected the request.\n%s", pformat(error_data["message"]))
-            )
-        return response_content["result"]
 
     # === SETUP METHODS === #
 

--- a/addons/payment_mercado_pago/const.py
+++ b/addons/payment_mercado_pago/const.py
@@ -4,7 +4,7 @@ from odoo.tools import LazyTranslate
 
 _lt = LazyTranslate(__name__)
 
-PROXY_URL = "https://mercadopago.api.odoo.com/api/mercado_pago"
+PROXY_URL = "https://mercadopago.api.odoo.com/api/mercado_pago/"
 
 PAYMENT_RETURN_ROUTE = "/payment/mercado_pago/return"
 OAUTH_RETURN_ROUTE = "/payment/mercado_pago/oauth/return"

--- a/addons/payment_mercado_pago/controllers/onboarding.py
+++ b/addons/payment_mercado_pago/controllers/onboarding.py
@@ -48,13 +48,13 @@ class MercadoPagoOnboardingController(Controller):
             return request.redirect(redirect_url)
 
         # Fetch an access token using the authorization token.
-        proxy_payload = self.env["payment.provider"]._prepare_json_rpc_payload({
+        proxy_payload = {
             "authorization_code": authorization_code,
             "account_country_code": provider_sudo.mercado_pago_account_country_id.code.lower(),
-        })
+        }
         try:
             response_content = provider_sudo._send_api_request(
-                "POST", "/get_access_token", json=proxy_payload, is_proxy_request=True
+                "POST", "2/get_access_token", json=proxy_payload, is_proxy_request=True
             )
         except ValidationError as e:
             return request.render(

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -73,7 +73,7 @@ class PaymentProvider(models.Model):
 
     @api.constrains("available_currency_ids")
     def _check_currency_is_supported(self):
-        for provider in self.filtered(lambda p: p.code == 'mercado_pago'):
+        for provider in self.filtered(lambda p: p.code == "mercado_pago"):
             account_country = provider.mercado_pago_account_country_id
             account_currency = const.CURRENCY_MAPPING.get(account_country.code)
             if not account_country:
@@ -160,7 +160,7 @@ class PaymentProvider(models.Model):
             "return_url": f"{return_url}?{urlencode(return_url_params)}",
             "account_country_code": self.mercado_pago_account_country_id.code.lower(),
         }
-        proxy_url = self._build_request_url("/authorize", is_proxy_request=True)
+        proxy_url = self._build_request_url("1/authorize", is_proxy_request=True)
         return {
             "type": "ir.actions.act_url",
             "url": f"{proxy_url}?{urlencode(proxy_url_params)}",
@@ -224,7 +224,7 @@ class PaymentProvider(models.Model):
             return super()._build_request_url(endpoint, is_proxy_request=is_proxy_request, **kwargs)
 
         if is_proxy_request:
-            return urljoin(f"{const.PROXY_URL}/1", endpoint)
+            return urljoin(const.PROXY_URL, endpoint)
 
         return urljoin("https://api.mercadopago.com", endpoint)
 
@@ -272,13 +272,13 @@ class PaymentProvider(models.Model):
         ):
             return self.mercado_pago_access_token
 
-        proxy_payload = self._prepare_json_rpc_payload({
+        proxy_payload = {
             "refresh_token": self.mercado_pago_refresh_token,
             "account_country_code": self.mercado_pago_account_country_id.code.lower(),
-        })
+        }
         response_content = self._send_api_request(
             "POST",
-            "/refresh_access_token",
+            "2/refresh_access_token",
             json=proxy_payload,
             is_proxy_request=True,
             is_refresh_token_request=True,
@@ -294,14 +294,6 @@ class PaymentProvider(models.Model):
             "mercado_pago_refresh_token": response_content["refresh_token"],
         })
         return self.mercado_pago_access_token
-
-    def _parse_response_content(self, response, *, is_proxy_request=False, **kwargs):
-        """Override of `payment` to parse the response content."""
-        if self.code != "mercado_pago" or not is_proxy_request:
-            return super()._parse_response_content(
-                response, is_proxy_request=is_proxy_request, **kwargs
-            )
-        return self._parse_proxy_response(response)
 
     def _parse_response_error(self, response):
         """Override of `payment` to parse the error message."""

--- a/addons/payment_razorpay/const.py
+++ b/addons/payment_razorpay/const.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-OAUTH_URL = "https://razorpay.api.odoo.com/api/razorpay/1"
+OAUTH_URL = "https://razorpay.api.odoo.com/api/razorpay/"
 
 # The currencies supported by Razorpay, in ISO 4217 format. Last updated on May 26, 2021.
 # See https://razorpay.com/docs/payments/payments/international-payments/#supported-currencies.

--- a/addons/payment_razorpay/controllers/onboarding.py
+++ b/addons/payment_razorpay/controllers/onboarding.py
@@ -48,12 +48,10 @@ class RazorpayController(Controller):
             return request.redirect(redirect_url)
 
         # Fetch an access token using the authorization token.
-        proxy_payload = self.env["payment.provider"]._prepare_json_rpc_payload({
-            "authorization_code": authorization_code
-        })
+        proxy_payload = {"authorization_code": authorization_code}
         try:
             response_content = provider_sudo._send_api_request(
-                "POST", "/get_access_token", json=proxy_payload, is_proxy_request=True
+                "POST", "2/get_access_token", json=proxy_payload, is_proxy_request=True
             )
         except ValidationError as e:
             return request.render(

--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -151,7 +151,7 @@ class PaymentProvider(models.Model):
             "provider_id": self.id,
             "csrf_token": request.csrf_token(),
         }
-        authorization_url = f"{const.OAUTH_URL}/authorize?{urlencode(params)}"
+        authorization_url = f"{const.OAUTH_URL}1/authorize?{urlencode(params)}"
         return {"type": "ir.actions.act_url", "url": authorization_url, "target": "self"}
 
     def _get_reset_values(self):
@@ -248,12 +248,10 @@ class PaymentProvider(models.Model):
         :return: dict
         """
         self.ensure_one()
-        proxy_payload = self._prepare_json_rpc_payload({
-            "refresh_token": self.razorpay_refresh_token
-        })
+        proxy_payload = {"refresh_token": self.razorpay_refresh_token}
 
         response_content = self._send_api_request(
-            "POST", "/refresh_access_token", json=proxy_payload, is_proxy_request=True
+            "POST", "2/refresh_access_token", json=proxy_payload, is_proxy_request=True
         )
         if response_content.get("access_token"):
             expiry = fields.Datetime.now() + timedelta(seconds=int(response_content["expires_in"]))
@@ -302,10 +300,3 @@ class PaymentProvider(models.Model):
         if self.code != "razorpay":
             return super()._parse_response_error(response)
         return response.json().get("error", {}).get("description", "")
-
-    def _parse_response_content(self, response, *, is_proxy_request=False, **kwargs):
-        if self.code != "razorpay" or not is_proxy_request:
-            return super()._parse_response_content(
-                response, is_proxy_request=is_proxy_request, **kwargs
-            )
-        return self._parse_proxy_response(response)

--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -373,10 +373,14 @@ class PaymentProvider(models.Model):
         :return: The connected account
         :rtype: dict
         """
-        proxy_payload = self._prepare_json_rpc_payload(
-            self._stripe_prepare_connect_account_payload()
+        payload = self._stripe_prepare_connect_account_payload()
+        proxy_payload = {
+            "payload": payload,
+            "proxy_data": self._stripe_prepare_proxy_data(stripe_payload=payload),
+        }
+        return self._send_api_request(
+            "POST", "2/accounts", json=proxy_payload, is_proxy_request=True
         )
-        return self._send_api_request("POST", "accounts", json=proxy_payload, is_proxy_request=True)
 
     def _stripe_prepare_connect_account_payload(self):
         """Prepare the payload for the creation of a connected account in Stripe format.
@@ -432,22 +436,15 @@ class PaymentProvider(models.Model):
             "refresh_url": f"{url_join(base_url, refresh_url)}?{url_encode(refresh_params)}",
             "type": "account_onboarding",
         }
-        proxy_payload = self._prepare_json_rpc_payload(payload)
+        proxy_payload = {
+            "payload": payload,
+            "proxy_data": self._stripe_prepare_proxy_data(stripe_payload=payload),
+        }
 
         account_link = self._send_api_request(
-            "POST", "account_links", json=proxy_payload, is_proxy_request=True
+            "POST", "2/account_links", json=proxy_payload, is_proxy_request=True
         )
         return account_link["url"]
-
-    def _prepare_json_rpc_payload(self, data):
-        res = super()._prepare_json_rpc_payload(data)
-        if self.code != "stripe":
-            return res
-        res["params"] = {
-            "payload": data,  # Stripe data.
-            "proxy_data": self._stripe_prepare_proxy_data(stripe_payload=data),
-        }
-        return res
 
     def _stripe_prepare_proxy_data(self, stripe_payload=None):  # noqa: ARG002
         """Prepare the contextual data passed to the proxy when making a request.
@@ -465,13 +462,11 @@ class PaymentProvider(models.Model):
 
     # === REQUEST HELPERS === #
 
-    def _build_request_url(self, endpoint, *, is_proxy_request=False, version=1, **kwargs):
+    def _build_request_url(self, endpoint, *, is_proxy_request=False, **kwargs):
         if self.code != "stripe":
-            return super()._build_request_url(
-                endpoint, is_proxy_request=is_proxy_request, version=version, **kwargs
-            )
+            return super()._build_request_url(endpoint, is_proxy_request=is_proxy_request, **kwargs)
         if is_proxy_request:
-            return url_join(const.PROXY_URL, f"{version}/{endpoint}")
+            return url_join(const.PROXY_URL, endpoint)
         return url_join("https://api.stripe.com/v1/", endpoint)
 
     def _build_request_headers(
@@ -502,13 +497,6 @@ class PaymentProvider(models.Model):
         if self.code != "stripe":
             return super()._parse_response_error(response)
         return response.json().get("error", {}).get("message", "")
-
-    def _parse_response_content(self, response, *, is_proxy_request=False, **kwargs):
-        if self.code != "stripe" or not is_proxy_request:
-            return super()._parse_response_content(
-                response, is_proxy_request=is_proxy_request, **kwargs
-            )
-        return self._parse_proxy_response(response)
 
     def _get_stripe_extra_request_headers(self):
         """Return the extra headers for the Stripe API request.

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -261,6 +261,6 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
         ) as mock:
             self.stripe._stripe_create_account_link("dummy", "dummy")
             mock.assert_called_once()
-            call_args = mock.call_args.kwargs["json"]["params"]["payload"].keys()
+            call_args = mock.call_args.kwargs["json"]["payload"].keys()
             for payload_param in ("account", "return_url", "refresh_url", "type"):
                 self.assertIn(payload_param, call_args)


### PR DESCRIPTION
This PR refactors the Mercado Pago, Razorpay, and Stripe payment
provider integrations to improve proxy request handling and URL routing.

- Remove unnecessary JSON-RPC payload handling for proxy requests,
  and send plain JSON payloads instead.

- Move proxy versioning logic from the URL prefix
  (e.g. "https://razorpay.api.odoo.com/api/razorpay/2")
  to the URL suffix (e.g. "2/get_access_token"),
  as some routes now use different versions.

Task-4876895
