### PR TITLE
[REF] mail,im_livechat: use discuss.channel model instead of mail.thread

### DIFF
--- a/addons/im_livechat/static/src/views/discuss_template.xml
+++ b/addons/im_livechat/static/src/views/discuss_template.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatDiscuss">
-        <t t-if="this.thread">
-            <Discuss hasSidebar="false" thread="this.thread"/>
-        </t>
+        <Discuss t-if="this.channel" hasSidebar="false" thread="this.channel.thread"/>
         <t t-else="">
             <div class="d-flex h-100 flex-column justify-content-center align-items-center">
                 <span class="fs-1">No conversation found</span>

--- a/addons/im_livechat/static/src/views/livechat_form_renderer.js
+++ b/addons/im_livechat/static/src/views/livechat_form_renderer.js
@@ -23,7 +23,7 @@ export class LivechatSessionFormRenderer extends FormRenderer {
                     return () => channel.shadowedBySelf--;
                 }
             },
-            () => [this.thread?.channel]
+            () => [this.channel]
         );
         onWillStart(() => this.getChannel(this.props));
         onWillUpdateProps(async (nextProps) => {
@@ -35,16 +35,13 @@ export class LivechatSessionFormRenderer extends FormRenderer {
     }
 
     /**
-     * Restore the discuss thread according to record id in the props if
+     * Restore the discuss channel according to record id in the props if
      * necessary.
      *
      * @param {Props} props
      */
     async getChannel(props) {
-        this.thread = await this.store["mail.thread"].getOrFetch({
-            model: "discuss.channel",
-            id: props.record.resId,
-        });
+        this.channel = await this.store["discuss.channel"].getOrFetch(props.record.resId);
     }
 
     redirectToSessions() {

--- a/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
+++ b/addons/im_livechat/static/src/views/livechat_view_controller_mixin.js
@@ -10,13 +10,8 @@ export const LivechatViewControllerMixin = (ViewController) =>
 
         async openRecord(record) {
             if (this.ui.isSmall) {
-                const thread = await this.store["mail.thread"].getOrFetch({
-                    model: "discuss.channel",
-                    id: record.resId,
-                });
-                if (thread) {
-                    return thread.open();
-                }
+                const channel = await this.store["discuss.channel"].getOrFetch(record.resId);
+                channel?.open();
             }
             return super.openRecord(record);
         }

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -19,11 +19,8 @@ export class DiscussCoreCommon {
 
     setup() {
         this.busService.subscribe("discuss.channel/delete", (payload, metadata) => {
-            const thread = this.store["mail.thread"].insert({
-                id: payload.id,
-                model: "discuss.channel",
-            });
-            this._handleNotificationChannelDelete(thread, metadata);
+            const channel = this.store["discuss.channel"].insert(payload.id);
+            this._handleNotificationChannelDelete(channel, metadata);
         });
         this.busService.subscribe("discuss.channel/new_message", (payload, metadata) => {
             // Insert should always be done before any async operation. Indeed,
@@ -60,13 +57,13 @@ export class DiscussCoreCommon {
     }
 
     /**
-     * @param {import("models").Thread} thread
+     * @param {import("models").DiscussChannel} channel
      * @param {{ notifId: number}} metadata
      */
-    async _handleNotificationChannelDelete(thread, metadata) {
-        await thread.closeChatWindow();
-        thread.messages.splice(0, thread.messages.length);
-        thread.delete();
+    async _handleNotificationChannelDelete(channel, metadata) {
+        await channel.closeChatWindow();
+        channel.messages.splice(0, channel.messages.length);
+        channel.delete();
     }
 
     async _handleNotificationNewMessage(payload, { id: notifId }) {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_core_public_web_service.js
@@ -23,18 +23,15 @@ export class DiscussCorePublicWeb {
             } = payload;
             this.store.insert(data);
             await this.store.fetchChannel(channel_id);
-            const thread = this.store["mail.thread"].get({
-                id: channel_id,
-                model: "discuss.channel",
-            });
+            const channel = this.store["discuss.channel"].get(channel_id);
             if (
-                thread?.channel &&
+                channel &&
                 invitedByUserId &&
                 invitedByUserId !== this.store.self_user?.id &&
                 !invite_to_rtc_call
             ) {
                 this.notificationService.add(
-                    _t("You have been invited to #%s", thread.channel.displayName),
+                    _t("You have been invited to #%s", channel.displayName),
                     { type: "info" }
                 );
             }

--- a/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
+++ b/addons/mail/static/src/discuss/web/discuss_core_common_service_patch.js
@@ -2,12 +2,12 @@ import { DiscussCoreCommon } from "@mail/discuss/core/common/discuss_core_common
 import { patch } from "@web/core/utils/patch";
 
 patch(DiscussCoreCommon.prototype, {
-    _handleNotificationChannelDelete(thread, metadata) {
+    _handleNotificationChannelDelete(channel, metadata) {
         const { notifId } = metadata;
         const filteredBookmarkedMessages = [];
         let bookmarkedCounter = 0;
         for (const msg of this.store.bookmarkBox.messages) {
-            if (!msg.thread?.eq(thread)) {
+            if (!msg.channel_id?.eq(channel)) {
                 filteredBookmarkedMessages.push(msg);
             } else {
                 bookmarkedCounter++;
@@ -18,17 +18,17 @@ patch(DiscussCoreCommon.prototype, {
             this.store.bookmarkBox.counter -= bookmarkedCounter;
         }
         this.store.inbox.messages = this.store.inbox.messages.filter(
-            (msg) => !msg.thread?.eq(thread)
+            (msg) => !msg.channel_id?.eq(channel)
         );
         if (notifId > this.store.inbox.counter_bus_id) {
-            this.store.inbox.counter -= thread.message_needaction_counter;
+            this.store.inbox.counter -= channel.message_needaction_counter;
         }
         this.store.history.messages = this.store.history.messages.filter(
-            (msg) => !msg.thread?.eq(thread)
+            (msg) => !msg.channel_id?.eq(channel)
         );
-        if (thread.discussAppAsThread) {
+        if (channel.discussAppAsThread) {
             this.store.discuss.thread = undefined;
         }
-        super._handleNotificationChannelDelete(thread, metadata);
+        super._handleNotificationChannelDelete(channel, metadata);
     },
 });


### PR DESCRIPTION
This commit removes the last remaining access to the `discuss.channel` model through `getOrFetch` from `mail.thread`.

PR enterprise: https://github.com/odoo/enterprise/pull/104122