### PR TITLE
[FIX] mail: no traceback on member typing in group chats

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -1,4 +1,5 @@
 import { ImStatus } from "@mail/core/common/im_status";
+import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
 
 import { Component, useEffect, useRef, useState, useSubEnv } from "@odoo/owl";
@@ -33,7 +34,8 @@ class ChatBubblePreview extends Component {
  * @extends {Component<Props, Env>}
  */
 export class ChatBubble extends Component {
-    static components = { CountryFlag, ImStatus };
+    // @deprecated ImStatus
+    static components = { CountryFlag, ImStatus, ThreadIcon };
     static props = ["chatWindow"];
     static template = "mail.ChatBubble";
 
@@ -78,5 +80,12 @@ export class ChatBubble extends Component {
     /** @returns {import("models").Channel} */
     get channel() {
         return this.props.chatWindow.channel;
+    }
+
+    get showThreadIcon() {
+        return (
+            this.channel.channel_type === "chat" ||
+            (this.channel.channel_type === "group" && this.channel.hasOtherMembersTyping)
+        );
     }
 }

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -5,14 +5,7 @@
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': !channel.isUnread or channel.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="channel.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="channel.importantCounter"/>
             <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
-            <ImStatus t-if="channel.showImStatus" className="'o-mail-ChatBubble-status position-absolute'" member="channel.correspondent">
-                <t t-set-slot="pre_icon">
-                    <i style="font-size: 18px; right: -2px; bottom: -2px; z-index: -1;" t-att-class="{
-                        'bg-success rounded-pill position-absolute': channel.correspondent?.isTyping,
-                        'fa fa-circle position-absolute text-100': !channel.correspondent?.isTyping,
-                    }"/>
-                </t>
-            </ImStatus>
+            <ThreadIcon t-if="showThreadIcon" thread="channel.thread" size="'large'" className="'o-mail-ChatBubble-status position-absolute'"/>
             <CountryFlag t-if="channel.showCorrespondentCountry" country="channel.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border shadow-sm'"/>
             <button class="o-mail-ChatHub-bubbleBtn btn shadow">
                 <img class="o-mail-ChatBubble-avatar bg-view rounded-circle object-fit-cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="channel.avatarUrl" alt="Channel image" draggable="false"/>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -290,10 +290,7 @@ export class DiscussChannel extends Record {
     /** @type {"loaded"|"loading"|"error"|undefined} */
     pinnedMessagesState = undefined;
     get showImStatus() {
-        return (
-            (this.channel_type === "chat" && this.correspondent) ||
-            (this.channel_type === "group" && this.hasOtherMembersTyping)
-        );
+        return this.channel_type === "chat" && this.correspondent;
     }
     sub_channel_ids = fields.Many("discuss.channel", {
         inverse: "parent_channel_id",

--- a/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
+++ b/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
@@ -11,9 +11,9 @@
         </xpath>
     </t>
     <t t-name="mail.ThreadIcon.typing">
-        <div t-if="props.thread.channel.hasOtherMembersTyping" class="bg-inherit rounded-pill" style="padding: 1px;">
+        <div t-if="props.thread.channel.hasOtherMembersTyping" class="rounded-pill" style="padding: 1px;" t-att-class="{ 'bg-300': env.inChatBubble, 'bg-inherit': !env.inChatBubble }"> 
             <div class="bg-success rounded-pill" style="padding: 3px;">
-                <Typing channel="props.thread.channel" size="props.size" displayText="false" />
+                <Typing channel="props.thread.channel" size="['sm', 'smaller'].includes(props.size) ? 'sm' : 'md'" displayText="false" />
             </div>
         </div>
     </t>


### PR DESCRIPTION
Before this commit, when another member of a group chat with more than 2 members was typing it would result in a traceback. Steps to reproduce:
1. Have `hr_homeworking` and/or `hr_holidays` installed
2. Create group chat with 2 other users
3. Open said group chat
4. Have another member start typing -> traceback

This happens because since [1] the condition to show the `ImStatus` component became `showImStatus`, which is true in group chats when another member is typing.
However since group chats with more than 2 members have no correspondent, this leads to the `ImStatus` component having no `persona` attribute, which in turn causes a crashes in templates without a guard on `persona` access.

This commit fixes the issue by making `showImStatus` only true in DMs, since it's not expected for group chats to have a correspondent and hence an IM status should not be shown.

[1]: https://github.com/odoo/odoo/pull/234715