### PR TITLE
[FIX] point_of_sale: fix duplicate iot actions

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -48,7 +48,6 @@ import { EpsonPrinter } from "@point_of_sale/app/utils/printer/epson_printer";
 import OrderPaymentValidation from "../utils/order_payment_validation";
 import { logPosMessage } from "../utils/pretty_console_log";
 import { initLNA } from "../utils/init_lna";
-import { uuid } from "@web/core/utils/strings";
 
 const { DateTime } = luxon;
 export const CONSOLE_COLOR = "#F5B427";
@@ -2062,11 +2061,10 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     async printOrderChanges(data, printer) {
-        const actionId = data.changes.data[0]?.uuid || uuid();
         const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
             data: data,
         });
-        return await printer.printReceipt(receipt, actionId);
+        return await printer.printReceipt(receipt, data);
     }
 
     filterChangeByCategories(categories, currentOrderChange) {


### PR DESCRIPTION
This PR fixes the user getting stuck on the point of sale if some actions are being ignored by the iot box because these are considered as already executed.

Currently the uuid asigned to an action doesn't change if an order is being cancelled so the iot box will systematically ignore the cancellation of pos orders if they were sent to the preparation printer before.

This PR fixes this issue by instead using a hash of the data used to generate the receipt as a uuid of an action. If anything in the data changed the iot box will not ignore such actions anymore

Enterprise: https://github.com/odoo/enterprise/pull/104315
