### PR TITLE
[FIX] calendar: prevent context loss on recurring event deletion

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -113,7 +113,7 @@ export class AttendeeCalendarController extends CalendarController {
             },
             {
                 onClose: () => {
-                    location.reload();
+                    this.model.load();
                 },
             }
         );


### PR DESCRIPTION
Deleting a recurring calendar event triggers a full page reload, which resets the view to default, clearing active filters and causing context-dependent fields (like "Resources") to disappear during subsequent record creation.

### Steps to reproduce

1. Filter the Calendar view (e.g., "Everybody").
2. Delete a recurring event.
3. Observe the page reload and filter reset.
4. Try to create a new record; context-specific fields are missing.

The issue occurs because the deletion action forces a browser refresh (location.reload()), wiping the web client's in-memory state. This state holds the active filters and context keys necessary for rendering specific fields. When cleared, the application reverts to its default configuration.

opw-5433604