### PR TITLE
[FIX] mass_mailing: properly await ThemeSelector in tests

### DIFF
--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.js
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.js
@@ -111,17 +111,21 @@ export class ThemeSelectorIframe extends Component {
             props: this.getThemeSelectorProps(),
         });
         await Promise.all([
-            loadBundle("mass_mailing.assets_iframe_theme_selector", {
-                targetDoc: this.iframeRef.el.contentDocument,
-                css: true,
-                js: false,
-            }),
+            this.loadIframeAssets(),
             this.themeSelectorRoot.mount(this.iframeRef.el.contentDocument.body),
         ]);
         browser.requestAnimationFrame(() => {
             if (status(this) !== "destroyed") {
                 this.state.show = true;
             }
+        });
+    }
+
+    loadIframeAssets() {
+        return loadBundle("mass_mailing.assets_iframe_theme_selector", {
+            targetDoc: this.iframeRef.el.contentDocument,
+            css: true,
+            js: false,
         });
     }
 

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -1,4 +1,4 @@
-import { expect, test, describe, beforeEach, getFixture, before } from "@odoo/hoot";
+import { expect, test, describe, beforeEach, getFixture, before, waitUntil } from "@odoo/hoot";
 import {
     defineModels,
     fields,
@@ -17,6 +17,7 @@ import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { unmockedOrm } from "@web/../tests/_framework/module_set.hoot";
 import { MassMailingIframe } from "../src/iframe/mass_mailing_iframe";
 import { MassMailingHtmlField } from "../src/fields/html_field/mass_mailing_html_field";
+import { ThemeSelector } from "../src/themes/theme_selector/theme_selector";
 import { user } from "@web/core/user";
 
 class Mailing extends models.Model {
@@ -190,16 +191,44 @@ const mailViewArch = `
 /**
  * @type {MassMailingHtmlField}
  */
-let htmlField;
+let htmlField, themeSelector;
 describe.current.tags("desktop");
 beforeEach(() => {
+    htmlField = undefined;
+    themeSelector = undefined;
     patchWithCleanup(MassMailingHtmlField.prototype, {
         setup() {
             super.setup();
             htmlField = this;
         },
     });
+    patchWithCleanup(ThemeSelector.prototype, {
+        setup() {
+            super.setup();
+            themeSelector = this;
+        },
+    });
 });
+
+/**
+ * The ThemeSelector rendering is optimized to minimize UX transition delays
+ * for the user, but that makes it a bit tricky to wait for in tests. This
+ * function properly waits for everything required to select a theme/favorite
+ * by clicking on it.
+ */
+async function waitForThemeSelector() {
+    await waitFor(".o_mass_mailing_theme_selector_iframe_container iframe:not([hidden])", {
+        timeout: 3000,
+    });
+    await waitUntil(
+        () =>
+            themeSelector &&
+            themeSelector.props.favoriteThemes.promise &&
+            !themeSelector.state.loading,
+        { timeout: 3000 }
+    );
+}
+
 describe("field HTML", () => {
     beforeEach(() => {
         patchWithCleanup(MassMailingIframe.prototype, {
@@ -226,12 +255,8 @@ describe("field HTML", () => {
             arch: mailViewArch,
         });
         expect(queryOne(".o_mass_mailing_iframe_wrapper iframe")).toHaveClass("d-none");
-        await click(
-            waitFor(
-                ":iframe .o_mailing_template_preview_wrapper div[role='menuitem']:contains(Start From Scratch)",
-                { timeout: 1000 }
-            )
-        );
+        await waitForThemeSelector();
+        await contains(":iframe .o_mailing_template_preview_wrapper [data-name='empty']").click();
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass("o_empty_theme");
         await clickSave();
@@ -295,7 +320,10 @@ describe("field HTML", () => {
         });
         await contains(".o_data_cell").click();
         await waitFor(".o_dialog");
-        await contains(".o_dialog :iframe [data-name='event']", { timeout: 1000 }).click();
+        await waitForThemeSelector();
+        await contains(
+            ".o_dialog :iframe .o_mailing_template_preview_wrapper [data-name='event']"
+        ).click();
         await waitFor(".o_dialog .o_mass_mailing-builder_sidebar", { timeout: 1000 });
         await contains(".o_dialog :iframe .s_text_block", { timeout: 1000 }).click();
         await waitFor(
@@ -314,8 +342,8 @@ describe("field HTML", () => {
             resId: 1,
             arch: mailViewArch,
         });
-        await waitFor(".o_mass_mailing_theme_selector_iframe_container iframe:not([hidden])", { timeout: 3000 });
-        await click(waitFor(":iframe .o_mailing_template_preview_wrapper [data-name='default']"));
+        await waitForThemeSelector();
+        await contains(":iframe .o_mailing_template_preview_wrapper [data-name='default']").click();
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass(
             "o_default_theme"
@@ -393,8 +421,8 @@ describe("field HTML: with loaded assets", () => {
             resId: 1,
             arch: mailViewArch,
         });
-        await waitFor(".o_mass_mailing_theme_selector_iframe_container iframe:not([hidden])", { timeout: 3000 });
-        await click(waitFor(":iframe .o_mailing_template_preview_wrapper [data-name='default']"));
+        await waitForThemeSelector();
+        await contains(":iframe .o_mailing_template_preview_wrapper [data-name='default']").click();
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         const { bundleControls } = await htmlField.ensureIframeLoaded();
 


### PR DESCRIPTION
The ThemeSelector rendering was optimized ([commit]) to minimize UX transition
delays for the user, but that makes it a bit tricky to wait for in tests. This
commit adds a function to properly wait for everything required to select a
theme/favorite by clicking on it, in order to reduce non-determinism in
`mass_mailing` tests.

[commit]: https://github.com/odoo/odoo/commit/0f7ee1764e8b59029003c6ad7269e185b30c6b43

It also removes some assets loading during `mass_mailing` tests that are not
relevant. This helps shave off 10-40% test time per test, depending on the
complexity of the test.

runbot-error-237513
runbot-error-237747
runbot-error-237769
runbot-error-237770
runbot-error-237772

task-5500038