### PR TITLE
[FIX] point_of_sale: Ensure company_id is set on pos.order creation

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -70,7 +70,8 @@ class PosOrder(models.Model):
         draft = True if order.get('state') == 'draft' else False
         pos_session = self.env['pos.session'].browse(order['session_id'])
         if pos_session.state == 'closing_control' or pos_session.state == 'closed':
-            order['session_id'] = self._get_valid_session(order).id
+            pos_session = self._get_valid_session(order)
+            order['session_id'] = pos_session.id
 
         if not order.get('source'):
             order['source'] = 'pos'
@@ -82,6 +83,9 @@ class PosOrder(models.Model):
                     "partner_id": False,
                     "to_invoice": False,
                 })
+
+        if not order.get('company_id'):
+            order['company_id'] = pos_session.config_id.company_id.id
 
         pos_order = False
         record_uuid_mapping = order.pop('relations_uuid_mapping', {})


### PR DESCRIPTION
When creating an order, if due to some reason the company_id is not set on the order data, we set it to the company of the POS session's config.

opw-5470175

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
