### PR TITLE
[FIX] html_builder: move to last selected tab when no options present

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -142,7 +142,9 @@ export class Builder extends Component {
                         if (!currentOptionsContainers.length) {
                             // If there is no option, fallback on the current
                             // fallback tab.
-                            this.setTab(this.noSelectionTab);
+                            if (this.state.activeTab === "customize") {
+                                this.setTab(this.noSelectionTab);
+                            }
                             return;
                         }
                         this.setTab("customize");
@@ -279,8 +281,9 @@ export class Builder extends Component {
 
     setTab(tab) {
         this.state.activeTab = tab;
-        // Set the fallback tab on the "THEME" tab if it was selected.
-        this.noSelectionTab = tab === "theme" ? "theme" : "blocks";
+        if (tab !== "customize") {
+            this.noSelectionTab = tab;
+        }
     }
 
     undo() {

--- a/addons/html_builder/static/tests/custom_tab/misc.test.js
+++ b/addons/html_builder/static/tests/custom_tab/misc.test.js
@@ -3,6 +3,7 @@ import {
     addBuilderOption,
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
+import { Builder } from "@html_builder/builder";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { OptionsContainer } from "@html_builder/sidebar/option_container";
@@ -11,7 +12,7 @@ import { redo, undo } from "@html_editor/../tests/_helpers/user_actions";
 import { withSequence } from "@html_editor/utils/resource";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
-import { onWillStart, xml } from "@odoo/owl";
+import { Component, onWillStart, xml } from "@odoo/owl";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
@@ -325,6 +326,49 @@ test("fallback on the 'Blocks' tab if no option match the selected element", asy
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target > div").click();
     expect(".o-snippets-tabs button:contains('Add')").toHaveClass("active");
+});
+
+test("move back on the 'Blocks' tab if no more option match the selected element", async () => {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".parent-target";
+            static template = xml`<BuilderRow label="'Row 1'">
+                <BuilderButton classAction="'my-custom-class'"/>
+            </BuilderRow>`;
+        }
+    );
+    await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
+    await contains(":iframe .parent-target > div").click();
+    expect(".o-snippets-tabs button[data-name=customize]").toHaveClass("active");
+    await contains("button.oe_snippet_remove").click();
+    expect(".o-snippets-tabs button[data-name=blocks]").toHaveClass("active");
+});
+
+test("move back on the 'Theme' tab if no more option match the selected element, and it was active just before", async () => {
+    patchWithCleanup(Builder.prototype, {
+        setup() {
+            super.setup();
+            this.ThemeTab = class DummyThemeTab extends Component {
+                static template = xml`<div>Dummy Theme Tab</div>`;
+                static props = {};
+            };
+        },
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".parent-target";
+            static template = xml`<BuilderRow label="'Row 1'">
+                <BuilderButton classAction="'my-custom-class'"/>
+            </BuilderRow>`;
+        }
+    );
+    await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
+    await contains(".o-snippets-tabs button[data-name=theme]").click();
+    expect(".o-snippets-tabs button[data-name=theme]").toHaveClass("active");
+    await contains(":iframe .parent-target > div").click();
+    expect(".o-snippets-tabs button[data-name=customize]").toHaveClass("active");
+    await contains("button.oe_snippet_remove").click();
+    expect(".o-snippets-tabs button[data-name=theme]").toHaveClass("active");
 });
 
 test("display empty message if no option container is visible", async () => {

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -3,6 +3,7 @@ import {
     goToTheme,
     registerWebsitePreviewTour,
     clickToolbarButton,
+    goBackToBlocks,
 } from '@website/js/tours/tour_utils';
 import {FONT_SIZE_CLASSES} from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 
@@ -39,6 +40,7 @@ function checkComputedFontSize(fontSizeClass, stage) {
 
 function getFontSizeTestSteps(fontSizeClass) {
     return [
+        goBackToBlocks(),
         ...insertSnippet({id: "s_text_block", name: "Text", groupName: "Text"}),
         ...clickToolbarButton(
             `text block first paragraph [${fontSizeClass}]`,


### PR DESCRIPTION
During [website builder refactor], there was a mistake in handling fallback of the builder tab. If the user is in the "customize" (aka "Edit") tab and changes the document in a way that there is no more options in the tab, the builder was supposed to move back to the last other tab opened, but just always fell back to "blocks" (aka "Add")

Steps to reproduce:
- Open website builder
- Drop a section
- Click on "Theme" tab
- Click on the section
- Click on "Remove this block"
- Bug: the builder falls back to the "Add" tab instead of "Theme" tab

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-5493971
