### PR TITLE
[FIX] website: fix test snippets_all_drag_and_drop with popup

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -93,13 +93,9 @@ for (let snippet of snippetsNames) {
             run: "click",
         });
     } else if (isModal) {
-        snippetSteps.splice(5, 2, {
+        snippetSteps.splice(5, 0, {
             content: `Make sure ${snippet.name} is shown`,
             trigger: ":iframe body.modal-open",
-        }, {
-            content: `Hide the ${snippet.name} popup`,
-            trigger: `:iframe [data-snippet='${snippet.name}'] .s_popup_close`,
-            run: "click",
         });
     } else if (isDropInOnlySnippet) {
         // The 'drop in only' snippets have their 'data-snippet' attribute


### PR DESCRIPTION
**Problem**
Before this commit, the tour `test_03_snippets_all_drag_and_drop` could fail with the error `Element (:iframe .o_snippet_preview_wrap[data-snippet-id="s_popup"]) has not been found`. The failure was reproducible locally and appeared non-deterministically on runbot.

**Cause**
The tour steps could occasionally execute too quickly, leading to non-determinist behavior where snippets were dropped inside a popup that had been inserted but not yet closed. When the dropzone is inside an open popup, some snippets (e.g. `s_popup`) are excluded from the Snippet Viewer, resulting in the error reported above.

**Solution**
The tour flow is modified such that popup snippets are removed after being dropped, as already happens for every other snippet category. This completely removes the risk that new snippets are dropped into a popup.

**Note**
This bug was already fixed starting from version 19.0 by [1]. The performance boost indroduced by [2] made the same bug appear also on 18.4, thus the need for this commit.

[1]: https://github.com/odoo/odoo/pull/242231
[2]: https://github.com/odoo/odoo/pull/243102

runbot-233328
