### PR TITLE
[FIX] html_builder, *: ensure compatibility with RTL

### DIFF
--- a/addons/html_builder/static/src/core/builder_component_plugin.js
+++ b/addons/html_builder/static/src/core/builder_component_plugin.js
@@ -5,7 +5,7 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { BuilderDateTimePicker } from "./building_blocks/builder_datetimepicker";
 import { BuilderSlidingPanel } from "./building_blocks/builder_sliding_panel";
 import { BuilderRow } from "./building_blocks/builder_row";
-import { BuilderButton } from "./building_blocks/builder_button";
+import { BuilderButton, BuilderButtonLtrRtl } from "./building_blocks/builder_button";
 import { BuilderNumberInput } from "./building_blocks/builder_number_input";
 import { BuilderSelect } from "./building_blocks/builder_select";
 import { BuilderSelectItem } from "./building_blocks/builder_select_item";
@@ -49,6 +49,7 @@ export class BuilderComponentPlugin extends Plugin {
             DropdownItem,
             BuilderButtonGroup,
             BuilderButton,
+            BuilderButtonLtrRtl,
             BuilderTextInput,
             BuilderNumberInput,
             BuilderRange,

--- a/addons/html_builder/static/src/core/building_blocks/builder_button.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_button.js
@@ -2,10 +2,12 @@ import { Component } from "@odoo/owl";
 import {
     clickableBuilderComponentProps,
     useActionInfo,
+    useLanguageDirection,
     useSelectableItemComponent,
 } from "../utils";
 import { BuilderComponent } from "./builder_component";
 import { Image } from "../img";
+import { _t } from "@web/core/l10n/translation";
 
 export class BuilderButton extends Component {
     static template = "html_builder.BuilderButton";
@@ -18,6 +20,7 @@ export class BuilderButton extends Component {
         label: { type: String, optional: true },
         iconImg: { type: String, optional: true },
         iconImgAlt: { type: String, optional: true },
+        iconImgAttrs: { type: Object, optional: true },
         icon: { type: String, optional: true },
         className: { type: String, optional: true },
         classActive: { type: String, optional: true },
@@ -30,6 +33,7 @@ export class BuilderButton extends Component {
     static defaultProps = {
         type: "secondary",
         titleActive: "",
+        iconImgAttrs: {},
     };
 
     setup() {
@@ -68,5 +72,149 @@ export class BuilderButton extends Component {
             return `oi ${this.props.icon}`;
         }
         return "";
+    }
+}
+
+const ltrRtlSplittableProps = [
+    "className",
+    "actionParam",
+    "actionValue",
+    "classAction",
+    "styleAction",
+    "styleActionValue",
+    "attributeAction",
+    "attributeActionValue",
+    "dataAttributeAction",
+    "dataAttributeActionValue",
+];
+
+/**
+ * Many options are BuilderButtonGroups with at least a "Left" and a "Right"
+ * button, but their action actually depends on the start and end of the line
+ * (e.g. `flex-row` vs `flex-row-reverse`). They need some logic to work across
+ * all 4 possible combinations of LTR / RTL in the backend (builder) and the
+ * frontend (iframe).
+ *
+ * The `BuilderButtonLtrRtl` is a helper component to share the logic.
+ *
+ * |                  | **Backend LTR** | **Backend RTL** |
+ * | ---------------- | --------------- | --------------- |
+ * | **Frontend LTR** |    LTR / LTR    |    LTR / RTL    |
+ * | **Frontend RTL** |    RTL / LTR    |    RTL / RTL    |
+ *
+ * The place of the button (visually on the left or on the right) depends on the
+ * _backend language_: in English, the 1st button is on the left, the 2nd is on
+ * the right. In Arabic, the 1st button is on the right, the 2nd is on the left.
+ * This is done by default (normal flow of the DOM). We then need to adapt each
+ * button's label, icon, and action.
+ *
+ * **UNDERLYING LOGIC**:
+ * - The label and icon of the button depend on the _backend direction_ (as
+ * opposed to English, the 1st button in Arabic is on the right and should
+ * always be labelled "right" with an arrow icon pointing right).
+ * - The action of the button depends on whether both backend and frontend have
+ * the same direction or not: if both are the same, the 1st button should have a
+ * "start" action (in English: left = start, in Arabic: right = start). If both
+ * are different, the 1st button should have an "end" action (backend in English
+ * with a frontend in Arabic: left = end, right = start).
+ *
+ * **API**:
+ * - All the "ltrRtlSplittableProps" can either take a single value if it
+ * applies to both, or a `sameDir` key (when the backend and frontend directions
+ * are the same) and a `diffDir` key (when they are different).
+ * - The `label` prop takes a `left` and a `right` key for translatable strings,
+ * applied as title / aria-label. By default, they are set on "Left" and
+ * "Right". You can override the prop if you need a more specific text.
+ * - The mandatory `position` prop takes either "start" or "end". It refers to
+ * the position of the button in the UI, i.e. the normal flow of the document.
+ * Always set the 1st `BuilderButtonLtrRtl` to "start" and the last one to "end"
+ * - Note that icons are mirrored by default when the backend is RTL.
+ *
+ *  Examples:
+ *
+ *      <BuilderButtonGroup>
+ *          <BuilderButtonLtrRtl position="'start'"
+ *              classAction="{ sameDir: 'text-start', diffDir: 'text-end' }"
+ *              icon="'fa-align-left'"/>
+ *          <BuilderButtonLtrRtl position="'end'"
+ *              classAction="{ sameDir: 'text-end', diffDir: 'text-start' }"
+ *              icon="'fa-align-right'"/>
+ *      </BuilderButtonGroup>
+ *
+ * Keep custom translatable strings in `t-set`, otherwise they won't be
+ * translated:
+ *
+ *      <BuilderButtonGroup action="customAction">
+ *          <t t-set="slideToLeft">Slide to left</t>
+ *          <t t-set="slideToRight">Slide to right</t>
+ *          <t t-set="label" t-value="{ left: slideToLeft, right: slideToRight }"/>
+ *          <BuilderButtonLtrRtl position="'start'"
+ *              label="label"
+ *              actionParam="{ sameDir: 'start', diffDir: 'end' }"/>
+ *          <BuilderButtonLtrRtl position="'end'"
+ *              label="label"
+ *              actionParam="{ sameDir: 'end', diffDir: 'start' }"/>
+ *      </BuilderButtonGroup>
+ */
+export class BuilderButtonLtrRtl extends Component {
+    static template = "html_builder.BuilderButtonLtrRtl";
+    static components = { BuilderButton };
+    static props = {
+        position: { validate: (v) => ["start", "end"].includes(v) },
+        label: { type: Object, optional: true },
+        title: { type: String, optional: true },
+        id: { type: String, optional: true },
+        iconImg: { type: String, optional: true },
+        icon: { type: String, optional: true },
+        className: { type: Object, optional: true },
+        actionParam: { type: Object, optional: true },
+        actionValue: { type: Object, optional: true },
+        classAction: { type: Object, optional: true },
+        styleAction: { type: Object, optional: true },
+        styleActionValue: { type: Object, optional: true },
+        attributeAction: { type: Object, optional: true },
+        attributeActionValue: { type: Object, optional: true },
+        dataAttributeAction: { type: Object, optional: true },
+        dataAttributeActionValue: { type: Object, optional: true },
+        slots: { type: Object, optional: true },
+    };
+
+    static defaultProps = {
+        label: { left: _t("Left"), right: _t("Right") },
+        className: { sameDir: undefined, diffDir: undefined },
+        actionParam: { sameDir: undefined, diffDir: undefined },
+        actionValue: { sameDir: undefined, diffDir: undefined },
+        classAction: { sameDir: undefined, diffDir: undefined },
+        styleAction: { sameDir: undefined, diffDir: undefined },
+        styleActionValue: { sameDir: undefined, diffDir: undefined },
+        attributeAction: { sameDir: undefined, diffDir: undefined },
+        attributeActionValue: { sameDir: undefined, diffDir: undefined },
+        dataAttributeAction: { sameDir: undefined, diffDir: undefined },
+        dataAttributeActionValue: { sameDir: undefined, diffDir: undefined },
+    };
+
+    setup() {
+        this.langDir = useLanguageDirection();
+        this.iconImgAttrs =
+            this.langDir.backend === "ltr" ? {} : { style: "transform: scaleX(-1);" };
+
+        for (const prop of ltrRtlSplittableProps) {
+            if (
+                this.props[prop] instanceof Object &&
+                "sameDir" in this.props[prop] &&
+                "diffDir" in this.props[prop]
+            ) {
+                this[prop] = this.props[prop];
+            } else {
+                this[prop] = { sameDir: this.props[prop], diffDir: this.props[prop] };
+            }
+        }
+    }
+
+    get title() {
+        if ((this.langDir.backend === "ltr") === (this.props.position === "start")) {
+            return this.props.label.left;
+        }
+        return this.props.label.right;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_button.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_button.xml
@@ -18,12 +18,34 @@
             t-on-click="() => this.onClick()"
             t-on-pointerenter="() => this.onPointerEnter(props.id)"
             t-on-pointerleave="() => this.onPointerLeave(props.id)">
-            <Image t-if="props.iconImg" src="props.iconImg" attrs="{alt:props.iconImgAlt}"/>
+            <Image t-if="props.iconImg" src="props.iconImg" attrs="{ alt: props.iconImgAlt, ...props.iconImgAttrs }"/>
             <i t-if="props.icon" t-att-class="iconClassName" role="img"/>
             <t t-if="props.label"  t-out="props.label"/>
             <t t-slot="default"/>
         </button>
     </BuilderComponent>
+</t>
+
+<t t-name="html_builder.BuilderButtonLtrRtl">
+    <t t-set="areFrontendBackendSame" t-value="this.langDir.frontend === this.langDir.backend"/>
+    <BuilderButton
+        title="this.title"
+        id="this.props.id"
+        actionParam="areFrontendBackendSame ? this.actionParam.sameDir : this.actionParam.diffDir"
+        actionValue="areFrontendBackendSame ? this.actionValue.sameDir : this.actionValue.diffDir"
+        classAction="areFrontendBackendSame ? this.classAction.sameDir : this.classAction.diffDir"
+        styleAction="areFrontendBackendSame ? this.styleAction.sameDir : this.styleAction.diffDir"
+        styleActionValue="areFrontendBackendSame ? this.styleActionValue.sameDir : this.styleActionValue.diffDir"
+        attributeAction="areFrontendBackendSame ? this.attributeAction.sameDir : this.attributeAction.diffDir"
+        attributeActionValue="areFrontendBackendSame ? this.attributeActionValue.sameDir : this.attributeActionValue.diffDir"
+        dataAttributeAction="areFrontendBackendSame ? this.dataAttributeAction.sameDir : this.dataAttributeAction.diffDir"
+        dataAttributeActionValue="areFrontendBackendSame ? this.dataAttributeActionValue.sameDir : this.dataAttributeActionValue.diffDir"
+        className="areFrontendBackendSame ? this.className.sameDir : this.className.diffDir"
+        icon="this.props.icon"
+        iconImg="this.props.iconImg"
+        iconImgAttrs="this.iconImgAttrs">
+        <t t-slot="default"/>
+    </BuilderButton>
 </t>
 
 </templates>

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -9,6 +9,7 @@ import {
     toRaw,
 } from "@odoo/owl";
 import { convertNumericToUnit, getHtmlStyle } from "@html_editor/utils/formatting";
+import { localization } from "@web/core/l10n/localization";
 import { useBus } from "@web/core/utils/hooks";
 import { effect } from "@web/core/utils/reactive";
 import { useDebounced } from "@web/core/utils/timing";
@@ -942,6 +943,14 @@ export function useInputDebouncedCommit(ref) {
     // holding up/down on a number or range input.
 }
 
+export function useLanguageDirection() {
+    const comp = useComponent();
+    return {
+        frontend: comp.env.editor.config.isEditableRTL ? "rtl" : "ltr",
+        backend: localization.direction,
+    };
+}
+
 export const basicContainerBuilderComponentProps = {
     id: { type: String, optional: true },
     applyTo: { type: String, optional: true },
@@ -1182,6 +1191,8 @@ export class BaseOptionComponent extends Component {
         this.processThrough = context.processThrough;
         /** @type { EditorContext['checkPredicates'] } **/
         this.checkPredicates = context.checkPredicates;
+
+        this.langDir = useLanguageDirection();
 
         this.isActiveItem = useIsActiveItem();
         const comp = useComponent();

--- a/addons/html_builder/static/src/plugins/block_alignment_option.xml
+++ b/addons/html_builder/static/src/plugins/block_alignment_option.xml
@@ -4,9 +4,13 @@
 <t t-name="html_builder.BlockAlignmentOption">
     <BuilderRow label.translate="Alignment" t-if="!this.isActiveItem('so_width_100')" level="1">
         <BuilderButtonGroup>
-            <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'me-auto'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                classAction="{ sameDir: 'me-auto', diffDir: 'ms-auto' }"
+                icon="'fa-align-left'"/>
             <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"/>
-            <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'ms-auto'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                classAction="{ sameDir: 'ms-auto', diffDir: 'me-auto' }"
+                icon="'fa-align-right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -37,10 +37,18 @@
 <t t-name="html_builder.ImageAndFaOption">
     <BuilderRow label.translate="Alignment">
         <BuilderSelect>
+            <t t-set="alignLeft">Align Left</t>
+            <t t-set="alignRight">Align Right</t>
+            <t t-set="left">Left</t>
+            <t t-set="right">Right</t>
             <BuilderSelectItem action="'imageAlignClassAction'" actionParam="''" title.translate="Unalign">None</BuilderSelectItem>
-            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'me-auto float-start'" title.translate="Align Left">Left</BuilderSelectItem>
+            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'me-auto float-start'"
+                title="this.langDir.frontend === 'ltr' ? alignLeft : alignRight"
+                t-out="this.langDir.frontend === 'ltr' ? left : right"/>
             <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'mx-auto d-block'" title.translate="Align Center">Center</BuilderSelectItem>
-            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'ms-auto float-end'" title.translate="Align Right">Right</BuilderSelectItem>
+            <BuilderSelectItem action="'imageAlignClassAction'" actionParam="'ms-auto float-end'"
+                title="this.langDir.frontend === 'ltr' ? alignRight : alignLeft"
+                t-out="this.langDir.frontend === 'ltr' ? right : left"/>
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Style">

--- a/addons/html_builder/static/src/plugins/rating_option.xml
+++ b/addons/html_builder/static/src/plugins/rating_option.xml
@@ -35,7 +35,9 @@
     <BuilderRow label.translate="Title Position">
         <BuilderSelect>
             <BuilderSelectItem classAction="''">Top</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_rating_inline'">Left</BuilderSelectItem>
+            <t t-set="left">Left</t>
+            <t t-set="right">Right</t>
+            <BuilderSelectItem classAction="'s_rating_inline'" t-out="this.langDir.frontend === 'ltr' ? left : right"/>
             <BuilderSelectItem classAction="'s_rating_no_title'">None</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/html_builder/static/src/plugins/separator_option.xml
+++ b/addons/html_builder/static/src/plugins/separator_option.xml
@@ -13,9 +13,13 @@
     </BuilderRow>
     <BuilderRow label.translate="Alignment" t-if="!this.isActiveItem('so_width_100')">
         <BuilderButtonGroup>
-            <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'me-auto'"></BuilderButton>
-            <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"></BuilderButton>
-            <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'ms-auto'"></BuilderButton>
+            <BuilderButtonLtrRtl position="'start'"
+                classAction="{ sameDir: 'me-auto', diffDir: 'ms-auto' }"
+                icon="'fa-align-left'"/>
+            <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                classAction="{ sameDir: 'ms-auto', diffDir: 'me-auto' }"
+                icon="'fa-align-right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/html_builder/static/src/plugins/text_alignment_option.xml
+++ b/addons/html_builder/static/src/plugins/text_alignment_option.xml
@@ -4,9 +4,15 @@
 <t t-name="html_builder.TextAlignmentOption">
     <BuilderRow label.translate="Alignment">
         <BuilderButtonGroup>
-            <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'text-start'"/>
-            <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'text-center'"/>
-            <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'text-end'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                classAction="{ sameDir: 'text-start', diffDir: 'text-end' }"
+                icon="'fa-align-left'"/>
+            <BuilderButton icon="'fa-align-center'"
+                title.translate="Center"
+                classAction="'text-center'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                classAction="{ sameDir: 'text-end', diffDir: 'text-start' }"
+                icon="'fa-align-right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -119,6 +119,7 @@ class BuilderContainer extends Component {
         headerContent: String,
         Plugins: Array,
         onEditorLoad: Function,
+        iframeLangDir: String,
     };
 
     setup() {
@@ -134,7 +135,13 @@ class BuilderContainer extends Component {
                 }
 
                 const el = this.iframeRef.el;
-                el.contentDocument.body.innerHTML = `<div id="wrapwrap">${this.props.headerContent}<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch">${this.props.content}</div></div>`;
+                el.contentDocument.body.innerHTML = `<div id="wrapwrap" class="${
+                    this.props.iframeLangDir === "rtl" ? "o_rtl" : ""
+                }">${
+                    this.props.headerContent
+                }<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch">${
+                    this.props.content
+                }</div></div>`;
                 resolve(el);
             });
         });
@@ -199,6 +206,7 @@ export async function setupHTMLBuilder(
         dropzoneSelectors,
         snippets,
         styleContent,
+        iframeLangDir = "ltr",
     } = {}
 ) {
     defineMailModels();
@@ -317,6 +325,7 @@ export async function setupHTMLBuilder(
             onEditorLoad: (editor) => {
                 attachedEditor = editor;
             },
+            iframeLangDir,
         },
     });
     await comp.iframeLoaded;

--- a/addons/mass_mailing/static/src/builder/options/alignment_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/alignment_option.xml
@@ -3,9 +3,9 @@
     <BuilderRow label.translate="Alignment" t-if="!this.isActiveItem('so_width_100')">
         <BuilderButtonGroup>
             <!-- TODO EGGMAIL: investigate how margins behave in email clients -->
-            <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'me-auto'"/>
+            <BuilderButtonLtrRtl position="'start'" icon="'fa-align-left'" classAction="{ sameDir: 'me-auto', diffDir: 'ms-auto' }"/>
             <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"/>
-            <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'ms-auto'"/>
+            <BuilderButtonLtrRtl position="'end'" icon="'fa-align-right'" classAction="{ sameDir: 'ms-auto', diffDir: 'me-auto' }"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/carousel_cards_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_cards_option.xml
@@ -9,8 +9,12 @@
 
         <BuilderRow label.translate="Position" level="1" t-if="isActiveItem('toggle_card_img_opt')">
             <BuilderButtonGroup applyTo="'.s_card'">
-                <BuilderButton title.translate="Left" classAction="'flex-lg-row'" iconImg="'/html_builder/static/img/options/pos_left.svg'"/>
-                <BuilderButton title.translate="Right" classAction="'flex-lg-row-reverse'" iconImg="'/html_builder/static/img/options/pos_right.svg'"/>
+                <BuilderButtonLtrRtl position="'start'"
+                    classAction="{ sameDir: 'flex-lg-row', diffDir: 'flex-lg-row-reverse' }"
+                    iconImg="'/html_builder/static/img/options/pos_left.svg'"/>
+                <BuilderButtonLtrRtl position="'end'"
+                    classAction="{ sameDir: 'flex-lg-row-reverse', diffDir: 'flex-lg-row' }"
+                    iconImg="'/html_builder/static/img/options/pos_right.svg'"/>
             </BuilderButtonGroup>
         </BuilderRow>
 

--- a/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
+++ b/addons/website/static/src/builder/plugins/carousel_item_header_buttons.js
@@ -1,5 +1,5 @@
 import { useOperation } from "@html_builder/core/operation_plugin";
-import { useDomState } from "@html_builder/core/utils";
+import { useDomState, useLanguageDirection } from "@html_builder/core/utils";
 import { Component } from "@odoo/owl";
 
 export class CarouselItemHeaderMiddleButtons extends Component {
@@ -12,6 +12,7 @@ export class CarouselItemHeaderMiddleButtons extends Component {
 
     setup() {
         this.callOperation = useOperation();
+        this.langDir = useLanguageDirection();
         this.state = useDomState((editingElement) => {
             const carouselItemsNumber = editingElement.parentElement.children.length;
             return {

--- a/addons/website/static/src/builder/plugins/carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_option.xml
@@ -5,7 +5,7 @@
     <BuilderRow label.translate="Slide">
         <BuilderButton type="'success'" title.translate="Add Slide"  action="'addSlide'">Add Slide</BuilderButton>
     </BuilderRow>
-    
+
     <BuilderRow label.translate="Style">
         <BuilderSelect>
             <BuilderSelectItem classAction="''">Regular</BuilderSelectItem>
@@ -70,18 +70,23 @@
 </t>
 
 <t t-name="website.CarouselItemHeaderMiddleButtons">
+    <t t-set="backward">Move Backward</t>
+    <t t-set="forward">Move Forward</t>
+    <t t-set="slidePrev" t-value="() => this.slide('prev')"/>
+    <t t-set="slideNext" t-value="() => this.slide('next')"/>
+    <t t-set="areFrontendBackendSame" t-value="this.langDir.frontend === this.langDir.backend"/>
     <button class="btn btn-primary ms-0 py-0 px-1 me-1"
-            title="Move Backward"
-            aria-label="Move Backward"
+            t-att-title="areFrontendBackendSame ? backward : forward"
+            t-att-aria-label="areFrontendBackendSame ? backward : forward"
             t-att-class="{ disabled: !state.hasMultiItems }"
-            t-on-click="() => this.slide('prev')">
+            t-on-click="areFrontendBackendSame ? slidePrev : slideNext">
         <span class="fa fa-fw fa-angle-left"/>
     </button>
     <button class="btn btn-primary py-0 px-1 me-2"
-            title="Move Forward"
-            aria-label="Move Forward"
+            t-att-title="areFrontendBackendSame ? forward : backward"
+            t-att-aria-label="areFrontendBackendSame ? forward : backward"
             t-att-class="{ disabled: !state.hasMultiItems }"
-            t-on-click="() => this.slide('next')">
+            t-on-click="areFrontendBackendSame ? slideNext : slidePrev">
         <span class="fa fa-fw fa-angle-right"/>
     </button>
     <button class="btn btn-success ms-0 py-0 px-1 me-1"

--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -155,8 +155,12 @@
                 <i class="fa fa-eye-slash"/>
             </BuilderButton>
             <BuilderButton title.translate="Top" actionValue="'top'" iconImg="'/website/static/src/img/snippets_options/pos_top.svg'"/>
-            <BuilderButton title.translate="Left" actionValue="'left'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
-            <BuilderButton title.translate="Right" actionValue="'right'" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                actionValue="{ sameDir: 'left', diffDir: 'right' }"
+                iconImg="'/html_builder/static/img/options/pos_left.svg'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                actionValue="{ sameDir: 'right', diffDir: 'left' }"
+                iconImg="'/html_builder/static/img/options/pos_right.svg'"/>
         </BuilderButtonGroup>
     </BuilderRow>
     <BuilderRow label.translate="Link to country">
@@ -443,9 +447,11 @@
 <t t-name="website.s_website_form_submit_option">
     <BuilderRow label.translate="Button Position">
         <BuilderSelect>
-            <BuilderSelectItem classAction="'text-start s_website_form_no_submit_label'">Left</BuilderSelectItem>
+            <t t-set="left">Left</t>
+            <t t-set="right">Right</t>
+            <BuilderSelectItem classAction="'text-start s_website_form_no_submit_label'" t-out="this.langDir.frontend === 'ltr' ? left : right"/>
             <BuilderSelectItem classAction="'text-center s_website_form_no_submit_label'">Center</BuilderSelectItem>
-            <BuilderSelectItem classAction="'text-end s_website_form_no_submit_label'">Right</BuilderSelectItem>
+            <BuilderSelectItem classAction="'text-end s_website_form_no_submit_label'" t-out="this.langDir.frontend === 'ltr' ? right: left"/>
             <BuilderSelectItem classAction="''">Input Aligned</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/accordion_option.xml
+++ b/addons/website/static/src/builder/plugins/options/accordion_option.xml
@@ -54,8 +54,12 @@
         </BuilderRow>
         <BuilderRow label.translate="Position" level="1" applyTo="':scope > .accordion-item > .accordion-header'">
             <BuilderButtonGroup>
-                <BuilderButton title.translate="Left" classAction="'justify-content-end flex-row-reverse o_icons_position_reversed'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
-                <BuilderButton title.translate="Right" classAction="'justify-content-between'" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>
+                <BuilderButtonLtrRtl position="'start'"
+                    classAction="{ sameDir: 'justify-content-end flex-row-reverse o_icons_position_reversed', diffDir: 'justify-content-between' }"
+                    iconImg="'/html_builder/static/img/options/pos_left.svg'"/>
+                <BuilderButtonLtrRtl position="'end'"
+                    classAction="{ sameDir: 'justify-content-between', diffDir: 'justify-content-end flex-row-reverse o_icons_position_reversed' }"
+                    iconImg="'/html_builder/static/img/options/pos_right.svg'"/>
             </BuilderButtonGroup>
         </BuilderRow>
     </BuilderContext>

--- a/addons/website/static/src/builder/plugins/options/announcement_scroll_option.xml
+++ b/addons/website/static/src/builder/plugins/options/announcement_scroll_option.xml
@@ -9,8 +9,12 @@
     </BuilderRow>
     <BuilderRow label.translate="Direction">
         <BuilderSelect>
-            <BuilderSelectItem classAction="'s_announcement_scroll_direction_left'">Left</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_announcement_scroll_direction_right'">Right</BuilderSelectItem>
+            <BuilderSelectItem classAction="`s_announcement_scroll_direction_${this.langDir.frontend === 'ltr' ? 'left' : 'right'}`">
+                Left
+            </BuilderSelectItem>
+            <BuilderSelectItem classAction="`s_announcement_scroll_direction_${this.langDir.frontend === 'ltr' ? 'right' : 'left'}`">
+                Right
+            </BuilderSelectItem>
             <BuilderSelectItem id="'announcement_scroll_direction_none_opt'"
                     classAction="'s_announcement_scroll_direction_none'">
                 None

--- a/addons/website/static/src/builder/plugins/options/avatars_option.xml
+++ b/addons/website/static/src/builder/plugins/options/avatars_option.xml
@@ -15,9 +15,13 @@
 
     <BuilderRow label.translate="Alignment">
         <BuilderButtonGroup>
-            <BuilderButton className="'fa fa-fw fa-align-left'" title.translate="Left" classAction="''"/>
-            <BuilderButton className="'fa fa-fw fa-align-center'" title.translate="Center" classAction="'o_avatars_center'"/>
-            <BuilderButton className="'fa fa-fw fa-align-right'" title.translate="Right" classAction="'o_avatars_end'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                classAction="{ sameDir: '', diffDir: 'o_avatars_end' }"
+                icon="'fa-fw fa-align-left'"/>
+            <BuilderButton icon="'fa-fw fa-align-center'" title.translate="Center" classAction="'o_avatars_center'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                classAction="{ sameDir: 'o_avatars_end', diffDir: '' }"
+                icon="'fa-fw fa-align-right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 

--- a/addons/website/static/src/builder/plugins/options/blockquote_option.xml
+++ b/addons/website/static/src/builder/plugins/options/blockquote_option.xml
@@ -19,9 +19,13 @@
         </BuilderRow>
         <BuilderRow label.translate="Alignment" t-if="!this.isActiveItem('so_width_100')" level="1">
             <BuilderButtonGroup>
-                <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'me-auto'"/>
+                <BuilderButtonLtrRtl position="'start'"
+                    classAction="{ sameDir: 'me-auto', diffDir: 'ms-auto' }"
+                    icon="'fa-align-left'"/>
                 <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"/>
-                <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'ms-auto'"/>
+                <BuilderButtonLtrRtl position="'end'"
+                    classAction="{ sameDir: 'ms-auto', diffDir: 'me-auto' }"
+                    icon="'fa-align-right'"/>
             </BuilderButtonGroup>
         </BuilderRow>
     </t>
@@ -31,8 +35,13 @@
     </BuilderRow>
     <BuilderRow label.translate="Decoration">
         <BuilderSelect>
+            <t t-set="left">Left line</t>
+            <t t-set="right">Right line</t>
             <BuilderSelectItem classAction="'s_blockquote_default'">None</BuilderSelectItem>
-            <BuilderSelectItem classAction="'s_blockquote_with_line'" id="'blockquote_with_line_opt'">Left line</BuilderSelectItem>
+            <BuilderSelectItem
+                id="'blockquote_with_line_opt'"
+                classAction="'s_blockquote_with_line'"
+                t-out="this.langDir.frontend === 'ltr' ? left : right"/>
             <BuilderSelectItem classAction="'s_blockquote_with_icon'">Icon</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
@@ -48,9 +57,15 @@
         </BuilderRow>
         <BuilderRow t-if="this.isActiveItem('blockquote_show_author_opt')" label.translate="Author Alignment" level="1">
             <BuilderSelect>
-                <BuilderSelectItem classAction="'flex-row align-items-start justify-content-start text-start'">Left</BuilderSelectItem>
+                <t t-set="left">Left</t>
+                <t t-set="right">Right</t>
+                <BuilderSelectItem
+                    classAction="'flex-row align-items-start justify-content-start text-start'"
+                    t-out="this.langDir.frontend === 'ltr' ? left : right"/>
                 <BuilderSelectItem classAction="'flex-column align-items-center text-center'">Center</BuilderSelectItem>
-                <BuilderSelectItem classAction="'flex-row-reverse align-items-start justify-content-start text-end'">Right</BuilderSelectItem>
+                <BuilderSelectItem
+                    classAction="'flex-row-reverse align-items-start justify-content-start text-end'"
+                    t-out="this.langDir.frontend === 'ltr' ? right : left"/>
             </BuilderSelect>
         </BuilderRow>
     </BuilderContext>

--- a/addons/website/static/src/builder/plugins/options/card_image_option.xml
+++ b/addons/website/static/src/builder/plugins/options/card_image_option.xml
@@ -12,16 +12,14 @@
                     actionParam="'card-img-top'"
                     iconImg="'/website/static/src/img/snippets_options/pos_top.svg'"
                     title.translate="Top"/>
-                <BuilderButton
-                    classAction="'o_card_img_horizontal flex-lg-row'"
-                    actionParam="'rounded-start'"
-                    iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"
-                    title.translate="Left"/>
-                <BuilderButton
-                    classAction="'o_card_img_horizontal flex-lg-row-reverse'"
-                    actionParam="'rounded-end'"
-                    iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"
-                    title.translate="Right"/>
+                <BuilderButtonLtrRtl position="'start'"
+                    classAction="{ sameDir: 'o_card_img_horizontal flex-lg-row', diffDir: 'o_card_img_horizontal flex-lg-row-reverse' }"
+                    actionParam="{ sameDir: 'rounded-start', diffDir: 'rounded-end' }"
+                    iconImg="'/html_builder/static/img/options/pos_left.svg'"/>
+                <BuilderButtonLtrRtl position="'end'"
+                    classAction="{ sameDir: 'o_card_img_horizontal flex-lg-row-reverse', diffDir: 'o_card_img_horizontal flex-lg-row' }"
+                    actionParam="{ sameDir: 'rounded-end', diffDir: 'rounded-start' }"
+                    iconImg="'/html_builder/static/img/options/pos_right.svg'"/>
                 <BuilderButton
                     id="'card_img_bottom_opt'"
                     classAction="'o_card_img_bottom flex-column-reverse'"
@@ -31,7 +29,7 @@
             </BuilderButtonGroup>
 
         <!-- Remove image -->
-            <BuilderButton 
+            <BuilderButton
                 action="'removeCoverImage'"
                 preview="false"
                 icon="'oi-close'"

--- a/addons/website/static/src/builder/plugins/options/card_width_option.xml
+++ b/addons/website/static/src/builder/plugins/options/card_width_option.xml
@@ -14,9 +14,13 @@
     </BuilderRow>
     <BuilderRow t-if="getItemValue('card_width') !== '100%'" label.translate="Alignment" level="1">
         <BuilderButtonGroup action="'setCardAlignment'">
-            <BuilderButton icon="'fa-align-left'" title.translate="Left" actionParam="'me-auto'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                actionParam="{ sameDir: 'me-auto', diffDir: 'ms-auto' }"
+                icon="'fa-align-left'"/>
             <BuilderButton icon="'fa-align-center'" title.translate="Center" actionParam="'mx-auto'"/>
-            <BuilderButton icon="'fa-align-right'" title.translate="Right" actionParam="'ms-auto'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                actionParam="{ sameDir: 'ms-auto', diffDir: 'me-auto' }"
+                icon="'fa-align-right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -159,9 +159,13 @@
         </BuilderRow>
         <BuilderRow label.translate="Alignment" level="2">
             <BuilderButtonGroup applyTo="'.s_countdown_inline_wrapper'">
-                <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="''"/>
+                <BuilderButtonLtrRtl position="'start'"
+                    classAction="{ sameDir: '', diffDir: 'align-self-end text-end' }"
+                    icon="'fa-align-left'"/>
                 <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'align-self-center text-center'"/>
-                <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'align-self-end text-end'"/>
+                <BuilderButtonLtrRtl position="'end'"
+                    classAction="{ sameDir: 'align-self-end text-end', diffDir: '' }"
+                    icon="'fa-align-right'"/>
             </BuilderButtonGroup>
         </BuilderRow>
         <BuilderRow label.translate="Font Monospace" applyTo="'.s_countdown_inline'" level="2">

--- a/addons/website/static/src/builder/plugins/options/cover_properties_option.xml
+++ b/addons/website/static/src/builder/plugins/options/cover_properties_option.xml
@@ -29,9 +29,11 @@
 
     <BuilderRow label.translate="Text Alignment" t-if="this.state.useTextAlign">
         <BuilderSelect>
-            <BuilderSelectItem classAction="''">Left</BuilderSelectItem>
+            <t t-set="left">Left</t>
+            <t t-set="right">Right</t>
+            <BuilderSelectItem classAction="''" t-out="this.langDir.frontend === 'ltr' ? left : right"/>
             <BuilderSelectItem classAction="'text-center'">Centered</BuilderSelectItem>
-            <BuilderSelectItem classAction="'text-end'">Right</BuilderSelectItem>
+            <BuilderSelectItem classAction="'text-end'" t-out="this.langDir.frontend === 'ltr' ? right : left"/>
         </BuilderSelect>
     </BuilderRow>
 </BuilderContext>

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
@@ -5,11 +5,17 @@
     <xpath expr="//BuilderRow[*[@id=&quot;'template_opt'&quot;]]" position="after">
         <BuilderRow label.translate="Arrow Position">
             <BuilderSelect>
+                <t t-set="left">Bottom Left</t>
+                <t t-set="right">Bottom Right</t>
                 <BuilderSelectItem classAction="''">Default</BuilderSelectItem>
                 <BuilderSelectItem classAction="'o_arrows_inside'">Inside</BuilderSelectItem>
-                <BuilderSelectItem classAction="'o_arrows_bottom o_arrows_bottom_left'">Bottom Left</BuilderSelectItem>
+                <BuilderSelectItem
+                    classAction="'o_arrows_bottom o_arrows_bottom_left'"
+                    t-out="this.langDir.frontend === 'ltr' ? left : right"/>
                 <BuilderSelectItem classAction="'o_arrows_bottom o_arrows_bottom_center'">Bottom Center</BuilderSelectItem>
-                <BuilderSelectItem classAction="'o_arrows_bottom o_arrows_bottom_right'">Bottom Right</BuilderSelectItem>
+                <BuilderSelectItem
+                    classAction="'o_arrows_bottom o_arrows_bottom_right'"
+                    t-out="this.langDir.frontend === 'ltr' ? right : left"/>
             </BuilderSelect>
         </BuilderRow>
 	    <BuilderRow label.translate="Slider Speed" t-if="numberOfRecords > 1">

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -46,8 +46,12 @@
     </BuilderRow>
     <BuilderRow label.translate="Cover Image" t-if="isSingleMode and !!showCoverImageOption?.()">
         <BuilderButtonGroup>
-            <BuilderButton title.translate="Left" classAction="'s_dynamic_snippet_cover_left'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
-            <BuilderButton title.translate="Right" classAction="''" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                classAction="{ sameDir: 's_dynamic_snippet_cover_left', diffDir: '' }"
+                iconImg="'/html_builder/static/img/options/pos_left.svg'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                classAction="{ sameDir: '', diffDir: 's_dynamic_snippet_cover_left' }"
+                iconImg="'/html_builder/static/img/options/pos_right.svg'"/>
         </BuilderButtonGroup>
     </BuilderRow>
     <BuilderRow id="number_of_records_opt_row" label.translate="Fetched Elements" t-if="!!dynamicOptionParams.domState.filterId or isSingleMode">
@@ -59,8 +63,10 @@
     </BuilderRow>
     <BuilderRow label.translate="Section Title" t-if="!isSingleMode">
         <BuilderButtonGroup applyTo="'.s_dynamic_snippet_title'">
+            <t t-set="left">Left</t>
+            <t t-set="right">Right</t>
             <BuilderButton label.translate="Top" classAction="dynamicOptionParams.getSnippetTitleClasses('top')"/>
-            <BuilderButton label.translate="Left" classAction="dynamicOptionParams.getSnippetTitleClasses('left')"/>
+            <BuilderButton label="this.langDir.frontend === 'ltr' ? left : right" classAction="dynamicOptionParams.getSnippetTitleClasses('left')"/>
             <BuilderButton label.translate="None" title.translate="No title" classAction="dynamicOptionParams.getSnippetTitleClasses('none')"/>
         </BuilderButtonGroup>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/embed_code_option.xml
+++ b/addons/website/static/src/builder/plugins/options/embed_code_option.xml
@@ -11,9 +11,13 @@
     </BuilderRow>
     <BuilderRow label.translate="Alignment">
         <BuilderButtonGroup>
-            <BuilderButton className="'fa fa-fw fa-align-left'" title.translate="Left" classAction="'text-start'"/>
-            <BuilderButton className="'fa fa-fw fa-align-center'" title.translate="Center" classAction="'text-center'"/>
-            <BuilderButton className="'fa fa-fw fa-align-right'" title.translate="Right" classAction="'text-end'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                classAction="{ sameDir: 'text-start', diffDir: 'text-end' }"
+                icon="'fa-fw fa-align-left'"/>
+            <BuilderButton icon="'fa-fw fa-align-center'" title.translate="Center" classAction="'text-center'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                classAction="{ sameDir: 'text-end', diffDir: 'text-start' }"
+                icon="'fa-fw fa-align-right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/footer_option.xml
+++ b/addons/website/static/src/builder/plugins/options/footer_option.xml
@@ -92,9 +92,11 @@
             varsOnClean: {'footer-scrolltop': 'false'}
         }"/>
         <BuilderSelect t-if="this.isActiveItem('footer_scrolltop_opt')" applyTo="'#o_footer_scrolltop_wrapper'">
-            <BuilderSelectItem classAction="'justify-content-start'">Left</BuilderSelectItem>
+            <t t-set="left">Left</t>
+            <t t-set="right">Right</t>
+            <BuilderSelectItem classAction="'justify-content-start'" t-out="this.langDir.frontend === 'ltr' ? left : right"/>
             <BuilderSelectItem classAction="'justify-content-center'">Center</BuilderSelectItem>
-            <BuilderSelectItem classAction="'justify-content-end'">Right</BuilderSelectItem>
+            <BuilderSelectItem classAction="'justify-content-end'" t-out="this.langDir.frontend === 'ltr' ? right : left"/>
         </BuilderSelect>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/gallery_element_option.xml
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option.xml
@@ -4,10 +4,33 @@
 <t t-name="website.GalleryElementOption">
     <BuilderRow label.translate="Re-order" disabled="!state.hasMultiItems">
         <BuilderButtonGroup preview="false" action="'setGalleryElementPosition'">
-            <BuilderButton icon="'fa-angle-double-left'" title.translate="Move to first"  actionValue="'first'" className="!state.hasMultiItems || state.isFirstItem ? 'disabled': ''"/>
-            <BuilderButton icon="'fa-angle-left'" title.translate="Move to previous" actionValue="'prev'" className="!state.hasMultiItems ? 'disabled': ''"/>
-            <BuilderButton icon="'fa-angle-right'" title.translate="Move to next" actionValue="'next'" className="!state.hasMultiItems ? 'disabled': ''"/>
-            <BuilderButton icon="'fa-angle-double-right'" title.translate="Move to last" actionValue="'last'" className="!state.hasMultiItems || state.isLastItem ? 'disabled': ''"/>
+            <t t-set="moveFirst">Move to first</t>
+            <t t-set="moveLast">Move to last</t>
+            <t t-set="movePrev">Move to previous</t>
+            <t t-set="moveNext">Move to next</t>
+            <t t-set="shouldDisableFirst" t-value="!state.hasMultiItems || state.isFirstItem"/>
+            <t t-set="shouldDisableLast" t-value="!state.hasMultiItems || state.isLastItem"/>
+            <t t-set="areFrontendBackendSame" t-value="this.langDir.frontend === this.langDir.backend"/>
+            <BuilderButton
+                icon="'fa-angle-double-left'"
+                title="areFrontendBackendSame ? moveFirst : moveLast"
+                actionValue="areFrontendBackendSame ? 'first' : 'last'"
+                className="(areFrontendBackendSame ? shouldDisableFirst : shouldDisableLast) ? 'disabled' : ''"/>
+            <BuilderButton
+                icon="'fa-angle-left'"
+                title="areFrontendBackendSame ? movePrev : moveNext"
+                actionValue="areFrontendBackendSame ? 'prev' : 'next'"
+                className="!state.hasMultiItems ? 'disabled' : ''"/>
+            <BuilderButton
+                icon="'fa-angle-right'"
+                title="areFrontendBackendSame ? moveNext : movePrev"
+                actionValue="areFrontendBackendSame ? 'next' : 'prev'"
+                className="!state.hasMultiItems ? 'disabled' : ''"/>
+            <BuilderButton
+                icon="'fa-angle-double-right'"
+                title="areFrontendBackendSame ? moveLast : moveFirst"
+                actionValue="areFrontendBackendSame ? 'last' : 'first'"
+                className="(areFrontendBackendSame ? shouldDisableLast : shouldDisableFirst) ? 'disabled' : ''"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
@@ -22,6 +22,7 @@ export class GalleryElementOption extends BaseOptionComponent {
     static selector =
         ".s_image_gallery img, .s_carousel .carousel-item, .s_quotes_carousel .carousel-item, .s_carousel_intro .carousel-item, .s_carousel_cards .carousel-item";
     setup() {
+        super.setup();
         this.state = useDomState((editingElement) => {
             const isImageWall = editingElement.closest('[data-snippet="s_images_wall"]');
             if (isImageWall) {

--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
@@ -37,75 +37,85 @@
         'website.template_header_vertical_align_right',
     ]"/>
 
+    <t t-set="isFrontendLTR" t-value="this.langDir.frontend === 'ltr'"/>
+    <t t-set="areFrontendBackendSame" t-value="this.langDir.frontend === this.langDir.backend"/>
+    <t t-set="alignLeft">Align Left</t>
+    <t t-set="alignRight">Align Right</t>
+
     <BuilderRow label.translate="Desktop Menu" tooltip.translate="Change the burger button position/menu items alignment">
         <!-- Reason why we enable this option for those templates only:
             website.template_header_hamburger => Hamburger Icon Position
             website.template_header_sidebar => Sidebar Position
         -->
         <BuilderButtonGroup action="'websiteConfig'" t-if="hasSomeViews(['website.template_header_hamburger', 'website.template_header_sidebar'])">
-            <BuilderButton
+            <t t-set="positionLeft" t-value="{ views: [], vars: { 'hamburger-position': 'left' } }"/>
+            <t t-set="positionRight" t-value="{
+                views: ['website.template_header_hamburger_align_right', 'website.template_header_sidebar_position_right'],
+                vars: { 'hamburger-position': 'right' },
+            }"/>
+            <BuilderButtonLtrRtl position="'start'"
                 icon="'fa-long-arrow-left'"
-                actionParam="{
-                    views: [],
-                    vars: { 'hamburger-position': 'left' }
-                }"/>
-            <BuilderButton
+                actionParam="{ sameDir: positionLeft, diffDir: positionRight }"/>
+            <BuilderButtonLtrRtl position="'end'"
                 icon="'fa-long-arrow-right'"
-                actionParam="{
-                    views: ['website.template_header_hamburger_align_right', 'website.template_header_sidebar_position_right'],
-                    vars: { 'hamburger-position': 'right' }
-                }"/>
+                actionParam="{ sameDir: positionRight, diffDir: positionLeft }"/>
         </BuilderButtonGroup>
 
         <BuilderSelect action="'websiteConfig'">
-            <BuilderSelectItem actionParam="{ views: align_left_views }">
-                <span><i class="fa fa-align-left fa-fw"></i></span>
+            <BuilderSelectItem actionParam="{ views: areFrontendBackendSame ? align_left_views : align_right_views }">
+                <div t-att-title="isFrontendLTR ? alignLeft : alignRight">
+                    <i class="fa fa-align-left fa-fw" role="img" aria-hidden="true"/>
+                    <span class="visually-hidden" t-out="isFrontendLTR ? alignLeft : alignRight"/>
+                </div>
             </BuilderSelectItem>
             <BuilderSelectItem actionParam="{ views: align_center_views }">
-                <span><i class="fa fa-align-center fa-fw"></i></span>
+                <div title="Center">
+                    <i class="fa fa-align-center fa-fw" role="img" aria-hidden="true"/>
+                    <span class="visually-hidden">Center</span>
+                </div>
             </BuilderSelectItem>
-            <BuilderSelectItem actionParam="{ views: align_right_views }">
-                <span><i class="fa fa-align-right fa-fw"></i></span>
+            <BuilderSelectItem actionParam="{ views: areFrontendBackendSame ? align_right_views : align_left_views }">
+                <div t-att-title="isFrontendLTR ? alignRight : alignLeft">
+                    <i class="fa fa-align-right fa-fw" role="img" aria-hidden="true"/>
+                    <span class="visually-hidden" t-out="isFrontendLTR ? alignRight : alignLeft"/>
+                </div>
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
 
     <BuilderRow label.translate="Mobile Menu">
         <BuilderButtonGroup action="'websiteConfig'">
-            <BuilderButton icon="'fa-long-arrow-left'"
-                actionParam="{
-                    views: ['website.template_header_mobile_position_left'],
-                    vars: { 'hamburger-position-mobile': 'left' }
-                }"/>
-            <BuilderButton
+            <t t-set="positionLeft" t-value="{
+                views: ['website.template_header_mobile_position_left'],
+                vars: { 'hamburger-position-mobile': 'left' },
+            }"/>
+            <t t-set="positionRight" t-value="{ views: [], vars: { 'hamburger-position-mobile': 'right' } }"/>
+            <BuilderButtonLtrRtl position="'start'"
+                icon="'fa-long-arrow-left'"
+                actionParam="{ sameDir: positionLeft, diffDir: positionRight }"/>
+            <BuilderButtonLtrRtl position="'end'"
                 icon="'fa-long-arrow-right'"
-                actionParam="{
-                    views: [],
-                    vars: { 'hamburger-position-mobile': 'right' }
-                }"/>
+                actionParam="{ sameDir: positionRight, diffDir: positionLeft }"/>
         </BuilderButtonGroup>
 
         <BuilderSelect action="'websiteConfig'">
-            <BuilderSelectItem
-                actionParam="{
-                    views: [],
-                }"
-            >
-                <span><i class="fa fa-align-left fa-fw"></i></span>
+            <BuilderSelectItem actionParam="{ views: areFrontendBackendSame ? [] : ['website.template_header_mobile_align_right'] }">
+                <div t-att-title="isFrontendLTR ? alignLeft : alignRight">
+                    <i class="fa fa-align-left fa-fw" role="img" aria-hidden="true"/>
+                    <span class="visually-hidden" t-out="isFrontendLTR ? alignLeft : alignRight"/>
+                </div>
             </BuilderSelectItem>
-            <BuilderSelectItem
-                actionParam="{
-                    views: ['website.template_header_mobile_align_center'],
-                }"
-            >
-                <span><i class="fa fa-align-center fa-fw"></i></span>
+            <BuilderSelectItem actionParam="{ views: ['website.template_header_mobile_align_center'] }">
+                <div title="Center">
+                    <i class="fa fa-align-center fa-fw" role="img" aria-hidden="true"/>
+                    <span class="visually-hidden">Center</span>
+                </div>
             </BuilderSelectItem>
-            <BuilderSelectItem
-                actionParam="{
-                    views: ['website.template_header_mobile_align_right'],
-                }"
-            >
-                <span><i class="fa fa-align-right fa-fw"></i></span>
+            <BuilderSelectItem actionParam="{ views: areFrontendBackendSame ? ['website.template_header_mobile_align_right'] : [] }">
+                <div t-att-title="isFrontendLTR ? alignRight : alignLeft">
+                    <i class="fa fa-align-right fa-fw" role="img" aria-hidden="true"/>
+                    <span class="visually-hidden" t-out="isFrontendLTR ? alignRight : alignLeft"/>
+                </div>
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/media_list_item_option.xml
+++ b/addons/website/static/src/builder/plugins/options/media_list_item_option.xml
@@ -17,8 +17,14 @@
 
     <BuilderRow label.translate="Layout">
         <BuilderButtonGroup applyTo="':scope > .row'">
-            <BuilderButton title.translate="Left" id="'media_left_opt'" classAction="''" iconImg="'/website/static/src/img/snippets_options/image_left.svg'"/>
-            <BuilderButton title.translate="Right" classAction="'flex-row-reverse'" iconImg="'/website/static/src/img/snippets_options/image_right.svg'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                id="this.langDir.backend === 'ltr' ? 'media_left_opt' : ''"
+                classAction="{ sameDir: '', diffDir: 'flex-row-reverse' }"
+                iconImg="'/website/static/src/img/snippets_options/image_left.svg'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                id="this.langDir.backend === 'ltr' ? '' : 'media_left_opt'"
+                classAction="{ sameDir: 'flex-row-reverse', diffDir: '' }"
+                iconImg="'/website/static/src/img/snippets_options/image_right.svg'"/>
         </BuilderButtonGroup>
     </BuilderRow>
     <BuilderRow label.translate="Image Size">

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option.xml
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option.xml
@@ -34,19 +34,28 @@
         </BuilderRow>
         <BuilderRow t-if="isActiveItem('regular_opt')" label.translate="Alignment" level="1">
             <BuilderSelect applyTo="'.s_tabs_nav .nav'">
-                <BuilderSelectItem classAction="''">Left</BuilderSelectItem>
+                <t t-set="left">Left</t>
+                <t t-set="right">Right</t>
+                <BuilderSelectItem classAction="''" t-out="this.langDir.frontend === 'ltr' ? left : right"/>
                 <BuilderSelectItem classAction="'justify-content-center mx-auto'">Center</BuilderSelectItem>
-                <BuilderSelectItem classAction="'justify-content-end ms-auto'">Right</BuilderSelectItem>
+                <BuilderSelectItem classAction="'justify-content-end ms-auto'" t-out="this.langDir.frontend === 'ltr' ? right : left"/>
             </BuilderSelect>
         </BuilderRow>
     </t>
     <BuilderRow label.translate="Slide">
         <BuilderButtonGroup applyTo="'.s_tabs_content'">
-            <BuilderButton className="'fa fa-fw fa-long-arrow-left'" title.translate="Slide to left" classAction="'s_tabs_slide_right'"/>
-            <BuilderButton className="'fa fa-fw fa-long-arrow-up'" title.translate="Slide up" classAction="'s_tabs_slide_down'"/>
-            <BuilderButton className="'fa fa-fw fa-long-arrow-down'" title.translate="Slide down" classAction="'s_tabs_slide_up'"/>
-            <BuilderButton className="'fa fa-fw fa-long-arrow-right'" title.translate="Slide to right" classAction="'s_tabs_slide_left'"/>
-            <BuilderButton className="'fa fa-fw fa-ban'" title.translate="No Slide Effect" classAction="''"/>
+            <t t-set="slideToLeft">Slide to left</t>
+            <t t-set="slideToRight">Slide to right</t>
+            <t t-set="label" t-value="{ left: slideToLeft, right: slideToRight }"/>
+            <BuilderButtonLtrRtl position="'start'" label="label"
+                icon="'fa-fw fa-long-arrow-left'"
+                classAction="{ sameDir: 's_tabs_slide_right', diffDir: 's_tabs_slide_left' }"/>
+            <BuilderButton icon="'fa-fw fa-long-arrow-up'" title.translate="Slide up" classAction="'s_tabs_slide_down'"/>
+            <BuilderButton icon="'fa-fw fa-long-arrow-down'" title.translate="Slide down" classAction="'s_tabs_slide_up'"/>
+             <BuilderButtonLtrRtl position="'end'" label="label"
+                icon="'fa-fw fa-long-arrow-right'"
+                classAction="{ sameDir: 's_tabs_slide_left', diffDir: 's_tabs_slide_right' }"/>
+            <BuilderButton icon="'fa-fw fa-ban'" title.translate="No Slide Effect" classAction="''"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website/static/src/builder/plugins/options/social_media_option.xml
+++ b/addons/website/static/src/builder/plugins/options/social_media_option.xml
@@ -4,8 +4,10 @@
 <t t-name="website.SocialMediaOption">
     <BuilderRow label.translate="Title Position">
         <BuilderSelect applyTo="'.s_share_title, .s_social_media_title'">
+            <t t-set="left">Left</t>
+            <t t-set="right">Right</t>
             <BuilderSelectItem classAction="'d-block'">Top</BuilderSelectItem>
-            <BuilderSelectItem classAction="''">Left</BuilderSelectItem>
+            <BuilderSelectItem classAction="''" t-out="this.langDir.frontend === 'ltr' ? left : right"/>
             <BuilderSelectItem classAction="'d-none'">None</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/table_of_content_option.xml
+++ b/addons/website/static/src/builder/plugins/options/table_of_content_option.xml
@@ -16,9 +16,13 @@
 <t t-name="website.TableOfContentNavbarOption">
     <BuilderRow label.translate="Position" action="'navbarPosition'">
         <BuilderButtonGroup>
-            <BuilderButton icon="'fa-long-arrow-left'" title.translate="Left" actionParam="'left'"/>
+            <BuilderButtonLtrRtl position="'start'"
+                actionParam="{ sameDir: 'left', diffDir: 'right'}"
+                icon="'fa-long-arrow-left'"/>
             <BuilderButton icon="'fa-long-arrow-up'" title.translate="Top" actionParam="'top'"/>
-            <BuilderButton icon="'fa-long-arrow-right'" title.translate="Right" actionParam="'right'"/>
+            <BuilderButtonLtrRtl position="'end'"
+                actionParam="{ sameDir: 'right', diffDir: 'left' }"
+                icon="'fa-long-arrow-right'"/>
         </BuilderButtonGroup>
     </BuilderRow>
     <BuilderRow label.translate="Sticky" tooltip.translate="Keep this element fixed while scrolling">

--- a/addons/website/static/src/builder/plugins/options/timeline_list_option.xml
+++ b/addons/website/static/src/builder/plugins/options/timeline_list_option.xml
@@ -16,9 +16,14 @@
 
     <BuilderRow label.translate="Alignment">
         <BuilderButtonGroup applyTo="'.s_timeline_list_wrapper'">
-            <BuilderButton icon="'fa-align-left'" title.translate="Align Left" classAction="'justify-content-start'"/>
+            <t t-set="left">Align Left</t>
+            <t t-set="right">Align Right</t>
+            <t t-set="label" t-value="{ left: left, right: right }"/>
+            <BuilderButtonLtrRtl position="'start'" label="label" icon="'fa-align-left'"
+                classAction="{ sameDir: 'justify-content-start', diffDir: 'justify-content-end' }"/>
             <BuilderButton icon="'fa-align-center'" title.translate="Align Center" classAction="'justify-content-center'"/>
-            <BuilderButton icon="'fa-align-right'" title.translate="Align Right" classAction="'justify-content-end'"/>
+            <BuilderButtonLtrRtl position="'end'" label="label" icon="'fa-align-right'"
+                classAction="{ sameDir: 'justify-content-end', diffDir: 'justify-content-start' }"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website_sale/static/src/website_builder/product_image_option.xml
+++ b/addons/website_sale/static/src/website_builder/product_image_option.xml
@@ -12,17 +12,30 @@
             label.translate="Replace" />
         <BuilderButton
             action="'removeMedia'"
-            className="'flex-grow-1'" 
+            className="'flex-grow-1'"
             type="'danger'"
             preview="false"
-            label.translate="Remove"/>   
+            label.translate="Remove"/>
     </BuilderRow>
     <BuilderRow label.translate="Re-order">
         <BuilderButtonGroup preview="false" action="'setPosition'">
-            <BuilderButton icon="'fa-angle-double-left'" title.translate="Move to first"  actionValue="'first'"/>
-            <BuilderButton icon="'fa-angle-left'" title.translate="Move to previous" actionValue="'left'"/>
-            <BuilderButton icon="'fa-angle-right'" title.translate="Move to next" actionValue="'right'"/>
-            <BuilderButton icon="'fa-angle-double-right'" title.translate="Move to last" actionValue="'last'"/>
+            <t t-set="moveFirst">Move to first</t>
+            <t t-set="moveLast">Move to last</t>
+            <t t-set="movePrev">Move to previous</t>
+            <t t-set="moveNext">Move to next</t>
+            <t t-set="areFrontendBackendSame" t-value="this.langDir.frontend === this.langDir.backend"/>
+            <BuilderButton icon="'fa-angle-double-left'"
+                title="areFrontendBackendSame ? moveFirst : moveLast"
+                actionValue="areFrontendBackendSame ? 'first': 'last'"/>
+            <BuilderButton icon="'fa-angle-left'"
+                title="areFrontendBackendSame ? movePrev : moveNext"
+                actionValue="areFrontendBackendSame ? 'left': 'right'"/>
+            <BuilderButton icon="'fa-angle-right'"
+                title="areFrontendBackendSame ? moveNext : movePrev"
+                actionValue="areFrontendBackendSame ? 'right': 'left'"/>
+            <BuilderButton icon="'fa-angle-double-right'"
+                title="areFrontendBackendSame ? moveLast : moveFirst"
+                actionValue="areFrontendBackendSame ? 'last': 'first'"/>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>

--- a/addons/website_sale/static/src/website_builder/product_page_option.xml
+++ b/addons/website_sale/static/src/website_builder/product_page_option.xml
@@ -92,14 +92,14 @@
             action="'productPageContainerOrder'"
             applyTo="'#product_detail_main'"
         >
-            <BuilderButton
-                actionParam="{ previewClass: ''}"
-                actionValue="'regular'"
+            <BuilderButtonLtrRtl position="'start'"
+                actionParam="{ sameDir: { previewClass: '' }, diffDir: { previewClass: 'flex-lg-row-reverse' } }"
+                actionValue="{ sameDir: 'regular', diffDir: 'inverse' }"
                 iconImg="'/website/static/src/img/snippets_options/image_left.svg'"
             />
-            <BuilderButton
-                actionParam="{ previewClass: 'flex-lg-row-reverse'}"
-                actionValue="'inverse'"
+            <BuilderButtonLtrRtl position="'end'"
+                actionParam="{ sameDir: { previewClass: 'flex-lg-row-reverse' }, diffDir: { previewClass: '' } }"
+                actionValue="{ sameDir: 'inverse', diffDir: 'regular' }"
                 iconImg="'/website/static/src/img/snippets_options/image_right.svg'"
             />
         </BuilderButtonGroup>
@@ -146,8 +146,17 @@
     >
 	    <BuilderRow label.translate="Thumbnails" level="1">
 	        <BuilderButtonGroup action="'websiteConfig'" id="'o_wsale_thumbnail_pos'">
-	            <BuilderButton className="'fa fa-fw fa-long-arrow-left'" actionParam="{ views: ['website_sale.carousel_product_indicators_left'] }" title="Left"></BuilderButton>
-	            <BuilderButton className="'fa fa-fw fa-long-arrow-down'" actionParam="{ views: ['website_sale.carousel_product_indicators_bottom'] }" title="Bottom"></BuilderButton>
+                <BuilderButtonLtrRtl t-if="this.langDir.frontend === this.langDir.backend"
+                    position="'start'"
+                    icon="'fa-fw fa-long-arrow-left'"
+                    actionParam="{ views: ['website_sale.carousel_product_indicators_left'] }"
+                />
+                <BuilderButton icon="'fa-fw fa-long-arrow-down'" actionParam="{ views: ['website_sale.carousel_product_indicators_bottom'] }" title.translate="Bottom"/>
+                <BuilderButtonLtrRtl t-if="this.langDir.frontend !== this.langDir.backend"
+                    position="'end'"
+                    icon="'fa-fw fa-long-arrow-right'"
+                    actionParam="{ views: ['website_sale.carousel_product_indicators_left'] }"
+                />
 	        </BuilderButtonGroup>
 	    </BuilderRow>
     </t>

--- a/addons/website_sale/static/src/website_builder/product_ribbon_options.xml
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options.xml
@@ -71,8 +71,14 @@
                 </BuilderRow>
                 <BuilderRow label.translate="Position" level="1">
                     <BuilderSelect actionParam="'position'">
-                        <BuilderSelectItem actionValue="'left'">Left</BuilderSelectItem>
-                        <BuilderSelectItem actionValue="'right'">Right</BuilderSelectItem>
+                        <t t-set="left">Left</t>
+                        <t t-set="right">Right</t>
+                        <BuilderSelectItem actionValue="'left'"
+                            t-out="this.langDir.frontend === 'ltr' ? left : right"
+                        />
+                        <BuilderSelectItem actionValue="'right'"
+                            t-out="this.langDir.frontend === 'ltr' ? right : left"
+                        />
                     </BuilderSelect>
                 </BuilderRow>
             </BuilderContext>

--- a/addons/website_sale/static/src/website_builder/products_item_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_item_option.xml
@@ -20,10 +20,27 @@
         </div>
         <BuilderRow label.translate="Re-order" t-if="this.displayReOrder">
             <BuilderButtonGroup action="'changeSequence'">
-                <BuilderButton actionValue="'top'" title.translate="Push to top" className="'fa fa-fw fa-angle-double-left'" />
-                <BuilderButton actionValue="'up'" title.translate="Push up" className="'fa fa-fw fa-angle-left ms-1'" />
-                <BuilderButton actionValue="'down'" title.translate="Push down" className="'fa fa-fw fa-angle-right mx-1'" />
-                <BuilderButton actionValue="'bottom'" title.translate="Push to bottom" className="'fa fa-fw fa-angle-double-right'" />
+                <t t-set="pushTop">Push to top</t>
+                <t t-set="pushBottom">Push to bottom</t>
+                <t t-set="pushUp">Push up</t>
+                <t t-set="pushDown">Push down</t>
+                <t t-set="areFrontendBackendSame" t-value="this.langDir.frontend === this.langDir.backend"/>
+                <BuilderButton
+                    actionValue="areFrontendBackendSame ? 'top' : 'bottom'"
+                    title="areFrontendBackendSame ? pushTop : pushBottom"
+                    icon="'fa-fw fa-angle-double-left'" />
+                <BuilderButton
+                    actionValue="areFrontendBackendSame ? 'up' : 'down'"
+                    title="areFrontendBackendSame ? pushUp : pushDown"
+                    icon="'fa-fw fa-angle-left'" className="'ms-1'" />
+                <BuilderButton
+                    actionValue="areFrontendBackendSame ? 'down' : 'up'"
+                    title="areFrontendBackendSame ? pushDown : pushUp"
+                    icon="'fa-fw fa-angle-right'" className="'mx-1'" />
+                <BuilderButton
+                    actionValue="areFrontendBackendSame ? 'bottom' : 'top'"
+                    title="areFrontendBackendSame ? pushBottom : pushTop"
+                    icon="'fa-fw fa-angle-double-right'" />
             </BuilderButtonGroup>
         </BuilderRow>
     </t>


### PR DESCRIPTION
*: website, website_sale, mass_mailing

Many builder options relied on the words "left" / "right" or/and on arrows icons pointing left or right. Most of those options don't actually enforce "left" or "right", but a logical property dependent on the language direction (e.g. `flex-direction: row` vs `row-reverse`).

Say you have these buttons in LTR (e.g. English):

```
Button: [Left]  [Center]   [Right]
Action:  row       -     row-reverse
```

In RTL (e.g. Arabic), it will be rendered:

```
Button:   [Right]   [Center]  [Left]
Action: row-reverse    -       row
```

Which is not intuitive as it goes against the affordance (left being on the right and vice versa). It is also wrong, as the actions should be reversed in RTL:

```
Button:   [Left]   [Center]  [Right]
Action: row-reverse    -       row
```

But this is only part of the story, because the builder language and the frontend language may or may not use languages in the same direction: in the end, the labels of the buttons and the actions that they do should depend on both the backend language and the frontend language, with 4 possible layouts.

In order to ease that kind of `BuilderButton` templating, we add a `BuilderButtonLtrRtl` component in charge of adapting the labels, icons and actions depending on the language combination.

task-5482001
