### PR TITLE
[FIX] html_editor: correct table insert position

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1,7 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isBlock } from "@html_editor/utils/blocks";
-import { fillShrunkPhrasingParent, removeClass, splitTextNode } from "@html_editor/utils/dom";
+import { fillShrunkPhrasingParent, removeClass } from "@html_editor/utils/dom";
 import {
     getDeepestPosition,
     isProtected,
@@ -10,7 +10,7 @@ import {
 } from "@html_editor/utils/dom_info";
 import { ancestors, closestElement, descendants, lastLeaf } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
-import { DIRECTIONS, leftPos, rightPos, nodeSize } from "@html_editor/utils/position";
+import { leftPos, rightPos, nodeSize } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { findInSelection } from "@html_editor/utils/selection";
 import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
@@ -164,22 +164,6 @@ export class TablePlugin extends Plugin {
 
     _insertTable({ rows = 2, cols = 2 } = {}) {
         const newTable = this.createTable({ rows, cols });
-        let sel = this.dependencies.selection.getEditableSelection();
-        if (!sel.isCollapsed) {
-            this.dependencies.delete.deleteSelection();
-        }
-        while (!isBlock(sel.anchorNode)) {
-            const anchorNode = sel.anchorNode;
-            const isTextNode = anchorNode.nodeType === Node.TEXT_NODE;
-            const newAnchorNode = isTextNode
-                ? splitTextNode(anchorNode, sel.anchorOffset, DIRECTIONS.LEFT) + 1 && anchorNode
-                : this.dependencies.split.splitElement(anchorNode, sel.anchorOffset).shift();
-            const newPosition = rightPos(newAnchorNode);
-            sel = this.dependencies.selection.setSelection(
-                { anchorNode: newPosition[0], anchorOffset: newPosition[1] },
-                { normalize: false }
-            );
-        }
         const [table] = this.dependencies.dom.insert(newTable);
         return table;
     }

--- a/addons/html_editor/static/tests/table/misc.test.js
+++ b/addons/html_editor/static/tests/table/misc.test.js
@@ -1,20 +1,82 @@
-import { expect, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor } from "../_helpers/editor";
 import { click, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
-import { setSelection } from "../_helpers/selection";
+import { getContent, setSelection } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
 import { expectElementCount } from "../_helpers/ui_expectations";
+import { unformat } from "../_helpers/format";
 
 function insertTable(editor, cols, rows) {
     execCommand(editor, "insertTable", { cols, rows });
 }
 
-test("can insert a table", async () => {
-    const { el, editor } = await setupEditor("<p>hello[]</p>", {});
-    insertTable(editor, 4, 3);
-    expect(el.querySelectorAll("tr").length).toBe(3);
-    expect(el.querySelectorAll("td").length).toBe(12);
+describe("insertTable", () => {
+    test("creates correct rows and columns", async () => {
+        const { el, editor } = await setupEditor("<p>hello[]</p>", {});
+        insertTable(editor, 4, 3);
+        expect(el.querySelectorAll("tr")).toHaveLength(3);
+        expect(el.querySelectorAll("td")).toHaveLength(12);
+    });
+
+    test("inserts table at the start", async () => {
+        const { el, editor } = await setupEditor("<p>[]hello</p>", {});
+        insertTable(editor, 1, 1);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>hello</p>
+            `)
+        );
+    });
+
+    test("inserts table in the middle", async () => {
+        const { el, editor } = await setupEditor("<p>he[]llo</p>", {});
+        insertTable(editor, 1, 1);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p>he</p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p>llo</p>
+            `)
+        );
+    });
+
+    test("inserts table at the end", async () => {
+        const { el, editor } = await setupEditor("<p>hello[]</p>", {});
+        insertTable(editor, 1, 1);
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p>hello</p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td>
+                                <p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p><br></p>
+            `)
+        );
+    });
 });
 
 test("can color cells", async () => {


### PR DESCRIPTION
### Steps to Reproduce : 

- Open To-Do and type some text.
- Place the cursor at the start of the block.
- Insert a table. (e.g.: /table)
- The table appears after the text instead of before it.

### Purpose of this PR:

- Table insertion logic was previously duplicated inside TablePlugin, where it tried to manually split text and inline nodes before inserting the table. However, this responsibility is now correctly handled by `DomPlugin.insert()`, which already:
  - deletes the current selection if needed.
  - splits text and inline nodes safely.
  - handles block boundaries and unsplittable elements.
  - normalizes the DOM after insertion.
  - places the cursor at a valid position.

task-5480759

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
