### PR TITLE
[IMP] pos_restaurant: Sum guests of linked tables

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -164,6 +164,11 @@ patch(PosStore.prototype, {
     async mergeOrders(sourceOrder, destOrder) {
         let whileGuard = 0;
         const mergedCourses = this.mergeCourses(sourceOrder, destOrder);
+
+        // Sum the guest counts from both orders
+        const totalGuests = sourceOrder.getCustomerCount() + destOrder.getCustomerCount();
+        destOrder.setCustomerCount(totalGuests);
+
         while (sourceOrder.lines.length) {
             const orphanLine = sourceOrder.lines[0];
             const destinationLine = destOrder?.lines?.find((l) => l.canBeMergedWith(orphanLine));

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -415,6 +415,19 @@ describe("restaurant pos_store.js", () => {
         expect(line2.course_id.id).toBe(course2.id);
     });
 
+    test("mergeOrders sums guest counts", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const table1 = models["restaurant.table"].get(2);
+        const table2 = models["restaurant.table"].get(3);
+        const order1 = store.addNewOrder({ table_id: table1 });
+        order1.setCustomerCount(3);
+        const order2 = store.addNewOrder({ table_id: table2 });
+        order2.setCustomerCount(5);
+        await store.mergeOrders(order1, order2);
+        expect(order2.getCustomerCount()).toBe(8);
+    });
+
     test("getCustomerCount", async () => {
         const store = await setupPosEnv();
         const table = store.models["restaurant.table"].get(2);


### PR DESCRIPTION
When two tables are linked in the pos, we would like to sum the guests.

Here an example :

If Table 1 has two guests and Table 2 has three guests, then Table 1&2 will have five guests.

task: 5490906

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
