### PR TITLE
[IMP] html_builder, website: enable discarding auto-saving changes

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -103,9 +103,9 @@ export class SavePlugin extends Plugin {
                 }
             }
         });
+        await Promise.all(saveProms);
         // used to track dirty out of the editable scope, like header, footer or wrapwrap
-        const willSaves = this.getResource("save_handlers").map((c) => c());
-        await Promise.all(saveProms.concat(willSaves));
+        await Promise.all(this.getResource("save_handlers").map((c) => c()));
         this.dependencies.history.reset();
     }
 

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -495,10 +495,14 @@ class IrUiView(models.Model):
             if value is not None:
                 # TODO: batch writes?
                 record = Model.browse(int(el.get('data-oe-id')))
+                vals = {field: value}
+                if model == 'website.menu':
+                    vals['mega_menu_classes'] = [c for c in el.classes if c not in ['dropdown-menu', 'o_mega_menu', 'o_savable']]
+
                 if not self.env.context.get('lang') and self.get_default_lang_code():
-                    record.with_context(lang=self.get_default_lang_code()).write({field: value})
+                    record.with_context(lang=self.get_default_lang_code()).write(vals)
                 else:
-                    record.write({field: value})
+                    record.write(vals)
 
                 if callable(Model._fields[field].translate):
                     self._copy_custom_snippet_translations(record, field)

