### PR TITLE
[FIX] stock: make move_line.lot_name reflect lot_id.name

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1709,6 +1709,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                 lot_id=reserved_quant.lot_id.id or False,
                 package_id=package.id or False,
                 owner_id =reserved_quant.owner_id.id or False,
+                lot_name=reserved_quant.lot_id.name or False,
             )
         return vals
 

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -354,12 +354,14 @@ class StockQuant(models.Model):
     def write(self, vals):
         """ Override to handle the "inventory mode" and create the inventory move. """
         forbidden_fields = self._get_forbidden_fields_write()
-        if self._is_inventory_mode() and any(field for field in forbidden_fields if field in vals.keys()):
+        forbidden_fields_in_vals = [field for field in forbidden_fields if field in vals.keys()]
+        if self._is_inventory_mode() and any(forbidden_fields_in_vals):
             if any(quant.location_id.usage == 'inventory' for quant in self):
                 # Do nothing when user tries to modify manually a inventory loss
                 return
-            self = self.sudo()
-            raise UserError(_("Quant's editing is restricted, you can't do this operation."))
+            for field in forbidden_fields_in_vals:
+                if any((quant[field].id != vals[field] and quant[field] != vals[field]) for quant in self):
+                    raise UserError(_("Quant's editing is restricted, you can't change the field %s.") % field)
         return super(StockQuant, self).write(vals)
 
     @api.ondelete(at_uninstall=False)


### PR DESCRIPTION
### Issue:
Lot name is shown empty in rental return move.

#### To reproduce:
1- Create a rental product tracked by lot and add a quantity with lot number.
2- Create a rental order with the created product and confirm it.
3- Validate the outgoing transfer.
4- In return transfer, open stock move using the small button(the button with 4 vertical lines).
5- As you see Lot/Serial Number is shown empty.

### Cause and fix:
This is because `lot_name` is not reflecting the `lot_id.name`. This can be fixed by adding the value in create and write.

opw-5435865