### PR TITLE
[REF] im_livechat: remove rating mixins from discuss

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -161,9 +161,10 @@ class ImLivechatChannelMemberHistory(models.Model):
         agent_histories = self.filtered(lambda h: h.livechat_member_type in ("agent", "bot"))
         (self - agent_histories).rating_id = None
         for history in agent_histories:
-            history.rating_id = history.channel_id.rating_ids.filtered(
-                lambda r: r.rated_partner_id == history.partner_id
-            )[:1]  # Live chats only allow one rating.
+            livechat_rating = history.channel_id.livechat_rating
+            history.rating_id = (
+                livechat_rating if livechat_rating.rated_partner_id == history.partner_id else None
+            )
 
     @api.depends("create_date", "channel_id.livechat_end_dt", "channel_id.message_ids")
     def _compute_session_duration_hour(self):

--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -126,11 +126,11 @@ class Im_LivechatReportChannel(models.Model):
                     ELSE C.livechat_failure
                 END AS session_outcome,
                 C.country_id,
-                NULLIF(C.rating_last_value, 0) AS rating,
+                NULLIF(R.rating, 0) AS rating,
                 CASE
-                    WHEN C.rating_last_value = 1 THEN 'Unhappy'
-                    WHEN C.rating_last_value = 5 THEN 'Happy'
-                    WHEN C.rating_last_value = 3 THEN 'Neutral'
+                    WHEN R.rating = 1 THEN 'Unhappy'
+                    WHEN R.rating = 5 THEN 'Happy'
+                    WHEN R.rating = 3 THEN 'Neutral'
                     ELSE null
                 END as rating_text,
                 C.livechat_operator_id as partner_id,
