### PR TITLE
[REF] mail: `isNotificationPermissionDismissed` local storage field

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -12,7 +12,6 @@ import { Deferred, Mutex } from "@web/core/utils/concurrency";
 import { renderToElement } from "@web/core/utils/render";
 import { debounce } from "@web/core/utils/timing";
 import { session } from "@web/session";
-import { browser } from "@web/core/browser/browser";
 import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { getOrigin } from "@web/core/utils/urls";
@@ -88,25 +87,7 @@ export class Store extends BaseStore {
         },
     ];
 
-    isNotificationPermissionDismissed = fields.Attr(false, {
-        compute() {
-            return (
-                browser.localStorage.getItem("mail.user_setting.push_notification_dismissed") ===
-                "true"
-            );
-        },
-        /** @this {import("models").DiscussApp} */
-        onUpdate() {
-            if (this.isNotificationPermissionDismissed) {
-                browser.localStorage.setItem(
-                    "mail.user_setting.push_notification_dismissed",
-                    "true"
-                );
-            } else {
-                browser.localStorage.removeItem("mail.user_setting.push_notification_dismissed");
-            }
-        },
-    });
+    isNotificationPermissionDismissed = fields.Attr(false, { localStorage: true });
 
     messagePostMutex = new Mutex();
 

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_2.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_2.js
@@ -1,0 +1,20 @@
+import { addUpgrade } from "@mail/core/common/upgrade/upgrade_helpers";
+
+/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnParam} UpgradeFnParam */
+/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnReturn} UpgradeFnReturn */
+
+export const upgrade_19_2 = {
+    /**
+     * @param {string} key
+     * @param {((param: UpgradeFnParam) => UpgradeFnReturn)|UpgradeFnReturn} upgrade
+     * @returns {UpgradeFnReturn}
+     */
+    add(key, upgrade) {
+        return addUpgrade({ key, version: "19.2", upgrade });
+    },
+};
+
+upgrade_19_2.add("mail.user_setting.push_notification_dismissed", {
+    key: "Store,undefined:isNotificationPermissionDismissed",
+    value: true,
+});

--- a/addons/mail/static/tests/core/common/upgrade_19_2.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_2.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "@odoo/hoot";
+import {
+    defineMailModels,
+    patchBrowserNotification,
+    start,
+} from "@mail/../tests/mail_test_helpers";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
+import { toRawValue } from "@mail/utils/common/local_storage";
+import { Store } from "@mail/model/store";
+import { getService } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("'Turn on notification' messaging menu item is dismissed", async () => {
+    localStorage.setItem("mail.user_setting.push_notification_dismissed", "true");
+    patchBrowserNotification("default");
+    const IS_NOTIFICATION_PERMISSION_LS = makeRecordFieldLocalId(
+        Store.localId(),
+        "isNotificationPermissionDismissed"
+    );
+    await start();
+    expect(getService("mail.store").isNotificationPermissionDismissed).toBe(true);
+    expect(localStorage.getItem(IS_NOTIFICATION_PERMISSION_LS)).toBe(toRawValue(true));
+    expect(localStorage.getItem("mail.user_setting.push_notification_dismissed")).toBe(null);
+});


### PR DESCRIPTION
This commit converts field `Store.isNotificationPermissionDismissed` to simpler syntax `{ localStorage: true }`.

As the key changes, this also adds upgrade script to preserve the setting.