### PR TITLE
[FIX] web: show scanned barcode for iOS

### DIFF
--- a/addons/web/static/src/webclient/barcode/crop_overlay.js
+++ b/addons/web/static/src/webclient/barcode/crop_overlay.js
@@ -2,6 +2,7 @@
 
 import { Component, useRef, onPatched } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
+import { isIOS } from "@web/core/browser/feature_detection";
 import { clamp } from "@web/core/utils/numbers";
 
 export class CropOverlay extends Component {
@@ -17,6 +18,7 @@ export class CropOverlay extends Component {
         onPatched(() => {
             this.setupCropRect();
         });
+        this.isIOS = isIOS();
     }
 
     setupCropRect() {

--- a/addons/web/static/src/webclient/barcode/crop_overlay.scss
+++ b/addons/web/static/src/webclient/barcode/crop_overlay.scss
@@ -6,17 +6,30 @@
         grid-column: 1 / -1;
     }
 
-    .o_crop_overlay {
+    .o_crop_overlay::after {
+        content: '';
+        display: block;
+    }
+
+    .o_crop_overlay:not(.o_crop_overlay_ios) {
         background-color: RGB(0 0 0 / 0.75);
         mix-blend-mode: darken;
 
         &::after {
-            content: '';
-            display: block;
             height: 100%;
             width: 100%;
             clip-path: inset(var(--o-crop-y, 0px) var(--o-crop-x, 0px));
             background-color: white;
+        }
+    }
+
+    .o_crop_overlay.o_crop_overlay_ios {
+        position: relative;
+
+        &::after {
+            position: absolute;
+            inset: var(--o-crop-y, 0px) var(--o-crop-x, 0px);
+            border: 1px solid black;
         }
     }
 

--- a/addons/web/static/src/webclient/barcode/crop_overlay.xml
+++ b/addons/web/static/src/webclient/barcode/crop_overlay.xml
@@ -9,7 +9,7 @@
         >
             <t t-slot="default"/>
             <t t-if="props.isReady">
-                <div class="o_crop_overlay"/>
+                <div class="o_crop_overlay" t-att-class="{'o_crop_overlay_ios': isIOS}"/>
                 <img class="o_crop_icon" src="/web/static/img/transform.svg" draggable="false"/>
             </t>
         </div>


### PR DESCRIPTION
Issue
-----
There is an issue in WebKit with mix-blend-mode

https://bugs.webkit.org/show_bug.cgi?id=286619

Because of this issue, in barcode, the user gets a solid white square over the scanning zone, so they don't see the barcode being scanned.

-----
Ticket:
opw-5386846