### PR TITLE
[FIX] calendar: prevent error when creating a reminder

### DIFF
--- a/addons/calendar/models/calendar_alarm.py
+++ b/addons/calendar/models/calendar_alarm.py
@@ -71,7 +71,7 @@ class CalendarAlarm(models.Model):
         display_interval = self._interval_selection.get(self.interval, '')
         display_alarm_type = {
             key: value for key, value in self._fields['alarm_type']._description_selection(self.env)
-        }[self.alarm_type]
+        }.get(self.alarm_type, '')
         self.name = "%s - %s %s" % (display_alarm_type, self.duration, display_interval)
         if self.notify_responsible:
             self.name += " - " + _("Notify Responsible")


### PR DESCRIPTION
Currently, an error occurs when user creates a reminder.

**Steps to Reproduce:**
 - Install the `calendar` module.
 - Go to `Calendar` > `Configuration` > `Reminders`.
 - Create a `new reminder` and clear the `Type` field.

`KeyError: False`

**Cause**:
 - Error started occurring in 19.0 due to a change in selection field behavior. Since change https://github.com/odoo/odoo/pull/214422/commits/8d2a42ac419fdf7943a0c11beb8c5de6c6f85bef, selection fields no longer display an “empty” value.
 - To remove a value from a selection field, the user must clear the field, similar to a many2one field.
 - When the Type field is cleared, its value becomes False, which raise the error here [1].

**Fix:**
 - This commit ensures that when the alarm type is False, display_alarm_type is set to an empty value 
    similar to the display interval [2].
 - Since both fields are required, once they are set again, the correct name is computed accordingly.

[1]: https://github.com/odoo/odoo/blob/2ee2f7678ed262036ee8cf8719ceafd3d69d4062/addons/calendar/models/calendar_alarm.py#L72-L74

[2]: https://github.com/odoo/odoo/blob/97e90f14ea40e4dc8645f845ef78eb579bb3e8dc/addons/calendar/models/calendar_alarm.py#L71

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
