### PR TITLE
[REF] iot_drivers: replace `owner` by `session_id`

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -59,7 +59,6 @@ class Driver(Thread):
 
         session_id = data.get('session_id')
         if session_id:
-            self.data["owner"] = session_id
             self.data["session_id"] = session_id
 
         try:

--- a/addons/iot_drivers/iot_handlers/drivers/ctypes_terminal_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/ctypes_terminal_driver.py
@@ -147,7 +147,6 @@ class CtypesTerminalDriver(Driver, ABC):
         self.device_type = 'payment'
         self.device_connection = 'network'
         self.cid = None
-        self.owner = None
         self.queue_actions = Queue()
         self.terminal_busy = False
 

--- a/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/display_driver_L.py
@@ -27,7 +27,6 @@ class DisplayDriver(Driver):
         self.device_type = 'display'
         self.device_connection = 'hdmi'
         self.device_name = device['name']
-        self.owner = False
         self.customer_display_data = {}
 
         saved_url, self.orientation = helpers.load_browser_state()

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -55,7 +55,7 @@ class PrinterDriverBase(Driver, ABC):
             self._recent_action_ids.pop(action_unique_id, None)  # avoid filtering duplicates on errors
         self.data['status'] = status
         self.data['message'] = message
-        event_manager.device_changed(self, {'session_id': self.data.get('owner')})
+        event_manager.device_changed(self)
 
     def print_receipt(self, data):
         _logger.debug("print_receipt called for printer %s", self.device_name)

--- a/addons/iot_drivers/tools/communication.py
+++ b/addons/iot_drivers/tools/communication.py
@@ -19,7 +19,6 @@ def handle_message(message_type: str, communication_type: str, **kwargs: dict) -
     """
     device_identifier = kwargs.get('device_identifier', IOT_IDENTIFIER)
     base_response = {
-        'owner': kwargs.get('session_id', '0'),  # TODO: remove 'owner' in future versions
         'session_id': kwargs.get('session_id', '0'),
         'iot_box_identifier': IOT_IDENTIFIER,
         'device_identifier': device_identifier,


### PR DESCRIPTION
To maintain consistency, we rename `owner` to
`session_id` in drivers and responses to longpolling requests.

see odoo/enterprise#104157