### PR TITLE
[IMP] l10n_latam_check: Allow multiple liquidity lines for checks in Payment JE

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -60,7 +60,6 @@ class AccountPayment(models.Model):
             error_msg = "\n".join(f"* {msg}" for msg in msgs)
             raise ValidationError(error_msg)
         super().action_post()
-        self._l10n_latam_check_split_move()
 
     def _get_latam_checks(self):
         self.ensure_one()
@@ -130,67 +129,6 @@ class AccountPayment(models.Model):
         self._get_reconciled_checks_error()
         super().action_draft()
 
-    def _l10n_latam_check_split_move(self):
-        for payment in self.filtered(lambda x: x.payment_method_code == 'own_checks' and x.payment_type == 'outbound'):
-            if len(payment.l10n_latam_new_check_ids) == 1:
-                liquidity_line = payment._seek_for_lines()[0]
-                payment.l10n_latam_new_check_ids.outstanding_line_id = liquidity_line.id
-                continue
-
-            vals = {
-                'journal_id': payment.journal_id.id,
-                'move_type': 'entry',
-                'line_ids': [],
-            }
-            payment_liquidity_line = payment._seek_for_lines()[0]
-
-            # One line per check
-            checks_total = sum(payment.l10n_latam_new_check_ids.mapped('amount'))
-            liquidity_balance_total = 0.0
-            for check in payment.l10n_latam_new_check_ids:
-                liquidity_amount_currency = -check.amount
-
-                if check == payment.l10n_latam_new_check_ids[-1]:
-                    liquidity_balance = payment.currency_id.round(payment_liquidity_line.balance - liquidity_balance_total)
-                else:
-                    liquidity_balance = payment.currency_id.round(payment_liquidity_line.balance * check.amount / checks_total)
-                    liquidity_balance_total += liquidity_balance
-
-                vals['line_ids'].append(
-                    Command.create({
-                        'name': _(
-                            'Check %(check_number)s - %(suffix)s',
-                            check_number=check.name,
-                            suffix=''.join([item[1] for item in payment._get_aml_default_display_name_list()])),
-                        'date_maturity': check.payment_date,
-                        'amount_currency': liquidity_amount_currency,
-                        'currency_id': check.currency_id.id,
-                        'debit': max(0.0, liquidity_balance),
-                        'credit': -min(liquidity_balance, 0.0),
-                        'partner_id': payment_liquidity_line.partner_id.id,
-                        'account_id': payment_liquidity_line.account_id.id,
-                        'l10n_latam_check_ids': [Command.link(check.id)]
-                    }),
-                )
-
-            # Cancel payment line
-            vals['line_ids'].append(
-                Command.create({
-                    'name': payment_liquidity_line.name,
-                    'date_maturity': payment_liquidity_line.date_maturity,
-                    'amount_currency': -payment_liquidity_line.amount_currency,
-                    'currency_id': payment_liquidity_line.currency_id.id,
-                    'debit': -payment_liquidity_line.debit,
-                    'credit': -payment_liquidity_line.credit,
-                    'partner_id': payment_liquidity_line.partner_id.id,
-                    'account_id': payment_liquidity_line.account_id.id,
-                }),
-            )
-            move_id = self.env['account.move'].create(vals)
-            move_id.action_post()
-            split_move_counterpart_line = move_id.line_ids.filtered(lambda x: x.amount_currency == -payment_liquidity_line.amount_currency)
-            (split_move_counterpart_line + payment_liquidity_line).reconcile()
-
     def _l10n_latam_check_unlink_split_move(self):
         self.ensure_one()
         for check in self.l10n_latam_new_check_ids:
@@ -236,33 +174,43 @@ class AccountPayment(models.Model):
     @api.model
     def _get_trigger_fields_to_synchronize(self):
         res = super()._get_trigger_fields_to_synchronize()
-        return res + ('l10n_latam_new_check_ids',)
+        return res + ('l10n_latam_new_check_ids', 'payment_method_line_id')
 
-    def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
-        """ Add check name and operation on liquidity line """
-        res = super()._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
+    def _prepare_move_liquidity_lines(self, default_vals):
+        l10n_latam_checks = self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids
+        if not l10n_latam_checks:
+            return super()._prepare_move_liquidity_lines(default_vals)
 
