### PR TITLE
[FIX] point_of_sale: Weigh scale shows accurate price

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -913,10 +913,19 @@ export class PosStore extends WithLazyGetterTrap {
                 const decimalAccuracy = this.models["decimal.precision"].find(
                     (dp) => dp.name === "Product Unit"
                 ).digits;
+
+                const overridedValues = {};
+                if (order.pricelist_id) {
+                    overridedValues.pricelist = order.pricelist_id;
+                }
+                if (order.fiscal_position_id) {
+                    overridedValues.fiscalPosition = order.fiscal_position_id;
+                }
+
                 this.scale.setProduct(
                     values.product_id,
                     decimalAccuracy,
-                    values.product_id.getTaxDetails().total_included
+                    values.product_id.getTaxDetails({ overridedValues }).total_included
                 );
                 const weight = await this.weighProduct();
                 if (weight) {


### PR DESCRIPTION
Before this commit, the pricelist and fiscal position where not taken into account when displaying the price on the weigh scale. This caused confusion when selling products with pricelists or fiscal positions that modified the price.

opw-5456144

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
