### PR TITLE
[FIX] hr_holidays: fix access error for my department filter

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -45,6 +45,7 @@ class HrEmployee(models.Model):
     hr_icon_display = fields.Selection(selection_add=[
         ('presence_holiday_absent', 'On leave'),
         ('presence_holiday_present', 'Present but on leave')])
+    member_of_department = fields.Boolean('Member of Department', compute='_compute_member_of_department', search='_search_part_of_department')
 
     def _compute_current_leave(self):
         self.current_leave_id = False
@@ -178,6 +179,11 @@ class HrEmployee(models.Model):
             else:
                 employee.show_leaves = False
 
+    @api.depends('version_id.member_of_department')
+    def _compute_member_of_department(self):
+        for employee in self.sudo():
+            employee.member_of_department = employee.current_version_id.member_of_department
+
     def _search_absent_employee(self, operator, value):
         if operator != 'in':
             return NotImplemented
@@ -192,6 +198,10 @@ class HrEmployee(models.Model):
             ('date_to', '>=', today_start),
         ])
         return [('id', 'in', holidays.employee_id.ids)]
+
+    def _search_part_of_department(self, operator, value):
+        version_ids = self.env['hr.version'].sudo()._search([('member_of_department', operator, value)])
+        return [('version_ids', 'in', version_ids)]
 
     @api.model_create_multi
     def create(self, vals_list):


### PR DESCRIPTION
**Steps to reproduce:**
1- Install Time off app with demo data
2- Log in as Marc Demo
3- Go to Time Off > Overview
4- Enable `My Department` filter

**Issue:**
An access error is raised because of not having enough rights to access the field `version_id` on hr.employee.

**Fix:**
Adding the field `member_of_department` directly on hr.employee to to do the compute and search on that field in sudo to know if the employees in the Overview are part of the department of the current user. Hence, avoiding the need to access the `hr.version` model which the user does not have access to.

Task: 5470085