### PR TITLE
[IMP] hr: Display first contract date on Kanban

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -212,6 +212,8 @@ class HrEmployee(models.Model):
         ("other", "Other")], compute="_compute_work_location_type", tracking=True)
 
     # All version fields needing a specific group to be accessible should also have `inherited=True` set on its definition to make sure those fields are linked to `_inherits` on `hr.version`
+    first_contract_date = fields.Date(compute='_compute_first_contract_date', groups="hr.group_hr_manager", store=True,
+                                    help="The date of the first contract of the employee in the company.")
     contract_date_start = fields.Date(readonly=False, related="version_id.contract_date_start", inherited=True, groups="hr.group_hr_manager")
     contract_date_end = fields.Date(readonly=False, related="version_id.contract_date_end", inherited=True, groups="hr.group_hr_manager")
     trial_date_end = fields.Date(readonly=False, related="version_id.trial_date_end", inherited=True, groups="hr.group_hr_manager")
@@ -562,6 +564,11 @@ class HrEmployee(models.Model):
             ('doctor', self.env._('Doctor')),
             ('other', self.env._('Other')),
         ]
+
+    @api.depends('version_ids.contract_date_start')
+    def _compute_first_contract_date(self):
+        for employee in self:
+            employee.first_contract_date = employee._get_first_contract_date()
 
     def _get_first_versions(self):
         self.ensure_one()

--- a/addons/hr/tests/test_hr_version.py
+++ b/addons/hr/tests/test_hr_version.py
@@ -814,3 +814,67 @@ class TestHrVersion(TestHrCommon):
         self.assertEqual(len(employee.version_ids), 2)
         version.unlink()
         self.assertEqual(len(employee.version_ids), 1)
+
+    def test_first_contract_date_on_create(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'Youssef Ahmed',
+            'date_version': '2026-01-01',
+            'contract_date_start': '2026-01-01',
+        })
+
+        self.assertEqual(employee.first_contract_date, date(2026, 1, 1), "First contract date should be 2026-01-01 when creating an employee with a single contract.")
+
+    def test_first_contract_date_with_new_version(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'Youssef Ahmed',
+            'date_version': '2026-01-01',
+            'contract_date_start': '2026-01-01',
+        })
+
+        employee.create_version({
+            'date_version': '2026-02-01',
+        })
+
+        self.assertEqual(employee.first_contract_date, date(2026, 1, 1))
+
+    def test_first_contract_date_with_new_contract(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'Youssef Ahmed',
+            'date_version': '2026-01-01',
+            'contract_date_start': '2026-01-01',
+            'contract_date_end': '2026-01-31',
+        })
+
+        employee.create_version({
+            'date_version': '2026-02-01',
+            'contract_date_start': '2026-02-01',
+            'contract_date_end': '2026-02-28',
+        })
+
+        employee.create_version({
+            'date_version': '2026-03-01',
+            'contract_date_start': '2026-03-01',
+        })
+
+        self.assertEqual(employee.first_contract_date, date(2026, 1, 1))
+
+    def test_first_contract_date_with_unlink_versions(self):
+        employee = self.env['hr.employee'].create({
+            'name': 'Youssef Ahmed',
+        })
+
+        version_1 = employee.create_version({
+            'date_version': '2026-01-01',
+            'contract_date_start': '2026-01-01',
+            'contract_date_end': '2026-01-31',
+        })
+        employee.create_version({
+            'date_version': '2026-02-01',
+            'contract_date_start': '2026-02-01',
+        })
+
+        self.assertEqual(employee.first_contract_date, date(2026, 1, 1))
+
+        version_1.unlink()
+
+        self.assertEqual(employee.first_contract_date, date(2026, 2, 1))

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -703,9 +703,9 @@
                                     <i class="fa fa-fw me-2 fa-phone text-primary" title="Phone"/>
                                     <field name="work_phone" />
                                 </div>
-                                <div t-if="record.contract_date_start.raw_value" groups="hr.group_hr_manager" t-att-class="{'text-danger': record.contract_date_end.raw_value &lt; luxon.DateTime.now().toISO()}">
+                                <div t-if="record.first_contract_date.raw_value" groups="hr.group_hr_manager" t-att-class="{'text-danger': record.contract_date_end.raw_value &lt; luxon.DateTime.now().toISO()}">
                                     <i class="fa fa-fw me-2 fa-briefcase text-primary" title="Contract"/>
-                                    <field name="contract_date_start"/>
+                                    <field name="first_contract_date"/>
                                     <span t-if="record.contract_date_end.raw_value"> - </span>
                                     <field t-if="record.contract_date_end.raw_value" name="contract_date_end"/>
                                 </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On kanban, you see the start_contract_date of the latest version, but it should be the first contract date in the company

Current behavior before PR:

Desired behavior after PR is merged:
. Display first contract date start on Employee Kanban view instead of start contract date of the latest version


task-5481072

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
