### PR TITLE
[FIX] mail: fixing document visibility issue after an activity edit in the chatter.

### DIFF
--- a/addons/mail/views/mail_activity_plan_template_views.xml
+++ b/addons/mail/views/mail_activity_plan_template_views.xml
@@ -36,7 +36,7 @@
                                 <field class="oe_inline" name="delay_from"/>
                             </div>
                         </group>
-                        <field name="note" nolabel="1" class="oe-bordered-editor" placeholder="e.g. Log a note"/>
+                        <field name="note" nolabel="1" class="oe-bordered-editor" placeholder="e.g. Log a note" widget="html_mail"/>
                     </sheet>
                 </form>
             </field>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -163,7 +163,7 @@
                         </group>
                         <field name="user_id" widget="many2one_avatar_user"/>
                     </group>
-                    <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..." widget="html_mail" />
+                    <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..." widget="html_mail"/>
                     <footer>
                         <field name="id" invisible="1"/>
                         <button id="mail_activity_schedule" string="Schedule" close="1" name="action_close_dialog" type="object" class="btn-primary"
@@ -217,7 +217,7 @@
                             <field name="date_deadline"/>
                         </group>
                     </group>
-                    <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..."/>
+                    <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..." widget="html_mail"/>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
Description:
Previously, when editing an existing activity and attaching new documents from the user’s device, the edits were saved correctly, but the document previews were not displayed in the chatter.

This issue had already been addressed by the framework editor team; however, their fix was not applied to the Mail module.

In this PR, we apply the existing framework fix to the Mail module to restore document preview functionality.

related PR:
https://github.com/odoo/odoo/pull/240114

task-5423808