### PR TITLE
[FIX] hr_payroll: fix error not raise on compute sheet

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -413,8 +413,8 @@ class HrVersion(models.Model):
             return False
         period_start = date_from or date.min
         period_end = date_to or date.max
-        contract_end = self.date_end or date.max
-        return period_start <= contract_end and self.date_start <= period_end
+        contract_end = self.contract_date_end or date.max
+        return period_start <= contract_end and self.contract_date_start <= period_end
 
     def _is_fully_flexible(self):
         """ return True if the version has a fully flexible working calendar """


### PR DESCRIPTION
Bug:
When there is an issue on a payslip with an error level, and we try to compute the sheet, the sheet is computed. Instead of computing, it should raise and the message should specify what errors need to be resolved first.

Cause:
When computing the sheet, we were calling the self._get_error_message() without using the result, which is a string.

Fix:
Actually raise a ValidationError and use the result of self._get_error_message() for the error message. Introducing the raise brought other problems because some code supposed to fail was running seamlessly fine. But now, the raise is called and those needed to be solved as well. The issue raised multiple times is the "No contract in the payslip period".

Task: 5153497
