### PR TITLE
[IMP] Preparation display: Merge same products in one orderline

### DIFF
--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -75,6 +75,7 @@ def setup_product_combo_items(self):
     self.desk_accessories_combo = self.env["product.combo"].create(
         {
             "name": "Desk Accessories Combo",
+            "qty_max": 3,
             "combo_item_ids": [
                 Command.create({
                     "product_id": combo_product_1.id,


### PR DESCRIPTION
When ordering a combo product, the POS will split the included products from the extra products in different orderlines. This is done because of the extra products have a different price/unit than the extra items.

But for the preparation display we don't care about different prices, so this PR will make the different orderlines of the same combo be merged in the preparation display if they target the same product.

Task-[5473387](https://www.odoo.com/odoo/project/1737/tasks/5473387) 
Enterprise PR-[#104188](https://github.com/odoo/enterprise/pull/104188)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
