### PR TITLE
[18.0][FIX] account: search taxes with sudo()

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -213,7 +213,7 @@ class AccountTax(models.Model):
                         ('country_id', '=', tax.country_id.id),
                         ('id', '!=', tax.id),
                     ])
-            if duplicates := self.search(expression.OR(domains)):
+            if duplicates := self.sudo().search(expression.OR(domains)):
                 raise ValidationError(
                     _("Tax names must be unique!")
                     + "\n" + "\n".join(_(


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In companies with many branches, a user could create a tax name that already exists in another branch. This happened because Odoo only checked for duplicates in the branches the user could see.

To reproduce:
1. Create `Branch A` and `Branch B`.
2. A user with access ONLY to `Branch A` creates "Tax 1".
3. A user with access ONLY to `Branch B` creates "Tax 1".
4. Both are saved, creating a duplicate name.

This fix adds sudo() to the check. Now, Odoo will check all branches to make sure the name is unique, even if the user cannot see the other branches.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
