### PR TITLE
[FIX] l10n_it: Remove integer rounding from monthly VAT

### DIFF
--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -6,7 +6,7 @@
         <field name="country_id" ref="base.it"/>
         <field name="filter_fiscal_position" eval="True"/>
         <field name="availability_condition">country</field>
-        <field name="integer_rounding">HALF-UP</field>
+        <field name="integer_rounding"></field>
         <field name="column_ids">
             <record id="tax_monthly_report_vat_balance" model="account.report.column">
                 <field name="name">Balance</field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**: Integer rounding is only required on annual l10n_it VAT reports. It appears that it was incorrectly added to the monthly report when the two were split in #193662.

**Current behavior before PR**: Integer rounding on monthly l10n_it tax reports.

**Desired behavior after PR is merged**: No more integer rounding on monthly l10n_it tax reports.

[opw-5292310](https://www.odoo.com/odoo/project.task/project.task/5292310)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
