### PR TITLE
[FIX] html_builder, website: disable non-custom website form option list editing

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -36,6 +36,7 @@ export class BuilderList extends Component {
         records: { type: String, optional: true },
         defaultNewValue: { type: Object, optional: true },
         forbidLastItemRemoval: { type: Boolean, optional: true },
+        isInputDisabled: { type: Boolean, optional: true },
     };
     static defaultProps = {
         addItemTitle: _t("Add"),
@@ -46,6 +47,7 @@ export class BuilderList extends Component {
         mode: "button",
         defaultNewValue: {},
         forbidLastItemRemoval: false,
+        isInputDisabled: false,
     };
     static components = { BuilderComponent, Dropdown };
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -34,6 +34,7 @@
                                                     t-att-name="entry[0]"
                                                     t-att-value="item[entry[0]]"
                                                     t-att-data-id="item._id"
+                                                    t-att-disabled="props.isInputDisabled"
                                                     t-on-input="onInput"
                                                     t-on-change="onChange"
                                             />

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -226,7 +226,8 @@
                 default="{ display_name: state.valueList.defaultItemName, selected: false }"
                 defaultNewValue="{ id: state.valueList.defaultItemName }"
                 forbidLastItemRemoval="true"
-                records="state.valueList.availableRecords" />
+                records="state.valueList.availableRecords"
+                isInputDisabled="state.valueList.isInputDisabled" />
         </div>
     </BuilderRow>
     <BuilderRow label.translate="Visibility">

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -715,6 +715,7 @@ export class FormOptionPlugin extends Plugin {
                 defaults: JSON.stringify(defaults),
                 availableRecords: availableRecords,
                 newRecordId: isFieldCustom(fieldEl) ? getNewRecordId(fieldEl) : "",
+                isInputDisabled: !isFieldCustom(fieldEl),
             });
         }
         return {

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -467,3 +467,71 @@ test("Label falls back to default value (data-translated-name) when removed", as
         "Default value"
     );
 });
+
+test("Option list input editing is disabled for non-custom forms", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    const { getEditor } = await setupWebsiteBuilder(
+        `<section class="s_website_form"><form data-model_name="mail.mail">
+            <div data-name="Field" class="s_website_form_field mb-3 col-12" data-type="many2one">
+                <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <label class="col-form-label col-sm-auto s_website_form_label" for="ozp7023vqhe">
+                        <span class="s_website_form_label_content">Selection Field</span>
+                    </label>
+                    <div class="col-sm">
+                        <select class="form-select s_website_form_input" name="Phone Number" id="ozp7023vqhe">
+                            <option id="ozp7023vqhe0" value="Option 1">Option 1</option>
+                            <option id="ozp7023vqhe1" value="Option 2">Option 2</option>
+                            <option id="ozp7023vqhe2" value="Option 3">Option 3</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="s_website_form_submit">
+                <div class="s_website_form_label"/>
+                <a>Submit</a>
+            </div>
+        </form></section>`
+    );
+    getEditor();
+    await contains(":iframe .s_website_form_field").click();
+    expect(".options-container[data-container-title='Field'] .we-bg-options-container").toHaveCount(1);
+
+    const inputs = [...document.querySelectorAll('.hb-row')]
+        .find(el => el.textContent.includes('Option List'))
+        .querySelectorAll('.o-hb-input-base');
+    expect([...inputs].every(input => input.disabled)).toBe(true);
+});
+
+test("Option list input editing is enabled for custom forms", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    const { getEditor } = await setupWebsiteBuilder(
+        `<section class="s_website_form"><form data-model_name="mail.mail">
+            <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="many2one">
+                <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <label class="col-form-label col-sm-auto s_website_form_label" for="ozp7023vqhe">
+                        <span class="s_website_form_label_content">Selection Field</span>
+                    </label>
+                    <div class="col-sm">
+                        <select class="form-select s_website_form_input" name="Phone Number" id="ozp7023vqhe">
+                            <option id="ozp7023vqhe0" value="Option 1">Option 1</option>
+                            <option id="ozp7023vqhe1" value="Option 2">Option 2</option>
+                            <option id="ozp7023vqhe2" value="Option 3">Option 3</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="s_website_form_submit">
+                <div class="s_website_form_label"/>
+                <a>Submit</a>
+            </div>
+        </form></section>`
+    );
+    getEditor();
+    await contains(":iframe .s_website_form_field").click();
+    expect(".options-container[data-container-title='Field'] .we-bg-options-container").toHaveCount(1);
+
+    const inputs = [...document.querySelectorAll('.hb-row')]
+        .find(el => el.textContent.includes('Option List'))
+        .querySelectorAll('.o-hb-input-base');
+    expect([...inputs].every(input => input.disabled)).toBe(false);
+});


### PR DESCRIPTION
Currently an error is generated when a user tries to submit their website
form, which is created as follows:

- Install `website_helpdesk`
- On the website, add a new form component with action as `Create a Ticket`
- Add an existing field `Priority` on the form and edit the first
  option `Low priority` as `Low` and save the component
- An error will be generated when the user submits the form with
  the edited option `Low`

Error: `ValueError: Wrong value for helpdesk.ticket.priority: 'High'`

This error occurs when a user edits an option and the modified value does
not exist in the field. In earlier versions, this issue did not arise because
users were not allowed to edit options of existing fields. However, after the
recent changes introduced in commit [1], the website builder was rewritten
using Owl and the new HTML editor. As a result, this scenario is no longer
handled correctly, which leads to the error.

This commit will fix the above issue by disabling the editing options when
the form field is an existing field.


[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Sentry-7175566174