### PR TITLE
[FIX] stock_account: correct FIFO COGS calculation

### DIFF
--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -69,7 +69,8 @@ class AccountMoveLine(models.Model):
         # FIFO
         moves = self._get_stock_moves().filtered(lambda m: m.state == 'done')
         if not moves:
-            return self.product_id._run_fifo(self.quantity)
+            fifo_value = self.product_id._run_fifo(self.quantity)
+            return fifo_value / self.quantity if self.quantity else fifo_value
 
         price_unit = moves._get_price_unit()
         valuation_account = self.product_id.product_tmpl_id.get_product_accounts(fiscal_pos=self.move_id.fiscal_position_id)['stock_valuation']


### PR DESCRIPTION
The COGS value was incorrectly computed for FIFO products with perpetual valuation when quantities were greater than one.

Steps to reproduce:
- Create a product with FIFO and perpetual valuation
- Create and receive a purchase order of 10 units at $10 per unit
- Create and validate a vendor bill for 10 units at $10 per unit
- The COGS line shows $1000 instead of $100

Root cause:
The `_run_fifo` method returns the total stock move value and not the unit price when the quantity is greater than one.

Fix:
The correction is applied in `_get_cogs_value`, which explicitly expects and returns the unit price.

opw-5430902
opw-5438827