### PR TITLE
[FIX] stock_account: Handle average cost in negative quantity

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -345,14 +345,16 @@ class ProductProduct(models.Model):
                     lot_qty = move._get_valued_qty(lot)
                     in_value = (in_value * lot_qty / in_qty) if in_qty else 0
                     in_qty = lot_qty
-                if quantity < 0 and quantity + in_qty >= 0:
-                    positive_qty = quantity + in_qty
-                    ratio = positive_qty / in_qty
-                    avco_total_value = ratio * in_value
-                else:
-                    avco_total_value += in_value
+                previous_qty = quantity
                 quantity += in_qty
-                avco_value = avco_total_value / quantity if quantity else 0
+                # Regular case, value from accumulation
+                if previous_qty > 0:
+                    avco_total_value += in_value
+                    avco_value = avco_total_value / quantity
+                # From negative quantity case, value from last_in
+                elif previous_qty <= 0:
+                    avco_value = in_value / in_qty if in_qty else avco_value
+                    avco_total_value = avco_value * quantity
             if move.is_out or move.is_dropship:
                 out_qty = move._get_valued_qty()
                 out_value = out_qty * avco_value

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2956,3 +2956,52 @@ class TestStockValuation(TestStockValuationCommon):
         product_value_form = Form(product_value)
 
         self.assertFalse(product_value_form.current_value_details)
+
+    def test_average_cost_in_negative_quantity(self):
+        self.product_avco.standard_price = 10
+
+        self._make_out_move(self.product_avco, 10)
+        self.assertEqual(self.product_avco.qty_available, -10)
+        self.assertEqual(self.product_avco.standard_price, 10)
+
+        # New IN cost while staying in negative ==>> standard_price updated to last IN cost (current move)
+        self._make_in_move(self.product_avco, 5, unit_cost=15)
+        self.assertEqual(self.product_avco.qty_available, -5)
+        self.assertEqual(self.product_avco.standard_price, 15)
+
+        # New IN cost while reaching 0 quantity ==>> standard_price updated to last IN cost (current move)
+        self._make_in_move(self.product_avco, 5, unit_cost=20)
+        self.assertEqual(self.product_avco.qty_available, 0)
+        self.assertEqual(self.product_avco.standard_price, 20)
+
+        # Going back to negative for last test
+        self._make_out_move(self.product_avco, 5)
+        self.assertEqual(self.product_avco.qty_available, -5)
+        self.assertEqual(self.product_avco.standard_price, 20)
+
+        # New IN cost while going back to positive ==>> standard_price updated to last IN cost (current move)
+        self._make_in_move(self.product_avco, 10, unit_cost=25)
+        self.assertEqual(self.product_avco.qty_available, 5)
+        self.assertEqual(self.product_avco.standard_price, 25)
+
+    def test_average_cost_dropship_in_negative_quantity(self):
+        self.product_avco.standard_price = 10
+
+        self._make_out_move(self.product_avco, 10)
+        self.assertEqual(self.product_avco.qty_available, -10)
+        self.assertEqual(self.product_avco.standard_price, 10)
+
+        # Make dropship move, where the quantity stay in negative
+        self._make_dropship_move(self.product_avco, 5, unit_cost=15)
+        self.assertEqual(self.product_avco.qty_available, -10)
+        self.assertEqual(self.product_avco.standard_price, 10)
+
+        # Make dropship move, where the quantity reach 0
+        self._make_dropship_move(self.product_avco, 10, unit_cost=15)
+        self.assertEqual(self.product_avco.qty_available, -10)
+        self.assertEqual(self.product_avco.standard_price, 10)
+
+        # Make dropship move, where the quantity do not go in positive
+        self._make_dropship_move(self.product_avco, 15, unit_cost=15)
+        self.assertEqual(self.product_avco.qty_available, -10)
+        self.assertEqual(self.product_avco.standard_price, 10)


### PR DESCRIPTION
## Issue
When doing a receipt with a different Unit Cost than the current one in negative quantity, the average cost would become aberrant.

## Steps to Reproduce
- Create product P, Average Costing method, cost at 0
- Create & Validate a delivery for 10 unit of P
- Create & Confirm a Purchase Order for 5 Units of 0 at *10 / Unit
- Receive the 5 Units ==>> The product standard cost becomes $-10 !
This is because the system sees -5 Units on hand for a total of $50, and do the average. In Odoo 18, the Delivery would have been reevaluated to the receipt value, so the total value after the receipt would have been $0 for -5 Units.

## Solution
When the product quantity is negative, we use the cost from the last receipt as the new average cost.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
