### PR TITLE
[FIX] website: wait for builder remount before proceeding in tour

### DIFF
--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -28,12 +28,8 @@ registerWebsitePreviewTour(
             trigger: ":iframe .o_loading_screen",
         },
         {
-            content: "Wait for the loading screen to disappear",
-            trigger: ":iframe:not(:has(.o_loading_screen))",
-        },
-        {
-            content: "Wait for the 'Content Saved' notification",
-            trigger: ".o_notification :contains('Content Saved')",
+            content: "Wait for the builder to mount after iframe reload",
+            trigger: ":iframe body.editor_enable",
         },
         {
             content: "Check that the header changed to 'Sidebar'",


### PR DESCRIPTION
When changing the header template to 'Sidebar', the loading screen disappears
but the WebsiteBuilder component remounts asynchronously.
If the tour proceeds to the theme tab before the remount completes, the builder
resets to the Edit tab (its initial state), breaking the test flow.

We wait for the builder to remount, and add `.editor_enable` class to the body
of the iframe, so then nothing disrupts the flow.

runbot-234504
