### PR TITLE
[FIX] website: remove delay of hoverable async preview

### DIFF
--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -841,12 +841,7 @@ class TemplatePreviewableWebsiteConfigAction extends WebsiteConfigAction {
         // The promise ensures this completes before continuing, avoiding a race
         // that could mark the element o_dirty and trigger an unnecessary save.
         if (params.previewClass) {
-            await new Promise((resolve) => {
-                requestAnimationFrame(() => {
-                    params.previewClass.split(/\s+/).forEach((cls) => el.classList.add(cls));
-                    resolve();
-                });
-            });
+            params.previewClass.split(/\s+/).forEach((cls) => el.classList.add(cls));
         }
     }
 }


### PR DESCRIPTION
With commit aa3a2a694930d077aab5ff55e72655cc453a64ff, the delay of one animation frame in the preview of `templatePreviewableWebsiteConfig` is not necessary anymore. This was the only preview with a delay that can be triggered by hovering a button (the others needs to open a dropdown or input in text field).

With commit be032732d1f5d1f7b28da3fa7bf19bffbef4a46d, previews are reverted as soon as the user starts typing, to avoid loosing the typed text when the preview is reverted. But this does not handle completely previews that are async: they may revert just after the first character is typed, and thus loose that character. This commit eliminates async preview that can be triggered while keeping focus in the editor.

task-5493193