### PR TITLE
[FIX] website: only update menu on page creation if the menu has no page

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -633,7 +633,7 @@ class Website(Home):
         # If that URL is also a menu, we update it accordingly.
         # NB: we don't want to slugify on menu creation as it could redirect
         # towards files (with spaces, apostrophes, etc.).
-        menu = request.env['website.menu'].search([('url', '=', '/' + path)])
+        menu = request.env['website.menu'].search([('url', '=', '/' + path), ('page_id', '=', False)])
         if menu:
             menu.page_id = page['page_id']
 


### PR DESCRIPTION
With commit 19302cd40347065fcd937bd54e6dce27fe4940cc, when a page is created, menu entries with a url corresponding to the created page are updated to set their `page_id` to the new page.

The update may also be triggered when creating several pages with the same name in a row.

This commit updates a menu entry on page creation only if no page were already associated to the menu.

Steps to reproduce:
- Create a new page, call it "test" (will be available on `/test`)
- Create a new page, call it "test" (will be available on `/test-1`)
- Go to editor menu
- Bug: both entries point to `/test-1`
- Create a new page, call it "test" (will be available on `/test-2`)
- Go to editor menu
- Bug: the first one (and the new one) is pointing now to `/test-2`

task-5186653
