### PR TITLE
[REF] mail: simplify SCSS of message bubble color in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -10,56 +10,27 @@
     opacity: 50%;
 }
 
-.o-mail-Message-bubble {
-    &.o-blue {
-        background-color: mix($gray-100, darken($info, 10%), 85.5%) !important;
-        border-color: mix(lighten(mix($gray-100, darken($info, 10%), 85.5%), 2.5%), black, 75%) !important;
-    
-        &.o-muted {
-            background-color: darken(mix($gray-100, darken($info, 10%), 87.5%), 5%) !important;
-        }
-    }
-    &.o-green {
-        background-color: mix($gray-100, darken($success, 2.5%), 85.5%) !important;
-        border-color: mix(lighten(mix($gray-100, darken($success, 2.5%), 85.5%), 2.5%), black, 75%) !important;
-    
-        &.o-muted {
-            background-color: darken(mix($gray-100, darken($success, 2.5%), 85.5%), 5%) !important;
-        }
-    }
-    &.o-orange {
-        background-color: mix($gray-100, darken($warning, 5%), 70.5%) !important;
-        border-color: mix(lighten(mix($gray-100, darken($warning, 5%), 70.5%), 2.5%), black, 75%) !important;
-    
-        &.o-muted {
-            background-color: darken(mix($gray-100,  darken($warning, 5%), 70.5%), 10%) !important;
-        }
-    }
-}
+.o-mail-Message-bubble, .o-mail-Message-bubbleTail {
+    $_bubble_colors_map: (
+        'o-blue': darken($info, 10%),
+        'o-green': darken($success, 2.5%),
+        'o-orange': $warning,
+    );
 
-.o-mail-Message-bubbleTail {
-     &.o-blue {
-        .o-mail-Message-bubbleTailBg {
-            color: mix($gray-100, darken($info, 10%), 85.5%) !important;
-        }
-        .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, darken($info, 10%), 85.5%), 2.5%), black, 75%) !important;
-        }
-    }
-    &.o-green {
-        .o-mail-Message-bubbleTailBg {
-            color: mix($gray-100, darken($success, 2.5%), 85.5%) !important;
-        }
-        .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, darken($success, 2.5%), 85.5%), 2.5%), black, 75%) !important;
-        }
-    }
-    &.o-orange {
-        .o-mail-Message-bubbleTailBg {
-            color: mix($gray-100, darken($warning, 5%), 70.5%) !important;
-        }
-        .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, darken($warning, 5%), 70.5%), 2.5%), black, 75%) !important;
+    @each $_type, $_color in $_bubble_colors_map {
+        &.#{$_type} {
+            $_border-base: mix($_color, $body-color, 75%);
+            $_base_bg: mix($white, $gray-100, 15%);
+            $_base_bg_muted: mix($white, $gray-100, 85%);
+            @if $_type == 'o-orange' {
+                --o-message-bubble-bg: #{mix($_base_bg, $_color, 72.5%)};
+                --o-message-bubble-bg-muted: #{mix($_base_bg_muted, $_color, 82.5%)};
+            } @else {
+                --o-message-bubble-bg: #{mix($_base_bg, $_color, 82.5%)};
+                --o-message-bubble-bg-muted: #{mix($_base_bg_muted, $_color, 82.5%)};
+            }
+            --o-message-bubble-border-color: #{mix($_base_bg, $_border-base, 82.5%)};
+            --o-message-bubble-color-base: #{$_color};
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -74,7 +74,7 @@
     border-color: var(--o-message-bubble-border-color) !important;
 
     &.o-muted {
-        background-color: $o-view-background-color !important;
+        background-color: var(--o-message-bubble-bg-muted) !important;
     }
 }
 
@@ -103,6 +103,7 @@
         &.#{$_type} {
             $_border-base: mix($_color, $body-color, 75%);
             --o-message-bubble-bg: #{mix($o-view-background-color, $_color, 90%)};
+            --o-message-bubble-bg-muted: #{$o-view-background-color};
             --o-message-bubble-border-color: #{mix($o-view-background-color, $_border-base, 80%)};
             --o-message-bubble-color-base: #{$_color};
         }


### PR DESCRIPTION
Reduce amount of LOCs to define dark theme version of message bubble colors, to match with the shape of how this is defined in white theme.

While the intent of the change is just simpler LOCs, the visual in dark theme has subtle changes:
- bubble colors are very slightly more saturated in dark theme
- bubble have more visible border, giving more a 3D look

Before

<img width="778" height="639" alt="before" src="https://github.com/user-attachments/assets/4f4aa3e3-9e2f-44bf-9437-665203831103" />

After

<img width="771" height="642" alt="after" src="https://github.com/user-attachments/assets/1c4f4b84-0eb0-45ce-bda3-3a849e93d49d" />
