### PR TITLE
[FIX] stock_account,sale_stock: compute cogs

### DIFF
--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -7,7 +7,7 @@ from odoo.addons.mrp_account.tests.common import TestBomPriceCommon, TestBomPric
 from odoo.tests import Form
 from odoo.tests.common import new_test_user
 from odoo.tools import float_compare, float_round
-from odoo import fields, Command
+from odoo import fields
 
 
 class TestMrpAccount(TestBomPriceCommon):
@@ -158,6 +158,18 @@ class TestMrpAccount(TestBomPriceCommon):
         ])
         self.assertEqual(productB_debit_line.account_id, self.account_stock_valuation)
         self.assertEqual(productB_credit_line.account_id, self.account_production)
+
+    def test_mo_overview_comp_different_uom(self):
+        """ Test that the overview takes into account the uom of the component in the price computation
+        """
+        self.screw.uom_id = self.env.ref('uom.product_uom_pack_6')
+        self.bom_1.bom_line_ids.filtered(lambda l: l.product_id == self.screw).product_uom_id = self.env.ref('uom.product_uom_unit')
+        mo = self._create_mo(self.bom_1, 1)
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 677.08, "718.75 - 50 + 50/6")
+        mo.button_mark_done()
+        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
+        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 677.08)
 
 
 class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
@@ -442,45 +454,3 @@ class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
         mo.move_raw_ids.picked = True
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
-
-    def test_mo_overview_comp_different_uom(self):
-        """ Test that the overview takes into account the uom of the component in the price computation
-        """
-        product_chocolate = self.env['product.product'].create({
-            'name': 'Chocolate',
-            'is_storable': True,
-            'uom_id': self.env.ref('uom.product_uom_kgm').id,
-            'standard_price': 40,
-        })
-        self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': product_chocolate.id,
-            'inventory_quantity': 20,
-            'location_id': self.env.ref('stock.stock_location_stock').id,
-        })
-        product_chococake = self.env['product.product'].create({
-            'name': 'Choco Cake',
-            'is_storable': True,
-        })
-
-        self.env['mrp.bom'].create({
-            'product_id': product_chococake.id,
-            'product_tmpl_id': product_chococake.product_tmpl_id.id,
-            'product_uom_id': product_chococake.uom_id.id,
-            'product_qty': 1.0,
-            'type': 'normal',
-            'bom_line_ids': [
-                Command.create({'product_id': product_chocolate.id, 'product_qty': 100, 'product_uom_id': self.env.ref('uom.product_uom_gram').id}),
-            ],
-        })
-        mo = self.env['mrp.production'].create({
-            'name': 'MO',
-            'product_qty': 1.0,
-            'product_id': product_chococake.id,
-        })
-
-        mo.action_confirm()
-        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
-        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 4)
-        mo.button_mark_done()
-        overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
-        self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 4)

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -239,16 +239,14 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon, TestStockValua
                            partner_id=self.subcontractor_partner1.id)
 
         amls = self.env['account.move.line'].search([('id', 'not in', all_amls_ids)])
-        self.assertRecordValues(amls, [
+        self.assertRecordValues(amls.sorted("account_id, product_id"), [
             # Receipt from subcontractor
-            {'account_id': self.account_production.id,    'product_id': self.finished.id,    'debit': 0.0,   'credit': 40.0},
-            {'account_id': self.account_stock_valuation.id,   'product_id': self.finished.id,    'debit': 40.0,  'credit': 0.0},
-            # Delivery com2 to subcontractor
-            {'account_id': self.account_stock_valuation.id,   'product_id': self.comp1.id,       'debit': 0.0,   'credit': 10.0},
             {'account_id': self.account_production.id,    'product_id': self.comp1.id,       'debit': 10.0,  'credit': 0.0},
-            # Delivery com2 to subcontractor
-            {'account_id': self.account_stock_valuation.id,   'product_id': self.comp2.id,       'debit': 0.0,   'credit': 20.0},
             {'account_id': self.account_production.id,    'product_id': self.comp2.id,       'debit': 20.0,  'credit': 0.0},
+            {'account_id': self.account_production.id,    'product_id': self.finished.id,    'debit': 0.0,   'credit': 40.0},
+            {'account_id': self.account_stock_valuation.id,   'product_id': self.comp1.id,       'debit': 0.0,   'credit': 10.0},
+            {'account_id': self.account_stock_valuation.id,   'product_id': self.comp2.id,       'debit': 0.0,   'credit': 20.0},
+            {'account_id': self.account_stock_valuation.id,   'product_id': self.finished.id,    'debit': 40.0,  'credit': 0.0},
         ])
 
     def test_subcontract_without_prod_account(self):

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -158,3 +158,19 @@ class AccountMoveLine(models.Model):
     def _sale_can_be_reinvoice(self):
         self.ensure_one()
         return self.move_type != 'entry' and self.display_type != 'cogs' and super()._sale_can_be_reinvoice()
+
+    def _get_cogs_qty(self):
+        self.ensure_one()
+        valuation_account = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=self.move_id.fiscal_position_id)['stock_valuation']
+        posted_cogs_qty = sum(self.sale_line_ids.order_id.invoice_ids.filtered(lambda m: m.move_type == 'out_invoice').line_ids.filtered(
+            lambda line: line.product_id == self.product_id and line.display_type == 'cogs' and line.account_id == valuation_account
+        ).mapped('quantity'))
+        return posted_cogs_qty + super()._get_cogs_qty()
+
+    def _get_posted_cogs_value(self):
+        self.ensure_one()
+        valuation_account = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=self.move_id.fiscal_position_id)['stock_valuation']
+        posted_cogs_value = - sum(self.sale_line_ids.order_id.invoice_ids.filtered(lambda m: m.move_type == 'out_invoice').line_ids.filtered(
+            lambda line: line.product_id == self.product_id and line.display_type == 'cogs' and line.account_id == valuation_account
+        ).mapped('balance'))
+        return posted_cogs_value + super()._get_posted_cogs_value()

--- a/addons/sale_stock/tests/common.py
+++ b/addons/sale_stock/tests/common.py
@@ -20,3 +20,4 @@ class TestSaleStockCommon(TestSaleCommon, ProductVariantsCommon):
         })
         delivery_route_3.rule_ids[1].write({'action': 'pull'})
         delivery_route_3.rule_ids[2].write({'action': 'pull'})
+        cls.account_income = cls.company.income_account_id

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1,79 +1,51 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from unittest import skip
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 
-from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import (
-    ValuationReconciliationTestCommon,
-)
+from odoo.addons.stock_account.tests.common import TestStockValuationCommon
 
 
 @tagged('post_install', '-at_install')
-@skip('Temporary to fast merge new valuation')
-class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
+class TestAngloSaxonValuation(TestStockValuationCommon):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.account_income = cls.company.income_account_id
+        cls.partner_b = cls.env['res.partner'].create({'name': 'Partner B'})
 
-        cls.env.user.company_id.anglo_saxon_accounting = True
-
-        cls.product = cls.env['product.product'].create({
-            'name': 'product',
-            'is_storable': True,
-            'categ_id': cls.stock_account_product_categ.id,
-        })
-
-    def _inv_adj_two_units(self):
+    def _inv_adj_two_units(self, product):
         self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product.id,  # tracking serial
+            'product_id': product.id,  # tracking serial
             'inventory_quantity': 2,
-            'location_id': self.company_data['default_warehouse'].lot_stock_id.id,
+            'location_id': self.stock_location.id,
         }).action_apply_inventory()
 
