### PR TITLE
[FIX] orm: filter 'pg_class' queries with current_schema

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -70,9 +70,11 @@ class SequenceMixin(models.AbstractModel):
                   JOIN pg_index ix ON t.oid = ix.indrelid
                   JOIN pg_attribute a ON a.attrelid = t.oid
                                      AND a.attnum = ANY(ix.indkey)
+                  JOIN pg_namespace n ON t.relnamespace = n.oid
                  WHERE t.relkind = 'r'
                    AND t.relname = %(table)s
                    AND a.attname = %(column)s
+                   AND n.nspname = current_schema
                    AND ix.indisunique
                 """,
                 table=self._table,

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1862,7 +1862,9 @@ class IrModelConstraint(models.Model):
                     FROM pg_constraint cs
                     JOIN pg_class cl
                     ON (cs.conrelid = cl.oid)
+                    JOIN pg_namespace n ON cl.relnamespace = n.oid
                     WHERE cs.contype IN %s AND cs.conname = %s AND cl.relname = %s
+                    AND n.nspname = current_schema
                     """, ('c', 'u', 'x') if typ == 'u' else (typ,), hname, table
                 )):
                     self.env.execute_query(SQL(

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -32,7 +32,13 @@ def _alter_sequence(cr, seq_name, number_increment=None, number_next=None):
     """ Alter a PostreSQL sequence. """
     if number_increment == 0:
         raise UserError(_("Step must not be zero."))
-    cr.execute("SELECT relname FROM pg_class WHERE relkind=%s AND relname=%s", ('S', seq_name))
+    cr.execute(
+        "SELECT relname FROM pg_class"
+        "  JOIN pg_namespace n ON pg_class.relnamespace = n.oid"
+        " WHERE relkind = %s AND relname = %s"
+        "   AND n.nspname = current_schema",
+        ('S', seq_name)
+    )
     if not cr.fetchone():
         # sequence is not created yet, we're inside create() so ignore it, will be set later
         return

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -560,7 +560,9 @@ def _add_manual_models(env: Environment):
                 """ SELECT a.attname
                     FROM pg_attribute a
                     JOIN pg_class t ON a.attrelid = t.oid AND t.relname = %s
-                    WHERE a.attnum > 0 -- skip system columns """,
+                    JOIN pg_namespace n ON t.relnamespace = n.oid
+                    WHERE a.attnum > 0 -- skip system columns
+                      AND n.nspname = current_schema """,
                 [table_name]
             )
             columns = {colinfo[0] for colinfo in env.cr.fetchall()}

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3117,8 +3117,10 @@ class BaseModel(metaclass=MetaModel):
                      if field.store and field.column_type]
         cr.execute(SQL(
             """ SELECT a.attname, a.attnotnull
-                  FROM pg_class c, pg_attribute a
+                  FROM pg_class c, pg_attribute a, pg_namespace n
                  WHERE c.relname=%s
+                   AND c.relnamespace = n.oid
+                   AND n.nspname = current_schema
                    AND c.oid=a.attrelid
                    AND a.attisdropped=%s
                    AND pg_catalog.format_type(a.atttypid, a.atttypmod) NOT IN ('cid', 'tid', 'oid', 'xid')
@@ -7115,8 +7117,10 @@ def get_columns_from_sql_diagnostics(cr, diagnostics, *, check_registry=False) -
             ) as "columns"
         FROM pg_constraint
         JOIN pg_class t ON t.oid = conrelid
+        JOIN pg_namespace n ON t.relnamespace = n.oid
         WHERE conname = %s
             AND t.relname = %s
+            AND n.nspname = current_schema
     """, diagnostics.constraint_name, diagnostics.table_name))
     columns = cr.fetchone()
     return columns[0] if columns else []

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -897,7 +897,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
             JOIN pg_class AS c2 ON fk.confrelid = c2.oid
             JOIN pg_attribute AS a1 ON a1.attrelid = c1.oid AND fk.conkey[1] = a1.attnum
             JOIN pg_attribute AS a2 ON a2.attrelid = c2.oid AND fk.confkey[1] = a2.attnum
+            JOIN pg_namespace n ON c1.relnamespace = n.oid
             WHERE fk.contype = 'f' AND c1.relname IN %s
+              AND n.nspname = current_schema
         """
         cr.execute(query, [tuple({table for table, column in self._foreign_keys})])
         existing = {

--- a/odoo/tools/populate.py
+++ b/odoo/tools/populate.py
@@ -180,8 +180,10 @@ def field_needs_variation(model: Model, field: Field) -> bool:
                    JOIN pg_class t ON t.oid = idx.indrelid
                    JOIN pg_class i ON i.oid = idx.indexrelid
                    JOIN pg_attribute a ON a.attnum = ANY (idx.indkey) AND a.attrelid = t.oid
+                   JOIN pg_namespace n ON t.relnamespace = n.oid
               WHERE t.relname = %s  -- tablename
                 AND a.attname = %s  -- column
+                AND n.nspname = current_schema
                 AND idx.indisunique = TRUE) AS is_unique;
         """, model_._table, field_.name)
         return model_.env.execute_query(query)[0][0]

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -407,10 +407,12 @@ def get_depending_views(cr, table, column):
         JOIN pg_class as dependent ON pg_depend.refobjid = dependent.oid
         JOIN pg_attribute ON pg_depend.refobjid = pg_attribute.attrelid
             AND pg_depend.refobjsubid = pg_attribute.attnum
+        JOIN pg_namespace n ON dependee.relnamespace = n.oid
         WHERE dependent.relname = %s
         AND pg_attribute.attnum > 0
         AND pg_attribute.attname = %s
         AND dependee.relkind in ('v', 'm')
+        AND n.nspname = current_schema
     """, table, column))
     return cr.fetchall()
 
