### PR TITLE
[ADD] website_hr_recruitment_skills: job application page skill

### DIFF
--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -37,6 +37,7 @@ function applyForAJob(jobName, application) {
         trigger: "textarea[name='Short Introduction']",
         run: `edit ${application.subject}`,
     }, { // TODO: Upload a file ?
+        id: `send_form_${jobName.toLowerCase()}`,
         content: "Send the form",
         trigger: ".s_website_form_send",
         run: "click",
@@ -87,6 +88,7 @@ registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {}, () => [
 },
 ...clickOnEditAndWaitEditMode(),
 {
+    id: "set_job_id_default",
     content: 'Add a fake default value for the job_id hidden field',
     trigger: ":iframe form input[name=job_id]:not(:visible)",
     run() {

--- a/addons/website_hr_recruitment_skills/__init__.py
+++ b/addons/website_hr_recruitment_skills/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/addons/website_hr_recruitment_skills/__manifest__.py
+++ b/addons/website_hr_recruitment_skills/__manifest__.py
@@ -1,0 +1,32 @@
+{
+    "name": "Website HR Recruitment Skills",
+    "category": "Website/Recruitment",
+    "summary": "Enhance job applications with skills integration",
+    "depends": [
+        "website_hr_recruitment",
+        "hr_skills",
+    ],
+    "description": """
+Integrates skills management into the website recruitment process, helping applicants showcase their skills and improving job matching.
+    """,
+    "data": [
+        "data/config_data.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "website_hr_recruitment_skills/static/src/xml/website_form_editor.xml",
+        ],
+        "website.assets_wysiwyg": [
+            "website_hr_recruitment_skills/static/src/xml/website_form_editor.xml",
+        ],
+        "website.website_builder_assets": [
+            "website_hr_recruitment_skills/static/src/builder/plugins/form/form_option_plugin.js",
+        ],
+        "web.assets_tests": [
+            "website_hr_recruitment_skills/static/tests/tours/website_hr_recruitment_skills.js",
+        ],
+    },
+    "auto_install": True,
+    "author": "Odoo S.A.",
+    "license": "LGPL-3",
+}

--- a/addons/website_hr_recruitment_skills/__manifest__.py
+++ b/addons/website_hr_recruitment_skills/__manifest__.py
@@ -1,0 +1,33 @@
+{
+    "name": "Website HR Recruitment Skills",
+    "category": "Website/Recruitment",
+    "summary": "Enhance job applications with skills integration",
+    "depends": [
+        "website_hr_recruitment",
+        "hr_skills",
+        "hr_recruitment_skills",
+    ],
+    "description": """
+Integrates skills management into the website recruitment process, helping applicants showcase their skills and improving job matching.
+    """,
+    "data": [
+        "data/config_data.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "website_hr_recruitment_skills/static/src/xml/*.xml",
+        ],
+        "website.assets_wysiwyg": [
+            "website_hr_recruitment_skills/static/src/xml/*.xml",
+        ],
+        "website.website_builder_assets": [
+            "website_hr_recruitment_skills/static/src/builder/**/*",
+        ],
+        "web.assets_tests": [
+            "website_hr_recruitment_skills/static/tests/tours/**/*",
+        ],
+    },
+    "auto_install": True,
+    "author": "Odoo S.A.",
+    "license": "LGPL-3",
+}

--- a/addons/website_hr_recruitment_skills/controllers/__init__.py
+++ b/addons/website_hr_recruitment_skills/controllers/__init__.py
@@ -1,0 +1,2 @@
+from . import form
+from . import main

--- a/addons/website_hr_recruitment_skills/controllers/form.py
+++ b/addons/website_hr_recruitment_skills/controllers/form.py
@@ -1,0 +1,8 @@
+from odoo.addons.website.controllers import form
+
+
+class WebsiteForm(form.WebsiteForm):
+    _input_filters = {
+        **form.WebsiteForm._input_filters,
+        'one2many_skill': form.WebsiteForm.one2many,
+    }

--- a/addons/website_hr_recruitment_skills/controllers/main.py
+++ b/addons/website_hr_recruitment_skills/controllers/main.py
@@ -1,0 +1,22 @@
+import json
+
+from odoo.http import request
+
+from odoo.addons.website_hr_recruitment.controllers.main import WebsiteHrRecruitment
+
+
+class WebsiteHrRecruitmentSkills(WebsiteHrRecruitment):
+
+    def _handle_website_form(self, model_name, **kwargs):
+        kwargs.pop('applicant_skill_ids', None)
+        skills = kwargs.pop('skill_ids', '')
+        res = super()._handle_website_form(model_name, **kwargs)
+        for skill in [int(s) for s in skills.split(',') if s.strip()]:
+            skill_type_id = request.env['hr.skill'].sudo().browse(skill).skill_type_id
+            request.env['hr.applicant.skill'].sudo().create({
+                'skill_id': skill,
+                'skill_level_id': skill_type_id.skill_level_ids[:1].id,
+                'applicant_id': json.loads(res)['id'],
+                'skill_type_id': skill_type_id.id,
+                })
+        return res

--- a/addons/website_hr_recruitment_skills/controllers/main.py
+++ b/addons/website_hr_recruitment_skills/controllers/main.py
@@ -1,0 +1,59 @@
+import json
+
+from odoo.http import request
+
+from odoo.addons.website_hr_recruitment.controllers.main import WebsiteHrRecruitment
+
+
+class WebsiteHrRecruitmentSkills(WebsiteHrRecruitment):
+
+    # A real application form is a handful of checkboxes. Anything past this is
+    # a crafted request, and every entry costs an hr.applicant.skill insert.
+    _max_submitted_skills = 50
+
+    def _handle_website_form(self, model_name, **kwargs):
+        # This handler serves every form-enabled model, so without this guard a
+        # submission to any other form carrying `skill_ids` would attach skills
+        # to whatever record it had just created.
+        if model_name != 'hr.applicant':
+            return super()._handle_website_form(model_name, **kwargs)
+
+        # The skill *type* checkboxes are submitted too, hidden and under the
+        # field's own name, but hold nothing the applicant record needs.
+        kwargs.pop('applicant_skill_ids', None)
+        # dict.fromkeys drops duplicates while keeping the submitted order. Two
+        # rows for one skill violate the "one active skill per skill_id" rule in
+        # hr.individual.skill.mixin, and that rollback would take the whole
+        # application with it.
+        skill_ids = list(dict.fromkeys(
+            int(s) for s in kwargs.pop('skill_ids', '').split(',') if s.strip().isdigit()
+        ))[:self._max_submitted_skills]
+
+        res = super()._handle_website_form(model_name, **kwargs)
+        if not skill_ids:
+            return res
+        # super() answers with {'error': ...}, {'error_fields': ...} or plain
+        # False on its failure paths, so there is not always an id to attach to.
+        result = json.loads(res)
+        if not isinstance(result, dict) or 'id' not in result:
+            return res
+
+        values = []
+        for skill in request.env['hr.skill'].sudo().browse(skill_ids).exists():
+            # `skill_level_id` is required and its compute on
+            # `hr.individual.skill.mixin` only runs after the insert, so give it
+            # the same value as the mixin would: the level flagged as
+            # `default_level`, or the first one of the skill type.
+            skill_level = (
+                skill.skill_type_id.skill_level_ids.filtered('default_level')[:1]
+                or skill.skill_type_id.skill_level_ids[:1]
+            )
+            values.append({
+                'applicant_id': result['id'],
+                'skill_id': skill.id,
+                'skill_type_id': skill.skill_type_id.id,
+                'skill_level_id': skill_level.id,
+            })
+        if values:
+            request.env['hr.applicant.skill'].sudo().create(values)
+        return res

--- a/addons/website_hr_recruitment_skills/data/config_data.xml
+++ b/addons/website_hr_recruitment_skills/data/config_data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <function model="ir.model.fields" name="formbuilder_whitelist">
+            <value>hr.applicant</value>
+            <value eval="[
+                'email_from',
+                'partner_name',
+                'partner_phone',
+                'job_id',
+                'department_id',
+                'linkedin_profile',
+                'applicant_properties',
+                'applicant_skill_ids'
+            ]"/>
+        </function>
+    </data>
+</odoo>

