### PR TITLE
[IMP] {mrp_}product_expiry*: show expiry and removal dates on quant list

### DIFF
--- a/addons/mrp_product_expiry/models/mrp_production.py
+++ b/addons/mrp_product_expiry/models/mrp_production.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, _
+from odoo import Command, _, models
 
 
 class MrpProduction(models.Model):
@@ -18,8 +18,8 @@ class MrpProduction(models.Model):
         # user already confirmed the wizard about using expired lots.
         if self.env.context.get('skip_expired'):
             return False
-        expired_lot_ids = self.move_raw_ids.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert).lot_id.ids
-        if expired_lot_ids:
+        expired_move_line_ids = self.move_raw_ids.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert).ids
+        if expired_move_line_ids:
             return {
                 'name': _('Confirmation'),
                 'type': 'ir.actions.act_window',
@@ -27,13 +27,13 @@ class MrpProduction(models.Model):
                 'view_mode': 'form',
                 'views': [(False, 'form')],
                 'target': 'new',
-                'context': self._get_expired_context(expired_lot_ids),
+                'context': self._get_expired_context(expired_move_line_ids),
             }
 
-    def _get_expired_context(self, expired_lot_ids):
+    def _get_expired_context(self, expired_move_line_ids):
         context = dict(self.env.context)
         context.update({
-            'default_lot_ids': [(6, 0, expired_lot_ids)],
+            'default_move_line_ids': [Command.set(expired_move_line_ids)],
             'default_production_ids': self.ids,
         })
         return context

--- a/addons/mrp_product_expiry/wizard/confirm_expiry.py
+++ b/addons/mrp_product_expiry/wizard/confirm_expiry.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import _, fields, models
 
 
 class ExpiryPickingConfirmation(models.TransientModel):
@@ -10,12 +10,11 @@ class ExpiryPickingConfirmation(models.TransientModel):
     production_ids = fields.Many2many('mrp.production', readonly=True)
     workorder_id = fields.Many2one('mrp.workorder', readonly=True)
 
-    @api.depends('lot_ids')
     def _compute_descriptive_fields(self):
         if self.production_ids or self.workorder_id:
