### PR TITLE
[FIX] base: bypass access rules when reading user's company count

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1359,9 +1359,10 @@ class UsersMultiCompany(models.Model):
             'base.group_multi_company', raise_if_not_found=False)
         if group_multi_company_id:
             for user in users:
-                if len(user.company_ids) <= 1 and group_multi_company_id in user.group_ids.ids:
+                company_count = len(user.sudo().company_ids)
+                if company_count <= 1 and group_multi_company_id in user.group_ids.ids:
                     user.write({'group_ids': [Command.unlink(group_multi_company_id)]})
-                elif len(user.company_ids) > 1 and group_multi_company_id not in user.group_ids.ids:
+                elif company_count > 1 and group_multi_company_id not in user.group_ids.ids:
                     user.write({'group_ids': [Command.link(group_multi_company_id)]})
         return users
 
@@ -1373,9 +1374,10 @@ class UsersMultiCompany(models.Model):
             'base.group_multi_company', raise_if_not_found=False)
         if group_multi_company_id:
             for user in self:
-                if len(user.company_ids) <= 1 and group_multi_company_id in user.group_ids.ids:
+                company_count = len(user.sudo().company_ids)
+                if company_count <= 1 and group_multi_company_id in user.group_ids.ids:
                     user.write({'group_ids': [Command.unlink(group_multi_company_id)]})
-                elif len(user.company_ids) > 1 and group_multi_company_id not in user.group_ids.ids:
+                elif company_count > 1 and group_multi_company_id not in user.group_ids.ids:
                     user.write({'group_ids': [Command.link(group_multi_company_id)]})
         return res
 
@@ -1387,9 +1389,10 @@ class UsersMultiCompany(models.Model):
         group_multi_company_id = self.env['ir.model.data']._xmlid_to_res_id(
             'base.group_multi_company', raise_if_not_found=False)
         if group_multi_company_id:
-            if len(user.company_ids) <= 1 and group_multi_company_id in user.group_ids.ids:
+            company_count = len(user.sudo().company_ids)
+            if company_count <= 1 and group_multi_company_id in user.group_ids.ids:
                 user.update({'group_ids': [Command.unlink(group_multi_company_id)]})
-            elif len(user.company_ids) > 1 and group_multi_company_id not in user.group_ids.ids:
+            elif company_count > 1 and group_multi_company_id not in user.group_ids.ids:
                 user.update({'group_ids': [Command.link(group_multi_company_id)]})
         return user
 


### PR DESCRIPTION
### Impacted versions:

19.0 and later

### Steps to reproduce:
- Install at least 2 languages
- Create multiple companies
- Log in as marc demo and select only one company 
- Try to update profile picture or modify preferred lang

### Current behavior:
When a non-admin user operates in a multi-company environment
with only some companies active in their context, the `res_company_rule_employee`
record rule blocks access to `company_ids` when trying to read all assigned companies.

This causes an Access Error in the `res.users.new()` method when it attempts to
count the user's companies to manage the `base.group_multi_company` group membership,
preventing users from changing their profile picture and updating their preferred language

Task: [5458607](https://www.odoo.com/odoo/project/49/tasks/5458607)