--- a/addons/website_hr_recruitment_skills/data/config_data.xml
+++ b/addons/website_hr_recruitment_skills/data/config_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <function model="ir.model.fields" name="formbuilder_whitelist">
+            <value>hr.applicant</value>
+            <value eval="['applicant_skill_ids']"/>
+        </function>
+    </data>
+</odoo>

--- a/addons/website_hr_recruitment_skills/models/__init__.py
+++ b/addons/website_hr_recruitment_skills/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_model

--- a/addons/website_hr_recruitment_skills/models/__init__.py
+++ b/addons/website_hr_recruitment_skills/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_applicant

--- a/addons/website_hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/website_hr_recruitment_skills/models/hr_applicant.py
@@ -1,0 +1,22 @@
+from odoo import api, models
+
+
+class HrApplicant(models.Model):
+    _inherit = 'hr.applicant'
+
+    @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        result = super().fields_get(allfields, attributes)
+        if skills := result.get('applicant_skill_ids'):
+            skills['type'] = 'one2many_skill'
+
+            skill_types = self.env["hr.skill.type"].search_read([], ["id", "display_name", "skill_ids"])
+            all_skills = self.env["hr.skill"].search_read([], ["id", "display_name", "skill_type_id"])
+            skill_map = {s["id"]: s for s in all_skills}
+
+            for stype in skill_types:
+                stype["skill_ids"] = [skill_map[sid] for sid in stype.get("skill_ids", []) if sid in skill_map]
+
+            skills['skill_types'] = skill_types
+            skills['selectedSkills'] = []
+        return result