-            # Shows expired lots only if we are more than one expired lot.
-            self.show_lots = len(self.lot_ids) > 1
-            if self.show_lots:
+            self.show_list = len(self.move_line_ids) > 1
+            self.show_lots = bool(self.move_line_ids.lot_id)
+            if self.show_list:
                 # For multiple expired lots, they are listed in the wizard view.
                 self.description = _(
                     "You are going to use some expired components."
@@ -26,18 +25,18 @@ class ExpiryPickingConfirmation(models.TransientModel):
                 self.description = _(
                     "You are going to use the component %(product_name)s, %(lot_name)s which is expired."
                     "\nDo you confirm you want to proceed?",
-                    product_name=self.lot_ids.product_id.display_name,
-                    lot_name=self.lot_ids.name,
+                    product_name=self.move_line_ids.product_id.display_name,
+                    lot_name=self.move_line_ids.lot_id.name,
                 )
         else:
             super()._compute_descriptive_fields()
 
     def confirm_produce(self):
         ctx = dict(self.env.context, skip_expired=True)
-        ctx.pop('default_lot_ids')
+        ctx.pop('default_move_line_ids')
         return self.production_ids.with_context(ctx).button_mark_done()
 
     def confirm_workorder(self):
         ctx = dict(self.env.context, skip_expired=True)
-        ctx.pop('default_lot_ids')
+        ctx.pop('default_move_line_ids')
         return self.workorder_id.with_context(ctx).record_production()

--- a/addons/mrp_product_expiry/wizard/confirm_expiry_view.xml
+++ b/addons/mrp_product_expiry/wizard/confirm_expiry_view.xml
@@ -6,15 +6,14 @@
         <field name="inherit_id" ref="product_expiry.confirm_expiry_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='description']" position="after">
-                <field name="picking_ids" invisible="1"/>
                 <field name="production_ids" invisible="1"/>
                 <field name="workorder_id" invisible="1"/>
             </xpath>
             <xpath expr="//button[@name='process']" position="attributes">
-                <attribute name="invisible">not picking_ids</attribute>
+                <attribute name="invisible">production_ids</attribute>
             </xpath>
             <xpath expr="//button[@name='process_no_expired']" position="attributes">
-                <attribute name="invisible">not picking_ids</attribute>
+                <attribute name="invisible">production_ids</attribute>
             </xpath>
             <xpath expr="//button[@special='cancel']" position="attributes">
                 <attribute name="invisible">production_ids</attribute>

--- a/addons/product_expiry/models/stock_move.py
+++ b/addons/product_expiry/models/stock_move.py
@@ -27,6 +27,11 @@ class StockMove(models.Model):
                 vals['expiration_date'] = vals.get('expiration_date') or expiration_date
         return vals_list
 
+    def action_show_details(self):
+        action = super().action_show_details()
+        action['context']['show_expiration_date'] = self.use_expiration_date
+        return action
+
     def _generate_serial_move_line_commands(self, field_data, location_dest_id=False, origin_move_line=None):
         """Override to add a default `expiration_date` into the move lines values."""
         move_lines_commands = super()._generate_serial_move_line_commands(field_data, location_dest_id, origin_move_line)

--- a/addons/product_expiry/models/stock_move.py
+++ b/addons/product_expiry/models/stock_move.py
@@ -25,6 +25,7 @@ class StockMove(models.Model):
             expiration_date = from_date + datetime.timedelta(days=product.expiration_time)
             for vals in vals_list:
                 vals['expiration_date'] = vals.get('expiration_date') or expiration_date
+                vals['removal_date'] = vals['expiration_date'] - datetime.timedelta(days=product.removal_time)
         return vals_list
 
     def action_show_details(self):

--- a/addons/product_expiry/models/stock_move_line.py
+++ b/addons/product_expiry/models/stock_move_line.py
@@ -47,8 +47,8 @@ class StockMoveLine(models.Model):
     @api.depends('product_id', 'expiration_date', 'lot_id.removal_date')
     def _compute_removal_date(self):
         for move_line in self:
-            if move_line.lot_id.removal_date:
-                move_line.removal_date = move_line.lot_id.removal_date
+            if lot_id := move_line.quant_id.lot_id or move_line.lot_id:
+                move_line.removal_date = lot_id.removal_date
             elif move_line.picking_type_use_create_lots:
                 if move_line.product_id.use_expiration_date and move_line.expiration_date:
                     move_line.removal_date = move_line.expiration_date - datetime.timedelta(days=move_line.product_id.removal_time)

--- a/addons/product_expiry/models/stock_picking.py
+++ b/addons/product_expiry/models/stock_picking.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import datetime
 
-from odoo import models, _
+from odoo import Command, _, models
 
 
 class StockPicking(models.Model):
@@ -23,13 +23,12 @@ class StockPicking(models.Model):
         return expired_pickings
 
     def _action_generate_expired_wizard(self):
-        expired_lot_ids = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now())).lot_id.ids
+        expired_move_line_ids = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now())).ids
         view_id = self.env.ref('product_expiry.confirm_expiry_view').id
         context = dict(self.env.context)
 
         context.update({
-            'default_picking_ids': [(6, 0, self.ids)],
-            'default_lot_ids': [(6, 0, expired_lot_ids)],
+            'default_move_line_ids': [Command.set(expired_move_line_ids)],
         })
         return {
             'name': _('Confirmation'),

--- a/addons/product_expiry/models/stock_picking.py
+++ b/addons/product_expiry/models/stock_picking.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import datetime
 
-from odoo import models, _
+from odoo import Command, _, models
 
 
 class StockPicking(models.Model):
@@ -23,18 +23,12 @@ class StockPicking(models.Model):
         return expired_pickings
 
     def _action_generate_expired_wizard(self):
-        expired_move_lines = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now()))
+        expired_move_line_ids = self.move_line_ids.filtered(lambda ml: ml.lot_id.product_expiry_alert or (ml.removal_date and ml.removal_date <= datetime.datetime.now())).ids
         view_id = self.env.ref('product_expiry.confirm_expiry_view').id
         context = dict(self.env.context)
 
