### PR TITLE
[IMP] iot_drivers: remove unique id on action failure

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -114,13 +114,16 @@ class PrinterDriver(PrinterDriverBase):
         self.send_status('disconnected', 'Printer was disconnected')
         super().disconnect()
 
-    def print_raw(self, data):
+    def print_raw(self, data, action_unique_id=None):
         """Print raw data to the printer
 
         :param data: The data to print
+        :param action_unique_id: The unique identifier of the action triggering the print
         """
-        if not self.check_printer_status():
-            return
+        if not self.check_printer_status(action_unique_id):
+            _logger.warning("Printer %s is not ready, aborting raw print", self.device_name)
+            # raise error caught in driver.py -> don't register action_unique_id
+            raise Exception("Printer not ready")
 
         try:
             with cups_lock:
@@ -129,9 +132,12 @@ class PrinterDriver(PrinterDriverBase):
                 conn.writeRequestData(data, len(data))
                 conn.finishDocument(self.device_identifier)
             self.job_ids.append(job_id)
+            if action_unique_id:
+                self.job_action_ids[job_id] = action_unique_id
         except IPPError:
             _logger.exception("Printing failed")
             self.send_status(status='error', message='ERROR_FAILED')
+            raise  # ensure error caught in driver.py -> don't register action_unique_id
 
     @classmethod
     def format_star(cls, im):
@@ -256,13 +262,15 @@ class PrinterDriver(PrinterDriverBase):
 
     def _action_default(self, data):
         _logger.debug("_action_default called for printer %s", self.device_name)
-        self.print_raw(b64decode(data['document']))
+        self.print_raw(b64decode(data['document']), action_unique_id=data.get('action_unique_id'))
         return {'print_id': data['print_id']} if 'print_id' in data else {}
 
     def _cancel_job_with_error(self, job_id, error_message):
         self.job_ids.remove(job_id)
         conn.cancelJob(job_id)
-        self.send_status(status='error', message=error_message)
+        self.send_status(
+            status='error', message=error_message, action_unique_id=self.job_action_ids.pop(job_id, None)
+        )
 
     def _check_job_status(self, job_id):
         try:
@@ -272,6 +280,7 @@ class PrinterDriver(PrinterDriverBase):
                 job_state = job['job-state']
                 if job_state == IPP_JOB_COMPLETED:
                     self.job_ids.remove(job_id)
+                    self.job_action_ids.pop(job_id, None)
                     self.send_status(status='success')
                 # Generic timeout, e.g. USB printer has been unplugged
                 elif job['time-at-creation'] + self.job_timeout_seconds < time.time():
@@ -285,6 +294,7 @@ class PrinterDriver(PrinterDriverBase):
         except IPPError:
             _logger.exception('IPP error occurred while fetching CUPS jobs')
             self.job_ids.remove(job_id)
+            self._recent_action_ids.pop(self.job_action_ids.pop(job_id, None), None)
 
 
 class PrinterController(http.Controller):
@@ -293,8 +303,11 @@ class PrinterController(http.Controller):
     def default_printer_action(self, data):
         printer = next((d for d in iot_devices if iot_devices[d].device_type == 'printer' and iot_devices[d].device_connection == 'direct'), None)
         if printer:
-            iot_devices[printer].action(data)
-            return True
+            try:
+                iot_devices[printer].action(data)
+                return True
+            except Exception:  # noqa: BLE001
+                return False
         return False
 
 

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -63,10 +63,10 @@ class PrinterDriver(PrinterDriverBase):
         self.send_status('disconnected', 'Printer was disconnected')
         super().disconnect()
 
-    def print_raw(self, data):
-        if not self.check_printer_status():
+    def print_raw(self, data, action_unique_id=None):
+        if not self.check_printer_status(action_unique_id):
             _logger.warning("Printer %s is not ready, aborting raw print", self.device_name)
-            return
+            raise Exception("Printer not ready")
         job_id = False
         page_started = False
         try:
@@ -77,6 +77,9 @@ class PrinterDriver(PrinterDriverBase):
                 win32print.WritePrinter(self.printer_handle, data)
                 win32print.EndPagePrinter(self.printer_handle)
                 win32print.EndDocPrinter(self.printer_handle)
+                self.job_ids.append(job_id)
+                if action_unique_id:
+                    self.job_action_ids[job_id] = action_unique_id
         except pywintypes.error as error:
             _logger.error("Error while printing raw data to printer %s: %s", self.device_name, error)
             if job_id or page_started:
@@ -86,8 +89,13 @@ class PrinterDriver(PrinterDriverBase):
                             win32print.EndPagePrinter(self.printer_handle)
                         if job_id:
                             win32print.EndDocPrinter(self.printer_handle)
+                            self.job_ids.append(job_id)
+                            if action_unique_id:
+                                self.job_action_ids[job_id] = action_unique_id
                 except pywintypes.error as err:
                     _logger.error("Error while finalizing print job to printer %s after failure: %s", self.device_name, err)
+                    self.send_status(status='error', message='ERROR_FAILED')
+                    raise
 
     def print_report(self, data):
         with win32print_lock:
