### PR TITLE
[FIX] {account_,}payment: allow generating QR codes without HTTP request

### DIFF
--- a/addons/account_payment/wizards/payment_link_wizard.py
+++ b/addons/account_payment/wizards/payment_link_wizard.py
@@ -99,7 +99,7 @@ class PaymentLinkWizard(models.TransientModel):
         if self.res_model != 'account.move':
             return res
 
-        return payment_utils.generate_access_token(self.res_id, self.amount)
+        return payment_utils.generate_access_token(self.res_id, self.amount, env=self.env)
 
     def _prepare_anchor(self):
         """ Override of `payment` to set the 'portal_pay' anchor. """

--- a/addons/payment/utils.py
+++ b/addons/payment/utils.py
@@ -2,7 +2,7 @@
 
 from hashlib import sha1
 
-from odoo import fields
+from odoo import api, fields
 from odoo.http import request
 from odoo.tools import consteq, float_round
 from odoo.tools.misc import hmac as hmac_tool
@@ -12,7 +12,7 @@ from odoo.addons.payment.const import CURRENCY_MINOR_UNITS
 
 # Access token management
 
-def generate_access_token(*values):
+def generate_access_token(*values, env=None):
     """ Generate an access token based on the provided values.
 
     The token allows to later verify the validity of a request, based on a given set of values.
@@ -21,11 +21,14 @@ def generate_access_token(*values):
     All values must be convertible to a string.
 
     :param list values: The values to use for the generation of the token
+    :param api.Environment env: The environment to use for the generation of the token
     :return: The generated access token
     :rtype: str
     """
+    env = env or (request and request.env)
+    assert isinstance(env, api.Environment), "Environment required to generate access token."
     token_str = '|'.join(str(val) for val in values)
-    access_token = hmac_tool(request.env(su=True), 'generate_access_token', token_str)
+    access_token = hmac_tool(env(su=True), 'generate_access_token', token_str)
     return access_token
 
 

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -94,7 +94,7 @@ class PaymentLinkWizard(models.TransientModel):
     def _prepare_access_token(self):
         self.ensure_one()
         return payment_utils.generate_access_token(
-            self.partner_id.id, self.amount, self.currency_id.id
+            self.partner_id.id, self.amount, self.currency_id.id, env=self.env,
         )
 
     def _prepare_anchor(self):


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. In Accounting/Invoicing settings, enable "Add QR-code link on PDF";
2. create an automation rule for the `account.move` model;
3. set "Trigger" to "Create & Edit";
4. set "Apply on" domain to `[("state", "=", "posted")]`;
5. set "When updating" to "Status";
6. add an action to execute the following code:
    ```python
    env['account.move.send']._generate_and_send_invoices(records)
    ```
7. call `action_post` on an invoice via RPC or Odoo Shell.

Issue
-----
> odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
> RuntimeError: object is not bound

Cause
-----
In order to add a payment link QR code to the invoice[^1], it needs to generate an access token for the portal. This happens via the `generate_access_token` function from `odoo.addons.payment.utils`. Issue is that it relies on having access to a `odoo.http.request` object, so that it can use its `env` to retrieve the `database.secret` config parameter.

When this flow gets triggered via an API call (or Odoo Shell), the `request` object is unbound, causing the error.

[^1]: feature added via commit bcb73cd159885

Solution
--------
Introduce an optional `env` kwarg to `generate_access_token`, falling back on `request.env` if it's not provided.

opw-5487075