### PR TITLE
[REF] mail, *: DiscussAppCategory.hidden as local storage field

### DIFF
--- a/addons/im_livechat/static/tests/upgrade_19_2.test.js
+++ b/addons/im_livechat/static/tests/upgrade_19_2.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { patchBrowserNotification, start, startServer } from "@mail/../tests/mail_test_helpers";
+import { makeRecordFieldLocalId } from "@mail/model/misc";
+import { toRawValue } from "@mail/utils/common/local_storage";
+import { getService, serverState } from "@web/../tests/web_test_helpers";
+import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
+import { defineLivechatModels } from "./livechat_test_helpers";
+
+describe.current.tags("desktop");
+defineLivechatModels();
+
+test("Preserves force hide of of livechat looking for help", async () => {
+    // From dev tools can force hide a category like "looking for help", by setting `DiscussAppCategory.hidden = true`
+    localStorage.setItem("mail.sidebar_category_im_livechat.category_need_help_hidden", "true");
+    patchBrowserNotification("default");
+    const LOOKING_FOR_HELP_CATEGORY_HIDDEN_LS = makeRecordFieldLocalId(
+        DiscussAppCategory.localId("im_livechat.category_need_help"),
+        "hidden"
+    );
+    const pyEnv = await startServer();
+    pyEnv["res.users"].write([serverState.userId], {
+        group_ids: pyEnv["res.groups"]
+            .search_read([["id", "=", serverState.groupLivechatId]])
+            .map(({ id }) => id),
+    });
+    await start();
+    expect(
+        getService("mail.store").DiscussAppCategory.get("im_livechat.category_need_help").hidden
+    ).toBe(true);
+    expect(localStorage.getItem(LOOKING_FOR_HELP_CATEGORY_HIDDEN_LS)).toBe(toRawValue(true));
+    expect(
+        localStorage.getItem("mail.sidebar_category_im_livechat.category_need_help_hidden")
+    ).toBe(null);
+});

--- a/addons/mail/static/src/core/public_web/discuss_app/upgrade_19_2.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/upgrade_19_2.js
@@ -1,0 +1,20 @@
+import { addUpgrade } from "@mail/core/common/upgrade/upgrade_helpers";
+
+/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnParam} UpgradeFnParam */
+/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnReturn} UpgradeFnReturn */
+
+export const upgrade_19_2 = {
+    /**
+     * @param {string|(key: string) => string} key
+     * @param {((param: UpgradeFnParam) => UpgradeFnReturn)|UpgradeFnReturn} upgrade
+     * @returns {UpgradeFnReturn}
+     */
+    add(key, upgrade) {
+        return addUpgrade({ key, version: "19.2", upgrade });
+    },
+};
+
+upgrade_19_2.add(/^mail\.sidebar_category_(.*)_hidden$/, ({ matchOfKey }) => ({
+    key: `DiscussAppCategory,${matchOfKey[1]}:hidden`,
+    value: true,
+}));

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/discuss_app_category_model.js
@@ -42,20 +42,8 @@ export class DiscussAppCategory extends Record {
         },
     });
     discussCategoryAsAppCategory = fields.One("discuss.category", { inverse: "appCategory" });
-    // Hide categories from the devtools if really bothered.
-    hidden = fields.Attr(undefined, {
-        compute() {
-            return Boolean(localStorage.getItem(`mail.sidebar_category_${this.id}_hidden`));
-        },
-        onUpdate() {
-            if (!this.hidden && this.hidden !== undefined) {
-                localStorage.removeItem(`mail.sidebar_category_${this.id}_hidden`);
-            } else {
-                localStorage.setItem(`mail.sidebar_category_${this.id}_hidden`, true);
-            }
-        },
-        eager: true,
-    });
+    /** Hide categories from the devtools if really bothered. */
+    hidden = fields.Attr(undefined, { localStorage: true, eager: true });
     hideWhenEmpty = false;
     canView = false;
     app = fields.One("DiscussApp", {


### PR DESCRIPTION
*: im_livechat

Before this commit, DiscussAppCategory.hidden field was saved in local storage with explicit compute and onUpdate hooks.

Recently such fields can simply be saved by passing option `{ localStorage: true }`, which is what this commit does.

As the field was saved per discuss app category, the keys are dynamic and upgrade scripts were designed with specific keys for upgrade. This commit improves upgrade script so that upgrade can pass a a key as a RegExp. This RegExp is matched with all keys in local storage and matched candidates are used in upgrade script. This improvement allows to find all keys matching a `DiscussAppCategory.hidden` local storage field for any category, including custom-named categories.