### PR TITLE
[FIX] web: add Promise.withResolvers polyfill

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -66,7 +66,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/scss/ui.scss',
             'web/static/src/views/fields/translation_dialog.scss',
 
-            'web/static/src/polyfills/clipboard.js',
+            'web/static/src/polyfills/**/*.js',
 
             'web/static/lib/popper/popper.js',
             'web/static/lib/bootstrap/js/dist/util/index.js',
@@ -152,6 +152,7 @@ This module provides the core of the Odoo Web Client.
         'web.assets_frontend_minimal': [
             'web/static/src/polyfills/object.js',
             'web/static/src/polyfills/array.js',
+            'web/static/src/polyfills/promise.js',
             'web/static/src/module_loader.js',
             'web/static/src/polyfills/set.js',
             'web/static/src/session.js',

--- a/addons/web/static/src/polyfills/promise.js
+++ b/addons/web/static/src/polyfills/promise.js
@@ -1,0 +1,11 @@
+// @odoo-module ignore
+if (!Promise.withResolvers) {
+    Promise.withResolvers = function withResolvers() {
+        let resolve, reject;
+        const promise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        return { promise, resolve, reject };
+    };
+}


### PR DESCRIPTION
This commit adds a polyfill for Promise.withResolvers. Such a polyfill had been introduced in [1], which deprecated Deferred in favour of withResolvers, but withResolvers was already used in v19, thus leading to tracebacks for people running (very) old versions of their browsers.

This commit backports the polyfill.

[1] https://github.com/odoo/odoo/pull/235237

task~[special request from our cto]



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
