### PR TITLE
[FIX] website_sale: Keep popups above product image column

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1068,6 +1068,10 @@ $-product-radius-map: (
     container: product-details / inline-size;
     z-index: 0;
 
+    &:has(.s_popup) {
+        z-index: 2;
+    }
+    
     @include media-breakpoint-up(lg) {
         padding-top: var(--o-wsale-product-col-details-padding-top-lg, 0px);
     }


### PR DESCRIPTION
Steps to reproduce:
===================
- Go to website sale & pick any product.
- Go to edit mode & drop a popup in the product description

-> Popup appear behind of the product image.

Cause:
=====
Product popups inserted inside the description column (#product_details) inherit it's z-index, while the adjacent .o_wsale_product_images column stays with z-index: 1. Since the details column z-index: 0, any popup inside it remained under the image column.

Solution:
=========
Override the z-index only when a popup is present

opw-5458436

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
