### PR TITLE
[FIX] point_of_sale: error when Expiration Dates is unchecked

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1628,13 +1628,14 @@ class PosOrderLine(models.Model):
         )
 
         result = []
+        has_lot_expiration_date = 'expiration_date' in self.env['stock.lot']._fields
         for lot_recordset, total_quantity in groups:
             if lot_recordset:
                 result.append({
                     'id': lot_recordset.id,
                     'name': lot_recordset.name,
                     'product_qty': total_quantity,
-                    'expiration_date': lot_recordset.expiration_date,
+                    'expiration_date': lot_recordset.expiration_date if has_lot_expiration_date else False,
                 })
 
         return result


### PR DESCRIPTION
Steps to reproduce:
=
- Install only `point_of_sale` with demo data.
- Ensure `Settings->Inventory->Traceability->Expiration Dates` is unchecked.
- Open POS.
- Click a product that uses lots.

Issue:
=
- PoS always shows the warning “The existing serial/lot numbers could not be retrieved. Continue without checking the validity of serial/lot numbers?” even though lots are available.
- Terminal error:`AttributeError: 'stock.lot' object has no attribute 'expiration_date'`

Reason:
=
- When *Expiration Dates* is unchecked and the `product_expiry` module is not installed, the `expiration_date` field is not available (it is defined in `product_expiry` module by inheriting `stock.quant` model).

Fix:
=
- Check field existence using the model’s _fields registry before accessing `expiration_date`, to prevent traceback.

runbot-234958, 234959, 234960, 234961, 234964

