### PR TITLE
[IMP] mail: apply whatsapp channel rename globally

### DIFF
--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -438,6 +438,9 @@ export class DiscussChannel extends Record {
     get showUnreadBanner() {
         return this.self_member_id?.message_unread_counter_ui > 0;
     }
+    get supportsChannelRename() {
+        return ["channel", "group"];
+    }
     sub_channel_ids = fields.Many("discuss.channel", {
         inverse: "parent_channel_id",
         sort: (a, b) => compareDatetime(b.lastInterestDt, a.lastInterestDt) || b.id - a.id,
@@ -655,7 +658,7 @@ export class DiscussChannel extends Record {
             newName !== this.displayName &&
             ((newName && this.channel?.channel_type === "channel") || this.channel?.isChatChannel)
         ) {
-            if (["channel", "group"].includes(this.channel_type)) {
+            if (this.supportsChannelRename.includes(this.channel_type)) {
                 this.name = newName;
                 await this.store.env.services.orm.call(
                     "discuss.channel",


### PR DESCRIPTION
**Current behavior before PR:**
renaming a WhatsApp channel only affected the current user.

**Desired behavior after PR is merged:**
the channel name change is shared with all users, ensuring consistent conversation names across the team.

Task-[5475084](https://www.odoo.com/odoo/project/1519/tasks/5475084)

Related Enterprise PR: https://github.com/odoo/enterprise/pull/103960

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
