### PR TITLE
[FIX] l10n_hr_edi: Incorrect credentials error handling

### DIFF
--- a/addons/l10n_hr_edi/models/account_move_send.py
+++ b/addons/l10n_hr_edi/models/account_move_send.py
@@ -115,9 +115,12 @@ class AccountMoveSend(models.AbstractModel):
                 addendum.mer_document_status = '50'
                 invoice_data['error'] = e.message
             else:
-                if not isinstance(response, list) and response.get('File'):
+                if not isinstance(response, list) and not response.get('ElectronicId'):
                     addendum.mer_document_status = '50'
-                    invoice_data['error'] = response.get('File')['Messages']
+                    errors = []
+                    for key in response:
+                        errors.append(response[key].get('Messages'))
+                    invoice_data['error'] = errors
                 else:
                     addendum.mer_document_eid = response['ElectronicId']
                     addendum.mer_document_status = '20'

--- a/addons/l10n_hr_edi/tools.py
+++ b/addons/l10n_hr_edi/tools.py
@@ -79,7 +79,7 @@ def _make_request(company, endpoint_type, params=False):
     # Structure-specific error handling
     if response.status_code != 200:
         try:
-            error_message = response.json().get('message')
+            error_message = response.json().get('errors')
         except (requests.exceptions.JSONDecodeError, TypeError):
             error_message = False
         raise UserError(company.env._("Error handling request: %s", error_message) if error_message else company.env._("HTTP %s: Connection error.", response.status_code))


### PR DESCRIPTION
Fixing incorrect error display that occurred while trying to send an invoice to MER with incorrect credentials set up.
(no task/error ID)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