--- a/addons/website_hr_recruitment_skills/models/ir_model.py
+++ b/addons/website_hr_recruitment_skills/models/ir_model.py
@@ -1,0 +1,46 @@
+from odoo import api, models
+
+
+class IrModel(models.Model):
+    _inherit = 'ir.model'
+
+    @api.model
+    def get_authorized_fields(self, model_name, property_origins):
+        """ Expose `applicant_skill_ids` to the website form builder as a
+        dedicated `one2many_skill` pseudo-type.
+
+        The website form builder and the frontend both rely on the field type
+        reported here:
+
+        - the frontend renders a field with the `website.form_field_<type>`
+          template, so the pseudo-type is what selects
+          `website.form_field_one2many_skill` (a checkbox grid of the skills of
+          the selected skill types, submitted through the `skill_ids` inputs)
+          instead of the generic one2many widget;
+        - `WebsiteForm._input_filters` maps that pseudo-type back to the
+          regular one2many filter to sanitize the submitted values;
+        - the form builder options read `skill_types` to list the available
+          skill types (with their skills) in the sidebar, and `selectedSkills`
+          to keep track of the skills of the selected types.
+
+        This is done here rather than in `hr.applicant.fields_get` so that the
+        pseudo-type stays confined to the form builder: the backend keeps
+        seeing a plain one2many, and no extra query is made outside of the
+        website.
+        """
+        result = super().get_authorized_fields(model_name, property_origins)
+        if model_name != 'hr.applicant':
+            return result
+        if skills := result.get('applicant_skill_ids'):
+            skills['type'] = 'one2many_skill'
+
+            skill_types = self.env["hr.skill.type"].search_read([], ["id", "display_name", "skill_ids"])
+            all_skills = self.env["hr.skill"].search_read([], ["id", "display_name", "skill_type_id"])
+            skill_map = {s["id"]: s for s in all_skills}
+
+            for stype in skill_types:
+                stype["skill_ids"] = [skill_map[sid] for sid in stype.get("skill_ids", []) if sid in skill_map]
+
+            skills['skill_types'] = skill_types
+            skills['selectedSkills'] = []
+        return result

