### PR TITLE
[FIX] web_editor: allow non admin editors to add unsplash images

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -619,6 +619,9 @@ class Web_Editor(http.Controller):
                     }])
 
         if attachment.url:
+            # Use SUPERUSER_ID since non admin editors will not have permission
+            # to modify the url field of an attachment.
+            attachment = attachment.with_user(SUPERUSER_ID)
             # Don't keep url if modifying static attachment because static images
             # are only served from disk and don't fallback to attachments.
             if re.match(r'^/\w+/static/', attachment.url):


### PR DESCRIPTION
Non admin users with either "restricted" or "editor and designers" access are not allowed to add images using unsplash because they require permission to make changes in the url field in attachment.

Steps to reproduce:
1. Login via non admin user with "Editor and Designer" access.
2. Try to edit it via editor and add an image with unsplash.
3. Try saving it.

You won't be able to save it due to the access right issue.

opw-5221162