-    def _so_and_confirm_two_units(self):
-        sale_order = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 2.0,
-                    'price_unit': 12,
-                    'tax_ids': False,  # no love taxes amls
-                })],
+    def _so_deliver(self, product, quantity=1, price=1, picking=True):
+        so_2 = self.env['sale.order'].sudo().create({
+            'partner_id': self.owner.id,
+            'warehouse_id': self.warehouse.id,
+            'order_line': [Command.create({
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom_qty': quantity,
+                'price_unit': price,
+                'tax_ids': False,
+            })],
         })
-        sale_order.flush_recordset()
-        sale_order.action_confirm()
-        return sale_order
+        so_2.action_confirm()
+        if picking:
+            so_2.picking_ids.move_ids.write({'quantity': quantity, 'picked': True})
+            so_2.picking_ids.button_validate()
+        return so_2
 
     def _fifo_in_one_eight_one_ten(self):
         # Put two items in stock.
-        in_move_1 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': 8,
-        })
-        in_move_1._action_confirm()
-        in_move_1.write({'quantity': 1, 'picked': True})
-        in_move_1._action_done()
-        in_move_2 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': 10,
-        })
-        in_move_2._action_confirm()
-        in_move_2.write({'quantity': 1, 'picked': True})
-        in_move_2._action_done()
+        self._make_in_move(self.product_fifo_auto, 1, 8)
+        self._make_in_move(self.product_fifo_auto, 1, 10)
 
     # -------------------------------------------------------------------------
     # Standard Ordered
@@ -82,18 +54,17 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         """Standard price set to 10. Get 2 units in stock. Sale order 2@12. Standard price set
         to 14. Invoice 2 without delivering. The amount in Stock OUT and COGS should be 14*2.
         """
-        self.product.categ_id.property_cost_method = 'standard'
-        self.product.invoice_policy = 'order'
-        self.product.standard_price = 10.0
+        self.product_standard_auto.invoice_policy = 'order'
+        self.product_standard_auto.standard_price = 10.0
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_standard_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_standard_auto, 2, 12, picking=False)
 
         # standard price to 14
-        self.product.standard_price = 14.0
+        self.product_standard_auto.standard_price = 14.0
 
         # Invoice the sale order.
         invoice = sale_order._create_invoices()
@@ -102,16 +73,16 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 28)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 28)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
@@ -119,15 +90,11 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         """Standard price set to 10. Get 2 units in stock. Sale order 2@12. Deliver 1, invoice 1,
         change the standard price to 14, deliver one, change the standard price to 16, invoice 1.
         The amounts used in Stock OUT and COGS should be 10 then 14."""
-        self.product.categ_id.property_cost_method = 'standard'
-        self.product.invoice_policy = 'order'
-        self.product.standard_price = 10.0
-
-        # Put two items in stock.
-        sale_order = self._so_and_confirm_two_units()
+        self.product_standard_auto.invoice_policy = 'order'
+        self.product_standard_auto.standard_price = 10.0
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_standard_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
@@ -135,53 +102,50 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
 
         # Invoice 1
         invoice = sale_order._create_invoices()
-        invoice_form = Form(invoice)
-        with invoice_form.invoice_line_ids.edit(0) as invoice_line:
-            invoice_line.quantity = 1
-        invoice_form.save()
+        invoice.invoice_line_ids[0].quantity = 1
         invoice.action_post()
 
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 10)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 10)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 12)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 12)
 
         # change the standard price to 14
-        self.product.standard_price = 14.0
+        self.product_standard_auto.standard_price = 14.0
 
         # deliver the backorder
         sale_order.picking_ids[0].move_ids.write({'quantity': 1, 'picked': True})
         sale_order.picking_ids[0].button_validate()
 
         # change the standard price to 16
-        self.product.standard_price = 16.0
+        self.product_standard_auto.standard_price = 16.0
 
-        # invoice 1
+        # invoice 2
         invoice2 = sale_order._create_invoices()
         invoice2.action_post()
         amls = invoice2.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 14)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 14)
+        self.assertEqual(stock_out_aml.credit, 22)
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml.debit, 22)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 12)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 12)
 
@@ -189,22 +153,27 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         """Standard price set to 10. Get 2 units in stock. Sale order 2@12. Deliver 1, change the
         standard price to 14, deliver one, invoice 2. The amounts used in Stock OUT and COGS should
         be 12*2."""
-        self.product.categ_id.property_cost_method = 'standard'
-        self.product.invoice_policy = 'order'
-        self.product.standard_price = 10
+        self.product_standard_auto.invoice_policy = 'order'
+        self.product_standard_auto.standard_price = 10
+        self._use_inventory_location_accounting()
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_standard_auto)
+        amls = self.env['account.move.line'].search([('product_id', '=', self.product_standard_auto.id)])
+        self.assertRecordValues(amls, [
+            {'account_id': self.account_inventory.id, 'debit': 0.0, 'credit': 20.0},
+            {'account_id': self.account_stock_valuation.id, 'debit': 20.0, 'credit': 0.0},
+        ])
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_standard_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
         Form.from_action(self.env, sale_order.picking_ids.button_validate()).save().process()
 
         # change the standard price to 14
-        self.product.standard_price = 14.0
+        self.product_standard_auto.standard_price = 14.0
 
         # deliver the backorder
         sale_order.picking_ids.filtered('backorder_id').move_ids.write({'quantity': 1, 'picked': True})
@@ -217,129 +186,69 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 24)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 24)
+        self.assertEqual(stock_out_aml.credit, 28)
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml.debit, 28)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
+
+        closing_move = self._close()
+        self.assertRecordValues(closing_move.line_ids, [
+            {'account_id': self.account_stock_variation.id, 'debit': 0.0, 'credit': 8.0},
+            {'account_id': self.account_stock_valuation.id, 'debit': 8.0, 'credit': 0.0},
+        ])
 
     # -------------------------------------------------------------------------
     # Standard Delivered
     # -------------------------------------------------------------------------
     def test_standard_delivered_invoice_pre_delivery(self):
         """Not possible to invoice pre delivery."""
-        self.product.categ_id.property_cost_method = 'standard'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_standard_auto.invoice_policy = 'delivery'
+        self.product_standard_auto.standard_price = 10
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_standard_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_standard_auto, 2, 12, picking=False)
 
         # Invoice the sale order.
         # Nothing delivered = nothing to invoice.
         with self.assertRaises(UserError):
             sale_order._create_invoices()
 
