### PR TITLE
[FIX] mail: proper ratio of avatar in follower list menu

### DIFF
--- a/addons/mail/static/src/chatter/web_portal/chatter.scss
+++ b/addons/mail/static/src/chatter/web_portal/chatter.scss
@@ -47,8 +47,7 @@
 }
 
 .o-mail-Follower-avatar {
-    width: $o-mail-Avatar-sizeSmall;
-    height: $o-mail-Avatar-sizeSmall;
+    --Avatar-size: #{$o-mail-Avatar-sizeSmall};
 }
 
 .o-mail-Follower:has(.o-mail-Follower-action:hover), .o-mail-FollowerList-unfollow:has(.o-mail-Follower-action:hover) {

--- a/addons/mail/static/src/core/web/follower.xml
+++ b/addons/mail/static/src/core/web/follower.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Follower">
         <DropdownItem class="'o-mail-Follower d-flex justify-content-between p-0'">
             <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 o-min-width-0" t-att-class="{ 'o-inactive opacity-75 text-reset text-decoration-line-through': !props.follower.is_active }" href="#" role="menuitem" t-on-click.prevent="(ev) => this.onClickDetails(ev)">
-                <img class="o-mail-Follower-avatar me-2 rounded" t-att-src="props.follower.partner.avatarUrl" alt=""/>
+                <img class="o-mail-Follower-avatar o_avatar me-2 rounded" t-att-src="props.follower.partner.avatarUrl" alt=""/>
                 <span class="flex-shrink text-truncate" t-esc="props.follower.displayName"/>
             </a>
             <div t-if="props.follower.isEditable" class="d-flex align-items-center me-2">


### PR DESCRIPTION
Before this commit, follower list menu had avatar that do not preserve ratio of avatars. This is noticeable for avatars that have ratio quite different from 1:1, like 3:2 or 2:3 or even less squarish.

This happens because of missing `.o_object_fit_cover`, that [1] erroneously removed from REF of follower template part into its own component.

This commit uses an equivalent but more official solution: `.o_avatar`, which is a classname dedicated for avatars, which has `.o_object_fit_cover` property.

Task-5412078

Before / After
<img width="638" height="526" alt="Screenshot 2026-01-12 at 17 23 54" src="https://github.com/user-attachments/assets/b8d3a921-52a8-48b7-a0d0-5fbfdd33a92c" /> <img width="640" height="528" alt="Screenshot 2026-01-12 at 17 23 33" src="https://github.com/user-attachments/assets/8070420c-f341-4085-bcb2-2fba060765f0" />

[1]: https://github.com/odoo/odoo/pull/200382