### PR TITLE
[FIX] website_crm_partner_assign: allow stage update from portal

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -284,6 +284,12 @@ class CrmLead(models.Model):
             raise UserError(_("Not allowed to update the following field(s): %s.", ", ".join([key for key in values if not key in fields])))
         return self.sudo().write(values)
 
+    def update_stage_from_portal(self, stage_id):
+        """ Allow portal users to update the stage of their assigned leads """
+        self._assert_portal_write_access()
+        self.sudo().write({'stage_id': stage_id})
+        return True
+
     @api.model
     def create_opp_portal(self, values):
         if not (self.env.user.partner_id.grade_id or self.env.user.commercial_partner_id.grade_id):

--- a/addons/website_crm_partner_assign/static/src/interactions/crm_partner_assign.js
+++ b/addons/website_crm_partner_assign/static/src/interactions/crm_partner_assign.js
@@ -64,9 +64,7 @@ export class CRMPartnerAssign extends Interaction {
      * @param {number} stageID
      */
     async changeOppStage(leadID, stageID) {
-        await this.services.orm.write("crm.lead", [leadID], { stage_id: stageID }, {
-            context: Object.assign({ website_partner_assign: 1 }),
-        });
+        await this.services.orm.call("crm.lead", "update_stage_from_portal", [[leadID], stageID]);
         window.location.reload();
     }
 


### PR DESCRIPTION
Steps to reproduce:
1. As a portal user, access an assigned opportunity.
2. Try to change the stage of the opportunity using the stage dropdown.

Current behavior:
- The stage change is not allowed, and an error is raised because we don't have rights to directl modify a crm.lead as a portal user.

Solution:
- Following the behaviour on the how we handle the other details of the opportunity from the portal, we add a dedicated method that allows portal users to update the stage of their assigned leads, if they have the rights to.

opw-5346055



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
