### PR TITLE
[FIX] point_of_sale: handle change rodunding with UP and DOWN methods

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -97,7 +97,9 @@ export class PosOrderAccounting extends Base {
             (isNegative ? -roundingSanatizer : roundingSanatizer);
 
         const amount = isNegative ? -this.currency.round(total) : this.currency.round(total);
-        return this.config.cash_rounding ? this.config.rounding_method.round(amount) : amount;
+        return this.config.cash_rounding
+            ? this.config.rounding_method.asymmetricRound(amount)
+            : amount;
     }
     get orderIsRounded() {
         const cashPm = this.payment_ids.some((p) => p.payment_method_id.is_cash_count);

--- a/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
@@ -91,6 +91,46 @@ test("Rounding sale UP 10 (all methods)", async () => {
     expect(order.canBeValidated()).toBe(true);
     expect(order.appliedRounding).toBe(7.46);
     expect(order.change).toBe(0);
+    order.payment_ids[0].delete();
+
+    order.addPaymentline(cardPm);
+    expect(order.payment_ids[0].amount).toBe(60);
+    order.payment_ids[0].setAmount(70);
+    expect(order.payment_ids[0].amount).toBe(70);
+    expect(order.canBeValidated()).toBe(true);
+    expect(order.appliedRounding).toBe(0);
+    expect(order.change).toBe(-10);
+});
+
+test("Rounding sale DOWN 10 (all methods)", async () => {
+    const store = await setupPosEnv();
+    const { cashPm, cardPm } = prepareRoundingVals(store, 10, "DOWN", false);
+    const order = await getFilledOrderForPriceCheck(store);
+
+    expect(order.displayPrice).toBe(52.54);
+
+    order.addPaymentline(cardPm);
+    expect(order.payment_ids[0].amount).toBe(50);
+    expect(order.canBeValidated()).toBe(true);
+    expect(order.appliedRounding).toBe(-2.54);
+    expect(order.change).toBe(0);
+    order.payment_ids[0].delete();
+    expect(order.canBeValidated()).toBe(false);
+
+    order.addPaymentline(cashPm);
+    expect(order.payment_ids[0].amount).toBe(50);
+    expect(order.canBeValidated()).toBe(true);
+    expect(order.appliedRounding).toBe(-2.54);
+    expect(order.change).toBe(0);
+    order.payment_ids[0].delete();
+
+    order.addPaymentline(cardPm);
+    expect(order.payment_ids[0].amount).toBe(50);
+    order.payment_ids[0].setAmount(70);
+    expect(order.payment_ids[0].amount).toBe(70);
+    expect(order.canBeValidated()).toBe(true);
+    expect(order.appliedRounding).toBe(0);
+    expect(order.change).toBe(-20);
 });
 
 test("Rounding sale DOWN 1 (cash only)", async () => {


### PR DESCRIPTION
When using cash rounding with UP or DOWN methods, the change was not being calculated correctly when paying more than the total amount due.

opw-5476693

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