-    def test_standard_delivered_invoice_post_partial_delivery(self):
-        """Standard price set to 10. Get 2 units in stock. Sale order 2@12. Deliver 1, invoice 1,
-        change the standard price to 14, deliver one, change the standard price to 16, invoice 1.
-        The amounts used in Stock OUT and COGS should be 10 then 14."""
-        self.product.categ_id.property_cost_method = 'standard'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
-
-        # Put two items in stock.
-        sale_order = self._so_and_confirm_two_units()
-
-        # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
-
-        # Deliver one.
-        sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
-        Form.from_action(self.env, sale_order.picking_ids.button_validate()).save().process()
-
-        # Invoice 1
-        invoice = sale_order._create_invoices()
-        invoice_form = Form(invoice)
-        with invoice_form.invoice_line_ids.edit(0) as invoice_line:
-            invoice_line.quantity = 1
-        invoice_form.save()
-        invoice.action_post()
-
-        # Check the resulting accounting entries
-        amls = invoice.line_ids
-        self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
-        self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 10)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 10)
-        self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
-        self.assertEqual(receivable_aml.debit, 12)
-        self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
-        self.assertEqual(income_aml.debit, 0)
-        self.assertEqual(income_aml.credit, 12)
-
-        # change the standard price to 14
-        self.product.standard_price = 14.0
-
-        # deliver the backorder
-        sale_order.picking_ids[0].move_ids.write({'quantity': 1, 'picked': True})
-        sale_order.picking_ids[0].button_validate()
-
-        # change the standard price to 16
-        self.product.standard_price = 16.0
-
-        # invoice 1
-        invoice2 = sale_order._create_invoices()
-        invoice2.action_post()
-        amls = invoice2.line_ids
-        self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
-        self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 14)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 14)
-        self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
-        self.assertEqual(receivable_aml.debit, 12)
-        self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
-        self.assertEqual(income_aml.debit, 0)
-        self.assertEqual(income_aml.credit, 12)
-
     def test_standard_delivered_invoice_post_delivery(self):
         """Standard price set to 10. Get 2 units in stock. Sale order 2@12. Deliver 1, change the
         standard price to 14, deliver one, invoice 2. The amounts used in Stock OUT and COGS should
         be 12*2."""
-        self.product.categ_id.property_cost_method = 'standard'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_standard_auto.invoice_policy = 'delivery'
+        self.product_standard_auto.standard_price = 10
+        self._use_inventory_location_accounting()
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_standard_auto)
+        amls = self.env['account.move.line'].search([('product_id', '=', self.product_standard_auto.id)])
+        self.assertRecordValues(amls, [
+            {'account_id': self.account_inventory.id, 'debit': 0.0, 'credit': 20.0},
+            {'account_id': self.account_stock_valuation.id, 'debit': 20.0, 'credit': 0.0},
+        ])
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_standard_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
         Form.from_action(self.env, sale_order.picking_ids.button_validate()).save().process()
 
         # change the standard price to 14
-        self.product.standard_price = 14.0
+        self.product_standard_auto.standard_price = 14.0
 
         # deliver the backorder
         sale_order.picking_ids.filtered('backorder_id').move_ids.write({'quantity': 1, 'picked': True})
@@ -352,33 +261,38 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 24)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 24)
+        self.assertEqual(stock_out_aml.credit, 28)
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml.debit, 28)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
+
+        closing_move = self._close()
+        self.assertRecordValues(closing_move.line_ids, [
+            {'account_id': self.account_stock_variation.id, 'debit': 0.0, 'credit': 8.0},
+            {'account_id': self.account_stock_valuation.id, 'debit': 8.0, 'credit': 0.0},
+        ])
 
     # -------------------------------------------------------------------------
     # AVCO Ordered
     # -------------------------------------------------------------------------
     def test_avco_ordered_invoice_pre_delivery(self):
         """Standard price set to 10. Sale order 2@12. Invoice without delivering."""
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'order'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'order'
+        self.product_avco_auto.standard_price = 10
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_avco_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
 
         # Invoice the sale order.
         invoice = sale_order._create_invoices()
@@ -387,30 +301,29 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 20)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 20)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
     def test_avco_ordered_invoice_post_partial_delivery(self):
         """Standard price set to 10. Sale order 2@12. Invoice after delivering 1."""
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'order'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'order'
+        self.product_avco_auto.standard_price = 10
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_avco_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
@@ -423,34 +336,29 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 20)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 20)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
     def test_avco_ordered_invoice_post_delivery(self):
         """Standard price set to 10. Sale order 2@12. Invoice after full delivery."""
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'order'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'order'
+        self.product_avco_auto.standard_price = 10
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_avco_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
-
-        # Deliver one.
-        sale_order.picking_ids.move_ids.write({'quantity': 2, 'picked': True})
-        sale_order.picking_ids.button_validate()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12)
 
         # Invoice the sale order.
         invoice = sale_order._create_invoices()
@@ -459,22 +367,22 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 20)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 20)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
     def test_avco_ordered_return_and_receipt(self):
         """ Sell and deliver some products before the user encodes the products receipt """
-        product = self.product
+        product = self.product_avco_auto
         product.invoice_policy = 'order'
         product.is_storable = True
         product.categ_id.property_cost_method = 'average'
@@ -482,22 +390,8 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         product.list_price = 100
         product.standard_price = 50
 
-        so = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'partner_invoice_id': self.partner_a.id,
-            'partner_shipping_id': self.partner_a.id,
-            'order_line': [(0, 0, {
-                'name': product.name,
-                'product_id': product.id,
-                'product_uom_qty': 5.0,
-                'product_uom_id': product.uom_id.id,
-                'price_unit': product.list_price})],
-        })
-        so.action_confirm()
-
+        so = self._so_deliver(product, 5, product.list_price)
         pick = so.picking_ids
-        pick.move_ids.write({'quantity': 5, 'picked': True})
-        pick.button_validate()
 
         product.standard_price = 40
 
@@ -512,22 +406,16 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         return_pick.move_ids.write({'quantity': 1, 'picked': True})
         return_pick.button_validate()
 
-        picking = self.env['stock.picking'].create({
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'picking_type_id': self.company_data['default_warehouse'].in_type_id.id,
-        })
         # We don't set the price_unit so that the `standard_price` will be used (see _get_price_unit()):
-        self.env['stock.move'].create({
+        move = self.env['stock.move'].create({
             'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'picking_id': picking.id,
+            'location_dest_id': self.stock_location.id,
             'product_id': product.id,
             'product_uom': product.uom_id.id,
             'quantity': 1,
             'picked': True,
         })
-        picking.button_validate()
+        move._action_done()
 
         invoice = so._create_invoices()
         invoice.action_post()
@@ -538,15 +426,14 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
     # -------------------------------------------------------------------------
     def test_avco_delivered_invoice_pre_delivery(self):
         """Standard price set to 10. Sale order 2@12. Invoice without delivering. """
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'delivery'
+        self.product_avco_auto.standard_price = 10
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_avco_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
 
         # Invoice the sale order.
         # Nothing delivered = nothing to invoice.
@@ -555,15 +442,14 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
 
     def test_avco_delivered_invoice_post_partial_delivery(self):
         """Standard price set to 10. Sale order 2@12. Invoice after delivering 1."""
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'delivery'
+        self.product_avco_auto.standard_price = 10
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_avco_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
@@ -576,30 +462,29 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 10)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 10)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 12)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 12)
 
     def test_avco_delivered_invoice_post_delivery(self):
         """Standard price set to 10. Sale order 2@12. Invoice after full delivery."""
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'delivery'
+        self.product_avco_auto.standard_price = 10
 
         # Put two items in stock.
-        self._inv_adj_two_units()
+        self._inv_adj_two_units(self.product_avco_auto)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 2, 'picked': True})
         sale_order.picking_ids.button_validate()
