### PR TITLE
[IMP] sale: add expiry filter to quotations

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -1056,6 +1056,8 @@
                 <filter string="Sales Orders" name="sales" domain="[('state', '=', 'sale')]"/>
                 <separator/>
                 <filter string="Create Date" name="filter_create_date" date="create_date"/>
+                <separator/>
+                <filter string="Expired" name="expired" domain="[('is_expired', '=', True)]"/>
             </filter>
         </field>
     </record>


### PR DESCRIPTION
Sales teams currently lack a clear way to identify expired quotations, leading to missed follow-ups. Since the `is_expired` field is a non-stored computed field, it cannot be filtered directly in the UI. This commit:
- Implements a _search_is_expired method to allow filtering on the field.
- Adds a "Expired " filter to the Sales/Order/Quotations search view.

task-5431396
