### PR TITLE
[FIX] *: Fix json decode error imports

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -8,6 +8,7 @@ import logging
 import requests
 from werkzeug.urls import url_quote
 from base64 import b64encode
+from json import JSONDecodeError
 from odoo.addons.account.tools import LegacyHTTPAdapter
 
 from odoo import api, models, _
@@ -57,7 +58,7 @@ class AccountEdiFormat(models.Model):
         if not request_response.ok:
             try:
                 response_data = request_response.json()
-            except requests.exceptions.JSONDecodeError as ex:
+            except JSONDecodeError as ex:
                 return {
                     'error': str(ex),
                     'blocking_level': 'error'
@@ -70,7 +71,7 @@ class AccountEdiFormat(models.Model):
 
         try:
             response_data = request_response.json()
-        except requests.exceptions.JSONDecodeError:
+        except JSONDecodeError:
             response_data = {}
 
         return {

--- a/addons/l10n_hr_edi/tools.py
+++ b/addons/l10n_hr_edi/tools.py
@@ -6,6 +6,7 @@ edi_proxy_user cannot be used as a basis as it is too closely tied to Odoo's own
 
 import logging
 import requests
+from json import JSONDecodeError
 
 from odoo.exceptions import UserError
 
@@ -80,14 +81,14 @@ def _make_request(company, endpoint_type, params=False):
     if response.status_code != 200:
         try:
             error_message = response.json().get('message')
-        except (requests.exceptions.JSONDecodeError, TypeError):
+        except (JSONDecodeError, TypeError):
             error_message = False
         raise UserError(company.env._("Error handling request: %s", error_message) if error_message else company.env._("HTTP %s: Connection error.", response.status_code))
 
     if endpoint != endpoints['receive']:
         try:
             response_json = response.json()
-        except (requests.exceptions.JSONDecodeError, TypeError):
+        except (JSONDecodeError, TypeError):
             raise MojEracunServiceError('Invalid response format received')
         if 'error' in response_json:
             message = company.env._('The url that this service requested returned an error. The url it tried to contact was %(url)s. %(error_message)s', url=url, error_message=response_json['error']['message'])

--- a/addons/l10n_ro_edi_stock/models/etransport_api.py
+++ b/addons/l10n_ro_edi_stock/models/etransport_api.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 import requests
 import re
 
@@ -67,7 +68,7 @@ class ETransportAPI:
 
         try:
             response_data = response.json()
-        except requests.exceptions.JSONDecodeError as e:
+        except JSONDecodeError as e:
             return {'error': str(e)}
 
         if response_data['ExecutionStatus'] == 1:

--- a/addons/l10n_rs_edi/models/account_move.py
+++ b/addons/l10n_rs_edi/models/account_move.py
@@ -1,4 +1,5 @@
 import uuid
+from json import JSONDecodeError
 import requests
 
 from odoo import _, api, fields, models
@@ -139,7 +140,7 @@ class AccountMove(models.Model):
         dict_response = {}
         try:
             dict_response = response.json()
-        except requests.exceptions.JSONDecodeError as e:
+        except JSONDecodeError as e:
             error_message = _("Invalid response from eFaktura: %s", str(e))
         self.l10n_rs_edi_state = 'sending_failed' if error_message else 'sent'
         self.l10n_rs_edi_error = error_message


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:


Installing `requests==2.25.1` and using the following line of code:

    from requests.exceptions import JSONDecodeError

Script to reproduce it

```bash
python3.10 -m pip install -q virtualenv
python3.10 -m virtualenv /tmp/requests_test
source /tmp/requests_test/bin/activate
pip install -q requests==2.25.1
python -c "from json import JSONDecodeError"
python -c "from requests.exceptions import JSONDecodeError"
# ImportError: cannot import name 'JSONDecodeError' from 'requests.exceptions' (/tmp/requests_test/lib/python3.10/site-packages/requests/exceptions.py)
```

<img width="1503" height="738" alt="Screenshot 2026-01-13 at 11 05 36 a m" src="https://github.com/user-attachments/assets/c81d04c3-111c-4fb4-9b7e-f09059b54d3a" />



# Current behavior before PR:

It raises the following error:

    ImportError: cannot import name 'JSONDecodeError' from 'requests.exceptions' (python3.10/site-packages/requests/exceptions.py)

It was removed from the following commit in the `requests` package:

    https://github.com/psf/requests/commit/db575eeedcfdb03bf31285afd3033e301df8b685

# Desired behavior after PR is merged:

This change fixes this error importing the original exception from `json` package

Also, fixing similar alias imports

Enterprise PR related:
 - https://github.com/odoo/enterprise/pull/104202
