### PR TITLE
[REV] point_of_sale: revert print idempotency

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -48,7 +48,6 @@ import { EpsonPrinter } from "@point_of_sale/app/utils/printer/epson_printer";
 import OrderPaymentValidation from "../utils/order_payment_validation";
 import { logPosMessage } from "../utils/pretty_console_log";
 import { initLNA } from "../utils/init_lna";
-import { uuid } from "@web/core/utils/strings";
 
 const { DateTime } = luxon;
 export const CONSOLE_COLOR = "#F5B427";
@@ -2062,11 +2061,10 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     async printOrderChanges(data, printer) {
-        const actionId = data.changes.data[0]?.uuid || uuid();
         const receipt = renderToElement("point_of_sale.OrderChangeReceipt", {
             data: data,
         });
-        return await printer.printReceipt(receipt, actionId);
+        return await printer.printReceipt(receipt);
     }
 
     filterChangeByCategories(categories, currentOrderChange) {

--- a/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
@@ -17,10 +17,9 @@ export class BasePrinter {
      * Add the receipt to the queue of receipts to be printed and process it.
      * We clear the print queue if printing is not successful.
      * @param {String} receipt: The receipt to be printed, in HTML
-     * @param {String} receiptId: uuid uniquely identifying a receipt to be printed
      * @returns {{ successful: boolean; message?: { title: string; body?: string }}}
      */
-    async printReceipt(receipt, receiptId) {
+    async printReceipt(receipt) {
         if (receipt) {
             this.receiptQueue.push(receipt);
         }
@@ -31,7 +30,7 @@ export class BasePrinter {
                 await htmlToCanvas(receipt, { addClass: "pos-receipt-print" })
             );
             try {
-                printResult = await this.sendPrintingJob(image, receiptId);
+                printResult = await this.sendPrintingJob(image);
             } catch (error) {
                 // Error in communicating to the IoT box.
                 this.receiptQueue.length = 0;


### PR DESCRIPTION
Since preparation printers are ignoring the print job requests sent a lot of users are being blocked in pos UI.
This reverts commit fcd0aab5f1349310e161b175f118eb8d3db818e4.
This unblocks the user's UI in case of a duplicate print

Enterprise: https://github.com/odoo/enterprise/pull/104421

