### PR TITLE
[FIX] point_of_sale: display correct negative change with rounding

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -97,7 +97,12 @@ export class PosOrderAccounting extends Base {
             (isNegative ? -roundingSanatizer : roundingSanatizer);
 
         const amount = isNegative ? -this.currency.round(total) : this.currency.round(total);
-        return this.config.cash_rounding ? this.config.rounding_method.round(amount) : amount;
+        if (this.config.cash_rounding) {
+            return this.currency.isNegative(amount)
+                ? this.config.rounding_method.asymmetricRound(amount)
+                : this.config.rounding_method.round(amount);
+        }
+        return amount;
     }
     get orderIsRounded() {
         const cashPm = this.payment_ids.some((p) => p.payment_method_id.is_cash_count);

--- a/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/rounding.test.js
@@ -326,3 +326,23 @@ test("Rouding sale HALF-UP 0.05 with two payment method", async () => {
     expect(order.appliedRounding).toBe(0);
     expect(order.change).toBe(0);
 });
+
+test("Rouding change nearest assymetric", async () => {
+    const store = await setupPosEnv();
+    const cashPm = prepareRoundingVals(store, 1, "HALF-UP", false);
+    const order = store.addNewOrder();
+    const product = store.models["product.template"].get(1);
+    store.models["product.product"].get(1).lst_price = 16.5;
+    order.pricelist_id = false;
+    await store.addLineToOrder(
+        {
+            product_tmpl_id: product,
+            qty: 1,
+        },
+        order
+    );
+    expect(order.displayPrice).toBe(16.5);
+    const paymentLine = order.addPaymentline(cashPm);
+    paymentLine.data.setAmount(20);
+    expect(order.change).toBe(-3);
+});


### PR DESCRIPTION
**Steps to reproduce:**
- Make a rounding method, put 1.00 as the value and nearest as the method
- Make a product without tax, the price should be 16.50
- Go to the PoS, order that product
- On the payment screen, click Cash, the value is rounded to 17
- Input "20" to change the payment line's value
- The change is "-4", which doesn't make sense as the price to pay was 17

**Why the fix:**
Before this commit, we used the round function, which is symmetric, meaning that as round(1.23) with a
precision of 0.1 and UP method will return 1.3, the same with round(-1.23) will return -1.3, meaning the rounding method will return the same number and just change the sign depending on if the input is positive and negative.

This causes inconsitencies, because clicking Cash would set the price to pay to 17, but paying 20 would set the change to -4.

With an assymetric rounding we prevent this problem, as it inverts the rounding method if the value is negative. In our case, this means that the change will be rounded DOWN, to -3.

opw-5476694