@@ -611,16 +496,16 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 20)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 20)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
@@ -629,24 +514,21 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         Standard price set to 10. Sale order 2@12. One of the delivered
         products was owned by an external partner. Invoice after full delivery.
         """
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'delivery'
+        self.product_avco_auto.standard_price = 10
 
-        self.env['stock.quant']._update_available_quantity(self.product, self.company_data['default_warehouse'].lot_stock_id, 1, owner_id=self.partner_b)
-        self.env['stock.quant']._update_available_quantity(self.product, self.company_data['default_warehouse'].lot_stock_id, 1)
+        self.env['stock.quant']._update_available_quantity(self.product_avco_auto, self.stock_location, 1, owner_id=self.partner_b)
+        self.env['stock.quant']._update_available_quantity(self.product_avco_auto, self.stock_location, 1)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
         # Deliver both products (there should be two SML)
         sale_order.picking_ids.move_line_ids.write({'quantity': 1, 'picked': True})
         sale_order.picking_ids.button_validate()
 
         # Invoice one by one
         invoice01 = sale_order._create_invoices()
-        with Form(invoice01) as invoice_form:
-            with invoice_form.invoice_line_ids.edit(0) as line_form:
-                line_form.quantity = 1
+        invoice01.invoice_line_ids[0].quantity = 1
         invoice01.action_post()
 
         invoice02 = sale_order._create_invoices()
@@ -655,15 +537,17 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # COGS should ignore the owned product
         self.assertRecordValues(invoice01.line_ids, [
             # pylint: disable=bad-whitespace
-            {'account_id': self.company_data['default_account_revenue'].id,     'debit': 0,     'credit': 12},
-            {'account_id': self.company_data['default_account_receivable'].id,  'debit': 12,    'credit': 0},
-            {'account_id': self.company_data['default_account_stock_out'].id,   'debit': 0,     'credit': 10},
-            {'account_id': self.company_data['default_account_expense'].id,     'debit': 10,    'credit': 0},
+            {'account_id': self.account_income.id,     'debit': 0,     'credit': 12},
+            {'account_id': self.account_receivable.id,  'debit': 12,    'credit': 0},
+            {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 10},
+            {'account_id': self.account_expense.id,     'debit': 10,    'credit': 0},
         ])
         self.assertRecordValues(invoice02.line_ids, [
             # pylint: disable=bad-whitespace
-            {'account_id': self.company_data['default_account_revenue'].id,     'debit': 0,     'credit': 12},
-            {'account_id': self.company_data['default_account_receivable'].id,  'debit': 12,    'credit': 0},
+            {'account_id': self.account_income.id,     'debit': 0,     'credit': 12},
+            {'account_id': self.account_receivable.id,  'debit': 12,    'credit': 0},
+            {'account_id': self.account_stock_valuation.id,   'debit': 0,     'credit': 10},
+            {'account_id': self.account_expense.id,     'debit': 10,    'credit': 0},
         ])
 
     def test_avco_fully_owned_and_delivered_invoice_post_delivery(self):
@@ -671,13 +555,12 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         Standard price set to 10. Sale order 2@12. The products are owned by an
         external partner. Invoice after full delivery.
         """
-        self.product.categ_id.property_cost_method = 'average'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_avco_auto.invoice_policy = 'delivery'
+        self.product_avco_auto.standard_price = 10
 
-        self.env['stock.quant']._update_available_quantity(self.product, self.company_data['default_warehouse'].lot_stock_id, 2, owner_id=self.partner_b)
+        self.env['stock.quant']._update_available_quantity(self.product_avco_auto, self.stock_location, 2, owner_id=self.partner_b)
 
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_avco_auto, 2, 12, picking=False)
         sale_order.picking_ids.move_line_ids.write({'quantity': 2, 'picked': True})
         sale_order.picking_ids.button_validate()
 
@@ -688,8 +571,8 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         amls = invoice.line_ids
         self.assertRecordValues(amls, [
             # pylint: disable=bad-whitespace
-            {'account_id': self.company_data['default_account_revenue'].id,     'debit': 0,     'credit': 24},
-            {'account_id': self.company_data['default_account_receivable'].id,  'debit': 24,    'credit': 0},
+            {'account_id': self.account_income.id,     'debit': 0,     'credit': 24},
+            {'account_id': self.account_receivable.id,  'debit': 24,    'credit': 0},
         ])
 
     # -------------------------------------------------------------------------
@@ -698,13 +581,12 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
     def test_fifo_ordered_invoice_pre_delivery(self):
         """Receive at 8 then at 10. Sale order 2@12. Invoice without delivering.
         As no standard price is set, the Stock OUT and COGS amounts are 0."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'order'
+        self.product_fifo_auto.invoice_policy = 'order'
 
         self._fifo_in_one_eight_one_ten()
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 12, picking=False)
 
         # Invoice the sale order.
         invoice = sale_order._create_invoices()
@@ -713,70 +595,65 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertAlmostEqual(stock_out_aml.credit, 18)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertAlmostEqual(cogs_aml.debit, 18)
+        self.assertEqual(stock_out_aml.credit, 18)
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml.debit, 18)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
     def test_fifo_ordered_invoice_post_partial_delivery(self):
         """Receive 1@8, 1@10, so 2@12, standard price 12, deliver 1, invoice 2: the COGS amount
         should be 20: 1 really delivered at 10 and the other valued at the standard price 10."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'order'
+        self.product_fifo_auto.invoice_policy = 'order'
 
         self._fifo_in_one_eight_one_ten()
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
         Form.from_action(self.env, sale_order.picking_ids.button_validate()).save().process()
 
         # upate the standard price to 12
-        self.product.standard_price = 12
+        self.product_fifo_auto.standard_price = 12
 
         # Invoice 2
         invoice = sale_order._create_invoices()
-        invoice_form = Form(invoice)
-        with invoice_form.invoice_line_ids.edit(0) as invoice_line:
-            invoice_line.quantity = 2
-        invoice_form.save()
+        invoice.invoice_line_ids[0].quantity = 2
         invoice.action_post()
 
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 20)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 20)
+        self.assertEqual(stock_out_aml.credit, 16)
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml.debit, 16)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
     def test_fifo_ordered_invoice_post_delivery(self):
         """Receive at 8 then at 10. Sale order 2@12. Invoice after delivering everything."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'order'
+        self.product_fifo_auto.invoice_policy = 'order'
 
         self._fifo_in_one_eight_one_ten()
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 2, 'picked': True})
@@ -789,16 +666,16 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 18)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 18)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
@@ -806,14 +683,13 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
     # FIFO Delivered
     # -------------------------------------------------------------------------
     def test_fifo_delivered_invoice_pre_delivery(self):
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_fifo_auto.invoice_policy = 'delivery'
+        self.product_fifo_auto.standard_price = 10
 
         self._fifo_in_one_eight_one_ten()
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 12, picking=False)
 
         # Invoice the sale order.
         # Nothing delivered = nothing to invoice.
@@ -823,55 +699,50 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
     def test_fifo_delivered_invoice_post_partial_delivery(self):
         """Receive 1@8, 1@10, so 2@12, standard price 12, deliver 1, invoice 2: the price used should be 10:
         one at 8 and one at 10."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
+        self.product_fifo_auto.invoice_policy = 'delivery'
 
         self._fifo_in_one_eight_one_ten()
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
         Form.from_action(self.env, sale_order.picking_ids.button_validate()).save().process()
 
         # upate the standard price to 12
-        self.product.standard_price = 12
+        self.product_fifo_auto.standard_price = 12
 
         # Invoice 2
         invoice = sale_order._create_invoices()
