### PR TITLE
[FIX] mail: restrict discuss settings to administrators

### DIFF
--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -31,6 +31,7 @@
         id="mail.menu_settings"
         parent="mail.menu_configuration"
         action="action_open_discuss_settings"
+        groups="base.group_system"
         sequence="1"
     />
     <menuitem name="Notifications"


### PR DESCRIPTION
**Steps to reproduce:**

Open Discuss > Configuration > Settings.

**Current behavior before PR:**

Non-admin users encounter an access error when clicking 'Settings'.

**Desired behavior after PR is merged:**

The 'Settings' menu item is now hidden for users who are not part of the 'Role / Administrator' group.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
