### PR TITLE
[FIX] stock: fix error when product is not added in delivery operations

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -770,7 +770,13 @@ class StockPicking(models.Model):
         all_moves._fields['forecast_availability'].compute_value(all_moves)
         for picking in pickings:
             # In case of draft the behavior of forecast_availability is different : if forecast_availability < 0 then there is a issue else not.
-            if any(move.product_id.uom_id.compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty) == -1 for move in picking.move_ids):
+            if any(
+                move.product_id
+                and move.product_id.uom_id.compare(
+                    move.forecast_availability, 0 if move.state == 'draft' else move.product_qty
+                ) == -1
+                for move in picking.move_ids
+            ):
                 picking.products_availability = _('Not Available')
                 picking.products_availability_state = 'late'
             else:


### PR DESCRIPTION
Currently, an error occurs when a user edits a delivery order after adding a product line, but without selecting any product.

**Steps to Reproduce:**
1. Install the **Stock** module.
2. Create a new Delivery Order and click **"Mark as To-do"**.
3. Click **"Add a product"**, but do not select any product.
4. Change the 'Scheduled Date' or 'Delivery Address'.

Video Ref: [LINK](https://drive.google.com/file/d/1v_MZ0nfNa_lzTjV1gChchCw4g_aKzP-8/view?usp=drive_link)

**Error:**
`ValueError - Expected singleton: uom.uom()`

**Cause:**
When a stock move is created without a product, `move.product_id` remains empty, which leads to the singleton error during product availability computation.

**Fix:**
This commit adds a check before performing the UOM comparison.

sentry-7173331233