### PR TITLE
[FIX] *: apply quality failure to correct subcontracting production

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -327,8 +327,12 @@ class StockMove(models.Model):
                 'product_qty': wip_production.product_qty + quantity_to_remove
             }).change_prod_qty()
 
+        productions = productions - wip_production
+        if self.env.context.get('failed_quality'):
+            productions = productions.sorted(lambda p: (p.lot_producing_id.id != self.env.context.get('failed_lot_id'), not p.subcontracting_has_been_recorded))
+
         # Cancel productions until reach new_quantity
-        for production in (productions - wip_production):
+        for production in productions:
             if float_compare(quantity_to_remove, production.product_qty, precision_rounding=production.product_uom_id.rounding) >= 0:
                 if len(productions + wip_production) == 1:
                     production.qty_producing = 0


### PR DESCRIPTION
*:mrp_subcontracting{,_quality}, quality_control
**Issue**
In subcontracting, a failing quality check could lead to inconsistent quantities.

**Steps to reproduce**
- Create two tracked products (final and component)
- Create a BoM for the final product using the component, with subcontracting
- Create a pass/fail Quality check with:
  - Operation type: Receipts
  - Control per Quantity
- Create a PO for the final product:
  - With a quantity of 3
  - With the associated partner be the one mentioned in the subcontracting BOM
  - Confirm it
- Open the associated receipt
- Record 2/3 products
- Perform the quality check and fail 1 product

-> The quantity is removed from the 1 unrecorded product instead of the recorded ones
-> It is no longer possible to record additional products, although 1 should still be available

**Cause**
While recording products, the subcontracting production is split into multiple productions:
https://github.com/odoo/odoo/blob/a03fb90069c5a51340c81626cc90dbea22ca45bb/addons/mrp_subcontracting/models/mrp_production.py#L76
https://github.com/odoo/odoo/blob/a03fb90069c5a51340c81626cc90dbea22ca45bb/addons/mrp_subcontracting/models/mrp_production.py#L94

When a quality check fails, the quantity is reduced on the stock move:
https://github.com/odoo/enterprise/blob/2d3722242461a77ed954cc09835539e8010494f8/quality_control/models/quality.py#L471

This reduction is propagated to the subcontracting productions, removing the quantity from the first production,
then the next one if needed.
The production order is determined here:
https://github.com/odoo/odoo/blob/a03fb90069c5a51340c81626cc90dbea22ca45bb/addons/mrp_subcontracting/models/stock_move.py#L320

As a result, the reduction could be applied to a production unrelated to the inspected lot.

**Solution**
In case of a quality failure, ensure subcontracting productions are ordered so that:
- productions linked to the inspected finished lot (when lot tracking is enabled), and
- among them, productions that have already been recorded
are reduced first when applying the quality failure.

opw-5427873