### PR TITLE
[FIX] web: do no crash on "Enter" in form with x2m kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -194,7 +194,7 @@ export class KanbanRenderer extends Component {
             {
                 area: () => this.rootRef.el,
                 isAvailable: (target) => {
-                    if (this.props.quickCreateState.isOpen) {
+                    if (this.props.quickCreateState?.isOpen) {
                         return false;
                     }
                     if (target.closest(".o_kanban_selection_active") !== null) {
@@ -349,7 +349,7 @@ export class KanbanRenderer extends Component {
             return true;
         }
         if (isGrouped) {
-            if (this.props.quickCreateState.isOpen) {
+            if (this.props.quickCreateState?.isOpen) {
                 return false;
             }
             if (this.canCreateGroup() && !this.state.columnQuickCreateIsFolded) {

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -2420,6 +2420,33 @@ test("one2many kanban order with handle widget", async () => {
     expect.verifySteps(["web_read"]);
 });
 
+test("press Enter in a form with a one2many kanban", async () => {
+    Partner._records[0].p = [2, 4];
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="p">
+                    <kanban>
+                        <templates>
+                            <t t-name="card">
+                                <field name="foo"/>
+                            </t>
+                        </templates>
+                    </kanban>
+                </field>
+            </form>`,
+        resId: 1,
+    });
+
+    await press("Enter");
+
+    expect(".o_kanban_renderer").toHaveCount(1);
+    expect(".o_kanban_record:not(.o_kanban_ghost):not(.o-kanban-button-new)").toHaveCount(2);
+});
+
 test("one2many field when using the pager", async () => {
     const ids = [];
     for (let i = 0; i < 45; i++) {


### PR DESCRIPTION
Be in a form view containing an x2many field displayed as a kanban view. Press "Enter". Before this commit, it crashed, because the kanban renderer tried to access it's `quickCreateState` props which was undefined. The props is indeed optional, so we must be careful when reading/using it.

Issue introduced by https://github.com/odoo/odoo/pull/228632

Spotted by task~5441808


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
