### PR TITLE
[18.0][FIX] stock: Don't allow inventory users to modify locations

### DIFF
--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -5,7 +5,7 @@ access_stock_warehouse_user,stock.warehouse.user,model_stock_warehouse,base.grou
 access_stock_location_partner_manager,stock.location.partner.manager,model_stock_location,base.group_partner_manager,1,0,0,0
 access_stock_location_manager,stock.location.manager,model_stock_location,stock.group_stock_manager,1,1,1,1
 access_stock_location_all_user,stock.location.all.user,model_stock_location,base.group_user,1,0,0,0
-access_stock_location_user,stock.location.user,model_stock_location,stock.group_stock_user,1,1,0,0
+access_stock_location_user,stock.location.user,model_stock_location,stock.group_stock_user,1,0,0,0
 access_stock_picking_user,stock.picking user,model_stock_picking,stock.group_stock_user,1,1,1,1
 access_stock_picking_manager,stock.picking manager,model_stock_picking,stock.group_stock_manager,1,1,1,1
 access_stock_picking_type_all,stock.picking.type all users,model_stock_picking_type,base.group_user,1,0,0,0


### PR DESCRIPTION
During the development of the task of the PR
https://github.com/odoo/odoo/pull/149149, this permission was added as a possible way to fix some found problems, but that's not the way to fix them, as allowing inventory users to modify locations is something very dangerous and out of scope of what an inventory user should do.

Reverting the permission, and doing manual tests with an inventory user for doing a "update quantity" or a "inventory adjustment", there's no problem, so maybe that permission was needed in a past codebase.

@Tecnativa 