@@ -123,10 +131,11 @@ class PrinterDriver(PrinterDriverBase):
 
         document = b64decode(data['document'])
         mimetype = guess_mimetype(document)
+        action_unique_id = data.get('action_unique_id')
         if mimetype == 'application/pdf':
             self.print_report(document)
         else:
-            self.print_raw(document)
+            self.print_raw(document, action_unique_id=action_unique_id)
         _logger.debug("_action_default finished with mimetype %s for printer %s", mimetype, self.device_name)
         return {'print_id': data['print_id']} if 'print_id' in data else {}
 
@@ -146,7 +155,9 @@ class PrinterDriver(PrinterDriverBase):
     def _cancel_job_with_error(self, job_id, error_message):
         self.job_ids.remove(job_id)
         win32print.SetJob(self.printer_handle, job_id, 0, None, win32print.JOB_CONTROL_DELETE)
-        self.send_status(status='error', message=error_message)
+        self.send_status(
+            status='error', message=error_message, action_unique_id=self.job_action_ids.pop(job_id, None)
+        )
 
     def _check_job_status(self, job_id):
         try:
@@ -155,6 +166,7 @@ class PrinterDriver(PrinterDriverBase):
             _logger.debug('job details for job id #%d: %s', job_id, job)
             if job['Status'] & win32print.JOB_STATUS_PRINTED:
                 self.job_ids.remove(job_id)
+                self.job_action_ids.pop(job_id, None)
                 self.send_status(status='success')
             # Print timeout, e.g. network printer is disconnected
             if elapsed_time.seconds > self.job_timeout_seconds:
@@ -171,6 +183,7 @@ class PrinterDriver(PrinterDriverBase):
             else:
                 _logger.exception('Win32 error occurred while querying print job')
             self.job_ids.remove(job_id)
+            self._recent_action_ids.pop(self.job_action_ids.pop(job_id, None), None)
 
 
 proxy_drivers['printer'] = PrinterDriver

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -60,6 +60,7 @@ class PrinterDriverBase(Driver, ABC):
 
         self.device_type = 'printer'
         self.job_ids = []
+        self.job_action_ids = {}
         self.escpos_device = None
 
         self._actions.update({
@@ -78,12 +79,15 @@ class PrinterDriverBase(Driver, ABC):
         ) else 'disconnected'
         return {'status': status, 'messages': ''}
 
-    def send_status(self, status, message=None):
+    def send_status(self, status, message=None, action_unique_id=None):
         """Sends a status update event for the printer.
 
         :param str status: The value of the status
         :param str message: A comprehensive message describing the status
+        :param str action_unique_id: The unique identifier of the action
         """
+        if status == "error":
+            self._recent_action_ids.pop(action_unique_id, None)  # avoid filtering duplicates on errors
         self.data['status'] = status
         self.data['message'] = message
         event_manager.device_changed(self, {'session_id': self.data.get('owner')})
@@ -100,7 +104,7 @@ class PrinterDriverBase(Driver, ABC):
         im = im.convert("1")
 
         print_command = getattr(self, 'format_%s' % self.receipt_protocol)(im)
-        self.print_raw(print_command)
+        self.print_raw(print_command, action_unique_id=data.get("action_unique_id"))
 
     @classmethod
     def format_escpos_bit_image_raster(cls, im):
@@ -221,20 +225,20 @@ class PrinterDriverBase(Driver, ABC):
 
         commands = self.RECEIPT_PRINTER_COMMANDS[self.receipt_protocol]
         for drawer in commands['drawers']:
-            self.print_raw(drawer)
+            self.print_raw(drawer, action_unique_id=data.get("action_unique_id"))
 
-    def check_printer_status(self):
+    def check_printer_status(self, action_unique_id=None):
         if not self.escpos_device:
             return True
         try:
             with EscposIO(self.escpos_device, autocut=False) as esc:
                 esc.printer.open()
                 if not esc.printer.is_online():
-                    self.send_status(status='error', message='ERROR_OFFLINE')
+                    self.send_status(status='error', message='ERROR_OFFLINE', action_unique_id=action_unique_id)
                     return False
                 paper_status = esc.printer.paper_status()
                 if paper_status == 0:
-                    self.send_status(status='error', message='ERROR_NO_PAPER')
+                    self.send_status(status='error', message='ERROR_NO_PAPER', action_unique_id=action_unique_id)
                     return False
                 elif paper_status == 1:
                     self.send_status(status='warning', message='WARNING_LOW_PAPER')
@@ -254,10 +258,11 @@ class PrinterDriverBase(Driver, ABC):
             time.sleep(1)
 
     @abstractmethod
-    def print_raw(self, data):
+    def print_raw(self, data, action_unique_id=None):
         """Sends the raw data to the printer.
 
         :param data: The data to send to the printer
+        :param str action_unique_id: The unique identifier of the action
         """
         pass
 


### PR DESCRIPTION
We currently reject an action if it has the same id of a previous one.

If the action failed, we still registered it, making it impossible to be executed again.

We now only register if the action succeeds.
