### PR TITLE
[FIX] mail: proper `group_public_id` for public channel

### DIFF
--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -27,7 +27,9 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
 
     def test_attachment_delete_linked_to_public_channel(self):
         """Test access to delete an attachment associated with a public channel"""
-        channel = self.env["discuss.channel"].create({"name": "public channel"})
+        channel = self.env["discuss.channel"].create(
+            {"group_public_id": None, "name": "public channel"}
+        )
         self._execute_subtests_delete(
             product(
                 (self.guest, self.user_portal, self.user_public),


### PR DESCRIPTION
Since #206619, the fixed test has used a wrong value for `group_public_id`, as if it's not set, the default is `Internal User`. This change sets it to `None` to make the channel public.

