### PR TITLE
[FIX] hr_holidays: prevent wrong time off manager assignation

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -161,7 +161,7 @@ class HrEmployee(models.Model):
         for employee in self:
             previous_manager = employee._origin.parent_id.user_id
             manager = employee.parent_id.user_id
-            if manager and employee.leave_manager_id == previous_manager or not employee.leave_manager_id:
+            if manager and (employee.leave_manager_id == previous_manager or not employee.leave_manager_id) and manager.has_group('hr_holidays.group_hr_holidays_user'):
                 employee.leave_manager_id = manager
             elif not employee.leave_manager_id:
                 employee.leave_manager_id = False
@@ -213,7 +213,7 @@ class HrEmployee(models.Model):
         self = self.with_context(no_leave_resource_calendar_update=True)  # noqa: PLW0642
         if 'parent_id' in values:
             manager = self.env['hr.employee'].browse(values['parent_id']).user_id
-            if manager:
+            if manager and manager.has_group('hr_holidays.group_hr_holidays_user'):
                 to_change = self.filtered(lambda e: e.leave_manager_id == e.parent_id.user_id or not e.leave_manager_id)
                 to_change.write({'leave_manager_id': values.get('leave_manager_id', manager.id)})
 

--- a/addons/hr_holidays/tests/test_allocation_access_rights.py
+++ b/addons/hr_holidays/tests/test_allocation_access_rights.py
@@ -202,3 +202,14 @@ class TestAccessRightsHolidayManager(TestAllocationRights):
         self.assertEqual(allocation.state, 'validate', "It should have been validated")
         allocation.action_refuse()
         self.assertEqual(allocation.state, 'refuse', "It should have been refused")
+
+    def test_manager_without_time_off_access_rights(self):
+        """ Test checking that when setting as manager a user that doesn't have access rights to time off,
+        that user isn't set as time off manager"""
+        self.user_responsible.write({
+            'group_ids': [(6, 0, [self.env.ref('hr.group_hr_user').id])],
+        })
+        self.employee_emp.write({
+            'parent_id': self.user_responsible.employee_id.id,
+        })
+        self.assertFalse(self.employee_emp.leave_manager_id)


### PR DESCRIPTION
---
## Short functional explanation of the error
When setting the manager of an employee, this manager will automatically become the time off manager, even if they have no access rights to time off management.

## Reproduction Steps
1. Create a User. Under roles, set every access right to 'no', except Employees under Human Resources.
2. Create a corresponding Employee (let's call it E).
3. Go to another employee's page. In the Work tab, set the manager as E and hit save.
4. Click on Settings tab.

### Expected behavior
Under Approvers, the Time off field shouldn't be set at E.

### Unexpected behavior
The Time Off field is set at E.

## Origin of the issue
When setting a time off manager, we simply use the employee manager values, which have different access rights than the ones corresponding to time off managers:
https://github.com/odoo/odoo/blob/92486bab9b73f4370629452c454c25371d5063ac/addons/hr_holidays/models/hr_employee.py#L162-L164

opw-5470249


