### PR TITLE
[IMP] point_of_sale: Ignore already invoiced orders

### DIFF
--- a/addons/point_of_sale/tests/test_pos_invoice_consolidation.py
+++ b/addons/point_of_sale/tests/test_pos_invoice_consolidation.py
@@ -15,6 +15,55 @@ class TestPosInvoiceConsolidation(TestPoSCommon, CommonPosTest):
         cls.product1 = cls.create_product('Product 1', cls.categ_basic, 10.0)
         cls.product2 = cls.create_product('Product 2', cls.categ_basic, 20.0)
 
+    def test_ignore_generated_invoices(self):
+        self.open_new_session()
+
+        with self.with_user(self.user1.login):
+            orders_user1 = self._create_orders([{
+                'pos_order_lines_ui_args': [(self.product1, 1)],
+                'customer': self.customer,
+                'is_invoiced': False,
+                'uuid': 'u1-order',
+            }])
+            # This flattens the dict into the recordset
+            orders_user1 = sum(orders_user1.values(), self.env['pos.order'])
+
+        with self.with_user(self.user2.login):
+            orders_user2 = self._create_orders([
+                {
+                    'pos_order_lines_ui_args': [(self.product1, 2)],
+                    'customer': self.customer,
+                    'is_invoiced': False,
+                }, {
+                    'pos_order_lines_ui_args': [(self.product2, 1)],
+                    'customer': self.customer,
+                    'is_invoiced': False,
+                }
+            ])
+            # This flattens the dict into the recordset
+            orders_user2 = sum(orders_user2.values(), self.env['pos.order'])
+
+        self.env['pos.make.invoice'].create({'consolidated_billing': True}).with_context(active_ids=orders_user1.ids).action_create_invoices()
+
+        invoice_user1 = orders_user1.account_move
+        invoice_user2 = orders_user2.account_move
+
+        self.assertEqual(len(invoice_user1), 1, "User 1 should have one invoice")
+        self.assertEqual(orders_user1.amount_total, invoice_user1.amount_total)
+
+        self.assertEqual(len(invoice_user2), 0, "User 2 should have no invoices")
+
+        all_orders = orders_user1 + orders_user2
+        self.env['pos.make.invoice'].create({'consolidated_billing': True}).with_context(active_ids=all_orders.ids).action_create_invoices()
+        invoice_user1 = orders_user1.account_move
+        invoice_user2 = orders_user2.account_move
+
+        self.assertEqual(len(invoice_user1), 1, "User 1 should have one invoice")
+        self.assertEqual(orders_user1.amount_total, invoice_user1.amount_total)
+
+        self.assertEqual(len(invoice_user2), 1, "User 2 should have one invoice")
+        self.assertEqual(sum(orders_user2.mapped('amount_total')), invoice_user2.amount_total)
+
     def test_invoice_grouped_by_user_id(self):
         self.open_new_session()
 


### PR DESCRIPTION
When trying to create a consolidated invoice in the POS from multiple orders, if any of them would not be valid (i.e. invoice already generated, or order still in draft), then Odoo would throw an error and not do anything.

Now the orders for which invoices can't be generated will just be ignored, but for the rest of the orders the invoices will be generated as usual. This should make it easier to bulk select and generate invoices only where necessary.

Task-[5491082](https://www.odoo.com/odoo/project/1737/tasks/5491082)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
