### PR TITLE
[FIX] sale_loyalty: prevent discount to be recomputed on reward line

### DIFF
--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -23,6 +23,10 @@ class SaleOrderLine(models.Model):
         reward = self.filtered('reward_id')
         super(SaleOrderLine, self - reward)._compute_name()
 
+    def _compute_discount(self):
+        rewards = self.filtered('reward_id')
+        return super(SaleOrderLine, self - rewards)._compute_discount()
+
     @api.depends('reward_id')
     def _compute_is_reward_line(self):
         for line in self:


### PR DESCRIPTION
### Issue:
Due to this issue, the free product reward line might have a non-zero price.

#### To reproduce:
1- Install `website_sale_loyalty` and `sale_subscription`.
2- Enable `Discounts` on configuration.
3- Create a `promotion`:
   - rule: minimum quantity: 0, minimum purchase: 10
   - reward: free product, quantity: 1

4- Set a non-zero price on reward product from product page.
5- Create a product with price of 6 and publish it on the website.
6- On website, add 1 unit of created product to cart.
7- Open cart, and increase the quantity.
8- As you see the free product is added to cart but the price is non-zero.

### Cause:
Based on #89397, the reward line have the discount of 100. In the `_compute_discount` this discount is set to 0: https://github.com/odoo/odoo/blob/e48a7f1b03f23a4c96e35ee4350029439ec73e47/addons/sale/models/sale_order_line.py#L797

As `compute_discount` only depends on `product_id`, `product_uom_id`, `product_uom_qty` this shouldn't cause issue.

However, in `sale_subscription` its override includes `sale_order.plan_id` as dependency:
https://github.com/odoo/enterprise/blob/d0375627c6f8de6098dfe93a80f522f31e3a4174/sale_subscription/models/sale_order_line.py#L86-L90
Which setting `plan_id` to `False` here makes discount to be recomputed: https://github.com/odoo/enterprise/blob/d0375627c6f8de6098dfe93a80f522f31e3a4174/website_sale_subscription/models/sale_order.py#L27-L30

### Fix:
This can be avoided by filtering reward lines in a `_compute_discount` override. As none of reward lines regardless of reward type are expected to have a discount calculated this fix will not break any other flows.

It's noteworthy to mention that in the test, `_compute_discount` is directly called in order to mimic the flow without the need to install `sale_subscription`, as the `sale_subscription` is not root cause of the issue and the same issue could reproduced by any other modules overriding `_compute_discount`.

opw-5485796

