### PR TITLE
[IMP] base: add new caribbean guilder currency

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -342,7 +342,7 @@
         <record id="cw" model="res.country">
             <field name="name">Curaçao</field>
             <field name="code">cw</field>
-            <field name="currency_id" ref="ANG" />
+            <field name="currency_id" ref="XCG" />
             <field eval="599" name="phone_code" />
         </record>
         <record id="cx" model="res.country">
@@ -1353,7 +1353,7 @@
         <record id="sx" model="res.country">
             <field name="name">Sint Maarten (Dutch part)</field>
             <field name="code">sx</field>
-            <field name="currency_id" ref="ANG" />
+            <field name="currency_id" ref="XCG" />
             <field eval="1721" name="phone_code" />
         </record>
         <record id="sy" model="res.country">

--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -806,6 +806,17 @@
             <field name="position">before</field>
         </record>
 
+        <record id="XCG" model="res.currency">
+            <field name="name">XCG</field>
+            <field name="full_name">Caribbean Guilder</field>
+            <field name="symbol">Cg</field>
+            <field name="rounding">0.01</field>
+            <field name="active" eval="False"/>
+            <field name="currency_unit_label">Guilder</field>
+            <field name="currency_subunit_label">Cents</field>
+            <field name="position">after</field>
+        </record>
+
         <record id="DJF" model="res.currency">
             <field name="name">DJF</field>
             <field name="iso_numeric">262</field>

--- a/odoo/addons/base/data/res_currency_rate_demo.xml
+++ b/odoo/addons/base/data/res_currency_rate_demo.xml
@@ -432,6 +432,12 @@
             <field name="rate">2.11</field>
         </record>
 
+        <record forcecreate="0" id="rateXCG" model="res.currency.rate">
+            <field name="currency_id" ref="XCG" />
+            <field name="name">2025-01-15</field>
+            <field name="rate">1.80302</field>
+        </record>
+
         <record forcecreate="0" id="rateDJF" model="res.currency.rate">
             <field name="currency_id" ref="DJF" />
             <field name="name">2010-01-01</field>


### PR DESCRIPTION
Introduce the Caribbean Guilder (XCG) as an available currency and set it as the default currency for Curaçao and Sint Maarten.

Related PR-https://github.com/odoo/enterprise/pull/104404
taskID-5490423