### PR TITLE
[FIX] point_of_sale: avoid pricelist cache computation with no data

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -504,6 +504,9 @@ export class PosStore extends Reactive {
     computeProductPricelistCache(data) {
         if (data) {
             data = this.models[data.model].readMany(data.ids);
+            if (data.length === 0) {
+                return;
+            }
         }
         computeProductPricelistCache(this, data);
     }


### PR DESCRIPTION
Before this commit, if scanning a barcode that does not correspond to any product, computeProductPricelistCache was called with no data, therefor it recomputed the cache for all records.

opw-5476560

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
