### PR TITLE
[MOV] core: http.router.root.geoip -> http.geoip

### DIFF
--- a/odoo/addons/test_http/tests/test_common.py
+++ b/odoo/addons/test_http/tests/test_common.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from werkzeug.datastructures import ResponseCacheControl
 from werkzeug.http import parse_cache_control_header
 
+import odoo.http.geoip
 from odoo.http.router import Application, root
 from odoo.http.session import Session
 from odoo.tools import config, reset_cached_properties
@@ -29,8 +30,8 @@ class TestHttpBase(HttpCaseWithUserDemo):
             'server_wide_modules': ['base', 'web', 'rpc', 'test_http'],
         }))
         cls.classPatch(Application, 'session_store', session_store)
-        cls.classPatch(Application, 'geoip_city_db', geoip_resolver)
-        cls.classPatch(Application, 'geoip_country_db', geoip_resolver)
+        cls.classPatch(odoo.http.geoip, '_geoip_city_db', lambda: geoip_resolver)
+        cls.classPatch(odoo.http.geoip, '_geoip_country_db', lambda: geoip_resolver)
 
     def setUp(self):
         super().setUp()

--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -5,8 +5,6 @@ import threading
 from os.path import join as opj
 from urllib.parse import urlparse
 
-import geoip2
-import maxminddb
 import werkzeug
 from psycopg2 import OperationalError
 from werkzeug.urls import url_encode  # TODO: use urllib
@@ -194,25 +192,6 @@ class Application:
         if not db:
             return self.nodb_routing_map
         return request.env['ir.http'].routing_map()
-
-    @functools.cached_property
-    def geoip_city_db(self):
-        try:
-            return geoip2.database.Reader(config['geoip_city_db'])
-        except (OSError, maxminddb.InvalidDatabaseError):
-            _logger.debug(
-                "Couldn't load Geoip City file at %s. IP Resolver disabled.",
-                config['geoip_city_db'], exc_info=True,
-            )
-            raise
-
-    @functools.cached_property
-    def geoip_country_db(self):
-        try:
-            return geoip2.database.Reader(config['geoip_country_db'])
-        except (OSError, maxminddb.InvalidDatabaseError) as exc:
-            _logger.debug("Couldn't load Geoip Country file (%s). Fallbacks on Geoip City.", exc)
-            raise
 
     def set_csp(self, response):
         headers = response.headers


### PR DESCRIPTION
Following the split[^1] of the odoo/http.py file as the odoo/http/
module, there are a few things that feel to be at the wrong place.

`http.router.root.geoip` is one of those things. The `geoip` lazy
property on Application is defined there because we needed a global
namespace, which `root = Application()` is, and it was easy just add
something there.

Now that http is split, the right place for the geoip singleton is
inside `odoo.http.geoip`.

[^1]: https://github.com/odoo-dev/odoo/commit/ec12678f70431cf301372e9bd3358396b1a05ddb