### PR TITLE
[FIX] mrp: wait for filtering and catalog update

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_product_catalog.js
+++ b/addons/mrp/static/tests/tours/mrp_product_catalog.js
@@ -61,11 +61,29 @@ registry.category("web_tour.tours").add('test_mrp_multi_step_product_catalog_com
             run: 'press Enter',
         },
         {
+            content: "Wait for filtering",
+            trigger: '.o_kanban_renderer:not(:has(.o_kanban_record:contains("Table")))',
+        },
+        {
             trigger: '.o_kanban_record:contains(Wooden Leg)',
             run: "click",
         },
         {
-            trigger: '.o_kanban_record:contains(Wooden Leg)',
+            trigger: '.o_kanban_record:contains(Wooden Leg) .o_product_catalog_quantity .o_input',
+            run: 'edit 2',
+        },
+        {
+            trigger: '.o_kanban_record:contains(Wooden Leg) .o_product_catalog_quantity .o_input',
+            run: () => {
+                const productQuantity = document.querySelector('.o_kanban_record .o_product_catalog_quantity .o_input').value;
+                if (productQuantity !== "2") {
+                    throw new Error(`Product quantity not correctly set to 2.`);
+                }
+            },
+        },
+        {
+            content: "Force POL quantity update",
+            trigger: 'button.o_facet_remove',
             run: "click",
         },
         {
@@ -75,4 +93,7 @@ registry.category("web_tour.tours").add('test_mrp_multi_step_product_catalog_com
         {
             trigger: 'div.o_field_widget:contains("WH/MO/")',
         },
+        {
+            trigger: '.o_data_row .o_field_mrp_should_consume:contains(2)',
+        }
 ]});

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5550,7 +5550,7 @@ class TestTourMrpOrder(HttpCase):
         the catalog.
         '''
         # Enable storage locations
-        self.env['res.config.settings'].create({'group_stock_multi_locations': True}).execute()
+        self.env.user.group_ids += self.env.ref('stock.group_stock_multi_locations')
         # Set WH manufacture to 2-step
         warehouse = self.env.ref('stock.warehouse0')
         warehouse.manufacture_steps = 'pbm'


### PR DESCRIPTION
Error message
-----
```
FAIL: TestTourMrpOrder.test_mrp_multi_step_product_catalog_component_transfer
Traceback (most recent call last):
  File "/data/build/odoo/addons/mrp/tests/test_order.py", line 5433, in test_mrp_multi_step_product_catalog_component_transfer
    self.assertEqual(component_transfer.product_uom_qty, 2)
AssertionError: 1.0 != 2
```

Cause
-----
It looks like somehow one of the 2 clicks on the product is either not registered, or the update of the POL's quantity isn't triggered / doesn't happen fast enough, so the tour ends with a quantity of 1 for the product. I see 2 possible causes for this:

1. The product is visible in the initial view. So when the view updates (because of the filtering step), the next step - clicking on the product - the clicks can already be triggered, which might lead to an inconsistent state.
2. There is some synchronicity issue with the quantity update's debounce
https://github.com/odoo/odoo/blob/11292070870ef22663364eda5a4b243dea68856a/addons/product/static/src/product_catalog/kanban_record.js#L16-L18

Solution
-----
Add extra steps to wait for filtering to be applied. Also add extra steps to ensure correct update of the POL's quantity.

-----
Runbot error 237956
