### PR TITLE
[FIX] mail: correctly subtract channel needaction counter from global

### DIFF
--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -30,7 +30,7 @@ const StorePatch = {
                 acc + (thread.model === "discuss.channel" ? thread.message_needaction_counter : 0),
             0
         );
-        return super.computeGlobalCounter() + channelsContribution + channelsNeedactionCounter;
+        return super.computeGlobalCounter() + channelsContribution - channelsNeedactionCounter;
     },
     /** @returns {import("models").Thread[]} */
     getSelfImportantChannels() {


### PR DESCRIPTION
This commit corrects a regression intoduced in [1]: the messaging menu now subtracts the channels needaction counter from the inbox counter, rather than adding it

[1] https://github.com/odoo/odoo/pull/229751