### PR TITLE
[FIX] l10n_sa: fix timezone

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -43,7 +43,7 @@ class AccountMove(models.Model):
                 seller_name_enc = get_qr_encoding(1, record.company_id.display_name)
                 company_vat_enc = get_qr_encoding(2, record.company_id.vat)
                 time_sa = fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'), record.l10n_sa_confirmation_datetime)
-                timestamp_enc = get_qr_encoding(3, time_sa.strftime("%Y-%m-%dT%H:%M:%S"))
+                timestamp_enc = get_qr_encoding(3, time_sa.strftime(self._get_iso_format_asia_riyadh_date('T')))
                 totals = record._get_l10n_sa_totals()
                 invoice_total_enc = get_qr_encoding(4, float_repr(abs(totals['total_amount']), 2))
                 total_vat_enc = get_qr_encoding(5, float_repr(abs(totals['total_tax']), 2))
@@ -58,7 +58,7 @@ class AccountMove(models.Model):
             if move.country_code == 'SA' and move.is_sale_document():
                 vals = {}
                 if not move.l10n_sa_confirmation_datetime:
-                    vals['l10n_sa_confirmation_datetime'] = datetime.combine(move.invoice_date, fields.Datetime.now().time())
+                    vals['l10n_sa_confirmation_datetime'] = datetime.combine(move.invoice_date, fields.Datetime.now().time()).strftime(self._get_iso_format_asia_riyadh_date())
                 if not move.delivery_date:
                     vals['delivery_date'] = move.invoice_date
                 if vals:
@@ -68,6 +68,9 @@ class AccountMove(models.Model):
     def get_l10n_sa_confirmation_datetime_sa_tz(self):
         self.ensure_one()
         return format_datetime(self.env, self.l10n_sa_confirmation_datetime, tz='Asia/Riyadh', dt_format='Y-MM-dd\nHH:mm:ss')
+
+    def _get_iso_format_asia_riyadh_date(self, separator=' '):
+        return f'%Y-%m-%d{separator}%H:%M:%S'
 
     def _get_l10n_sa_totals(self):
         self.ensure_one()


### PR DESCRIPTION
The time information added to the date of the invoice post for ZATCA in iso format which adds +03:00. However ZATCA expects the time to be sent as is in Asia/Riyadh timezone.

- Set up a ZATCA company and onboard a journal

- To simulate the timezone issue, replace the hour value with 23h in the following line: vals['l10n_sa_confirmation_datetime'] = datetime.combine(move.invoice_date, fields.Datetime.now().time()). (use .replace(hour=23)))

- Create, confirm, and send an invoice to ZATCA

opw-5373067

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
