### PR TITLE
[FIX] point_of_sale: avoid creating unnecessary line

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
@@ -100,13 +100,34 @@ export class ComboConfiguratorPopup extends Component {
     get configurationFromValues() {
         const values = this.props.values;
         const conf = {};
+        const order = this.pos.getOrder();
+        // Track already processed order lines
+        order._usedComboLineUuids ||= new Set();
+        order._comboLineUuidsToRemainingQty ||= new Map();
         for (const comboId in values) {
             for (const lineUuid in values[comboId]) {
                 if (lineUuid === "upsell") {
                     continue;
                 }
                 const line = this.pos.models["pos.order.line"].getBy("uuid", lineUuid);
-                conf[values[comboId][lineUuid].combo_item.id] = {
+                order._comboLineUuidsToRemainingQty.set(lineUuid, line.qty);
+            }
+        }
+        for (const comboId in values) {
+            for (const lineUuid in values[comboId]) {
+                if (lineUuid === "upsell" || order._usedComboLineUuids.has(lineUuid)) {
+                    continue;
+                }
+                const line = this.pos.models["pos.order.line"].getBy("uuid", lineUuid);
+                let remainingQty = order._comboLineUuidsToRemainingQty.get(lineUuid) || 0;
+                remainingQty -= values[comboId][lineUuid].qty;
+                order._comboLineUuidsToRemainingQty.set(lineUuid, remainingQty);
+                if (remainingQty <= 0) {
+                    order._usedComboLineUuids.add(lineUuid);
+                }
+                // Preserve distinct configurations when multiple lines reference the
+                // same combo item but have different configuration details.
+                conf[`${values[comboId][lineUuid].combo_item.id}_${lineUuid}`] = {
                     attribute_value_ids: line.attribute_value_ids.map((a) => a.id),
                     attribute_custom_values: Object.fromEntries(
                         line.custom_attribute_value_ids.map((c) => [
@@ -168,6 +189,7 @@ export class ComboConfiguratorPopup extends Component {
         const itemsIncluded = [];
         const itemsExtra = [];
         const comboFreeQtyTracker = {};
+        const configurationKeys = Object.keys(this.state.configuration);
         Object.values(this.state.qty).forEach((comboItems) => {
             Object.entries(comboItems)
                 .filter(([, qty]) => qty > 0)
@@ -180,24 +202,57 @@ export class ComboConfiguratorPopup extends Component {
                         comboFreeQtyTracker[comboId] = 0;
                     }
 
-                    const remainingFreeQty = comboFreeQty - comboFreeQtyTracker[comboId];
-                    if (remainingFreeQty > 0) {
-                        const includedQty = Math.min(qty, remainingFreeQty);
-                        itemsIncluded.push({
-                            combo_item_id: comboItemId,
-                            configuration: this.state.configuration[comboItemId.id],
-                            qty: includedQty,
-                        });
-                        comboFreeQtyTracker[comboId] += includedQty;
-                        qty -= includedQty;
+                    const idStr = String(comboItemId.id);
+                    const comboConfigurationsKeys = configurationKeys.filter((key) =>
+                        String(key).startsWith(idStr)
+                    );
+                    if (comboConfigurationsKeys.length === 0) {
+                        comboConfigurationsKeys.push(comboItemId.id);
                     }
 
-                    if (qty > 0) {
-                        itemsExtra.push({
-                            combo_item_id: comboItemId,
-                            configuration: this.state.configuration[comboItemId.id],
-                            qty: qty,
-                        });
+                    // Build a map of qty per configuration key from values prop
+                    const qtyPerKey = {};
+                    if (this.props.values && comboConfigurationsKeys.length > 1) {
+                        const values = this.props.values[comboId] || {};
+                        for (const key of comboConfigurationsKeys) {
+                            const lineUuid = String(key).substring(idStr.length + 1);
+                            qtyPerKey[key] = values[lineUuid]?.qty || 0;
+                        }
+                    } else {
+                        // Single configuration: all qty belongs to it
+                        qtyPerKey[comboConfigurationsKeys[0]] = qty;
+                    }
+
+                    let remainingFreeQty = comboFreeQty - comboFreeQtyTracker[comboId];
+                    for (const key of comboConfigurationsKeys) {
+                        const keyQty = qtyPerKey[key] || 0;
+                        if (keyQty <= 0) {
+                            continue;
+                        }
+                        if (remainingFreeQty > 0) {
+                            const includedQty = Math.min(keyQty, remainingFreeQty);
+                            itemsIncluded.push({
+                                combo_item_id: comboItemId,
+                                configuration: this.state.configuration[key],
+                                qty: includedQty,
+                            });
+                            comboFreeQtyTracker[comboId] += includedQty;
+                            remainingFreeQty -= includedQty;
+                            const extraQty = keyQty - includedQty;
+                            if (extraQty > 0) {
+                                itemsExtra.push({
+                                    combo_item_id: comboItemId,
+                                    configuration: this.state.configuration[key],
+                                    qty: extraQty,
+                                });
+                            }
+                        } else {
+                            itemsExtra.push({
+                                combo_item_id: comboItemId,
+                                configuration: this.state.configuration[key],
+                                qty: keyQty,
+                            });
+                        }
                     }
                 });
         });

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -347,6 +347,53 @@ registry.category("web_tour.tours").add("test_convert_orderlines_to_combo", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_convert_orderlines_to_combo_with_same_product", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Combo Product 1"),
+            ProductConfiguratorPopup.pickColor("Blue"),
+            Dialog.confirm(),
+            ProductScreen.clickDisplayedProduct("Combo Product 1"),
+            ProductConfiguratorPopup.pickColor("Red"),
+            Dialog.confirm(),
+            ProductScreen.clickDisplayedProduct("Combo Product 4"),
+            ProductScreen.clickDisplayedProduct("Combo Product 6"),
+            ProductScreen.clickApplyCombo(),
+            inLeftSide([
+                ...Order.hasLine({
+                    productName: "Combo Product 1",
+                    quantity: "1",
+                    attributeLine: "Red",
+                }),
+                ...Order.hasLine({
+                    productName: "Combo Product 1",
+                    quantity: "1",
+                    attributeLine: "Blue",
+                }),
+                ...Order.hasLine({
+                    productName: "Combo Product 4",
+                    quantity: "1",
+                }),
+                ...Order.hasLine({
+                    productName: "Combo Product 6",
+                    quantity: "1",
+                }),
+                {
+                    content: "there only 5 order lines",
+                    trigger: ".order-container",
+                    run: () => {
+                        const orderLines = document.querySelectorAll(".orderline");
+                        if (orderLines.length !== 5) {
+                            throw new Error("Expected 5 order lines");
+                        }
+                    },
+                },
+            ]),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_combo_item_image_display", {
     steps: () =>
         [

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -350,6 +350,53 @@ registry.category("web_tour.tours").add("test_convert_orderlines_to_combo", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_convert_orderlines_to_combo_with_same_product", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Combo Product 1"),
+            ProductConfiguratorPopup.pickColor("Blue"),
+            Dialog.confirm(),
+            ProductScreen.clickDisplayedProduct("Combo Product 1"),
+            ProductConfiguratorPopup.pickColor("Red"),
+            Dialog.confirm(),
+            ProductScreen.clickDisplayedProduct("Combo Product 4"),
+            ProductScreen.clickDisplayedProduct("Combo Product 6"),
+            ProductScreen.clickApplyCombo(),
+            inLeftSide([
+                ...Order.hasLine({
+                    productName: "Combo Product 1",
+                    quantity: "1",
+                    attributeLine: "Red",
+                }),
+                ...Order.hasLine({
+                    productName: "Combo Product 1",
+                    quantity: "1",
+                    attributeLine: "Blue",
+                }),
+                ...Order.hasLine({
+                    productName: "Combo Product 4",
+                    quantity: "1",
+                }),
+                ...Order.hasLine({
+                    productName: "Combo Product 6",
+                    quantity: "1",
+                }),
+                {
+                    content: "there only 5 order lines",
+                    trigger: ".order-container",
+                    run: () => {
+                        const orderLines = document.querySelectorAll(".orderline");
+                        if (orderLines.length !== 5) {
+                            throw new Error("Expected 5 order lines");
+                        }
+                    },
+                },
+            ]),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_combo_item_image_display", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -39,7 +39,7 @@ def setup_product_combo_items(self):
         "name": "Category 3",
     })
 
-    combo_product_1 = self.env["product.product"].create(
+    self.combo_product_1 = self.env["product.product"].create(
         {
             "name": "Combo Product 1",
             "is_storable": True,
@@ -77,7 +77,7 @@ def setup_product_combo_items(self):
             "name": "Desk Accessories Combo",
             "combo_item_ids": [
                 Command.create({
-                    "product_id": combo_product_1.id,
+                    "product_id": self.combo_product_1.id,
                     "extra_price": 0,
                 }),
                 Command.create({

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -39,7 +39,7 @@ def setup_product_combo_items(self):
         "name": "Category 3",
     })
 
-    combo_product_1 = self.env["product.product"].create(
+    self.combo_product_1 = self.env["product.product"].create(
         {
             "name": "Combo Product 1",
             "is_storable": True,
@@ -77,7 +77,7 @@ def setup_product_combo_items(self):
             "name": "Desk Accessories Combo",
             "combo_item_ids": [
                 Command.create({
-                    "product_id": combo_product_1.id,
+                    "product_id": self.combo_product_1.id,
                     "extra_price": 0,
                 }),
                 Command.create({
@@ -174,25 +174,25 @@ def setup_product_combo_items(self):
         }
     )
 
-    chair_color_attribute = self.env['product.attribute'].create({
+    self.chair_color_attribute = self.env['product.attribute'].create({
         'name': 'Color',
         'display_type': 'color',
         'create_variant': 'no_variant',
     })
-    chair_color_red = self.env['product.attribute.value'].create({
+    self.chair_color_red = self.env['product.attribute.value'].create({
         'name': 'Red',
-        'attribute_id': chair_color_attribute.id,
+        'attribute_id': self.chair_color_attribute.id,
         'html_color': '#ff0000',
     })
-    chair_color_blue = self.env['product.attribute.value'].create({
+    self.chair_color_blue = self.env['product.attribute.value'].create({
         'name': 'Blue',
-        'attribute_id': chair_color_attribute.id,
+        'attribute_id': self.chair_color_attribute.id,
         'html_color': '#0000ff',
     })
     self.env['product.template.attribute.line'].create({
         'product_tmpl_id': combo_product_9.product_tmpl_id.id,
-        'attribute_id': chair_color_attribute.id,
-        'value_ids': [(6, 0, [chair_color_red.id, chair_color_blue.id])]
+        'attribute_id': self.chair_color_attribute.id,
+        'value_ids': [(6, 0, [self.chair_color_red.id, self.chair_color_blue.id])]
     })
 
     self.chairs_combo = self.env["product.combo"].create(

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3811,6 +3811,15 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_convert_orderlines_to_combo', login="pos_user")
 
+    def test_convert_orderlines_to_combo_with_same_product(self):
+        setup_product_combo_items(self)
+        self.desk_accessories_combo.qty_max = 2
+        self.combo_product_1.product_tmpl_id.attribute_line_ids = [Command.create({
+            'attribute_id': self.chair_color_attribute.id,
+            'value_ids': [(6, 0, [self.chair_color_red.id, self.chair_color_blue.id])],
+        })]
+        self.start_pos_tour('test_convert_orderlines_to_combo_with_same_product')
+
     def test_sync_from_ui_one_by_one(self):
         """
         Sync from UI is now syncing orders one by one.

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3691,6 +3691,30 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_convert_orderlines_to_combo', login="pos_user")
 
+    def test_convert_orderlines_to_combo_with_same_product(self):
+        setup_product_combo_items(self)
+        self.desk_accessories_combo.qty_max = 2
+        chair_color_attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'display_type': 'color',
+            'create_variant': 'no_variant',
+        })
+        chair_color_red = self.env['product.attribute.value'].create({
+            'name': 'Red',
+            'attribute_id': chair_color_attribute.id,
+            'html_color': '#ff0000',
+        })
+        chair_color_blue = self.env['product.attribute.value'].create({
+            'name': 'Blue',
+            'attribute_id': chair_color_attribute.id,
+            'html_color': '#0000ff',
+        })
+        self.combo_product_1.product_tmpl_id.attribute_line_ids = [Command.create({
+            'attribute_id': chair_color_attribute.id,
+            'value_ids': [(6, 0, [chair_color_red.id, chair_color_blue.id])],
+        })]
+        self.start_pos_tour('test_convert_orderlines_to_combo_with_same_product')
+
     def test_sync_from_ui_one_by_one(self):
         """
         Sync from UI is now syncing orders one by one.


### PR DESCRIPTION
Steps:
---
- Open the Burger combo choice.
- Set the maximum quantity to 2.
- Open the restaurant.
- Add a cheese burger with Belgian fresh homemade fries.
- Add another cheese burger with sweet potato fries.
- Add Coca-Cola.
- Click Apply.

Issue:
---
- A new cheese burger line is created even though a cheese burger line already exists.

Cause:
---
- When the same product has different configurations but belongs to the same `combo_item`, the last configuration overrides the previous one due to using the same key.

Fix:
---
- Differentiate configurations by appending `lineUuid` to the configuration key.
- Ensure each product configuration is handled independently when computing included and extra combo items.

task-5480195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
