### PR TITLE
[FIX] stock_picking_batch: prevent error on partial wave validation

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -243,8 +243,11 @@ class StockPickingBatch(models.Model):
 
         # Run sanity_check as a batch and ignore the one in button_validate() since it is done here.
         pickings._sanity_check(separate_pickings=False)
-        # Skip sanity_check in pickings button_validate() & remove 'waiting' pickings from the batch
-        context = {'skip_sanity_check': True, 'pickings_to_detach': empty_waiting_pickings.ids}
+        context = {
+            'skip_sanity_check': True,   # Skip sanity_check in pickings button_validate()
+            'pickings_to_detach': empty_waiting_pickings.ids,  # Remove 'waiting' pickings from the batch
+            'batches_to_validate': self.ids,  # Skip current batch in auto_wave
+        }
         if len(empty_pickings) != len(pickings):
             # If some pickings are at least partially done, other pickings (empty & waiting) will be removed from batch without being cancelled in case of no backorder
             pickings = pickings - empty_pickings


### PR DESCRIPTION
## How to reproduce:
- Enable Wave transfert in setting
- Go to the Receipt Operation type:
    - Create Backorder: always
    - Automatic Batches: Enabled
    - Wave Grouping: Products
- Create and confirm (don't validate) 2 Receipts for 10 units of a storable product P
- The 2 receipt should have been added to a new wave transfer with 2 lines for P
- On the first line, set the quantity to 0
- On the second line, set the quantity to 1
- Try to validate the wave transfer ==>> UserError "The following transfers cannot be added to batch transfer WAVE/XXXX. Please check their states and operation types."

## Issue:
Backorders are generated before the current batch is marked 'done' (it waits for empty pickings to be detached). The auto-batch logic incorrectly identifies the current 'in_progress' batch as a candidate for the new backorders, attempting a merge that violates validation constraints.

## Solution:
Exclude the current wave/batch from the auto_wave search domain using a context variable passed during validation.

OPW-5413921

---

Test result before fix:
```
2026-01-13 10:37:26,541 27952 INFO oes_test_18.0 odoo.addons.stock_picking_batch.tests.test_auto_waving: Starting TestAutoWaving.test_auto_wave_skip_current_batch ... 
2026-01-13 10:37:26,820 27952 INFO oes_test_18.0 odoo.addons.stock_picking_batch.tests.test_auto_waving: ====================================================================== 
2026-01-13 10:37:26,820 27952 ERROR oes_test_18.0 odoo.addons.stock_picking_batch.tests.test_auto_waving: ERROR: TestAutoWaving.test_auto_wave_skip_current_batch
Traceback (most recent call last):
  File "/home/odoo/Odoo/src/18.0/odoo/addons/stock_picking_batch/tests/test_auto_waving.py", line 440, in test_auto_wave_skip_current_batch
    wave.action_done()
  File "/home/odoo/Odoo/src/18.0/odoo/addons/stock_picking_batch/models/stock_picking_batch.py", line 264, in action_done
    return pickings.with_context(**context).button_validate()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/Odoo/src/18.0/odoo/addons/stock_picking_batch/models/stock_picking.py", line 145, in button_validate
    res = super().button_validate()
          ^^^^^^^^^^^^^^^^^^^^^^^^^
...
  File "/home/odoo/Odoo/src/18.0/odoo/odoo/fields.py", line 1418, in __set__
    records.write({self.name: write_value})
  File "/home/odoo/Odoo/src/18.0/odoo/addons/stock_picking_batch/models/stock_picking.py", line 112, in write
    self.batch_id._sanity_check()
  File "/home/odoo/Odoo/src/18.0/odoo/addons/stock_picking_batch/models/stock_picking_batch.py", line 323, in _sanity_check
    raise UserError(_(
odoo.exceptions.UserError: The following transfers cannot be added to batch transfer WAVE/00012. Please check their states and operation types.
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
