### PR TITLE
[FIX] pos_self_order: set table_id on self-orders for meal payment with table service

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -15,10 +15,33 @@ class PosOrder(models.Model):
             return super()._get_open_order(order)
 
         domain = []
-        if order.get('table_id', False) and order.get('state') == 'draft':
-            domain += ['|', ('uuid', '=', order.get('uuid')), '&', ('table_id', '=', order.get('table_id')), ('state', '=', 'draft')]
+        merge_table_id = order.get("table_id")
+
+        # For self-ordering in service-at-table + pay-after-meal, fall back to the
+        # self_ordering_table_id so orders from different devices can be merged when
+        # opening the table on the floor screen.
+        if (
+            not merge_table_id
+            and order.get("self_ordering_table_id")
+            and config_id.self_ordering_service_mode == "table"
+            and config_id.self_ordering_pay_after == "meal"
+        ):
+            merge_table_id = order.get("self_ordering_table_id")
+
+        if merge_table_id and order.get("state") == "draft":
+            domain += [
+                "|",
+                ("uuid", "=", order.get("uuid")),
+                "|",
+                "&",
+                ("table_id", "=", merge_table_id),
+                ("state", "=", "draft"),
+                "&",
+                ("self_ordering_table_id", "=", merge_table_id),
+                ("state", "=", "draft"),
+            ]
         else:
-            domain += [('uuid', '=', order.get('uuid'))]
+            domain += [("uuid", "=", order.get("uuid"))]
         return self.env["pos.order"].search(domain, limit=1, order='id desc')
 
     def read_pos_data(self, data, config):

--- a/addons/pos_restaurant/static/src/app/pos_app.js
+++ b/addons/pos_restaurant/static/src/app/pos_app.js
@@ -1,0 +1,11 @@
+import { Chrome } from "@point_of_sale/app/pos_app";
+import { patch } from "@web/core/utils/patch";
+
+patch(Chrome.prototype, {
+    sendOrderToCustomerDisplay(selectedOrder, scaleData) {
+        super.sendOrderToCustomerDisplay(selectedOrder, scaleData);
+        if (this.pos.config.module_pos_restaurant) {
+            this.pos.addPendingOrder([selectedOrder.id]);
+        }
+    },
+});

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -34,10 +34,11 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         self.pos_config.with_user(self.pos_user).open_ui()
         self.pos_config.current_session_id.set_opening_control(0, "")
-        self_route = self.pos_config._get_self_order_route(table_id=floor.table_ids[0].id)
+        self_route_table = self.pos_config._get_self_order_route(table_id=floor.table_ids[0].id)
+        self_route = self.pos_config._get_self_order_route()
 
         # Test selection of different presets
-        self.start_tour(self_route, "self_mobile_each_table_takeaway_in")
+        self.start_tour(self_route_table, "self_mobile_each_table_takeaway_in")
         self.start_tour(self_route, "self_mobile_each_table_takeaway_out")
         orders = self.env['pos.order'].search([], order="id desc", limit=2)
         self.assertEqual(orders[0].preset_id, self.out_preset)
@@ -48,7 +49,7 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         })
 
         # Mobile, each, counter
-        self.start_tour(self_route, "self_mobile_each_counter_takeaway_in")
+        self.start_tour(self_route_table, "self_mobile_each_counter_takeaway_in")
         self.start_tour(self_route, "self_mobile_each_counter_takeaway_out")
 
         self.env['pos.order'].search([('state', '=', 'draft')]).write({'state': 'cancel'})
@@ -58,16 +59,15 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
         })
 
         # Mobile, meal, table
-        self.start_tour(self_route, "self_mobile_meal_table_takeaway_in")
+        self.start_tour(self_route_table, "self_mobile_meal_table_takeaway_in")
         self.start_tour(self_route, "self_mobile_meal_table_takeaway_out")
-
         self.env['pos.order'].search([('state', '=', 'draft')]).write({'state': 'cancel'})
         self.pos_config.write({
             'self_ordering_service_mode': 'counter',
         })
 
         # Mobile, meal, counter
-        self.start_tour(self_route, "self_mobile_meal_counter_takeaway_in")
+        self.start_tour(self_route_table, "self_mobile_meal_counter_takeaway_in")
         self.start_tour(self_route, "self_mobile_meal_counter_takeaway_out")
 
         # Cancel in meal


### PR DESCRIPTION
When using QR code self-ordering with "service at table" and "payment at the end of the meal", self-orders were only visible individually on the POS terminal when clicking on the table, even though multiple orders existed for the same table. Only the last order made was visible.

Steps to reproduce:
-------------------
* Configure POS with self-ordering mode 'mobile', pay_after='meal', service_mode='table'
* Open POS session
* Scan QR code from table and create a self-order
* Create another order from POS terminal on the same table
* Click on the table from the floor plan

> Observation:
Only the last order was visible when clicking on the table, even though both orders appeared in the Orders tab with the same table tag.

Why the fix:
------------
Self-orders created via QR scan initially only had `self_ordering_table_id` set, but not `table_id`. The existing `DevicesSynchronisation` merge logic only merges orders that have the same `table_id`. By setting `table_id` on self-orders when the conditions are met (pay_after='meal' and preset.service_at='table') self-orders can now be automatically merged with regular POS orders on the same table during sync, ensuring all orders are visible when clicking on a table.

opw-5250653