### PR TITLE
[FIX] l10n_sa_edi: prevent error when company street is missing

### DIFF
--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -128,7 +128,7 @@ class AccountJournal(models.Model):
 
     def _l10n_sa_csr_required_fields(self):
         """ Return the list of fields required to generate a valid CSR as per ZATCA requirements """
-        return ['l10n_sa_private_key_id', 'vat', 'name', 'city', 'country_id', 'state_id']
+        return ['l10n_sa_private_key_id', 'vat', 'name', 'city', 'country_id', 'state_id', 'street']
 
     def _l10n_sa_generate_csr(self):
         """

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -507,3 +507,28 @@ class TestEdiZatca(TestSaEdiCommon):
 
         for field_name in expected_error_fields:
             self.assertIn(field_name, error_message, f"Error message should contain '{field_name}'")
+
+    def test_otp_validation_without_company_street(self):
+        """Test that validating OTP fails when the company street is missing."""
+        self.company.street = False
+
+        journal = self.env['account.journal'].search([
+            *self.env['account.journal']._check_company_domain(self.company),
+            ('type', '=', 'sale'),
+        ], limit=1)
+
+        wizard = self.env['l10n_sa_edi.otp.wizard'].create({
+            'journal_id': journal.id,
+            'l10n_sa_otp': '123456',
+        })
+
+        self.assertFalse(journal.l10n_sa_csr_errors)
+
+        wizard.validate()
+
+        self.assertTrue(journal.l10n_sa_csr_errors)
+        self.assertEqual(
+            str(journal.l10n_sa_csr_errors),
+            '<p>Please, make sure all the following fields have been '
+            'correctly set on the Company:\n - Street</p>'
+        )


### PR DESCRIPTION
This error occurs when attempting to set the "OTP" received from "ZATCA".

Steps to reproduce:
- Install `l10n_sa_edi` module > Switch to `SA Company`
- Go to `SA Company` and remove `Street`
- Journals > Open journal with type 'Sale' > ZATCA > Onboard Journal > Enter any OTP > Request

Traceback:
`TypeError- value argument must be a str`

At [1], the error occurs because the company has an empty street field, causing the value argument to be a `boolean` instead of the expected `string`.

[1]- https://github.com/odoo/odoo/blob/40a0b44231fd9a725ccf3667c4992e691e24cde7/addons/l10n_sa_edi/models/certificate.py#L71

sentry-7185302332

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
