### PR TITLE
[FIX] stock_account: Fix lot column alignment and modernize invoice lot table layout

### DIFF
--- a/addons/stock_account/views/report_invoice.xml
+++ b/addons/stock_account/views/report_invoice.xml
@@ -5,7 +5,7 @@
           <t groups="stock_account.group_lot_on_invoice">
             <t t-set="lot_values" t-value="o._get_invoiced_lot_values()"/>
             <div t-if="not lot_values" class="oe_structure">&#8203;</div>
-            <table t-else="" class="table table-sm mt-2" style="width: 50%;" name="invoice_snln_table">
+            <table t-else="" class="table table-borderless table-sm mt-2" style="width: 50%;" name="invoice_snln_table">
                 <thead>
                     <tr>
                         <th><span>Product</span></th>
@@ -17,10 +17,10 @@
                     <tr t-foreach="lot_values" t-as="snln_line">
                         <td><t t-esc="snln_line['product_name']">Bacon</t></td>
                         <td class="text-end">
-                            <t t-esc="snln_line['quantity']">6.00</t>
-                            <t t-esc="snln_line['uom_name']" groups="uom.group_uom">units</t>
+                            <span t-esc="snln_line['quantity']">6.00</span>
+                            <span t-esc="snln_line['uom_name']" groups="uom.group_uom">units</span>
                         </td>
-                        <td><t class="text-end" t-esc="snln_line['lot_name']">BC46282798</t></td>
+                        <td class="text-end"><t t-esc="snln_line['lot_name']">BC46282798</t></td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
since commit https://github.com/odoo/odoo/commit/86d3b4f, some typos in the invoice lot table template caused the lot name column to be incorrectly aligned.

this commit fixes the alignment issue by correcting the misplaced `text-end` class. It also replaces `<t>` tags with `<span>` elements for inline content, ensuring proper spacing and more predictable rendering in the report.

additionally, the table layout is improved by switching to a `borderless table`, making it more consistent with the current invoice report design.

Description of the issue/feature this PR addresses:

Current behavior before PR: 

<img width="797" height="863" alt="image" src="https://github.com/user-attachments/assets/52774edc-9247-4b1f-b104-7f94a56d0f20" />


Desired behavior after PR is merged:

<img width="796" height="870" alt="image" src="https://github.com/user-attachments/assets/7f899369-2890-42c6-b0bf-f790d34e2324" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
