### PR TITLE
[FIX] portal_rating, *: display rating card if it's requested

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/portal_chatter_patch.xml
+++ b/addons/portal_rating/static/src/chatter/frontend/portal_chatter_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="portal.Chatter" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Chatter-top')]/*[1]" position="before">
-            <div t-if="ratingStats and ratingStats.total" class="my-2" t-att-class="{ 'mb-4':props.twoColumns }">
+            <div t-if="env.displayRating and ratingStats and ratingStats.total" class="my-2" t-att-class="{ 'mb-4':props.twoColumns }">
                 <t t-call="portal_rating.rating_card">
                     <t t-set="two_columns" t-value="props.twoColumns"/>
                     <t t-set="rating_stats" t-value="ratingStats"/>

--- a/addons/test_mail_full/controllers/portal.py
+++ b/addons/test_mail_full/controllers/portal.py
@@ -24,7 +24,7 @@ class PortalTest(http.Controller):
     def test_portal_rating_record_page(self, res_id, **kwargs):
         record = request.env["mail.test.rating"]._get_thread_with_access(res_id, **kwargs)
         values = {
-            "display_rating": True,
+            "display_rating": kwargs.get("display_rating"),
             "hash": kwargs.get("hash"),
             "object": record,
             "pid": kwargs.get("pid"),

--- a/addons/test_mail_full/static/tests/tours/portal_rating_tour.js.js
+++ b/addons/test_mail_full/static/tests/tours/portal_rating_tour.js.js
@@ -1,9 +1,15 @@
 import { registry } from "@web/core/registry";
 
+const ratingCardSelector = ".o_website_rating_card_container";
+
 registry.category("web_tour.tours").add("portal_rating_tour", {
     steps: () => [
         {
-            trigger: "#chatterRoot:shadow :not(:has(.o_website_rating_card_container))",
+            // Ensure that the rating data has been fetched before making a negative assertion for rating cards.
+            trigger: "#chatterRoot:shadow .o-mail-Message-body:text(Message without rating)",
+        },
+        {
+            trigger: `#chatterRoot:shadow .o-mail-Chatter-top:not(:has(${ratingCardSelector}))`,
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Composer-input",
@@ -14,11 +20,27 @@ registry.category("web_tour.tours").add("portal_rating_tour", {
             run: "click",
         },
         {
-            trigger: "#chatterRoot:shadow .o_website_rating_card_container",
+            trigger: `#chatterRoot:shadow .o-mail-Chatter-top ${ratingCardSelector} .o_website_rating_table_row[data-star='4']:has(:text(100%))`,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("portal_display_rating_tour", {
+    steps: () => [
+        {
+            trigger: `#chatterRoot:shadow .o-mail-Chatter-top ${ratingCardSelector}`,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("portal_not_display_rating_tour", {
+    steps: () => [
+        {
+            // Ensure that the rating data has been fetched before making a negative assertion for rating cards.
+            trigger: "#chatterRoot:shadow .o-mail-Message-body:text(Message with rating)",
         },
         {
-            trigger: "#chatterRoot:shadow .o_website_rating_table_row[data-star='4']:contains(100%)",
+            trigger: `#chatterRoot:shadow .o-mail-Chatter-top:not(:has(${ratingCardSelector}))`,
         },
-        
     ],
 });

--- a/addons/test_mail_full/tests/test_ui.py
+++ b/addons/test_mail_full/tests/test_ui.py
@@ -46,7 +46,30 @@ class TestUIPortal(TestPortal):
 
     def test_rating_record_portal(self):
         record_rating = self.env["mail.test.rating"].create({"name": "Test rating record"})
+        # To check if there is no message with rating, there is no rating cards feature.
+        record_rating.message_post(
+            body="Message without rating",
+            message_type="comment",
+            subtype_xmlid="mail.mt_comment",
+        )
         self.start_tour(
-            f"/my/test_portal_rating_records/{record_rating.id}?token={record_rating._portal_ensure_token()}",
-            "portal_rating_tour",
+            f"/my/test_portal_rating_records/{record_rating.id}?display_rating=True&token={record_rating._portal_ensure_token()}",
+            "portal_rating_tour"
+        )
+
+    def test_display_rating_portal(self):
+        record_rating = self.env["mail.test.rating"].create({"name": "Test rating record"})
+        record_rating.message_post(
+            body="Message with rating",
+            message_type="comment",
+            rating_value="5",
+            subtype_xmlid="mail.mt_comment",
+        )
+        self.start_tour(
+            f"/my/test_portal_rating_records/{record_rating.id}?display_rating=True&token={record_rating._portal_ensure_token()}",
+            "portal_display_rating_tour",
+        )
+        self.start_tour(
+            f"/my/test_portal_rating_records/{record_rating.id}?display_rating=False&token={record_rating._portal_ensure_token()}",
+            "portal_not_display_rating_tour",
         )


### PR DESCRIPTION
*: test_mail_full

Modules using portal rating can set an `data-display_rating` attribute when calling the portal chatter template to indicate whether they want the rating feature displayed. Currently, only two modules have this attribute set to true: ecommerce and elearning. For other modules that don't set this attribute, even if there is a rating, such as when rating a ticket in the helpdesk module, we don't want the rating card feature to be shown in portal chatter. This change ensures that the feature is only available if the module requests it.

task-5347848
