### PR TITLE
[FIX] hr: fix various issues once employee is archived

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -484,11 +484,19 @@ class HrEmployee(models.Model):
         return versions
 
     def _get_first_version_date(self, no_gap=True):
-        versions = self._get_first_versions_filtered(no_gap=no_gap)
+        if 'active_test' not in self.env.context:
+            self_ctx = self.with_context(active_test=self.active)
+        else:
+            self_ctx = self
+        versions = self_ctx._get_first_versions_filtered(no_gap=no_gap)
         return min(versions.mapped('date_start')) if versions else False
 
     def _get_first_contract_date(self, no_gap=True):
-        versions = self._get_first_versions_filtered(no_gap=no_gap).filtered(lambda x: x.contract_date_start)
+        if 'active_test' not in self.env.context:
+            self_ctx = self.with_context(active_test=self.active)
+        else:
+            self_ctx = self
+        versions = self_ctx._get_first_versions_filtered(no_gap=no_gap).filtered(lambda x: x.contract_date_start)
         return min(versions.mapped('contract_date_start')) if versions else False
 
     @api.depends('name')

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1476,6 +1476,7 @@ We can redirect you to the public employee list."""
             'departure_description': False,
             'departure_date': False
         })
+        self.version_id.action_unarchive()
         return res
 
     def action_archive(self):
@@ -1506,6 +1507,7 @@ We can redirect you to the public employee list."""
                     'context': {'active_id': self.id},
                     'views': [[False, 'form']]
                 }
+        self.version_ids.action_archive()
         return res
 
     @api.onchange('company_id')

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1473,7 +1473,10 @@ We can redirect you to the public employee list."""
 
     def unlink(self):
         resources = self.mapped('resource_id')
+        # TODO: [XBO] (in master) would be better to define ondelete='cascade' on employee_id field in `hr.version`
+        versions = self.with_context(active_test=False).version_ids
         super().unlink()
+        versions.unlink()
         return resources.unlink()
 
     def _get_employee_m2o_to_empty_on_archived_employees(self):

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -520,10 +520,10 @@ class HrEmployee(models.Model):
         for employee in self:
             employee.work_location_type = employee.version_id.work_location_id.location_type or 'other'
 
-    @api.depends('version_ids.date_version', 'version_ids.active', 'active')
+    @api.depends('version_ids.date_version', 'version_ids.active')
     def _compute_current_version_id(self):
         for employee in self:
-            version = self.env['hr.version'].search(
+            version = self.env['hr.version'].with_context(active_test=employee.active).search(
                 [('employee_id', 'in', employee.ids), ('date_version', '<=', fields.Date.today())],
                 order='date_version desc',
                 limit=1,
@@ -531,8 +531,8 @@ class HrEmployee(models.Model):
             new_current_version = False
             if version:
                 new_current_version = version
-            elif employee.version_ids:
-                new_current_version = employee.version_ids[0]
+            elif employee.with_context(active_test=employee.active).version_ids:
+                new_current_version = employee.with_context(active_test=employee.active).version_ids[0]
             # To not trigger computed properties if still the same version
             if employee.current_version_id != new_current_version:
                 employee.current_version_id = new_current_version

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -768,6 +768,19 @@ class HrEmployee(models.Model):
         return False, False
 
     def _compute_versions_count(self):
+        if any(not e.active for e in self):
+            version_read_group = self.env['hr.version'].with_context(active_test=False)._read_group(
+                [('employee_id', 'in', self.ids)],
+                ['employee_id', 'active'],
+                ['id:count'],
+            )
+            version_count_per_employee = defaultdict(lambda: 0)
+            for employee, active, count in version_read_group:
+                if not employee.active or active:
+                    version_count_per_employee[employee] += count
+            for employee in self:
+                employee.versions_count = version_count_per_employee.get(employee, 0)
+            return
         version_count_per_employee = dict(
             self.env['hr.version']._read_group(
                 [('employee_id', 'in', self.ids)],
@@ -1777,6 +1790,9 @@ We can redirect you to the public employee list."""
 
     def action_open_versions(self):
         self.ensure_one()
