### PR TITLE
[FIX] payment: import JSONDecodeError from json.decoder package

### DIFF
--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import uuid
+from json.decoder import JSONDecodeError
 from pprint import pformat
 
 import requests
@@ -804,7 +805,7 @@ class PaymentProvider(models.Model):
         except requests.exceptions.HTTPError:
             try:
                 error_msg = self._parse_response_error(response)
-            except requests.exceptions.JSONDecodeError:  # The provider failed to parse plain text.
+            except JSONDecodeError:  # The provider failed to parse plain text.
                 error_msg = response.text
             raise ValidationError(_("The payment provider rejected the request.\n%s", error_msg))
         return self._parse_response_content(response, **kwargs)

--- a/addons/payment/tests/test_payment_provider.py
+++ b/addons/payment/tests/test_payment_provider.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from json.decoder import JSONDecodeError
 from unittest.mock import patch
 
 import requests
-from requests.exceptions import JSONDecodeError
 
 from odoo.exceptions import ValidationError
 from odoo.fields import Command


### PR DESCRIPTION
The JSONDecodeError was previously imported from requests.exceptions, which only includes that symbol starting with requests==2.27, while Odoo 19.0 requires requests==2.25.1 to be compatible with Python 3.10.

```sql
Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/odoo/service/server.py", line 1510, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'], reinit_modules=config['reinit'])
  File "/home/odoo/src/odoo/19.0/odoo/tools/func.py", line 88, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/odoo/orm/registry.py", line 199, in new
    load_modules(
  File "/home/odoo/src/odoo/19.0/odoo/modules/loading.py", line 456, in load_modules
    load_module_graph(
  File "/home/odoo/src/odoo/19.0/odoo/modules/loading.py", line 274, in load_module_graph
    suite = loader.make_suite([module_name], 'at_install')
  File "/home/odoo/src/odoo/19.0/odoo/tests/loader.py", line 107, in make_suite
    return OdooSuite(sorted(tests, key=lambda t: getattr(t, 'test_sequence', 0)))
  File "/home/odoo/src/odoo/19.0/odoo/tests/loader.py", line 103, in <genexpr>
    for m in get_test_modules(module_name)
  File "/home/odoo/src/odoo/19.0/odoo/tests/loader.py", line 50, in get_test_modules
    results = _get_tests_modules(importlib.util.find_spec(f'odoo.addons.{module}'))
  File "/home/odoo/src/odoo/19.0/odoo/tests/loader.py", line 61, in _get_tests_modules
    tests_mod = importlib.import_module(spec.name)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/odoo/src/odoo/19.0/addons/payment/tests/__init__.py", line 9, in <module>
    from . import test_payment_provider
  File "/home/odoo/src/odoo/19.0/addons/payment/tests/test_payment_provider.py", line 6, in <module>
    from requests.exceptions import JSONDecodeError
ImportError: cannot import name 'JSONDecodeError' from 'requests.exceptions' (/home/odoo/.odoo-venvs/17.0/lib/python3.10/site-packages/requests/exceptions.py)

```
UPG - 3750613
OPW - 5463120