### PR TITLE
[IMP] mail: Use partner-id for messages card popover.

### DIFF
--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -55,7 +55,7 @@ patch(Message.prototype, {
         };
     },
     hasAuthorClickable() {
-        return this.message.author_id?.main_user_id;
+        return this.message.author_id;
     },
     onClickAuthor(ev) {
         if (this.hasAuthorClickable()) {
@@ -63,7 +63,8 @@ patch(Message.prototype, {
             const target = ev.currentTarget;
             if (!this.avatarCard.isOpen) {
                 this.avatarCard.open(target, {
-                    id: this.message.author_id.main_user_id.id,
+                    id: this.message.author_id.id,
+                    model: "res.partner"
                 });
             }
         }

--- a/addons/mail/static/src/discuss/core/common/channel_member.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member.js
@@ -27,22 +27,26 @@ export class ChannelMember extends Component {
         return this.props.member;
     }
 
+    get isClickable() {
+        return this.canOpenChat;
+    }
+
     get attClass() {
-        return { "cursor-pointer": this.canOpenChat, "o-offline": !this.member.isOnline };
+        return { "cursor-pointer": this.isClickable, "o-offline": !this.member.isOnline };
     }
 
     get canOpenChat() {
         if (this.store.inPublicPage) {
             return false;
         }
-        if (this.member.partner_id) {
+        if (this.member.partner_id?.main_user_id) {
             return true;
         }
         return false;
     }
 
     onClickAvatar(ev) {
-        if (!this.canOpenChat) {
+        if (!this.isClickable) {
             return;
         }
         this.store.openChat({ partnerId: this.member.partner_id.id });

--- a/addons/mail/static/src/discuss/core/web/channel_member_patch.js
+++ b/addons/mail/static/src/discuss/core/web/channel_member_patch.js
@@ -18,14 +18,18 @@ patch(ChannelMember.prototype, {
     get attClass() {
         return { ...super.attClass, "o-active": this.state.isAvatarCardOpen };
     },
+    get isClickable(){
+        return this.member.partner_id;
+    },
     onClickAvatar(ev) {
-        if (!this.canOpenChat) {
+        if (!this.isClickable) {
             return;
         }
         if (!this.avatarCard.isOpen) {
             this.avatarCard.open(ev.currentTarget, {
-                id: this.member.partner_id.main_user_id?.id,
+                id: this.member.partner_id.id,
                 channelMember: this.member,
+                model: "res.partner"
             });
             this.state.isAvatarCardOpen = true;
         }


### PR DESCRIPTION
Description:
In order to unify the UI for all communication modes in the Discuss app, we have updated the setup of message popover cards to use the res_partner ID.

Previously, the Discuss app specifically required a res_user ID for these cards, which meant messages from partners without a linked user account did not display a popover. By switching to the partner ID, we ensure that all participants—regardless of user status—have functional popover cards and consistent access to their partner pages.

task-5333399