-        expired_lot_ids = expired_move_lines.lot_id.ids
-        expired_move_line = expired_move_lines[:1]
-
         context.update({
-            'default_picking_ids': [(6, 0, self.ids)],
-            'default_lot_ids': [(6, 0, expired_lot_ids)],
-            'expired_product_name': expired_move_line.product_id.display_name,
-            'expired_lot_name': expired_move_line.lot_name,
+            'default_move_line_ids': [Command.set(expired_move_line_ids)],
         })
         return {
             'name': _('Confirmation'),

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -734,11 +734,10 @@ class TestStockLot(TestStockCommon):
         picking.button_validate()
         context = {
             'button_validate_picking_ids': [picking.id],
-            'default_picking_ids': [picking.id],
-            'default_lot_ids': [lot.id],
+            'default_move_line_ids': picking.move_line_ids.ids,
         }
         wizard = self.env['expiry.picking.confirmation'].with_context(context).create({})
-        self.assertFalse(wizard.picking_ids.move_line_ids.removal_date)
+        self.assertFalse(wizard.move_line_ids.removal_date)
         wizard.process_no_expired()
 
     def test_lot_dates_form_update(self):

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -736,11 +736,10 @@ class TestStockLot(TestStockCommon):
         picking.button_validate()
         context = {
             'button_validate_picking_ids': [picking.id],
-            'default_picking_ids': [picking.id],
-            'default_lot_ids': [lot.id],
+            'default_move_line_ids': picking.move_line_ids.ids,
         }
         wizard = self.env['expiry.picking.confirmation'].with_context(context).create({})
-        self.assertFalse(wizard.picking_ids.move_line_ids.removal_date)
+        self.assertFalse(wizard.move_line_ids.removal_date)
         wizard.process_no_expired()
 
     def test_lot_dates_form_update(self):

--- a/addons/product_expiry/views/production_lot_views.xml
+++ b/addons/product_expiry/views/production_lot_views.xml
@@ -47,10 +47,14 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='create_date']" position="after">
                 <field name="product_qty" column_invisible="True"/>
-                <field name="alert_date" optional="hide" widget='remaining_days' invisible="product_qty &lt;= 0"/>
-                <field name="use_date" optional="hide"/>
-                <field name="removal_date" optional="hide"/>
-                <field name="expiration_date" optional="hide"/>
+                <field name="alert_date" optional="hide" widget='remaining_days' invisible="product_qty &lt;= 0" readonly="not use_expiration_date"/>
+                <field name="use_date" optional="hide" readonly="not use_expiration_date"/>
+                <field name="removal_date" optional="hide" readonly="not use_expiration_date"
+                    decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                <field name="expiration_date" optional="hide" readonly="not use_expiration_date"
+                    decoration-danger="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
         </field>
     </record>

--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -23,11 +23,11 @@
             <xpath expr="//field[@name='lot_name']" position="after" >
                 <field name="picking_type_use_existing_lots" column_invisible="True"/>
                 <field name="expiration_date" force_save="1" column_invisible="not parent.use_expiration_date" readonly="picking_type_use_existing_lots"
-                 decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
-                 decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"/>
+                    decoration-danger="is_expired if state == 'done' else expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="is_expired if state == 'done' else expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
                 <field name="removal_date" force_save="1" column_invisible="not parent.use_expiration_date" readonly="picking_type_use_existing_lots"
-                 decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
-                 decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                    decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
         </field>
     </record>
@@ -40,11 +40,12 @@
             <xpath expr="//field[@name='lot_name']" position="after">
                 <field name="picking_type_use_existing_lots" column_invisible="True"/>
                 <field name="tracking" column_invisible="True"/>
-                <field name="expiration_date" decoration-danger="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
-                 decoration-bf="is_expired if state == 'done' else expiration_date &lt; context_today().strftime('%Y-%m-%d')"
-                 force_save="1" readonly="picking_type_use_existing_lots" invisible="tracking not in ['lot', 'serial']"/>
+                <field name="expiration_date" force_save="1" readonly="picking_type_use_existing_lots" invisible="tracking not in ['lot', 'serial']"
+                    decoration-danger="is_expired if state == 'done' else expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="is_expired if state == 'done' else expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
                 <field name="removal_date" force_save="1" readonly="1" invisible="tracking not in ['lot', 'serial']"
-                 decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')" decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                    decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
             <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="is_expired" column_invisible="True"/>

--- a/addons/product_expiry/views/stock_quant_views.xml
+++ b/addons/product_expiry/views/stock_quant_views.xml
@@ -1,21 +1,5 @@
 <?xml version="1.0" encoding='UTF-8'?>
 <odoo>
-    <record id="view_stock_quant_tree" model="ir.ui.view">
-        <field name="name">stock.quant.list.inherit.expiry_date</field>
-        <field name="model">stock.quant</field>
-        <field name="inherit_id" ref="stock.view_stock_quant_tree"/>
-        <field name="arch" type="xml">
-            <xpath expr="//list" position="attributes">
-                <attribute name="decoration-danger">
-                    (removal_date and removal_date &lt; current_date) or quantity &lt; 0
-                </attribute>
-            </xpath>
-            <xpath expr="//field[@name='quantity']" position="after" >
-                <field name="removal_date"/>
-            </xpath>
-        </field>
-    </record>
-
     <record id="view_stock_quant_tree_editable" model="ir.ui.view">
         <field name="name">stock.quant.list.editable.inherit.expiry_date</field>
         <field name="model">stock.quant</field>
