### PR TITLE
[FIX] website_forum: fix double navigation on mobile

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -30,7 +30,7 @@
         <t t-if="_page_name == 'single_question'">
             <div class="flex-grow-1">
                 <div class="o_wforum_breadcrumb_root_single d-flex align-items-center mb-2">
-                    <a t-attf-href="/forum/#{ _forum_slug }">
+                    <a t-if="breadcrumb_kind == 'base'" t-attf-href="/forum/#{ _forum_slug }">
                         <i class="d-inline-block fa fa-angle-left me-2 small"/><t t-out="_forum_name"/>
                     </a>
                     <button class="btn d-lg-none position-relative ms-auto p-2" data-bs-toggle="offcanvas" data-bs-target="#o_wforum_offcanvas">


### PR DESCRIPTION
This PR fixes an oversight introduces in Commit[^1]. With Commit 1, we improved the navigation by showing the back button everywhere on the forum but this created an issue due to a rule in `website_slides_forum` rendering the whole breadcrumb if the forum is a course one.

| saas-19.1 and above | This PR |
|--------|--------|
| <img width="391" height="205" alt="image" src="https://github.com/user-attachments/assets/385a6d95-d8b4-4693-8c13-457e2b06f2fe" /> | <img width="390" height="145" alt="image" src="https://github.com/user-attachments/assets/429979a9-ed09-4fe7-8ded-e95909a9c97b" /> | 

[^1]: https://github.com/odoo/odoo/commit/bb5b7cfa284a55e6dd3a5deb4870bcfae28033af

task-5490243

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
