### PR TITLE
[FIX] mrp_subcontracting: reserved quantity not cleared on stock.quant when removing component line

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -39,7 +39,6 @@ class MrpProduction(models.Model):
             for move in production.move_raw_ids:
                 lines = line_by_product.pop(move.product_id, self.env['stock.move.line'])
                 lines_to_delete = move.move_line_ids - lines
-                move.move_line_ids = lines
                 lines_to_delete.unlink()
             for product_id, lines in line_by_product.items():
                 qty = sum(line.product_uom_id._compute_quantity(line.quantity, product_id.uom_id) for line in lines)

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1180,9 +1180,14 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         # Change consumption by removing the second line
         action = receipt.move_ids.action_show_details()
         mo = self.env['mrp.production'].browse(action['res_id'])
+        subcontract_location = self.subcontractor_partner1.property_stock_subcontractor
+        reserved_before = sum(self.env['stock.quant']._gather(self.comp2, subcontract_location, strict=True).mapped('reserved_quantity'))
+        self.assertEqual(reserved_before, 1)
         line_to_remove = mo.move_line_raw_ids[1]
         with Form(mo.with_context(action['context']), view=action['view_id']) as mo_form:
             mo_form.move_line_raw_ids.remove(1)
+        reserved_after = sum(self.env['stock.quant']._gather(self.comp2, subcontract_location, strict=True).mapped('reserved_quantity'))
+        self.assertEqual(reserved_after, 0)
         mo.subcontracting_record_component()
         self.assertFalse(line_to_remove.exists())
 


### PR DESCRIPTION
### Odoo Version

- [x] 17.0
- [ ] 18.0
- [ ] 19.0
- [ ] Other (specify)

### Steps to Reproduce

Current behaviour:
- Create a serial-tracked subcontracted product with 1 serial-tracked component.
- Add two of the component product with different serials to the subcontractor’s location.
- Create a PO for 2 units of the finished product, then confirm it.
- Open the related picking.
- Open the “Record Components” wizard.
- Set the quantity, then remove the second line.
- Confirm production (do not update consumption).
- Go to Inventory > Reporting > Locations.
- Result:
  - For the serial that belonged to the removed second line:
  - On Hand Quantity = 0
  - Reserved Quantity = 1

Expected behaviour:
- For the serial that belonged to the removed second line:
- On Hand Quantity = 0
- Reserved Quantity = 0

Additional context
Although https://github.com/odoo/odoo/pull/229310
 deletes the unreferenced stock.move.line, it looks like the corresponding stock.quant reservation might still remain, resulting in a stale reserved quantity.

@qrtl QT6196