### PR TITLE
[FIX] hr, hr_payroll: fix employee filter

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -7,11 +7,7 @@
             <field name="arch" type="xml">
                 <search string="Employees">
                     <field name="name" string="Employee"
-                           filter_domain="[
-                           '|',
-                                ('registration_number', 'ilike', self),
-                                    '|',
-                                        ('work_email', 'ilike', self), ('name', 'ilike', self)]"/>
+                        filter_domain="['|', ('work_email', 'ilike', self), ('name', 'ilike', self)]"/>
                     <searchpanel view_types="kanban,list,graph,pivot,hierarchy">
                         <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
                         <field name="department_id" icon="fa-users" enable_counters="1"/>


### PR DESCRIPTION
Bug:
Searching for Employees without hr_payroll installed causes an error

Cause:
a field from hr_payroll was referenced in hr views filter

Task-5487616
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
