### PR TITLE
[FIX] mass_mailing: UX Fixes and Improvements

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -121,11 +121,13 @@ export class BuilderColorPicker extends Component {
         selectedTab: { type: String, optional: true },
         defaultColor: { type: String, optional: true },
         defaultOpacity: { type: Number, optional: true },
+        colorPrefix: { type: String, optional: true },
     };
     static defaultProps = {
         enabledTabs: ["theme", "gradient", "custom"],
         defaultColor: "#FFFFFF00",
         selectedTab: "theme",
+        colorPrefix: "color-prefix-",
     };
     static components = {
         ColorSelector: ColorSelector,
@@ -146,7 +148,7 @@ export class BuilderColorPicker extends Component {
                 applyColorResetPreview: onPreviewRevert,
                 getUsedCustomColors:
                     this.props.getUsedCustomColors || this.getUsedCustomColors.bind(this),
-                colorPrefix: "color-prefix-",
+                colorPrefix: this.props.colorPrefix,
                 cssVarColorPrefix: "hb-cp-",
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,

--- a/addons/html_builder/static/src/plugins/add_product_option.js
+++ b/addons/html_builder/static/src/plugins/add_product_option.js
@@ -1,5 +1,7 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { _t } from "@web/core/l10n/translation";
 
 export class BaseAddProductOption extends BaseOptionComponent {
     static template = "html_builder.AddProductOption";
+    buttonLabel = _t("Add Product");
 }

--- a/addons/html_builder/static/src/plugins/add_product_option.xml
+++ b/addons/html_builder/static/src/plugins/add_product_option.xml
@@ -9,7 +9,7 @@
             actionParam="`${this.productSelector}:last-of-type`"
             preview="false"
             applyTo="this.buttonApplyTo">
-            Add Product
+            <t t-out="buttonLabel"/>
         </BuilderButton>
     </BuilderRow>
 </t>

--- a/addons/html_builder/static/src/plugins/border_configurator_option.xml
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.xml
@@ -17,7 +17,7 @@
     </BuilderRow>
 
     <!-- TODO: handle the dependency with border_width_opt bg_color_opt-->
-    <BuilderRow t-if="props.withRoundCorner" label.translate="Round Corners">
+    <BuilderRow t-if="props.withRoundCorner and state.hasBorder" label.translate="Round Corners">
         <BuilderNumberInput action="props.action" actionParam="{ mainParam: getStyleActionParam('radius'), extraClass: props.withBSClass and 'rounded' }" unit="'px'" min="0" composable="true"/>
     </BuilderRow>
 </t>

--- a/addons/html_builder/static/src/plugins/cta_badge_option.xml
+++ b/addons/html_builder/static/src/plugins/cta_badge_option.xml
@@ -3,7 +3,7 @@
 
 <t t-name="html_builder.CTABadgeOption">
     <BorderConfigurator label.translate="Border"/>
-    <ShadowOption/>
+    <ShadowOption t-if="!this.excludeShadowOption"/>
 </t>
 
 </templates>

--- a/addons/html_builder/static/src/plugins/size_option.xml
+++ b/addons/html_builder/static/src/plugins/size_option.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-<t t-name="website.SizeOption">
+<t t-name="html_builder.SizeOption">
     <BuilderRow label.translate="Size">
         <BuilderSelect>
             <BuilderSelectItem classAction="'s_alert_sm'">Small</BuilderSelectItem>

--- a/addons/html_builder/static/src/plugins/size_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/size_option_plugin.js
@@ -5,7 +5,7 @@ import { registry } from "@web/core/registry";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 
 export class SizeOption extends BaseOptionComponent {
-    static template = "website.SizeOption";
+    static template = "html_builder.SizeOption";
     static selector = ".s_alert";
 }
 
@@ -16,4 +16,4 @@ class SizeOptionPlugin extends Plugin {
         builder_options: [withSequence(after(BLOCK_ALIGN), SizeOption)],
     };
 }
-registry.category("website-plugins").add(SizeOptionPlugin.id, SizeOptionPlugin);
+registry.category("builder-plugins").add(SizeOptionPlugin.id, SizeOptionPlugin);

--- a/addons/html_editor/static/src/main/position_plugin.js
+++ b/addons/html_editor/static/src/main/position_plugin.js
@@ -29,9 +29,12 @@ export class PositionPlugin extends Plugin {
         if (this.window !== window) {
             this.addDomListener(this.window, "resize", this.layoutGeometryChange);
         }
-        const scrollableElements = [this.editable, ...ancestors(this.editable)].filter(
-            (node) => couldBeScrollableX(node) || couldBeScrollableY(node)
-        );
+        const scrollableElements = [
+            this.editable,
+            ...ancestors(this.editable).filter(
+                (node) => couldBeScrollableX(node) || couldBeScrollableY(node)
+            ),
+        ];
         for (const scrollableElement of scrollableElements) {
             this.addDomListener(scrollableElement, "scroll", () => {
                 this.layoutGeometryChange();

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -95,6 +95,7 @@
             'web/static/src/scss/pre_variables.scss',
             'web/static/lib/bootstrap/scss/_variables.scss',
             'web/static/lib/bootstrap/scss/_maps.scss',
+            'web/static/lib/bootstrap/scss/_alert.scss',
             ('include', 'web._assets_bootstrap_frontend'),
 
             # useful scss from /html_editor web.assets_frontend
@@ -109,6 +110,7 @@
             ('after', 'web/static/lib/bootstrap/scss/_maps.scss', 'mass_mailing/static/src/scss/mass_mailing.ui.scss'),
 
             'html_editor/static/src/scss/bootstrap_overridden.scss',
+            'html_builder/static/src/scss/background.scss',
 
             'web/static/src/libs/fontawesome/css/font-awesome.css',
             'web/static/lib/odoo_ui_icons/*',

--- a/addons/mass_mailing/static/src/builder/color_picker.js
+++ b/addons/mass_mailing/static/src/builder/color_picker.js
@@ -1,0 +1,8 @@
+import { BuilderColorPicker } from "@html_builder/core/building_blocks/builder_colorpicker";
+
+export class MassMailingColorPicker extends BuilderColorPicker {
+    static defaultProps = {
+        ...BuilderColorPicker.defaultProps,
+        colorPrefix: "",
+    };
+}

--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
@@ -6,6 +6,7 @@ import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/backend/plugin_sets";
 import { registry } from "@web/core/registry";
 import { CustomizeTab } from "@html_builder/sidebar/customize_tab";
 import { OptionsContainerWithSnippetVersionControl } from "./options/options_container";
+import { PowerButtonsPlugin } from "@html_editor/main/power_buttons_plugin";
 
 class CustomizeTabWithSnippetVersionControl extends CustomizeTab {
     static components = {
@@ -45,8 +46,12 @@ export class MassMailingBuilder extends Component {
             "EmbeddedFilePlugin",
             "FilePlugin",
             "AddDocumentsAttachmentPlugin",
+            "BannerPlugin",
         ];
-        const builderEditorPlugins = removePlugins([...CORE_PLUGINS], pluginsToRemove);
+        const builderEditorPlugins = removePlugins(
+            [...CORE_PLUGINS, PowerButtonsPlugin],
+            pluginsToRemove
+        );
         const optionalPlugins = [
             ...(this.props.builderProps.config.dynamicPlaceholder
                 ? removePlugins(

--- a/addons/mass_mailing/static/src/builder/options/alignment_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/alignment_option.xml
@@ -1,0 +1,11 @@
+<templates>
+<t t-name="mass_mailing.BlockAlignmentOption">
+    <BuilderRow label.translate="Alignment" t-if="!this.isActiveItem('so_width_100')">
+        <BuilderButtonGroup>
+            <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'me-auto'"/>
+            <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"/>
+            <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'ms-auto'"/>
+        </BuilderButtonGroup>
+    </BuilderRow>
+</t>
+</templates>

--- a/addons/mass_mailing/static/src/builder/options/blockquote_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/blockquote_option.xml
@@ -3,13 +3,6 @@
         <BuilderRow label.translate="Edge Spacing">
             <BuilderRange action="'setClassRange'" actionParam="['p-1', 'p-2', 'p-3', 'p-4', 'p-5']" max="4"/>
         </BuilderRow>
-        <BuilderRow label.translate="Author Alignment" applyTo="'.s_blockquote_infos'">
-            <BuilderSelect>
-                <BuilderSelectItem classAction="'flex-row align-items-start justify-content-start text-start'">Left</BuilderSelectItem>
-                <BuilderSelectItem classAction="'flex-column align-items-center text-center'">Center</BuilderSelectItem>
-                <BuilderSelectItem classAction="'flex-row-reverse align-items-start justify-content-start text-end'">Right</BuilderSelectItem>
-            </BuilderSelect>
-        </BuilderRow>
         <t t-call="mass_mailing.BorderOption"/>
     </t>
 </templates>

--- a/addons/mass_mailing/static/src/builder/options/border_options.xml
+++ b/addons/mass_mailing/static/src/builder/options/border_options.xml
@@ -1,5 +1,5 @@
 <templates>
     <t t-name="mass_mailing.BorderOption">
-        <BorderConfigurator label.translate="Border"/>
+        <BorderConfigurator label.translate="Border" withRoundCorner="this.withRoundCorner"/>
     </t>
 </templates>

--- a/addons/mass_mailing/static/src/builder/options/company_team_options.xml
+++ b/addons/mass_mailing/static/src/builder/options/company_team_options.xml
@@ -1,0 +1,11 @@
+<templates>
+    <t t-name="mass_mailing.CompanyTeamShapesWidth">
+        <BuilderRow label.translate="Content Width" applyTo="'div:is(.o_container_small, .container, .container-fluid)'">
+            <BuilderButtonGroup action="'classAction'">
+                <BuilderButton actionParam="'o_container_small'"><Img src="'/mass_mailing/static/src/img/snippets_options/content_width_small.svg'" /></BuilderButton>
+                <BuilderButton actionParam="'container'"><Img src="'/mass_mailing/static/src/img/snippets_options/content_width_normal.svg'" /></BuilderButton>
+                <BuilderButton actionParam="'container-fluid'"><Img src="'/mass_mailing/static/src/img/snippets_options/content_width_full.svg'" /></BuilderButton>
+            </BuilderButtonGroup>
+        </BuilderRow>
+    </t>
+</templates>

--- a/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
@@ -1,12 +1,5 @@
 <templates>
     <t t-name="mass_mailing.ImageAndFaOption">
-        <BuilderRow label.translate="Alignment">
-            <BuilderSelect>
-                <BuilderSelectItem classAction="'float-start'">Left</BuilderSelectItem>
-                <BuilderSelectItem classAction="'mx-auto'">Center</BuilderSelectItem>
-                <BuilderSelectItem classAction="'float-end'">Right</BuilderSelectItem>
-            </BuilderSelect>
-        </BuilderRow>
         <t t-call="mass_mailing.BorderOption"/>
         <t t-call="mass_mailing.HorizontalPaddingOption"/>
         <t t-call="mass_mailing.VerticalPaddingOption"/>

--- a/addons/mass_mailing/static/src/builder/options/masonry_block_template_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/masonry_block_template_option.xml
@@ -22,19 +22,19 @@
             </div>
             <div class="col-md-6 col-12 s_col_no_resize o_masonry_grid_container">
                 <div class="row h-100">
-                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
                     <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                        <h3><font style="color: white">A great title</font></h3>
-                        <p><font style="color: white">And a great subtitle</font></p>
+                        <h3>A great title</h3>
+                        <p>And a great subtitle</p>
                     </div>
                     <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc4" data-name="Block">
                         <h3><font style="color: white">A great title</font></h3>
                         <p><font style="color: white">And a great subtitle</font></p>
                     </div>
-                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
@@ -48,14 +48,14 @@
             <div class="col-md-6 col-12 s_col_no_resize o_masonry_grid_container">
                 <div class="row h-100">
                     <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                        <h3><font style="color: white">A great title</font></h3>
-                        <p><font style="color: white">And a great subtitle</font></p>
-                    </div>
-                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
-                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
+                        <h3>A great title</h3>
+                        <p>And a great subtitle</p>
+                    </div>
+                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
@@ -89,7 +89,7 @@
             </div>
             <div class="col-md-3 col-12 s_col_no_resize o_masonry_grid_container">
                 <div class="row h-100">
-                    <div class="col-md-12 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-12 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
@@ -110,10 +110,10 @@
             <div class="col-md-6 col-12 s_col_no_resize o_masonry_grid_container">
                 <div class="row">
                     <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                        <h3><font style="color: white">A great title</font></h3>
-                        <p><font style="color: white">And a great subtitle</font></p>
+                        <h3>A great title</h3>
+                        <p>And a great subtitle</p>
                     </div>
-                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
@@ -133,7 +133,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
@@ -151,10 +151,10 @@
             <div class="col-md-3 col-12 s_col_no_resize o_masonry_grid_container">
                 <div class="row h-100">
                     <div class="col-md-12 col-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                        <h3><font style="color: white">A great title</font></h3>
-                        <p><font style="color: white">And a great subtitle</font></p>
+                        <h3>A great title</h3>
+                        <p>And a great subtitle</p>
                     </div>
-                    <div class="col-md-12 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-12 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
@@ -166,7 +166,7 @@
             </div>
             <div class="col-md-3 col-12 s_col_no_resize o_masonry_grid_container">
                 <div class="row h-100">
-                    <div class="col-md-12 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                    <div class="col-md-12 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                         <h3>A great title</h3>
                         <p>And a great subtitle</p>
                     </div>
@@ -181,7 +181,7 @@
 
     <t t-name="mass_mailing.s_masonry_block_alternation_text_template">
         <div class="row">
-            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                 <h3>A great title</h3>
                 <p>And a great subtitle</p>
             </div>
@@ -189,27 +189,27 @@
                 <h3><font style="color: white">A great title</font></h3>
                 <p><font style="color: white">And a great subtitle</font></p>
             </div>
-            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                 <h3>A great title</h3>
                 <p>And a great subtitle</p>
             </div>
             <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                <h3><font style="color: white">A great title</font></h3>
-                <p><font style="color: white">And a great subtitle</font></p>
+                <h3>A great title</h3>
+                <p>And a great subtitle</p>
             </div>
         </div>
     </t>
 
     <t t-name="mass_mailing.s_masonry_block_alternation_text_image_template">
         <div class="row">
-            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                 <h3>A great title</h3>
                 <p>And a great subtitle</p>
             </div>
             <div class="col-md-3 col-12 oe_img_bg text-center pt224 pb224" data-name="Block" style="background-image: url(/web/image/mass_mailing.s_masonry_block_default_image_1);">
                 <p><br/></p>
             </div>
-            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                 <h3>A great title</h3>
                 <p>And a great subtitle</p>
             </div>
@@ -232,22 +232,22 @@
                 <p><br/></p>
             </div>
             <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                <h3><font style="color: white">A great title</font></h3>
-                <p><font style="color: white">And a great subtitle</font></p>
+                <h3>A great title</h3>
+                <p>And a great subtitle</p>
             </div>
         </div>
     </t>
 
     <t t-name="mass_mailing.s_masonry_block_alternation_text_image_text_template">
         <div class="row">
-            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                 <h3>A great title</h3>
                 <p>And a great subtitle</p>
             </div>
             <div class="col-md-6 col-12 oe_img_bg text-center pt224 pb224" data-name="Block" style="background-image: url(/web/image/mass_mailing.s_masonry_block_default_image_1);">
                 <p><br/></p>
             </div>
-            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+            <div class="col-md-3 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                 <h3>A great title</h3>
                 <p>And a great subtitle</p>
             </div>

--- a/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/border_option_plugin.js
@@ -5,33 +5,37 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
 
-export class BorderOption1 extends BaseOptionComponent {
+class MassMailingBorderOption extends BaseOptionComponent {
     static template = "mass_mailing.BorderOption";
+    static components = { BorderConfigurator };
+    withRoundCorner = true;
+}
+
+export class BorderOption1 extends MassMailingBorderOption {
     static selector =
         ".s_three_columns .row > div, .s_comparisons .row > div, .s_mail_block_event .row > div";
     static applyTo = ".card";
-    static components = { BorderConfigurator };
 }
 
-export class BorderOption2 extends BaseOptionComponent {
-    static template = "mass_mailing.BorderOption";
-    static selector = ".s_text_block";
-    static components = { BorderConfigurator };
+export class BorderOption2 extends MassMailingBorderOption {
+    static selector = ".s_text_block, .o_mail_block_discount2";
 }
 
-export class BorderOption3 extends BaseOptionComponent {
-    static template = "mass_mailing.BorderOption";
-    static selector = ".o_mail_block_discount2";
-    static applyTo = "table";
-    static components = { BorderConfigurator };
+export class BorderOption3 extends MassMailingBorderOption {
+    static selector = "table, table td, table tr";
+    withRoundCorner = false;
 }
 
-export class BorderOption4 extends BaseOptionComponent {
-    static template = "mass_mailing.BorderOption";
+export class BorderOption4 extends MassMailingBorderOption {
     static selector = ".row > div";
-    static exclude = ".o_mail_wrapper_td, .s_image_gallery .row > div";
-    static components = { BorderConfigurator };
+    static exclude = [
+        ".o_mail_wrapper_td, .s_image_gallery .row > div",
+        BorderOption1.selector,
+        BorderOption2.selector,
+        BorderOption3.selector,
+    ].join(",");
 }
+
 
 export class BorderOptionPlugin extends Plugin {
     static id = "mass_mailing.BorderOption";

--- a/addons/mass_mailing/static/src/builder/plugins/colorpicker_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/colorpicker_option_plugin.js
@@ -10,7 +10,7 @@ export class ColorPickerOption extends BaseOptionComponent {
     static selector = `.note-editable .oe_structure > div:not(:has(> .o_mail_snippet_general)),
         .note-editable .oe_structure > .o_mail_snippet_general,
         .note-editable .oe_structure > .o_mail_snippet_general .o_cc,
-        .s_mail_color_blocks_2 .row > div`;
+        .s_mail_color_blocks_2 .row > div, table td, .s_cta_badge`;
     static exclude = ".o_mail_no_colorpicker, .o_mail_no_options, .s_mail_color_blocks_2";
 }
 
@@ -18,7 +18,7 @@ export class ColorPickerOption2 extends BaseOptionComponent {
     static template = "mass_mailing.ColorPickerOption";
     static selector =
         ".s_three_columns .row > div, .s_comparisons .row > div, .s_mail_block_event .row > div";
-    static applyTo = ".card-body";
+    static applyTo = ".card-body, .card-footer";
 }
 
 class ColorPickerOptionPlugin extends Plugin {

--- a/addons/mass_mailing/static/src/builder/plugins/colorpicker_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/colorpicker_plugin.js
@@ -1,0 +1,16 @@
+import { Plugin } from "@html_editor/plugin";
+import { MassMailingColorPicker } from "../color_picker";
+import { registry } from "@web/core/registry";
+
+class MassMailingColorPickerPlugin extends Plugin {
+    static id = "mass_mailing.ColorPickerPlugin";
+    resources = {
+        builder_components: {
+            MassMailingColorPicker,
+        },
+    };
+}
+
+registry
+    .category("mass_mailing-plugins")
+    .add(MassMailingColorPickerPlugin.id, MassMailingColorPickerPlugin);

--- a/addons/mass_mailing/static/src/builder/plugins/company_teams_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/company_teams_option_plugin.js
@@ -1,0 +1,18 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { registry } from "@web/core/registry";
+
+class CompanyTeamShapesWidthOption extends BaseOptionComponent {
+    static selector = ".s_company_team_shapes";
+    static template = "mass_mailing.CompanyTeamShapesWidth";
+}
+
+export class CompanyTeamOptionPlugin extends Plugin {
+    static id = "mass_mailing.CompanyTeamOption";
+    resources = {
+        builder_options: [withSequence(1, CompanyTeamShapesWidthOption)],
+    };
+}
+
+registry.category("mass_mailing-plugins").add(CompanyTeamOptionPlugin.id, CompanyTeamOptionPlugin);

--- a/addons/mass_mailing/static/src/builder/plugins/cta_badge_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/cta_badge_plugin.js
@@ -1,0 +1,30 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { CTABadgeOption } from "@html_builder/plugins/cta_badge_option_plugin";
+import { BLOCK_ALIGN } from "@html_builder/utils/option_sequence";
+import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+
+export class CTABadgeAlignmentOption extends BaseOptionComponent {
+    static selector = ".s_cta_badge";
+    static template = "mass_mailing.BlockAlignmentOption";
+}
+
+patch(CTABadgeOption.prototype, {
+    get excludeShadowOption() {
+        return (
+            super.excludeShadowOption ||
+            this.env.getEditingElement().matches(".o_mail_snippet_general")
+        );
+    },
+});
+
+export class CTABadgePlugin extends Plugin {
+    static id = "mass_mailing.CTABadgePlugin";
+    resources = {
+        builder_options: [withSequence(BLOCK_ALIGN, CTABadgeAlignmentOption)],
+    };
+}
+
+registry.category("mass_mailing-plugins").add(CTABadgePlugin.id, CTABadgePlugin);

--- a/addons/mass_mailing/static/src/builder/plugins/customize_mailing_variables.js
+++ b/addons/mass_mailing/static/src/builder/plugins/customize_mailing_variables.js
@@ -104,7 +104,7 @@ export const CUSTOMIZE_MAILING_VARIABLES = Object.assign(
 
 export const CUSTOMIZE_MAILING_VARIABLES_DEFAULTS = {
     "--wrapper-background-color": {
-        "background-color": "",
+        "background-color": "#FFFFFF",
     },
     "--h1-font-size": {
         "font-size": "28px",

--- a/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
@@ -1,0 +1,33 @@
+import { Plugin } from "@html_editor/plugin";
+import { closestBlock } from "@html_editor/utils/blocks";
+import { registry } from "@web/core/registry";
+
+export class EmptyNotEditableElementsPlugin extends Plugin {
+    static id = "mass_mailing.EmptyNotEditableElements";
+    static dependencies = ["selection"];
+    resources = {
+        normalize_handlers: [this.normalize.bind(this)],
+    };
+
+    /**
+     * @param {HTMLElement} element
+     */
+    normalize(element) {
+        const potentiallyEmptyElements = element.querySelectorAll(
+            ".o_not_editable :is([data-oe-zws-inline], :not(img, a):empty)"
+        );
+        potentiallyEmptyElements.forEach((emptyElement) => {
+            const emptyBlock = closestBlock(emptyElement);
+            if (emptyBlock.closest(".o_not_editable")) {
+                emptyBlock.remove();
+            }
+        });
+        if (!this.dependencies.selection.isSelectionInEditable) {
+            this.dependencies.selection.resetSelection();
+        }
+    }
+}
+
+registry
+    .category("mass_mailing-plugins")
+    .add(EmptyNotEditableElementsPlugin.id, EmptyNotEditableElementsPlugin);

--- a/addons/mass_mailing/static/src/builder/plugins/layout_column_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/layout_column_option_plugin.js
@@ -8,7 +8,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 
 export class MassMailingLayoutColumnOption extends LayoutColumnOption {
     static selector = ".o_mail_snippet_general";
-    static exclude = ".s_reviews_wall";
+    static exclude = ".s_reviews_wall, .s_mail_alert";
     static applyTo = ":scope > *:has(> .row:not(.s_nb_column_fixed)), * > .s_allow_columns";
 }
 

--- a/addons/mass_mailing/static/src/builder/plugins/mass_mailing_setup_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/mass_mailing_setup_plugin.js
@@ -11,7 +11,6 @@ export class MassMailingSetupPlugin extends Plugin {
             "mass_mailing.iframe_add_dialog",
         ],
         clean_for_save_handlers: this.cleanForSave.bind(this),
-        powerbox_blacklist_selectors: ".o_mail_wrapper_td",
     };
 
     setup() {

--- a/addons/mass_mailing/static/src/builder/plugins/reviews_wall_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/reviews_wall_option_plugin.js
@@ -1,4 +1,5 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
 import { LayoutColumnOption } from "@html_builder/plugins/layout_column_option";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
@@ -6,6 +7,7 @@ import { registry } from "@web/core/registry";
 export class CustomerTestimonialsBlockquote extends BaseOptionComponent {
     static template = "mass_mailing.CustomerTestimonialsBlockquote";
     static selector = ".s_reviews_wall .s_mail_blockquote";
+    static components = { BorderConfigurator };
 }
 
 export class MassMailingLayoutColumnOption extends LayoutColumnOption {

--- a/addons/mass_mailing/static/src/builder/plugins/schedule_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/schedule_option_plugin.js
@@ -1,0 +1,21 @@
+import { BaseAddProductOption } from "@html_builder/plugins/add_product_option";
+import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { BEGIN } from "@html_builder/utils/option_sequence";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+
+export class MassMailingScheduleAddProductOption extends BaseAddProductOption {
+    static selector = ".s_schedule:has(table)";
+    productSelector = "tr";
+    buttonLabel = _t("Add Activity");
+}
+
+export class ScheduleOptionPlugin extends Plugin {
+    static id = "mass_mailing.ScheduleOptionPlugin";
+    resources = {
+        builder_options: [withSequence(BEGIN, MassMailingScheduleAddProductOption)],
+    };
+}
+
+registry.category("mass_mailing-plugins").add(ScheduleOptionPlugin.id, ScheduleOptionPlugin);

--- a/addons/mass_mailing/static/src/builder/snippet_viewer/snippet_viewer.scss
+++ b/addons/mass_mailing/static/src/builder/snippet_viewer/snippet_viewer.scss
@@ -5,3 +5,14 @@
         }
     }
 }
+
+.o_snippet_preview_wrap {
+    [data-snippet] {
+        min-height: 100px; // Same as snippet container
+
+        .container {
+            padding: 0;
+            max-width: 100%;
+        }
+    }
+}

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -14,6 +14,7 @@ import { Deferred } from "@web/core/utils/concurrency";
 import { effect } from "@web/core/utils/reactive";
 import { useChildRef, useService } from "@web/core/utils/hooks";
 import { batched } from "@web/core/utils/timing";
+import { PowerButtonsPlugin } from "@html_editor/main/power_buttons_plugin";
 
 export class MassMailingHtmlField extends HtmlField {
     static template = "mass_mailing.HtmlField";
@@ -237,6 +238,7 @@ export class MassMailingHtmlField extends HtmlField {
         delete config.Plugins;
         return {
             ...config,
+            allowChecklist: false,
             record: this.props.record,
             mobileBreakpoint: "md",
             defaultImageMimetype: "image/png",
@@ -260,7 +262,8 @@ export class MassMailingHtmlField extends HtmlField {
                 ...MAIN_EDITOR_PLUGINS,
                 ...DYNAMIC_PLACEHOLDER_PLUGINS,
                 ...registry.category("basic-editor-plugins").getAll(),
-            ],
+                PowerButtonsPlugin,
+            ].filter((P) => !["banner", "prompt"].includes(P.id)),
         };
     }
 

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -293,6 +293,10 @@ export class MassMailingIframe extends Component {
         if (status(this) === "destroyed") {
             return;
         }
+        this.editor.config.localOverlayContainers = {
+            key: this.env.localOverlayContainerKey,
+            ref: this.overlayRef,
+        };
         this.editor.attachTo(
             this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR)
         );

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.scss
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.scss
@@ -9,7 +9,7 @@
         overflow: hidden !important;
         transform: none !important;
         z-index: ($zindex-fixed + $zindex-modal-backdrop) / 2;
-        background-color: $gray-100;
+        background-color: $o-view-background-color;
         .o_is_mobile {
             margin: auto;
         }

--- a/addons/mass_mailing/static/src/scss/themes/theme_default.scss
+++ b/addons/mass_mailing/static/src/scss/themes/theme_default.scss
@@ -117,20 +117,9 @@ div.col:not([align]) {
 
 }
 
-.card {
-    border-color: #d2d2d2;
-    .card-header,.card-footer {
-        background-color: inherit!important;
-    }
-    .card-body {
-        background-color: white!important;
-    }
-}
-
 // ===== Misc =====
 
 .o_mail_snippet_general .container {
-    width: 100%;
     border-collapse:separate;
 }
 

--- a/addons/mass_mailing/static/src/snippets/s_alert/000.scss
+++ b/addons/mass_mailing/static/src/snippets/s_alert/000.scss
@@ -18,21 +18,17 @@
             }
         }
     }
-    .s_alert_sm {
+    &.s_alert_sm {
         padding: $grid-gutter-width/3;
         font-size: $font-size-sm;
     }
-    .s_alert_md {
+    &.s_alert_md {
         padding: $grid-gutter-width/2;
         font-size: $font-size-base;
     }
-    .s_alert_lg {
+    &.s_alert_lg {
         padding: $grid-gutter-width;
         font-size: $font-size-lg;
-    }
-    .s_alert_icon {
-        margin-right: 10px;
-        background-color: rgba($color: #000000, $alpha: 0.15);
     }
     .s_alert_content {
         overflow: hidden;

--- a/addons/mass_mailing/static/src/themes/theme_service.js
+++ b/addons/mass_mailing/static/src/themes/theme_service.js
@@ -42,6 +42,9 @@ export class ThemeModel extends Reactive {
                 nowrap: hasDataOption(theme, "nowrap"),
                 title: theme.getAttribute("title") || "",
             };
+            if (!themeOptions.layoutStyles.includes("background-color")) {
+                themeOptions.layoutStyles += "background-color: #F7F7F7;";
+            }
             if (hasDataOption(theme, "images-info")) {
                 const imagesInfo = Object.assign(
                     { all: {} },

--- a/addons/mass_mailing/static/src/themes/theme_wrapper.xml
+++ b/addons/mass_mailing/static/src/themes/theme_wrapper.xml
@@ -1,6 +1,6 @@
 <templates id="template">
     <t t-name="mass_mailing.ThemeLayout">
-        <div data-name="Mailing" class="o_layout oe_unremovable oe_unmovable"
+        <div data-name="Mailing" class="o_layout oe_unremovable oe_unmovable" style=""
             t-att-class="className" t-att-style="layoutStyles">
             <t t-if="nowrap" t-call="mass_mailing.ThemeStructure"/>
             <t t-else="" t-call="mass_mailing.ThemeWrapper"/>

--- a/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_columns_snippets.xml
@@ -1,8 +1,8 @@
 <odoo>
 <template id="s_three_columns" name="Columns">
-    <section class="s_three_columns o_mail_snippet_general o_cc o_cc2 pt32 pb32" data-vxml="001">
+    <section class="s_three_columns o_mail_snippet_general o_cc pt32 pb32" data-vxml="001">
         <div class="container">
-            <div class="row d-flex align-items-stretch">
+            <div class="row">
                 <div class="col-md-4 o_mail_no_colorpicker pt16 pb16 col-12">
                     <div class="card text-bg-white h-100">
                         <div class="o_not_editable">
@@ -61,38 +61,38 @@
 </template>
 
 <template name="Media List" id="s_media_list">
-    <section class="s_media_list pt32 pb32 o_colored_level o_cc o_cc2 o_mail_snippet_general" data-vcss="001" data-vxml="001">
+    <section class="s_media_list pt32 pb32 o_colored_level o_cc o_mail_snippet_general" data-vcss="001" data-vxml="001">
         <div class="container">
             <div class="row s_nb_column_fixed">
                 <div class="col-md-12 s_media_list_item pt16 pb16 col-12" data-name="Media item">
-                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc o_cc1">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc">
                         <div class="col-md-4 align-self-stretch s_media_list_img_wrapper o_not_editable col-12">
-                            <img src="/web/image/mass_mailing.s_media_list_default_image_1" class="s_media_list_img o_editable_media h-100 w-100" alt=""/>
+                            <img src="/web/image/mass_mailing.s_media_list_default_image_1" class="s_media_list_img img-fluid o_editable_media" alt=""/>
                         </div>
-                        <div class="col-md-8 s_media_list_body ps-md-4 col-12">
+                        <div class="col-md-8 s_media_list_body ps-md-4 col-12 o_cc">
                             <h2>Media heading</h2>
-                            <p>Use this snippet to build various types of components that feature a left- or right-aligned image alongside textual content. Duplicate the element to create a list that fits your needs.</p>
-                            <p><a href="#">Discover more <span class="fa fa-long-arrow-right align-middle ms-1"/></a></p>
+                            <p>Use this snippet to build various types of components that feature a left- or right-aligned image alongside textual content. Duplicate the element to create a list that fits your needs.
+                            <br/><a href="#">Discover more <span class="fa fa-long-arrow-right align-middle ms-1"/></a></p>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-12 s_media_list_item pt16 pb16" data-name="Media item">
-                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc o_cc1">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc">
                         <div class="col-md-4 align-self-stretch s_media_list_img_wrapper o_not_editable  col-12">
-                            <img src="/web/image/mass_mailing.s_media_list_default_image_2" class="s_media_list_img o_editable_media h-100 w-100" alt=""/>
+                            <img src="/web/image/mass_mailing.s_media_list_default_image_2" class="s_media_list_img o_editable_media img-fluid" alt=""/>
                         </div>
-                        <div class="col-md-8 s_media_list_body ps-md-4 col-12">
+                        <div class="col-md-8 s_media_list_body ps-md-4 col-12 o_cc">
                             <h2>Event heading</h2>
                             <p>Speakers from all over the world will join our experts to give inspiring talks on various topics. Stay on top of the latest business management trends &amp; technologies</p>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-12 s_media_list_item pt16 pb16" data-name="Media item">
-                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc o_cc1">
+                    <div class="row s_col_no_resize o_mail_no_colorpicker g-0 align-items-center o_colored_level o_cc">
                         <div class="col-md-4 align-self-stretch s_media_list_img_wrapper o_not_editable">
-                            <img src="/web/image/mass_mailing.s_media_list_default_image_3" class="s_media_list_img o_editable_media h-100 w-100" alt=""/>
+                            <img src="/web/image/mass_mailing.s_media_list_default_image_3" class="s_media_list_img o_editable_media img-fluid" alt=""/>
                         </div>
-                        <div class="col-md-8 s_media_list_body ps-md-4 col-12">
+                        <div class="col-md-8 s_media_list_body ps-md-4 col-12 o_cc">
                             <h2>Post heading</h2>
                             <p>Use this component for creating a list of featured elements to which you want to bring attention.</p>
                             <p><a href="#">Continue reading <span class="fa fa-long-arrow-right align-middle ms-1"/></a></p>
@@ -121,7 +121,7 @@
                                     />
                             </div>
                         </div>
-                        <div class="col-10 col-md-9 d-flex flex-column pe-0">
+                        <div class="col-10 col-md-9 pe-0">
                             <h6>Easy returns</h6>
                             <p class="mb-0">
                                 <span class="o_small-fs"><font style="color: rgb(99, 99, 99);">Free 30-day returns with quick refunds or easy exchanges and no stress.</font></span>
@@ -142,7 +142,7 @@
                                     />
                             </div>
                         </div>
-                        <div class="col-10 col-md-9 d-flex flex-column pe-0">
+                        <div class="col-10 col-md-9 pe-0">
                             <h6>Free shipping</h6>
                             <p class="mb-0">
                                 <span class="o_small-fs"><font style="color: rgb(99, 99, 99);">Enjoy fast, free shipping on all orders, no minimum, no hidden fees.</font></span>
@@ -163,7 +163,7 @@
                                     />
                             </div>
                         </div>
-                        <div class="col-10 col-md-9 d-flex flex-column pe-0">
+                        <div class="col-10 col-md-9 pe-0">
                             <h6>Secure payment</h6>
                             <p class="mb-0">
                                 <span class="o_small-fs"><font style="color: rgb(99, 99, 99);">Your information is protected with encrypted checkout and trusted payment methods.</font></span>
@@ -177,10 +177,10 @@
 </template>
 
 <template id="s_numbers" name="Numbers">
-    <section class="s_numbers o_mail_snippet_general o_cc o_cc1" data-vxml="001">
+    <section class="s_numbers o_mail_snippet_general o_cc" data-vxml="001">
         <div class="container">
             <div class="row">
-                <div class="col-md-4 pt24 pb24 o_cc o_cc2 col-12" style="text-align: center;">
+                <div class="col-md-4 pt24 pb24 o_cc col-12" style="text-align: center;">
                     <p><font style="font-size: 48px;">12</font></p>
                     <p>Useful options</p>
                 </div>
@@ -188,7 +188,7 @@
                     <p><font style="font-size: 48px; color: white;">45</font></p>
                     <p><font style="color: white;">Beautiful snippets</font></p>
                 </div>
-                <div class="col-md-4 pt24 pb24 o_cc o_cc2 col-12" style="text-align: center;">
+                <div class="col-md-4 pt24 pb24 o_cc col-12" style="text-align: center;">
                     <p><font style="font-size: 48px;">8</font></p>
                     <p>Amazing pages</p>
                 </div>
@@ -198,7 +198,7 @@
 </template>
 
 <template id="s_event" name="Event">
-    <section class="s_mail_block_event o_mail_snippet_general bg-100" data-vxml="001">
+    <section class="s_mail_block_event o_mail_snippet_general" data-vxml="001">
         <div class="container">
             <div class="row align-items-center">
                 <div class="o_mail_no_colorpicker col-md-6 pt32 pb32 col-12">
@@ -244,7 +244,9 @@
 <template id="s_product_list" name="Items">
     <section class="s_mail_product_list o_mail_snippet_general" data-vxml="001">
         <div class="container pt16">
-            <h2><span class="h3-fs">Our finest selection</span></h2>
+            <div class="ps-3">
+                <h2><span class="h3-fs">Our finest selection</span></h2>
+            </div>
             <div class="row">
                 <div class="col-md-4 o_cc pt16 pb16 col-12">
                     <div class="o_not_editable mb-3">

--- a/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_headers_snippets.xml
@@ -3,7 +3,7 @@
     <section class="s_header_social o_mail_block_header_social o_mail_snippet_general pt16 pb16" data-name="Left Logo" data-vxml="001">
         <div class="container">
             <div class="row">
-                <div class="col-md-4 pt16 pb16">
+                <div class="col-md-6 pt16 pb16">
                     <div class="o_not_editable">
                         <a t-att-href="(company_id.website) or '#'" style="text-decoration:none;float:none;" target="_blank">
                             <img t-if="company_id.logo or user_id.company_id.logo" class="o_b64_image_to_save o_editable_media"
@@ -11,7 +11,7 @@
                         </a>
                     </div>
                 </div>
-                <div class="col-md-8 o_mail_header_social" style="text-align: right;">
+                <div class="col-md-6 o_mail_header_social" style="text-align: right;">
                     <t t-call="mass_mailing.social_links"/>
                 </div>
             </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_images_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_images_snippets.xml
@@ -4,7 +4,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-12 oe_img_bg pt56 pb48 col-12" style="background-image: url('/web/image/mass_mailing.s_cover_default_image'); background-position: 50% 84.7081%;">
-                    <div class="o_we_bg_filter bg-black-50" contenteditable="false"></div>
+                    <div class="o_we_bg_filter bg-black-75" contenteditable="false"></div>
                     <h1 style="text-align: center;"><span style="font-size: 62px;"><strong><font class="text-white">Your journey starts here</font></strong></span></h1>
                     <p class="lead" style="text-align: center;"><font class="text-white">Write one or two paragraphs describing your product, services or a specific feature.<br/> To be successful your content needs to be useful to your readers.</font></p>
                 </div>
@@ -16,14 +16,14 @@
 <template id="s_image_text" name="Image - Text">
     <section class="s_text_image o_mail_snippet_general pt32 pb32" data-vxml="001">
         <div class="container">
-            <div class="row align-items-center">
+            <div class="row align-items-start">
                 <div class="col-md-6 pt16 pb16 col-12">
                     <div class="o_not_editable">
                         <img src="/web/image/mass_mailing.s_image_text_default_image" class="img o_editable_media img-fluid w-100" />
                     </div>
                 </div>
-                <div class="col-md-5 o_cc offset-md-1 pt16 pb16 col-12">
-                    <h2><span class="h3-fs">Discover New <strong>Opportunities</strong></span></h2>
+                <div class="col-md-6 o_cc pt16 pb16 col-12">
+                    <h2>Discover New <strong>Opportunities</strong></h2>
                     <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                     <p>Start with the customer - find out what they want and give it to them.</p>
                     <p><a href="https://www.example.com" class="btn btn-secondary o_translate_inline">Learn more</a></p>
@@ -34,16 +34,16 @@
 </template>
 
 <template id="s_text_image" name="Text - Image">
-    <section class="s_text_image o_mail_snippet_general pt80 pb80" data-vxml="001">
+    <section class="s_text_image o_mail_snippet_general pt32 pb32" data-vxml="001">
         <div class="container">
-            <div class="row align-items-center">
-                <div class="col-md-5 col-12 pt16 pb16">
-                    <h2><span class="h3-fs">Enhance Your <strong>Experience</strong></span></h2>
+            <div class="row align-items-start">
+                <div class="col-md-6 col-12 pt16 pb16">
+                    <h2>Enhance Your <strong>Experience</strong></h2>
                     <p>Write one or two paragraphs describing your product or services. To be successful your content needs to be useful to your readers.</p>
                     <p>Start with the customer - find out what they want and give it to them.</p>
                     <p><a href="https://www.example.com" class="btn btn-secondary">Learn more</a></p>
                 </div>
-                <div class="col-md-6 offset-md-1 col-12 pt16 pb16">
+                <div class="col-md-6 col-12 pt16 pb16">
                     <div class="o_not_editable">
                         <img src="/web/image/mass_mailing.s_text_image_default_image" class="img o_editable_media img-fluid mx-auto rounded" alt="" data-mimetype="image/webp"/>
                     </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_inner_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_inner_snippets.xml
@@ -8,15 +8,15 @@
 
 
 <template id="s_rating" name="Rating">
-    <div class="s_rating o_mail_snippet_general pt16 pb16" style="padding: 0 15px;" data-vcss="001" data-vxml="001" data-icon="fa-star">
+    <div class="s_rating o_mail_snippet_general pt16 pb16 s_rating_no_title" style="padding: 0 15px;" data-vcss="001" data-vxml="001" data-icon="fa-star">
         <h3 class="s_rating_title">Quality</h3>
         <div class="s_rating_icons o_not_editable">
-            <span class="s_rating_active_icons">
+            <span class="s_rating_active_icons" style="color: #f3cc00;">
                 <i class="fa fa-star"></i>
                 <i class="fa fa-star"></i>
                 <i class="fa fa-star"></i>
             </span>
-            <span class="s_rating_inactive_icons">
+            <span class="s_rating_inactive_icons" style="color: var(--border-color);">
                 <i class="fa fa-star-o"></i>
                 <i class="fa fa-star-o"></i>
             </span>
@@ -35,26 +35,16 @@
 </template>
 
 <template id="s_alert" name="Alert">
-    <div class="s_mail_alert o_mail_snippet_general pt16 pb16 mx-auto" data-name="Alert" data-vxml="001">
-        <div class="container">
-            <div class="row">
-                <div class="col-md-12 col-12">
-                    <div class="oe_unmovable s_alert s_alert_md s_alert_info w-100" style="background-color: rgb(209 236 241); border-width: 1px !important; border-color: rgb(190 229 235) !important;">
-                        <div class="o_not_editable">
-                            <span class="fa fa-lg fa-info-circle fa-stack o_editable_media d-flex align-items-center justify-content-center s_alert_icon rounded-1"/>
-                        </div>
-                        <div class="s_alert_content">
-                            <p class="mb-0">Explain the benefits you offer. <br/>Don't write about products or services here, write about solutions.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
+    <div class="oe_unmovable s_alert s_mail_alert s_alert_md alert alert-info w-100 row" style="border-width: 1px !important; border-color: rgb(190 229 235) !important;">
+        <i class="fa fa-2x fa-info-circle fa-stack o_not_editable s_alert_icon rounded-1 col-auto"/>
+        <div class="s_alert_content col-9">
+            <p class="mb-0">Explain the benefits you offer. <br/>Don't write about products or services here, write about solutions.</p>
         </div>
     </div>
 </template>
 
 <template name="CTA Badge" id="s_cta_badge">
-    <div class="s_cta_badge badge o_mail_snippet_general border rounded py-2 px-3" data-name="CTA Badge" style="border-radius: 32px !important;">
+    <div class="s_cta_badge badge d-block mx-auto o_mail_snippet_general border rounded py-2 px-3" data-name="CTA Badge" style="border-radius: 32px !important;">
         <p class="mb-0">
             <span class="fa fa-fw fa-info-circle" role="img"/>&#160;&#160;What do you want to promote&amp;nbsp;? &#160;&#160;&#160;&#160;<a href="#">See more <span class="fa fa-long-arrow-right" role="img"/></a>
         </p>

--- a/addons/mass_mailing/views/snippets/mass_mailing_marketing_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_marketing_snippets.xml
@@ -4,7 +4,7 @@
         <div class="container">
             <div class="row gap-4 gap-md-0">
                 <div class="col-12 col-md-6" data-name="Plan">
-                    <div class="card o_cc o_cc1 h-100 my-0">
+                    <div class="card h-100 my-0">
                         <div class="card-body">
                             <h5 class="card-title">Beginner</h5>
                             <div class="my-2">
@@ -16,10 +16,10 @@
                             <p class="card-text small">Ideal for newcomers. Essential features to kickstart sales and marketing. Perfect for small teams.</p>
                             <p><a href="#" class="btn btn-outline-primary w-100">Start Now</a></p>
                             <ul class="list-group list-group-flush text-start">
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check text-success" role="img"/>  Sales &amp; marketing for 2</li>
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check text-success" role="img"/>  Account management</li>
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-times text-danger" role="img"/>  No customization</li>
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-times text-danger" role="img"/>  No support</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-check text-success" role="img"/>  Sales &amp; marketing for 2</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-check text-success" role="img"/>  Account management</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-times text-danger" role="img"/>  No customization</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-times text-danger" role="img"/>  No support</li>
                             </ul>
                         </div>
                         <div class="card-footer text-center">
@@ -30,7 +30,7 @@
                     </div>
                 </div>
                 <div class="col-12 col-md-6" data-name="Plan">
-                    <div class="card o_cc o_cc1 h-100 my-0">
+                    <div class="card h-100 my-0">
                         <div class="card-body">
                             <h5 class="card-title">Professional</h5>
                             <div class="my-2">
@@ -42,10 +42,10 @@
                             <p class="card-text small">Comprehensive tools for growing businesses. Optimize your processes and productivity across your team.</p>
                             <p><a href="#" class="btn btn-primary w-100">Start Now</a></p>
                             <ul class="list-group list-group-flush text-start">
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check text-success" role="img"/>  Complete CRM for any team</li>
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check text-success" role="img"/>  Access all modules</li>
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check text-success" role="img"/>  Limited customization</li>
-                                <li class="list-group-item px-0 bg-transparent text-reset"><span class="fa fa-check text-success" role="img"/>  Email support</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-check text-success" role="img"/>  Complete CRM for any team</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-check text-success" role="img"/>  Access all modules</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-check text-success" role="img"/>  Limited customization</li>
+                                <li class="list-group-item px-0 bg-transparent"><span class="fa fa-check text-success" role="img"/>  Email support</li>
                             </ul>
                         </div>
                         <div class="card-footer text-center">
@@ -142,10 +142,10 @@
         <p style="text-align: center;">
             Here's your coupon code - but hurry! Ends 9/28
         </p>
-        <table border="0" cellpadding="0" cellspacing="0" align="center" class="border" style="border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+        <table border="0" cellpadding="0" data-name="Promo Ticket" cellspacing="0" align="center" class="border" style="border-collapse:collapse; mso-table-lspace:0pt; mso-table-rspace:0pt;">
             <tr>
-                <td width="50" height="50" align="center" class="o_mail_no_options mx-auto o_cc o_cc3" style="width:50px!important; min-width: 50px; max-width:5.6rem; text-align: center;"><span class="fa fa-2x fa-ticket"/></td>
-                <td width="200" height="50" align="center" class="o_cc" style="font-size: 15px; line-height: 22px; font-weight: 700; min-width: 150px; width: 200px; text-align: center;"><p class="mb0">ENDOFSUMMER20</p></td>
+                <td width="50" data-name="Icon Cell" height="50" align="center" class="mx-auto o_cc o_cc3" style="width:50px !important; min-width: 50px; max-width:5.6rem; text-align: center;"><span class="fa fa-2x fa-ticket"/></td>
+                <td width="200" data-name="Code Cell" height="50" align="center" class="o_cc" style="font-size: 15px; line-height: 22px; font-weight: 700; min-width: 150px; width: 200px; text-align: center;"><p class="mb0">ENDOFSUMMER20</p></td>
             </tr>
         </table>
         <div class="s_hr o_mail_snippet_general o_not_editable o_colored_level pt8 pb8" data-name="Separator">

--- a/addons/mass_mailing/views/snippets/mass_mailing_masonry_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_masonry_snippets.xml
@@ -18,19 +18,19 @@
         </div>
         <div class="col-md-6 col-12 s_col_no_resize o_masonry_grid_container">
             <div class="row h-100">
-                <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
                 <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                    <h3><font style="color: white">A great title</font></h3>
-                    <p><font style="color: white">And a great subtitle</font></p>
+                    <h3>A great title</h3>
+                    <p>And a great subtitle</p>
                 </div>
                 <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc4" data-name="Block">
                     <h3><font style="color: white">A great title</font></h3>
                     <p><font style="color: white">And a great subtitle</font></p>
                 </div>
-                <div class="col-md-6 col-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-6 col-12 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
@@ -45,14 +45,14 @@
         <div class="col-md-6 s_col_no_resize o_masonry_grid_container">
             <div class="row h-100">
                 <div class="col-md-6 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                    <h3><font style="color: white">A great title</font></h3>
-                    <p><font style="color: white">And a great subtitle</font></p>
-                </div>
-                <div class="col-md-6 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
-                <div class="col-md-6 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-6 pt24 pb8 text-center o_cc" data-name="Block">
+                    <h3>A great title</h3>
+                    <p>And a great subtitle</p>
+                </div>
+                <div class="col-md-6 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
@@ -86,7 +86,7 @@
         </div>
         <div class="col-md-3 s_col_no_resize o_masonry_grid_container">
             <div class="row h-100">
-                <div class="col-md-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-12 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
@@ -107,10 +107,10 @@
         <div class="col-md-6 s_col_no_resize o_masonry_grid_container">
             <div class="row">
                 <div class="col-md-6 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                    <h3><font style="color: white">A great title</font></h3>
-                    <p><font style="color: white">And a great subtitle</font></p>
+                    <h3>A great title</h3>
+                    <p>And a great subtitle</p>
                 </div>
-                <div class="col-md-6 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-6 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
@@ -130,7 +130,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-6 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-6 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
@@ -148,10 +148,10 @@
         <div class="col-md-3 s_col_no_resize o_masonry_grid_container">
             <div class="row h-100">
                 <div class="col-md-12 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-                    <h3><font style="color: white">A great title</font></h3>
-                    <p><font style="color: white">And a great subtitle</font></p>
+                    <h3>A great title</h3>
+                    <p>And a great subtitle</p>
                 </div>
-                <div class="col-md-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-12 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
@@ -163,7 +163,7 @@
         </div>
         <div class="col-md-3 s_col_no_resize o_masonry_grid_container">
             <div class="row h-100">
-                <div class="col-md-12 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+                <div class="col-md-12 pt24 pb8 text-center o_cc" data-name="Block">
                     <h3>A great title</h3>
                     <p>And a great subtitle</p>
                 </div>
@@ -178,7 +178,7 @@
 
 <template id="s_masonry_block_alternation_text_template" groups="base.group_user">
     <div class="row">
-        <div class="col-md-3 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+        <div class="col-md-3 pt24 pb8 text-center o_cc" data-name="Block">
             <h3>A great title</h3>
             <p>And a great subtitle</p>
         </div>
@@ -186,27 +186,27 @@
             <h3><font style="color: white">A great title</font></h3>
             <p><font style="color: white">And a great subtitle</font></p>
         </div>
-        <div class="col-md-3 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+        <div class="col-md-3 pt24 pb8 text-center o_cc" data-name="Block">
             <h3>A great title</h3>
             <p>And a great subtitle</p>
         </div>
         <div class="col-md-3 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-            <h3><font style="color: white">A great title</font></h3>
-            <p><font style="color: white">And a great subtitle</font></p>
+            <h3>A great title</h3>
+            <p>And a great subtitle</p>
         </div>
     </div>
 </template>
 
 <template id="s_masonry_block_alternation_text_image_template" groups="base.group_user">
     <div class="row">
-        <div class="col-md-3 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+        <div class="col-md-3 pt24 pb8 text-center o_cc" data-name="Block">
             <h3>A great title</h3>
             <p>And a great subtitle</p>
         </div>
         <div class="col-md-3 oe_img_bg text-center pt224 pb224" data-name="Block" style="background-image: url(/web/image/mass_mailing.s_masonry_block_default_image_1);">
             <p><br/></p>
         </div>
-        <div class="col-md-3 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+        <div class="col-md-3 pt24 pb8 text-center o_cc" data-name="Block">
             <h3>A great title</h3>
             <p>And a great subtitle</p>
         </div>
@@ -229,22 +229,22 @@
             <p><br/></p>
         </div>
         <div class="col-md-3 pt24 pb8 text-center o_cc o_cc3" data-name="Block">
-            <h3><font style="color: white">A great title</font></h3>
-            <p><font style="color: white">And a great subtitle</font></p>
+            <h3>A great title</h3>
+            <p>And a great subtitle</p>
         </div>
     </div>
 </template>
 
 <template id="s_masonry_block_alternation_text_image_text_template" groups="base.group_user">
     <div class="row">
-        <div class="col-md-3 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+        <div class="col-md-3 pt24 pb8 text-center o_cc" data-name="Block">
             <h3>A great title</h3>
             <p>And a great subtitle</p>
         </div>
         <div class="col-md-6 oe_img_bg text-center pt224 pb224" data-name="Block" style="background-image: url(/web/image/mass_mailing.s_masonry_block_default_image_1);">
             <p><br/></p>
         </div>
-        <div class="col-md-3 pt24 pb8 text-center o_cc o_cc2" data-name="Block">
+        <div class="col-md-3 pt24 pb8 text-center o_cc" data-name="Block">
             <h3>A great title</h3>
             <p>And a great subtitle</p>
         </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
@@ -12,7 +12,7 @@
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_1/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_1" class="img-fluid rounded-circle o_editable_media"/>
                         </div>
-                        <div class="col-md-9 col-12">
+                        <div class="col-md-9 col-12 o_cc">
                             <h4><font class="h5-fs">Tony Fred</font></h4>
                             <p class="text-muted mb-3">Chief Executive Officer</p>
                             <p>
@@ -28,7 +28,7 @@
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img alt="" src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_2/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_2" class="img-fluid rounded-circle o_editable_media"/>
                         </div>
-                        <div class="col-md-9 col-12">
+                        <div class="col-md-9 col-12 o_cc">
                             <h4><font class="h5-fs">Mich Stark</font></h4>
                             <p class="text-muted mb-3">Chief Commercial Officer</p>
                             <p>Mich loves taking on challenges. With his multi-year experience as Commercial Director in the software industry, Mich has helped the company to get where it is today. Mich is among the best minds.</p>
@@ -40,7 +40,7 @@
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img alt="" src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_3/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_3" class="img-fluid rounded-circle o_editable_media"/>
                         </div>
-                        <div class="col-md-9 col-12">
+                        <div class="col-md-9 col-12 o_cc">
                             <h4><font class="h5-fs">Aline Turner</font></h4>
                             <p class="text-muted mb-3">Chief Technical Officer</p>
                             <p>Aline is one of the iconic people in life who can say they love what they do. She mentors 100+ in-house developers and looks after the community of thousands of developers.</p>
@@ -52,7 +52,7 @@
                         <div class="col-md-3 col-12 pb24 o_not_editable" contenteditable="false">
                             <img alt="" src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_4/html_builder/geometric_round/geo_round_circle.svg" data-shape="html_builder/geometric_round/geo_round_circle" data-original-src="/web/image/mass_mailing.s_company_team_default_image_4" class="img-fluid rounded-circle o_editable_media"/>
                         </div>
-                        <div class="col-md-9 col-12">
+                        <div class="col-md-9 col-12 o_cc">
                             <h4><font class="h5-fs">Iris Joe</font></h4>
                             <p class="text-muted mb-3">Chief Financial Officer</p>
                             <p>Iris, with her international experience, helps us easily understand the numbers and improves them. She is determined to drive success and delivers her professional acumen to bring the company to the next level.</p>
@@ -68,7 +68,6 @@
     <section class="s_company_team_shapes o_mail_snippet_general o_cc o_cc2 pt48 pb48">
         <div class="container">
             <h2 style="text-align: center;">Our talented crew</h2>
-            <p><br/></p>
             <div class="row">
                 <div class="col-6 col-md-4 pb24">
                     <div class="mb-3 o_not_editable"><img src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_1/html_builder/geometric_round/geo_round_square.svg" class="img img-fluid o_editable_media" alt="" data-original-src="/web/image/mass_mailing.s_company_team_default_image_1" data-shape="html_builder/geometric_round/geo_round_square" data-original-mimetype="image/jpeg" data-file-name="s_company_team_image_1.svg" data-shape-colors=";;;;" style="width: 100% !important;"/></div>
@@ -106,9 +105,9 @@
                 <h2>Customers testimonials</h2>
                 <p>What our customers are saying about us.</p>
             </div>
-            <div class="row align-items-stretch">
+            <div class="row">
                 <div class="col-md-6 col-12 pt16 pb16">
-                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc o_cc1 d-flex flex-column gap-4 w-100 h-100 mx-autorounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
+                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc w-100 h-100 mx-auto rounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
                         <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
                             <p class="mb-0 s_rating_title"><strong>Rating</strong></p>
                             <div class="s_rating_icons o_not_editable">
@@ -123,8 +122,10 @@
                                 </span>
                             </div>
                         </div>
-                        <p class="mb-auto">"Engaging with this team was effortless from start to end. Their proficiency and meticulous approach greatly enhanced our project. I couldn't be happier with the final product!"</p>
-                        <div class="row ms-0 flex-row align-items-start justify-content-start text-start s_blockquote_infos">
+                        <div class="py-4">
+                            <p class="mb-0">"Engaging with this team was effortless from start to end. Their proficiency and meticulous approach greatly enhanced our project. I couldn't be happier with the final product!"</p>
+                        </div>
+                        <div class="row ms-0 s_blockquote_infos">
                             <div class="px-0 col-md-2 col-2 o_not_editable">
                                 <img src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_1/html_builder/geometric_round/geo_round_circle.svg" class="s_blockquote_author_avatar img img-fluid p-0 o_editable_media" data-original-src="/web/image/mass_mailing.s_company_team_default_image_1" alt=""/>
                             </div>
@@ -138,7 +139,7 @@
                     </blockquote>
                 </div>
                 <div class="col-md-6 col-12 pt16 pb16">
-                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc o_cc1 d-flex flex-column gap-4 w-100 h-100 mx-autorounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
+                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc w-100 h-100 mx-auto rounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
                         <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
                             <p class="mb-0 s_rating_title"><strong>Rating</strong></p>
                             <div class="s_rating_icons o_not_editable">
@@ -153,8 +154,10 @@
                                 </span>
                             </div>
                         </div>
-                        <p class="mb-auto">"Working with this team was smooth and efficient at every stage. Their skills and commitment to quality had a major impact on our project. I am thrilled with the final results!"</p>
-                        <div class="row ms-0 s_blockquote_infos flex-row align-items-start justify-content-start text-start">
+                        <div class="py-4">
+                            <p class="mb-auto">"Working with this team was smooth and efficient at every stage. Their skills and commitment to quality had a major impact on our project. I am thrilled with the final results!"</p>
+                        </div>
+                        <div class="row ms-0 s_blockquote_infos">
                             <div class="px-0 col-md-2 col-2 o_not_editable">
                                 <img src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_2/html_builder/geometric_round/geo_round_circle.svg" class="s_blockquote_author_avatar img img-fluid p-0 o_editable_media" data-original-src="/web/image/mass_mailing.s_company_team_default_image_2" alt=""/>
                             </div>
@@ -168,7 +171,7 @@
                     </blockquote>
                 </div>
                 <div class="col-md-6 col-12 pt16 pb16">
-                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc o_cc1 d-flex flex-column gap-4 w-100 h-100 mx-autorounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
+                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc w-100 h-100 mx-auto rounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
                         <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
                             <p class="mb-0 s_rating_title"><strong>Rating</strong></p>
                             <div class="s_rating_icons o_not_editable">
@@ -183,8 +186,10 @@
                                 </span>
                             </div>
                         </div>
-                        <p class="mb-auto">"From the first meeting, it was clear we were in good hands. They took our vision and turned it into something even better than we had imagined. Highly recommend!"</p>
-                        <div class="row ms-0 flex-row align-items-start justify-content-start text-start s_blockquote_infos">
+                        <div class="py-4">
+                            <p class="mb-auto">"From the first meeting, it was clear we were in good hands. They took our vision and turned it into something even better than we had imagined. Highly recommend!"</p>
+                        </div>
+                        <div class="row ms-0 s_blockquote_infos">
                             <div class="px-0 col-md-2 col-2 o_not_editable">
                                 <img src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_4/html_builder/geometric_round/geo_round_circle.svg" data-original-src="/web/image/mass_mailing.s_company_team_default_image_4" class="s_blockquote_author_avatar img img-fluid rounded-circle p-0 o_editable_media" alt=""/>
                             </div>
@@ -198,7 +203,7 @@
                     </blockquote>
                 </div>
                 <div class="col-md-6 col-12 pt16 pb16">
-                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc o_cc1 d-flex flex-column gap-4 w-100 h-100 mx-autorounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
+                    <blockquote class="s_mail_blockquote s_blockquote oe_unmovable o_mail_snippet_general o_cc w-100 h-100 mx-auto rounded fst-normal" data-snippet="s_blockquote" data-name="Review" style="border: 0;border-radius: 6.4px !important;">
                         <div class="s_rating s_rating_no_title" data-snippet="s_rating" data-name="Rating" data-vcss="001" data-icon="fa-star" aria-label="4 out of 5 stars">
                             <p class="mb-0 s_rating_title"><strong>Rating</strong></p>
                             <div class="s_rating_icons o_not_editable">
@@ -213,8 +218,10 @@
                                 </span>
                             </div>
                         </div>
-                        <p class="mb-auto">"Exceptional service and great communication throughout the entire process. They went above and beyond to ensure our project was a complete success."</p>
-                        <div class="row ms-0 flex-row align-items-start justify-content-start text-start s_blockquote_infos">
+                        <div class="py-4">
+                            <p class="mb-auto">"Exceptional service and great communication throughout the entire process. They went above and beyond to ensure our project was a complete success."</p>
+                        </div>
+                        <div class="row ms-0 s_blockquote_infos">
                             <div class="px-0 col-md-2 col-2 o_not_editable">
                                 <img src="/html_editor/image_shape/mass_mailing.s_company_team_default_image_5/html_builder/geometric_round/geo_round_circle.svg" class="s_blockquote_author_avatar img img-fluid rounded-circle p-0 o_editable_media" data-original-src="/web/image/mass_mailing.s_company_team_default_image_5" alt=""/>
                             </div>

--- a/addons/mass_mailing/views/snippets/mass_mailing_text_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_text_snippets.xml
@@ -12,7 +12,7 @@
     <section class="s_link_list o_mail_snippet_general pt40 pb32">
         <div class="container">
             <div class="row">
-                <div class="offset-md-1 col-md-10 col-12">
+                <div class="col-md-12 col-12">
                     <h3>DON'T MISS THIS</h3>
                     <ul>
                         <li>
@@ -103,11 +103,11 @@
 </template>
 
 <template id="s_pricelist_boxed" name="Pricelist Boxed">
-    <section class="s_pricelist_boxed o_mail_snippet_general pt72 pb72 o_colored_level" data-scroll-background-ratio="1">
+    <section class="s_pricelist_boxed o_mail_snippet_general pt72 pb72 o_colored_level">
         <div class="container">
             <div class="row">
-                <div class="offset-md-2 col-md-8 px-3 pt48 pb48 o_cc o_cc1 col-12" data-name="Menu">
-                    <div class="row">
+                <div class="col-md-12 px-3 pt48 pb48 o_cc col-12" data-name="Menu">
+                    <div class="row mx-auto">
                         <div class="col-md-12" data-name="Menu Heading">
                             <h2 style="text-align:center;">Our Menu</h2>
                             <p style="text-align:center;">Savor our fresh, local cuisine with a modern twist.<br/>Deliciously crafted for every taste!</p>
@@ -179,7 +179,7 @@
                 </div>
             </div>
             <div class="col-md-2 col-3">
-                <p t-out="price"></p>
+                <p t-out="price" style="text-align: right;"></p>
             </div>
         </div>
         <div t-if="description" class="row">

--- a/addons/mass_mailing/views/snippets_themes.xml
+++ b/addons/mass_mailing/views/snippets_themes.xml
@@ -111,12 +111,12 @@
     <section class="s_header_text_social o_mail_block_header_text_social o_mail_snippet_general" data-name="Left Text">
         <div class="container">
             <div class="row">
-                <div class="col-md-4 pt16 pb16">
+                <div class="col-md-6 pt16 pb16">
                     <h1>
                         <a t-att-href="(company_id.website) or '#'" target="_blank" t-out="company_id.partner_id.name"/>
                     </h1>
                 </div>
-                <div class="col-md-8 o_mail_header_social" style="text-align: right;">
+                <div class="col-md-6 o_mail_header_social" style="text-align: right;">
                     <t t-call="mass_mailing.social_links"/>
                 </div>
             </div>


### PR DESCRIPTION
This commit fixes some UX issues and improves upon the already in place options
and snippets.

These fixes allow for a better usage of the builder and user-friendlier options
for some of the snippets.

We reintroduced the PowerButtonsPlugin inside the mass_mailing builder which
needed adjustments for the position computations and the calls to the position
updates.
The position computations didn't take into account that the editable can be
inside an iframe. This means that the reference position between an editable in
the proper document and an iframe's document could be different as the local
overlay doesn't sit at the same position. In the case of the iframe, the local
overlay sits right beside the iframe which means that we need to not take into
account the buttons position when computing the style attribute. A compensation
for the iframeElement's DOMRect was thus added to it when in this case.

We also added the editable as permanent part of the scrollable elements inside
the `PositionPlugin`. This enables the fullscreen mode to handle scrolling to
update the position of the buttons.

This commit also removes some usages of the d-flex class as the `display: flex`
css property isn't well supported inside email client. Thus, we are starting the
cleaning process so that the convert_inline can have an easier job converting
the email to a client-friendly format.

task-5380467

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
