### PR TITLE
[IMP] mail: allow passing activity plan template to activity_schedule

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -77,6 +77,8 @@ class MailActivity(models.Model):
     activity_decoration = fields.Selection(related='activity_type_id.decoration_type', readonly=True)
     icon = fields.Char('Icon', related='activity_type_id.icon', readonly=True)
     activity_plan_id = fields.Many2one('mail.activity.plan', string='Plan', ondelete='set null', copy=False)
+    activity_template_id = fields.Many2one('mail.activity.plan.template', string='Generated From',
+                                           index='btree_not_null')
     summary = fields.Char('Summary')
     note = fields.Html('Note', sanitize_style=True)
     date_deadline = fields.Date('Due Date', index=True, required=True, default=fields.Date.context_today)

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -21,6 +21,7 @@
                             nolabel="1"/>
                         <br/>
                         <field name="activity_type_id"
+                            domain="[('id', 'in', activity_type_available_ids)]"
                             required="not plan_id"
                             widget="selection_badge_icons"
                             options="{'related_icon_field': 'icon'}"


### PR DESCRIPTION
Extend the activity_schedule API to accept an optional mail.activity.plan.template parameter.

This allows callers scheduling activities from plans to propagate contextual information related to the originating plan template without altering existing behavior.

The new argument is optional and backward-compatible, as it is ignored by default when not provided.

task-5379922

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
