### PR TITLE
[FIX] html_editor: fix non-deterministic toolbar test

### DIFF
--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1811,7 +1811,7 @@ test("toolbar update should be run only once", async () => {
     await waitFor(".o-we-toolbar");
     counter = 0;
     click(".o-we-toolbar .btn[name='bold']");
-    await animationFrame();
+    await waitFor(".btn[name='bold'].active");
     expect(getContent(el)).toBe("<p><strong>[test]</strong></p>");
     expect(counter).toBe(1);
 });


### PR DESCRIPTION
Waiting one animation frame for the toolbar to update is not enough because the toolbar is a popover and is therefore affected by [1].

Use `waitFor` to avoid non-deterministic test failures on runbot.

runbot-237773

[1]: https://github.com/odoo/odoo/commit/54da715df84789f9a1acc0cfc91be41dcdbab140