### PR TITLE
[FIX] website: image size test

### DIFF
--- a/addons/website/static/tests/builder/image_size.test.js
+++ b/addons/website/static/tests/builder/image_size.test.js
@@ -1,5 +1,5 @@
-import { expect, test } from "@odoo/hoot";
-import { animationFrame, clear, edit, press } from "@odoo/hoot-dom";
+import { animationFrame, expect, test } from "@odoo/hoot";
+import { clear, edit, press } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { testImg, testImgSrc, testGifImg, testGifImgSrc } from "./image_test_helpers";
@@ -101,7 +101,7 @@ test("images can be resized by slider, text input and button", async () => {
     await contains(".options-container [data-action-id='mediaSizeText'] input").click();
     await edit("50");
     await press("Enter");
-    await animationFrame();
+    await waitSidebarUpdated();
     expect(":iframe .test-options-target img").toHaveStyle(
         { width: "50% !important" },
         { inline: true }
@@ -110,7 +110,7 @@ test("images can be resized by slider, text input and button", async () => {
     await contains(":iframe .test-options-target img").click();
     await waitSidebarUpdated();
     await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
-    await animationFrame();
+    await waitSidebarUpdated();
     expect(":iframe .test-options-target img").toHaveStyle(
         { width: "auto !important" },
         { inline: true }
@@ -173,13 +173,13 @@ test("videos can be resized by slider, text input and button", async () => {
     expect(".options-container button[data-action-id='setMediaSizeAuto']").toHaveClass("active");
 
     await contains(".options-container [data-action-id='mediaSizeText'] input").click();
-    await edit("3");
+    await edit("3"); // preview
     await animationFrame();
     //min width is clipped to 5%
     expect(":iframe .media_iframe_video").toHaveStyle({ width: "5% !important" }, { inline: true });
 
     await contains(".options-container [data-action-id='mediaSizeText'] input").click();
-    await edit("110");
+    await edit("110"); // preview
     await animationFrame();
     //max width is clipped to 100%
     expect(":iframe .media_iframe_video").toHaveStyle(
@@ -192,7 +192,7 @@ test("videos can be resized by slider, text input and button", async () => {
     await contains(".options-container [data-action-id='mediaSizeText'] input").click();
     await edit("50");
     await press("Enter");
-    await animationFrame();
+    await waitSidebarUpdated();
     expect(":iframe .media_iframe_video").toHaveStyle(
         { width: "50% !important" },
         { inline: true }
@@ -201,7 +201,7 @@ test("videos can be resized by slider, text input and button", async () => {
     await contains(":iframe .media_iframe_video").click();
     await waitSidebarUpdated();
     await contains(".options-container button[data-action-id='setMediaSizeAuto']").click();
-    await animationFrame();
+    await waitSidebarUpdated();
     expect(":iframe .media_iframe_video").toHaveStyle(
         { width: "auto !important" },
         { inline: true }

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -205,7 +205,7 @@ test("Cloning an image gallery should produce a unique ID", async () => {
 });
 
 test("Changing layout of an image gallery to grid should remove size option on images", async () => {
-    await setupWebsiteBuilder(
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
         `
         <section class="s_image_gallery o_masonry" data-columns="2" data-snippet="s_images_wall">
             <div class="container">
@@ -220,7 +220,7 @@ test("Changing layout of an image gallery to grid should remove size option on i
         `
     );
     await contains(":iframe .first_img").click();
-    await waitFor("[data-label='Mode']");
+    await waitSidebarUpdated();
     expect("[data-label='Mode']").toHaveCount(1);
     expect(queryOne("[data-label='Mode'] .dropdown-toggle").textContent).toBe("Masonry");
     expect("[data-label='Size']").toHaveCount(1);
@@ -231,7 +231,9 @@ test("Changing layout of an image gallery to grid should remove size option on i
     expect(":iframe .o_grid").toHaveCount(1);
     expect(":iframe .o_masonry_col").toHaveCount(0);
     expect(queryOne("[data-label='Mode'] .dropdown-toggle").textContent).toBe("Grid");
+
     await contains(":iframe .first_img").click();
+    await waitSidebarUpdated();
     expect("[data-label='Size']").toHaveCount(0);
 });
 


### PR DESCRIPTION
The image_size tests were failing in a nondeterministic way. Image-related options can take an indeterminate amount of time to complete, so waiting for a single animation frame is not always sufficient.

Use `waitSidebarUpdated`` to ensure there are no pending actions and that the UI is fully updated before asserting.

Error-237539

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
