### PR TITLE
[FIX] point_of_sale: prevent double error when scanning offline

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -651,9 +651,12 @@ export class PosData extends Reactive {
 
     async callRelated(model, method, args = [], kwargs = {}, queue = true) {
         const data = await this.execute({ type: "call", model, method, args, kwargs, queue });
-        this.deviceSync.dispatch(data);
-        const results = this.models.loadData(data, [], true);
-        return results;
+        if (data) {
+            this.deviceSync?.dispatch && this.deviceSync.dispatch(data);
+            const results = this.models.loadData(data, [], true);
+            return results;
+        }
+        return false;
     }
 
     async create(model, values, queue = true) {

--- a/addons/point_of_sale/static/tests/tours/barcode_scanning_tour.js
+++ b/addons/point_of_sale/static/tests/tours/barcode_scanning_tour.js
@@ -1,6 +1,7 @@
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
+import * as Offline from "@point_of_sale/../tests/tours/utils/offline_util";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
 
@@ -104,6 +105,19 @@ registry.category("web_tour.tours").add("BarcodeScanPartnerTour", {
             // scan the customer barcode
             scan_barcode("0421234567890"),
             ProductScreen.customerIsSelected("John Doe"),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_offline_barcode_not_in_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Offline.setOfflineMode(),
+            scan_barcode("2100005000000"),
+            ProductScreen.clickDisplayedProduct("Magnetic Board"),
+            ProductScreen.clickPayButton(),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/utils/offline_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/offline_util.js
@@ -1,0 +1,33 @@
+import { run } from "@point_of_sale/../tests/tours/utils/common";
+import { ConnectionLostError } from "@web/core/network/rpc";
+
+const originalFetch = window.fetch;
+const originalSend = XMLHttpRequest.prototype.send;
+const originalConsoleError = console.error;
+
+export function setOfflineMode() {
+    return run(() => {
+        window.fetch = () => {
+            throw new ConnectionLostError();
+        };
+        XMLHttpRequest.prototype.send = () => {
+            throw new ConnectionLostError();
+        };
+        console.error = (...args) => {
+            const message = args[0] instanceof Error ? args[0].message : args[0];
+            if (typeof message === "string" && message.includes("ConnectionLostError")) {
+                console.info("Connection lost error handled in offline mode:", ...args);
+            } else {
+                originalConsoleError.apply(console, args);
+            }
+        };
+    }, "Offline mode is now enabled");
+}
+
+export function setOnlineMode() {
+    return run(() => {
+        window.fetch = originalFetch;
+        XMLHttpRequest.prototype.send = originalSend;
+        console.error = originalConsoleError;
+    }, "Offline mode is now disabled");
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2472,6 +2472,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(order.amount_total, 2.80, "The total amount should be rounded to 2 decimals")
         self.assertEqual(order.amount_return, 0, "The return amount should be rounded to 2 decimals")
 
+    def test_offline_barcode_not_in_pos(self):
+        """
+        Tests that an unwanted error is not thrown when trying to scan a barcode while offline
+        for a product that is not in the PoS.
+        """
+        self.wall_shelf.available_in_pos = False
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_offline_barcode_not_in_pos', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
**Steps to reproduce:**
- Set a barcode on a product that is not in the used point of sale
- Go to PoS, cut the server connection
- Go to the debug window and enter the barcode
- An error saying the connection is cut appears (expected)
- A traceback appears (unexpected)

**Why the fix:**
This bug only happens in 18.0, so this is a backport of ca1ba4b which was basically fixing the same issue. We check if we have data before making some operations on them as to avoid making operations on an undefined value.

opw-5450575