### PR TITLE
[FIX] account: hide empty group header in grouped view widget

### DIFF
--- a/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.xml
+++ b/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.xml
@@ -18,11 +18,13 @@
     </t>
 
     <tbody t-name="account.GroupedItemsTemplate">
-        <tr style="background-color: #dee2e6;">
-            <td t-attf-colspan="{{props.options.columns.length}}">
-                <t t-out="props.group_vals.group_name"/>
-            </td>
-        </tr>
+        <t t-if="props.group_vals.group_name">
+            <tr style="background-color: #dee2e6;">
+                <td t-attf-colspan="{{props.options.columns.length}}">
+                    <t t-out="props.group_vals.group_name"/>
+                </td>
+            </tr>
+        </t>
         <t t-foreach="props.group_vals.items_vals" t-as="item_vals" t-key="item_vals_index">
             <ListItem item_vals="item_vals[2]" options="props.options"/>
         </t>


### PR DESCRIPTION
Reason:
The grouped_view_widget renders a header row even when group_name is empty, creating unnecessary empty header rows in the UI.

Fix:
Add t-if condition to only render the header row when group_name exists.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
