### PR TITLE
[IMP] account: improve form and list views of bills

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -749,6 +749,7 @@ class AccountMove(models.Model):
         groups="account.group_account_invoice,account.group_account_readonly",
     )
     duplicated_ref_ids = fields.Many2many(comodel_name='account.move', compute='_compute_duplicated_ref_ids')
+    is_draft_duplicated_ref_ids = fields.Boolean(compute="_compute_is_draft_duplicated_ref_ids")
     need_cancel_request = fields.Boolean(compute='_compute_need_cancel_request')
 
     show_update_fpos = fields.Boolean(string="Has Fiscal Position Changed", store=False)  # True if the fiscal position was changed
@@ -1499,6 +1500,7 @@ class AccountMove(models.Model):
                     'move_id': line.move_id.id,
                     'date': fields.Date.to_string(line.date),
                     'account_payment_id': line.payment_id.id,
+                    'move_ref': line.ref or "",
                 })
 
             if payments_widget_vals['content']:
@@ -2054,7 +2056,7 @@ class AccountMove(models.Model):
             move.duplicated_ref_ids = move_to_duplicate_move.get(move._origin, self.env['account.move'])
 
     def _fetch_duplicate_reference(self, matching_states=('draft', 'posted')):
-        moves = self.filtered(lambda m: m.is_sale_document() or m.is_purchase_document() and m.ref)
+        moves = self.filtered(lambda m: m.is_sale_document() or m.is_purchase_document())
 
         if not moves:
             return {}
