### PR TITLE
[FIX] base: handle translated attributes as DOM elements in t-call

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2042,7 +2042,10 @@ class IrQweb(models.AbstractModel):
                 code.append(indent_code(f"values[{varname!r}] = {self._compile_format(exprf)}", level))
             elif 't-valuef.translate' in el.attrib:
                 exprf = el.attrib.pop('t-valuef.translate')
-                code.append(indent_code(f"values[{varname!r}] = {self._compile_format(exprf)}", level))
+                if self.env.context.get('edit_translations'):
+                    code.append(indent_code(f"values[{varname!r}] = Markup({self._compile_format(exprf)})", level))
+                else:
+                    code.append(indent_code(f"values[{varname!r}] = {self._compile_format(exprf)}", level))
             elif varname[0] == '{':
                 code.append(indent_code(f"values.update({self._compile_expr(varname)})", level))
             else:
@@ -2577,10 +2580,17 @@ class IrQweb(models.AbstractModel):
 
         # args to values
         for key in list(el.attrib):
-            if key.endswith(('.f', '.translate')):
-                name = key.removesuffix(".f").removesuffix(".translate")
+            if key.endswith('.f'):
+                name = key.removesuffix(".f")
                 value = el.attrib.pop(key)
                 code.append(indent_code(f"t_call_values[{name!r}] = {self._compile_format(value)}", level))
+            elif key.endswith('.translate'):
+                name = key.removesuffix(".f").removesuffix(".translate")
+                value = el.attrib.pop(key)
+                if self.env.context.get('edit_translations'):
+                    code.append(indent_code(f"t_call_values[{name!r}] = Markup({self._compile_format(value)})", level))
+                else:
+                    code.append(indent_code(f"t_call_values[{name!r}] = {self._compile_format(value)}", level))
             elif not key.startswith('t-'):
                 value = el.attrib.pop(key)
                 code.append(indent_code(f"t_call_values[{key!r}] = {self._compile_expr(value)}", level))

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -1525,23 +1525,24 @@ class TestXMLTranslation(TransactionCase):
         self.env['ir.ui.view'].create({
             'type': 'qweb',
             'key': 'test',
-            'arch': '<t t-out="placeholder"/>',
+            'arch': '<button><t t-out="placeholder"/></button>',
         })
         view0 = self.env['ir.ui.view'].with_context(lang='fr_FR', edit_translations=True).create({
             'type': 'qweb',
             'arch': '<t t-call="test" placeholder="hello"/>',
         })
-        self.assertEqual(view0._render_template(view0.id, {'hello': 'world'}), 'world')
+        self.assertEqual(view0._render_template(view0.id, {'hello': 'world'}), '<button>world</button>')
         self.assertEqual(view0.arch_db, '<t t-call="test" placeholder="hello"/>')
 
         view0.arch = '<t t-call="test" placeholder.translate="hello"/>'
         translate_node = (
-            f'&lt;span data-oe-model=&#34;ir.ui.view&#34; data-oe-id=&#34;{view0.id}&#34;'
-            ' data-oe-field=&#34;arch_db&#34; data-oe-translation-state=&#34;to_translate&#34;'
-            ' data-oe-translation-source-sha=&#34;2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824&#34;&gt;hello&lt;/span&gt;'
+            f'<span data-oe-model="ir.ui.view" data-oe-id="{view0.id}"'
+            ' data-oe-field="arch_db" data-oe-translation-state="to_translate"'
+            ' data-oe-translation-source-sha="2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824">hello</span>'
         )
-        self.assertEqual(view0._render_template(view0.id), translate_node)
-        self.assertEqual(view0.arch_db, f'<t t-call="test" placeholder.translate="{translate_node.replace("&#34;", "&quot;")}"/>')
+        self.assertEqual(view0._render_template(view0.id), f'<button>{translate_node}</button>')
+        translate_attr = translate_node.replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+        self.assertEqual(view0.arch_db, f'<t t-call="test" placeholder.translate="{translate_attr}"/>')
 
     def test_update_field_translations_source_lang(self):
         """ call update_field_translations with source_lang """


### PR DESCRIPTION
Following the semantic change in QWeb `t-call`, node attributes are now treated as function arguments. Previously, these were defined via `t-set`, which produced QwebContent capable of holding XML/HTML.

When `edit_translations` is active, translated strings are wrapped in `<span>` tags containing translation metadata. To maintain backward compatibility and allow in-place translation, values from `.translate` attributes are now explicitly marked as Markup safe elements. This ensures that the translation wrappers are correctly rendered as HTML rather than escaped text.

Exemple:
```xml
<t t-call="payment.submit_button">
    <button><t t-out="submit_button_label"/></button>
</t>

<t t-name="payment.mytemplate">
    <div class="modal-body">
        <div class="float-end mt-2" t-att-data-provider-id="provider_sudo.id">
            <t t-call="payment.submit_button" submit_button_label.translate="Pay"/>
        </div>
    </div>
</t>
```
When reading the views, `submit_button_label` value must be translated. We We want the button to be rendered with the translated value and not to display the escaped char like "<".

see: https://github.com/odoo-dev/odoo/commit/eb6e88a25050fff2bd09317739dd51ba451450df

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
