### PR TITLE
[FIX] hw_drivers: chromium not taking args into account

### DIFF
--- a/addons/hw_drivers/browser.py
+++ b/addons/hw_drivers/browser.py
@@ -68,7 +68,7 @@ class Browser:
         # Reopen to take new url or additional args into account
         self.close_browser()
 
-        browser_args = list(CHROMIUM_ARGS) if self.browser == 'chromium-browser' else []
+        browser_args = list(CHROMIUM_ARGS) if self.browser == 'chromium' else []
 
         if state == BrowserState.KIOSK:
             browser_args.extend(["--kiosk", "--touch-events"])


### PR DESCRIPTION
In odoo/odoo#233676 we switched from `chromium-browser` to `chromium` to adapt to new executable name in raspbian.

We also need to update this name in the check to set the arguments of the browser, or they will never be passed.

This fixes the issue where the IoT Box freezes when using it for kiosk, as the browser was eating all the memory.