### PR TITLE
[FIX] point_of_sale: Fix grouping product with selected category

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2738,22 +2738,30 @@ export class PosStore extends WithLazyGetterTrap {
             return sortedProducts.length ? [["0", sortedProducts]] : [];
         } else {
             const groupedByCategory = {};
+            const selectedCategories = this.selectedCategory
+                ? this.selectedCategory.getAllChildren().map((c) => c.id)
+                : false;
             for (const product of sortedProducts) {
                 if (product.pos_categ_ids.length === 0) {
+                    // Only display product without category if we don't have a category selected
+                    if (selectedCategories) {
+                        continue;
+                    }
                     if (!groupedByCategory[0]) {
                         groupedByCategory[0] = [];
                     }
                     groupedByCategory[0].push(product);
                     continue;
                 }
-                const category_ids = this.selectedCategory
-                    ? [this.selectedCategory.id]
-                    : product.pos_categ_ids.map((c) => c.id);
-                for (const categ_id of category_ids) {
-                    if (!groupedByCategory[categ_id]) {
-                        groupedByCategory[categ_id] = [];
+                const productCategories = product.pos_categ_ids.map((c) => c.id);
+                for (const categId of productCategories) {
+                    if (selectedCategories && !selectedCategories.includes(categId)) {
+                        continue;
                     }
-                    groupedByCategory[categ_id].push(product);
+                    if (!groupedByCategory[categId]) {
+                        groupedByCategory[categId] = [];
+                    }
+                    groupedByCategory[categId].push(product);
                 }
             }
             const res = Object.entries(groupedByCategory).sort(([a], [b]) => {

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -397,6 +397,15 @@ describe("pos_store.js", () => {
         expect(grouped[0][0]).toBe("1");
         expect(grouped[0][1][0].name).toBe("Multi Category Product");
         expect(grouped[0][1][1].name).toBe("TEST");
+
+        // Case 5: Grouping with category 'Food' selected (parent of 'Burger' & 'Pizza')
+        store.selectedCategory = store.models["pos.category"].get(3);
+        grouped = store.productToDisplayByCateg;
+        expect(grouped.length).toBe(3);
+        expect(grouped[0][0]).toBe("3");
+        expect(grouped[0][1][0].name).toBe("Club sandwich");
+        expect(grouped[1][1][0].name).toBe("Bacon burger");
+        expect(grouped[2][1][0].name).toBe("Pizza margarita");
     });
 
     test("onDeleteOrder", async () => {


### PR DESCRIPTION
Fix an issue in the POS when using  `Group products by category` settings with a selected category would not group the product by category anymore. We now make sure that even when we select a category in POS, the products are still grouped by category.

task-id: 5481961



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