+        context = {}
+        if not self.active:
+            context['search_default_archived'] = 1
         return {
             'type': 'ir.actions.act_window',
             'name': self.employee_id.name + self.env._(' Records'),
@@ -1785,7 +1801,8 @@ We can redirect you to the public employee list."""
             'view_mode': 'list,graph,pivot',
             'views': [(self.env.ref('hr.hr_version_list_view').id, 'list'), (False, 'graph'), (False, 'pivot')],
             'domain': [('employee_id', '=', self.employee_id.id)],
-            'search_view_id': self.env.ref('hr.hr_version_search_view').id
+            'search_view_id': self.env.ref('hr.hr_version_search_view').id,
+            'context': context,
         }
 
     def _get_store_avatar_card_fields(self, target):

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -282,19 +282,19 @@ class HrVersion(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_last_version(self):
-        for employee_id, versions in self.grouped('employee_id').items():
-            if employee_id.version_ids == versions:
+        for employee, versions in self.grouped('employee_id').items():
+            if employee.active and employee.version_ids == versions:
                 raise ValidationError(
-                    self.env._('Employee %s must always have at least one active version.') % employee_id.name
+                    self.env._('Employee %s must always have at least one active version.', employee.name),
                 )
 
     def write(self, vals):
         # Employee Versions Validation
         if 'employee_id' in vals:
-            if self.filtered(lambda v: v.employee_id and v.employee_id.version_ids <= self and vals['employee_id'] != v.employee_id.id):
+            if self.filtered(lambda v: v.employee_id.active and v.employee_id.version_ids <= self and vals['employee_id'] != v.employee_id.id):
                 raise ValidationError(self.env._("Cannot unassign all the active versions of an employee."))
         if 'active' in vals and not vals['active']:
-            if self.filtered(lambda v: v.employee_id and v.employee_id.version_ids <= self):
+            if self.filtered(lambda v: v.employee_id.active and v.employee_id.version_ids <= self):
                 raise ValidationError(self.env._("Cannot archive all the active versions of an employee."))
 
         if self.env.context.get('sync_contract_dates') or ("contract_date_start" not in vals and "contract_date_end" not in vals):

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -305,8 +305,14 @@ class HrVersion(models.Model):
                 raise ValidationError(self.env._("Cannot modify multiple versions contract dates with different contracts at once."))
 
         multiple_versions = self
+
+        def get_active_test(employee):
+            return employee.env.context.get('active_test', employee.active)
+
         if vals.get("contract_date_start"):
-            unique_versions = multiple_versions.filtered(lambda v: len(v.employee_id.version_ids) == 1)
+            unique_versions = multiple_versions.filtered(
+                lambda v: len(v.employee_id.with_context(active_test=get_active_test(v.employee_id)).version_ids) == 1
+            )
             multiple_versions -= unique_versions
             if len(unique_versions):
                 unique_versions.with_context(sync_contract_dates=True).write({
@@ -337,7 +343,7 @@ class HrVersion(models.Model):
                 dates_vals["contract_date_end"] = first_version.contract_date_end
 
             if first_version.contract_date_start:
-                versions_to_sync = employee._get_contract_versions(
+                versions_to_sync = employee.with_context(active_test=get_active_test(employee))._get_contract_versions(
                     date_start=first_version.contract_date_start,
                     date_end=first_version.contract_date_end,
                 )

--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.js
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.js
@@ -27,6 +27,10 @@ export class VersionsTimeline extends StatusBarField {
         });
     }
 
+    get showAddButton() {
+        return !('active' in this.props.record.fields) || this.props.record.data.active;
+    }
+
     /** @override **/
     getDomain() {
         const { record } = this.props;

--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.js
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.js
@@ -29,9 +29,15 @@ export class VersionsTimeline extends StatusBarField {
 
     /** @override **/
     getDomain() {
-        return Domain.and([super.getDomain(),
-            [["employee_id", "=", this.props.record.evalContext.id]]]
-        ).toList()
+        const { record } = this.props;
+        const additionalDomains = [[["employee_id", "=", record.evalContext.id]]];
+        if ('active' in record.fields && !record.data.active) {
+            additionalDomains.push([['active', '=', false]]);
+        }
+        return Domain.and([
+            super.getDomain(),
+            ...additionalDomains,
+        ]).toList();
     }
 
     /** @override **/

--- a/addons/hr/static/src/components/versions_timeline/versions_timeline.xml
+++ b/addons/hr/static/src/components/versions_timeline/versions_timeline.xml
@@ -5,6 +5,7 @@
         <div t-ref="root" position="after">
             <div class="o_arrow_button_wrapper">
                 <button
+                    t-if="showAddButton"
                     t-ref="datetime-picker-target-version"
                     title="New Employee Record"
                     t-on-click="onClickDateTimePickerBtn"

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -720,6 +720,26 @@ class TestHrEmployee(TestHrCommon):
         self.assertNotEqual(partner.email, second_employee.work_email)
         self.assertNotEqual(partner.email, first_employee.work_email)
 
+    def test_unlink_employee_also_unlink_related_versions(self):
+        self.employee.create_version({
+            'date_version': fields.Date.today() - relativedelta(days=10),
+        })
+        self.employee_without_image.create_version({
+            'date_version': fields.Date.today() - relativedelta(days=5),
+        })
+        self.employee_without_image.create_version({
+            'date_version': fields.Date.today() - relativedelta(days=1),
+            'active': False,
+        })
+        self.assertEqual(len(self.employee.version_ids), 2)
+        self.assertEqual(len(self.employee_without_image.version_ids), 2)
+        (self.employee + self.employee_without_image).invalidate_recordset(['version_ids'])
+        self.assertEqual(len(self.employee.with_context(active_test=False).version_ids), 2)
+        self.assertEqual(len(self.employee_without_image.with_context(active_test=False).version_ids), 3)
+
+        employee_versions = self.employee.with_context(active_test=False).version_ids + self.employee_without_image.with_context(active_test=False).version_ids
+        (self.employee + self.employee_without_image).unlink()
+        self.assertFalse(employee_versions.exists())
 
 @tagged('-at_install', 'post_install')
 class TestHrEmployeeLinks(HttpCase):

--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -159,9 +159,9 @@ class HrEmployee(models.Model):
         if not self.env['hr.employee.public'].browse(res_id).has_access('read'):
             raise AccessError(self.env._("You cannot access the resume of this employee."))
         res = []
-        employee_versions = self.env['hr.employee'].sudo().browse(res_id).version_ids
-        if not employee_versions:
-            return res
+        employee_sudo = self.env['hr.employee'].sudo().browse(res_id)
+        # Fallback on current version if the employee is archived and all his versions are archived.
+        employee_versions = employee_sudo.version_ids or employee_sudo.current_version_id
         interval_date_start = False
         for i in range(len(employee_versions) - 1):
             current_version = employee_versions[i]

--- a/addons/pos_hr/tests/test_res_config_settings.py
+++ b/addons/pos_hr/tests/test_res_config_settings.py
@@ -26,7 +26,7 @@ class TestConfigureShopsPoSHR(TestPosHrHttpCommon, TestConfigureShops):
            the current company. And if none exists it create one for the user."""
 
         # First test that an employee is created if none exists
-        self.env['hr.employee'].search([]).unlink()
+        self.env['hr.employee'].search([]).sudo().unlink()
         self.main_pos_config.with_context(from_settings_view=True).write({
             'basic_employee_ids': [],
         })


### PR DESCRIPTION
## [FIX] hr: make sure the current version is archived when employee archived

Before this commit, when the employee is archived, this employee still
has a version active (the current one), the issue is the work entries
will be generated because we assume the version active means the
contract is active even if the employee is archived.

This commit makes sure we no longer need a version active when the
employee is active and it also archive/unarchive the current version
when the employee is archived/unarchived.

## [FIX] hr: don't reset current version when employee archived

Before this commit, when the employee is archived, the current version
is reset to find an active version, the problem is the compute will find
no active versions for that archived employee.

This commit makes sure the current_version_id is not reset once an
employee is archived.

## [FIX] hr_skills: make sure we take current version when employee is archived

## [FIX] hr: display archived in version in timeline when employee archived

Before this commit, once the employee is archived, the user cannot see
all versions for that employee since they are no longer active.

This commit makes sure the version timeline shows all versions from that
employee when that employee is archived.

## [FIX] hr: hide add button in version timeline when employee is archived

Before this commit, the user can go to history of an employee to add new
versions. However, if the employee is archived because that employee no
longer works for the company then it does not make sense to allow to
create new version for that employee.

This commit makes sure the user cannot add a new version for an archived
employee.

task-5349397
