### PR TITLE
[IMP] pos_self_order: Remove "add note" in kiosk

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -68,7 +68,7 @@
                         </t>
                     </div>
                 </div>
-                <div class="container o_self_container">
+                <div class="container o_self_container" t-if="!selfOrder.kioskMode">
                     <hr/>
                     <div class="d-flex justify-content-between order-note"
                         t-on-click="() => (display_change_quantity and (this.state.showOrderNote = !this.state.showOrderNote))">

--- a/addons/pos_self_order/static/tests/unit/pages/cart_page.test.js
+++ b/addons/pos_self_order/static/tests/unit/pages/cart_page.test.js
@@ -1,4 +1,5 @@
 import { test, expect } from "@odoo/hoot";
+import { queryFirst } from "@odoo/hoot-dom";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { CartPage } from "@pos_self_order/app/pages/cart_page/cart_page";
 import { setupSelfPosEnv, getFilledSelfOrder, addComboProduct } from "../utils";
@@ -66,4 +67,13 @@ test("getPrice", async () => {
     // For combo parent line
     const parentLine = await addComboProduct(store);
     expect(comp.getPrice(parentLine)).toBe(500);
+});
+
+test("add note button is not shown in kiosk mode", async () => {
+    const store = await setupSelfPosEnv("kiosk");
+    await getFilledSelfOrder(store);
+    await mountWithCleanup(CartPage, {});
+
+    const orderNoteContainer = queryFirst(".order-note");
+    expect(orderNoteContainer).toBe(null);
 });


### PR DESCRIPTION
The goal of this pr was to remove the "Add note" button in the Kiosk.

task: 5470923

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
