### PR TITLE
[FIX] web: preserve search view when drilling down from pivot/graph

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -856,6 +856,7 @@ export class GraphRenderer extends Component {
                 domain,
                 name: this.model.metaData.title,
                 res_model: this.model.metaData.resModel,
+                search_view_id: this.env.config.views?.find((v) => v[1] === "search"),
                 target: "current",
                 type: "ir.actions.act_window",
                 views,

--- a/addons/web/static/src/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/views/pivot/pivot_renderer.js
@@ -312,6 +312,7 @@ export class PivotRenderer extends Component {
                 type: "ir.actions.act_window",
                 name: this.model.metaData.title,
                 res_model: this.model.metaData.resModel,
+                search_view_id: this.env.config.views?.find((v) => v[1] === "search"),
                 views: views,
                 view_mode: "list",
                 target: "current",

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -1871,6 +1871,7 @@ test("clicking on bar charts triggers a do_action", async () => {
                 domain: [["bar", "=", false]],
                 name: "Foo Analysis",
                 res_model: "foo",
+                search_view_id: [67, "search"],
                 target: "current",
                 type: "ir.actions.act_window",
                 views: [
@@ -1885,6 +1886,7 @@ test("clicking on bar charts triggers a do_action", async () => {
     const view = await mountView({
         type: "graph",
         resModel: "foo",
+        searchViewId: 67,
         arch: /* xml */ `
             <graph string="Foo Analysis">
                 <field name="bar" />
@@ -1910,6 +1912,7 @@ test("middle click on bar charts triggers a do_action", async () => {
                 domain: [["bar", "=", false]],
                 name: "Foo Analysis",
                 res_model: "foo",
+                search_view_id: [67, "search"],
                 target: "current",
                 type: "ir.actions.act_window",
                 views: [
@@ -1924,6 +1927,7 @@ test("middle click on bar charts triggers a do_action", async () => {
     const view = await mountView({
         type: "graph",
         resModel: "foo",
+        searchViewId: 67,
         arch: /* xml */ `
             <graph string="Foo Analysis">
                 <field name="bar" />
@@ -1949,6 +1953,7 @@ test("Clicking on bar charts removes group_by and search_default_* context keys"
                 domain: [["bar", "=", false]],
                 name: "Foo Analysis",
                 res_model: "foo",
+                search_view_id: [67, "search"],
                 target: "current",
                 type: "ir.actions.act_window",
                 views: [
@@ -1963,6 +1968,7 @@ test("Clicking on bar charts removes group_by and search_default_* context keys"
     const view = await mountView({
         type: "graph",
         resModel: "foo",
+        searchViewId: 67,
         arch: /* xml */ `
             <graph string="Foo Analysis">
                 <field name="bar" />
@@ -1990,6 +1996,7 @@ test("clicking on a pie chart trigger a do_action with correct views", async () 
                 domain: [["bar", "=", false]],
                 name: "Foo Analysis",
                 res_model: "foo",
+                search_view_id: [67, "search"],
                 target: "current",
                 type: "ir.actions.act_window",
                 views: [
@@ -2004,6 +2011,7 @@ test("clicking on a pie chart trigger a do_action with correct views", async () 
     const view = await mountView({
         type: "graph",
         resModel: "foo",
+        searchViewId: 67,
         arch: /* xml */ `
             <graph string="Foo Analysis" type="pie">
                 <field name="bar" />
@@ -2038,6 +2046,7 @@ test("middle click on a pie chart trigger a do_action with correct views", async
                 domain: [["bar", "=", false]],
                 name: "Foo Analysis",
                 res_model: "foo",
+                search_view_id: [67, "search"],
                 target: "current",
                 type: "ir.actions.act_window",
                 views: [
@@ -2052,6 +2061,7 @@ test("middle click on a pie chart trigger a do_action with correct views", async
     const view = await mountView({
         type: "graph",
         resModel: "foo",
+        searchViewId: 67,
         arch: /* xml */ `
             <graph string="Foo Analysis" type="pie">
                 <field name="bar" />

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -520,6 +520,7 @@ test("clicking on a cell triggers a doAction", async () => {
                 domain: [["product_id", "=", 37]],
                 name: "Partners",
                 res_model: "partner",
+                search_view_id: [67, "search"],
                 target: "current",
                 type: "ir.actions.act_window",
                 view_mode: "list",
@@ -535,6 +536,7 @@ test("clicking on a cell triggers a doAction", async () => {
     await mountView({
         type: "pivot",
         resModel: "partner",
+        searchViewId: 67,
         arch: `
 			<pivot string="Partners">
 				<field name="product_id" type="row"/>
@@ -3860,6 +3862,7 @@ test("middle clicking on a cell triggers a doAction", async () => {
                 domain: [["product_id", "=", 37]],
                 name: "Partners",
                 res_model: "partner",
+                search_view_id: [67, "search"],
                 target: "current",
                 type: "ir.actions.act_window",
                 view_mode: "list",
@@ -3878,6 +3881,7 @@ test("middle clicking on a cell triggers a doAction", async () => {
     await mountView({
         type: "pivot",
         resModel: "partner",
+        searchViewId: 67,
         arch: `
 			<pivot string="Partners">
 				<field name="product_id" type="row"/>


### PR DESCRIPTION
Clicking on a pivot cell or graph bar/pie opens a new view, but the 
search_view_id was not being passed. As a result, the default search view was 
used, even when the action defined a specific one.

This caused inconsistent search views between the pivot/graph view and the 
drilled-down view.

This PR fixes the issue by correctly passing the current action's 
search_view_id when opening a new view from pivot/graph.

Steps to reproduce:
- install website_sale
- goto website > reporting > online sales
- click pivot cell
- the new opened list view does not have same search view as before
<img width="1920" height="563" alt="image" src="https://github.com/user-attachments/assets/e54656bb-088f-464b-8de2-a88a3a3ab22d" />
<img width="1920" height="635" alt="image" src="https://github.com/user-attachments/assets/e95ed61b-7573-4d58-9875-827c3124a039" />


task-[5469929](https://www.odoo.com/odoo/project/1519/tasks/5469929)