### PR TITLE
[IMP] base_vat: support 8-digit VAT numbers for Ukraine

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -78,6 +78,7 @@ _ref_vat = {
     'sm': 'SM24165',
     'th': '1234545678781',
     'tr': _lt('17291716060 (NIN) or 1729171602 (VKN)'),
+    'ua': _lt('12345678 or UA12345678 (EDRPOU), 1234567890 (RNOPP) or 123456789012 (IPN)'),
     'uy': _lt("Example: '219999830019' (format: 12 digits, all numbers, valid check digit)"),
     've': 'V-12345678-1, V123456781, V-12.345.678-1',
     'xi': 'XI123456782',
@@ -562,24 +563,7 @@ class ResPartner(models.Model):
         return self.__check_vat_sa_re.match(vat) or False
 
     def check_vat_ua(self, vat):
-        res = []
-        for partner in self:
-            if partner.commercial_partner_id.country_id.code == 'MX':
-                if len(vat) == 10:
-                    res.append(True)
-                else:
-                    res.append(False)
-            elif partner.commercial_partner_id.is_company:
-                if len(vat) == 12:
-                    res.append(True)
-                else:
-                    res.append(False)
-            else:
-                if len(vat) == 10 or len(vat) == 9:
-                    res.append(True)
-                else:
-                    res.append(False)
-        return all(res)
+        return len(vat[2:] if vat.startswith('UA') else vat) in {8, 10, 12}
 
     def check_vat_uy(self, vat):
         """ Taken from python-stdnum's master branch, as the release doesn't handle RUT numbers starting with 22.


### PR DESCRIPTION
with this commit:-
 - We are adding support for Ukrainian Tax ID numbers of 8 digits, which was 12 previously.
 - The following formats are now accepted:
   - National company numbers: 8 digits (e.g., 12345678)
   - European company numbers: 8 digits prefixed with 'UA' (e.g., UA12345678)
   - Individual numbers: 12 or 10 digits (e.g., 123456789012)
 - This change allows users to enter Ukrainian TINs that were previously incorrectly rejected due to length restrictions.
 
task-5414806
opw-5373469