### PR TITLE
[FIX] account: prevent error when saving report with invalid formula

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -643,7 +643,7 @@ class AccountReportExpression(models.Model):
     @api.constrains('formula')
     def _check_formula(self):
         def raise_formula_error(expression):
-            raise ValidationError(_("Invalid formula for expression '%(label)s' of line '%(line)s': %(formula)s",
+            raise ValidationError(self.env._("Invalid formula for expression '%(label)s' of line '%(line)s': %(formula)s",
                                     label=expression.label, line=expression.report_line_name,
                                     formula=expression.formula))
 
@@ -659,7 +659,7 @@ class AccountReportExpression(models.Model):
             for token in ACCOUNT_CODES_ENGINE_SPLIT_REGEX.split(expression.formula.replace(' ', '')):
                 if token:  # e.g. if the first character of the formula is "-", the first token is ''
                     token_match = ACCOUNT_CODES_ENGINE_TERM_REGEX.match(token)
-                    prefix = token_match['prefix']
+                    prefix = token_match and token_match['prefix']
                     if not prefix:
                         raise_formula_error(expression)
 

--- a/addons/account/tests/test_account_report.py
+++ b/addons/account/tests/test_account_report.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
@@ -50,3 +51,10 @@ class TestAccountReport(AccountTestInvoicingCommon):
         expression = copy.line_ids[1].expression_ids
         self.assertEqual(expression.formula, 'test_line_1_COPY.balance')
         self.assertEqual(expression.subformula, 'if_other_expr_above(test_line_1_COPY.balance, USD(0))')
+
+        with self.assertRaisesRegex(ValidationError, "Invalid formula for expression 'balance' of line 'test_line_2'"):
+            expression.write({
+                'engine': 'account_codes',
+                'formula': 'test(12)',
+                },
+            )


### PR DESCRIPTION
Saving an accounting report with an invalid ``Prefix of Account Codes`` formula will raise a traceback.

Steps to reproduce the error:
- Install ``accountant`` module
- Go to Accounting > Configuration > Accounting Reports > Open any report >
  Add a line > Add name > Add a line > Add a Expression >
  Computation Engine: Prefix of Account Codes > Formula: test( > Save the report

Traceback:
```py
TypeError: 'NoneType' object is not subscriptable
```

https://github.com/odoo/odoo/blob/1ac7834a9b9d07760700f6d7c73dfe270a247752/addons/account/models/account_report.py#L661-L662
Here, if the token does not match the regex,
``token_match`` will be ``None``, The code then accesses ``token_match['prefix']``
which leads to the above traceback.

https://github.com/odoo/odoo/blob/312964fdf68609dbd0fc1bb3be609b50e171b0c3/odoo/tools/translate.py#L556
Here, no translation language is detected by ``_get_lang``.
To resolve this, ``self.env._()`` is added instead of ``_()`` at below line.
https://github.com/odoo/odoo/blob/312964fdf68609dbd0fc1bb3be609b50e171b0c3/addons/account/models/account_report.py#L646-L648

sentry-7175078855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
