### PR TITLE
[IMP] sale: change button label in SO email

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1849,15 +1849,7 @@ class SaleOrder(models.Model):
             pass
         else:
             access_opt = customer_portal_group[2].setdefault('button_access', {})
-            is_tx_pending = self.get_portal_last_transaction().state == 'pending'
-            if self._has_to_be_signed():
-                if self._has_to_be_paid():
-                    access_opt['title'] = _("View Quotation") if is_tx_pending else _("Sign & Pay Quotation")
-                else:
-                    access_opt['title'] = _("Review & Sign Quotation")
-            elif self._has_to_be_paid() and not is_tx_pending:
-                access_opt['title'] = _("Review & Pay Quotation")
-            elif self.state in ('draft', 'sent'):
+            if self.state in ('draft', 'sent'):
                 access_opt['title'] = _("View Quotation")
 
         return groups


### PR DESCRIPTION
Change the label button to view SO in email from "Sign & Pay Quotation" and similars to "View Quotation", as they are a little bit too engaging and can block the customer from actually clicking on it.


task-5379535
