### PR TITLE
[IMP] hr_holidays: UX improvements

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -398,6 +398,7 @@ class HrEmployee(models.Model):
     @api.model
     def get_time_off_dashboard_data(self, target_date=None):
         return {
+            'has_future_allocation': self.env['hr.work.entry.type'].has_future_allocation(),
             'has_accrual_allocation': self.env['hr.work.entry.type'].has_accrual_allocation(),
             'allocation_data': self.env['hr.work.entry.type'].get_allocation_data_request(target_date, False),
             'allocation_request_amount': self.get_allocation_requests_amount(),

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1531,10 +1531,10 @@ class HrLeave(models.Model):
             view_name = 'hr_holidays.hr_leave_allocation_view_tree_my'
             domain = [('employee_id', '=', employee.id)]
         return {
-            'name': _('Allocation Requests'),
+            'name': self.env._('Allocation Requests'),
             'type': 'ir.actions.act_window',
             'res_model': 'hr.leave.allocation',
-            'views': [[self.env.ref(view_name).id, 'list']],
+            'views': [(self.env.ref(view_name).id, 'list'), (False, 'form')],
             'domain': domain,
             'context': context,
         }

--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -437,7 +437,18 @@ class HrWorkEntryType(models.Model):
             '|',
             ('date_to', '>', date.today()),
             ('date_to', '=', False),
-        ]))
+        ], limit=1))
+
+    @api.model
+    def has_future_allocation(self):
+        employee = self.env['hr.employee']._get_contextual_employee()
+        if not employee:
+            return False
+        return bool(self.env['hr.leave.allocation'].search_count([
+            ('employee_id', '=', employee.id),
+            ('state', '=', 'validate'),
+            ('date_from', '>', date.today()),
+        ], limit=1))
 
     @api.model
     def get_allocation_data_request(self, target_date=None, hidden_allocations=True):

--- a/addons/hr_holidays/static/src/components/time_off_new_dropdown/time_off_new_dropdown.js
+++ b/addons/hr_holidays/static/src/components/time_off_new_dropdown/time_off_new_dropdown.js
@@ -1,0 +1,16 @@
+import { Component } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+
+export class TimeOffNewDropdown extends Component{
+    static template = "hr_holidays.TimeOffNewDropdown";
+    static components = {
+        Dropdown,
+        DropdownItem,
+    };
+    static props = {
+        onNewTimeOffRequest: Function,
+        onNewAllocationRequest: Function,
+    }
+
+}

--- a/addons/hr_holidays/static/src/components/time_off_new_dropdown/time_off_new_dropdown.xml
+++ b/addons/hr_holidays/static/src/components/time_off_new_dropdown/time_off_new_dropdown.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="hr_holidays.TimeOffNewDropdown">
+        <Dropdown>
+            <button t-attf-class="btn btn-primary o-dropdown-caret d-inline-flex align-items-center">
+                New
+            </button>
+            <t t-set-slot="content">
+                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="props.onNewTimeOffRequest">
+                    New Time Off
+                </DropdownItem>
+                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="props.onNewAllocationRequest">
+                    New Allocation Request
+                </DropdownItem>
+            </t>
+        </Dropdown>
+    </t>
+</templates>

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -1,7 +1,7 @@
 import { onWillRender } from "@web/owl2/utils";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { user } from "@web/core/user";
-import { formatNumber, useNewAllocationRequest } from "@hr_holidays/views/hooks";
+import { formatNumber } from "@hr_holidays/views/hooks";
 import { useService } from "@web/core/utils/hooks";
 import { Component } from "@odoo/owl";
 