-        invoice_form = Form(invoice)
-        with invoice_form.invoice_line_ids.edit(0) as invoice_line:
-            invoice_line.quantity = 2
-        invoice_form.save()
+        invoice.line_ids[0].quantity = 2
         invoice.action_post()
 
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 20)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 20)
+        self.assertEqual(stock_out_aml.credit, 16)
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml.debit, 16)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
     def test_fifo_delivered_invoice_post_delivery(self):
         """Receive at 8 then at 10. Sale order 2@12. Invoice after delivering everything."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_fifo_auto.invoice_policy = 'delivery'
+        self.product_fifo_auto.standard_price = 10
 
         self._fifo_in_one_eight_one_ten()
 
         # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
+        sale_order = self._so_deliver(self.product_fifo_auto, 2, 12, picking=False)
 
         # Deliver one.
         sale_order.picking_ids.move_ids.write({'quantity': 2, 'picked': True})
@@ -884,71 +755,33 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 18)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 18)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 24)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 24)
 
     def test_fifo_delivered_invoice_post_delivery_2(self):
         """Receive at 8 then at 10. Sale order 10@12 and deliver without receiving the 2 missing.
         receive 2@12. Invoice."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_fifo_auto.invoice_policy = 'delivery'
+        self.product_fifo_auto.standard_price = 10
 
-        in_move_1 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 8,
-            'price_unit': 10,
-        })
-        in_move_1._action_confirm()
-        in_move_1.write({'quantity': 8, 'picked': True})
-        in_move_1._action_done()
+        self._make_in_move(self.product_fifo_auto, 8, 10)
 
         # Create and confirm a sale order for 2@12
-        sale_order = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 10.0,
-                    'price_unit': 12,
-                    'tax_ids': False,  # no love taxes amls
-                })],
-        })
-        sale_order.action_confirm()
-
-        # Deliver 10
-        sale_order.picking_ids.move_ids.write({'quantity': 10, 'picked': True})
-        sale_order.picking_ids.button_validate()
+        sale_order = self._so_deliver(self.product_fifo_auto, 10, 12)
 
         # Make the second receipt
-        in_move_2 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 2,
-            'price_unit': 12,
-        })
-        in_move_2._action_confirm()
-        in_move_2.write({'quantity': 2, 'picked': True})
-        in_move_2._action_done()
-        self.assertEqual(self.product.stock_valuation_layer_ids[-1].value, -4)  # we sent two at 10 but they should have been sent at 12
-        self.assertEqual(self.product.stock_valuation_layer_ids[-1].quantity, 0)
-        self.assertEqual(sale_order.order_line.move_ids.stock_valuation_layer_ids[-1].quantity, 0)
+        in_move = self._make_in_move(self.product_fifo_auto, 12, 2)
+        self.assertEqual(in_move.value, 24)  # we sent two at 10 but they should have been sent at 12
 
         # Invoice the sale order.
         invoice = sale_order._create_invoices()
@@ -957,175 +790,84 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls = invoice.line_ids
         self.assertEqual(len(amls), 4)
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertEqual(stock_out_aml.credit, 104)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml.debit, 104)
+        self.assertEqual(stock_out_aml.credit, 100)
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml.debit, 100)
         self.assertEqual(cogs_aml.credit, 0)
-        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml = amls.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml.debit, 120)
         self.assertEqual(receivable_aml.credit, 0)
-        income_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml = amls.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml.debit, 0)
         self.assertEqual(income_aml.credit, 120)
 
     def test_fifo_delivered_invoice_post_delivery_3(self):
         """Receive 5@8, receive 8@12, sale 1@20, deliver, sale 6@20, deliver. Make sure no rouding
         issues appear on the second invoice."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
+        self.product_fifo_auto.invoice_policy = 'delivery'
 
         # +5@8
-        in_move_1 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 5,
-            'price_unit': 8,
-        })
-        in_move_1._action_confirm()
-        in_move_1.write({'quantity': 5, 'picked': True})
-        in_move_1._action_done()
+        self._make_in_move(self.product_fifo_auto, 5, 8)
 
         # +8@12
-        in_move_2 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 8,
-            'price_unit': 12,
-        })
-        in_move_2._action_confirm()
-        in_move_2.write({'quantity': 8, 'picked': True})
-        in_move_2._action_done()
+        self._make_in_move(self.product_fifo_auto, 8, 12)
 
         # sale 1@20, deliver, invoice
-        sale_order = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 1,
-                    'price_unit': 20,
-                    'tax_ids': False,
-                })],
-        })
-        sale_order.action_confirm()
-        sale_order.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
-        sale_order.picking_ids.button_validate()
+        sale_order = self._so_deliver(self.product_fifo_auto, 1, 20)
         invoice = sale_order._create_invoices()
         invoice.action_post()
 
         # sale 6@20, deliver, invoice
-        sale_order = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 6,
-                    'price_unit': 20,
-                    'tax_ids': False,
-                })],
-        })
-        sale_order.action_confirm()
-        sale_order.picking_ids.move_ids.write({'quantity': 6, 'picked': True})
-        sale_order.picking_ids.button_validate()
+        sale_order = self._so_deliver(self.product_fifo_auto, 6, 20)
         invoice = sale_order._create_invoices()
         invoice.action_post()
 
         # check the last anglo saxon invoice line
         amls = invoice.line_ids
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 56)
         self.assertEqual(cogs_aml.credit, 0)
 
     def test_fifo_delivered_invoice_post_delivery_4(self):
         """Receive 8@10. Sale order 10@12. Deliver and also invoice it without receiving the 2 missing.
-        Now, receive 2@12. Make sure price difference is correctly reflected in expense account."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        Now, receive 2@12. Make sure price difference is correctly reflected in expense account at
+        closing."""
+        self.product_fifo_auto.invoice_policy = 'delivery'
+        self.product_fifo_auto.standard_price = 10
 
-        in_move_1 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 8,
-            'price_unit': 10,
-        })
-        in_move_1._action_confirm()
-        in_move_1.write({'quantity': 8, 'picked': True})
-        in_move_1._action_done()
+        self._make_in_move(self.product_fifo_auto, 8, 10)
+        self._create_bill(self.product_fifo_auto, 8, 10)
 
         # Create and confirm a sale order for 10@12
-        sale_order = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 10.0,
-                    'price_unit': 12,
-                    'tax_ids': False,  # no love taxes amls
-                })],
-        })
-        sale_order.action_confirm()
-
-        # Deliver 10
-        sale_order.picking_ids.move_ids.write({'quantity': 10, 'picked': True})
-        sale_order.picking_ids.button_validate()
+        sale_order = self._so_deliver(self.product_fifo_auto, 10, 12)
 
         # Invoice the sale order.
         invoice = sale_order._create_invoices()
         invoice.action_post()
 
         # Make the second receipt
-        in_move_2 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 2,
-            'price_unit': 12,
-        })
-        in_move_2._action_confirm()
-        in_move_2.write({'quantity': 2, 'picked': True})
-        in_move_2._action_done()
+        self._make_in_move(self.product_fifo_auto, 2, 12)
+        self._create_bill(self.product_fifo_auto, 2, 12)
 
         # check the last anglo saxon move line
-        revalued_anglo_expense_amls = sale_order.picking_ids.move_ids.stock_valuation_layer_ids[-1].stock_move_id.account_move_ids[-1].line_ids
-        revalued_cogs_aml = revalued_anglo_expense_amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(revalued_cogs_aml.debit, 4, 'Price difference should have correctly reflected in expense account.')
+        closing_move = self._close()
+        self.assertRecordValues(closing_move.line_ids, [
+            {'account_id': self.account_stock_valuation.id, 'debit': 0.0, 'credit': 4.0},
+            {'account_id': self.account_stock_variation.id, 'debit': 4.0, 'credit': 0.0},
+        ])
 
     def test_fifo_delivered_invoice_post_delivery_with_return(self):
         """Receive 2@10. SO1 2@12. Return 1 from SO1. SO2 1@12. Receive 1@20.
         Re-deliver returned from SO1. Invoice after delivering everything."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
