### PR TITLE
[FIX] point_of_sale: warn user before full sync

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -899,6 +899,19 @@ class PosConfig(models.Model):
         except (TypeError, ValueError, OverflowError):
             return DEFAULT_LIMIT_LOAD_PRODUCT
 
+    def get_product_loading_info(self):
+        """Return total product.template count matching the PoS domain and the configured loading limit.
+
+        Used by the frontend to warn the user before triggering a full sync when the product
+        count exceeds the configured limit or crosses the dangerous threshold (20 000+).
+        """
+        self.ensure_one()
+        ProductTemplate = self.env['product.template']
+        domain = ProductTemplate._load_pos_data_domain({}, self)
+        total_count = ProductTemplate.search_count(domain)
+        limit = self.get_limited_product_count()
+        return {'total_count': total_count, 'limit': limit}
+
     def _get_limited_partner_count(self):
         config_param = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.limited_customer_count', DEFAULT_LIMIT_LOAD_PARTNER)
         try:

--- a/addons/point_of_sale/static/src/app/components/popups/sync_popup/sync_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/sync_popup/sync_popup.js
@@ -1,12 +1,62 @@
 import { Dialog } from "@web/core/dialog/dialog";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+
+const DANGEROUS_PRODUCT_THRESHOLD = 20000;
 
 export class SyncPopup extends Component {
     static components = { Dialog };
     static template = "point_of_sale.SyncPopup";
     static props = ["close", "confirm", "title"];
 
+    setup() {
+        this.orm = useService("orm");
+        this.dialog = useService("dialog");
+    }
+
     async confirm(fullReload) {
+        if (fullReload) {
+            const info = await this.orm.call("pos.config", "get_product_loading_info", [
+                odoo.pos_config_id,
+            ]);
+            const { total_count, limit } = info;
+
+            if (total_count > limit) {
+                const isDangerous = total_count > DANGEROUS_PRODUCT_THRESHOLD;
+                const title = isDangerous
+                    ? _t("Dangerous: Too Many Products")
+                    : _t("Large Product Count Detected");
+                const body = isDangerous
+                    ? _t(
+                          "There are %(count)s products available for this PoS (configured limit: %(limit)s). " +
+                              "Loading this many products will severely slow down the system and " +
+                              "may cause it to crash or become unresponsive. " +
+                              "It is strongly recommended to use Limited Synchronization instead. " +
+                              "Do you still want to proceed?",
+                          { count: total_count, limit }
+                      )
+                    : _t(
+                          "There are %(count)s products available for this PoS (configured limit: %(limit)s). " +
+                              "Loading all products may slow down the Point of Sale. " +
+                              "Do you want to continue with Full Synchronization?",
+                          { count: total_count, limit }
+                      );
+
+                this.dialog.add(ConfirmationDialog, {
+                    title,
+                    body,
+                    confirm: () => {
+                        this.props.confirm(true);
+                        this.props.close();
+                    },
+                    cancel: () => {},
+                });
+                return;
+            }
+        }
+
         this.props.confirm(fullReload);
         this.props.close();
     }


### PR DESCRIPTION
When the user selects "Full" in the SyncPopup, the system now checks the
total number of PoS-available products against the configured
`point_of_sale.limited_product_count` system parameter before proceeding.

opw-5484051

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
