### PR TITLE
[FIX] core: export code translations from odoo.orm

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1493,7 +1493,7 @@ class TranslationModuleReader(TranslationReader):
         """
 
         # Also scan these non-addon paths
-        for bin_path in ['osv', 'report', 'modules', 'service', 'tools']:
+        for bin_path in ['orm', 'osv', 'report', 'modules', 'service', 'tools']:
             self._path_list.append((os.path.join(config.root_path, bin_path), True))
         # non-recursive scan for individual files in root directory but without
         # scanning subdirectories that may contain addons


### PR DESCRIPTION
New package odoo.orm was added in PR
https://github.com/odoo/odoo/pull/182727
The new package's name must be specified in
``TranslationModuleReader._export_translatable_resources`` to allow the framework to export its code translations.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
