### PR TITLE
[FIX] account_edi: Don't allow internal users to download JSON/XML

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -35,7 +35,7 @@ class AccountEdiDocument(models.Model):
     # == Not stored fields ==
     name = fields.Char(related='attachment_id.name')
     edi_format_name = fields.Char(string='Format Name', related='edi_format_id.name')
-    edi_content = fields.Binary(compute='_compute_edi_content', compute_sudo=True)
+    edi_content = fields.Binary(compute='_compute_edi_content')
 
     _unique_edi_document_by_move_by_format = models.Constraint(
         'UNIQUE(edi_format_id, move_id)',

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -160,7 +160,7 @@
                                         type="object"
                                         class="oe_link oe_inline"
                                         string="Download"
-                                        groups="base.group_no_one"
+                                        groups="account.group_account_invoice"
                                         invisible="not error or blocking_level == 'info'"/>
                             </list>
                         </field>

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -131,7 +131,7 @@ class L10nInEwaybill(models.Model):
         ("error", "Error")],
         string="Blocking Level", readonly=True)
 
-    content = fields.Binary(compute='_compute_content', compute_sudo=True)
+    content = fields.Binary(compute='_compute_content')
     cancel_reason = fields.Selection(selection=[
         ("1", "Duplicate"),
         ("2", "Data Entry Mistake"),


### PR DESCRIPTION
Steps to reproduce:
1. Create an Invoice
2. Send for EDI (should in error, easy way to do it in local turn off the internet)
3. Turn Debug mode
4. Click Download (A new window with URL with will be open) showing the JSON/XML
5. Change Marc Demo (or any user) being internal user without Invoicing rights
6. That user can access the JSON/XML with that particular URL

After this commit-
We make sure only Invoicing Users can download the JSON/Export

task-5481114


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
