### PR TITLE
[FIX] pos_sale: retrieve the lot number for so in pos

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -277,38 +277,43 @@ class StockMove(models.Model):
         moves_remaining = self - moves_to_assign
         existing_lots = moves_remaining._create_production_lots_for_pos_order(related_order_lines)
         move_lines_to_create = []
-        mls_qties = []
         if are_qties_done:
             for move in moves_remaining:
                 move.move_line_ids.quantity = 0
                 for line in lines_data[move.product_id.id]['order_lines']:
-                    sum_of_lots = 0
                     for lot in line.pack_lot_ids.filtered(lambda l: l.lot_name):
                         qty = 1 if line.product_id.tracking == 'serial' else abs(line.qty)
-                        ml_vals = dict(move._prepare_move_line_vals(qty))
                         if existing_lots:
                             existing_lot = existing_lots.filtered_domain([('product_id', '=', line.product_id.id), ('name', '=', lot.lot_name)])
-                            quant = self.env['stock.quant']
+                            quants = self.env['stock.quant']
                             if existing_lot:
-                                quant = self.env['stock.quant'].search(
+                                quants = self.env['stock.quant'].search(
                                     [('lot_id', '=', existing_lot.id), ('quantity', '>', '0.0'), ('location_id', 'child_of', move.location_id.id)],
                                     order='id desc',
-                                    limit=1
                                 )
-                                if quant:
-                                    ml_vals.update({
-                                        'quant_id': quant.id,
-                                    })
-                                else:
-                                    ml_vals.update({
-                                        'lot_name': existing_lot.name,
-                                        'lot_id': existing_lot.id,
-                                    })
+                            qty_left_to_assign = qty
+                            for quant in quants:
+                                if qty_left_to_assign <= 0:
+                                    break
+                                qty_chg = min(qty_left_to_assign, quant.quantity)
+                                ml_vals = dict(move._prepare_move_line_vals(qty_chg))
+                                qty_left_to_assign -= qty_chg
+                                ml_vals.update({
+                                    'quant_id': quant.id,
+                                })
+                                move_lines_to_create.append(ml_vals)
+                            if qty_left_to_assign > 0:
+                                ml_vals = dict(move._prepare_move_line_vals(qty_left_to_assign))
+                                ml_vals.update({
+                                    'lot_name': existing_lot.name,
+                                    'lot_id': existing_lot.id,
+                                })
+                                move_lines_to_create.append(ml_vals)
                         else:
+                            ml_vals = dict(move._prepare_move_line_vals(qty))
                             ml_vals.update({'lot_name': lot.lot_name})
-                        move_lines_to_create.append(ml_vals)
-                        mls_qties.append(qty)
-                        sum_of_lots += qty
+                            move_lines_to_create.append(ml_vals)
+
             self.env['stock.move.line'].create(move_lines_to_create)
         else:
             for move in moves_remaining:

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -77,7 +77,10 @@ class SaleOrderLine(models.Model):
                 if sale_line.product_id.tracking != 'none':
                     move_lines = sale_line.move_ids.move_line_ids.filtered(lambda ml: ml.product_id.id == sale_line.product_id.id)
                     item['lot_names'] = move_lines.lot_id.mapped('name')
-                    item['lot_qty_by_name'] = {line.lot_id.name: line.quantity for line in move_lines}
+                    lot_qty_by_name = {}
+                    for line in move_lines:
+                        lot_qty_by_name[line.lot_id.name] = lot_qty_by_name.get(line.lot_id.name, 0.0) + line.quantity
+                    item['lot_qty_by_name'] = lot_qty_by_name
                 if product_uom == sale_line_uom:
                     results.append(item)
                     continue

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1281,25 +1281,34 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             'location_id': self.warehouse.lot_stock_id.id,
         })
 
