### PR TITLE
[IMP] web, html_editor: preview gradient changes in the color picker

### DIFF
--- a/addons/html_editor/static/src/main/font/color_picker_gradient_tab.js
+++ b/addons/html_editor/static/src/main/font/color_picker_gradient_tab.js
@@ -31,6 +31,7 @@ export class ColorPickerGradientTab extends Component {
         defaultOpacity: { type: Number, optional: true },
         noTransparency: { type: Boolean, optional: true },
         selectedColor: { type: String, optional: true },
+        currentColorPreview: { type: String, optional: true },
         "*": { optional: true },
     };
     setup() {
@@ -42,6 +43,9 @@ export class ColorPickerGradientTab extends Component {
     }
 
     getCurrentGradientColor() {
+        if (isColorGradient(this.props.currentColorPreview)) {
+            return this.props.currentColorPreview;
+        }
         if (isColorGradient(this.props.selectedColor)) {
             return this.props.selectedColor;
         }
@@ -49,6 +53,13 @@ export class ColorPickerGradientTab extends Component {
 
     toggleGradientPicker() {
         this.state.showGradientPicker = !this.state.showGradientPicker;
+        if (
+            !this.state.showGradientPicker &&
+            this.props.currentColorPreview &&
+            this.props.currentColorPreview !== this.props.selectedColor
+        ) {
+            this.props.applyColor(this.props.currentColorPreview);
+        }
     }
 }
 

--- a/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
+++ b/addons/html_editor/static/src/main/font/gradient_picker/gradient_picker.xml
@@ -1,6 +1,6 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.GradientPicker">
-        <div class="d-flex flex-column">
+        <div class="d-flex flex-column" t-on-keydown="onKeydown">
 
             <div class="align-items-center d-flex justify-content-between my-3 o_type_row">
                 Type
@@ -159,8 +159,6 @@
             <ColorPicker
                 onColorSelect.bind="onColorChange"
                 onColorPreview.bind="onColorPreview"
-                setOnCloseCallback.bind="props.setOnCloseCallback"
-                setOperationCallbacks.bind="props.setOperationCallbacks"
                 defaultColor="this.currentColorHex"
                 selectedColor="this.currentColorHex"
                 noTransparency="props.noTransparency"

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -1,7 +1,8 @@
 <templates xml:space="preserve">
 <t t-name="web.ColorPicker">
     <div t-attf-class="o_font_color_selector user-select-none {{this.props.className}}"
-        t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true" t-ref="root">
+        t-on-pointerdown.stop="() => {}" data-prevent-closing-overlay="true" t-ref="root"
+        t-on-mouseenter="this.onMouseEnter">
         <div class="px-1 mb-1 pt-2 d-flex">
             <t t-if="isMobileOS">
                 <Dropdown>

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.xml
@@ -21,7 +21,7 @@
                 <div t-ref="opacitySliderPointer" class="o_opacity_pointer" tabindex="0" t-on-keydown="onOpacitySliderKeydown" role="slider" aria-label="Opacity" aria-orientation="vertical" aria-valuemin="0" aria-valuemax="100"/>
             </div>
         </div>
-        <div class="o_color_picker_inputs d-flex justify-content-between mb-2" t-on-change="debouncedOnChangeInputs">
+        <div class="o_color_picker_inputs d-flex justify-content-between mb-2">
             <t t-set="input_classes" t-value="'p-0 border-0 text-center font-monospace bg-transparent'" />
 
             <div class="o_hex_div d-flex align-items-baseline me-1">

--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -141,12 +141,7 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
     await contains('div[data-label="Background"] .o_we_color_preview').click();
     await contains(".o-hb-colorpicker .custom-tab").click();
     await contains(".o_color_picker_inputs input.o_hex_input").edit("#77FF006E");
-    // When writing "#77FF006E" in the input, a first call is made when the
-    // input value is "#77FF00" and another when it becomes "#77FF006E"
     await expect.waitForSteps([
-        '/website/static/src/scss/options/colors/user_color_palette.scss {"o-cc1-bg":"#77FF00"}',
-        '/website/static/src/scss/options/user_values.scss {"o-cc1-bg-gradient":"null"}',
-        "asset reload",
         '/website/static/src/scss/options/colors/user_color_palette.scss {"o-cc1-bg":"#77FF006E"}',
         '/website/static/src/scss/options/user_values.scss {"o-cc1-bg-gradient":"null"}',
         "asset reload",

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -251,7 +251,7 @@ registerWebsitePreviewTour(
                     },
                     {
                         timeout: 9000,
-                        message: `An image should have been added as background. 
+                        message: `An image should have been added as background.
                             The gradient should have been kept when adding the background image
                         `,
                     }
@@ -276,7 +276,7 @@ registerWebsitePreviewTour(
                     },
                     {
                         timeout: 9000,
-                        message: `The image should have been kept when changing the gradient. 
+                        message: `The image should have been kept when changing the gradient.
                             TThe gradient should have been changed.
                         `,
                     }
@@ -301,7 +301,7 @@ registerWebsitePreviewTour(
                 run: "click",
             },
             checkGradient:
-                "linear-gradient(135deg, rgb(203, 94, 238) 0%, rgb(139, 160, 237) 50%, rgb(75, 225, 236) 100%)",
+                "linear-gradient(135deg, #cb5eee 0%, rgba(139, 160, 237, 1) 50%, #4be1ec 100%)",
         }),
         ...updateAndCheckCustomGradient({
             updateStep: {
@@ -310,7 +310,7 @@ registerWebsitePreviewTour(
                 run: "range 45",
             },
             checkGradient:
-                "linear-gradient(135deg, rgb(203, 94, 238) 0%, rgb(139, 160, 237) 45%, rgb(75, 225, 236) 100%)",
+                "linear-gradient(135deg, #cb5eee 0%, rgba(139, 160, 237, 1) 45%, #4be1ec 100%)",
         }),
         ...updateAndCheckCustomGradient({
             updateStep: {
@@ -318,8 +318,7 @@ registerWebsitePreviewTour(
                 content: "Pick step color",
                 run: "edit #FF0000",
             },
-            checkGradient:
-                "linear-gradient(135deg, rgb(203, 94, 238) 0%, rgb(255, 0, 0) 45%, rgb(75, 225, 236) 100%)",
+            checkGradient: "linear-gradient(135deg, #cb5eee 0%, #FF0000 45%, #4be1ec 100%)",
         }),
         ...updateAndCheckCustomGradient({
             updateStep: {
@@ -327,7 +326,7 @@ registerWebsitePreviewTour(
                 content: "Delete step",
                 run: "click",
             },
-            checkGradient: "linear-gradient(135deg, rgb(203, 94, 238) 0%, rgb(75, 225, 236) 100%)",
+            checkGradient: "linear-gradient(135deg, #cb5eee 0%, #4be1ec 100%)",
         }),
         // Linear
         ...updateAndCheckCustomGradient({
@@ -336,7 +335,7 @@ registerWebsitePreviewTour(
                 content: "Change angle",
                 run: "edit 50 && click .o_color_picker_inputs",
             },
-            checkGradient: "linear-gradient(50deg, rgb(203, 94, 238) 0%, rgb(75, 225, 236) 100%)",
+            checkGradient: "linear-gradient(50deg, #cb5eee 0%, #4be1ec 100%)",
         }),
         // Radial
         ...updateAndCheckCustomGradient({
@@ -346,7 +345,7 @@ registerWebsitePreviewTour(
                 run: "click",
             },
             checkGradient:
-                "radial-gradient(circle closest-side at 25% 25%, rgb(203, 94, 238) 0%, rgb(75, 225, 236) 100%)",
+                "radial-gradient(circle closest-side at 25% 25%, #cb5eee 0%, #4be1ec 100%)",
         }),
         ...updateAndCheckCustomGradient({
             updateStep: {
@@ -355,7 +354,7 @@ registerWebsitePreviewTour(
                 run: "edit 33 && click .o_color_picker_inputs",
             },
             checkGradient:
-                "radial-gradient(circle closest-side at 33% 25%, rgb(203, 94, 238) 0%, rgb(75, 225, 236) 100%)",
+                "radial-gradient(circle closest-side at 33% 25%, #cb5eee 0%, #4be1ec 100%)",
         }),
         ...updateAndCheckCustomGradient({
             updateStep: {
@@ -364,7 +363,7 @@ registerWebsitePreviewTour(
                 run: "edit 75 && click .o_color_picker_inputs",
             },
             checkGradient:
-                "radial-gradient(circle closest-side at 33% 75%, rgb(203, 94, 238) 0%, rgb(75, 225, 236) 100%)",
+                "radial-gradient(circle closest-side at 33% 75%, #cb5eee 0%, #4be1ec 100%)",
         }),
         ...updateAndCheckCustomGradient({
             updateStep: {
@@ -373,7 +372,7 @@ registerWebsitePreviewTour(
                 run: "click",
             },
             checkGradient:
-                "radial-gradient(circle farthest-side at 33% 75%, rgb(203, 94, 238) 0%, rgb(75, 225, 236) 100%)",
+                "radial-gradient(circle farthest-side at 33% 75%, #cb5eee 0%, #4be1ec 100%)",
         }),
         // Revert to predefined gradient
         {


### PR DESCRIPTION
The gradient color picker was previewing changes all the time, causing reloads every time we changed the gradient color in the theme tab, header, or footer. Since the Theme tab requires reloading some CSS assets, changes made for the theme inside the color picker should only be applied when we exit the color picker, not for each operation inside it.

Steps to see the issue:
- Open the website builder
- Open the Theme tab
- Unfold on Color Presets
- Unfold one preset
- Open the Background Color picker
- Click on the Gradient tab 
- Click on "Custom" => The editor reloads
- Try adjusting the "Angle" knob => The editor will reload a bunch of times
- Make changes in the color HEX value => The editor reloads

Commit [f905ba132f] already made some changes towards that direction, but not all sliders and inputs were affected.

[f905ba132f]: https://github.com/odoo/odoo/commit/f905ba132f

task-5407617
