### PR TITLE
[FIX] website: add option to disable delay  translations

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -777,9 +777,12 @@ class Website(Home):
 
     @http.route('/website/save_xml', type='jsonrpc', auth='user', website=True)
     def save_xml(self, view_id, arch):
+        disable_delay_translations = self.env['ir.config_parameter'].sudo().get_param(
+            'website.disable_delay_translations'
+        ) not in ('False', '0', '', False)
         request.env['ir.ui.view'].browse(view_id).with_context(
             lang=request.website.default_lang_id.code,
-            delay_translations=True,
+            delay_translations=not disable_delay_translations,
         ).arch = arch
 
     @http.route("/website/get_switchable_related_views", type="jsonrpc", auth="user", website=True, readonly=True)

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -498,6 +498,11 @@ class IrUiView(models.Model):
             ], limit=1)
             if website_specific_view:
                 self = website_specific_view
+        if self.env.context.get('delay_translations'):
+            disable_delay_translations = self.env['ir.config_parameter'].sudo().get_param(
+                'website.disable_delay_translations'
+            ) not in ('False', '0', '', False)
+            self.env = self.with_context(delay_translations=not disable_delay_translations).env
         super().save(value, xpath=xpath)
 
     @api.model

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -27,6 +27,7 @@ from . import test_performance
 from . import test_qweb
 from . import test_redirect
 from . import test_res_users
+from . import test_save_xml
 from . import test_sitemap
 from . import test_skip_website_configurator
 from . import test_snippets

--- a/addons/website/tests/test_save_xml.py
+++ b/addons/website/tests/test_save_xml.py
@@ -1,0 +1,62 @@
+from odoo.addons.http_routing.tests.common import MockRequest
+from odoo.addons.website.controllers.main import Website
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestWebsiteSaveXml(HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.WebsiteController = Website()
+        cls.env['res.lang']._activate_lang('fr_FR')
+        cls.website = cls.env['website'].search([], limit=1)
+        cls.view = cls.env["ir.ui.view"].create({
+            "name": "Test View",
+            "type": "qweb",
+            "arch": "<div>OldEN</div>",
+            "website_id": cls.website.id,
+        })
+        cls.view.with_context(lang='fr_FR').arch = "<div>OldFR</div>"
+
+    def test_save_xml_delay_translations(self):
+        with MockRequest(self.env, website=self.website):
+            self.WebsiteController.save_xml(self.view.id, '<div>NewEN</div>')
+        self.assertEqual(
+            self.view.with_context(lang='fr_FR').arch,
+            '<div>OldFR</div>',
+        )
+        delayed_translation = self.view.with_context(lang='fr_FR', edit_translations=True).arch
+        self.assertIn(
+            '<div><span class="o_delay_translation"',
+            delayed_translation,
+        )
+        self.assertIn(
+            '>NewEN</span></div>',
+            delayed_translation,
+        )
+
+    def test_save_xml_disabled_delay_translations(self):
+        """Test that disable_delay_translations disable delayed translation on save_xml call"""
+        self.env['ir.config_parameter'].sudo().set_param('website.disable_delay_translations', '1')
+
+        self.assertEqual(
+            self.view.with_context(lang='fr_FR').arch,
+            '<div>OldFR</div>',
+        )
+        with MockRequest(self.env, website=self.website):
+            self.WebsiteController.save_xml(self.view.id, '<div>NewEN</div>')
+        self.assertEqual(
+            self.view.with_context(lang='fr_FR').arch,
+            '<div>NewEN</div>',
+        )
+        delayed_translation = self.view.with_context(lang='fr_FR', edit_translations=True).arch
+        self.assertNotIn(
+            '<div><span class="o_delay_translation"',
+            delayed_translation,
+        )
+        self.assertIn(
+            '>NewEN</span></div>',
+            delayed_translation,
+        )

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -450,6 +450,40 @@ class TestViewSaving(TestViewSavingCommon):
             )
         )
 
+    def test_save_view_delay_translations(self):
+        self.env['res.lang']._activate_lang('fr_FR')
+        view = self.env['ir.ui.view'].create({
+            'name': 'test_view',
+            'type': 'qweb',
+            'key': 'website.test_view',
+            'arch_db': '<span>Hello World</span>'
+        })
+        view.with_context(lang='fr_FR').arch = "<div>Bonjour Monde</div>"
+
+        # delayed translations are enabled by default (SavePlugin.saveView uses it by default)
+        view.with_context(delay_translations=True).save(value='<div>New World</div>', xpath='/div')
+        self.assertEqual(
+            view.with_context(lang='fr_FR').arch,
+            '<div>Bonjour Monde</div>',
+        )
+        delayed_translation = view.with_context(lang='fr_FR', edit_translations=True).arch
+        self.assertIn(
+            '<div><span class="o_delay_translation"',
+            delayed_translation,
+        )
+        self.assertIn(
+            '>New World</span></div>',
+            delayed_translation,
+        )
+
+        # delayed translations can be disabled thanks to ir.config_parameter
+        self.env['ir.config_parameter'].sudo().set_param('website.disable_delay_translations', '1')
+        view.with_context(delay_translations=True).save(value='<div>All New World</div>', xpath='/div')
+        self.assertEqual(
+            view.with_context(lang='fr_FR').arch,
+            '<div>All New World</div>',
+        )
+
 
 @tagged('-at_install', 'post_install')
 class TestCowViewSaving(TestViewSavingCommon, HttpCase):


### PR DESCRIPTION
Delayed translation (draft version from change of main language that
needs to be updated on each modified secondary language) on website
were added or disabled with:

- 2d08f97c0778469b409fca23f2be5f5a98ce3df8 (October 2023) in 17.0 added
  the delay translation feature
- 0e0a74f8c5fc9f45311e629a76608c6c986d635d (December 2023) in 17.0
  disabled the feature
- 03a85b13b2c46ef7174123d902e95d5103031c6c (September 2025) in 19.0
  enabled the feature again

Some website editor users may not expect the behavior (eg. changing a
background image, then needing to edit all secondary language so the
drafted change is saved).

For now we have not found a satisfying way to prevent delay translation
for simple use case that should not break translations: eg. removing a
snippet, changing attributes, ...

Because if we did special case, it would then become unexpected:

- will we need to update translations
- if there was a previous change that needed translation update, then we
  do a change that would not need translation update, what should we do

So this PR for now gives the option to create a ir.config_parameter:

- key: website.disable_delay_translations
- value: 1

That would disable the delay_translations feature for all websites if
the user doesn't want the feature.

opw-5187670
opw-5240423
opw-5250497
opw-5254832
opw-5344412
opw-5347408
opw-5419427
opw-5424761
opw-5481352
opw-5892371
opw-5931549