### PR TITLE
[FIX] website: fix the infinite loop on onPlaceChanged

### DIFF
--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.js
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.js
@@ -80,7 +80,7 @@ export class GoogleMapsOption extends BaseOptionComponent {
     onPlaceChanged() {
         /** @type {Place | undefined} */
         const place = this.googleMapsAutocomplete.getPlace();
-        this.onPlaceChanged(this.env.getEditingElement(), place);
+        this.commitPlace(this.env.getEditingElement(), place);
         this.state.formattedAddress = place?.formatted_address || "";
     }
 }


### PR DESCRIPTION
When we add the google map block and try to change the address, we're unable to do so because of the infinite loop. The issue is due to the onPlaceChanged call inside the onPlaceChanged. We'll use commitPlace instead to commit place's coordinates, then re-render the map to reflect it.

Steps to reproduce:
1. Add a google map block.
2. Try to change the address. It doesn't work due to the maximum call size exceeded due to infinite loop.

opw-5386094