@@ -149,6 +149,7 @@ class Im_LivechatReportChannel(models.Model):
         return SQL(
             """
             FROM discuss_channel C
+            LEFT JOIN rating_rating R ON R.id = C.livechat_rating
        LEFT JOIN LATERAL (
                 SELECT BOOL_OR(livechat_member_type = 'agent') AS has_agent,
                        BOOL_OR(livechat_member_type = 'bot') AS has_bot,

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -71,8 +71,12 @@ class TestImLivechatReport(TestImLivechatCommon):
         self.assertEqual(result[0]["time_to_answer:avg"], 7800 / 3600)
         self.assertEqual(int(result[0]['duration:avg']), 195)
         channel = self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)])
-        rated_channel = channel.copy({"rating_last_value": 5})
+        rated_channel = channel.copy()
+        rated_channel._apply_livechat_feedback(5)
+
         self._create_message(rated_channel, self.operator, "2023-03-18 11:00:00")
+        # flush channel, rating and message before custom sql query
+        self.env.flush_all()
         result = self.env["im_livechat.report.channel"].formatted_read_group([], aggregates=["rating:avg"])
         self.assertEqual(result[0]["rating:avg"], 5, "Rating average should be 5, excluding unrated sessions")
 

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -16,10 +16,10 @@
                     <separator/>
                     <filter name="ongoing" string="Ongoing" domain="[('livechat_end_dt', '=', False)]"/>
                     <separator/>
-                    <filter name="filter_session_rating_happy" domain="[('rating_ids', '!=', False), ('rating_avg', '&gt;=', 3.66)]" string="Happy"/>
-                    <filter name="filter_session_rating_neutral" domain="[('rating_ids', '!=', False), ('rating_avg', '&gt;=', 2.33), ('rating_avg', '&lt;', 3.66)]" string="Neutral"/>
-                    <filter name="fiter_session_rating_unhappy" domain="[('rating_ids', '!=', False), ('rating_avg', '&lt;', 2.33) ]" string="Unhappy"/>
-                    <filter name="filter_session_unrated" domain="[('rating_ids', '=', False)]" string="Unrated"/>
+                    <filter name="filter_session_rating_happy" domain="[('livechat_rating', '!=', False), ('livechat_rating_rating', '&gt;=', 3.66)]" string="Happy"/>
+                    <filter name="filter_session_rating_neutral" domain="[('livechat_rating', '!=', False), ('livechat_rating_rating', '&gt;=', 2.33), ('livechat_rating_rating', '&lt;', 3.66)]" string="Neutral"/>
+                    <filter name="fiter_session_rating_unhappy" domain="[('livechat_rating', '!=', False), ('livechat_rating_rating', '&lt;', 2.33) ]" string="Unhappy"/>
+                    <filter name="filter_session_unrated" domain="[('livechat_rating', '=', False)]" string="Unrated"/>
                     <separator />
                     <filter name="filter_session_date" date="create_date" string="Session Date">
                         <filter name="rated_on_last_24_hours" string="Last 24 Hours" domain="[('create_date', '&gt;', '-1d')]"/>
@@ -31,7 +31,7 @@
                     <group>
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>
                         <filter name="group_by_agent" string="Agent" domain="[]" context="{'group_by':'livechat_agent_partner_ids'}"/>
-                        <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'rating_last_text'}"/>
+                        <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'livechat_rating_text'}"/>
                         <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>
                         <filter name="group_by_customer_partner" string="Customer" domain="[]" context="{'group_by':'livechat_customer_partner_ids'}"/>
                         <separator orientation="vertical"/>
@@ -64,10 +64,10 @@
                     <field name="livechat_channel_id" optional="hide"/>
                     <field name="duration" widget="float_time" options="{'displaySeconds': True}" optional="show"/>
                     <field name="message_count" string="Messages" optional="show"/>
-                    <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
-                        decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
+                    <field name="livechat_rating_text" string="Rating" decoration-danger="livechat_rating_text == 'ko'"
+                        decoration-warning="livechat_rating_text == 'ok'" decoration-success="livechat_rating_text == 'top'"
                         widget="badge" optional="show"/>
-                    <field name="rating_last_feedback" string="Comment" optional="hide"/>
+                    <field name="livechat_rating_feedback" string="Comment" optional="hide"/>
                 </list>
             </field>
         </record>
@@ -96,7 +96,7 @@
                                         </span>
                                     </span>
                                 </div>
-                                <field name="rating_last_image" string="Rating" widget="image" options='{"size": [40, 40], "img_class": "bg-transparent"}' class="ms-auto" invisible="not rating_last_image"/>
+                                <field name="livechat_rating_image" string="Rating" widget="image" options='{"size": [40, 40], "img_class": "bg-transparent"}' class="ms-auto" invisible="not livechat_rating_image"/>
                             </div>
                             <footer class="pt-0">
                                 <t t-if="record.country_id.raw_value">
@@ -125,7 +125,7 @@
                 <pivot string="Sessions" display_quantity="1" sample="1">
                     <field name="livechat_operator_id" type="row"/>
                     <field name="create_date" interval="day" type="col"/>
-                    <field name="rating_last_value" type="measure" string="Rating (%)" widget="im_livechat.rating_percentage"/>
+                    <field name="livechat_rating_rating" type="measure" string="Rating (%)" widget="im_livechat.rating_percentage"/>
                 </pivot>
             </field>
         </record>
@@ -136,7 +136,7 @@
             <field name="arch" type="xml">
                 <graph string="Sessions" sample="1">
                     <field name="create_date" interval="day"/>
-                    <field name="rating_last_value" type="measure" string="Rating (%)" widget="im_livechat.rating_percentage"/>
+                    <field name="livechat_rating_rating" type="measure" string="Rating (%)" widget="im_livechat.rating_percentage"/>
                 </graph>
             </field>
         </record>


### PR DESCRIPTION
Before this PR, `rating.mixin` and `rating.parent.mixin` were used in `livechat.channel` and `discuss.channel` for inheritance. This means discuss channel is closely related to `rating.mixin` and therefore by inference `mail.thread`.

This prevents us to go forward with the split of discuss and thread.

In this PR, we are removing those inheritance, because the rating is too generic/difficult for a simple rating at the end of a livechat and the reasons stated above.

This was done by directly linking the rating in a field `livechat_rating` and moving some rating calculations directly in the `discuss.channel` model.

task-5437285

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
