### PR TITLE
[FIX] website_sale_comparison: comparison bar overlapped by grid snippets

### DIFF
--- a/addons/website/views/snippets/s_banner_categories.xml
+++ b/addons/website/views/snippets/s_banner_categories.xml
@@ -12,7 +12,7 @@
             <div class="o_grid_mode row" data-row-count="13" style="gap: 16px;">
                 <div data-name="Intro"
                         class="o_grid_item o_colored_level g-height-6 g-col-lg-8 col-lg-8 justify-content-start"
-                        style="--grid-item-padding-y: 72px; grid-area: 2 / 3 / 8 / 11;">
+                        style="z-index: 1; --grid-item-padding-y: 72px; grid-area: 2 / 3 / 8 / 11;">
                     <h1 style="text-align: center;">Explore Our New Collection</h1>
                     <p class="lead" style="text-align: center;">
                         Each item in our collection is grouped by category to make your browsing experience effortless. Take a look and dive into the different worlds we’ve curated for you.
@@ -26,7 +26,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_colored_level o_cc o_cc5 o_bg_img_center oe_img_bg justify-content-end g-col-lg-4 g-height-6 col-lg-4 col-10 offset-1 offset-lg-0"
-                        style="grid-area: 8 / 1 / 14 / 5; background-image: url('/web/image/website.shop_category_1_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
+                        style="grid-area: 8 / 1 / 14 / 5; z-index: 2;background-image: url('/web/image/website.shop_category_1_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
                     <h2 class="h3-fs">Sofas</h2>
@@ -35,7 +35,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 col-10 offset-1 offset-lg-0"
-                        style="grid-area: 8 / 5 / 14 / 9; background-image: url('/web/image/website.shop_category_2_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
+                        style="grid-area: 8 / 5 / 14 / 9; z-index: 3;background-image: url('/web/image/website.shop_category_2_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
                     <h2 class="h3-fs">Desks</h2>
@@ -44,7 +44,7 @@
                     </p>
                 </div>
                 <div class="o_grid_item o_cc o_cc5 o_colored_level o_bg_img_center oe_img_bg justify-content-end g-height-6 g-col-lg-4 col-lg-4 offset-1 offset-lg-0 col-10"
-                        style="grid-area: 8 / 9 / 14 / 13; background-image: url('/web/image/website.shop_category_3_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
+                        style="grid-area: 8 / 9 / 14 / 13; z-index: 4;background-image: url('/web/image/website.shop_category_3_1x1'); --grid-item-padding-y: 32px; --grid-item-padding-x: 32px;">
                     <div class="o_we_bg_filter"
                         style="background-image: linear-gradient(0deg, rgba(36, 36, 36, 0.52) 0%, rgba(255, 255, 255, 0) 50%);"/>
                     <h2 class="h3-fs">Drawers</h2>

--- a/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
+++ b/addons/website_sale_comparison/static/src/scss/website_sale_comparison.scss
@@ -99,11 +99,7 @@
 }
 
 .o_wsale_comparison_bottom_bar {
-    z-index: var(--o-wsale-comparison-bottom-bar-z-index, 3);
-
-    &:where(:has(.collapsing, .collapse.show)) {
-        --o-wsale-comparison-bottom-bar-z-index: 4;
-    }
+    z-index: $zindex-modal;
 
     box-shadow: 0px -12px 32px rgba($black, .175);
 


### PR DESCRIPTION
Reverting this Commit: https://github.com/odoo/odoo/commit/0cda08f0c215ae6c7db0c4226a8b60ad3884e6b7
Before this commit:
The product comparison bottom bar had a z-index of only 3 (or 4 when expanded). This low z-index value caused it to be overlapped by any website snippets using grid mode with more than 3 items, as grid items conventionally have incremental z-index values (1, 2, 3, 4, ...) for JavaScript consistency.

The issue was not limited to s_banner_categories but affected all grid-based snippets, making the comparison bar inaccessible when positioned behind snippet content.

Solution:
Increase the comparison bar's z-index to -modal (1055 in Bootstrap), ensuring it always appears above regular page content including grid snippets, while still remaining below actual modals and dialogs.

After this commit:
The comparison bar consistently appears on top of all snippet content, ensuring users can always access and interact with product comparisons regardless of the page layout or snippet configuration. 
opw:5426163




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
