### PR TITLE
[FIX] html_editor: clean media iframe video class from embedded videos

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_video_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/embedded_video_plugin.js
@@ -15,6 +15,16 @@ export class EmbeddedVideoPlugin extends VideoPlugin {
         mount_component_handlers: this.extendEmbeddedVideoProps.bind(this),
     };
 
+    setup() {
+        // we need to clean media_iframe_video class from embedded videos
+        // because it might have been added by the Video plugin
+        for (const video of this.document.querySelectorAll(
+            ".media_iframe_video[data-embedded='video']"
+        )) {
+            video.classList.remove("media_iframe_video");
+        }
+    }
+
     /** @override */
     get componentForMediaDialog() {
         return EmbeddedVideoSelector;


### PR DESCRIPTION
Previously, embedded video selector were adding a `.media_iframe_video` class,
which wasn't the expected behavior, and the fix for the issue has been
implemented in [1]. However, if the video had been added in 19.0 before that
commit, the video would still have that class, and wouldn't function properly.
Issue 1:
- In knowledge embedded videos with the specified class aren't visible to
everyone.

Issue 2:
- Video added in eLearning course description wouldn't be displayed on the
course's webpage. Same issue with product's description, or job summary.

[1]: https://github.com/odoo/odoo/commit/249a45cbe9bab1edfd61145c84c5ab033b9ca722

task-5442928
opw-5224050
opw-5454714