### PR TITLE
[IMP] pos*: revamp POS order form view layout

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -49,16 +49,23 @@
                         <field name="refunded_order_id" widget="statinfo" string="Refunded Orders" />
                     </button>
                 </div>
-                <group col="4" colspan="4" name="order_fields">
-                    <field name="name"/>
-                    <field name="source" readonly="True" />
-                    <field name="date_order"/>
-                    <field name="session_id"  readonly="state != 'draft'"/>
-                    <field string="User" name="user_id" readonly="account_move or state == 'done'"/>
-                    <field name="order_edit_tracking" invisible="1"/>
-                    <field name="is_edited" readonly="1" invisible="not order_edit_tracking"/>
-                    <field name="partner_id" context="{'res_partner_search_mode': 'customer'}" readonly="account_move"/>
-                    <field name="fiscal_position_id" options="{'no_create': True}" readonly="state != 'draft'"/>
+                <div class="oe_title">
+                    <h1>
+                        <field name="name"/>
+                    </h1>
+                </div>
+                <group>
+                    <group name="order_customer_details">
+                        <field name="date_order"/>
+                        <field name="partner_id" context="{'res_partner_search_mode': 'customer'}" readonly="account_move"/>
+                        <field name="fiscal_position_id" options="{'no_create': True}" readonly="state != 'draft'"/>
+                    </group>
+                    <group name="order_operational_details">
+                        <field string="Served by" name="user_id" readonly="account_move or state == 'done'" widget="many2one_avatar_user"/>
+                        <field name="session_id"  readonly="state != 'draft'"/>
+                        <field name="order_edit_tracking" invisible="1"/>
+                        <field name="is_edited" readonly="1" invisible="not order_edit_tracking"/>
+                    </group>
                 </group>
                 <notebook colspan="4">
                     <page string="Products" name="products">
@@ -87,7 +94,7 @@
                                 <field name="full_product_name" optional="hide" readonly="1"/>
                                 <field name="product_id" widget="product_label_section_and_note_field" />
                                 <field name="is_edited" readonly="1" column_invisible="not parent.order_edit_tracking"/>
-                                <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
+                                <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot" optional="hide"/>
                                 <field name="qty"/>
                                 <field name="customer_note" optional="hide"/>
                                 <field name="product_uom_id" groups="uom.group_uom"/>

--- a/addons/pos_hr/views/pos_order_view.xml
+++ b/addons/pos_hr/views/pos_order_view.xml
@@ -5,9 +5,11 @@
         <field name="model">pos.order</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='user_id']" position='replace'>
-                <field name="employee_id" readonly="1" invisible="not employee_id" options="{'no_open': True}"/>
-                <field name="user_id" readonly="1" invisible="employee_id"/>
+            <xpath expr="//field[@name='user_id']" position='attributes'>
+                <attribute name="invisible">employee_id</attribute>
+            </xpath>
+            <xpath expr="//field[@name='user_id']" position="after">
+                <field name="employee_id" readonly="1" invisible="not employee_id" options="{'no_open': True}" widget="many2one_avatar_user"/>
             </xpath>
         </field>
     </record>

--- a/addons/pos_restaurant/views/pos_order_views.xml
+++ b/addons/pos_restaurant/views/pos_order_views.xml
@@ -6,7 +6,7 @@
         <field name="model">pos.order</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"></field>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='order_fields']" position="inside">
+            <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="table_id"/>
                 <field name="customer_count"/>
             </xpath>


### PR DESCRIPTION
*= point_of_sale, pos_restaurant, pos_hr

In this commit:
================
The POS order form has been revamped to improve usability and clarity. Customer-related fields are now grouped in the first column, while order operation details are organized in the second column for a cleaner and more structured view.

Task-5481883


Related Ent. PR: https://github.com/odoo/enterprise/pull/104098

