### PR TITLE
[FIX] point_of_sale: display correct cash difference in report

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -213,16 +213,15 @@ class ReportSaleDetails(models.AbstractModel):
                         payment['count'] = True
             if not is_cash_method:
                 cash_name = _('Cash %(session_name)s', session_name=session.name)
-                previous_session = self.env['pos.session'].search([('id', '<', session.id), ('state', '=', 'closed'), ('config_id', '=', session.config_id.id)], limit=1)
-                final_count = previous_session.cash_register_balance_end_real + session.cash_real_transaction
+                final_count = session.cash_register_balance_start + session.cash_real_transaction
                 cash_difference = session.cash_register_balance_end_real - final_count
                 cash_moves = self.env['account.bank.statement.line'].search([('pos_session_id', '=', session.id)], order='date asc')
                 cash_in_out_list = []
 
-                if previous_session.cash_register_balance_end_real > 0:
+                if session.cash_register_balance_start > 0:
                     cash_in_out_list.append({
                         'name': _('Cash Opening'),
-                        'amount': previous_session.cash_register_balance_end_real,
+                        'amount': session.cash_register_balance_start,
                     })
 
                 # If there is a cash difference, we remove the last cash move which is the cash difference


### PR DESCRIPTION
**Steps to reproduce:**
- Open the PoS, input 100 as starting cash amount
- Make a Sale for $70 and pay in cash
- Close the PoS and input 170 as ending cash while closing the session
- Open the PoS again, input 100 as starting cash
- Close the PoS without making any sale and input 100 as closing cash
- Go to the session reports for the last session
- The **Difference** is wrong

**Why the fix:**
Before this commit, when closing the session without making any sale, the starting cash amount was set to the ending cash amount from the last session. This means that the input from the user at the begining of the session was not taken into account.

We now use the starting cash instead of last session's ending cash.

We also display the correct amount in the 'Cash Opening' section.

opw-5391239