### PR TITLE
[FIX] point_of_sale: test_order_invoice_search tour

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -527,6 +527,11 @@ registry.category("web_tour.tours").add("test_order_invoice_search", {
             Dialog.confirm("Open Register"),
             Chrome.clickOrders(),
             TicketScreen.selectFilter("Paid"),
+            {
+                content:
+                    "Verify that the order is paid; this ensures that the RPC process is complete.",
+                trigger: ".orders .order-row:eq(0):has(.badge.rounded:contains(Paid))",
+            },
         ].flat(),
 });
 


### PR DESCRIPTION
By adding a last step ( that check that there is at least one paid order), we ensure that the RPC is done before closing the tour.

error-runbot-id~233511
error-runbot-id~232677

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
