### PR TITLE
[FIX] account: don't load CoA if no country on install

### DIFF
--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -67,6 +67,7 @@ class IrModuleModule(models.Model):
         if (
             not was_installed and is_installed
             and not self.env.company.chart_template
+            and self.env.company.country_id
             and self.account_templates
             and (guessed := next((
                 tname

--- a/addons/account/tests/test_account_move_attachment.py
+++ b/addons/account/tests/test_account_move_attachment.py
@@ -8,7 +8,11 @@ class TestAccountMoveAttachment(HttpCase):
     def test_preserving_manually_added_attachments(self):
         """ Preserve attachments manually added (not coming from emails) to an invoice """
         self.authenticate("admin", "admin")
-
+        self.env['account.journal'].create({
+            'name': 'Test Journal',
+            'code': 'TEST',
+            'type': 'sale',
+        })
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
         })

--- a/addons/account/tests/test_digest.py
+++ b/addons/account/tests/test_digest.py
@@ -2,6 +2,7 @@
 
 from odoo import Command
 from odoo.addons.digest.tests.common import TestDigestCommon
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tools import mute_logger
 from odoo.tests import tagged
 
@@ -13,8 +14,15 @@ class TestAccountDigest(TestDigestCommon):
     @mute_logger('odoo.models.unlink')
     def setUpClass(cls):
         super().setUpClass()
-        account1 = cls.env['account.account'].search([('internal_group', '=', 'income'), ('company_ids', '=', cls.company_1.id)], limit=1)
-        account2 = cls.env['account.account'].search([('internal_group', '=', 'expense'), ('company_ids', '=', cls.company_1.id)], limit=1)
+        account1, account2 = cls.env['account.account'].with_company(cls.company_1).create([{
+            'name': 'Account 1 Company 1',
+            'account_type': 'income_other',
+            'code': 'aaaaaa',
+        }, {
+            'name': 'Account 2 Company 1',
+            'account_type': 'expense_depreciation',
+            'code': 'bbbbbb',
+        }])
         cls.env['account.journal'].with_company(cls.company_2).create({
             'name': 'Test Journal',
             'code': 'code',

--- a/addons/account/tests/test_kpi_provider.py
+++ b/addons/account/tests/test_kpi_provider.py
@@ -8,9 +8,42 @@ class TestKpiProvider(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
+        company = cls.env.ref('base.main_company')
+        cls.company_id = company.id
         cls.partner_id = cls.env['res.partner'].create({'name': 'Someone'})
-
+        cls.income_account, _, cls.suspense_account = cls.env['account.account'].with_company(cls.company_id).create([
+            {
+                'name': 'Income',
+                'code': '40000',
+                'account_type': 'income',
+            },
+            {
+                'name': 'Receivables',
+                'code': '10000',
+                'account_type': 'asset_receivable'
+            },
+            {
+                'name': 'Suspense',
+                'code': '20000',
+                'account_type': 'asset_current'
+            }
+        ])
+        company.account_journal_suspense_account_id = cls.suspense_account
+        cls.env['account.journal'].with_company(cls.company_id).create([
+            {
+                'name': 'Sales',
+                'type': 'sale',
+            },
+            {
+                'name': 'Miscellaneous',
+                'type': 'general'
+            },
+            {
+                'name': 'Purchase',
+                'type': 'purchase'
+            }
+        ]
+        )
         # Clean things for the test
         cls.env['account.move'].search([
             '|', ('state', '=', 'draft'),
@@ -22,11 +55,9 @@ class TestKpiProvider(TransactionCase):
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])
 
     def test_kpi_summary(self):
-        company_id = self.ref('base.main_company')
-        account_id = self.env['account.account'].search([('company_ids', '=', company_id)], limit=1)
         base_move = {
-            'company_id': company_id,
-            'invoice_line_ids': [Command.create({'account_id': account_id.id, 'quantity': 15, 'price_unit': 10})],
+            'company_id': self.company_id,
+            'invoice_line_ids': [Command.create({'account_id': self.suspense_account.id, 'quantity': 15, 'price_unit': 10})],
             'partner_id': self.partner_id.id,
         }
         self.env['account.move'].create(
@@ -45,11 +76,9 @@ class TestKpiProvider(TransactionCase):
         ])
 
     def test_kpi_summary_shouldnt_report_posted_moves(self):
-        company_id = self.ref('base.main_company')
-        account_id = self.env['account.account'].search([('company_ids', '=', company_id)], limit=1).id
         move = self.env['account.move'].create({
-            'company_id': company_id,
-            'invoice_line_ids': [Command.create({'account_id': account_id, 'quantity': 15, 'price_unit': 10})],
+            'company_id': self.company_id,
+            'invoice_line_ids': [Command.create({'account_id': self.income_account.id, 'quantity': 15, 'price_unit': 10})],
             'partner_id': self.partner_id.id,
             'move_type': 'out_invoice',
         })
@@ -61,11 +90,9 @@ class TestKpiProvider(TransactionCase):
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])
 
     def test_kpi_summary_reports_posted_but_to_check_moves(self):
-        company_id = self.ref('base.main_company')
-        account_id = self.env['account.account'].search([('company_ids', '=', company_id)], limit=1).id
         move = self.env['account.move'].create({
-            'company_id': company_id,
-            'invoice_line_ids': [Command.create({'account_id': account_id, 'quantity': 15, 'price_unit': 10})],
+            'company_id': self.company_id,
+            'invoice_line_ids': [Command.create({'account_id': self.income_account.id, 'quantity': 15, 'price_unit': 10})],
             'partner_id': self.partner_id.id,
             'move_type': 'out_invoice',
         })
@@ -79,11 +106,9 @@ class TestKpiProvider(TransactionCase):
         self.assertCountEqual(self.env['kpi.provider'].get_account_kpi_summary(), [])
 
     def test_kpi_summary_reports_unreconciled_bank_statements(self):
-        company_id = self.ref('base.main_company')
-        account_id = self.env['account.account'].search([('company_ids', '=', company_id), ('account_type', '=', 'income')], limit=1).id
         move = self.env['account.move'].create({
-            'company_id': company_id,
-            'line_ids': [Command.create({'account_id': account_id, 'quantity': 15, 'price_unit': 10})],
+            'company_id': self.company_id,
+            'line_ids': [Command.create({'account_id': self.income_account.id, 'quantity': 15, 'price_unit': 10})],
             'partner_id': self.env.user.partner_id.id,
             'move_type': 'out_invoice',
         })

--- a/addons/account/tests/test_mail_tracking_value.py
+++ b/addons/account/tests/test_mail_tracking_value.py
@@ -58,6 +58,11 @@ class TestTracking(AccountTestInvoicingCommon, MailCase):
                 'phone': '0455135790',
             })
         partner_admin = self.env.ref('base.partner_admin')
+        self.env['account.journal'].create({
+            'name': 'Test Journal',
+            'code': 'TEST',
+            'type': 'general',
+        })
         multiple_account_moves = [
             {
                 'description': 'Single account.move',

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -94,7 +94,7 @@ class TestUi(AccountTestInvoicingHttpCommon):
             'is_favorite': True,
             'default_code': '0',
         })
-        self.start_tour("/odoo/customer-invoices/new", 'test_use_product_catalog_on_invoice', login="admin")
+        self.start_tour("/odoo/customer-invoices/new", 'test_use_product_catalog_on_invoice', login=self.env.user.login)
 
     def test_deductible_amount_column(self):
         self.assertFalse(self.env.user.has_group('account.group_partial_purchase_deductibility'))
@@ -114,5 +114,5 @@ class TestUi(AccountTestInvoicingHttpCommon):
         self.start_tour(
             '/odoo/customer-invoices/new',
             'test_add_section_from_product_catalog_on_invoice',
-            login='admin',
+            login=self.env.user.login,
         )


### PR DESCRIPTION
Before this commit-
Load db without demo and install account,
The company country is overriden by US and
generic CoA is loaded

After this commit-
We only load CoA on installing account
if there is a country set on the company

task-none



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
