### PR TITLE
[FIX] html_editor: deselect custom selection

### DIFF
--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -87,8 +87,11 @@ export class SeparatorPlugin extends Plugin {
         }
     }
 
-    handleSelectionInHr() {
+    handleSelectionInHr(selectionData) {
         this.deselectHR();
+        if (!selectionData.documentSelectionIsInEditable) {
+            return;
+        }
         const traversedNodes = this.dependencies.selection.getTraversedNodes({ deep: true });
         for (const node of traversedNodes) {
             if (node.nodeName === "HR") {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -869,6 +869,7 @@ export class TablePlugin extends Plugin {
             return;
         }
         if (!selectionData.documentSelectionIsInEditable) {
+            this.deselectTable();
             return;
         }
         const selection = selectionData.editableSelection;

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -3,7 +3,7 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
 import { simulateArrowKeyPress } from "../_helpers/user_actions";
-import { animationFrame } from "@odoo/hoot-dom";
+import { animationFrame, click, tick } from "@odoo/hoot-dom";
 
 async function insertSeparator(editor) {
     execCommand(editor, "insertSeparator");
@@ -133,5 +133,19 @@ describe("insert separator", () => {
         await animationFrame();
 
         expect(getContent(el)).toBe(`<p>[abc]</p><hr contenteditable="false"><p>xyz</p>`);
+    });
+
+    test("should remove custom selection on separator when click outside of editor", async () => {
+        const { el } = await setupEditor('<p>[abc</p><hr contenteditable="false"><p>xyz]</p>');
+        expect(getContent(el)).toBe(
+            `<p>[abc</p><hr contenteditable="false" class="o_selected_hr"><p>xyz]</p>`
+        );
+
+        const selection = document.getSelection();
+        await click(document.body);
+        selection.setPosition(document.body);
+        await tick();
+
+        expect(getContent(el)).toBe(`<p>abc</p><hr contenteditable="false"><p>xyz</p>`);
     });
 });


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- In Todo, Type some text.
- Insert a table and a separator.
- Select text along with table and separator.
- Click outside the editor.

The text is deselected but table and separator are still selected.

**Desired behavior after PR is merged:**

Custom selection such as table and separator is deselected along with browser selection when clicking outside the editor.

task-5479981





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