+        self.product_fifo_auto.invoice_policy = 'delivery'
 
         # Receive 2@10.
-        in_move_1 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 2,
-            'price_unit': 10,
-        })
-        in_move_1._action_confirm()
-        in_move_1.write({'quantity': 2, 'picked': True})
-        in_move_1._action_done()
+        self._make_in_move(self.product_fifo_auto, 2, 10)
 
         # Create, confirm and deliver a sale order for 2@12 (SO1)
-        so_1 = self._so_and_confirm_two_units()
-        so_1.picking_ids.move_ids.write({'quantity': 2, 'picked': True})
-        so_1.picking_ids.button_validate()
+        so_1 = self._so_deliver(self.product_fifo_auto, 2, 12)
 
         # Return 1 from SO1
         stock_return_picking_form = Form(
@@ -1141,33 +883,10 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         return_pick._action_done()
 
         # Create, confirm and deliver a sale order for 1@12 (SO2)
-        so_2 = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 1.0,
-                    'price_unit': 12,
-                    'tax_ids': False,  # no love taxes amls
-                })],
-        })
-        so_2.action_confirm()
-        so_2.picking_ids.move_ids.write({'quantity': 1, 'picked': True})
-        so_2.picking_ids.button_validate()
+        so_2 = self._so_deliver(self.product_fifo_auto, 1, 12)
 
         # Receive 1@20
-        in_move_2 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': 20,
-        })
-        in_move_2._action_confirm()
-        in_move_2.write({'quantity': 1, 'picked': True})
-        in_move_2._action_done()
+        self._make_in_move(self.product_fifo_auto, 1, 20)
 
         # Re-deliver returned 1 from SO1
         stock_redeliver_picking_form = Form(
@@ -1191,41 +910,39 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         # Check the resulting accounting entries
         amls_1 = invoice_1.line_ids
         self.assertEqual(len(amls_1), 4)
-        stock_out_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml_1.debit, 0)
-        self.assertEqual(stock_out_aml_1.credit, 30)
-        cogs_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertEqual(cogs_aml_1.debit, 30)
+        self.assertEqual(stock_out_aml_1.credit, 25)
+        cogs_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.account_expense)
+        self.assertEqual(cogs_aml_1.debit, 25)
         self.assertEqual(cogs_aml_1.credit, 0)
-        receivable_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml_1.debit, 24)
         self.assertEqual(receivable_aml_1.credit, 0)
-        income_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml_1 = amls_1.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml_1.debit, 0)
         self.assertEqual(income_aml_1.credit, 24)
 
         amls_2 = invoice_2.line_ids
         self.assertEqual(len(amls_2), 4)
-        stock_out_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml_2.debit, 0)
         self.assertEqual(stock_out_aml_2.credit, 10)
-        cogs_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml_2.debit, 10)
         self.assertEqual(cogs_aml_2.credit, 0)
-        receivable_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.company_data['default_account_receivable'])
+        receivable_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.account_receivable)
         self.assertEqual(receivable_aml_2.debit, 12)
         self.assertEqual(receivable_aml_2.credit, 0)
-        income_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.company_data['default_account_revenue'])
+        income_aml_2 = amls_2.filtered(lambda aml: aml.account_id == self.account_income)
         self.assertEqual(income_aml_2.debit, 0)
         self.assertEqual(income_aml_2.credit, 12)
 
     def test_fifo_uom_computation(self):
-        self.env.company.anglo_saxon_accounting = True
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.categ_id.property_valuation = 'real_time'
+        self.product_fifo_auto.categ_id.property_valuation = 'real_time'
         quantity = 50.0
-        self.product.list_price = 1.5
-        self.product.standard_price = 2.0
+        self.product_fifo_auto.list_price = 1.5
+        self.product_fifo_auto.standard_price = 2.0
         unit_12 = self.env['uom.uom'].create({
             'name': 'Pack of 12 units',
             'relative_factor': 12,
@@ -1234,16 +951,15 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
 
         # Create, confirm and deliver a sale order for 12@1.5 without reception with std_price = 2.0 (SO1)
         so_1 = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 1,
-                    'product_uom_id': unit_12.id,
-                    'price_unit': 18,
-                    'tax_ids': False,  # no love taxes amls
-                })],
+            'partner_id': self.owner.id,
+            'order_line': [Command.create({
+                'name': self.product_fifo_auto.name,
+                'product_id': self.product_fifo_auto.id,
+                'product_uom_qty': 1,
+                'product_uom_id': unit_12.id,
+                'price_unit': 18,
+                'tax_ids': False,  # no love taxes amls
+            })],
         })
         so_1.action_confirm()
         so_1.picking_ids.move_ids.write({'quantity': 12, 'picked': True})
@@ -1279,30 +995,19 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         self.assertEqual(aml[3].credit, 0.0)
 
         # Create stock move 1
-        in_move_1 = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': quantity,
-            'price_unit': 1.0,
-        })
-        in_move_1._action_confirm()
-        in_move_1.write({'quantity': quantity, 'picked': True})
-        in_move_1._action_done()
+        self._make_in_move(self.product_fifo_auto, quantity, 1.0)
 
         # Create, confirm and deliver a sale order for 12@1.5 with reception (50 * 1.0, 50 * 0.0)(SO2)
         so_2 = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 1,
-                    'product_uom_id': unit_12.id,
-                    'price_unit': 18,
-                    'tax_ids': False,  # no love taxes amls
-                })],
+            'partner_id': self.owner.id,
+            'order_line': [Command.create({
+                'name': self.product_fifo_auto.name,
+                'product_id': self.product_fifo_auto.id,
+                'product_uom_qty': 1,
+                'product_uom_id': unit_12.id,
+                'price_unit': 18,
+                'tax_ids': False,  # no love taxes amls
+            })],
         })
         so_2.action_confirm()
         so_2.picking_ids.move_ids.write({'quantity': 12, 'picked': True})
