### PR TITLE
[FIX] point_of_sale: fix 0.01 rounding error in POS downpayments

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1521,7 +1521,7 @@ class AccountTax(models.Model):
         :param company:         The company owning the base line.
         :param rounding_method: The rounding method to be used. If not specified, it will be taken from the company.
         """
-        rounding_method = rounding_method or company.tax_calculation_rounding_method
+        rounding_method = rounding_method or base_line.get('rounding_method') or company.tax_calculation_rounding_method
         price_unit_after_discount = base_line['price_unit'] * (1 - (base_line['discount'] / 100.0))
         taxes_computation = base_line['tax_ids']._get_tax_details(
             price_unit=price_unit_after_discount,

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -604,7 +604,8 @@ export const accountTaxHelpers = {
      * PLZ KEEP BOTH METHODS CONSISTENT WITH EACH OTHERS.
      */
     add_tax_details_in_base_line(base_line, company, { rounding_method = null } = {}) {
-        rounding_method = rounding_method || company.tax_calculation_rounding_method;
+        rounding_method =
+            rounding_method || base_line.rounding_method || company.tax_calculation_rounding_method;
         const price_unit_after_discount = base_line.price_unit * (1 - (base_line.discount / 100.0));
         const currency_pd = base_line.currency_id.rounding;
         const company_currency_pd = company.currency_id.rounding;

--- a/addons/point_of_sale/static/src/app/models/utils/tax_utils.js
+++ b/addons/point_of_sale/static/src/app/models/utils/tax_utils.js
@@ -22,12 +22,13 @@ export const compute_price_force_price_include = (
         product_default_values,
         company,
         currency,
-        "total_included"
+        "total_included",
+        "round_globally"
     );
-    let new_price = tax_res.total_excluded;
+    let new_price = tax_res.raw_total_excluded_currency;
     new_price += tax_res.taxes_data
         .filter((tax) => models["account.tax"].get(tax.id).price_include)
-        .reduce((sum, tax) => (sum += tax.tax_amount), 0);
+        .reduce((sum, tax) => (sum += tax.raw_tax_amount_currency), 0);
     return new_price;
 };
 
@@ -39,7 +40,8 @@ export const getTaxesValues = (
     productDefaultValues,
     company,
     currency,
-    special_mode = null
+    special_mode = null,
+    rounding_method = null
 ) => {
     const baseLine = accountTaxHelpers.prepare_base_line_for_taxes_computation(
         {},
@@ -55,7 +57,7 @@ export const getTaxesValues = (
             special_mode: special_mode,
         }
     );
-    accountTaxHelpers.add_tax_details_in_base_line(baseLine, company);
+    accountTaxHelpers.add_tax_details_in_base_line(baseLine, company, { rounding_method });
     accountTaxHelpers.round_base_lines_tax_details([baseLine], company);
 
     const results = baseLine.tax_details;


### PR DESCRIPTION
When applying a downpayment in POS with tax-included prices, a rounding error of 0.01 cent could occur, preventing invoice creation.

For example, with an 8% tax and a downpayment of exactly 2,117.00:
- Calculation: 2117 ÷ 1.08 = 1960.185 → rounds to 1960.19
- Recalculation: 1960.19 × 1.08 = 2117.005 → rounds to 2117.01
- Result: 0.01 cent discrepancy

Root Cause:
-----------
The issue stems from cascading rounding errors when using 'round_per_line' method with standard product price precision (typically 2 decimals). Each intermediate calculation introduces a small rounding error that accumulates.

Solution:
---------
Apply two specific fixes for downpayment products only:

1. Use higher precision (6 decimals) instead of standard product price precision to maintain accuracy through the calculation chain

2. Force 'round_globally' rounding method instead of 'round_per_line' to ensure rounding happens only once at the final step, not at each intermediate calculation

3. Use raw (unrounded) amounts in tax calculations to preserve full precision until final rounding

opw-5040722
