### PR TITLE
[FIX] website, html_builder: undo in translate after color code dialog

### DIFF
--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -1,12 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
-import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { AttributeTranslateDialog } from "../translation_components/attributeTranslateDialog";
 import { SelectTranslateDialog } from "../translation_components/selectTranslateDialog";
-import {
-    localStorageNoDialogKey,
-    TranslatorInfoDialog,
-} from "../translation_components/translatorInfoDialog";
 import { withSequence } from "@html_editor/utils/resource";
 import { makeContentsInline, unwrapContents } from "@html_editor/utils/dom";
 
@@ -119,10 +114,6 @@ export class TranslationPlugin extends Plugin {
                     ev.preventDefault();
                 }
             });
-        }
-
-        if (!browser.localStorage.getItem(localStorageNoDialogKey)) {
-            this.dialogService.add(TranslatorInfoDialog);
         }
 
         const showNotification = (ev) => {

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -9,7 +9,7 @@ import { TranslateSetupEditorPlugin } from "./plugins/translate_setup_editor_plu
 import { VisibilityPlugin } from "@html_builder/core/visibility_plugin";
 import { removePlugins } from "@html_builder/utils/utils";
 import { closestElement } from "@html_editor/utils/dom_traversal";
-import { Component, onWillStart } from "@odoo/owl";
+import { Component, onMounted, onWillStart } from "@odoo/owl";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -35,6 +35,11 @@ import { ImageFieldPlugin } from "@html_builder/plugins/image_field_plugin";
 import { MonetaryFieldPlugin } from "@html_builder/plugins/monetary_field_plugin";
 import { Many2OneOptionPlugin } from "@html_builder/plugins/many2one_option_plugin";
 import { rpc } from "@web/core/network/rpc";
+import { browser } from "@web/core/browser/browser";
+import {
+    localStorageNoDialogKey,
+    TranslatorInfoDialog,
+} from "./translation_components/translatorInfoDialog";
 
 const TRANSLATION_PLUGINS = [
     BuilderOptionsTranslationPlugin,
@@ -83,6 +88,11 @@ export class WebsiteBuilder extends Component {
             this.translatedElements = this.props.translation
                 ? await rpc("/website/get_translated_elements")
                 : [];
+        });
+        onMounted(() => {
+            if (this.props.translation && !browser.localStorage.getItem(localStorageNoDialogKey)) {
+                this.dialog.add(TranslatorInfoDialog);
+            }
         });
     }
 

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -259,6 +259,19 @@ test("translate attribute history", async () => {
     expect(".modal .modal-body input").toHaveValue("title");
 });
 
+test("undo shortcut in translate", async () => {
+    const { getEditor } = await setupSidebarBuilderForTranslation({
+        websiteContent: `<h1>Homepage</h1>`,
+    });
+    await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    setSelection({ anchorNode: queryOne(":iframe h1"), anchorOffset: 0 });
+    await insertText(getEditor(), "New ");
+    expect(":iframe h1").toHaveText("New Homepage");
+    await press(["ctrl", "z"]);
+    await getEditor().shared.operation.next();
+    expect(":iframe h1").not.toHaveText("New Homepage");
+});
+
 test("translate select", async () => {
     await setupSidebarBuilderForTranslation({
         websiteContent: `


### PR DESCRIPTION
The builder uses `useHotkey` to bind the shortcuts for undo/redo. But when entering translate mode, if the dialog about color code appears, the hotkeys are associated with the active element of the dialog, and thus are skipped on dispatch when in the builder (and the dialog is closed).

This commit shows the dialog in `onMounted` of the builder, instead of `onWillStart`, so that the dialog appears just after (instead of just before) the hotkeys are bound to the active element.

Steps to reproduce:
- On a DB with a website in several languages
- Open the website builder in translate mode
- Discard the dialog explaining the color code. This is the dialog needed to trigger the bug. If the dialog does not appear, try with a new private window
- Do some edits in the page
- Click in the sidebar (otherwise keys are handled in the iframe)
- Press `ctrl+z`
- Bug: it does not "undo"

task-5481935
