### PR TITLE
[FIX] iot_drivers: fix bluetooth exceptions

### DIFF
--- a/addons/iot_drivers/iot_handlers/interfaces/bluetooth_interface_L.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/bluetooth_interface_L.py
@@ -1,4 +1,5 @@
 from gatt import DeviceManager as Gatt_DeviceManager
+from gatt.errors import NotReady
 import dbus
 from gi.repository import GLib
 import logging
@@ -63,8 +64,11 @@ class BtManager(Thread):
         dm = GattBtManager(adapter_name='hci0')
         for device in [device_con for device_con in dm.devices() if device_con.is_connected()]:
             device.disconnect()
-        dm.start_discovery()
-        dm.run()
+        try:
+            dm.start_discovery()
+            dm.run()
+        except NotReady:
+            _logger.error("Bluetooth adapter not ready. Set `is_adapter_powered` to `True` or run 'echo power on | sudo bluetoothctl'")
 
 
 class BTInterface(Interface):


### PR DESCRIPTION
This PR fixes the bluetooth exceptions seen on the iot box when the bluetooth adapter isn't ready

```
2026-01-14 10:05:48,596 2147 ERROR ? odoo.addons.iot_drivers.exception_logger: Exception in thread Thread-3:
2026-01-14 10:05:48,743 2147 ERROR ? odoo.addons.iot_drivers.exception_logger: Traceback (most recent call last):
2026-01-14 10:05:48,745 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/home/odoo/.local/lib/python3.13/site-packages/gatt/gatt_linux.py", line 138, in start_discovery
    self._adapter.SetDiscoveryFilter(discovery_filter)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
2026-01-14 10:05:48,746 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 72, in __call__
    return self._proxy_method(*args, **keywords)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
2026-01-14 10:05:48,746 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 141, in __call__
    return self._connection.call_blocking(self._named_service,
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
                                          self._object_path,
                                          ^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
                                          args,
                                          ^^^^^
                                          **keywords)
                                          ^^^^^^^^^^^
2026-01-14 10:05:48,746 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/usr/lib/python3/dist-packages/dbus/connection.py", line 696, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
        message, timeout)
2026-01-14 10:05:48,746 2147 ERROR ? odoo.addons.iot_drivers.exception_logger: dbus.exceptions.DBusException: org.bluez.Error.NotReady: Resource Not Ready
2026-01-14 10:05:48,746 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:
During handling of the above exception, another exception occurred:
2026-01-14 10:05:48,746 2147 ERROR ? odoo.addons.iot_drivers.exception_logger: Traceback (most recent call last):
2026-01-14 10:05:48,748 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/usr/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
2026-01-14 10:05:48,748 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/home/pi/odoo/addons/iot_drivers/iot_handlers/interfaces/bluetooth_interface_L.py", line 66, in run
    dm.start_discovery()
    ~~~~~~~~~~~~~~~~~~^^
2026-01-14 10:05:48,748 2147 ERROR ? odoo.addons.iot_drivers.exception_logger:   File "/home/odoo/.local/lib/python3.13/site-packages/gatt/gatt_linux.py", line 142, in start_discovery
    raise errors.NotReady(
        "Bluetooth adapter not ready. "
        "Set `is_adapter_powered` to `True` or run 'echo \"power on\" | sudo bluetoothctl'.")
2026-01-14 10:05:48,748 2147 ERROR ? odoo.addons.iot_drivers.exception_logger: gatt.errors.NotReady: Bluetooth adapter not ready. Set `is_adapter_powered` to `True` or run 'echo "power on" | sudo bluetoothctl'.
```