@@ -2103,13 +2105,23 @@ class AccountMove(models.Model):
                 move.move_type in ('in_invoice', 'in_refund')
                 AND duplicate_move.move_type in ('in_invoice', 'in_refund')
                 AND (
-                   move.ref = duplicate_move.ref
-                   AND (
-                       move.invoice_date IS NULL
-                       OR
-                       duplicate_move.invoice_date IS NULL
-                       OR
-                       date_part('year', move.invoice_date) = date_part('year', duplicate_move.invoice_date)
+                   -- case 1: same ref and (no date or same year)
+                     (
+                         move.ref = duplicate_move.ref
+                         AND (
+                             move.invoice_date IS NULL
+                             OR
+                             duplicate_move.invoice_date IS NULL
+                             OR
+                             date_part('year', move.invoice_date) = date_part('year', duplicate_move.invoice_date)
+                         )
+                     )
+                     -- case 2: different refs, same partner, amount and date
+                     OR (
+                            move.commercial_partner_id = duplicate_move.commercial_partner_id
+                            AND move.amount_total = duplicate_move.amount_total
+                            AND move.amount_total != 0.0
+                            AND move.invoice_date = duplicate_move.invoice_date
                    )
                 )
             """)
@@ -2143,6 +2155,11 @@ class AccountMove(models.Model):
             self.env['account.move'].browse(move_id): self.env['account.move'].browse(duplicate_ids)
             for move_id, duplicate_ids in result
         }
+
+    @api.depends('duplicated_ref_ids')
+    def _compute_is_draft_duplicated_ref_ids(self):
+        for move in self:
+            move.is_draft_duplicated_ref_ids = any(duplicate_move.state == 'draft' for duplicate_move in move.duplicated_ref_ids)
 
     @api.depends('company_id')
     def _compute_display_qr_code(self):
@@ -5205,7 +5222,10 @@ class AccountMove(models.Model):
         if self.env.context.get('name_as_amount_total'):
             currency_amount = self.currency_id.format(self.amount_total)
             if self.state == 'posted':
-                return _("%(ref)s (%(currency_amount)s)", ref=(self.ref or self.name), currency_amount=currency_amount)
+                ref = f" - {self.ref}" if self.ref else ""
+                return _("%(name)s%(ref)s at %(currency_amount)s", name=(self.name), ref=ref, currency_amount=currency_amount)
+            if self.name:
+                return _("%(name)s - Draft at (%(currency_amount)s)", name=(self.name), currency_amount=currency_amount)
             else:
                 return _("Draft (%(currency_amount)s)", currency_amount=currency_amount)
         name = ''
@@ -6117,6 +6137,10 @@ class AccountMove(models.Model):
 
     def action_activate_currency(self):
         self.currency_id.filtered(lambda currency: not currency.active).write({'active': True})
+
+    def action_delete_duplicates(self):
+        for move in self:
+            move.duplicated_ref_ids.unlink()
 
     def _get_mail_template(self):
         """

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -5,64 +5,67 @@
     <t t-name="account.AccountPaymentField">
         <div>
             <t t-set="info" t-value="this.getInfo()"/>
-            <t t-if="info.outstanding">
-                <div>
-                    <strong class="float-start" id="outstanding" t-out="info.title"/>
-                </div>
-            </t>
-            <table style="width:100%;">
-                <t t-foreach="info.lines" t-as="line" t-key="line_index">
-                    <tr>
+            <div class="d-flex flex-column align-items-end">
+                <table class="w-auto">
                     <t t-if="info.outstanding">
-                        <td>
-                            <a title="assign to invoice"
-                               role="button"
-                               class="oe_form_field btn btn-secondary outstanding_credit_assign d-print-none"
-                               t-att-data-id="line.id"
-                               style="margin-right: 0px; padding-left: 5px; padding-right: 5px;"
-                               href="#"
-                               data-bs-toggle="tooltip"
-                               t-on-click.prevent="() => this.assignOutstandingCredit(info.moveId, line.id)">Add</a>
-                        </td>
-                        <td style="max-width: 11em;">
-                            <a t-att-title="(line.bank_label ? line.bank_label + ' - ' : '') + line.formattedDate"
-                               role="button"
-                               class="oe_form_field btn btn-link open_account_move"
-                               t-on-click="() => this.openMove(line.move_id)"
-                               style="margin-right: 5px; text-overflow: ellipsis; overflow: hidden; white-space: nowrap; padding-left: 0px; width:100%; text-align:left;"
-                               data-bs-toggle="tooltip"
-                               t-att-payment-id="account_payment_id"
-                               t-out="line.journal_name"/>
-                        </td>
+                        <tr>
+                            <td colspan="2" class="text-start">
+                                <strong id="outstanding" t-out="info.title"/>
+                            </td>
+                        </tr>
                     </t>
-                    <t t-if="!info.outstanding">
-                        <td>
-                           <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line_index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-bs-toggle="tooltip" t-on-click.stop="(ev) => this.onInfoClick(ev, line)"></a>
+                    <t t-foreach="info.lines" t-as="line" t-key="line_index">
+                        <tr>
+                        <t t-if="info.outstanding">
+                            <td t-out="line.formattedDate"/>
+                            <td style="max-width: 9rem;">
+                                <a t-att-title="(line.bank_label ? line.bank_label + ' - ' : '') + (line.move_ref ? line.move_ref : '')"
+                                   role="button"
+                                   class="open_account_move oe_form_field btn btn-link w-100 text-start"
+                                   t-on-click="() => this.openMove(line.move_id)"
+                                   data-bs-toggle="tooltip"
+                                   t-att-payment-id="account_payment_id"
+                                   t-out="line.journal_name"/>
+                            </td>
+                            <td class="ps-2">
+                                <a title="assign to invoice"
+                                   role="button"
+                                   class="oe_form_field btn btn-secondary outstanding_credit_assign d-print-none text-truncate w-100 text-start"
+                                   t-att-data-id="line.id"
+                                   href="#"
+                                   data-bs-toggle="tooltip"
+                                   t-on-click.prevent="() => this.assignOutstandingCredit(info.moveId, line.id)">Add</a>
+                            </td>
+                        </t>
+                        <t t-if="!info.outstanding">
+                            <td>
+                               <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line_index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-bs-toggle="tooltip" t-on-click.stop="(ev) => this.onInfoClick(ev, line)"></a>
+                            </td>
+                            <td t-if="!line.is_exchange">
+                                <i class="o_field_widget text-start o_payment_label">
+                                    <t t-if="line.is_refund">Reversed on </t>
+                                    <t t-else="">Paid on </t>
+                                    <t t-out="line.formattedDate"></t>
+                                </i>
+                            </td>
+                            <td t-if="line.is_exchange" colspan="2">
+                                <i class="o_field_widget text-start text-muted text-start">
+                                    <span class="oe_form_field oe_form_field_float oe_form_field_monetary fw-bold">
+                                        <t t-out="line.amount_formatted"/>
+                                    </span>
+                                    <span> Exchange Difference</span>
+                                </i>
+                            </td>
+                        </t>
+                        <td t-if="!line.is_exchange" class="text-end ps-2 text-nowrap">
+                            <span class="oe_form_field oe_form_field_float oe_form_field_monetary">
+                                <t t-out="line.amount_formatted"/>
+                            </span>
                         </td>
-                        <td t-if="!line.is_exchange">
-                            <i class="o_field_widget text-start o_payment_label">
-                                <t t-if="line.is_refund">Reversed on </t>
-                                <t t-else="">Paid on </t>
-                                <t t-out="line.formattedDate"></t>
-                            </i>
-                        </td>
-                        <td t-if="line.is_exchange" colspan="2">
-                            <i class="o_field_widget text-start text-muted text-start">
-                                <span class="oe_form_field oe_form_field_float oe_form_field_monetary fw-bold">
-                                    <t t-out="line.amount_formatted"/>
-                                </span>
-                                <span> Exchange Difference</span>
-                            </i>
-                        </td>
+                        </tr>
                     </t>
-                    <td t-if="!line.is_exchange" style="text-align:right;">
-                        <span class="oe_form_field oe_form_field_float oe_form_field_monetary" style="margin-left: -10px;">
-                            <t t-out="line.amount_formatted"/>
-                        </span>
-                    </td>
-                    </tr>
-                </t>
-            </table>
+                </table>
+            </div>
         </div>
     </t>
 

--- a/addons/account/static/src/components/bill_guide/bill_guide.js
+++ b/addons/account/static/src/components/bill_guide/bill_guide.js
@@ -46,6 +46,17 @@ export class BillGuide extends Component {
             type: 'object',
         });
     }
