### PR TITLE
[FIX] stock: force page break on picking report

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -240,6 +240,9 @@
                             <p t-field="o.note"/>
                             <div class="oe_structure"></div>
                         </div>
+                        <t t-if="not o_last">
+                            <p style="page-break-after: always;"/>
+                        </t>
                     </t>
                 </div>
             </t>


### PR DESCRIPTION
When printing several picking operation at once, they are all in the same page.

Steps to reproduce:
-------------------
* Inventory>Operations>Deliveries
* Create several Deliveries
* Open list view to see all the deliveries
* Select several deliveries
* Print > Picking Operations -> All the picking operation report are on the same page.

Observation:
-------------
Since the change on the picking report layout
https://github.com/odoo/odoo/pull/152280/changes#diff-7542c191def78bd64f54f1c33fde2c73e19e4d27f92b195c464d1d84e55b682fL6-R8 the report now uses a single article container for all records, this don't trigger automatic page break.

opw-5481034
