### PR TITLE
[FIX] l10n_in: support GSTIN based on TAN for government entities

### DIFF
--- a/addons/l10n_in/tests/test_partner_details_on_invoice.py
+++ b/addons/l10n_in/tests/test_partner_details_on_invoice.py
@@ -120,3 +120,16 @@ class TestReports(L10nInTestInvoicingCommon):
                 'l10n_in_state_id': self.env.ref("l10n_in.state_in_oc").id,
             }]
         )
+
+    def test_government_gstin_extraction_tan(self):
+        """ Verify that a GSTIN based on a TAN (Government entity) correctly populates the TAN field and leaves the PAN field empty. """
+        gov_partner = self.env['res.partner'].create({
+            'name': "Gov Partner",
+            'country_id': self.env.ref('base.in').id,
+            'state_id': self.env.ref('base.state_in_dl').id,
+            'vat': '07DELN10357E1DH',
+        })
+        self.assertRecordValues(gov_partner, [{
+            'l10n_in_pan_entity_id': False,
+            'l10n_in_tan': 'DELN10357E',
+        }])


### PR DESCRIPTION
### Issue:
When using a GSTIN belonging to a government institution, saving the partner raises a ValidationError
This happens because these entities often use a TAN (Tax Deduction and Collection Account Number) instead of a PAN as the base for their GSTIN

### Cause:
In 19.0, PAN handling was refactored using the new `pan_entity` mechanism
With this change, PAN values are validated through `_check_pan_name()`, which incorrectly raises a `ValidationError` for GSTINs that rely on a TAN instead of a PAN:
`The entered PAN seems invalid. Please enter a valid PAN.` The PAN entity shouldn't be created for non PAN number

### Steps to reproduce:
- Install `l10n_in` and `contacts`, then switch to IN Company
- Create a new contact with GSTIN: `07DELN10357E1DH`
- Save and the Error is raised

### Notes:
At the same time, we'll set the TAN if the GSTIN is based on it
The documentation for the TAN structure:
https://incometaxindia.gov.in/tutorials/23.%20tan.pdf

opw-5461356