### PR TITLE
[FIX] resource: incorrect expected hours with timezone differences

### DIFF
--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -580,13 +580,11 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
                          number_of_accrued_days - leave.number_of_days,
                          "All the remaining days of the allocation will expire")
 
-        # Days between the target date and the expiration date (accrual_plan's carryover date)
+        # Days between the target date and the expiration date (inclusive counting)
         remaining_days_before_expiration = (allocation._get_carryover_date(target_date) - target_date).days
-        working_days_equivalent_needed = remaining_days_before_expiration * 24 / self.flex_40h_calendar.hours_per_day
-    
-        # Assert the closest allocation duration (number of working days equivalent (8 hours/day) remaining before the allocation expires)
+        working_days_equivalent_needed = remaining_days_before_expiration + 1
         self.assertEqual(round(allocation_data[logged_in_emp][0][1]['closest_allocation_duration']), working_days_equivalent_needed,
-                            "The closest allocation duration should be the number of working days equivalent (8 hours/day) remaining before the allocation expires")
+                        "The closest allocation duration should be the number of days remaining before the allocation expires (inclusive)")
 
     @users('enguerran')
     def test_no_carried_over_leaves_for_fully_flexible_resource(self):


### PR DESCRIPTION
Description:
------------------

When viewing attendance in Gantt view with flexible working schedules,
expected hours displayed incorrectly when device, company, and employee
calendar timezones differ (e.g., 1 day shows 16h instead of 8h).

Root cause:
------------------
 Two related timezone handling issues:
1. Gantt passes UTC boundaries that span multiple calendar days when
   converted to calendar timezone
2. Resource calendar creates flexible intervals using wrong timezone
   (employee timezone instead of calendar timezone)

Test update:
-------------------
Updated test_no_carried_over_leaves_for_flexible_resource to reflect
correct flexible calendar behavior. For flexible calendars, the duration
between dates counts inclusive calendar days. Changed the calculation
from `days * 24 / hours_per_day` to `(end_date - start_date).days + 1`
to properly account for inclusive date counting (e.g., Dec 30 to Dec 31
includes both days = 2 days).

Solution:
--------------
- hr_attendance_gantt: Normalize date boundaries to full calendar days
  in calendar timezone before passing to interval calculation
- resource: Force flexible hours block to consistently use calendar
  timezone for date extraction and interval creation

opw-5241330