@@ -1342,34 +1047,13 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         When posting a credit note for a returned product, the value of the anglo-saxo lines
         should be based on the returned product's value
         """
-        self.product.categ_id.property_cost_method = 'fifo'
-
         # Receive one @10, one @20 and one @60
-        in_moves = self.env['stock.move'].create([{
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': p,
-        } for p in [10, 20, 60]])
-        in_moves._action_confirm()
-        in_moves.write({'quantity': 1, 'picked': True})
-        in_moves._action_done()
+        svl_values = [10, 20, 60]
+        for val in svl_values:
+            self._make_in_move(self.product_fifo_auto, 1, val)
 
         # Sell 3 units
-        so = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 3.0,
-                    'price_unit': 100,
-                    'tax_ids': False,
-                })],
-        })
-        so.action_confirm()
+        so = self._so_deliver(self.product_fifo_auto, 3, 100, picking=False)
 
         # Deliver 1@10, then 1@20 and then 1@60
         pickings = []
@@ -1386,17 +1070,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice.action_post()
 
         # Receive one @100
-        in_moves = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': 100,
-        })
-        in_moves._action_confirm()
-        in_moves.write({'quantity': 1, 'picked': True})
-        in_moves._action_done()
+        self._make_in_move(self.product_fifo_auto, 1, 100)
 
         # Return the second picking (i.e. 1@20)
         ctx = {'active_id': pickings[1].id, 'active_model': 'stock.picking'}
@@ -1413,53 +1087,36 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         })
         action = refund_wizard.refund_moves()
         reverse_invoice = self.env['account.move'].browse(action['res_id'])
-        with Form(reverse_invoice) as reverse_invoice_form:
-            with reverse_invoice_form.invoice_line_ids.edit(0) as line:
-                line.quantity = 1
+        reverse_invoice.invoice_line_ids[0].quantity = 1
         reverse_invoice.action_post()
 
         amls = reverse_invoice.line_ids
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
-        self.assertEqual(stock_out_aml.debit, 20, 'Should be to the value of the returned product')
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
+        self.assertEqual(stock_out_aml.debit, 30, 'Should be to the value of the returned product')
         self.assertEqual(stock_out_aml.credit, 0)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 0)
-        self.assertEqual(cogs_aml.credit, 20, 'Should be to the value of the returned product')
+        self.assertEqual(cogs_aml.credit, 30, 'Should be to the value of the returned product')
+
+        closing_move = self._close()
+        self.assertRecordValues(closing_move.line_ids, [
+            {'account_id': self.account_stock_variation.id, 'debit': 0.0, 'credit': 180.0},
+            {'account_id': self.account_stock_valuation.id, 'debit': 180.0, 'credit': 0.0},
+        ])
 
     def test_fifo_return_and_create_invoice(self):
         """
         When creating an invoice for a returned product, the value of the anglo-saxo lines
         should be based on the returned product's value
         """
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
+        self.product_fifo_auto.invoice_policy = 'delivery'
 
         # Receive one @10, one @20 and one @60
-        in_moves = self.env['stock.move'].create([{
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': p,
-        } for p in [10, 20, 60]])
-        in_moves._action_confirm()
-        in_moves.write({'quantity': 1, 'picked': True})
-        in_moves._action_done()
-
+        svl_values = [10, 20, 60]
+        for val in svl_values:
+            self._make_in_move(self.product_fifo_auto, 1, val)
         # Sell 3 units
-        so = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 3.0,
-                    'price_unit': 100,
-                    'tax_ids': False,
-                })],
-        })
-        so.action_confirm()
+        so = self._so_deliver(self.product_fifo_auto, 3, 100, picking=False)
 
         # Deliver 1@10, then 1@20 and then 1@60
         pickings = []
@@ -1476,17 +1133,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice.action_post()
 
         # Receive one @100
-        in_moves = self.env['stock.move'].create({
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': 100,
-        })
-        in_moves._action_confirm()
-        in_moves.write({'quantity': 1, 'picked': True})
-        in_moves._action_done()
+        self._make_in_move(self.product_fifo_auto, 1, 100)
 
         # Return the second picking (i.e. 1@20)
         ctx = {'active_id': pickings[1].id, 'active_model': 'stock.picking'}
@@ -1502,49 +1149,32 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
             'active_ids': so.ids,
         }).sudo().create({}).create_invoices()
         reverse_invoice = so.invoice_ids[-1]
-        with Form(reverse_invoice) as reverse_invoice_form:
-            with reverse_invoice_form.invoice_line_ids.edit(0) as line:
-                line.quantity = 1
+        reverse_invoice.invoice_line_ids[0].quantity = 1
         reverse_invoice.action_post()
 
         amls = reverse_invoice.line_ids
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 20, 'Should be to the value of the returned product')
         self.assertEqual(stock_out_aml.credit, 0)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 0)
         self.assertEqual(cogs_aml.credit, 20, 'Should be to the value of the returned product')
 
+        closing_move = self._close()
+        self.assertRecordValues(closing_move.line_ids, [
+            {'account_id': self.account_stock_variation.id, 'debit': 0.0, 'credit': 190.0},
+            {'account_id': self.account_stock_valuation.id, 'debit': 190.0, 'credit': 0.0},
+        ])
+
     def test_fifo_several_invoices_reset_repost(self):
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
+        self.product_fifo_auto.invoice_policy = 'delivery'
 
         svl_values = [10, 15, 65]
         total_value = sum(svl_values)
-        in_moves = self.env['stock.move'].create([{
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': p,
-        } for p in svl_values])
-        in_moves._action_confirm()
-        in_moves.write({'quantity': 1, 'picked': True})
-        in_moves._action_done()
+        for val in svl_values:
+            self._make_in_move(self.product_fifo_auto, 1, val)
 
-        so = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 3.0,
-                    'price_unit': 100,
-                    'tax_ids': False,
-                })],
-        })
-        so.action_confirm()
+        so = self._so_deliver(self.product_fifo_auto, 3, 100, picking=False)
 
         # Deliver one by one, so it creates an out-SVL each time.
         # Then invoice the delivered quantity
@@ -1561,7 +1191,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
             invoice.action_post()
             invoices |= invoice
 
-        out_account = self.product.categ_id.property_stock_account_output_categ_id
+        out_account = self.account_stock_valuation
         invoice01, _invoice02, invoice03 = invoices
         cogs = invoices.line_ids.filtered(lambda l: l.account_id == out_account)
         self.assertEqual(cogs.mapped('credit'), svl_values)
@@ -1599,8 +1229,6 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         Note: This test will also ensure that a user who only has access to
         account app can post such an invoice
         """
-        self.product.categ_id.property_cost_method = 'fifo'
-
         accountman = self.env['res.users'].create({
             'name': 'Super Accountman',
             'login': 'super_accountman',
@@ -1608,35 +1236,9 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
             'group_ids': [(6, 0, self.env.ref('account.group_account_invoice').ids)],
         })
 
-        in_moves = self.env['stock.move'].create([{
-            'product_id': self.product.id,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.company_data['default_warehouse'].lot_stock_id.id,
-            'product_uom': self.product.uom_id.id,
-            'product_uom_qty': 1,
-            'price_unit': p,
-        } for p in [10, 50]])
-        in_moves._action_confirm()
-        in_moves.write({'quantity': 1, 'picked': True})
-        in_moves._action_done()
-
-        so = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 1.0,
-                    'price_unit': 100,
-                    'tax_ids': False,
-                })],
-        })
-        so.action_confirm()
-
-        picking = so.picking_ids
-        picking.move_ids.write({'quantity': 1.0, 'picked': True})
-        picking.button_validate()
-
+        self._make_in_move(self.product_fifo_auto, 1, 10)
+        self._make_in_move(self.product_fifo_auto, 1, 50)
+        so = self._so_deliver(self.product_fifo_auto, 1, 100)
         invoice01 = so._create_invoices()
 
         # Clear the cache to ensure access rights
@@ -1651,64 +1253,28 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice02.action_post()
 
         amls = invoice02.line_ids
-        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
+        stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.account_stock_valuation)
         self.assertEqual(stock_out_aml.debit, 0)
         self.assertEqual(stock_out_aml.credit, 10)
-        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
+        cogs_aml = amls.filtered(lambda aml: aml.account_id == self.account_expense)
         self.assertEqual(cogs_aml.debit, 10)
         self.assertEqual(cogs_aml.credit, 0)
