### PR TITLE
[FIX] point_of_sale: optional product images follow config's show images setting

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/optional_products_popup/optional_products_popup.xml
@@ -12,15 +12,15 @@
                 <!-- Optional Product Line -->
                 <div class="optional-product-line d-flex justify-content-between align-items-center">
                     <!-- Product Details -->
-                    <div class="d-flex flex-column align-items-left">
+                    <div class="d-flex flex-column align-items-left overflow-hidden">
                         <div class="d-flex align-items-center flex-grow-1">
-                            <img t-att-src="optional_product.product_tmpl_id.getImageUrl()" alt="Product Image"
-                                class="rounded me-3" style="width: 60px; height: 60px; object-fit: cover;"/>
-                            <div>
-                                <h5 class="product-name mb-1">
+                            <img t-if="pos.config.show_product_images" t-att-src="optional_product.product_tmpl_id.getImageUrl()" alt="Product Image"
+                                class="product-img rounded me-3" style="width: 60px; height: 60px; object-fit: cover;"/>
+                            <div class="overflow-hidden">
+                                <h5 class="product-name mb-1 text-truncate">
                                     <t t-out="optional_product.product_tmpl_id.display_name"/>
                                 </h5>
-                                <p class="text-muted small mb-1">
+                                <p class="text-muted small mb-1 text-truncate">
                                     <t t-out="optional_product.product_tmpl_id.productDescriptionMarkup"/>
                                 </p>
                             </div>
@@ -28,7 +28,7 @@
                     </div>
 
                     <!-- Add to Cart Buttons -->
-                    <div class="cart-buttons btn-group d-flex align-items-center" role="group">
+                    <div class="cart-buttons btn-group d-flex align-items-center ms-2 flex-shrink-0" role="group">
                         <t t-if="!optional_product.qty">
                             <button
                                 type="button"

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -11,11 +11,7 @@ export class ProductProduct extends Base {
     static pythonModel = "product.product";
 
     getImageUrl() {
-        return (
-            (this.image_128 &&
-                `/web/image?model=product.product&field=image_128&id=${this.id}&unique=${this.write_date}`) ||
-            ""
-        );
+        return `/web/image?model=product.product&field=image_128&id=${this.id}&unique=${this.write_date}`;
     }
 
     get searchString() {

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -262,11 +262,7 @@ export class ProductTemplate extends Base {
     }
 
     getImageUrl() {
-        return (
-            (this.image_128 &&
-                `/web/image?model=product.template&field=image_128&id=${this.id}&unique=${this.write_date}`) ||
-            ""
-        );
+        return `/web/image?model=product.template&field=image_128&id=${this.id}&unique=${this.write_date}`;
     }
 
     _isArchivedCombination(attributeValueIds) {

--- a/addons/point_of_sale/static/tests/pos/tours/optional_product_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/optional_product_tour.js
@@ -21,6 +21,8 @@ registry.category("web_tour.tours").add("test_optional_product", {
             // Add a product with optional products
             ProductScreen.clickDisplayedProduct("Desk Pad", false),
             Dialog.is({ title: "Optional Products" }),
+            // Check image of optional product
+            OptionalProduct.checkImage("Small Shelf", true),
             // Add a specific optional product
             OptionalProduct.addOptionalProduct("Small Shelf", 5),
             ProductScreen.selectedOrderlineHas("Small Shelf", "5.0"),
@@ -50,5 +52,14 @@ registry.category("web_tour.tours").add("test_optional_product", {
             ),
 
             Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_optional_product_image_not_display", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.clickDisplayedProduct("Desk Pad"),
+            OptionalProduct.checkImage("Small Shelf", false),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/optional_product_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/optional_product_util.js
@@ -55,3 +55,15 @@ export function addOptionalProduct(productName, quantity, configurable) {
         return step;
     }
 }
+
+export function checkImage(productName, shouldHaveImage = false) {
+    const baseSelector = `.modal .optional-product-line:has(.product-name:contains("${productName}"))`;
+    const trigger = shouldHaveImage
+        ? `${baseSelector}:has(img.product-img)`
+        : `${baseSelector}:not(:has(img.product-img))`;
+
+    return {
+        content: `Check image visibility for optional product "${productName}"`,
+        trigger,
+    };
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -712,6 +712,10 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_optional_product(self):
         # optional product in pos
+        image = _create_image(color="orange")
+
+        self.small_shelf.write({'image_1920': image})
+
         self.desk_pad.write({'pos_optional_product_ids': [
             Command.set([ self.small_shelf.id ])
         ]})
@@ -720,9 +724,14 @@ class TestUi(TestPointOfSaleHttpCommon):
             'pos_optional_product_ids': [Command.set([self.configurable_chair.id])],
             'barcode': 'lettertray'
         })
-
+        # Case 1: Images ON → images must be visible in optional product dialog
+        self.main_pos_config.show_product_images = True
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_optional_product')
+
+        # Case 2: Images OFF → product images should not be shown
+        self.main_pos_config.show_product_images = False
+        self.start_pos_tour('test_optional_product_image_not_display')
 
     def test_05_ticket_screen(self):
         self.pos_user.write({


### PR DESCRIPTION
Before this commit:
===================
- When the `Show product images` setting was disabled, the optional products UI
still displayed product images.
- If an optional product did not have an image, the UI displayed the image's alt
text
- Also when the product don't have image, the combo popup and product card just
display the product name.

After this commit:
==================
- Optional product images are displayed only when the `Show product images`
configuration is enabled.
- If the optional product doesn't have an image, we will display an image
placeholder instead of alt text.
- If there is no product image, the combo popup and product card will
display the image placeholder.

Task: 5480181


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
