### PR TITLE
[IMP] hr: add css class for field width to fit-content

### DIFF
--- a/addons/hr/static/src/scss/hr.scss
+++ b/addons/hr/static/src/scss/hr.scss
@@ -79,6 +79,14 @@
     }
 }
 
+.o_hr_narrow_field_fit {
+    width: fit-content!important;
+    max-width: fit-content!important;
+    * {
+        max-width: 100%;
+    }
+}
+
 .o_hr_percentage_narrow_field input {
     max-width: 8rem !important;
     width: 8rem !important;


### PR DESCRIPTION
Adds a css class to make the field take only the space needed for itself.
Similar to narrow_field but with fit-content instead.

Task-5380667