### PR TITLE
[FIX] point_of_sale: prevent positive margin on refunded orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1674,9 +1674,10 @@ class PosOrderLine(models.Model):
         tax_ids_after_fiscal_position = fpos.map_tax(self.tax_ids)
         price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
         taxes = tax_ids_after_fiscal_position.compute_all(price, self.order_id.currency_id, self.qty, product=self.product_id, partner=self.order_id.partner_id)
+        sign = -1 if self.order_id.is_refund else 1
         return {
-            'price_subtotal_incl': taxes['total_included'],
-            'price_subtotal': taxes['total_excluded'],
+            'price_subtotal_incl': taxes['total_included'] * sign,
+            'price_subtotal': taxes['total_excluded'] * sign,
         }
 
     @api.onchange('product_id')


### PR DESCRIPTION
## Issue
When refunding a POS order from the backend, the margin of the refund order is positive, which is incorrect.

## Steps to reproduce
1. Install POS (`point_of_sale`);
2. Create a product:
    - Sales Price: $10
    - Cost: $5
3. Open a register;
4. Make an order for the product and refund it from the frontend (to do so, create a new order, click the 3 dots on the ProductScreen, choose *Refund*, select the first order, and proceed);
5. Make a second order for the product, and refund it from the backend (POS > Orders > Orders);
6. **The first refund (from the frontend) has a positive margin (50%), while the second refund (from the backed) has a margin exceeding 100% (150%).**

## Cause
First, in the context of refunded orders, the `PosOrderLine.price_subtotal` was not consistently positive or negative, depending on whether the refund was done from the frontend or the backend of the POS. When refunding from the frontend, the `price_subtotal` would be positive, but it would be negative when refunding from the backend. This is because of the following line from `AccountTax._get_tax_details`, where `quantity` is negative, and `price_unit` is positive:

https://github.com/odoo/odoo/blob/3968a9f65697ae98debba9af07a8d7d12d5a1613/addons/account/models/account_tax.py#L1224

Whereas when we refund from the frontend, the `price_subtotal` is defined by the following lines and ends up being always positive:

https://github.com/odoo/odoo/blob/6c901f77a6a4fc2f2dc3fdb3dde53dc80afdfea5/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js#L198-L201

opw-5459698