### PR TITLE
[FIX] hr_attendance: make less OSM requests

### DIFF
--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -40,7 +40,7 @@ class ResCompany(models.Model):
     auto_check_out = fields.Boolean(string="Automatic Check Out", default=False)
     auto_check_out_tolerance = fields.Float(default=2, export_string_translation=False)
     absence_management = fields.Boolean(string="Absence Management", default=False)
-    attendance_device_tracking = fields.Boolean(string="Device & Location Tracking", default=True)
+    attendance_device_tracking = fields.Boolean(string="Device & Location Tracking", default=False)
 
     @api.depends("attendance_kiosk_key")
     def _compute_attendance_kiosk_url(self):


### PR DESCRIPTION
Use the _get_localisation helper that uses geoip when available
Disable geolocalisation of device by default (i.e. in the context of an office/event, all requests are in the same spot)

In addition to #243073