+
+    openVendorBill() {
+        return this.action.doAction({
+            type: "ir.actions.act_window",
+            res_model: "account.move",
+            views: [[false, "form"]],
+            context: {
+                default_move_type: "in_invoice",
+            },
+        });
+    }
 }
 
 

--- a/addons/account/static/src/components/bill_guide/bill_guide.scss
+++ b/addons/account/static/src/components/bill_guide/bill_guide.scss
@@ -18,6 +18,16 @@
     }
 }
 
+.bill-guide-img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.mb-9 {
+    margin-bottom: 9rem;
+}
+
 .account_drag_drop_btn {
     border-style: dashed !important;
     border-color: $o-brand-primary;

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -1,25 +1,25 @@
 <templates>
 
     <t t-name="account.BillGuide">
-        <div class="d-flex flex-row bill_guide_container mb-3">
-            <div class="bill_guide_left flex-shrink-0 py-3">
-                <div class="text-center">
-                    <img class="img-fluid" src="/web/static/img/folder.svg"/>
-                </div>
-                <div class="text-center mt-2">
-                    <span class="btn account_drag_drop_btn pe-none">Drag &amp; drop</span>
-                    <div>
-                        <span class="btn pe-none px-1 fw-normal">or</span>
-                        <a class="btn btn-link px-0 fw-normal"
-                            href="#"
-                            type="object"
-                            name="action_create_vendor_bill"
-                            journal_type="purchase"
-                            groups="account.group_account_invoice"
-                            t-on-click="() => this.handleButtonClick('action_create_vendor_bill')"
-                        >
-                            try our sample
-                        </a>
+         <div class="d-flex flex-row bill_guide_container mb-9">
+            <div class="bill_guide_left d-flex align-items-center justify-content-center py-3">
+                <div>
+                    <img class="bill-guide-img" src="/web/static/img/folder.svg"/>
+                    <div class="text-center mt-2">
+                        <span class="btn btn-lg account_drag_drop_btn pe-none">Drag &amp; drop</span>
+                        <div>
+                            <span class="btn pe-none px-1 fw-normal">or</span>
+                            <a class="btn btn-lg btn-link px-0 fw-normal"
+                                href="#"
+                                type="object"
+                                name="action_create_vendor_bill"
+                                journal_type="purchase"
+                                groups="account.group_account_invoice"
+                                t-on-click="() => this.handleButtonClick('action_create_vendor_bill')"
+                            >
+                                try our sample
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -32,11 +32,9 @@
                     <div class="vertical-line border-start flex-grow-1 mb-2"/>
                 </div>
             </div>
-            <div class="bill_guide_right flex-shrink-0 py-3">
+            <div class="bill_guide_right d-flex align-items-center justify-content-center py-3">
                 <div t-if="alias">
-                    <div class="text-center">
-                        <img class="img-fluid" src="/account/static/src/img/bill.svg" alt="Email bills"/>
-                    </div>
+                    <img class="bill-guide-img" src="/account/static/src/img/bill.svg" alt="Email bills"/>
                     <div class="text-center mt-2">
                         <div class="">
                             <span class="btn pe-none px-1 fw-normal">Send a bill to</span>
@@ -56,17 +54,13 @@
                     </div>
                 </div>
                 <div t-else="">
-                    <div class="text-center">
-                        <img class="img-fluid"
-                            src="/web/static/img/bill.svg"
-                            alt="Create bill manually"/>
-                    </div>
+                    <img class="bill-guide-img" src="/web/static/img/bill.svg" alt="Create bill manually"/>
                     <div class="text-center mt-2">
                         <div class="">
                             <a href="#"
                                 type="object"
                                 class="o_invoice_new"
-                                t-on-click="() => this.handleButtonClick('action_create_new')"
+                                t-on-click="() => this.openVendorBill()"
                                 groups="account.group_account_invoice"
                             >
                                 Create a bill manually

--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
@@ -9,6 +9,7 @@ class X2ManyButtons extends Component {
     static props = {
         ...standardFieldProps,
         treeLabel: { type: String },
+        nbRecordsShown: { type: Number, optional: true },
     };
 
     setup() {
@@ -50,5 +51,8 @@ X2ManyButtons.template = "account.X2ManyButtons";
 registry.category("fields").add("x2many_buttons", {
     component: X2ManyButtons,
     relatedFields: [{ name: "display_name", type: "char" }],
-    extractProps: ({ string }) => ({ treeLabel: string || _t("Records") }),
+    extractProps: ({ attrs, string }) => ({
+        treeLabel: string || _t("Records"),
+        nbRecordsShown: attrs.nb_records_shown ? parseInt(attrs.nb_records_shown) : 3,
+    }),
 });

--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
@@ -2,14 +2,14 @@
 <templates>
     <t t-name="account.X2ManyButtons">
         <div class="d-flex align-items-center">
-            <t t-foreach="this.currentField.records.slice(0, 3)" t-as="record" t-key="record.id">
+            <t t-foreach="this.currentField.records.slice(0, props.nbRecordsShown)" t-as="record" t-key="record.id">
                 <button class="btn btn-link p-0"
                         t-on-click="() => this.openFormAndDiscard(record.resId)"
                         t-att-data-hotkey="`shift+${record_index + 1}`"
                         t-out="record.data.display_name"/>
                 <span t-if="!record_last" class="pe-1">,</span>
             </t>
-            <t t-if="this.currentField.count gt 3">
+            <t t-if="this.currentField.count gt props.nbRecordsShown">
                 <button class="btn btn-link p-0" t-on-click="() => this.openTreeAndDiscard()" data-hotkey="shift+4">... (View all)</button>
             </t>
         </div>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -722,11 +722,11 @@
                         <button name="action_print_pdf"
                                 type="object"
                                 class="oe_highlight"
-                                invisible="state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type == 'entry'"
+                                invisible="state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type in ('entry', 'in_invoice','in_refund','in_receipt')"
                                 string="Print"/>
                         <button name="action_print_pdf"
                                 type="object"
-                                invisible="state != 'posted' or (not is_being_sent and not invoice_pdf_report_id)"
+                                invisible="state != 'posted' or (not is_being_sent and not invoice_pdf_report_id) or move_type in ('in_invoice','in_refund','in_receipt')"
                                 string="Print"/>
                         <!-- Register Payment (only invoices / receipts) -->
                         <button name="action_register_payment" id="account_invoice_payment_btn"
@@ -798,9 +798,17 @@
                         <field name="alerts" class="o_field_html" widget="actionable_errors"/>
                     </div>
                     <!--Duplicate check-->
-                    <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="not duplicated_ref_ids"  role="alert">
+                    <div class="d-flex alert alert-warning w-100 d-flex align-items-center gap-1" invisible="not duplicated_ref_ids"  role="alert">
                         <span>This document might be a duplicate of</span>
-                        <field name="duplicated_ref_ids" widget="x2many_buttons" string="Duplicated Documents" context="{'name_as_amount_total': True}"/>
+                        <field name="duplicated_ref_ids" widget="x2many_buttons" nb_records_shown="1" string="Duplicated Documents" context="{'name_as_amount_total': True}"/>
+                        <button name="action_delete_duplicates"
+                                type="object"
+                                class="btn btn-link text-danger ms-auto d-flex align-items-center gap-1"
+                                invisible="not is_draft_duplicated_ref_ids">
+                            <i class="fa fa-trash text-danger"/>
+                            <span class="text-danger" invisible="duplicated_ref_ids.length == 1">Delete all duplicates</span>
+                            <span class="text-danger" invisible="duplicated_ref_ids.length &gt; 1">Delete duplicate</span>
+                        </button>
                     </div>
                     <!-- Invoice outstanding credits -->
                     <div groups="account.group_account_invoice,account.group_account_readonly"
@@ -1336,7 +1344,7 @@
                                             <field name="tax_totals" widget="account-tax-totals-field" nolabel="1" colspan="2"
                                                    readonly="state != 'draft' or (move_type not in ('in_invoice', 'in_refund', 'in_receipt') and not quick_edit_mode)"/>
 
-                                            <field name="invoice_payments_widget" colspan="2" nolabel="1" widget="payment"/>
+                                            <field name="invoice_payments_widget" colspan="2" nolabel="1" widget="payment" invisible="not invoice_payments_widget"/>
                                             <field name="amount_residual" class="oe_subtotal_footer_separator"/>
                                         </group>
                                         <group

--- a/addons/account_edi_ubl_cii/tests/test_autopost_bills.py
+++ b/addons/account_edi_ubl_cii/tests/test_autopost_bills.py
@@ -1,5 +1,5 @@
 import base64
-from datetime import datetime
+from datetime import datetime, date, timedelta
 from xml.etree import ElementTree as et
 
 from odoo import fields
@@ -12,13 +12,15 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 @tagged('post_install', '-at_install')
 class TestAutoPostBills(AccountTestInvoicingCommon):
 
-    def import_facturx(self, filename='facturx_out_invoice.xml', ref=None):
+    def import_facturx(self, filename='facturx_out_invoice.xml', ref=None, date=None):
         self.env.cr._now = datetime.now()  # reset transaction's NOW, otherwise all move will have the same create_date
         with (file_open(f"account_edi_ubl_cii/tests/test_files/{filename}", 'rb', filter_ext=('.xml',)) as file):
             file_read = file.read()
             tree = et.ElementTree(et.fromstring(file_read.decode()))
             if ref:
                 tree.find('./{*}ExchangedDocument/{*}ID').text = ref
+            if date:
+                tree.find('./{*}ExchangedDocument/{*}IssueDateTime/{*}DateTimeString').text = date
             attachment = self.env['ir.attachment'].create({
                 'name': 'test_file.xml',
                 'datas': base64.encodebytes(et.tostring(tree.getroot())),
@@ -80,7 +82,7 @@ class TestAutoPostBills(AccountTestInvoicingCommon):
         wizard.action_automate_partner()
 
         # Create 4th bill without changes with automation enabled => should automatically post, no popup
-        move = self.import_facturx(ref="refbill4")  # new ref to avoid duplicates
+        move = self.import_facturx(ref="refbill4", date='20170102')  # new ref and date to avoid duplicates
         self.assertEqual(move.state, 'posted')
 
         # Reset
@@ -125,8 +127,9 @@ class TestAutoPostBills(AccountTestInvoicingCommon):
         self.assertEqual(move.state, "draft")
 
         # If there is a significant difference (see abnormal_amount), don't autopost even if 'always' is set
+        base_date = date(2018, 1, 1)
         for i in range(10):  # See test_unexpected_invoice
-            move = self.import_facturx(ref=f"ref{i}")  # automatically posted
+            move = self.import_facturx(ref=f"ref{i}", date=(base_date + timedelta(days=i)).strftime('%Y%m%d'))  # automatically posted
             self.assertEqual(move.state, "posted")
 
         move = self.import_facturx(filename='facturx_out_invoice_abnormal.xml')  # amounts * 100 here, a bit abnormal...


### PR DESCRIPTION
This commit improves the UI of bills, and how duplicates bills are handled and detected, the following changes were made: 
1- the "Drag and drop" icon size was too small, the icon size was increased 

2- the outstanding debits section needed clearer information  when displaying info about the other bills/transactions,    dates are now always visible and hovering shows the reference

3- There was no use for the print button on a bill, it was removed 

4- A bill could be a duplicate even if the reference was not set, before this commit, that behavior was not recognized, Also the displayed name for duplicate bills was not clear, making it difficult to recognize a bill just from its name

5- A delete all button (for duplicate bills) was added

This commit is the first part of this task, second part targeting master 
task-5258726