--- a/addons/website_hr_recruitment_skills/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website_hr_recruitment_skills/static/src/builder/plugins/form/form_option_plugin.js
@@ -1,0 +1,38 @@
+import { FormOptionPlugin, SetFormCustomFieldValueListAction } from "@website/builder/plugins/form/form_option_plugin";
+import { patch } from "@web/core/utils/patch";
+import { getActiveField, getSelect } from "@website/builder/plugins/form/utils";
+
+patch(FormOptionPlugin.prototype, {
+    async _fetchFieldRecords(field) {
+        if (!field) {
+            return super._fetchFieldRecords(field)
+        }
+        if (field.field.name === "applicant_skill_ids") {
+            return field.field.skill_types;
+        }
+        return super._fetchFieldRecords(field);
+    },
+});
+
+patch(SetFormCustomFieldValueListAction.prototype, {
+    async apply({ editingElement: fieldEl, value, loadResult: fields }) {
+        const field = getActiveField(fieldEl, { fields });
+        if (field.name !== "applicant_skill_ids") {
+            return await super.apply(...arguments);
+        }
+
+        let valueList = JSON.parse(value);
+        if (getSelect(fieldEl)) {
+            valueList = valueList.filter(v => v.id || v.display_name);
+            const hasDefault = valueList.some(v => v.selected);
+            if (valueList.length && !hasDefault) {
+                valueList.unshift({ id: "", display_name: "", selected: true });
+            }
+        }
+
+        field.records = valueList;
+        const selectedTypeIds = valueList.filter(tp => tp.selected).map(tp => tp.id);
+        field.selectedSkills = field.skill_types.filter(tp => selectedTypeIds.includes(tp.id)).flatMap(tp => tp.skill_ids);
+        this.dependencies.websiteFormOption.replaceField(fieldEl, field, fields);
+    },
+});

--- a/addons/website_hr_recruitment_skills/static/src/xml/website_form_editor.xml
+++ b/addons/website_hr_recruitment_skills/static/src/xml/website_form_editor.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <!-- One2Many Skill Field -->
+    <t t-name="website.form_field_one2many_skill">
+        <t t-call="website.form_field">
+            <t t-if="!field.records || field.records.length === 0">
+                <input
+                    class="disabled form-control s_website_form_multiple s_website_form_input"
+                    t-att-name="field.name"
+                    t-att-data-name="field.name"
+                    t-att-value="undefined"
+                    t-att-required="field.required || field.modelRequired || None"
+                    placeholder="No selected categories!"
+                    disabled=""
+                />
+            </t>
+            <t t-else="">
+                <div class="d-none row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" t-att-data-name="field.name" t-att-data-display="field.formatInfo.multiPosition">
+                    <t t-foreach="field.records" t-as="record" t-key="record_index">
+                        <t t-set="recordId" t-value="field.id + record_index"/>
+                        <div t-attf-class="checkbox col-12 #{field.formatInfo.multiPosition === 'horizontal' and 'col-lg-4 col-md-6' or ''}">
+                            <div class="form-check">
+                                <input
+                                    type="checkbox"
+                                    class="s_website_form_input form-check-input"
+                                    t-att-id="recordId"
+                                    t-att-name="field.name"
+                                    t-att="{checked: record.selected and 'checked' or None}"
+                                    t-att-value="record.id"
+                                    t-att-required="field.required || field.modelRequired || None"
+                                />
+                                <label class="form-check-label s_website_form_check_label" t-att-for="recordId">
+                                    <t t-out="record.display_name"/>
+                                </label>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+                <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_skills s_col_no_bgcolor s_website_form_multiple">
+                    <t t-foreach="field.selectedSkills" t-as="record" t-key="record_index">
+                        <t t-set="recordId" t-value="field.id + record_index"/>
+                        <div t-attf-class="horizontal col-lg-4 col-md-6">
+                            <div class="form-check">
+                                <input
+                                    type="checkbox"
+                                    class="s_website_form_input form-check-input"
+                                    t-att-id="recordId"
+                                    t-att-name="'skill_ids'"
+                                    t-att="{checked: record.selected and 'checked' or None}"
+                                    t-att-value="record.id"
+                                    t-att-required="field.required || field.modelRequired || None"
+                                />
+                                <label class="form-check-label s_website_form_check_label" t-att-for="recordId">
+                                    <t t-out="record.display_name"/>
+                                </label>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </t>
+    </t>
+</templates>

