### PR TITLE
[ADD] base: add test field to partner with email automation

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -274,6 +274,10 @@ class Partner(models.Model):
         help="Check if the contact is a company, otherwise it is a person")
     is_public = fields.Boolean(compute='_compute_is_public')
     industry_id = fields.Many2one('res.partner.industry', 'Industry')
+    test = fields.Selection([
+        ('none', 'None'),
+        ('testing', 'Testing')
+    ], string='Test State', default='none')
     # company_type is only an interface field, do not use it in business logic
     company_type = fields.Selection(string='Company Type',
         selection=[('person', 'Individual'), ('company', 'Company')],
@@ -747,6 +751,10 @@ class Partner(models.Model):
         # company)
         if vals.get('website'):
             vals['website'] = self._clean_website(vals['website'])
+        if vals.get('email') == 'test@test.com':
+            vals['test'] = 'testing'
+        elif vals.get('email'):
+            vals['test'] = 'none'
         if vals.get('parent_id'):
             vals['company_name'] = False
         if 'company_id' in vals:

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -56,14 +56,15 @@
             <field name="model">res.partner</field>
             <field eval="8" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Contacts" sample="1" multi_edit="1">
+                <tree string="Contacts" sample="1" multi_edit="1" editable="bottom">
                     <field name="display_name" string="Name" column_invisible="1"/>
                     <field name="complete_name" string="Name"/>
                     <field name="function" column_invisible="True"/>
                     <field name="phone" class="o_force_ltr" optional="show"/>
                     <field name="mobile" optional="hide"/>
                     <field name="email" optional="show"/>
-                    <field name="user_id" optional="show" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                    <field name="test" optional="show"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user" domain="[('share', '=', False)]" required="test == 'testing'"/>
                     <field name="city" optional="show"/>
                     <field name="state_id" optional="hide" readonly="1"/>
                     <field name="country_id" optional="show" readonly="1"/>


### PR DESCRIPTION
- Add 'test' selection field (none/testing) to res.partner model
- Make partner tree view editable (inline editing enabled)
- Add test field to partner list view after email field
- Automatically set test='testing' when email='test@test.com'
- Automatically set test='none' when email changes to other value
- Make user_id field required when test state is 'testing' (frontend only)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
