### PR TITLE
[FIX] web: Allow new lines in tree view tooltip strings

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -379,8 +379,10 @@
     </t>
 
     <t t-name="web.ListHeaderTooltip">
-        <t t-esc="field.label"/>
-        <div t-if="field.help" class="mt-2 o-tooltip--string" t-esc="field.help"/>
+        <div class="o-tooltip--string">
+            <t t-esc="field.label"/>
+            <div t-if="field.help" class="mt-2" t-esc="field.help"/>
+        </div>
     </t>
 
 </templates>


### PR DESCRIPTION
Tooltip `label` and `help` appear on the same line because the `o-tooltip--string` on the `help` make it display inline.

Move `o-tooltip--string` to be on the entire component instead.

reference comment: https://github.com/odoo/odoo/pull/243295#issuecomment-3742599307

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
