### PR TITLE
[FIX] website: enforce uniform carousel item height on image replacement

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -28,6 +28,7 @@ export class ImageGalleryImagesOption extends BaseOptionComponent {
 class ImageGalleryOption extends Plugin {
     static id = "imageGalleryOption";
     static dependencies = [
+        "edit_interaction",
         "media",
         "dom",
         "history",
@@ -55,7 +56,10 @@ class ImageGalleryOption extends Plugin {
         reorder_items_handlers: this.reorderGalleryItems.bind(this),
         on_will_remove_handlers: this.onWillRemove.bind(this),
         on_removed_handlers: this.onRemoved.bind(this),
-        on_replaced_media_handlers: ({ newMediaEl }) => this.updateCarouselThumbnail(newMediaEl),
+        on_replaced_media_handlers: ({ newMediaEl }) => {
+            this.updateCarouselThumbnail(newMediaEl);
+            this.restartInteractions(newMediaEl);
+        },
         on_image_updated_handlers: ({ imageEl }) => this.updateCarouselThumbnail(imageEl),
         on_image_saved_handlers: ({ imageEl }) => this.updateCarouselThumbnail(imageEl),
         on_snippet_dropped_handlers: ({ snippetEl }) => {
@@ -440,6 +444,13 @@ class ImageGalleryOption extends Plugin {
     updateCarouselThumbnail(mediaEl) {
         if (mediaEl.matches(".s_image_gallery img")) {
             forwardToThumbnail(mediaEl);
+        }
+    }
+
+    restartInteractions(element) {
+        const carouselItemEl = element.closest(".carousel-item");
+        if (carouselItemEl) {
+            this.dependencies.edit_interaction.restartInteractions();
         }
     }
 }


### PR DESCRIPTION
In a carousel snippet all carousel items keep a consistent height to prevent layout jitter when sliding. The height synchronization was broken in some snippets (e.g. s_image_gallery and s_carousel_cards) after replacing an image with one of a different aspect ratio. This fix restores the uniform height computation.

Steps to reproduce:
1. In the website builder, add a carousel snippet (e.g. s_image_gallery).
2. Replace one of its images with another which is significantly tall.
3. Navigate through the carousel and observe height changes causing a jitter effect.

task-5135520

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
