### PR TITLE
[IMP] mail: add button to clear search in search messages panel

### DIFF
--- a/addons/mail/static/src/core/common/search_message_input.js
+++ b/addons/mail/static/src/core/common/search_message_input.js
@@ -53,6 +53,12 @@ export class SearchMessageInput extends Component {
         this.props.closeSearch?.();
     }
 
+    onClickClearSearch() {
+        this.state.searchTerm = "";
+        this.state.searchedTerm = "";
+        this.props.messageSearch.clear();
+    }
+
     onKeydownSearch(ev) {
         if (ev.key !== "Enter") {
             return;

--- a/addons/mail/static/src/core/common/search_message_input.xml
+++ b/addons/mail/static/src/core/common/search_message_input.xml
@@ -4,8 +4,9 @@
         <div class="o-mail-SearchMessageInput d-flex py-2">
             <div class="input-group">
                 <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">
-                    <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
-                        <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0 rounded-start px-2 bg-view" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
+                    <div class="o_searchview_input_container d-flex align-items-center flex-grow-1 flex-wrap gap-1 h-100">
+                        <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0 rounded-start ps-2 bg-view" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
+                        <i class="fa fa-fw fa-times-circle me-2 opacity-50 opacity-100-hover" t-att-class="{ 'invisible': !state.searchedTerm }" role="img" aria-label="Clear Search" title="Clear Search" t-on-click="() => this.onClickClearSearch()"/>
                     </div>
                 </div>
                 <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">

--- a/addons/mail/static/tests/discuss/search_messages_panel.test.js
+++ b/addons/mail/static/tests/discuss/search_messages_panel.test.js
@@ -80,6 +80,10 @@ test("Search a message", async () => {
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
+    expect(".o_searchview_input").toHaveValue("message");
+    await click("i[aria-label='Clear Search']");
+    await contains(".o-mail-SearchMessagesPanel:not(:has(.o-mail-Message))");
+    expect(".o_searchview_input").toHaveValue("");
 });
 
 test.tags("desktop");


### PR DESCRIPTION
This commit adds a floating "x" button at end of input when the search messages panel shows search results. This button eases clearing the search input and results.

<img width="664" height="549" alt="Screenshot 2026-01-13 at 14 35 56" src="https://github.com/user-attachments/assets/f14211b5-ef01-4992-8e5c-3cfaa5d770ca" />

Task-5262379