### PR TITLE
[FIX] l10n_latam_base: Update identification type on country change

### DIFF
--- a/addons/l10n_latam_base/models/res_partner.py
+++ b/addons/l10n_latam_base/models/res_partner.py
@@ -33,6 +33,15 @@ class ResPartner(models.Model):
     def _onchange_vat(self):
         super()._onchange_vat()
 
+    @api.onchange('country_id')
+    def _onchange_country(self):
+        country = self.country_id or self.company_id.account_fiscal_country_id or self.env.company.account_fiscal_country_id
+        identification_type = self.l10n_latam_identification_type_id
+        if not identification_type or (identification_type.country_id != country):
+            self.l10n_latam_identification_type_id = self.env['l10n_latam.identification.type'].search(
+                [('country_id', '=', country.id), ('is_vat', '=', True)], limit=1) or self.env.ref(
+                    'l10n_latam_base.it_vat', raise_if_not_found=False)
+
     def _get_frontend_writable_fields(self):
         frontend_writable_fields = super()._get_frontend_writable_fields()
         frontend_writable_fields.add('l10n_latam_identification_type_id')


### PR DESCRIPTION
When the country of a partner is changed, the identification type should be updated accordingly. This ensures that the identification type remains consistent with the partner's country, improving data integrity and user experience.

Description of the issue/feature this PR addresses: When creating a new contact, the field `l10n_latam_identification_type_id` (Identification Type) defaults to 'VAT' regardless of the active company. This PR ensures that the default identification type dynamically changes based on the selected company. For instance, it should automatically set to 'CUIT' for Argentinian companies or 'RUT' for Uruguayan companies.

Current behavior before PR: The value 'VAT' is hardcoded as the default for the `l10n_latam_identification_type_id` field, regardless of the country or localization of the current company.

Desired behavior after PR is merged: The `l10n_latam_identification_type_id` field should be updated via an onchange method to reflect the appropriate identification type according to the current company's localization.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