-        # if only one check we don't create the split line, we add same data on liquidity line
-        if self.payment_method_code == 'own_checks' and self.payment_type == 'outbound' and len(self.l10n_latam_new_check_ids) == 1:
-            res[0].update({
-                'name': _(
-                    'Check %(check_number)s - %(suffix)s',
-                    check_number=self.l10n_latam_new_check_ids.name,
-                    suffix=''.join([item[1] for item in self._get_aml_default_display_name_list()])),
-                'date_maturity': self.l10n_latam_new_check_ids.payment_date,
-            })
-        # we dont check the payment method code because when deposited on bank/cash journals pay method is manual but we still change the label
-        # we dont want this names on the own checks because it doesn't add value, already each split/check line will have it name
-        elif (self.l10n_latam_new_check_ids or self.l10n_latam_move_check_ids) and self.payment_method_code != 'own_checks':
-            check_name = [check_name for check_name in (self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids).mapped('name') if check_name]
-            document_name = (
-                _('Checks %s received') if self.payment_type == 'inbound' else _('Checks %s delivered')) % (
-                ', '.join(check_name)
+        liquidity_vals = []
+        payment_currency = self.currency_id
+        check_suffix = ''.join([item[1] for item in self._get_aml_default_display_name_list()])
+        line_common_vals = {
+            'currency_id': self.currency_id.id,
+            'partner_id': self.partner_id.id,
+            'account_id': self.outstanding_account_id.id,
+        }
+        for check in l10n_latam_checks:
+            liquidity_amount = check.amount if self.payment_type == 'inbound' else -check.amount
+            balance = payment_currency._convert(
+                liquidity_amount,
+                self.company_id.currency_id,
+                self.company_id,
+                check.payment_date,
             )
-            res[0].update({
-                'name': document_name + ' - ' + ''.join([item[1] for item in self._get_aml_default_display_name_list()]),
+            liquidity_vals.append({
+                'name': _(
+                    "Check %(check_number)s - %(suffix)s",
+                    check_number=check.name,
+                    suffix=check_suffix,
+                ),
+                'date_maturity': check.payment_date,
+                'amount_currency': liquidity_amount,
+                'balance': balance,
+                'l10n_latam_check_ids': [Command.set(check.ids)],
+                **line_common_vals,
             })
-        return res
+
+        return liquidity_vals
 
     @api.depends('l10n_latam_move_check_ids')
     def _compute_destination_account_id(self):

--- a/addons/l10n_latam_check/models/l10n_latam_check.py
+++ b/addons/l10n_latam_check/models/l10n_latam_check.py
@@ -96,7 +96,7 @@ class L10n_LatamCheck(models.Model):
     @api.depends('outstanding_line_id.amount_residual')
     def _compute_issue_state(self):
         for rec in self:
-            if not rec.outstanding_line_id:
+            if rec.payment_method_code != 'own_checks' or not rec.outstanding_line_id:
                 rec.issue_state = False
             elif rec.amount and not rec.outstanding_line_id.amount_residual:
                 if any(

--- a/addons/l10n_latam_check/tests/test_own_checks.py
+++ b/addons/l10n_latam_check/tests/test_own_checks.py
@@ -92,3 +92,5 @@ class TestOwnChecks(L10nLatamCheckTest):
         })
         payment.action_post()
         self.assertEqual(payment.amount, 120)
+        # There should be 4 lines: 3 liquidity lines (one per check) + 1 counterpart line
+        self.assertEqual(len(payment.move_id.line_ids), 4)


### PR DESCRIPTION
Till now, if the payment was made using checks for LATAM countries, the payment journal entry that was created consisted only one liquidity line for the JE. This was not much suitable in case if payment is sent / recieved via multiple checks.

This commit intends to solve this issue by splitting the Payment JE liquidity line into multiple liquidity lines (one for each check) when payment is made through multiple checks.

To improve the payment synchronization with its journal entry, the `payment_method_line_id` field is also added in
`_get_trigger_fields_to_synchronize()` method so if payment method is updated from / to Checks, the JE is updated accordingly.

task-5207671

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
