### PR TITLE
[FIX] web: fix non-deterministic test for embedded actions

### DIFF
--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -555,6 +555,7 @@ test("an action containing embedded actions should reload if the page is refresh
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
     await contains(".o_embedded_actions .dropdown").click();
     await contains(".o_save_current_view ").click();
+    await animationFrame();
     await contains(".o_save_favorite ").click();
     expect(".o_embedded_actions > button").toHaveCount(3, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",


### PR DESCRIPTION
In this commit, we add a missing await for an animation frame in an embedded action test. This ensures that the test waits for the DOM to update properly before proceeding, preventing potential flakiness in the test execution.

runbot error~237752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
