### PR TITLE
[PERF] html_builder: speed up `getOriginalSnippet` of snippet service

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -25,6 +25,7 @@ export class SnippetModel extends Reactive {
             snippet_content: [],
             snippet_custom_content: [],
         };
+        this.originalSnippets = {};
     }
 
     get hasCustomGroup() {
@@ -167,6 +168,7 @@ export class SnippetModel extends Reactive {
     computeSnippetTemplates(snippetsDocument) {
         const snippetsBody = snippetsDocument.body;
         this.snippetsByCategory = {};
+        this.originalSnippets = {};
         for (const snippetCategory of snippetsBody.querySelectorAll("snippets")) {
             const snippets = [];
             for (const snippetEl of snippetCategory.children) {
@@ -207,6 +209,9 @@ export class SnippetModel extends Reactive {
                         snippet.groupName = "custom";
                         snippet.isCustom = true;
                         break;
+                }
+                if (["snippet_structure", "snippet_content"].includes(snippetCategory.id)) {
+                    this.originalSnippets[snippet.name] ??= snippet;
                 }
                 snippets.push(snippet);
             }
@@ -304,9 +309,7 @@ export class SnippetModel extends Reactive {
         if (!snippetKey) {
             return;
         }
-        return [...this.snippetStructures, ...this.snippetInnerContents].find(
-            (snippet) => snippet.name === snippetKey
-        );
+        return this.originalSnippets[snippetKey];
     }
 
     /**


### PR DESCRIPTION
__Before commit:__
The method `getOriginalSnippet` is called hundreds of times per website
builder test inside the `disableUndroppableSnippets` method from
`DisableSnippetsPlugin`.

Each time, it recreates the same snippet array and loops through them to
find one snippet by its name.

This may take around 100 ms for a single website builder test.

Moreover, `getOriginalSnippet` loops through `snippetStructures`, which
includes the custom snippets. This is unnecessary, since snippet names
are equal to the value of `data-snippet`, which is always copied from
the base snippet when a custom one is created.

__Fix:__
Create an object for which the snippet `name` values are the keys and
each value is the first snippet having this `name`. This allows
`getOriginalSnippet` to retrieve a snippet in `O(1)` instead of `O(n)`
and reduces total time spent in this function to virtually nothing.

task-5269391