### PR TITLE
[FIX] orm: query current_schema instead of 'public'

### DIFF
--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -177,7 +177,7 @@ def has_unaccent(cr: BaseCursor) -> FunctionStatus:
             LEFT JOIN pg_catalog.pg_namespace ns ON p.pronamespace = ns.oid
         WHERE p.proname = 'unaccent'
               AND p.pronargs = 1
-              AND ns.nspname = 'public'
+              AND ns.nspname = current_schema
     """)
     result = cr.fetchone()
     if not result:

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -783,7 +783,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
             FROM pg_attribute a
             JOIN pg_class c ON a.attrelid = c.oid
             JOIN pg_namespace n ON c.relnamespace = n.oid
-            WHERE n.nspname = 'public'
+            WHERE n.nspname = current_schema
             AND a.attnotnull = true
             AND a.attnum > 0
             AND a.attname != 'id';
@@ -987,7 +987,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
                   JOIN pg_namespace n ON (n.oid = c.relnamespace)
                  WHERE c.relname IN %s
                    AND c.relkind = 'r'
-                   AND n.nspname = 'public'
+                   AND n.nspname = current_schema
             """
             tables = tuple(m._table for m in self.models.values())
             cr.execute(query, [tables])


### PR DESCRIPTION
----
Description of the issue/feature this PR addresses:
See related OPW Ticket [opw-5495025](https://www.odoo.com/my/tasks/5495025)

Current behavior before PR:
Odoo seems to install correctly, and works normally.
However the database consistency is not ensured.  Foreign Keys are not created.
User receives `Record missing` errors after some time, when there was a Contact deleted, for example.

Issue is dangerous, because it can be latent and be undetected for weeks or months.

Desired behavior after PR is merged:

Odoo installs *with* the Foreign Keys, and works normally.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

---
Ticket
opw-5495025