@@ -20,7 +20,6 @@ export class TimeOffCardPopover extends Component {
         "close?",
         "allows_negative",
         "max_allowed_negative",
-        "onClickNewAllocationRequest?",
         "errorLeaves",
         "accrualExcess",
         "timeOffType",
@@ -77,9 +76,11 @@ export class TimeOffCardPopover extends Component {
         const context = isInHolidaysUserGroup
             ? {
                   search_default_group_date_from: true,
+                  expand_leave_list: true,
               }
             : {
                   search_default_group_date_from: true,
+                  expand_leave_list: true,
                   list_view_ref: "hr_holidays.hr_leave_view_tree_my",
                   form_view_ref: "hr_holidays.hr_leave_view_form",
               };
@@ -97,7 +98,6 @@ export class TimeOffCard extends Component {
             position: "bottom",
             popoverClass: "bg-view",
         });
-        this.newAllocationRequest = useNewAllocationRequest();
         this.actionService = useService("action");
         this.lang = user.lang;
         this.formatNumber = formatNumber;
@@ -136,7 +136,7 @@ export class TimeOffCard extends Component {
         const accrualExcess = this.getAccrualExcess(data);
         const closeExpire =
             data.closest_allocation_duration &&
-            data.closest_allocation_duration < data.virtual_remaining_leaves;
+            data.closest_allocation_duration < data.closest_allocation_remaining;
         this.warning = errorLeavesSignificant || accrualExcess || closeExpire;
     }
 
@@ -154,7 +154,6 @@ export class TimeOffCard extends Component {
             exceeding_duration: data.exceeding_duration,
             allows_negative: data.allows_negative,
             max_allowed_negative: data.max_allowed_negative,
-            onClickNewAllocationRequest: this.newAllocationRequestFrom.bind(this),
             errorLeaves: this.errorLeaves,
             accrualExcess: this.getAccrualExcess(data),
             timeOffType: holidayStatusId,
@@ -170,11 +169,6 @@ export class TimeOffCard extends Component {
             : -data.exceeding_duration > 0;
     }
 
-    async newAllocationRequestFrom() {
-        this.popover.close();
-        await this.newAllocationRequest(this.props.employeeId, this.props.holidayStatusId);
-    }
-
     async navigateTimeOffType() {
         const { employeeId, holidayStatusId, data } = this.props;
         const isInHolidaysUserGroup = await user.hasGroup("hr_holidays.group_hr_holidays_user");
@@ -188,11 +182,13 @@ export class TimeOffCard extends Component {
         const context = isInHolidaysUserGroup
             ? {
                   search_default_group_date_from: true,
+                  expand_leave_list: true,
               }
             : {
                   list_view_ref: "hr_holidays.hr_leave_view_tree_my",
                   form_view_ref: "hr_holidays.hr_leave_view_form",
                   search_default_group_date_from: true,
+                  expand_leave_list: true,
               };
 
         openLeaveWindow(this.actionService, resModel, name, domain, context);

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.scss
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.scss
@@ -20,6 +20,7 @@
         color: $body-color;
         font-size: 15px;
         margin-bottom: 3px;
+        font-weight: bolder;
     }
 
     .o_timeoff_name.btn-link:hover {

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -7,35 +7,36 @@
         <t t-set="show_popover" t-value="true"/>
 
         <strong class="o_timeoff_name cursor-pointer btn-link" t-on-click="this.navigateTimeOffType"><t t-out="this.props.name"/></strong>
-        <span class="o_timeoff_duration">
-            <span t-att-style="data.holds_changes ? 'color: #B6D369;' : ''">
-                <t t-out="parsed_duration"/>
+        <div class="d-flex flex-column justify-content-start cursor-pointer" t-on-click.stop="(ev) => (show_popover &amp;&amp; this.onClickInfo(ev))">
+            <span class="o_timeoff_duration">
+                <span t-att-style="data.holds_changes ? 'color: #B6D369;' : ''">
+                    <t t-out="parsed_duration"/>
+                </span>
             </span>
-        </span>
-        <span
-            t-att-class="'text-uppercase o_timeoff_details p-1' + (this.warning ? ' alert alert-warning' : '')"
-            t-on-click.stop="(ev) => (show_popover &amp;&amp; this.onClickInfo(ev))">
-            <t t-if="data.unit_of_measure == 'hour'" name="duration_unit">hours</t>
-            <t t-else="">days</t>
-            <t t-if="this.props.requires_allocation" name="duration_type">
-                available
-            </t>
-            <t t-else="">
-                taken
-            </t>
-            <span t-if="show_popover"
-                t-att-class="'o_timeoff_info fa' + (this.warning ? ' fa-exclamation-triangle' : ' fa-question-circle-o')"
-            />
-        </span>
-        <span t-if="this.props.requires_allocation and data.closest_allocation_expire !== false" class="text-uppercase o_timeoff_validity">
-            <t t-if="data.closest_allocation_remaining != data.virtual_remaining_leaves">
-                (<t t-out="data.closest_allocation_remaining"/> <t t-if="data.unit_of_measure == 'hour'">hours</t><t t-else="">days</t>
-                valid until <span t-out="data.closest_allocation_expire"/>)
-            </t>
-            <t t-else="">
-                (valid until <span t-out="data.closest_allocation_expire"/>)
-            </t>
-        </span>
+            <span
+                t-att-class="'text-uppercase o_timeoff_details p-1' + (this.warning ? ' alert alert-warning' : '')">
+                <t t-if="data.unit_of_measure == 'hour'" name="duration_unit">hours</t>
+                <t t-else="">days</t>
+                <t t-if="this.props.requires_allocation" name="duration_type">
+                    available
+                </t>
+                <t t-else="">
+                    taken
+                </t>
+                <span t-if="show_popover"
+                    t-att-class="'o_timeoff_info fa' + (this.warning ? ' fa-exclamation-triangle' : ' fa-question-circle-o')"
+                />
+            </span>
+            <span t-if="this.props.requires_allocation and data.closest_allocation_expire !== false" class="text-uppercase o_timeoff_validity">
+                <t t-if="data.closest_allocation_remaining != data.virtual_remaining_leaves">
+                    (<t t-out="data.closest_allocation_remaining"/> <t t-if="data.unit_of_measure == 'hour'">hours</t><t t-else="">days</t>
+                    valid until <span t-out="data.closest_allocation_expire"/>)
+                </t>
+                <t t-else="">
+                    (valid until <span t-out="data.closest_allocation_expire"/>)
+                </t>
+            </span>
+        </div>
     </div>
 
     <t t-name="hr_holidays.TimeOffCardMobile">
@@ -54,15 +55,14 @@
 
     <t t-name="hr_holidays.TimeOffCardPopover">
         <ul class="list-unstyled p-3 mb-0">
-            <li class="d-flex justify-content-between">
-                <span><span class="btn-link p-0 cursor-pointer" t-on-click="this.allocatedLeaves">Allocated</span> (<span class="btn-link p-0 cursor-pointer" t-on-click="this.props.onClickNewAllocationRequest">new request</span>):</span>
-                <span class="ps-1" t-out="this.props.allocated"/>
+            <li class="d-flex justify-content-between btn-link p-0 cursor-pointer" t-on-click="this.allocatedLeaves">
+                Allocated: <span class="ps-1" t-out="this.props.allocated"/>
             </li>
             <li class="d-flex justify-content-between" t-if="this.props.accrual_bonus != 0">
                 Accrual (Future): <span class="ps-1" t-out="this.props.accrual_bonus"/>
             </li>
             <li class="d-flex justify-content-between btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['validate'])">Approved: <span class="ps-1" t-out="this.props.approved"/></li>
-            <li class="d-flex justify-content-between border-bottom btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['confirm','validate1'])">Planned: <span class="ps-1" t-out="this.props.planned"/></li>
+            <li class="d-flex justify-content-between border-bottom btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['confirm','validate1'])">Pending: <span class="ps-1" t-out="this.props.planned"/></li>
             <li class="d-flex justify-content-between">Available: <span class="ps-1" t-out="this.props.left"/></li>
         </ul>
         <div t-if="this.props.warning" class="alert alert-warning mb-0 pb-0 o_time_off_card_popover_warning">

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -1,23 +1,8 @@
 import { useState } from "@web/owl2/utils";
-import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { TimeOffCard } from "./time_off_card";
-import { useNewAllocationRequest } from "@hr_holidays/views/hooks";
-import { _t } from "@web/core/l10n/translation";
-import { useBus, useService, useOwnedDialogs } from "@web/core/utils/hooks";
+import { useBus, useService } from "@web/core/utils/hooks";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { Component, onWillStart } from "@odoo/owl";
-import { userHasEmployeeInCurrentCompany } from "@hr_holidays/utils";
-
-function useUniqueDialog() {
-    const displayDialog = useOwnedDialogs();
-    let close = null;
-    return (...args) => {
-        if (close) {
-            close();
-        }
-        close = displayDialog(...args);
-    };
-}
 
 export class TimeOffDashboard extends Component {
     static components = { TimeOffCard, DateTimeInput };
@@ -27,14 +12,12 @@ export class TimeOffDashboard extends Component {
     setup() {
         this.orm = useService("orm");
         this.actionService = useService("action");
-        this.newRequest = useNewAllocationRequest();
         this.state = useState({
             date: luxon.DateTime.now(),
             today: luxon.DateTime.now(),
             holidays: [],
             allocationRequests: 0,
         });
-        this.displayDialog = useUniqueDialog();
         useBus(this.env.timeOffBus, "update_dashboard", async () => {
             await this.loadDashboardData();
         });
@@ -66,18 +49,7 @@ export class TimeOffDashboard extends Component {
         this.state.holidays = dashboardData['allocation_data'];
         this.state.allocationRequests = dashboardData['allocation_request_amount'];
         this.hasAccrualAllocation = dashboardData['has_accrual_allocation'];
-    }
-
-    async newAllocationRequest() {
-        const hasEmployee = await userHasEmployeeInCurrentCompany(this.orm);
-        if (!this.props.employeeId && !hasEmployee) {
-            this.displayDialog(AlertDialog, {
-                title: _t("UserError"),
-                body: _t("This operation is not allowed as you are not linked to an employee in the current company."),
-            });
-            return;
-        }
-        await this.newRequest(this.props.employeeId);
+        this.hasFutureAllocation = dashboardData['has_future_allocation'];
     }
 
     resetDate() {

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.scss
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.scss
@@ -10,8 +10,7 @@
 
 .o_timeoff_dashboard {
     display: flex;
-    flex-direction: row;
-
+    flex-direction: column;
     height: auto;
     box-shadow: inset 0 -1px 0 $border-color;
     position: sticky;

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
@@ -1,37 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <div t-name="hr_holidays.TimeOffDashboard" class="o_timeoff_dashboard">
-        <t t-foreach="this.state.holidays" t-as="holiday" t-key="holiday[3]">
-            <TimeOffCard
-                name="holiday[0]"
-                data="holiday[1]"
-                requires_allocation="holiday[2]"
-                holidayStatusId="holiday[3]"
-                employeeId="this.props.employeeId"/>
-        </t>
-        <div class="o_timeoff_card p-0 d-flex justify-content-around">
-            <div class="row justify-content-center align-items-center border-bottom h-25 w-100 p-0" t-if="this.hasAccrualAllocation">
-                Balance at the
-                <div class="p-1" style="max-width: 100px!important">
-                    <DateTimeInput
-                        type="'date'"
-                        value="this.state.date"
-                        onChange="(date) => this.loadDashboardData(date)"
-                        minDate="this.state.today"
-                        placeholder.translate="Today"/>
-                </div>
-                <button class="o_timeoff_today_button btn btn-secondary" t-on-click="this.resetDate">Today</button>
+        <div t-if="this.hasAccrualAllocation or this.hasFutureAllocation"
+                class="row justify-content-center align-items-center border-bottom w-100 p-1">
+            Balance at the
+            <div class="p-1" style="max-width: 100px!important">
+                <DateTimeInput
+                    type="'date'"
+                    value="this.state.date"
+                    onChange="(date) => this.loadDashboardData(date)"
+                    minDate="this.state.today"
+                    placeholder.translate="Today"/>
             </div>
-            <div class="d-flex flex-column justify-content-center align-items-center w-100">
+            <button class="o_timeoff_today_button btn btn-secondary" t-on-click="this.resetDate">Today</button>
+        </div>
+        <div class="d-flex flex-row p-0 justify-content-around">
+            <t t-foreach="this.state.holidays" t-as="holiday" t-key="holiday[3]">
+                <TimeOffCard
+                    name="holiday[0]"
+                    data="holiday[1]"
+                    requires_allocation="holiday[2]"
+                    holidayStatusId="holiday[3]"
+                    employeeId="this.props.employeeId"/>
+            </t>
+            <div t-if="this.state.allocationRequests" class="o_timeoff_card py-3">
                 <strong class="o_timeoff_name">Pending Requests</strong>
                 <span t-on-click="this.openPendingRequests"
-                    t-att-class="'o_timeoff_duration' + (this.state.allocationRequests ? ' cursor-pointer' : '')">
+                    class="o_timeoff_duration text-primary cursor-pointer">
                     <t t-out="this.state.allocationRequests"/>
                 </span>
-                <a class="text-uppercase o_timeoff_details p-1" t-on-click="this.newAllocationRequest">
-                    <t t-if="this.employeeId">Grant Time</t>
-                    <t t-else="">New Allocation Request</t>
-                </a>
             </div>
         </div>
     </div>

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -13,7 +13,13 @@ registry.category("web_tour.tours").add("hr_holidays_tour", {
             run: "click",
         },
         {
-            trigger: "button.btn-time-off",
+            trigger: ".o_timeoff_buttons .o-dropdown-caret",
+            content: _t("Click on this button to request time-off or allocation"),
+            tooltipPosition: "bottom",
+            run: "click",
+        },
+        {
+            trigger: ".o-dropdown-item:nth-child(1)",
             content: _t("Click on this button to request a time-off"),
             tooltipPosition: "bottom",
             run: "click",

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -1,15 +1,16 @@
 import { useSubEnv } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
 import { CalendarController } from "@web/views/calendar/calendar_controller";
-import { AlertDialog, ConfirmationDialog} from "@web/core/confirmation_dialog/confirmation_dialog";
+import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { userHasEmployeeInCurrentCompany } from "@hr_holidays/utils";
 
 import { serializeDate } from "@web/core/l10n/dates";
 
 import { TimeOffCalendarSidePanel } from "./calendar_side_panel/calendar_side_panel";
 import { TimeOffCalendarMobileFilterPanel } from "./calendar_filter_panel/calendar_mobile_filter_panel";
+import { TimeOffNewDropdown } from "../../components/time_off_new_dropdown/time_off_new_dropdown";
 import { TimeOffFormViewDialog } from "../view_dialog/form_view_dialog";
-import { useLeaveCancelWizard } from "../hooks";
+import { useLeaveCancelWizard, useNewAllocationRequest } from "../hooks";
 import { EventBus, onWillStart } from "@odoo/owl";
 
 export class TimeOffCalendarController extends CalendarController {
@@ -17,6 +18,7 @@ export class TimeOffCalendarController extends CalendarController {
         ...CalendarController.components,
         CalendarSidePanel: TimeOffCalendarSidePanel,
         MobileFilterPanel: TimeOffCalendarMobileFilterPanel,
+        NewButton: TimeOffNewDropdown,
     };
     static template = "hr_holidays.CalendarController";
     setup() {
@@ -25,6 +27,7 @@ export class TimeOffCalendarController extends CalendarController {
             timeOffBus: new EventBus(),
         });
         this.leaveCancelWizard = useLeaveCancelWizard();
+        this.newAllocRequest = useNewAllocationRequest();
 
         onWillStart(async () => {
             this.hasEmployee = await userHasEmployeeInCurrentCompany(this.orm);
@@ -79,6 +82,23 @@ export class TimeOffCalendarController extends CalendarController {
             size: "md",
             context: context,
         });
+    }
+
+    newAllocationRequest() {
+        if (!this.employeeId && !this.hasEmployee) {
+            this.displayDialog(AlertDialog, {
+                title: _t("UserError"),
+                body: _t("This operation is not allowed as you are not linked to an employee in the current company."),
+            });
+            return;
+        }
+        let empId;
+        if (this.props.context.active_id && this.props.context.active_model === "hr.employee") {
+            empId = this.props.context.active_id;
+        } else if (this.employeeId) {
+            empId = this.employeeId;
+        }
+        this.newAllocRequest({ employeeId: empId, forceLargeDialog: this.props.context.hide_employee_name ?? false })
     }
 
     _deleteRecord(resId, canCancel) {

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
@@ -6,9 +6,10 @@
             <t t-if="this.props.archInfo.canCreate" t-set-slot="control-panel-buttons">
                 <span class="o_timeoff_buttons btn-group">
                     <div class="btn-group">
-                        <button class="btn btn-primary btn-time-off " t-on-click="this.newTimeOffRequest" type="button">
-                            New
-                        </button>
+                        <NewButton
+                            onNewTimeOffRequest="() => this.newTimeOffRequest()"
+                            onNewAllocationRequest="() => this.newAllocationRequest()"
+                        />
                     </div>
                 </span>
             </t>

--- a/addons/hr_holidays/static/src/views/hooks.js
+++ b/addons/hr_holidays/static/src/views/hooks.js
@@ -45,17 +45,19 @@ export function useLeaveCancelWizard() {
 export function useNewAllocationRequest() {
     const addDialog = useOwnedDialogs();
     const component = useComponent();
-    return async (employeeId, holidayStatusId) => {
+    return async ({ employeeId, holidayStatusId, forceLargeDialog }) => {
         let size = "md";
         const context = {
             form_view_ref: "hr_holidays.hr_leave_allocation_view_form_dashboard",
             is_employee_allocation: true,
         };
-        if (employeeId) {
+        if (employeeId || forceLargeDialog) {
             size = "lg";
-            context["default_employee_id"] = employeeId;
             context["form_view_ref"] =
                 "hr_holidays.hr_leave_allocation_view_form_manager_dashboard";
+        }
+        if (employeeId) {
+            context["default_employee_id"] = employeeId;
         }
         if (holidayStatusId) {
             context["default_work_entry_type_id"] = holidayStatusId;

--- a/addons/hr_holidays/static/tests/tours/time_off_card_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_card_tour.js
@@ -71,8 +71,8 @@ registry.category("web_tour.tours").add("time_off_card_tour", {
             run: "click",
         },
         {
-            content: "Click on the link containing 'Planned'",
-            trigger: ".o_popover .btn-link:contains('Planned')",
+            content: "Click on the link containing 'Pending'",
+            trigger: ".o_popover .btn-link:contains('Pending')",
             run: "click",
         },
         {

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -595,7 +595,7 @@
         <field name="name">hr.holidays.view.list</field>
         <field name="model">hr.leave</field>
         <field name="arch" type="xml">
-            <list string="Time Off Requests" sample="1" duplicate="false" js_class="hr_holidays_payslip_list">
+            <list string="Time Off Requests" sample="1" expand="context.get('expand_leave_list', False)" duplicate="false" js_class="hr_holidays_payslip_list">
                 <header>
                     <button type="action"
                         name="%(hr_holidays.action_hr_leave_generate_multi_wizard)d"


### PR DESCRIPTION

- made the pending allocations clickable in list view (when you click pending requests in the dashboard and then try to open them in the list view)
- made the new button in the dashboard (calendar view) allow to create timeoff or allocations and removed old buttons to create allocations
- made the closest expiration warning appear when the time till closest allocation expiry is greater than the available leaves to take in the closest allocation instead of all allocations
- made the number in the timeoff card clickable to have the same behavior as "days available"
- allowed to select a date in the future if the employee has future allocations to show them in the dashboard
- made the list view of time off (accessed from the time off card) auto expand for pending and approved requests

task-id: 5473334

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