--- a/addons/website/static/src/@types/plugins.d.ts
+++ b/addons/website/static/src/@types/plugins.d.ts
@@ -1,6 +1,7 @@
 declare module "plugins" {
     import { CarouselOptionShared } from "@website/builder/plugins/carousel_option_plugin";
     import { CustomizeWebsiteShared } from "@website/builder/plugins/customize_website_plugin";
+    import { DiscardPluginShared } from "@website/builder/plugins/discard_plugin";
     import { content_manually_updated_handlers, EditInteractionShared } from "@website/builder/plugins/edit_interaction_plugin";
     import { WebsiteFontShared } from "@website/builder/plugins/font/font_plugin";
     import { FormOptionShared } from "@website/builder/plugins/form/form_option_plugin";
@@ -43,6 +44,7 @@ declare module "plugins" {
         chartOptionPlugin: ChartOptionShared;
         CookiesBarOptionPlugin: CookiesBarOptionShared;
         customizeWebsite: CustomizeWebsiteShared;
+        discard: DiscardPluginShared;
         dynamicSnippetCarouselOption: DynamicSnippetCarouselOptionShared;
         dynamicSnippetOption: DynamicSnippetOptionShared;
         edit_interaction: EditInteractionShared;

--- a/addons/website/static/src/builder/plugins/discard_plugin.js
+++ b/addons/website/static/src/builder/plugins/discard_plugin.js
@@ -1,0 +1,65 @@
+import { Plugin } from "@html_editor/plugin";
+import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+
+/**
+ * @typedef { Object } DiscardPluginShared
+ * @property { DiscardPlugin['getRollback'] } getRollback
+ * @property { DiscardPlugin['setRollback'] } setRollback
+ * @property { DiscardPlugin['rollback'] } rollback
+ */
+export class DiscardPlugin extends Plugin {
+    static id = "discard";
+    static dependencies = ["history"];
+    static shared = ["getRollback", "setRollback", "rollback", "isSafe"];
+
+    /** @type {import("plugins").WebsiteResources} */
+    resources = {
+        save_handlers: this.onSave.bind(this),
+    };
+
+    rollbacks = null;
+
+    getRollback(key, defaultValue = null) {
+        return this.rollbacks?.[key] ?? defaultValue;
+    }
+
+    setRollback(key, value) {
+        this.rollbacks ??= {};
+        this.rollbacks[key] = value;
+    }
+
+    isSafe() {
+        return this.rollbacks === null && !this.dependencies.history.canUndo();
+    }
+
+    setup() {
+        if (document.querySelector("body").classList.contains("o_builder_open")) {
+            // Retrieve saved rollback only if the page is reloaded because of
+            // a backend change made with the builder; so only if the builder is
+            // already open.
+            this.rollbacks = JSON.parse(localStorage.getItem("website.rollbacks"));
+        }
+        this.deleteSavedRollbacks();
+    }
+
+    async onSave() {
+        if (this.rollbacks) {
+            localStorage.setItem("website.rollbacks", JSON.stringify(this.rollbacks));
+        }
+    }
+
+    async rollback() {
+        if (this.rollbacks) {
+            await rpc("/website/rollback", this.rollbacks);
+        }
+        this.deleteSavedRollbacks();
+    }
+
+    deleteSavedRollbacks() {
+        localStorage.removeItem("website.rollbacks");
+    }
+}
+
+registry.category("website-plugins").add(DiscardPlugin.id, DiscardPlugin);
+registry.category("translation-plugins").add(DiscardPlugin.id, DiscardPlugin);

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -22,7 +22,6 @@ export class MegaMenuOptionPlugin extends Plugin {
             dropIn: ".o_mega_menu nav",
             dropNear: ".o_mega_menu .nav-link",
         },
-        save_handlers: this.saveMegaMenuClasses.bind(this),
         no_parent_containers: ".o_mega_menu",
         is_unremovable_selector: ".o_mega_menu > section",
         unsplittable_node_predicates: (node) =>
@@ -31,28 +30,6 @@ export class MegaMenuOptionPlugin extends Plugin {
 
     getTemplatePrefix() {
         return "website.";
-    }
-
-    async saveMegaMenuClasses() {
-        const proms = [];
-        for (const megaMenuEl of this.editable.querySelectorAll(
-            "[data-oe-field='mega_menu_content']"
-        )) {
-            // On top of saving the mega menu content like any other field
-            // content, we must save the custom classes that were set on the
-            // menu itself.
-            const classes = [...megaMenuEl.classList].filter(
-                (megaMenuClass) =>
-                    !["dropdown-menu", "o_mega_menu", "o_savable"].includes(megaMenuClass)
-            );
-
-            proms.push(
-                this.services.orm.write("website.menu", [parseInt(megaMenuEl.dataset.oeId)], {
-                    mega_menu_classes: classes.join(" "),
-                })
-            );
-        }
-        await Promise.all(proms);
     }
 }
 

--- a/addons/website/static/tests/builder/website_builder/discard.test.js
+++ b/addons/website/static/tests/builder/website_builder/discard.test.js
@@ -1,0 +1,186 @@
+import { before, expect, test, waitFor } from "@odoo/hoot";
+import { xml } from "@odoo/owl";
+import { contains, onRpc, models, defineModels } from "@web/../tests/web_test_helpers";
+import {
+    addOption,
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+import { waitForEndOfOperation } from "@html_builder/../tests/helpers";
+
+defineWebsiteModels();
+
+before(async () => {
+    class WebEditorAssets extends models.Model {
+        _name = "website.assets";
+        make_scss_customization(location, changes) {
+            expect.step("make_scss_customization");
+        }
+    }
+    defineModels([WebEditorAssets]);
+
+    onRpc("/website/theme_customize_data", async () => {
+        expect.step("theme_customize_data");
+    });
+
+    onRpc("/website/theme_customize_bundle_reload", async () => {
+        expect.step("bundle_reload");
+        return { success: true };
+    });
+
+    addOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButton action="'websiteConfig'" actionParam="{views: ['test_view']}">view_option</BuilderButton>`,
+    });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButton action="'websiteConfig'" actionParam="{assets: ['test_asset']}">asset_option</BuilderButton>`,
+    });
+});
+
+test("customize website actions are properly reverted on discard", async () => {
+    onRpc("/website/rollback", async (request) => {
+        expect.step("rollback");
+        const { params } = await request.json();
+        expect(params.theme).toEqual({
+            views: {
+                enable: [],
+                disable: ["test_view"],
+            },
+            assets: {
+                enable: [],
+                disable: ["test_asset"],
+            },
+        });
+
+        expect(params.scss).toEqual({
+            "/website/static/src/scss/options/user_values.scss": {
+                layout: "null",
+            },
+        });
+    });
+
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+
+    // Click on the test options to simulate a theme_customize_data RPC call
+    await contains(":iframe .test-options-target").click();
+    await contains("[data-action-id=websiteConfig]:contains('view_option')").click();
+    await expect.waitForSteps(["theme_customize_data"]);
+
+    await contains(":iframe .test-options-target").click();
+    await contains("[data-action-id=websiteConfig]:contains('asset_option')").click();
+    await expect.waitForSteps(["theme_customize_data"]);
+
+    // Edit a theme value to simulate a make_scss_customization ORM call
+    await contains("#theme-tab").click();
+    await contains("[data-label='Page Layout'] button").click();
+    await contains("[data-action-value='boxed']").click();
+    await expect.waitForSteps(["make_scss_customization", "bundle_reload"]);
+
+    // Check that when pressing discard a rollback RPC call is sent containing
+    // the original values
+    await contains(".o-snippets-top-actions [data-action='cancel']").click();
+    await contains(".modal-content footer .btn-primary").click();
+    await expect.waitForSteps(["rollback"]);
+});
+
+test("rollback data should not be kept from from one editing session to the other", async () => {
+    onRpc("/website/rollback", async () => {
+        expect.step("rollback");
+    });
+
+    const { openBuilderSidebar } = await setupWebsiteBuilder("");
+
+    // Edit a theme value to simulate a make_scss_customization ORM call
+    await contains("#theme-tab").click();
+    await contains("[data-label='Page Layout'] button").click();
+    await contains("[data-action-value='boxed']").click();
+    await expect.waitForSteps(["make_scss_customization", "bundle_reload"]);
+
+    // Save
+    await contains(".o-snippets-top-actions [data-action='save']").click();
+    await waitFor(".o-website-builder_sidebar:not(.o_builder_sidebar_open)");
+    expect.verifySteps([], {
+        message: "Rollback is not called on save",
+    });
+
+    // Cancel without changing anything
+    await openBuilderSidebar();
+    await contains(".o-snippets-top-actions [data-action='cancel']").click();
+    await waitFor(".o-website-builder_sidebar:not(.o_builder_sidebar_open)");
+    expect.verifySteps([], {
+        message: "Rollback is not called since nothing was modified in this editing session",
+    });
+});
+
+test("header rollback", async () => {
+    let enabled = ["website.template_header_default"];
+    onRpc("/website/theme_customize_data_get", async () => enabled);
+    onRpc("/website/theme_customize_data", async (request) => {
+        const { params } = await request.json();
+        expect.step(JSON.stringify(params.enable));
+        enabled = params.enable;
+    });
+
+    onRpc("/website/rollback", async (request) => {
+        const { params } = await request.json();
+        expect(params.theme).toEqual({
+            views: {
+                enable: ["website.template_header_default"],
+                disable: [
+                    "website.template_header_hamburger",
+                    "website.no_autohide_menu",
+                    "website.template_header_boxed",
+                    "website.template_header_stretch",
+                    "website.template_header_vertical",
+                    "website.template_header_search",
+                    "website.template_header_sales_one",
+                    "website.template_header_sales_two",
+                    "website.template_header_sales_three",
+                    "website.template_header_sales_four",
+                    "website.template_header_sidebar",
+                ],
+            },
+        });
+        expect.step("rollback");
+    });
+
+    await setupWebsiteBuilder("", {
+        beforeWrapwrapContent: `<input type="hidden" class="o_page_option_data" autocomplete="off" name="header_visible">`,
+        headerContent: `
+            <header id="top" data-anchor="true" data-name="Header">
+                    Header
+            </header>`,
+    });
+
+    await contains(":iframe header").click();
+
+    // Change the header template a couple times
+    await contains("[data-label=Template] button").click();
+    await contains("[data-action-param*='website.template_header_hamburger']").click();
+    await waitForEndOfOperation();
+    expect.verifySteps([
+        '["website.template_header_hamburger","website.no_autohide_menu"]',
+        "theme_customize_data",
+        "make_scss_customization",
+        "bundle_reload",
+    ]);
+
+    await contains("[data-label=Template] button").click();
+    await contains("[data-action-param*='website.template_header_boxed']").click();
+    await waitForEndOfOperation();
+    expect.verifySteps([
+        '["website.template_header_boxed"]',
+        "theme_customize_data",
+        "make_scss_customization",
+        "bundle_reload",
+    ]);
+    await waitForEndOfOperation();
+
+    // Discard
+    await contains(".o-snippets-top-actions [data-action='cancel']").click();
+    await contains(".modal-content footer .btn-primary").click();
+    await expect.waitForSteps(["rollback"]);
+});

--- a/addons/website/static/tests/tours/discard.js
+++ b/addons/website/static/tests/tours/discard.js
@@ -1,0 +1,154 @@
+import {
+    assertCssVariable,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+let previousFooterViewId = null;
+registerWebsitePreviewTour(
+    "discard_rollback",
+    {
+        edition: true,
+        url: "/",
+    },
+    () => [
+        // Add a snippet: to have a change that doesn't directly save to backend
+        ...insertSnippet({ id: "s_banner", name: "Banner", groupName: "Intro" }),
+        {
+            content: "Check that the snippet has been added",
+            trigger: ":iframe #wrap section.s_banner",
+        },
+        // Header modifications
+        {
+            content: "Click on header",
+            trigger: ":iframe header.o_header_standard",
+            run: "click",
+        },
+        {
+            content: "Change header scroll effect",
+            trigger: "[data-class-action=o_header_fade_out]:not(:visible)",
+            run: "click",
+        },
+        {
+            trigger: ":iframe:not(:has(.o_loading_screen))",
+        },
+        {
+            content: "Check that the header changed",
+            trigger: ":iframe header.o_header_fade_out",
+            run: "click",
+        },
+        // Call to action button modification (to test resetViewArch behavior)
+        {
+            content: "Click on call to action button",
+            trigger: ":iframe .navbar a[href='/contactus']:contains('Test Rollback Button')",
+            run: "click",
+        },
+        {
+            content: "Disable call to action button",
+            trigger:
+                "[data-label=Actions] [data-action-param*='website.header_call_to_action'].active",
+            run: "click",
+        },
+        {
+            trigger: ":iframe:not(:has(.o_loading_screen))",
+        },
+        {
+            content: "Check that the call to action button is not there anymore",
+            trigger: ":iframe .navbar:not(:has(a[href='/contactus']))",
+            run: "click",
+        },
+        // Footer modifications
+        assertCssVariable("--footer-template", "default"),
+        {
+            content: "Save footer view id and click on it",
+            trigger: ":iframe footer > #footer",
+            run({ anchor }) {
+                if (!anchor.dataset.oeId) {
+                    throw Error("The footer doesn't have a template id");
+                }
+                previousFooterViewId = anchor.dataset.oeId;
+                anchor.click();
+            },
+        },
+        {
+            content: "Change footer template",
+            trigger: "[data-action-param*=template_footer_descriptive]:not(:visible)",
+            run: "click",
+        },
+        {
+            trigger: ":iframe:not(:has(.o_loading_screen))",
+        },
+        assertCssVariable("--footer-template", "descriptive"),
+        {
+            content: "Check that the footer changed",
+            trigger: ":iframe footer > #footer",
+            run({ anchor }) {
+                if (!anchor.dataset.oeId) {
+                    throw Error("The footer doesn't have a template id");
+                }
+                if (anchor.dataset.oeId === previousFooterViewId) {
+                    throw Error("Footer view id didn't change");
+                }
+                previousFooterViewId = anchor.dataset.oeId;
+            },
+        },
+        // Page layout modifications to trigger make_scss_customization
+        {
+            content: "Switch to theme tab",
+            trigger: "#theme-tab",
+            run: "click",
+        },
+        assertCssVariable("--layout", "full"),
+        {
+            content: "Change Page layout",
+            trigger:
+                "[data-action-id=customizeWebsiteVariable][data-action-value=postcard]:not(:visible)",
+            run: "click",
+        },
+        {
+            trigger: ":iframe:not(:has(.o_loading_screen))",
+        },
+        assertCssVariable("--layout", "postcard"),
+        // Discard
+        {
+            content: "Click on discard",
+            trigger: ".o-snippets-top-actions [data-action='cancel']",
+            run: "click",
+        },
+        {
+            content: "Confirm dialog",
+            trigger: `.modal-content footer .btn-primary`,
+            run: "click",
+        },
+        {
+            trigger: ":iframe:not(:has(.o_loading_screen))",
+        },
+        // Check that everything has been correctly discarded
+        {
+            content: "The snippet should not be there",
+            trigger: ":iframe #wrap:not(:has(section.s_banner))",
+        },
+        {
+            content: "Check that the header rollbacked",
+            trigger: ":iframe header.o_header_standard",
+        },
+        {
+            content: "Check that call to action is there with the correct text",
+            trigger: ":iframe .navbar a[href='/contactus']:contains('Test Rollback Button')",
+        },
+        assertCssVariable("--footer-template", "default"),
+        {
+            content: "Check that the footer rollbacked",
+            trigger: ":iframe footer > #footer",
+            run({ anchor }) {
+                if (anchor.dataset.oeId === previousFooterViewId) {
+                    throw Error("The footer didn't rollback");
+                }
+            },
+        },
+        {
+            ...assertCssVariable("--layout", "full"),
+            content: "Check that Page layout rollbacked",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -741,3 +741,9 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_mega_footer(self):
         self.start_tour('/', 'mega_footer', login='admin')
+
+    def test_discard_rollback(self):
+        call_to_action_view = self.env['ir.ui.view'].search([('key', '=', 'website.header_call_to_action')], limit=1)
+        call_to_action_view.write({'arch_db': call_to_action_view.arch_db.replace('Contact Us', 'Test Rollback Button')})
+
+        self.start_tour("/", "discard_rollback", login="admin")


### PR DESCRIPTION
__Before this commit:__
The discard button of the website builder currently just prevents the
dirty elements from being saved. However, theme options or header and
footer template changes send direct requests to the backend, which
instantly save their new value. This means that pressing discard will
not revert those changes.

__Steps to reproduce:__
- Go to Website
- Open the editor
- Click on the navbar and change its color
- Click discard
=> The change is not discarded
(This also works with any header/theme/footer change)

__After this commit:__
A new discard plugin is introduced to allow rolling back these auto-
saving changes. Whenever such a modification is made, the original
value is kept in a dictionary and saved in local storage (using a
`save_handlers` method) in case the change also requires a page reload.
If the user then presses the Discard button, a rollback request is
made to apply the original values back.

If a change induces a page reload, the dirty elements will also be
saved, so we also need to keep them in this dictionary to be able to
revert them later. Since they are saved in the `save_element_handlers`,
we need to wait for them before calling the `save_handlers` where the
rollbacks are saved in local storage.

task-4257306