### PR TITLE
[FIX] account_{edi_ubl_cii,peppol_selfbilling}, l10n_account_edi_ubl_cii_tests: use company_registry for PartyIdentification and CompanyID

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -650,6 +650,10 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                         'cbc:ID': {'_text': commercial_partner.peppol_endpoint}
                     }
                 ]
+        elif commercial_partner.country_code == 'BE' and commercial_partner.company_registry:
+            party_node['cac:PartyIdentification'] = {
+                'cbc:ID': {'_text': commercial_partner.company_registry}
+            }
 
         party_node['cac:PartyTaxScheme'] = party_tax_scheme = [
             {
@@ -691,6 +695,10 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = {
                 '_text': ''.join(char for char in commercial_partner.company_registry if char.isdigit
                 ())
+            }
+        elif commercial_partner.country_code == 'BE' and commercial_partner.company_registry:
+            party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = {
+                '_text': commercial_partner.company_registry
             }
         else:
             party_node['cac:PartyLegalEntity']['cbc:CompanyID'] = {

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_custom_tax_recycling_contribution.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_custom_tax_recycling_contribution.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_fixed_tax_recycling_contribution.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_allowance_charge_fixed_tax_recycling_contribution.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_cash_rounding_add_invoice_line.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_cash_rounding_add_invoice_line.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_cash_rounding_biggest_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_cash_rounding_biggest_tax.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_multiple_taxes.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_multiple_taxes.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_discount_on_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_discount_on_lines.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_recycling_contribution_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_early_pay_discount_with_recycling_contribution_tax.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_fixed_tax_emptying_turned_as_extra_invoice_lines.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_item_description_name.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_item_description_name.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_manual_tax_amount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_manual_tax_amount.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_negative_price_unit.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_negative_price_unit.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_payee_financial_account.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_payee_financial_account.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes_plus_free_product.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_price_amount_rounding_precision_with_price_included_taxes_plus_free_product.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_price_unit_more_decimals.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_price_unit_more_decimals.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_send_and_print_additional_documents.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_send_and_print_additional_documents.xml
@@ -24,6 +24,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -43,7 +46,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -53,6 +56,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -72,7 +78,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_luxembourg_dig.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_luxembourg_dig.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_partner_with_gln.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_sent_to_partner_with_gln.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_currency_code_tax_totals_foreign_currency.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_currency_code_tax_totals_foreign_currency.xml
@@ -19,6 +19,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -38,7 +41,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -48,6 +51,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -67,7 +73,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_exempt.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_exempt.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_reverse_charge.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/be/test_invoice_tax_reverse_charge.xml
@@ -18,6 +18,9 @@
 	<cac:AccountingSupplierParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0202239951</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
@@ -37,7 +40,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
+				<cbc:CompanyID>0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>company_1_data</cbc:Name>
@@ -47,6 +50,9 @@
 	<cac:AccountingCustomerParty>
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+			<cac:PartyIdentification>
+				<cbc:ID>0477472701</cbc:ID>
+			</cac:PartyIdentification>
 			<cac:PartyName>
 				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
@@ -66,7 +72,7 @@
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
-				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
+				<cbc:CompanyID>0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>partner_be</cbc:Name>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -238,6 +238,21 @@ class TestAccountEdiUblCii(TestUblCiiCommon):
             'peppol_endpoint': '0477472701',
         }])
 