@@ -46,6 +30,22 @@
                 <field name="removal_date" groups="stock.group_production_lot"
                        column_invisible="not context.get('show_removal_date')"
                        decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')" decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_stock_quant_tree_simple" model="ir.ui.view">
+        <field name="name">stock.quant.view.list.inherit.product_expiry</field>
+        <field name="model">stock.quant</field>
+        <field name="inherit_id" ref="stock.view_stock_quant_tree_simple"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='lot_properties']" position="after">
+                <field name="expiration_date" optional="show" column_invisible="not context.get('show_expiration_date')"
+                    decoration-danger="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="expiration_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
+                <field name="removal_date" optional="show" column_invisible="not context.get('show_expiration_date')"
+                    decoration-danger="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"
+                    decoration-bf="removal_date &lt; (context_today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d')"/>
             </xpath>
         </field>
     </record>

--- a/addons/product_expiry/wizard/confirm_expiry.py
+++ b/addons/product_expiry/wizard/confirm_expiry.py
@@ -9,16 +9,16 @@ class ExpiryPickingConfirmation(models.TransientModel):
     _name = 'expiry.picking.confirmation'
     _description = 'Confirm Expiry'
 
-    lot_ids = fields.Many2many('stock.lot', readonly=True, required=True)
-    picking_ids = fields.Many2many('stock.picking', readonly=True)
+    move_line_ids = fields.Many2many('stock.move.line', readonly=True)
     description = fields.Char('Description', compute='_compute_descriptive_fields')
     show_lots = fields.Boolean('Show Lots', compute='_compute_descriptive_fields')
+    show_list = fields.Boolean('Show List', compute='_compute_descriptive_fields')
 
-    @api.depends('lot_ids')
+    @api.depends('move_line_ids')
     def _compute_descriptive_fields(self):
