### PR TITLE
[FIX] mail: auto-open member and livechat info should combine

### DIFF
--- a/addons/crm_livechat/static/tests/create_lead.test.js
+++ b/addons/crm_livechat/static/tests/create_lead.test.js
@@ -34,6 +34,7 @@ test("can create a lead from the thread action after the conversation ends", asy
     });
     await start();
     await openDiscuss(channel_id);
+    await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click(".o-mail-DiscussContent-header button[title='Create Lead']");
     await insertText(".o-livechat-LivechatCommandDialog-form input", "testlead");
     await click(".o-mail-ActionPanel button", { text: "Create Lead" });

--- a/addons/im_livechat/static/src/core/public_web/discuss_app/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app/discuss_app_model_patch.js
@@ -85,6 +85,13 @@ patch(DiscussApp.prototype, {
         this.isLivechatInfoPanelOpenByDefault = fields.Attr(true, { localStorage: true });
     },
 
+    shouldDisableMemberPanelAutoOpenFromClose(nextActiveAction) {
+        if (nextActiveAction?.id === "livechat-info") {
+            return false;
+        }
+        return super.shouldDisableMemberPanelAutoOpenFromClose(...arguments);
+    },
+
     _threadOnUpdate() {
         if (
             this.lastThread?.notEq(this.thread) &&

--- a/addons/im_livechat/static/src/core/web/discuss_content_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_content_patch.js
@@ -3,13 +3,12 @@ import { patch } from "@web/core/utils/patch";
 
 patch(DiscussContent.prototype, {
     actionPanelAutoOpenFn() {
-        if (!this.threadActions.activeAction) {
-            if (this.store.discuss.isLivechatInfoPanelOpenByDefault) {
-                this.threadActions.actions.find((a) => a.id === "livechat-info")?.actionPanelOpen();
-            }
-            return;
+        const livechatInfoAction = this.threadActions.actions.find((a) => a.id === "livechat-info");
+        if (livechatInfoAction && this.store.discuss.isLivechatInfoPanelOpenByDefault) {
+            livechatInfoAction.actionPanelOpen();
+        } else {
+            super.actionPanelAutoOpenFn();
         }
-        super.actionPanelAutoOpenFn();
     },
     get threadDescriptionAttClass() {
         return {

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -18,8 +18,10 @@ registerThreadAction("livechat-info", {
     actionPanelOpen: ({ store }) => {
         store.discuss.isLivechatInfoPanelOpenByDefault = true;
     },
-    actionPanelClose: ({ store }) => {
-        store.discuss.isLivechatInfoPanelOpenByDefault = false;
+    actionPanelClose: ({ action, store }) => {
+        if (action.condition) {
+            store.discuss.isLivechatInfoPanelOpenByDefault = false;
+        }
     },
     sequence: 10,
     sequenceGroup: 7,

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -50,6 +50,7 @@ test("Can invite a partner to a livechat channel", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("button[title='Members']");
     await click("button[title='Invite People']");
     await click("input", {
@@ -91,7 +92,7 @@ test("Available operators come first", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click("button[title='Members']");
+    await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
     await contains(".o-discuss-ChannelInvitation-selectable", { count: 2 });
     await contains(":nth-child(1 of .o-discuss-ChannelInvitation-selectable)", { text: "Ron" });
@@ -148,7 +149,7 @@ test("Partners invited most frequently by the current user come first", async ()
     await start();
     await openDiscuss();
     await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #1" });
-    await click("button[title='Members']");
+    await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
     await click("input", { parent: [".o-discuss-ChannelInvitation-selectable", { text: "John" }] });
     await click("button:enabled", { text: "Invite" });
@@ -192,7 +193,7 @@ test("shows operators are in call", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await click("button[title='Members']");
+    await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("[title='Invite People']");
     await contains(".o-discuss-ChannelInvitation-selectable:contains('bob in a call')");
     await contains(".o-discuss-ChannelInvitation-selectable:contains('john')");
@@ -229,7 +230,7 @@ test("Operator invite shows livechat_username", async () => {
     await start();
     await openDiscuss();
     await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #1" });
-    await click("button[title='Members']");
+    await contains(".o-livechat-ChannelInfoList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
     await contains("input", {
         parent: [".o-discuss-ChannelInvitation-selectable", { text: "Johnny" }],

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -279,3 +279,51 @@ test("info panel toggle state persists across chats", async () => {
     await contains(".o-mail-DiscussContent-threadName[title='Visitor 1']");
     await contains(".o-livechat-ChannelInfoList");
 });
+
+test("auto-open of livechat info & members panels should combine", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    pyEnv["discuss.channel"].create([
+        {
+            channel_member_ids: [
+                Command.create({
+                    partner_id: serverState.partnerId,
+                    livechat_member_type: "agent",
+                }),
+                Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+            ],
+            channel_type: "livechat",
+            livechat_operator_id: serverState.partnerId,
+        },
+        {
+            channel_type: "channel",
+            name: "General",
+        },
+    ]);
+    await start();
+    await openDiscuss();
+    await click(".o-mail-DiscussSidebarChannel:text('General')");
+    await contains(".o-discuss-ChannelMemberList");
+    await click(".o-mail-DiscussSidebarChannel:text('Visitor')");
+    await contains(".o-discuss-ChannelMemberList", { count: 0 });
+    await contains(".o-livechat-ChannelInfoList");
+    await click("button[name='livechat-info']");
+    await contains(".o-livechat-ChannelInfoList", { count: 0 });
+    await contains(".o-discuss-ChannelMemberList", { count: 0 });
+    await click(".o-mail-DiscussSidebarChannel:text('General')");
+    await contains(".o-discuss-ChannelMemberList");
+    await contains(".o-livechat-ChannelInfoList", { count: 0 });
+    await click("button[name='member-list']");
+    await contains(".o-discuss-ChannelMemberList", { count: 0 });
+    await contains(".o-livechat-ChannelInfoList", { count: 0 });
+    await click(".o-mail-DiscussSidebarChannel:text('Visitor')");
+    await click("button[name='livechat-info']");
+    await contains(".o-livechat-ChannelInfoList");
+    await contains(".o-discuss-ChannelMemberList", { count: 0 });
+    await click("button[name='member-list']");
+    await contains(".o-discuss-ChannelMemberList");
+    await contains(".o-livechat-ChannelInfoList", { count: 0 });
+    await click(".o-mail-DiscussSidebarChannel:text('General')");
+    await contains(".o-discuss-ChannelMemberList");
+    await contains(".o-livechat-ChannelInfoList", { count: 0 });
+});

--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -19,8 +19,13 @@ export const ACTION_TAGS = Object.freeze({
 /** @typedef {Component|Record} ActionOwner */
 
 /**
+ * @typedef {Object} ActionPanelCloseSpecificParams
+ * @property {Action} nextActiveAction
+ */
+
+/**
  * @typedef {Object} ActionDefinition
- * @property {(action: Action) => void} [actionPanelClose]
+ * @property {(params: Action & ActionPanelCloseSpecificParams) => void} [actionPanelClose]
  * @property {Component} [actionPanelComponent]
  * @property {(action: Action) => Object} [actionPanelComponentProps]
  * @property {(action: Action) => void} [actionPanelOpen]
@@ -101,12 +106,21 @@ export class Action {
         return Boolean(this.definition.actionPanelComponent);
     }
 
-    /** Closes the action panel of this action. */
-    actionPanelClose() {
+    /**
+     * Closes the action panel of this action.
+     *
+     * @param {Object} [param0={}]
+     * @param {Action} [param0.nextActiveAction] When action panel is closed by opening another panel,
+     *   this param tells which is the next active action
+     */
+    actionPanelClose({ nextActiveAction } = {}) {
         if (this.actions) {
             this.actions.activeAction = this.actions.actionStack.pop();
         }
-        this.definition.actionPanelClose?.call(this, this.params);
+        this.definition.actionPanelClose?.call(
+            this,
+            Object.assign(this.params, { nextActiveAction })
+        );
     }
 
     /** Optional component that is used as action panel of this component, i.e. when action is active. */
@@ -138,7 +152,7 @@ export class Action {
                 if (keepPrevious) {
                     this.actions.actionStack.push(this.actions.activeAction);
                 } else {
-                    this.actions.activeAction.actionPanelClose();
+                    this.actions.activeAction.actionPanelClose({ nextActiveAction: this });
                 }
             }
             this.actions.activeAction = this;

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
@@ -19,6 +19,11 @@ export class DiscussApp extends Record {
     });
     hasRestoredThread = false;
 
+    /** @param {import("@mail/core/common/action").Action} [nextActiveAction] */
+    shouldDisableMemberPanelAutoOpenFromClose(nextActiveAction) {
+        return true;
+    }
+
     _threadOnUpdate() {
         this.lastActiveId = this.store["mail.thread"].localIdToActiveId(this.thread?.localId);
     }

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -59,17 +59,8 @@ export class DiscussContent extends Component {
 
     actionPanelAutoOpenFn() {
         const memberListAction = this.threadActions.actions.find((a) => a.id === "member-list");
-        if (!memberListAction) {
-            return;
-        }
-        if (this.store.discuss.isMemberPanelOpenByDefault) {
-            if (!this.threadActions.activeAction) {
-                memberListAction.actionPanelOpen();
-            } else if (this.threadActions.activeAction === memberListAction) {
-                return; // no-op (already open)
-            } else {
-                this.store.discuss.isMemberPanelOpenByDefault = false;
-            }
+        if (memberListAction && this.store.discuss.isMemberPanelOpenByDefault) {
+            memberListAction.actionPanelOpen();
         }
     }
 

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -187,8 +187,12 @@ registerThreadAction("invite-people", {
     },
 });
 registerThreadAction("member-list", {
-    actionPanelClose: ({ owner, store }) => {
-        if (owner.env.inDiscussApp) {
+    actionPanelClose: ({ action, owner, store, nextActiveAction }) => {
+        if (
+            action.condition &&
+            owner.env.inDiscussApp &&
+            store.discuss?.shouldDisableMemberPanelAutoOpenFromClose(nextActiveAction)
+        ) {
             store.discuss.isMemberPanelOpenByDefault = false;
         }
     },

--- a/addons/mail/static/tests/discuss/core/attachment_panel.test.js
+++ b/addons/mail/static/tests/discuss/core/attachment_panel.test.js
@@ -22,7 +22,7 @@ test("Empty attachment panel", async () => {
 
 test("Attachment panel sort by date", async () => {
     const pyEnv = await startServer();
-    const channelId = await pyEnv["discuss.channel"].create({ name: "General" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     pyEnv["ir.attachment"].create([
         {
             res_id: channelId,
@@ -39,6 +39,7 @@ test("Attachment panel sort by date", async () => {
     ]);
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click(".o-mail-DiscussContent-header button[title='Attachments']");
     await contains(".o-mail-AttachmentCard-info:text('file2.pdf')", {
         after: [".o-mail-DateSection:text('September, 2023')"],

--- a/addons/mail/static/tests/discuss/core/bus_subscription.test.js
+++ b/addons/mail/static/tests/discuss/core/bus_subscription.test.js
@@ -67,7 +67,7 @@ test("bus subscription updated when joining locally pinned thread", async () => 
     await start();
     await openDiscuss(channelId);
     await waitForChannels([`discuss.channel_${channelId}`]);
-    await click("button[title='Members']");
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Mitchell Admin'))");
     await click(".o-discuss-ChannelInvitation [title='Invite']:enabled");

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -32,8 +32,8 @@ test("Can invite people from member panel", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
-    await contains(".o-mail-ActionPanel-header:text('Invite people')");
 });
 
 test("can invite users in channel from chat window", async () => {
@@ -85,6 +85,7 @@ test("should be able to search for a new user to invite from an existing chat", 
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
     await insertText(".o-discuss-ChannelInvitation-search", "TestPartner2");
     await contains(".o-discuss-ChannelInvitation-selectable:has(:text('TestPartner2'))");
@@ -107,6 +108,7 @@ test("Invitation form should display channel group restriction", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
     await contains(
         ".o-discuss-ChannelInvitation div:text('Access restricted to group \"testGroup\"')",

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -157,6 +157,7 @@ test("Channel member count update after user joined", async () => {
     pyEnv["res.partner"].create({ name: "Harry", user_ids: [userId] });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await contains(".o-discuss-ChannelMemberList h6:text('Offline - 1')");
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Harry'))");

--- a/addons/mail/static/tests/discuss/core/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/crosstab.test.js
@@ -19,6 +19,7 @@ test("Add member to channel", async () => {
     pyEnv["res.partner"].create({ name: "Harry", user_ids: [userId] });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await contains(".o-discuss-ChannelMember:text('Mitchell Admin')");
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Harry'))");

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -144,6 +144,7 @@ test("create sub thread from sub-thread list", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Threads']");
     await contains(".o-mail-SubChannelList:text('This channel has no thread yet.')");
     await click("button[aria-label='Create Thread']");
@@ -203,6 +204,7 @@ test("sub thread is available for channel and group, not for chat", async () => 
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Threads']");
     await insertText(
         ".o-mail-ActionPanel input[placeholder='Search by name']",

--- a/addons/mail/static/tests/discuss/core/web/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/web/crosstab.test.js
@@ -1,5 +1,6 @@
 import {
     click,
+    contains,
     defineMailModels,
     openDiscuss,
     start,
@@ -21,6 +22,7 @@ test("Channel subscription is renewed when channel is manually added", async () 
         },
     });
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Invite People']");
     await click(".o-discuss-ChannelInvitation-selectable:has(:text('Mitchell Admin'))");
     await click("[title='Invite']:enabled");

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
@@ -32,6 +32,7 @@ test("Pin message", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click(".o-mail-DiscussContent-header button[title='Pinned Messages']");
     await contains(
         '.o-discuss-PinnedMessagesPanel p:text("This channel doesn\'t have any pinned messages.")'
@@ -53,6 +54,7 @@ test("Unpin message", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click(".o-mail-DiscussContent-header button[title='Pinned Messages']");
     await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
@@ -99,6 +101,7 @@ test("Jump to message", async () => {
     }
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click(".o-mail-DiscussContent-header button[title='Pinned Messages']");
     await click(".o-discuss-PinnedMessagesPanel a[role='button']:text('Jump')");
     await contains(".o-mail-Thread .o-mail-Message-body:text('Hello world!')", { visible: true });

--- a/addons/mail/static/tests/discuss/search_messages_panel.test.js
+++ b/addons/mail/static/tests/discuss/search_messages_panel.test.js
@@ -36,6 +36,7 @@ test("Should open the search panel when search button is clicked", async () => {
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Search Messages']");
     await contains(".o-mail-SearchMessagesPanel");
     await contains(".o_searchview");
@@ -220,6 +221,7 @@ test("Should close the search panel when search button is clicked again", async 
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Search Messages']");
     await click("[title='Close Search']");
     await contains(".o-mail-SearchMessagesPanel");
@@ -301,6 +303,7 @@ test("Editing the searched term should not edit the current searched term", asyn
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Search Messages']");
     await insertText(".o_searchview_input", "message");
     triggerHotkey("Enter");

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2382,6 +2382,7 @@ test("Notification settings: basic rendering", async () => {
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Notification Settings']");
     await contains("button:text('All Messages')");
     await contains("button:text('Mentions Only')");
@@ -2452,6 +2453,7 @@ test("Notification settings: mute/unmute conversation works correctly", async ()
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("[title='Notification Settings']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("button:text('Mute Conversation')");

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -117,6 +117,7 @@ test("[text composer] can @user in restricted (group_public_id) channels", async
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
     await contains(
         ".o-discuss-ChannelInvitation-invitationBox:text('Access restricted to group \"Custom Channel Group\"')"
@@ -148,6 +149,7 @@ test("can @user in restricted (group_public_id) channels", async () => {
     const composerService = getService("mail.composer");
     composerService.setHtmlComposer();
     await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // wait for auto-open of this panel
     await click("button[title='Invite People']");
     await contains(
         ".o-discuss-ChannelInvitation-invitationBox:text('Access restricted to group \"Custom Channel Group\"')"

--- a/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
+++ b/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
@@ -2,6 +2,9 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("discuss.invite_by_email", {
     steps: () => [
+        // Wait for the auto-open of the memberlist. Otherwise, it will
+        // conflict with the opening of the invite panel.
+        { trigger: ".o-discuss-ChannelMemberList" },
         {
             trigger: "button[title='Members']",
             run: "click",


### PR DESCRIPTION
Before this commit, auto-open of member panel and livechat info panel did not combine from [1].

This means that when livechat info was auto-open in livechat, this necessarily meant the auto-open of member list was disabled, and vice-versa.

This is a problem because when navigating between livechat and non-livechat would necessarily imply the dismiss of either panel, which is not good because the best default is having livechat panel open by default, and for non-livechat conversations it should auto-open the member list panel.

This commit fixes the issue as follow:
- auto-close of panel are aware of whether action are active, as removal of auto-open from auto-close makes sense only when another panel is made active when the older panel was visible
- closing of member panel by opening the livechat info panel should preserve auto-open of member list for other conversations

Task-5496830

[1]: https://github.com/odoo/odoo/pull/238472