### PR TITLE
[FIX] l10n_it_stock_ddt: generate DDT before completing the picking action

### DIFF
--- a/addons/l10n_it_stock_ddt/models/stock_picking.py
+++ b/addons/l10n_it_stock_ddt/models/stock_picking.py
@@ -49,9 +49,9 @@ class StockPicking(models.Model):
                 )
 
     def _action_done(self):
-        super(StockPicking, self)._action_done()
         for picking in self.filtered(lambda p: p.picking_type_id.l10n_it_ddt_sequence_id):
             picking.l10n_it_ddt_number = picking.picking_type_id.l10n_it_ddt_sequence_id.next_by_id()
+        super()._action_done()
 
 
 class StockPickingType(models.Model):


### PR DESCRIPTION
When validating a delivery, Odoo did not include the DDT number in the report, as it was generated after rendering the PDF/email.
This fix changes the order to generate the DDT number before sending the email.

Steps to reproduce:
- Create a database with an Italian company and the `l10n_it_stock_ddt` module installed
- Turn on `Settings > Inventory > Shipping > Email Confirmation`
- Under `Settings > General Settings > Companies > Email Templates` click `Review all Templates`
- Edit the `Shipping: Send by Email` template
- Under the `Settings` tab, you find the `Dynamic reports` field (which is a `many2many`), add the `DDT report`.
- Create a SO, validate it
- On the top of the SO, you see the delivery button with one delivery, click it, then validate the delivery.
- In the chatter you see the message that was sent, with the `DDT report` PDF attached, with `False` instead of the DDT name.
- If you open the report, the title of the PDF is also missing the DDT name.

Ticket [link](https://www.odoo.com/odoo/project.task/5364265)
opw-5364265