### PR TITLE
[FIX] hr_holidays_attendance, hr_attendance: include attendance between two days in hourly accrual plans

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -12,7 +12,7 @@ from random import randint
 
 from odoo.http import request
 from odoo import models, fields, api, exceptions, _
-from odoo.addons.resource.models.utils import Intervals
+from odoo.addons.resource.models.utils import Intervals, sum_intervals
 from odoo.osv.expression import AND, OR
 from odoo.tools.float_utils import float_is_zero
 from odoo.exceptions import AccessError
@@ -212,19 +212,34 @@ class HrAttendance(models.Model):
             between check_in and check_out, without taking into account the lunch_interval"""
         for attendance in self:
             if attendance.check_out and attendance.check_in and attendance.employee_id:
-                calendar = attendance._get_employee_calendar()
-                resource = attendance.employee_id.resource_id
-                tz = timezone(resource.tz) if not calendar else timezone(calendar.tz)
-                check_in_tz = attendance.check_in.astimezone(tz)
-                check_out_tz = attendance.check_out.astimezone(tz)
-                lunch_intervals = []
-                if not attendance.employee_id.is_flexible:
-                    lunch_intervals = attendance.employee_id._employee_attendance_intervals(check_in_tz, check_out_tz, lunch=True)
-                attendance_intervals = Intervals([(check_in_tz, check_out_tz, attendance)]) - lunch_intervals
-                delta = sum((i[1] - i[0]).total_seconds() for i in attendance_intervals)
-                attendance.worked_hours = delta / 3600.0
+                attendance.worked_hours = attendance._get_worked_hours_in_range(attendance.check_in, attendance.check_out)
             else:
                 attendance.worked_hours = False
+
+    def _get_worked_hours_in_range(self, start_dt, end_dt):
+        """Returns the amount of hours worked because of this attendance during the
+        interval defined by [start_dt, end_dt]
+
+        :param start_dt: datetime starting the interval.
+        :param end_dt: datetime ending the interval.
+        :returns: float, hours worked
+        """
+        self.ensure_one()
+        calendar = self._get_employee_calendar()
+        resource = self.employee_id.resource_id
+        tz = timezone(resource.tz) if not calendar else timezone(calendar.tz)
+        start_dt_tz = max(self.check_in, start_dt).astimezone(tz)
+        end_dt_tz = min(self.check_out, end_dt).astimezone(tz)
+
+        if end_dt_tz < start_dt_tz:
+            return 0.0
+
+        lunch_intervals = []
+        if not self.employee_id.is_flexible:
+            lunch_intervals = self.employee_id._employee_attendance_intervals(start_dt_tz, end_dt_tz, lunch=True)
+        attendance_intervals = Intervals([(start_dt_tz, end_dt_tz, self)]) - lunch_intervals
+        delta = sum_intervals(attendance_intervals)
+        return delta
 
     @api.constrains('check_in', 'check_out')
     def _check_validity_check_in_check_out(self):

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -76,10 +76,16 @@ class HolidaysAllocation(models.Model):
         datetime_min_time = datetime.min.time()
         start_dt = datetime.combine(start_date, datetime_min_time)
         end_dt = datetime.combine(end_date, datetime_min_time)
+
+        # Search for any attendance overlapping the window
         attendances = self.env['hr.attendance'].sudo().search([
             ('employee_id', '=', self.employee_id.id),
-            ('check_in', '>=', start_dt),
-            ('check_out', '<=', end_dt),
+            ('check_in', '<', end_dt),
+            ('check_out', '>', start_dt),
         ])
-        work_entry_prorata = sum(attendances.mapped('worked_hours'))
-        return work_entry_prorata
+
+        total_worked_hours = 0.0
+        for attendance in attendances:
+            total_worked_hours += attendance._get_worked_hours_in_range(start_dt, end_dt)
+
+        return total_worked_hours

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -100,3 +100,91 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
             allocation_form.date_from = datetime.date(2024, 3, 25)
             allocation_form.name = 'Accrual allocation for employee'
             self.assertEqual(allocation_form.number_of_hours_display, 8.0)
+
+    def test_accrual_allocation_with_overlapping_attendance(self):
+        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+            'name': 'Accrual Plan For Test',
+            'is_based_on_worked_time': True,
+            'accrued_gain_time': 'end',
+            'carryover_date': 'year_start',
+            'level_ids': [(0, 0, {
+                'start_count': 0,
+                'added_value': 1,
+                'added_value_type': 'hour',
+                'frequency': 'hourly',
+                'cap_accrued_time': True,
+                'maximum_leave': 100,
+                'frequency_hourly_source': 'attendance'
+            })],
+        })
+        with freeze_time("2024-4-1"):
+            allocation = self.env['hr.leave.allocation'].create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+            allocation.action_validate()
+
+        self.env['hr.attendance'].create({
+            'employee_id': self.employee_emp.id,
+            'check_in': datetime.datetime(2024, 4, 1, 22, 0, 0),
+            'check_out': datetime.datetime(2024, 4, 2, 7, 0, 0),
+        })
+
+        with freeze_time(datetime.datetime(2024, 4, 2, 20, 0, 0)):
+            # Only counts the part of the attendance on the 01/04/2024: 2 hours
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 0.25)  # 2 / 8 = 0.25
+
+        with freeze_time(datetime.datetime(2024, 4, 3, 20, 0, 0)):
+            # Counts the whole attendance: 9 hours
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 1.125)  # 9 / 8 = 1.125
+
+    def test_accrual_allocation_with_overlapping_attendance_timezone(self):
+        self.employee_emp.tz = 'Asia/Tokyo'
+        self.employee_emp.resource_calendar_id.tz = 'Asia/Tokyo'
+        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+            'name': 'Accrual Plan For Test',
+            'is_based_on_worked_time': True,
+            'accrued_gain_time': 'end',
+            'carryover_date': 'year_start',
+            'level_ids': [(0, 0, {
+                'start_count': 0,
+                'added_value': 1,
+                'added_value_type': 'hour',
+                'frequency': 'hourly',
+                'cap_accrued_time': True,
+                'maximum_leave': 100,
+                'frequency_hourly_source': 'attendance'
+            })],
+        })
+        with freeze_time("2024-4-1"):
+            allocation = self.env['hr.leave.allocation'].create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+            allocation.action_validate()
+
+        self.env['hr.attendance'].create({
+            'employee_id': self.employee_emp.id,
+            'check_in': datetime.datetime(2024, 4, 1, 22, 0, 0),  # In Tokyo: 2024/04/02, 7h
+            'check_out': datetime.datetime(2024, 4, 2, 7, 0, 0),  # In Tokyo: 2024/04/02, 16h
+        })
+
+        with freeze_time(datetime.datetime(2024, 4, 2, 20, 0, 0)):
+            # Only counts the part of the attendance on the 01/04/2024 UTC: 2 hours
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 0.25)  # 2 / 8 = 0.25
+
+        with freeze_time(datetime.datetime(2024, 4, 3, 20, 0, 0)):
+            # Counts the whole attendance: 9 hours - 1h of lunchtime = 8h
+            allocation._update_accrual()
+            self.assertEqual(allocation.number_of_days, 1.0)  # 8 / 8 = 1.0


### PR DESCRIPTION
### Issue:
Attendances overlapping on two days are ignored for hourly accrual plans based on attendances.

### Steps to reproduce:
- Install 'hr_holidays_attendance'
- In Time Off > Configuration > Accrual Plan, create a new plan
	- Based on worked time
	- Hourly rule
	- Attendances as Source
- In Management > Allocations, create an allocation for an employee using the new accrual plan
- Create an Attendance for this employee in the period of the Accrual Plan
	- Check-in at 22pm for example
	- Check-out at 7am
- Run the cron "Accrual Time Off: Updates the number of time off"
- The Allocation ignores the worked time from the attendance

### Cause:
`_get_accrual_plan_level_work_entry_prorata()` is called on each day of the accrual period. So `start_dt` is `datetime.datetime(2026, 1, 2, 0, 0)` and `end_dt` is `datetime.datetime(2026, 1, 3, 0, 0)` for example. This means that the search will always excludes attendances overlapping on two days.

https://github.com/odoo/odoo/blob/26f3026ed45cc409cd7f67fa219d44f1adbac9b7/addons/hr_holidays_attendance/models/hr_leave_allocation.py#L79-L83

### Solution:
To count the attendances on several days, we need to split these attendances by day because `_get_accrual_plan_level_work_entry_prorata()` is only called with an interval of one day from midnight to midnight.

First we get all attendances overlapping with the day by changing the domain in the search.

Then we could simply take the difference between `max(attendance.check_in, start_dt)` and `min(attendance.check_out, end_dt)` but we also need to remove the lunch breaks (they were not counted in `attendance.worked_hours`). 

This would mean duplicating the code present in `_compute_worked_hours()`. To avoid this we create a new method for `hr.attendance` named `_get_worked_hours_in_range()`. That returns the number of hours worked due to this attendance in a given time frame. 
This new method can be used in both cases to get the needed value.

opw-5172669