-        # Shows expired lots only if we are more than one expired lot.
-        self.show_lots = len(self.lot_ids) > 1
-        if self.show_lots:
+        self.show_list = len(self.move_line_ids) > 1
+        self.show_lots = bool(self.move_line_ids.lot_id)
+        if self.show_list:
             # For multiple expired lots, they are listed in the wizard view.
             self.description = _(
                 "You are going to deliver some product expired lots."
@@ -29,8 +29,8 @@ class ExpiryPickingConfirmation(models.TransientModel):
             self.description = _(
                 "You are going to deliver the product %(product_name)s, %(lot_name)s which is expired or should at least be removed from stock."
                 "\nDo you confirm you want to proceed?",
-                product_name=self.lot_ids.product_id.display_name,
-                lot_name=self.lot_ids.name
+                product_name=self.move_line_ids.product_id.display_name,
+                lot_name=self.move_line_ids.lot_id.name or self.move_line_ids.lot_name,
             )
 
     def process(self):
@@ -38,14 +38,14 @@ class ExpiryPickingConfirmation(models.TransientModel):
         if picking_to_validate:
             picking_to_validate = self.env['stock.picking'].browse(picking_to_validate)
             ctx = dict(self.env.context, skip_expired=True)
-            ctx.pop('default_lot_ids')
+            ctx.pop('default_move_line_ids')
             return picking_to_validate.with_context(ctx).button_validate()
         return True
 
     def process_no_expired(self):
         """ Remove the expired mls and confirm the picking. """
         pickings_to_validate = self.env['stock.picking'].browse(self.env.context.get('button_validate_picking_ids'))
-        self.picking_ids.move_line_ids.filtered(
+        self.move_line_ids.filtered(
             lambda ml: ml.use_expiration_date and ml.removal_date and ml.removal_date < datetime.now()
         ).unlink()
         return pickings_to_validate.button_validate()

--- a/addons/product_expiry/wizard/confirm_expiry.py
+++ b/addons/product_expiry/wizard/confirm_expiry.py
@@ -9,16 +9,16 @@ class ExpiryPickingConfirmation(models.TransientModel):
     _name = 'expiry.picking.confirmation'
     _description = 'Confirm Expiry'
 
-    lot_ids = fields.Many2many('stock.lot', readonly=True, required=True)
-    picking_ids = fields.Many2many('stock.picking', readonly=True)
+    move_line_ids = fields.Many2many('stock.move.line', readonly=True)
     description = fields.Char('Description', compute='_compute_descriptive_fields')
     show_lots = fields.Boolean('Show Lots', compute='_compute_descriptive_fields')
+    show_list = fields.Boolean('Show List', compute='_compute_descriptive_fields')
 
-    @api.depends('lot_ids')
+    @api.depends('move_line_ids')
     def _compute_descriptive_fields(self):
-        # Shows expired lots only if we are more than one expired lot.
-        self.show_lots = len(self.lot_ids) > 1
-        if self.show_lots:
+        self.show_list = len(self.move_line_ids) > 1
+        self.show_lots = bool(self.move_line_ids.lot_id)
+        if self.show_list:
             # For multiple expired lots, they are listed in the wizard view.
             self.description = _(
                 "You are going to deliver some product expired lots."
@@ -29,8 +29,8 @@ class ExpiryPickingConfirmation(models.TransientModel):
             self.description = _(
                 "You are going to deliver the product %(product_name)s, %(lot_name)s which is expired or should at least be removed from stock."
                 "\nDo you confirm you want to proceed?",
-                product_name=self.lot_ids.product_id.display_name or self.env.context.get('expired_product_name'),
-                lot_name=self.lot_ids.name or self.env.context.get('expired_lot_name'),
+                product_name=self.move_line_ids.product_id.display_name,
+                lot_name=self.move_line_ids.lot_id.name or self.move_line_ids.lot_name,
             )
 
     def process(self):
@@ -38,14 +38,14 @@ class ExpiryPickingConfirmation(models.TransientModel):
         if picking_to_validate:
             picking_to_validate = self.env['stock.picking'].browse(picking_to_validate)
             ctx = dict(self.env.context, skip_expired=True)
-            ctx.pop('default_lot_ids')
+            ctx.pop('default_move_line_ids')
             return picking_to_validate.with_context(ctx).button_validate()
         return True
 
     def process_no_expired(self):
         """ Remove the expired mls and confirm the picking. """
         pickings_to_validate = self.env['stock.picking'].browse(self.env.context.get('button_validate_picking_ids'))
-        self.picking_ids.move_line_ids.filtered(
+        self.move_line_ids.filtered(
             lambda ml: ml.use_expiration_date and ml.removal_date and ml.removal_date < datetime.now()
         ).unlink()
         return pickings_to_validate.button_validate()

--- a/addons/product_expiry/wizard/confirm_expiry_view.xml
+++ b/addons/product_expiry/wizard/confirm_expiry_view.xml
@@ -9,10 +9,12 @@
                     <field name="description"/>
                 </p>
                 <field name="show_lots" invisible="1"/>
-                <field name="lot_ids" invisible="not show_lots">
-                    <list string="Expired Lot(s)">
+                <field name="show_list" invisible="1"/>
+                <field name="move_line_ids" invisible="not show_list">
+                    <list string="Expired Lot(s)" no_open="1">
                         <field name="product_id"/>
-                        <field name="name"/>
+                        <field name="lot_name" string="Lot/Serial Number" column_invisible="parent.show_lots"/>
+                        <field name="lot_id" column_invisible="not parent.show_lots"/>
                     </list>
                 </field>
                 <footer>

--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -34,7 +34,8 @@ export class SMLX2ManyField extends X2ManyField {
     }
 
     async onAdd({ context, editable } = {}) {
-        if (!this.props.record.data.show_quant) {
+        const data = this.props.record.data;
+        if (!data.show_quant) {
             return super.onAdd(...arguments);
         }
         // Compute the quant offset from move lines quantity changes that were not saved yet.
@@ -44,11 +45,12 @@ export class SMLX2ManyField extends X2ManyField {
             ...context,
             single_product: true,
             list_view_ref: "stock.view_stock_quant_tree_simple",
+            show_expiration_date: data.use_expiration_date,
         };
-        const productName = this.props.record.data.product_id.display_name;
+        const productName = data.product_id.display_name;
         const title = _t("Add line: %s", productName);
         let domain = [
-            ["product_id", "=", this.props.record.data.product_id.id],
+            ["product_id", "=", data.product_id.id],
             ["location_id", "child_of", this.props.context.default_location_id],
             ["quantity", ">", 0.0],
         ];


### PR DESCRIPTION
*: stock

In industries where `product validity is critical`, operators must ensure stock
is used before its expiration or removal date. Previously, these details were
not visible in `quant lists` across MRP, picking, and repair flows,
making it difficult to identify valid stock.

- Display `expiration` and `removal dates` for products with expiration tracking 
  across MRP, picking, and repair flows, highlighting them in red to help users 
  quickly identify valid stock.
- Ensure `removal date` is correctly displayed in move lines after selecting a quant 
  from the `Add Line view`.
- Fix expired product delivery warning where product and `lot names` were missing 
  in the message.
- Ensure `removal date` is properly set when `generating new Lots/Serial Numbers`.


Enterprise PR:- odoo/enterprise#105857
Upgrade PR:- odoo/upgrade#9627
TaskId-5421905