--- a/addons/website_hr_recruitment_skills/static/src/xml/website_form_editor.xml
+++ b/addons/website_hr_recruitment_skills/static/src/xml/website_form_editor.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <!-- One2Many Skill Field -->
+    <t t-name="website.form_field_one2many_skill">
+        <t t-call="website.form_field">
+            <t t-if="!field.records || field.records.length === 0">
+                <input
+                    class="disabled form-control s_website_form_multiple s_website_form_input"
+                    t-att-name="field.name"
+                    t-att-data-name="field.name"
+                    t-att-value="undefined"
+                    t-att-required="field.required || field.modelRequired || None"
+                    placeholder="No selected categories!"
+                    disabled=""
+                />
+            </t>
+            <t t-else="">
+                <div class="d-none row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" t-att-data-name="field.name" t-att-data-display="field.formatInfo.multiPosition">
+                    <t t-foreach="field.records" t-as="record" t-key="record_index">
+                        <t t-set="recordId" t-value="field.id + record_index"/>
+                        <div t-attf-class="checkbox col-12 #{field.formatInfo.multiPosition === 'horizontal' and 'col-lg-4 col-md-6' or ''}">
+                            <div class="form-check">
+                                <input
+                                    type="checkbox"
+                                    class="s_website_form_input form-check-input"
+                                    t-att-id="recordId"
+                                    t-att-name="field.name"
+                                    t-att="{checked: record.selected and 'checked' or None}"
+                                    t-att-value="record.id"
+                                    t-att-required="field.required || field.modelRequired || None"
+                                />
+                                <label class="form-check-label s_website_form_check_label" t-att-for="recordId">
+                                    <t t-out="record.display_name"/>
+                                </label>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+                <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_skills s_col_no_bgcolor s_website_form_multiple">
+                    <t t-foreach="field.selectedSkills" t-as="record" t-key="record_index">
+                        <t t-set="recordId" t-value="field.id + '_skill_' + record_index"/>
+                        <div t-attf-class="horizontal col-lg-4 col-md-6">
+                            <div class="form-check">
+                                <input
+                                    type="checkbox"
+                                    class="s_website_form_input form-check-input"
+                                    t-att-id="recordId"
+                                    t-att-name="'skill_ids'"
+                                    t-att="{checked: record.selected and 'checked' or None}"
+                                    t-att-value="record.id"
+                                    t-att-required="field.required || field.modelRequired || None"
+                                />
+                                <label class="form-check-label s_website_form_check_label" t-att-for="recordId">
+                                    <t t-out="record.display_name"/>
+                                </label>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+        </t>
+    </t>
+</templates>

