### PR TITLE
[IMP] web: use text-faded on inactive Many2One

### DIFF
--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -656,6 +656,7 @@ export class RelationalModel extends Model {
                 specification: fieldSpec,
             };
             const orm = cache ? this.orm.cache(cache) : this.orm;
+            // HERE
             const records = await orm.webRead(resModel, resIds, kwargs);
             if (!records.length) {
                 throw new FetchRecordError(resIds);

--- a/addons/web/static/src/views/fields/many2many_tags/kanban_many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/kanban_many2many_tags_field.xml
@@ -4,7 +4,9 @@
     <t t-name="web.KanbanMany2ManyTagsField">
         <div class="d-flex flex-wrap gap-1">
             <t t-foreach="this.tags" t-as="tag" t-key="tag.id">
-                <Tag color="tag.props.color" text="tag.props.text"/>
+                <span t-att-class="tag.className" class="d-inline-flex">
+                    <Tag color="tag.props.color" text="tag.props.text"/>
+                </span>
             </t>
         </div>
     </t>

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -8,7 +8,9 @@
             t-ref="many2ManyTagsField"
         >
             <TagsList t-props="this.tagsListProps" t-slot-scope="tag">
-                <Tag t-props="tag.props"/>
+                <span t-att-class="tag.className" class="d-inline-flex">
+                    <Tag t-props="tag.props"/>
+                </span>
             </TagsList>
             <div t-if="showM2OSelectionField" class="o_field_many2many_selection d-inline-flex w-100" t-ref="autoComplete">
                 <Many2XAutocomplete

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -11,7 +11,9 @@
                 <a class="o_quick_assign fa o_m2m_avatar btn-link d-flex align-items-center text-dark" href="#" role="button" tabindex="0" t-attf-class="{{ this.tags.length ? 'fa-pencil' : 'fa-user-plus' }}" t-att-data-tooltip="this.assignBtnTooltip" t-att-aria-label="this.assignBtnTooltip" t-on-click.stop.prevent="this.openPopover"/>
             </t>
             <TagsList t-props="this.tagsListProps" t-slot-scope="tag">
-                <Tag t-props="tag.props"/>
+                <span t-att-class="tag.className" class="d-inline-flex">
+                    <Tag t-props="tag.props"/>
+                </span>
             </TagsList>
             <div t-if="showM2OSelectionField" class="o_field_many2many_selection d-inline-flex w-100" t-ref="autoComplete">
                 <Many2XAutocomplete

--- a/addons/web/static/src/views/fields/many2one/many2one.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one.xml
@@ -17,7 +17,7 @@
     </t>
 
     <t t-name="web.Many2One">
-        <div class="o_many2one" t-att-class="props.cssClass">
+        <div class="o_many2one" t-att-class="props.cssClass" t-attf-class="{{ this.state.recordActive ? '' : 'text-muted' }}">
             <t t-if="props.readonly">
                 <t t-if="props.value">
                     <t t-if="props.canOpen">

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -5,6 +5,7 @@ import { computeM2OProps, Many2One } from "./many2one";
 import { standardFieldProps } from "../standard_field_props";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 
+// HERE
 /** @type {import("registries").FieldsRegistryItemShape["supportedOptions"]} */
 export const m2oSupportedOptions = [
     {


### PR DESCRIPTION
**WIP WIP WIP**

When a screen displays comodel records (M2x), the only way to check if the record is archived is to open it.

This commit sets a `text-faded` on M2x inactive comodel records and grays out the avatars of inactive contacts/users.

task-5469063