### PR TITLE
[IMP] base_import_module: add version to count modules

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -494,7 +494,7 @@ class IrModuleModule(models.Model):
         import requests  # noqa: PLC0415
         try:
             resp = requests.post(
-                f"{APPS_URL}/loempia/listindustrycategory",
+                f"{APPS_URL}/loempia/listindustrycategory/{major_version}",
                 json={'params': {}},
                 timeout=5.0,
             )


### PR DESCRIPTION
Before this commit, the count of industry modules by category in Apps application was always 0. With the change of API of apps.odoo.com, there is a possibility to display the exact count by category.

In this aim, this commit adds the version to the route arguments such that the count is correctly displayed.

task-5222706