### PR TITLE
[FIX] html_editor: prevent layout break on image caption toggle

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -4,7 +4,11 @@ import { closestBlock } from "@html_editor/utils/blocks";
 import { renderToElement } from "@web/core/utils/render";
 import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import { closestElement } from "@html_editor/utils/dom_traversal";
-import { EDITABLE_MEDIA_CLASS, isShrunkBlock } from "@html_editor/utils/dom_info";
+import {
+    EDITABLE_MEDIA_CLASS,
+    isParagraphRelatedElement,
+    isShrunkBlock,
+} from "@html_editor/utils/dom_info";
 import { boundariesOut, rightPos } from "@html_editor/utils/position";
 import { findInSelection } from "@html_editor/utils/selection";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -119,7 +123,7 @@ export class CaptionPlugin extends Plugin {
         } else if (
             !link &&
             (image.previousSibling || image.nextSibling) &&
-            closestBlock(image) !== this.editable
+            isParagraphRelatedElement(closestBlock(image))
         ) {
             // <p>wx<img/>yz</p> => <p>wx</p><p><img/></p><p>yz</p>
             this.dependencies.split.splitAroundUntil(image, closestBlock(image));
@@ -128,7 +132,7 @@ export class CaptionPlugin extends Plugin {
         // or <p><a><figure><img/></figure></a></p>
         image.before(figure);
         figure.append(image);
-        if (!link && figure.parentElement !== this.editable) {
+        if (!link && isParagraphRelatedElement(figure.parentElement)) {
             // => <figure><img/></figure></p>
             // but still <p><a><figure><img/></figure></p>
             unwrapContents(figure.parentElement);
@@ -175,7 +179,7 @@ export class CaptionPlugin extends Plugin {
         const figure = closestElement(image, "figure");
         if (figure) {
             figure.querySelector("figcaption").remove();
-            if (closestBlock(figure.parentElement) === this.editable) {
+            if (!isParagraphRelatedElement(closestBlock(figure.parentElement))) {
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
                 if (figure.parentElement.nodeName === "A") {
                     figure.parentElement.before(baseContainer);

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -1246,3 +1246,122 @@ test("should properly parse figure without fig caption", async () => {
         ),
     });
 });
+
+test("removing an image caption inside a table should wrap image in a base container", async () => {
+    const caption = "Hello";
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<table>
+                <tbody>
+                    <tr>
+                        <td>
+                            <p>a</p>
+                            <figure>
+                                <img class="img-fluid test-image" src="${base64Img}">
+                                <figcaption>${caption}</figcaption>
+                            </figure>
+                            <p>b[]</p>
+                        </td>
+                        <td><p>c</p></td>
+                    </tr>
+                </tbody>
+            </table>`
+        ),
+        stepFunction: async () => {
+            await click("img");
+            await waitFor(".o-we-toolbar button[name='image_caption']");
+            await click(".o-we-toolbar button[name='image_caption']");
+        },
+        contentAfter: unformat(
+            `<table>
+                <tbody>
+                    <tr>
+                        <td>
+                            <p>a</p>
+                            <p>
+                                [<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]
+                            </p>
+                            <p>b</p>
+                        </td>
+                        <td><p>c</p></td>
+                    </tr>
+                </tbody>
+            </table>`
+        ),
+    });
+});
+
+test("adding an image caption inside a list item should not split a list item", async () => {
+    const captionId = 1;
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<ul>
+                <li>
+                    ab
+                    <img class="img-fluid test-image" src="${base64Img}">
+                    cd
+                </li>
+            </ul>`
+        ),
+        stepFunction: async (editor) => {
+            await toggleCaption();
+            await waitFor("figcaption > input");
+            const input = queryOne("figure > figcaption > input");
+            expect(input.value).toBe("");
+            expect(editor.document.activeElement).toBe(input);
+            // Remove the editor selection for the test because it's irrelevant
+            // since the focus is not in it.
+            const selection = editor.document.getSelection();
+            selection.removeAllRanges();
+        },
+        contentAfterEdit: unformat(
+            `<ul>
+                <li>
+                    ab
+                    <figure contenteditable="false">
+                        <img class="img-fluid test-image o_editable_media" src="${base64Img}" data-caption-id="${captionId}" data-caption="">
+                        <figcaption ${getFigcaptionAttributes(captionId, "", true)}>
+                            <input ${CAPTION_INPUT_ATTRIBUTES}>
+                        </figcaption>
+                    </figure>
+                    cd
+                </li>
+            </ul>`
+        ),
+    });
+});
+
+test("removing an image caption inside list item should wrap image in a base container", async () => {
+    const caption = "Hello";
+    await testEditor({
+        config: configWithEmbeddedCaption,
+        contentBefore: unformat(
+            `<ul>
+                <li>
+                    ab
+                    <figure>
+                        <img class="img-fluid test-image" src="${base64Img}">
+                        <figcaption>${caption}</figcaption>
+                    </figure>
+                    cd[]
+                </li>
+            </ul>`
+        ),
+        stepFunction: async () => {
+            await click("img");
+            await waitFor(".o-we-toolbar button[name='image_caption']");
+            await click(".o-we-toolbar button[name='image_caption']");
+        },
+        contentAfter: unformat(
+            `<ul>
+                <li>
+                    <p>ab</p>
+                    <p>[<img class="img-fluid test-image" src="${base64Img}" data-caption="${caption}">]</p>
+                    <p>cd</p>
+                </li>
+            </ul>`
+        ),
+    });
+});


### PR DESCRIPTION
Description of the issue this PR addresses:

- When toggling an image caption, the logic only checks whether the image or figure’s closest block is editable. This causes images inside non-paragraph containers (such as table cells, list items, blockquotes, and columns) to be repositioned, breaking the original layout.

Desired behavior after PR is merged:

- Image caption toggling correctly handles paragraph-related containers, ensuring the image remains within its original structural context (tables, lists, blockquotes, columns) without altering the layout.

Steps to Reproduce:

- Open a to-do record.
- Insert a table.
- Add an image inside any table cell.
- Toggle the image caption multiple times (3–4 times).

task-5485697

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
