### PR TITLE
[FIX] mail: no access error on starring message without write access

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -894,7 +894,8 @@ class MailMessage(models.Model):
     def unstar_all(self):
         """ Unstar messages for the current partner. """
         starred_messages = self.search([("starred_partner_ids", "in", self.env.user.partner_id.id)])
-        starred_messages.starred_partner_ids = [Command.unlink(self.env.user.partner_id.id)]
+        # sudo: mail.message - a user can unstar messages they can read
+        starred_messages.sudo().starred_partner_ids = [Command.unlink(self.env.user.partner_id.id)]
         self.env.user._bus_send(
             "mail.message/toggle_star", {"message_ids": starred_messages.ids, "starred": False}
         )
@@ -904,13 +905,14 @@ class MailMessage(models.Model):
             to uid are set to (un)starred.
         """
         self.ensure_one()
-        # a user should always be able to star a message they can read
         self.check_access('read')
         starred = not self.starred
         if starred:
-            self.starred_partner_ids = [Command.link(self.env.user.partner_id.id)]
+            # sudo: mail.message - a user can star a message they can read
+            self.sudo().starred_partner_ids = [Command.link(self.env.user.partner_id.id)]
         else:
-            self.starred_partner_ids = [Command.unlink(self.env.user.partner_id.id)]
+            # sudo: mail.message - a user can unstar a message they can read
+            self.sudo().starred_partner_ids = [Command.unlink(self.env.user.partner_id.id)]
         self.env.user._bus_send(
             "mail.message/toggle_star", {"message_ids": [self.id], "starred": starred}
         )

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -1,11 +1,27 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.mail.tests import common
-from odoo.tests import new_test_user, tagged
+from odoo.tests import new_test_user, tagged, users
 
 
 @tagged("-at_install", "post_install", "mail_message")
 class TestMailMessage(common.MailCommon):
+    @users("employee")
+    def test_can_star_message_without_write_access(self):
+        message = self.env["mail.message"].sudo().create({
+            "author_id": self.partner_admin.id,
+            "model": "res.partner",
+            "res_id": self.partner_admin.id,
+            "body": "Hey this is me!",
+        })
+        message = message.sudo(False)
+        self.env.user.group_ids -= self.env.ref("base.group_partner_manager")
+        self.assertFalse(message.has_access("write"))
+        message.toggle_message_starred()
+        self.assertIn(self.env.user.partner_id, message.starred_partner_ids)
+        self.env["mail.message"].unstar_all()
+        self.assertNotIn(self.env.user.partner_id, message.starred_partner_ids)
+
     def test_unlink_failure_message_notify_author(self):
         recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")
         with self.mock_mail_gateway():


### PR DESCRIPTION
Before this commit, starring a message in a thread without write access would result in an access error.

This happens because since [1] a message is marked as starred by writing on the `starred_partner_ids` field of mail.message instead of the `starred_message_ids` field of res.partner.
This results in an access error when the uses does not have write access.

This commit fixes the issue by adding a sudo call to the write of `starred_partner_ids`, which is acceptable because a user should always be able to star a message they can read.

[1] https://github.com/odoo/odoo/pull/219282

task-5481662