### PR TITLE
[FIX] base: restore exception modal for cron direct call

### DIFF
--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -5,6 +5,7 @@ import { registry } from "@web/core/registry";
 import { htmlSprintf } from "@web/core/utils/html";
 
 import { markup } from "@odoo/owl";
+import { makeErrorFromResponse } from "../../core/network/rpc";
 
 export function displayNotificationAction(env, action) {
     const params = action.params || {};
@@ -23,6 +24,15 @@ export function displayNotificationAction(env, action) {
 }
 
 registry.category("actions").add("display_notification", displayNotificationAction);
+
+/**
+ * Client action to trigger an Exception on the interface.
+ */
+function displayException(env, action) {
+    throw makeErrorFromResponse(action.params);
+}
+
+registry.category("actions").add("display_exception", displayException);
 
 /**
  * Client action to reload the whole interface.

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -498,3 +498,27 @@ test("test home client action", async () => {
     await animationFrame();
     expect.verifySteps(["/web/webclient/version_info", "assign /"]);
 });
+
+test("test display_exception client action", async () => {
+    expect.errors(1);
+    await mountWithCleanup(WebClient);
+    getService("action").doAction({
+        type: "ir.actions.client",
+        tag: "display_exception",
+        params: {
+            code: 0,
+            message: "Odoo Server Error",
+            data: {
+                name: `odoo.exceptions.UserError`,
+                debug: "traceback",
+                arguments: [],
+                context: {},
+                message: "This is an error",
+            },
+        },
+    });
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(1);
+    expect("header .modal-title").toHaveText("Invalid Operation");
+    expect.verifyErrors([/RPC_ERROR/]);
+});

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+import contextvars
+import copy
 import logging
+import os
 import threading
 import time
-import os
-import psycopg2
-import psycopg2.errors
 import typing
 from datetime import datetime, timedelta, timezone
+
+import psycopg2
+import psycopg2.errors
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, sql_db
 from odoo.exceptions import LockError, UserError
+from odoo.http import serialize_exception
 from odoo.modules import Manifest
 from odoo.modules.registry import Registry
 from odoo.tools import SQL
@@ -19,6 +23,7 @@ from odoo.tools.constants import GC_UNLINK_LIMIT
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
+
     from odoo.sql_db import BaseCursor
 
 _logger = logging.getLogger(__name__)
@@ -57,6 +62,30 @@ class CompletionStatus:  # inherit from enum.StrEnum in 3.11
     FULLY_DONE = 'fully done'
     PARTIALLY_DONE = 'partially done'
     FAILED = 'failed'
+
+
+class ListLogHandler(logging.Handler):
+    def __init__(self, logger, level=logging.NOTSET):
+        super().__init__(level)
+        self.logger = logger
+        self.list_log_handler = contextvars.ContextVar('list_log_handler', default=None)
+
+    def emit(self, record):
+        logs = self.list_log_handler.get(None)
+        if logs is None:
+            return
+        record = copy.copy(record)
+        logs.append(record)
+
+    def __enter__(self):
+        # set a list in the current context
+        logs = []
+        self.list_log_handler.set(logs)
+        self.logger.addHandler(self)
+        return logs
+
+    def __exit__(self, *exc):
+        self.logger.removeHandler(self)
 
 
 class IrCron(models.Model):
@@ -135,7 +164,23 @@ class IrCron(models.Model):
         job = self._acquire_one_job(cron_cr, self.id, include_not_ready=True)
         if not job:
             raise UserError(self.env._("Job '%s' already executing", self.name))
-        self._process_job(cron_cr, job)
+
+        with ListLogHandler(_logger, logging.ERROR) as capture:
+            self._process_job(cron_cr, job)
+        if log_record := next((lr for lr in capture if hasattr(lr, 'exc_info')), None):
+            _exc_type, exception, _traceback = log_record.exc_info
+            e = RuntimeError()
+            e.__cause__ = exception
+            error = {
+                'code': 0,  # we don't care of this code
+                'message': "Odoo Server Error",
+                'data': serialize_exception(e),
+            }
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'display_exception',
+                'params': error,
+            }
         return True
 
     @staticmethod

--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -114,6 +114,21 @@ class TestIrCron(TransactionCase, CronMixinCase):
         self.assertEqual(self.cron.lastcall, fields.Datetime.now())
         self.assertEqual(self.partner.name, 'You have been CRONWNED')
 
+    def test_cron_direct_trigger_exception(self):
+        self.cron.code = textwrap.dedent("raise UserError('oops')")
+        with (
+            self.enter_registry_test_mode(),
+            self.assertLogs('odoo.addons.base.models.ir_cron', 40),  # logging.ERROR
+            self.registry.cursor() as cron_cr,
+        ):
+            action = self.cron.with_env(self.env(cr=cron_cr)).method_direct_trigger()
+
+        self.assertNotEqual(action, True)
+        action_params = action.pop('params')
+        self.assertEqual(action, {'type': 'ir.actions.client', 'tag': 'display_exception'})
+        self.assertEqual(list(action_params), ['code', 'message', 'data'])
+        self.assertEqual(list(action_params['data']), ['name', 'message', 'arguments', 'context', 'debug'])
+
     def test_cron_no_job_ready(self):
         self.cron.nextcall = fields.Datetime.now() + timedelta(days=1)
         self.cron.flush_recordset()


### PR DESCRIPTION
It is possible to run a cron via the "Run Manually" button of the ir.cron form view. In 18.4 and before, in case the cron failed due to an exception, that exception would appear in the web client. Since 19.0 and commit 78c00d2, the exception no longer bubbles-up to the web client. It is only logged in the server logs.

Many system admins and also the Odoo support use on the "Run Manually" to quickly test a cron and make sure it works. The change done in 19.0 is considered as a nasty surprise. They want their exceptions back!

When running a cron manually, we now track the logs that are emitted on the cron logger and search for an error with an exception. May we find one, we raise it with a proper traceback chain, which bubbles up to the web client and is shown in the "An error occured" modal.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
