### PR TITLE
[FIX] base: prevent Subject header folding to avoid strict mail server rejections

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -87,7 +87,7 @@ def _print_debug(self, *args):
 smtplib.SMTP._print_debug = _print_debug
 
 # Python 3: workaround for bpo-35805, only partially fixed in Python 3.8.
-RFC5322_IDENTIFICATION_HEADERS = {'message-id', 'in-reply-to', 'references', 'resent-msg-id'}
+RFC5322_IDENTIFICATION_HEADERS = {'message-id', 'in-reply-to', 'references', 'resent-msg-id', 'subject'}
 _noFoldPolicy = email.policy.SMTP.clone(max_line_length=None)
 class IdentificationFieldsNoFoldPolicy(email.policy.EmailPolicy):
     # Override _fold() to avoid folding identification fields, excluded by RFC2047 section 5


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Yahoo and other strict mail servers reject emails with `554 Invalid Subject header` when Subject headers are folded at 78 characters and contain RFC 2047 encoded-words representing non-ASCII characters.

The issue occurs because:
1. Long email subjects with accented characters (French: "arrière", "connecté", etc.) are RFC 2047 encoded
2. Python's `email.policy.SMTP` folds these headers at 78 characters per RFC 5322 SHOULD recommendation
3. Yahoo's strict validation rejects folded subjects when the fold occurs at certain positions within or between encoded-words
4. This results in customer-facing emails being rejected with no delivery failing silently, leading to missed communications.



Current behavior before PR:

> Subject: [SOS-1477030] Commande et livraison - Demande de retour - user pseudo 251003-GD1U0E - Cosmo Connected Casque Fusion avec feu =?utf-8?q?arri?==?utf-8?q?=C3=A8re_connect=C3=A9?= et accessoire (#1031590)

This subject:
- Is 168 characters when unfolded
- Is folded into 3 lines (78, 74, 60 chars)
- Contains RFC 2047 encoded "arrière connecté"
- Is technically RFC 2822 compliant
- **Gets rejected by Yahoo with "554 Invalid Subject header"**


While this is technically RFC 2822 compliant, Yahoo's strict validation rejects it.

Python's `email.policy.SMTP` folds headers at 78 characters to follow RFC 5322's SHOULD recommendation. However, when subjects contain non-ASCII characters that get RFC 2047 encoded, the folding can create patterns that strict mail servers reject.


Desired behavior after PR is merged:

- No folding of Subject headers, regardless of length
- Yahoo and all strict SMTP servers accept these emails
- Customer support emails deliver successfully

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
