### PR TITLE
[FIX] html_builder, website: fix on snippet dropped handler

### DIFF
--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -69,6 +69,7 @@ export class BlockTab extends Component {
         this.shared.operation.next(
             async () => {
                 this.cancelDragAndDrop = this.shared.history.makeSavePoint();
+                this.dragState = {};
                 let snippetEl;
                 const baseSectionEl = snippet.content.cloneNode(true);
                 this.state.ongoingInsertion = true;
@@ -446,6 +447,11 @@ export class BlockTab extends Component {
             if (cancel) {
                 this.cancelDragAndDrop();
                 return;
+            }
+            // Update `snippetEl` if it was replaced in the handler
+            if (this.dragState.replacedSnippetEl) {
+                snippetEl = this.dragState.replacedSnippetEl;
+                delete this.dragState.replacedSnippetEl;
             }
         }
         this.env.editor.config.updateInvisibleElementsPanel();

--- a/addons/website/static/src/builder/plugins/options/image_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_snippet_option_plugin.js
@@ -10,7 +10,7 @@ class ImageSnippetOptionPlugin extends Plugin {
         so_content_addition_selector: [".s_image"],
     };
 
-    async onSnippetDropped({ snippetEl }) {
+    async onSnippetDropped({ snippetEl, dragState }) {
         if (!snippetEl.matches(".s_image")) {
             return;
         }
@@ -24,6 +24,7 @@ class ImageSnippetOptionPlugin extends Plugin {
                 save: async (selectedImageEl) => {
                     isImageSelected = true;
                     snippetEl.replaceWith(selectedImageEl);
+                    dragState.replacedSnippetEl = selectedImageEl;
                 },
             });
             onClose.then(() => {

--- a/addons/website/static/tests/builder/website_builder/image_snippet_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_snippet_option.test.js
@@ -4,7 +4,13 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
-import { getDragHelper, waitForEndOfOperation } from "@html_builder/../tests/helpers";
+import {
+    addBuilderPlugin,
+    getDragHelper,
+    waitForEndOfOperation,
+} from "@html_builder/../tests/helpers";
+import { withSequence } from "@html_editor/utils/resource";
+import { Plugin } from "@html_editor/plugin";
 
 defineWebsiteModels();
 
@@ -76,4 +82,37 @@ test("Drag & drop an 'Image' snippet does not add a step in the history if we ca
 
     expect(contentEl).toHaveInnerHTML(`<div><p>Text</p></div>`);
     expect(".o-website-builder_sidebar .fa-undo").not.toBeEnabled();
+});
+
+test("Check that all the `on_snippet_dropped_handlers` work with the correct snippet when dropping a snippet", async () => {
+    class AddClassOnSnippetDroppedPlugin extends Plugin {
+        static id = "AddClassOnSnippetDroppedPlugin";
+        resources = {
+            on_snippet_dropped_handlers: withSequence(30, ({ snippetEl }) => {
+                snippetEl.classList.add("snippet-added");
+            }),
+        };
+    }
+    addBuilderPlugin(AddClassOnSnippetDroppedPlugin);
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`<div><p>Text</p></div>`);
+    const { moveTo, drop } = await contains(
+        ".o-website-builder_sidebar [name='Image'] .o_snippet_thumbnail"
+    ).drag();
+    await moveTo(":iframe .oe_drop_zone");
+    await drop(getDragHelper());
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    await contains(".o_select_media_dialog img[title='logo']").click();
+    await waitSidebarUpdated();
+    expect(":iframe img").toHaveClass("snippet-added");
 });


### PR DESCRIPTION
[FIX] html-builder, *: update snippet at each snippet dropped handler
*: website

In the `ImageSnippetOptionPlugin`, at the `on_snippet_dropped_handlers`
call, the `snippetEl` received as argument is replaced by the image
selected by the user in the media dialog. The problem is that the call
to subsequent handlers is done with `snippetEl` that is not an element
of the DOM anymore. This commit fixes this by updating `snippetEl` if
needed after each call to a `on_snippet_dropped_handlers` handler.

task-5785233