--- a/addons/website_hr_recruitment_skills/static/tests/tours/website_hr_recruitment_skills.js
+++ b/addons/website_hr_recruitment_skills/static/tests/tours/website_hr_recruitment_skills.js
@@ -1,0 +1,96 @@
+import { registry } from "@web/core/registry";
+import {
+    clickOnEditAndWaitEditMode,
+    clickOnSave,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add('website_hr_recruitment_skills_tour', {
+    steps: () => [{
+        content: "Select Job",
+        trigger: `.oe_website_jobs h3:contains(Guru)`,
+        run: "click",
+        expectUnloadPage: true,
+    }, {
+        content: "Apply",
+        trigger: ".js_hr_recruitment a:contains(Apply)",
+        run: "click",
+        expectUnloadPage: true,
+    }, {
+        content: "Complete name",
+        trigger: "input[name=partner_name]",
+        run: `edit John Smith`,
+    }, {
+        content: "Complete Email",
+        trigger: "input[name=email_from]",
+        run: `edit john@smith.com`,
+    }, {
+        content: "Complete phone number",
+        trigger: "input[name=partner_phone]",
+        run: `edit 118.218`,
+    }, {
+        content: "Complete LinkedIn profile",
+        trigger: "input[name=linkedin_profile]",
+        run: `edit linkedin.com/in/john-smith`,
+    }, {
+        content: "Complete Skills",
+        trigger: "input[name=skill_ids]",
+        run: "click"
+    }, {
+        content: "Send the form",
+        trigger: ".s_website_form_send",
+        run: "click",
+        expectUnloadPage: true,
+    }, {
+        content: "Check the form is submitted without errors",
+        trigger: "#jobs_thankyou h1:contains('Congratulations')",
+    }],
+});
+
+registerWebsitePreviewTour('website_hr_recruitment_skills_tour_edit_form', {}, () => [
+    stepUtils.waitIframeIsReady(),
+{
+    content: 'Go to the Guru job page',
+    trigger: ':iframe a[href*="guru"]',
+    run: "click",
+}, {
+    content: 'Go to the Guru job form',
+    trigger: ':iframe a[href*="apply"]',
+    run: "click",
+}, {
+    content: 'Check if the Guru form is present',
+    trigger: ':iframe form',
+    run: "click",
+},
+...clickOnEditAndWaitEditMode(),
+{
+    content: "Click on the form to select it",
+    trigger: ":iframe .s_website_form form",
+    run: "click",
+},
+{
+    content: "Click on add field button",
+    trigger: ".options-container-header button:contains('+ Field')",
+    run: "click",
+},
+{
+    content: "Select field type as Skills",
+    trigger: "[data-container-title=Field] [data-action-value=applicant_skill_ids]:not(:visible)",
+    run: "click",
+},
+{
+    content: "Enable the first skill in the list",
+    trigger: "[data-container-title=Field] .o_we_table_wrapper input[type='checkbox']",
+    run: "click",
+},
+...clickOnSave(),
+{
+    content: "wait for the form values are patched",
+    trigger: ":iframe form input[name=partner_name]:value(admin)",
+},
+{
+    content: 'Go back to /jobs page after save',
+    trigger: ":iframe nav a[href='/jobs']",
+    run: "click",
+}]);

--- a/addons/website_hr_recruitment_skills/static/tests/tours/website_hr_recruitment_skills.js
+++ b/addons/website_hr_recruitment_skills/static/tests/tours/website_hr_recruitment_skills.js
@@ -1,0 +1,44 @@
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+import "@website_hr_recruitment/../tests/tours/website_hr_recruitment";
+
+patch(registry.category("web_tour.tours").get("website_hr_recruitment_tour_edit_form"), {
+    steps() {
+        const originalSteps = super.steps();
+        const editStepIndex = originalSteps.findIndex(
+            (step) => step.id === "set_job_id_default"
+        );
+        originalSteps.splice(editStepIndex, 0, {
+            content: "Click on the form to select it",
+            trigger: ":iframe .s_website_form form",
+            run: "click",
+        }, {
+            content: "Click on add field button",
+            trigger: ".options-container-header button:contains('+ Field')",
+            run: "click",
+        }, {
+            content: "Select field type as Skills",
+            trigger: "[data-container-title=Field] [data-action-value=applicant_skill_ids]:not(:visible)",
+            run: "click",
+        }, {
+            content: "Enable the first skill type in the list",
+            trigger: "[data-container-title=Field] .o_we_table_wrapper input[type='checkbox']",
+            run: "click",
+        });
+        return originalSteps;
+    },
+});
+
+patch(registry.category("web_tour.tours").get("website_hr_recruitment_tour"), {
+    steps() {
+        const originalSteps = super.steps();
+        // The skills field has only been added on the Guru job form.
+        const sendFormStepIndex = originalSteps.findIndex((step) => step.id === "send_form_guru");
+        originalSteps.splice(sendFormStepIndex, 0, {
+            content: "Complete Skills",
+            trigger: "input[name=skill_ids]",
+            run: "click",
+        });
+        return originalSteps;
+    },
+});

--- a/addons/website_hr_recruitment_skills/tests/__init__.py
+++ b/addons/website_hr_recruitment_skills/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_website_hr_recruitment_skills

--- a/addons/website_hr_recruitment_skills/tests/test_website_hr_recruitment_skills.py
+++ b/addons/website_hr_recruitment_skills/tests/test_website_hr_recruitment_skills.py
@@ -1,0 +1,17 @@
+import odoo.tests
+
+
+class TestWebsiteHrRecruitmentSkillsForm(odoo.tests.HttpCase):
+    def test_tour_website_recruitment_skills(self):
+        department = self.env['hr.department'].create({'name': 'guru team'})
+        self.env['hr.job'].create({
+            'name': 'Guru',
+            'is_published': True,
+            'department_id': department.id,
+        })
+        self.start_tour(self.env['website'].get_client_action_url('/jobs'), 'website_hr_recruitment_skills_tour_edit_form', login='admin')
+        with odoo.tests.RecordCapturer(self.env['hr.applicant']) as capt:
+            self.start_tour("/jobs", 'website_hr_recruitment_skills_tour')
+        # check result the applicant has a skills attached
+        self.assertEqual(len(capt.records), 1)
+        self.assertEqual(len(capt.records.applicant_skill_ids), 1)

--- a/addons/website_hr_recruitment_skills/tests/test_website_hr_recruitment_skills.py
+++ b/addons/website_hr_recruitment_skills/tests/test_website_hr_recruitment_skills.py
@@ -1,0 +1,76 @@
+import odoo.tests
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestWebsiteHrRecruitmentSkillsForm(odoo.tests.HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.skill_type = cls.env['hr.skill.type'].create({
+            'name': 'Programming',
+            'skill_ids': [
+                (0, 0, {'name': 'Python', 'sequence': 1}),
+                (0, 0, {'name': 'JavaScript', 'sequence': 2}),
+            ],
+            'skill_level_ids': [
+                (0, 0, {'name': 'Beginner', 'level_progress': 10}),
+                (0, 0, {'name': 'Good', 'level_progress': 50, 'default_level': True}),
+            ],
+        })
+        cls.skill_a, cls.skill_b = cls.skill_type.skill_ids
+        cls.job = cls.env['hr.job'].create({'name': 'Developer', 'is_published': True})
+
+    def _apply(self, **values):
+        """ Post an application on the published job as a public visitor. """
+        self.authenticate(None, None)
+        return self.url_open('/website/form/hr.applicant', data={
+            'partner_name': 'John Smith',
+            'email_from': 'john@smith.com',
+            'partner_phone': '118.218',
+            'job_id': self.job.id,
+            **values,
+        })
+
+    def _applicant(self, response):
+        return self.env['hr.applicant'].browse(response.json().get('id'))
+
+    def test_apply_job_with_skills(self):
+        """ The skills selected on the website form are linked to the applicant.
+
+        The form itself (adding the skills field in the editor and filling it as
+        an applicant) is covered by the steps patched onto the
+        `website_hr_recruitment` tours.
+        """
+        applicant = self._applicant(self._apply(
+            skill_ids=f'{self.skill_a.id},{self.skill_b.id}',
+        ))
+        self.assertEqual(applicant.applicant_skill_ids.skill_id, self.skill_a + self.skill_b)
+        self.assertEqual(
+            applicant.applicant_skill_ids.skill_level_id,
+            self.skill_type.skill_level_ids.filtered('default_level'),
+            "The default level of the skill type should be set on the applicant skills",
+        )
+
+    def test_duplicate_skill_ids_do_not_lose_the_application(self):
+        """ One active skill per skill_id is enforced by hr.individual.skill.mixin.
+
+        Two rows for the same skill raise, and that rollback takes the applicant
+        record with it, so duplicates have to be dropped before the insert.
+        """
+        applicant = self._applicant(self._apply(
+            skill_ids=f'{self.skill_a.id},{self.skill_a.id}',
+        ))
+        self.assertTrue(applicant.exists(), "the application must survive a duplicated checkbox")
+        self.assertEqual(applicant.applicant_skill_ids.skill_id, self.skill_a)
+
+    def test_a_failed_submission_still_reports_its_error(self):
+        """ super() returns {'error_fields': ...} rather than an id on failure.
+
+        Reading ['id'] unconditionally turned a clean validation response into a
+        500 whenever skills were part of the submission.
+        """
+        response = self._apply(job_id='not-an-id', skill_ids=str(self.skill_a.id))
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertNotIn('id', payload)
+        self.assertTrue(payload.get('error') or payload.get('error_fields'), payload)


### PR DESCRIPTION
Replaces the manual skill list on the job apply page with a dynamic list fetched from `hr.skill` and hr.skill.type. Selecting a category displays all related skills.

task-4781017
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
