### PR TITLE
[FIX] website: properly mock Clipboard API calls in tours

### DIFF
--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -3,6 +3,8 @@
 import wTourUtils from '@website/js/tours/tour_utils';
 import { browser } from '@web/core/browser/browser';
 
+const oldWriteText = browser.navigator.clipboard.writeText;
+
 wTourUtils.registerWebsitePreviewTour('snippet_editor_panel_options', {
     test: true,
     url: '/',
@@ -52,15 +54,16 @@ wTourUtils.dragNDrop({
     trigger: '#oe_snippets .snippet-option-anchor we-button',
     run() {
         // Patch and ignore write on clipboard in tour as we don't have permissions
-        const oldWriteText = browser.navigator.clipboard.writeText;
         browser.navigator.clipboard.writeText = () => { console.info('Copy in clipboard ignored!') };
         this.$anchor[0].click();
-        browser.navigator.clipboard.writeText = oldWriteText;
     }
 }, {
     content: "Check the copied url from the notification toast",
     trigger: '.o_notification_manager .o_notification_content',
     run() {
+        // Cleanup the patched clipboard method
+        browser.navigator.clipboard.writeText = oldWriteText;
+
         const { textContent } = this.$anchor[0];
         const url = textContent.substring(textContent.indexOf('/'));
 

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -3,6 +3,8 @@
 import wTourUtils from "@website/js/tours/tour_utils";
 import { browser } from "@web/core/browser/browser";
 
+const oldWriteText = browser.navigator.clipboard.writeText;
+
 wTourUtils.registerWebsitePreviewTour("snippet_popup_display_on_click", {
     test: true,
     url: "/",
@@ -22,16 +24,17 @@ wTourUtils.registerWebsitePreviewTour("snippet_popup_display_on_click", {
         in_modal: false,
         run() {
             // Patch and ignore write on clipboard in tour as we don't have permissions
-            const oldWriteText = browser.navigator.clipboard.writeText;
             browser.navigator.clipboard.writeText = () => { console.info('Copy in clipboard ignored!') };
             this.$anchor[0].click();
-            browser.navigator.clipboard.writeText = oldWriteText;
         }
     },
     {
         content: "Check the copied anchor from the notification toast",
         trigger: ".o_notification_manager .o_notification_content",
         run() {
+            // Cleanup the patched clipboard method
+            browser.navigator.clipboard.writeText = oldWriteText;
+
             const notificationContent = this.$anchor[0].innerText;
             const anchor = notificationContent.substring(notificationContent.indexOf("#"));
 

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -3,6 +3,8 @@
 import { registry } from "@web/core/registry";
 import { browser } from "@web/core/browser/browser";
 
+const oldWriteText = browser.navigator.clipboard.writeText;
+
 function fillSelect2(inputID, search) {
     return [
         {
@@ -56,10 +58,8 @@ registry.category("web_tour.tours").add('website_links_tour', {
             trigger: '#btn_shorten_url',
             run: function () {
                 // Patch and ignore write on clipboard in tour as we don't have permissions
-                const oldWriteText = browser.navigator.clipboard.writeText;
                 browser.navigator.clipboard.writeText = () => { console.info('Copy in clipboard ignored!') };
                 $('#btn_shorten_url').click();
-                browser.navigator.clipboard.writeText = oldWriteText;
             },
         },
         // 2. Visit it
@@ -68,6 +68,9 @@ registry.category("web_tour.tours").add('website_links_tour', {
             extra_trigger: '#o_website_links_recent_links .truncate_text:first():contains("Contact Us")',
             trigger: '#o_website_links_link_tracker_form #generated_tracked_link:contains("/r/")',
             run: function () {
+                // Cleanup the patched clipboard method
+                browser.navigator.clipboard.writeText = oldWriteText;
+
                 window.location.href = $('#generated_tracked_link').text();
             },
         },


### PR DESCRIPTION
Reliably mocking Clipboard API calls in tours should be done in two steps:
- the step that will actually do the call should do the patching, followed by the actual action.
- the cleanup should only be done in the following step to ensure the action's listener has actually finished.

This commit applies this principle to avoid the "cleanup" to be executed before the action's listener has actually reached the call to the Clipboard API (because of slower processing, slower network...), which would defeat the mocking purpose (and either get the browser to indefinitely wait for the user's clipboard usage approval or a permission error depending on the browser's default behavior).

Note: this was mainly brought to light by the new Chrome 143+ default policy which revoke all permissions in headless mode.
