### PR TITLE
[FIX] mail: guard local time formatting against 'localtime' timezone

### DIFF
--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -45,7 +45,7 @@
                         <a t-if="phone" class="o-mail-avatar-card-tel text-truncate" t-att-title="phone" t-att-href="'tel:'+phone">
                             <i class="fa fa-fw fa-phone me-1"/><t t-esc="phone"/>
                         </a>
-                        <div t-if="state.partnerLocalDateTimeFormatted" class="text-muted">
+                        <div t-if="state.partnerLocalDateTimeFormatted" class="o-mail-avatar-card-localtime text-muted">
                             <i class="fa fa-fw fa-clock-o me-1"/><t t-out="state.partnerLocalDateTimeFormatted"/>
                         </div>
                         <div class="o_avatar_card_buttons d-flex gap-2 mt-2">

--- a/addons/mail/static/src/utils/common/dates.js
+++ b/addons/mail/static/src/utils/common/dates.js
@@ -3,6 +3,10 @@ import { localization } from "@web/core/l10n/localization";
 
 const { DateTime } = luxon;
 
+function resolveTimeZoneName(tz) {
+    return tz === "localtime" ? "local" : tz;
+}
+
 /**
  * @param {luxon.DateTime} datetime
  */
@@ -19,12 +23,18 @@ export function computeDelay(datetime) {
  * @param {string} currentUserTz
  */
 export function formatLocalDateTime(partnerTz, currentUserTz) {
-    if (!partnerTz || !currentUserTz || partnerTz === currentUserTz) {
+    const resolvedCurrentUserTz = resolveTimeZoneName(currentUserTz);
+    const resolvedPartnerTz = resolveTimeZoneName(partnerTz);
+    if (
+        !resolvedPartnerTz ||
+        !resolvedCurrentUserTz ||
+        [resolvedPartnerTz, resolvedCurrentUserTz].includes("local")
+    ) {
         return null;
     }
     const now = DateTime.now();
-    const partnerDateTime = now.setZone(partnerTz);
-    const currentUserDateTime = now.setZone(currentUserTz);
+    const partnerDateTime = now.setZone(resolvedPartnerTz);
+    const currentUserDateTime = now.setZone(resolvedCurrentUserTz);
     const format = currentUserDateTime.hasSame(partnerDateTime, "day")
         ? localization.timeFormat.replace(":ss", "")
         : localization.dateTimeFormat.replace(":ss", "");

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -19,6 +19,7 @@ export class ResPartner extends webModels.ResPartner {
         string: "Main attachment",
     });
     is_in_call = fields.Boolean({ compute: "_compute_is_in_call" });
+    tz = fields.Char();
 
     _views = {
         form: /* xml */ `
@@ -445,6 +446,6 @@ export class ResPartner extends webModels.ResPartner {
     }
 
     _get_store_avatar_card_fields() {
-        return ["email", "partner_share", "name", "phone"];
+        return ["email", "partner_share", "name", "phone", "tz"];
     }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -56,6 +56,7 @@ export class ResUsers extends webModels.ResUsers {
                                         "is_admin",
                                         mailDataHelpers.Store.one("main_user_id", []),
                                         "name",
+                                        "tz",
                                         "user",
                                     ],
                                 })


### PR DESCRIPTION
Purpose of commit:
Avatar cards displays “Invalid DateTime local time” when a user’s tz was stored
as the literal “localtime”, which Luxon can’t resolve. Add a helper to resolve
“localtime” to the browser zone and keep a validity guard so formatting only
runs with valid timezones.

Steps to reproduce:
- Login with user A change the timezone of the user A from the preferences tab. Change it to "localtime"
- Login with user B, open avatar card of user A, the below error is shown.
<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/bd0ad9dd-619f-41dc-bdf1-0a111e2a8862" />

task-5477788