@@ -440,8 +442,10 @@ def constraint_definition(cr, tablename, constraintname):
         SELECT COALESCE(d.description, pg_get_constraintdef(c.oid))
         FROM pg_constraint c
         JOIN pg_class t ON t.oid = c.conrelid
+        JOIN pg_namespace n ON t.relnamespace = n.oid
         LEFT JOIN pg_description d ON c.oid = d.objoid
         WHERE t.relname = %s AND conname = %s
+          AND n.nspname = current_schema
     """, tablename, constraintname))
     return cr.fetchone()[0] if cr.rowcount else None
 
@@ -492,12 +496,14 @@ def get_foreign_keys(cr, tablename1, columnname1, tablename2, columnname2, ondel
             JOIN pg_class AS c2 ON fk.confrelid = c2.oid
             JOIN pg_attribute AS a1 ON a1.attrelid = c1.oid AND fk.conkey[1] = a1.attnum
             JOIN pg_attribute AS a2 ON a2.attrelid = c2.oid AND fk.confkey[1] = a2.attnum
+            JOIN pg_namespace n ON c1.relnamespace = n.oid
             WHERE fk.contype = 'f'
             AND c1.relname = %s
             AND a1.attname = %s
             AND c2.relname = %s
             AND a2.attname = %s
             AND fk.confdeltype = %s
+            AND n.nspname = current_schema
         """,
         tablename1, columnname1, tablename2, columnname2, deltype,
     ))
@@ -513,12 +519,14 @@ def fix_foreign_key(cr, tablename1, columnname1, tablename2, columnname2, ondele
     cr.execute(SQL(
         """ SELECT con.conname, c2.relname, a2.attname, con.confdeltype as deltype
               FROM pg_constraint as con, pg_class as c1, pg_class as c2,
-                   pg_attribute as a1, pg_attribute as a2
+                   pg_attribute as a1, pg_attribute as a2, pg_namespace n
              WHERE con.contype='f' AND con.conrelid=c1.oid AND con.confrelid=c2.oid
                AND array_lower(con.conkey, 1)=1 AND con.conkey[1]=a1.attnum
                AND array_lower(con.confkey, 1)=1 AND con.confkey[1]=a2.attnum
                AND a1.attrelid=c1.oid AND a2.attrelid=c2.oid
-               AND c1.relname=%s AND a1.attname=%s """,
+               AND c1.relname=%s AND a1.attname=%s
+               AND c1.relnamespace = n.oid
+               AND n.nspname = current_schema """,
         tablename1, columnname1,
     ))
     found = False
@@ -549,8 +557,10 @@ def index_definition(cr, indexname):
         SELECT idx.indexdef, d.description
         FROM pg_class c
         JOIN pg_indexes idx ON c.relname = idx.indexname
+        JOIN pg_namespace n ON c.relnamespace = n.oid
         LEFT JOIN pg_description d ON c.oid = d.objoid
         WHERE c.relname = %s AND c.relkind = 'i'
+          AND n.nspname = current_schema
     """, indexname))
     return cr.fetchone() if cr.rowcount else (None, None)
 


### PR DESCRIPTION
Safety measure to prevent hidden bugs and data corruption which can happen when multiple schema are used in PostgreSQL.

Description of the issue/feature this PR addresses:
Related to:
- PR  #243833
- OPW [opw-5495025](https://www.odoo.com/my/tasks/5495025)
- issue reported earlier: #97891




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