-
-    def test_fifo_edit_svl_without_reinvoice(self):
-        """Edit SVL move line after delivering. Check no reinvoicing occurs."""
-        self.product.categ_id.property_cost_method = 'fifo'
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
-        self.product.expense_policy = 'cost'
-
-        self._fifo_in_one_eight_one_ten()
-
-        # Create and confirm a sale order for 2@12
-        sale_order = self._so_and_confirm_two_units()
-        self.assertEqual(len(sale_order.order_line), 1)
-        self.assertEqual(sale_order.order_line.product_uom_qty, 2.0)
-
-        # Deliver one.
-        sale_order.picking_ids.move_ids.write({'quantity': 2, 'picked': True})
-        sale_order.picking_ids.button_validate()
-        svl_am = sale_order.order_line.move_ids.stock_valuation_layer_ids.account_move_id
-        svl_am.button_draft()
-        svl_am.action_post()
-
-        # Check no reinvoice line addded to the sale order
-        self.assertEqual(len(sale_order.order_line), 1)
-        self.assertEqual(sale_order.order_line.product_uom_qty, 2.0)
 
     def test_anglo_saxon_cogs_with_down_payment(self):
         """Create a SO with a product invoiced on delivered quantity.
         Do a 100% down payment, deliver a part of it with a backorder
         then invoice the delivered part from the down payment.
         Deliver the remaining part and invoice it."""
-        self.product.invoice_policy = 'delivery'
-        self.product.standard_price = 10
+        self.product_fifo_auto.invoice_policy = 'delivery'
+        self.product_fifo_auto.standard_price = 10
         self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product.id,  # tracking serial
+            'product_id': self.product_fifo_auto.id,  # tracking serial
             'inventory_quantity': 20,
-            'location_id': self.company_data['default_warehouse'].lot_stock_id.id,
+            'location_id': self.stock_location.id,
         }).action_apply_inventory()
 
         # Create a SO with a product invoiced on delivered quantity
-        so = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 10.0,
-                    'price_unit': 100,
-                    'tax_ids': False,
-                })],
-        })
-        so.action_confirm()
+        so = self._so_deliver(self.product_fifo_auto, 10, 100, picking=False)
 
         # Do a 100% down payment
         self.env['sale.advance.payment.inv'].sudo().create({
@@ -1749,16 +1315,16 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice.action_post()
 
         # Check the resulting accounting entries
-        account_stock_out = self.company_data['default_account_stock_out']
-        account_expense = self.company_data['default_account_expense']
+        account_stock_out = self.account_stock_valuation
+        account_expense = self.account_expense
         invoice_1_cogs = credit_note.line_ids.filtered(lambda l: l.display_type == 'cogs')
         invoice_2_cogs = invoice.line_ids.filtered(lambda l: l.display_type == 'cogs')
         self.assertRecordValues(invoice_1_cogs, [
-            {'debit': 0, 'credit': 40, 'account_id': account_stock_out.id, 'reconciled': True},
+            {'debit': 0, 'credit': 40, 'account_id': account_stock_out.id, 'reconciled': False},
             {'debit': 40, 'credit': 0, 'account_id': account_expense.id, 'reconciled': False},
         ])
         self.assertRecordValues(invoice_2_cogs, [
-            {'debit': 0, 'credit': 60, 'account_id': account_stock_out.id, 'reconciled': True},
+            {'debit': 0, 'credit': 60, 'account_id': account_stock_out.id, 'reconciled': False},
             {'debit': 60, 'credit': 0, 'account_id': account_expense.id, 'reconciled': False},
         ])
 
@@ -1772,28 +1338,17 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         In that scenario, if there have been any manual changes to a product's `standard_price`,
         there will be inaccurate product expense account (COGs) lines on the affected invoice.
         """
-        product = self.product
-        in_move = self.env['stock.move'].create({
-            'product_id': product.id,
-            'price_unit': 100,
-            'product_uom_qty': 12,
-            'location_id': self.env.ref('stock.stock_location_suppliers').id,
-            'location_dest_id': self.env.user._get_default_warehouse_id().lot_stock_id.id,
-        })
-        in_move._action_confirm()
-        in_move._action_assign()
-        in_move.move_line_ids.quantity = 12
-        in_move.picked = True
-        in_move._action_done()
+        self._make_in_move(self.product_fifo_auto, 12, 100)
 
         sale_order = self.env['sale.order'].sudo().create({
-            'partner_id': self.partner_a.id,
+            'partner_id': self.owner.id,
+            'warehouse_id': self.warehouse.id,
             'order_line': [Command.create({
-                'product_id': product.id,
+                'product_id': self.product_fifo_auto.id,
                 'product_uom_qty': 10,
                 'price_unit': 100,
             }), Command.create({
-                'product_id': product.id,
+                'product_id': self.product_fifo_auto.id,
                 'product_uom_qty': 2,
                 'price_unit': 100,
             })],
@@ -1801,6 +1356,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         sale_order.action_confirm()
         delivery = sale_order.picking_ids
         delivery.move_ids.filtered(lambda m: m.product_uom_qty == 2).quantity = 0
+        delivery.move_ids.picked = True
         r = delivery.button_validate()
         Form(self.env[r['res_model']].with_context(r['context'])).save().process()
         backorder_delivery = sale_order.picking_ids.filtered(lambda p: p.state != 'done')
@@ -1815,7 +1371,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         qty_ten_invoice_line.quantity = 5
         invoice.invoice_date = fields.Date.today()
         invoice.action_post()
-        product.standard_price = 50
+        self.product_fifo_autostandard_price = 50
         self.env['sale.advance.payment.inv'].with_context(
             active_ids=sale_order.ids,
         ).sudo().create({}).create_invoices()

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -233,7 +233,16 @@ class StockMove(models.Model):
             return 0
         total_value = sum(self.mapped('value'))
         total_qty = sum(m._get_valued_qty() for m in self)
-        return total_value / total_qty if total_qty else self.product_id.standard_price
+        return total_value / total_qty if total_qty else 0
+
+    def _get_cogs_price_unit(self, quantity=0):
+        """ Returns the COGS unit price to value this stock move
+        quantity should be given in product uom """
+
+        total_qty = sum(m._get_valued_qty() for m in self)
+        if not total_qty:
+            return 0
+        return sum(self.mapped('value')) / total_qty if self.product_id.cost_method == 'fifo' else self.product_id.standard_price
 
     @api.model
     def _get_valued_types(self):
@@ -292,8 +301,7 @@ class StockMove(models.Model):
                 move.value = move.product_id.with_context(fifo_qty_already_processed=fifo_qty_processed[move.product_id])._run_fifo(valued_qty)
                 fifo_qty_processed[move.product_id] += valued_qty
             else:
-                qty = move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id, rounding_method='HALF-UP')
-                move.value = move.product_id.standard_price * qty
+                move.value = move.product_id.standard_price * move._get_valued_qty()
 
         # Recompute the standard price
         self.env['product.product'].browse(products_to_recompute)._update_standard_price()

--- a/addons/stock_account/tests/common.py
+++ b/addons/stock_account/tests/common.py
@@ -301,6 +301,7 @@ class TestStockValuationCommon(BaseCommon):
         cls.account_stock_variation = cls.account_stock_valuation.account_stock_variation_id
         cls.account_payable = cls.company.partner_id.property_account_payable_id
         cls.account_receivable = cls.company.partner_id.property_account_receivable_id
+        cls.account_income = cls.company.income_account_id
 
         cls.picking_type_in = cls.warehouse.in_type_id
         cls.picking_type_out = cls.warehouse.out_type_id


### PR DESCRIPTION
This commit makes the cogs computation correct again.
In case the invoice has some linked stock move, the cogs price unit will
be the standard price in 'standard' and 'avco'. The fifo computation
will be the based on the stack.
Computing cogs value will ignore the potential owner_id set in the stock
move related to the invoice being posted when computing the cogs price
unit in `_get_price_unit()`.
This commit looks up related stock move of the invoice for all cost
method to compute the cost based on the valued stock move line.

This commit also re-enable the anglosaxon tests related to outgoing flow

opw: 5266208

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
