### PR TITLE
[FIX] purchase_edi_ubl_bis3, sale_edi_ubl: amend SO/PO to UBL BIS3 order export logic; update test datafile

### DIFF
--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -109,13 +109,19 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
         }
 
     def _add_purchase_order_seller_supplier_party_nodes(self, document_node, vals):
+        supplier_party = self._get_party_node({**vals, 'partner': vals['supplier'], 'role': 'supplier'})
+        supplier_party.pop('cac:PartyTaxScheme', None)
         document_node['cac:SellerSupplierParty'] = {
-            'cac:Party': self._get_party_node({**vals, 'partner': vals['supplier'], 'role': 'supplier'})
+            'cac:Party': supplier_party,
         }
 
     def _add_purchase_order_delivery_nodes(self, document_node, vals):
+        delivery_party = self._get_party_node({**vals, 'partner': vals['partner_shipping'], 'role': 'delivery'})
+        delivery_party.pop('cbc:EndpointID', None)
+        delivery_party.pop('cac:PartyTaxScheme', None)
+        delivery_party.pop('cac:PartyLegalEntity', None)
         document_node['cac:Delivery'] = {
-            'cac:DeliveryParty': self._get_party_node({**vals, 'partner': vals['partner_shipping'], 'role': 'delivery'})
+            'cac:DeliveryParty': delivery_party,
         }
 
     def _add_purchase_order_payment_terms_nodes(self, document_node, vals):
@@ -136,21 +142,11 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
     def _add_purchase_order_tax_total_nodes(self, document_node, vals):
         # OVERRIDE
         ubl_values = vals['_ubl_values']
-        company = vals['company']
-        company_currency = company.currency_id
-        currency = vals['currency_id']
 
         tax_total_nodes = document_node['cac:TaxTotal'] = []
         for tax_total in ubl_values['tax_totals_currency'].values():
-            tax_total_node = self._ubl_get_tax_total_node(vals, tax_total)
+            tax_total_node = self._ubl_get_purchase_order_tax_total_node(vals, tax_total)
             tax_total_nodes.append(tax_total_node)
-
-        # Only one subtotal expressed in foreign currency in case of multi currencies.
-        if currency != company_currency:
-            for tax_total in ubl_values['tax_totals'].values():
-                tax_total_node = self._ubl_get_tax_total_node(vals, tax_total)
-                tax_total_node['cac:TaxSubtotal'] = []
-                tax_total_nodes.append(tax_total_node)
 
     def _add_purchase_order_monetary_total_nodes(self, document_node, vals):
         ubl_values = vals['_ubl_values']
@@ -323,6 +319,15 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
         discount_node['cbc:MultiplierFactorNumeric'] = None
         discount_node['cbc:BaseAmount'] = None
         return discount_node
+
+    def _ubl_get_purchase_order_tax_total_node(self, vals, tax_total):
+        currency = tax_total['currency']
+        return {
+            'cbc:TaxAmount': {
+                '_text': FloatFmt(tax_total['amount'], min_dp=currency.decimal_places),
+                'currencyID': currency.name,
+            },
+        }
 
     # -------------------------------------------------------------------------
     # Purchase Order EDI Import

--- a/addons/purchase_edi_ubl_bis3/tests/data/test_po_edi.xml
+++ b/addons/purchase_edi_ubl_bis3/tests/data/test_po_edi.xml
@@ -39,12 +39,6 @@
       <cac:PartyName>
         <cbc:Name>partner_a</cbc:Name>
       </cac:PartyName>
-      <cac:PartyTaxScheme>
-        <cbc:CompanyID>NL123456782B90</cbc:CompanyID>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_a</cbc:RegistrationName>
         <cbc:CompanyID>NL123456782B90</cbc:CompanyID>
@@ -64,16 +58,6 @@
           <cbc:IdentificationCode>US</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
-      <cac:PartyLegalEntity>
-        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
-      </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:Contact>
@@ -81,15 +65,6 @@
   </cac:Delivery>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="USD">69.00</cbc:TaxAmount>
-    <cac:TaxSubtotal>
-      <cbc:TaxableAmount currencyID="USD">460.00</cbc:TaxableAmount>
-      <cbc:TaxAmount currencyID="USD">69.00</cbc:TaxAmount>
-      <cac:TaxCategory>
-        <cbc:ID>S</cbc:ID>
-        <cbc:Percent>15.0</cbc:Percent>
-        <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
-      </cac:TaxCategory>
-    </cac:TaxSubtotal>
   </cac:TaxTotal>
   <cac:AnticipatedMonetaryTotal>
     <cbc:LineExtensionAmount currencyID="USD">460.00</cbc:LineExtensionAmount>

--- a/addons/sale_edi_ubl/tests/data/test_so_edi.xml
+++ b/addons/sale_edi_ubl/tests/data/test_so_edi.xml
@@ -42,12 +42,6 @@
           <cbc:IdentificationCode>US</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
-      <cac:PartyTaxScheme>
-        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
         <cbc:CompanyID>BE0477472701</cbc:CompanyID>
@@ -62,16 +56,6 @@
       <cac:PartyName>
         <cbc:Name>partner_a</cbc:Name>
       </cac:PartyName>
-      <cac:PartyTaxScheme>
-        <cbc:CompanyID>NL123456782B90</cbc:CompanyID>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:PartyTaxScheme>
-      <cac:PartyLegalEntity>
-        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
-        <cbc:CompanyID>NL123456782B90</cbc:CompanyID>
-      </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_a</cbc:Name>
       </cac:Contact>
@@ -82,17 +66,6 @@
   </cac:PaymentTerms>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="USD">69.00</cbc:TaxAmount>
-    <cac:TaxSubtotal>
-      <cbc:TaxableAmount currencyID="USD">460.00</cbc:TaxableAmount>
-      <cbc:TaxAmount currencyID="USD">69.00</cbc:TaxAmount>
-      <cac:TaxCategory>
-        <cbc:ID>S</cbc:ID>
-        <cbc:Percent>15.0</cbc:Percent>
-        <cac:TaxScheme>
-          <cbc:ID>VAT</cbc:ID>
-        </cac:TaxScheme>
-      </cac:TaxCategory>
-    </cac:TaxSubtotal>
   </cac:TaxTotal>
   <cac:AnticipatedMonetaryTotal>
     <cbc:LineExtensionAmount currencyID="USD">460.00</cbc:LineExtensionAmount>


### PR DESCRIPTION
Current UBL BIS3 Order export does not align with PEPPOL UBL BIS3 Order syntax. Updated some UBL generation logic along with the test datafiles:

Tax amount node (`cac:TaxAmount`)
- Remove tax subtotal node

Seller party node (`cac:SellerSupplierParty`)
- Remove party tax scheme node

Delivery Party node (`cac:Delivery/cac:DeliveryParty`)
- Remove endpoint ID node
- Remove party tax scheme node
- Remove party legal entity node

Along with the changes, the recent refactor ([#239960](vscode-file://vscode-app/usr/share/cursor/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)) in invoice EDI also affected the order EDI export: it creates two different tax total node if PO/SO currency != company currency. PEPPOL UBL BIS3 Order spec does not allow this, therefore the company currency tax totals node is dropped.

[Task-5704151](https://www.odoo.com/odoo/action-4043/5704151)
