### PR TITLE
[FIX] im_livechat: do not show notification messages in lead

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -622,8 +622,12 @@ class DiscussChannel(models.Model):
         self.ensure_one()
         parts = []
         previous_message_author = None
-        # sudo - mail.message: getting empty messages to exclude them is allowed.
-        for message in (self.message_ids - self.message_ids.sudo()._filter_empty()).sorted("id"):
+        # sudo - mail.message: getting empty/notification messages to exclude them is allowed.
+        messages = (
+            self.message_ids.sudo().filtered(lambda m: m.message_type != "notification")
+            - self.message_ids.sudo()._filter_empty()
+        )
+        for message in messages.sorted("id"):
             # sudo - res.partner: accessing livechat username or name is allowed to visitor
             message_author = message.author_id.sudo() or message.author_guest_id
             if previous_message_author != message_author:

--- a/addons/im_livechat/tests/chatbot_common.py
+++ b/addons/im_livechat/tests/chatbot_common.py
@@ -151,7 +151,11 @@ class ChatbotCase(common.HttpCase):
             {
                 "thread_model": "discuss.channel",
                 "thread_id": discuss_channel.id,
-                "post_data": {"body": body or email or chatbot_script_answer.name},
+                "post_data": {
+                    "body": body or email or chatbot_script_answer.name,
+                    "message_type": "comment",
+                    "subtype_xmlid": "mail.mt_comment",
+                },
             },
         )
         if email:

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -233,10 +233,11 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         )
         attachment1 = self.env["ir.attachment"].create({"name": "test.txt"})
         attachment2 = self.env["ir.attachment"].with_user(self.visitor_user).create({"name": "test2.txt"})
-        channel.message_post(body="Operator Here")
-        channel.message_post(body="", attachment_ids=[attachment1.id])
-        channel.with_user(self.visitor_user).message_post(body="Visitor Here")
-        channel.with_user(self.visitor_user).message_post(body="", attachment_ids=[attachment2.id])
+        channel.message_post(body="Operator Here", message_type="comment")
+        channel.message_post(body="", message_type="comment", attachment_ids=[attachment1.id])
+        channel.with_user(self.visitor_user).message_post(body="Visitor Here", message_type="comment")
+        channel.with_user(self.visitor_user).message_post(body="", message_type="comment", attachment_ids=[attachment2.id])
+        channel.message_post(body="Some notification", message_type="notification")
         channel_history = channel.with_user(self.visitor_user)._get_channel_history()
         self.assertEqual(
             channel_history,


### PR DESCRIPTION
Before this commit, system notifications such as "user join/leave the chat" would be displayed in the created lead/ticket. Those messages are not useful in anyway and should be excluded.

task-5491212

enterprise: https://github.com/odoo/enterprise/pull/104336
