### PR TITLE
[IMP] base: improve load return value

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1012,7 +1012,7 @@ class BaseModel(metaclass=MetaModel):
                 except psycopg2.Warning as e:
                     savepoint.rollback()
                     info = rec_data['info']
-                    messages.append(dict(info, type='warning', message=str(e)))
+                    messages.append(dict(info, type='error', message=str(e)))
                 except psycopg2.Error as e:
                     savepoint.rollback()
                     info = rec_data['info']
@@ -1080,6 +1080,8 @@ class BaseModel(metaclass=MetaModel):
             ids = False
             # cancel all changes done to the registry/ormcache
             self.pool.reset_changes()
+        else:
+            assert len(ids) == len(data)
         savepoint.close(rollback=False)
 
         nextrow = info['rows']['to'] + 1


### PR DESCRIPTION
Mark error for psycopg2.Warning when ``load``
So that we can promise ``not ids or len(ids) == len(data)``


One motivation for the PR is to allow POC like https://github.com/odoo/odoo/pull/224997
to handle `translations` after `load`
if we can promise `not ids or len(ids) == len(data)``
we will have `not ids or len(ids) == len(data) == len(translations)``
and can use `for loaded_record, translation in zip(model.browse(ret['ids'], translations, strict=True)` after `load`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
