### PR TITLE
[FIX] website: prevent race condition when opening the editor

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -269,7 +269,7 @@ export class WebsiteBuilderClientAction extends Component {
     }
 
     async onEditPage() {
-        if (!this.websiteContext) {
+        if (!this.websiteContent.el) {
             await this.iframeLoaded;
         }
         this.websiteContext.showResourceEditor = false;


### PR DESCRIPTION
Steps to reproduce:
1. Set network speed to 3G
2. Create website Page from the systry new menu
3. click on edit button You'll face the traceback.

The website editor could try to open before the iframe finished loading, leading to non-deterministic behavior. This commit ensures the editor initializes only after the iframe load event, making the edit action consistent and reliable.

Erlier fixed was not covering the all the cases. PR: https://github.com/odoo/odoo/pull/238054

runbot-233039
