### PR TITLE
[FIX] web: editable list: special data key to ignore clicks

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -2170,6 +2170,10 @@ export class ListRenderer extends Component {
         if (this.rootRef.el.closest(".o-overlay-item") !== target.closest(".o-overlay-item")) {
             return;
         }
+        // Specific data attribute to explicitly ignore clicks
+        if (target.closest("[data-list-ignore-click]")) {
+            return;
+        }
         this.props.list.leaveEditMode();
     }
 

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -4356,6 +4356,35 @@ test("unselecting a line with missing required data", async () => {
     expect("tr.o_data_row").toHaveCount(0);
 });
 
+test("keep focus when click must be ignored", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="turtles">
+                    <list editable="top">
+                        <field name="turtle_int"/>
+                    </list>
+                </field>
+                <div data-list-ignore-click="">
+                    Click me
+                </div>
+            </form>`,
+        resId: 1,
+    });
+
+    // edit the first row
+    await contains(".o_data_cell").click();
+    expect(".o_data_row").toHaveClass("o_selected_row");
+
+    // click on the element on which clicks should be ignored
+    await contains("div[data-list-ignore-click]").click();
+
+    // the line should still be selected
+    expect("tr.o_data_row.o_selected_row").toHaveCount(1);
+});
+
 test("pressing enter in a o2m with a required empty field", async () => {
     Turtle._fields.turtle_foo = fields.Char({ required: true });
     onRpc((args) => {


### PR DESCRIPTION
Since commit 37d78a4, the global click listener sets `capture: true`, which prevents other components to stop the propagation of the click event in order to maintain the focus on the selected list element.

This commit introduces a special data key that can be set on an element so that any click occurring within it will be ignored by the list renderer.

task-none but necessary for https://github.com/odoo/enterprise/pull/103732
