### PR TITLE
[FIX] point_of_sale: Fix UI button class in pos

### DIFF
--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.scss
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.scss
@@ -1,7 +1,3 @@
 .popup-text {
   font-size: 125%;
 }
-
-.button {
-  max-width: 200px;
-}


### PR DESCRIPTION
The issue was to put the button css class at a max width of 200px. But it's not used anymore. So it can be deleted

bug was created from this pr : https://github.com/odoo/odoo/pull/229478

task : 5493872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
