### PR TITLE
[FIX] hr_skills: fix duplicate skill issue

### DIFF
--- a/addons/hr_skills/models/hr_skill_type.py
+++ b/addons/hr_skills/models/hr_skill_type.py
@@ -2,7 +2,7 @@
 
 from random import randint
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, Command
 from odoo.exceptions import ValidationError
 
 
@@ -42,4 +42,12 @@ class HrSkillType(models.Model):
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
-        return [dict(vals, name=self.env._("%s (copy)", skill_type.name), color=0) for skill_type, vals in zip(self, vals_list)]
+        return [
+            {
+                **vals,
+                "name": self.env._("%(skill_type_name)s (copy)", skill_type_name=skill_type.name),
+                "color": 0,
+                "skill_ids": [Command.create({"name": skill.name}) for skill in skill_type.skill_ids],
+            }
+            for skill_type, vals in zip(self, vals_list)
+        ]


### PR DESCRIPTION
Version:
- saas-18.2

Steps to reproduce:
- Install the hr_skills module
- Go to the Skills menu
- Select a skill and click Duplicate

Issue:
- A validation error appears when duplicating a skill

Solution:
- Updated the copy_data method so skills can be duplicated without causing a validation error

Task - 5481185

