### PR TITLE
[FIX] html_editor: remove bottom margin on last element in table cells

### DIFF
--- a/addons/html_editor/static/src/main/table/table.scss
+++ b/addons/html_editor/static/src/main/table/table.scss
@@ -2,3 +2,11 @@ th.o_table_header {
     background-color: #F7F7F7;
     font-weight: 900;
 }
+
+.o_table {
+    th, td {
+        > *:last-child {
+            margin-bottom: 0;
+        }
+    }
+}


### PR DESCRIPTION
Problem:
Table cells had extra space because the last element (e.g. a `<p>`) kept its bottom margin. This caused the cell content to appear misaligned vertically.

Solution:
Remove the bottom margin on the last element inside table cells. This is a backport of 3048f1a2447d1d5089defa055c858adb1e915c91.

Steps to reproduce:
- Website.
- Add a table in the footer.
- Add text in a cell.
- Select "Paragraph" as block from the toolbar.
- Align the cell content.
- Observe the content is not vertically aligned.

opw-5412426

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