+        lot_1001, lot_1002 = self.env['stock.lot'].create([{
+                'name': '1001',
+                'product_id': self.product.id,
+                'location_id': self.shelf_1.id,
+            },
+            {
+                'name': '1002',
+                'product_id': self.product.id,
+                'location_id': self.shelf_2.id,
+            },
+            ])
         quants = self.env['stock.quant'].with_context(inventory_mode=True).create({
             'product_id': self.product.id,
             'inventory_quantity': 1,
             'location_id': self.shelf_1.id,
-            'lot_id': self.env['stock.lot'].create({
-                'name': '1001',
-                'product_id': self.product.id,
-                'location_id': self.shelf_1.id,
-            }).id,
+            'lot_id': lot_1001.id,
         })
         quants |= self.env['stock.quant'].with_context(inventory_mode=True).create({
             'product_id': self.product.id,
             'inventory_quantity': 2,
             'location_id': self.shelf_2.id,
-            'lot_id': self.env['stock.lot'].create({
-                'name': '1002',
-                'product_id': self.product.id,
-                'location_id': self.shelf_2.id,
-            }).id,
+            'lot_id': lot_1002.id
+        })
+        quants |= self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product.id,
+            'inventory_quantity': 3,
+            'location_id': self.shelf_2.id,
+            'lot_id': lot_1001.id,
         })
         quants.action_apply_inventory()
 
@@ -1310,22 +1319,22 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             'order_line': [(0, 0, {
                 'product_id': self.product.id,
                 'name': self.product.name,
-                'product_uom_qty': 3,
+                'product_uom_qty': 6,
                 'product_uom': self.product.uom_id.id,
                 'price_unit': self.product.lst_price,
             })],
         })
         sale_order.action_confirm()
+        self.assertEqual(sale_order.order_line.move_ids.move_lines_count, 3)
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_multiple_lots_sale_order', login="accountman")
         self.main_pos_config.current_session_id.action_pos_session_close()
-        mls = self.env["stock.move.line"].search([('picking_code', '=', 'outgoing'), ('product_id', '=', self.product.id)], limit=2)
-        self.assertEqual(sum(mls.mapped('quantity')), 3)
-        self.assertEqual(len(mls), 2)
-        self.assertEqual(mls[0].lot_id.name, '1001')
-        self.assertEqual(mls[0].quantity, 1)
-        self.assertEqual(mls[1].lot_id.name, '1002')
-        self.assertEqual(mls[1].quantity, 2)
+        mls = self.env["stock.move.line"].search([('picking_code', '=', 'outgoing'), ('product_id', '=', self.product.id)], limit=3)
+        self.assertRecordValues(mls, [
+            {'lot_id': lot_1001.id, 'quantity': 3, 'location_id': self.shelf_2.id},
+            {'lot_id': lot_1001.id, 'quantity': 1, 'location_id': self.shelf_1.id},
+            {'lot_id': lot_1002.id, 'quantity': 2, 'location_id': self.shelf_2.id},
+        ])
 
     def test_import_so_to_pos_no_existing_lot(self):
         self.product = self.env['product.product'].create({


### PR DESCRIPTION
When opening an SO in POS that has a product tracked by lot that is split into several location, the lot number will only appear in one of the line and not the others

Steps to reproduce:
-------------------
1. Create a Product A tracked by lot, create lot 111 and add 1 unit to location A and another one to location B
1. Create a sales order
2. Add two units of the product to the sale order
3. Confirm the sales order
4. Open the transfer, make the transfer retrieve the product from several location with the same lot.
5. Save the transfer
6. Open the sales order in POS
7. Load the SN/lots
-> Two line of qty 1 appear for the product A but only the first one has the lot number

Additional Issue:
8. Change the number of the product for the first line to 2 and erase the second line
9. Confirm and Pay
10. Close POS
11. Open move lines for this product (Inventory>product>In/out)
-> It moves 2 product from one location (when there is only product)

Observation:
-------------
When loading the SO in POS, we will retrieve the SO: https://github.com/odoo/odoo/blob/cb1f5d9c6db64b9ace9b7aa46bd6f94e4462176b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js#L104 While retrieving the SO, we will also retrieve the SOL, with additional information: https://github.com/odoo/odoo/blob/d9b2e5ee730a4e79586bfd3f09adfb794d2dc1f3/addons/pos_sale/models/sale_order.py#L79 -> Issue is that when several moves_line have the sale lot_id.name, their quantity will be overwritten.

Addition Issue :
When closing pos, all the move will be processed, when processing those moves, the origin only check if the quantity is more than 0 and not if there is enought units. https://github.com/odoo/odoo/blob/cb1f5d9c6db64b9ace9b7aa46bd6f94e4462176b/addons/point_of_sale/models/stock_picking.py#L293-L297

opw-5347992