### PR TITLE
[FIX] mail: prevent template duplication on save

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -2130,8 +2130,11 @@ function correctBorderAttributes(style) {
 
 function waitUntilImagesLoaded(root) {
     const promises = [];
-    for (const img of root.querySelectorAll("img")) {
-        promises.push(loadImage(getImageSrc(img)));
+    for (const img of root.querySelectorAll('img[src]:not([src=""])')) {
+        const src = getImageSrc(img);
+        if (src) {
+            promises.push(loadImage(src));
+        }
     }
-    return Promise.all(promises);
+    return Promise.allSettled(promises);
 }


### PR DESCRIPTION
Problem:
In Email templates, having an email with an image using `t-att-src` (Qweb) on save will duplicate the template.

Cause:
Images without a `src` attribute (or empty src) make `waitUntilImagesLoaded` fail immediately if the image loading promise rejects. Because the errors were not caught, the inline conversion process was interrupted and duplicating content.

Solution:
Use `Promise.allSettled` instead of `Promise.all` to ensure the system waits for all images to finish loading regardless of success or failure. Additionally, filter the query selector to strictly select images with a non-empty `src` attribute (`img[src]:not([src=""])`) to avoid processing invalid or dynamic Qweb images.

Steps to reproduce:
- Open An email template with Qweb image.
- Do a change and save.
- Observe the content is duplicated.

opw-5489040

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
