### PR TITLE
[FIX] mail: reduce eye strain when using discuss app in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -1,6 +1,11 @@
 import { Store as BaseStore, fields, makeStore, storeInsertFns } from "@mail/core/common/record";
 import { threadCompareRegistry } from "@mail/core/common/thread_compare";
-import { cleanTerm, generateEmojisOnHtml, prettifyMessageText } from "@mail/utils/common/format";
+import {
+    attClassObjectToString,
+    cleanTerm,
+    generateEmojisOnHtml,
+    prettifyMessageText,
+} from "@mail/utils/common/format";
 import { compareDatetime } from "@mail/utils/common/misc";
 
 import { reactive } from "@odoo/owl";
@@ -211,11 +216,12 @@ export class Store extends BaseStore {
     }
 
     discussDropdownMenuClass(ctx) {
-        const res = ["o-discuss-dropdownMenu", "d-flex", "flex-column", "border-secondary"];
-        if (this.shouldSimulateDarkTheme(ctx)) {
-            res.push("o-simulateDarkTheme");
-        }
-        return res.join(" ");
+        const simulateDarkTheme = this.shouldSimulateDarkTheme(ctx);
+        return attClassObjectToString({
+            "o-discuss-dropdownMenu d-flex flex-column border-secondary": true,
+            "o-simulateDarkTheme": simulateDarkTheme,
+            "bg-view": !simulateDarkTheme,
+        });
     }
 
     standaloneInboxMessages = fields.Many("mail.message", {


### PR DESCRIPTION
Dropdown menu are quite light in dark theme. Outside of discuss not many UI elements require dropdown. However discuss use them a lot, so this becomes a problem to have light background so often.

This commit adds `.bg-view` to all discuss dropdown, which is visually unchanged in white theme but in dark theme this makes it darker so easier to read with less eye strain.

Task-5492040

Before / After

<img width="961" height="671" alt="Screenshot 2026-01-13 at 17 24 12" src="https://github.com/user-attachments/assets/09ab5f8f-5927-4beb-a814-d77cd61f8a01" />
<img width="957" height="667" alt="Screenshot 2026-01-13 at 17 23 56" src="https://github.com/user-attachments/assets/4ec0ef3b-7af5-4b69-b48e-40c3788eb95e" />