+    def test_export_company_registry_in_party_nodes(self):
+        """Check that company_registry is used for PartyIdentification and CompanyID."""
+        self.partner_be.company_registry = '1234567890'
+        invoice = self.env['account.move'].create({
+            'partner_id': self.partner_be.id,
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id})]
+        })
+        invoice.action_post()
+
+        xml_tree = etree.fromstring(self.env['account.edi.xml.ubl_bis3']._export_invoice(invoice)[0])
+        customer_nodes = xml_tree.xpath('//cac:AccountingCustomerParty/cac:Party', namespaces=self.ubl_namespaces)
+        self.assertEqual(customer_nodes[0].find('.//{*}PartyIdentification/{*}ID').text, '1234567890')
+        self.assertEqual(customer_nodes[0].find('.//{*}PartyLegalEntity/{*}CompanyID').text, '1234567890')
+
     def test_import_partner_peppol_fields(self):
         """ Check that the peppol fields are used to retrieve the partner when importing a Bis 3 xml. """
         invoice = self.env['account.move'].create({

--- a/addons/account_peppol_selfbilling/tests/test_files/test_selfbilling.xml
+++ b/addons/account_peppol_selfbilling/tests/test_files/test_selfbilling.xml
@@ -19,6 +19,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0477472701</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_be</cbc:Name>
       </cac:PartyName>
@@ -38,7 +41,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_be</cbc:RegistrationName>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cbc:CompanyID>0477472701</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_be</cbc:Name>
@@ -48,6 +51,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0202239951</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -67,7 +73,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cbc:CompanyID>0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>company_1_data</cbc:Name>

--- a/addons/account_peppol_selfbilling/tests/test_files/test_selfbilling_credit_note.xml
+++ b/addons/account_peppol_selfbilling/tests/test_files/test_selfbilling_credit_note.xml
@@ -19,6 +19,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0477472701</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_be</cbc:Name>
       </cac:PartyName>
@@ -38,7 +41,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_be</cbc:RegistrationName>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cbc:CompanyID>0477472701</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_be</cbc:Name>
@@ -48,6 +51,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0202239951</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -67,7 +73,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cbc:CompanyID>0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>company_1_data</cbc:Name>

--- a/addons/account_peppol_selfbilling/tests/test_files/test_selfbilling_reverse_charge.xml
+++ b/addons/account_peppol_selfbilling/tests/test_files/test_selfbilling_reverse_charge.xml
@@ -48,6 +48,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0202239951</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -67,7 +70,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cbc:CompanyID>0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>company_1_data</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case1.xml
@@ -25,7 +25,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_1</cbc:ID>
+                <cbc:ID>0202239951</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_1</cbc:Name>
@@ -46,7 +46,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cbc:CompanyID>0202239951</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_1</cbc:Name>
@@ -57,7 +57,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_2</cbc:ID>
+                <cbc:ID>0477472701</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_2</cbc:Name>
@@ -78,7 +78,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+                <cbc:CompanyID>0477472701</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case2.xml
@@ -25,7 +25,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_1</cbc:ID>
+                <cbc:ID>0202239951</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_1</cbc:Name>
@@ -46,7 +46,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cbc:CompanyID>0202239951</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_1</cbc:Name>
@@ -57,7 +57,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_2</cbc:ID>
+                <cbc:ID>0477472701</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_2</cbc:Name>
@@ -78,7 +78,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+                <cbc:CompanyID>0477472701</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case3.xml
@@ -25,7 +25,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_1</cbc:ID>
+                <cbc:ID>0202239951</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_1</cbc:Name>
@@ -46,7 +46,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cbc:CompanyID>0202239951</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_1</cbc:Name>
@@ -57,7 +57,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_2</cbc:ID>
+                <cbc:ID>0477472701</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_2</cbc:Name>
@@ -78,7 +78,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+                <cbc:CompanyID>0477472701</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case4.xml
@@ -25,7 +25,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_1</cbc:ID>
+                <cbc:ID>0202239951</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_1</cbc:Name>
@@ -46,7 +46,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cbc:CompanyID>0202239951</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_1</cbc:Name>
@@ -57,7 +57,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_2</cbc:ID>
+                <cbc:ID>0477472701</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_2</cbc:Name>
@@ -78,7 +78,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+                <cbc:CompanyID>0477472701</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice.xml
@@ -23,7 +23,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_1</cbc:ID>
+        <cbc:ID>0202239951</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_1</cbc:Name>
@@ -44,7 +44,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cbc:CompanyID>0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_1</cbc:Name>
@@ -55,7 +55,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_2</cbc:ID>
+        <cbc:ID>0477472701</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_2</cbc:Name>
@@ -76,7 +76,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cbc:CompanyID>0477472701</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_no_prices.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_no_prices.xml
@@ -15,6 +15,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0202239951</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_1</cbc:Name>
       </cac:PartyName>
@@ -34,7 +37,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cbc:CompanyID>0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_1</cbc:Name>
@@ -44,6 +47,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0477472701</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_2</cbc:Name>
       </cac:PartyName>
@@ -63,7 +69,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cbc:CompanyID>0477472701</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_quantity_and_or_unit_price_zero.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_quantity_and_or_unit_price_zero.xml
@@ -21,6 +21,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0202239951</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_1</cbc:Name>
       </cac:PartyName>
@@ -40,7 +43,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cbc:CompanyID>0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_1</cbc:Name>
@@ -50,6 +53,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID>0477472701</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_2</cbc:Name>
       </cac:PartyName>
@@ -69,7 +75,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cbc:CompanyID>0477472701</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_refund.xml
@@ -22,7 +22,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_1</cbc:ID>
+        <cbc:ID>0202239951</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_1</cbc:Name>
@@ -43,7 +43,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cbc:CompanyID>0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_1</cbc:Name>
@@ -54,7 +54,7 @@
     <cac:Party>
       <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>ref_partner_2</cbc:ID>
+        <cbc:ID>0477472701</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_2</cbc:Name>
@@ -75,7 +75,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cbc:CompanyID>0477472701</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_pay_term.xml
@@ -27,7 +27,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_1</cbc:ID>
+                <cbc:ID>0202239951</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_1</cbc:Name>
@@ -48,7 +48,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cbc:CompanyID>0202239951</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_1</cbc:Name>
@@ -59,7 +59,7 @@
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
             <cac:PartyIdentification>
-                <cbc:ID>ref_partner_2</cbc:ID>
+                <cbc:ID>0477472701</cbc:ID>
             </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_2</cbc:Name>
@@ -80,7 +80,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+                <cbc:CompanyID>0477472701</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/ubl_test_import_partner.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/ubl_test_import_partner.xml
@@ -18,6 +18,9 @@
     <cac:AccountingSupplierParty>
         <cac:Party>
             <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID>0202239951</cbc:ID>
+            </cac:PartyIdentification>
             <cac:PartyName>
                 <cbc:Name>partner_1</cbc:Name>
             </cac:PartyName>
@@ -37,7 +40,7 @@
             </cac:PartyTaxScheme>
             <cac:PartyLegalEntity>
                 <cbc:RegistrationName>partner_1</cbc:RegistrationName>
-                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cbc:CompanyID>0202239951</cbc:CompanyID>
             </cac:PartyLegalEntity>
             <cac:Contact>
                 <cbc:Name>partner_1</cbc:Name>


### PR DESCRIPTION
The base `_get_party_node` uses `commercial_partner.ref` for `PartyIdentification` and `commercial_partner.vat` for `CompanyID`. There was no logic to prefer `company_registry` when available.

Refs:
An independent invoice example: https://developer.vertexinc.com/einvoicing/docs/belgium-example-documents

https://github.com/odoo/odoo/blob/40c862476382c68d7f452284074f5b44955d1f98/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L1564-L1566

https://github.com/odoo/odoo/blob/40c862476382c68d7f452284074f5b44955d1f98/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L1585

Steps To Reproduce:
- Have accounting, account_edi_ubl_cii and contacts installed.
- Create a Belgian company and set the VAT, Company ID and Reference (under Sales & Purchase tab).
- Create a contact and set his eInvoice format in Accounting tab to EU Standard (Peppol Bis 3.0) and make sure to give him a country.
- Go to accounting -> Customers -> Invoices and create an invoice for the contact you created.
- Send the invoice to the contact and download the XML from the chatter and inspect it.
- PartyIdentification/ID shows the partner's ref field value (e.g., "(odoobe)") instead of the company registration number.
- PartyLegalEntity/CompanyID uses the VAT number instead of the company registration number (ondernemingsnummer).


Ticket [link](https://www.odoo.com/odoo/project.task/5418190)
opw-5418190