### PR TITLE
[FIX] website: Save cookie consent with primary button style

### DIFF
--- a/addons/website/static/src/interactions/cookies/cookies_bar.js
+++ b/addons/website/static/src/interactions/cookies/cookies_bar.js
@@ -24,7 +24,8 @@ export class CookiesBar extends Popup {
         },
         "#cookies-consent-essential, #cookies-consent-all": { "t-on-click": this.onAcceptClick },
         // Override to avoid side effects on hide.
-        ".js_close_popup": { "t-on-click": () => { } },
+        ".js_close_popup": { "t-on-click": () => {} },
+        ".btn-primary": { "t-on-click": () => {} },
         ".modal": {
             "t-on-keydown.capture": (ev) => {
                 if (ev.key === "Escape") {


### PR DESCRIPTION
Steps to reproduce:
===================
1. Enable the Cookies Bar in website settings.
2. Go to the website and enter Edit mode.
3. Select the Cookie Bar and change the button "I agree" style shape to "Default"  (this applies the `.btn-primary` class). & Save
4. Accept the cookies & refresh

-> The cookie bar appears again because the consent was not saved.

Cause:
======
The `CookiesBar` widget inherits from the generic `Popup` widget. The `Popup` class defines a default behavior for elements with the `.btn-primary` class: clicking them triggers `onBtnPrimaryClick`, which closes the popup.

By default, the cookie bar button uses `.btn-outline-primary`, avoiding this behavior. However, when the user changes the style to "Default", the button receives the `.btn-primary` class. Consequently, the parent `Popup` handler is triggered. It closes the modal prematurely, interrupting the `CookiesBar`'s specific logic (specifically `onAcceptClick`),So onHideModal won't be called inside the function, and as a result, the user's consent cookie is never written.

Solution:
=========
Override the event to avoid side effects on hide.

opw-5484578

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
