### PR TITLE
[IMP] (project_,crm_)mail_plugin: use the mail redirect

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1322,6 +1322,17 @@ class CrmLead(models.Model):
     # VIEWS
     # ------------------------------------------------------------
 
+    def _get_access_action(self, access_uid=None, force_website=False):
+        self.ensure_one()
+        user = self.env['res.users'].sudo().browse(access_uid) if access_uid else self.env.user
+        if user and not user.share and self.with_user(user).has_access('read') and not force_website:
+            return {
+                "type": "ir.actions.act_url",
+                "url": f"/odoo/crm/{self.id}",
+                "target": "self",
+            }
+        return super()._get_access_action(access_uid, force_website)
+
     def redirect_lead_opportunity_view(self):
         self.ensure_one()
         return {

--- a/addons/crm_mail_plugin/controllers/mail_plugin.py
+++ b/addons/crm_mail_plugin/controllers/mail_plugin.py
@@ -14,12 +14,6 @@ _logger = logging.getLogger(__name__)
 
 
 class MailPluginController(mail_plugin.MailPluginController):
-    def _get_record_redirect_url(self, model, record_id):
-        if model == 'crm.lead':
-            return f'/odoo/crm/{int(record_id)}'
-
-        return super()._get_record_redirect_url(model, record_id)
-
     def _search_records(self, model, terms, limit=30):
         if model == "crm.lead":
             domain = Domain.OR([('name', 'ilike', term)] for term in terms)

--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -7,6 +7,7 @@ from markupsafe import Markup
 from werkzeug.exceptions import BadRequest, Forbidden
 
 from odoo import http, tools, _
+from odoo.addons.portal.controllers.mail import MailController
 from odoo.fields import Domain
 from odoo.exceptions import AccessError
 from odoo.http import request
@@ -16,7 +17,7 @@ from odoo.tools.misc import format_date
 _logger = logging.getLogger(__name__)
 
 
-class MailPluginController(http.Controller):
+class MailPluginController(MailController):
     @http.route('/mail_plugin/partner/get', type="jsonrpc", auth="outlook", cors="*")
     def res_partner_get(self, email=None, partner_id=None, **kwargs):
         """
@@ -74,14 +75,7 @@ class MailPluginController(http.Controller):
     def redirect_to_record(self, model, record_id):
         if model not in self._mail_models_access_whitelist('read'):
             raise Forbidden()
-
-        cids = request.env.user.company_ids.ids
-        request.future_response.set_cookie('cids', '-'.join(map(str, cids)))
-
-        return request.redirect(self._get_record_redirect_url(model, record_id))
-
-    def _get_record_redirect_url(self, model, record_id):
-        return f'/odoo/{model}/{int(record_id)}'
+        return self._redirect_to_record(model, int(record_id))
 
     @http.route('/mail_plugin/search_records/<string:model>', type='jsonrpc', auth='outlook', cors='*')
     def search_records(self, model, query, limit=30):

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2050,6 +2050,17 @@ class ProjectTask(models.Model):
             child_tasks.action_archive()
         return super().action_archive()
 
+    def _get_access_action(self, access_uid=None, force_website=False):
+        self.ensure_one()
+        user = self.env['res.users'].sudo().browse(access_uid) if access_uid else self.env.user
+        if user and not user.share and self.with_user(user).has_access('read') and not force_website:
+            return {
+                "type": "ir.actions.act_url",
+                "url": f'/odoo/all-tasks/{self.id}',
+                "target": "self",
+            }
+        return super()._get_access_action(access_uid, force_website)
+
     # ---------------------------------------------------
     # Rating business
     # ---------------------------------------------------

--- a/addons/project_mail_plugin/controllers/mail_plugin.py
+++ b/addons/project_mail_plugin/controllers/mail_plugin.py
@@ -15,12 +15,6 @@ _logger = logging.getLogger(__name__)
 
 class MailPluginController(mail_plugin.MailPluginController):
 
-    def _get_record_redirect_url(self, model, record_id):
-        if model == 'project.task':
-            return f'/odoo/all-tasks/{int(record_id)}'
-
-        return super()._get_record_redirect_url(model, record_id)
-
     @route()
     def search_records(self, model, query, limit=30):
         """An empty search on project should return them all."""


### PR DESCRIPTION
Purpose
=======
Use `_redirect_to_record` from the mail controller (that internally uses `_get_access_action`), and update the access actions for the models used in the mail plugins.

Task-5473802
