### PR TITLE
[FIX] pos_self_order: clickProduct util

### DIFF
--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -1,7 +1,7 @@
 export function clickProduct(productName) {
     return {
         content: `Click on product '${productName}'`,
-        trigger: `.o_self_product_box span:contains('${productName}')`,
+        trigger: `.product_list .o_self_product_box span:contains('${productName}')`,
         run: "click",
     };
 }


### PR DESCRIPTION
Before this commit, trigger to click on a product in the product list was the same trigger to click on a product in a cart list ...

With the following scenario, step CartPage.clickBack() can take few times to show the back screen, but as the trigger is the same for clickProduct on a product list screen than a cart screen, the last step clik on "o_self_product_box" ... but in the cart (and not in the product list)

ProductPage.clickProduct("Coca-Cola"), => OK
ProductPage.clickProduct("Coca-Cola"), => OK
Utils.clickBtn("Checkout"), => OK
CartPage.checkProduct("Coca-Cola", "5.06", "2"), => OK CartPage.clickBack(), => OK
ProductPage.clickProduct("Coca-Cola"), => NOK

To fix it, it is enought to just be more precise on the trigger to avoid confusions.
This fix fixes probably a pair of tours.

error-runbot-id~227669
(and probably others)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
