### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: avoid sale/purchase sync state conflict

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -206,7 +206,7 @@ class AccountMove(models.Model):
                     else:
                         invoice.message_post(body=_("The invoice status couldn't be retrieved from Nilvera."))
 
-    def _get_nilvera_last_fetch_date(self, invoice_channel):
+    def _get_nilvera_last_fetch_date(self, invoice_channel, journal_type):
         """
         Fetches the last fetched date for Nilvera e-invoice synchronization specific to the
         current company. If no value exists, it sets a default date of one month prior to
@@ -214,7 +214,7 @@ class AccountMove(models.Model):
         """
         # A config param is used to be able to store the date in stable. One for einvoice and one for earchive.
         # Should be removed in master and replaced with two date fields on the company.
-        param_key = f"l10n_tr_nilvera_{invoice_channel}.last_fetched_date.{self.env.company.id}"
+        param_key = f"l10n_tr_nilvera_{invoice_channel}_{journal_type}.last_fetched_date.{self.env.company.id}"
         last_fetched_date = self.env['ir.config_parameter'].sudo().get_param(param_key)
         if not last_fetched_date:
             last_fetched_date = (fields.Date.today() - relativedelta(months=1)).strftime("%Y-%m-%d")
@@ -224,7 +224,7 @@ class AccountMove(models.Model):
     def _l10n_tr_nilvera_get_documents(self, invoice_channel="einvoice", document_category="Purchase", journal_type="in_invoice"):
         with _get_nilvera_client(self.env.company) as client:
             endpoint = f"/{invoice_channel}/{quote(document_category)}"
-            start_date = self._get_nilvera_last_fetch_date(invoice_channel)
+            start_date = self._get_nilvera_last_fetch_date(invoice_channel, journal_type)
             end_date = fields.Datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
             page = 1
 
@@ -248,7 +248,7 @@ class AccountMove(models.Model):
 
             moves = self.env['account.move']
             journal = self._l10n_tr_get_nilvera_invoice_journal(journal_type)
-            date_param_key = f"l10n_tr_nilvera_{invoice_channel}.last_fetched_date.{self.env.company.id}"
+            date_param_key = f"l10n_tr_nilvera_{invoice_channel}_{journal_type}.last_fetched_date.{self.env.company.id}"
             while page <= total_pages:
                 # Reuse first response, fetch subsequent pages.
                 if page > 1:


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:
Nilvera e-invoice synchronization stores the last fetched date in a system parameter to allow incremental fetching on subsequent runs. Currently, this parameter is shared between sales and purchase flows, causing their synchronization states to overwrite each other.

# Current behavior before PR:
When sales and purchase documents are synchronized from Nilvera, both flows use the same configuration parameter to store the last fetched date. As a result, running one synchronization (e.g. sales) may prevent the other flow (e.g. purchases) from fetching new documents, leading to missing or incomplete imports.

# Desired behavior after PR is merged:
Sales and purchase synchronizations maintain independent last fetched dates by using journal-specific configuration keys. This allows both flows to run reliably and incrementally without interfering with each other.

taskId - 5494295

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
