### PR TITLE
[18.0][FIX]: correct plan_id assignment when having multiple schedulers

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -143,7 +143,7 @@ class MailActivitySchedule(models.TransientModel):
         for scheduler in self:
             if self.env.context.get('plan_mode'):
                 scheduler.plan_id = scheduler.env['mail.activity.plan'].search(
-                    [('id', 'in', self.plan_available_ids.ids)], order='id', limit=1)
+                    [('id', 'in', scheduler.plan_available_ids.ids)], order='id', limit=1)
             else:
                 scheduler.plan_id = False
 


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

Same pattern as in https://github.com/odoo/odoo/pull/189843 but for _compute_plan_id method





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
