### PR TITLE
[FIX] point_of_sale: allow forcing payment cancellations

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -74,6 +74,9 @@
                                         <div t-if="line.payment_status == 'waiting'" class="button send_force_done" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
                                             Force done
                                         </div>
+                                        <div t-if="line.payment_status == 'waitingCancel'" class="button send_force_done" title="Force Cancel" t-on-click="() => line.set_payment_status('retry')">
+                                            Force cancel
+                                        </div>
                                     </div>
                                 </t>
                                 <t t-elif="line.payment_status == 'reversing'">


### PR DESCRIPTION
Before this commit, if an electronic payment failed (e.g. due to the payment terminal/IoT box not being reachable) and the user subsequently tried to cancel the payment from the POS, they would reach a blocked state. The payment never cancels but it cannot be deleted.

This commit adds a 'Force cancel' button, similar to the 'Force done' button already present, to allow the user to get unblocked in this situation.

task-5485237

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
