### PR TITLE
[IMP] account_peppol: improve Peppol configuration UX

### DIFF
--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -6,7 +6,11 @@ class ResConfigSettings(models.TransientModel):
 
     account_peppol_edi_user = fields.Many2one(related='company_id.account_peppol_edi_user')
     account_peppol_edi_mode = fields.Selection(related='account_peppol_edi_user.edi_mode')
-    account_peppol_contact_email = fields.Char(related='company_id.account_peppol_contact_email', readonly=False)
+    account_peppol_contact_email = fields.Char(
+        compute='_compute_account_peppol_contact_email',
+        inverse='_inverse_account_peppol_contact_email',
+    )
+
     account_peppol_eas = fields.Selection(related='company_id.peppol_eas', readonly=False)
     account_peppol_edi_identification = fields.Char(related='account_peppol_edi_user.edi_identification')
     account_peppol_endpoint = fields.Char(related='company_id.peppol_endpoint', readonly=False)
@@ -18,6 +22,14 @@ class ResConfigSettings(models.TransientModel):
     peppol_use_parent_company = fields.Boolean(compute='_compute_peppol_use_parent_company')
     peppol_parent_company_name = fields.Char(compute='_compute_peppol_use_parent_company')
     account_is_token_out_of_sync = fields.Boolean(related='account_peppol_edi_user.is_token_out_of_sync', readonly=False)
+    peppol_participation_role = fields.Selection(
+        selection=[
+            ('sending_and_receiving', 'Sending & Receiving'),
+            ('sending_only', 'Sending Only'),
+        ],
+        compute='_compute_peppol_participation_role',
+        inverse='_inverse_peppol_participation_role',
+    )
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
@@ -36,6 +48,53 @@ class ResConfigSettings(models.TransientModel):
             else:
                 setting.peppol_parent_company_name = None
 
+    @api.depends('account_peppol_proxy_state')
+    def _compute_peppol_participation_role(self):
+        for record in self:
+            state = record.company_id.account_peppol_proxy_state
+            if state == 'sender':
+                record.peppol_participation_role = 'sending_only'
+            elif state in ('smp_registration', 'receiver'):
+                record.peppol_participation_role = 'sending_and_receiving'
+            else:
+                record.peppol_participation_role = False
+
+    def _inverse_peppol_participation_role(self):
+        for record in self:
+            if record.account_peppol_edi_user:
+                if record.peppol_participation_role == 'sending_only' and record.account_peppol_proxy_state != 'sender':
+                    # Reset the participant back to sender and unregister it from the SMP
+                    record.account_peppol_edi_user._peppol_deregister_participant_to_sender()
+                elif record.peppol_participation_role == 'sending_and_receiving' and record.account_peppol_proxy_state not in ('smp_registration', 'receiver'):
+                    # Set the participant to sender as well as register it on the SMP
+                    record.account_peppol_edi_user._peppol_register_sender_as_receiver()
+                    record.account_peppol_edi_user._peppol_get_participant_status()
+
+    @api.depends('company_id.account_peppol_contact_email')
+    def _compute_account_peppol_contact_email(self):
+        for record in self:
+            record.account_peppol_contact_email = record.company_id.account_peppol_contact_email
+
+    def _inverse_account_peppol_contact_email(self):
+        for record in self:
+            company = record.company_id
+            if record.account_peppol_contact_email == company.account_peppol_contact_email:
+                continue
+
+            # Update company field
+            company.account_peppol_contact_email = record.account_peppol_contact_email
+
+            # Sync with IAP (Peppol proxy)
+            params = {
+                'update_data': {
+                    'peppol_contact_email': record.account_peppol_contact_email,
+                }
+            }
+            record.account_peppol_edi_user._call_peppol_proxy(
+                endpoint='/api/peppol/1/update_user',
+                params=params,
+            )
+
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
@@ -45,6 +104,7 @@ class ResConfigSettings(models.TransientModel):
         registration_action = registration_wizard._action_open_peppol_form(reopen=False)
         return registration_action
 
+    # Deprecated
     def button_open_peppol_config_wizard(self):
         view = self.env.ref('account_peppol.peppol_config_wizard_form').sudo()
         # TODO remove in master this hack to have the possibility of being only a sender
@@ -73,6 +133,7 @@ class ResConfigSettings(models.TransientModel):
             }
         }
 
+    # Dreprecated
     def button_peppol_register_sender_as_receiver(self):
         """Register the existing user as a receiver."""
         self.ensure_one()
@@ -90,3 +151,11 @@ class ResConfigSettings(models.TransientModel):
         """
         self.ensure_one()
         self.account_peppol_edi_user._peppol_out_of_sync_disconnect_this_database()
+
+    def button_peppol_deregister(self):
+        """Unregister the user from Peppol network."""
+        self.ensure_one()
+
+        if self.account_peppol_edi_user:
+            self.account_peppol_edi_user._peppol_deregister_participant()
+        return True

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -6,11 +6,11 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@id='account_peppol_install']" position="replace">
-                <div id="account_peppol" class="col-12 o_setting_box">
+                <div id="account_peppol" class="col-12 o_setting_box col-lg-6 o_searchable_setting">
                     <div class="o_setting_right_pane border-0" invisible="account_is_token_out_of_sync">
                         <!-- Info in case of sender. -->
                         <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'sender'">
-                            You are sending your e-invoices via Odoo with this Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.
+                            Your Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.
                             <span class="ps-2" invisible="account_peppol_edi_mode == 'prod'">
                                 (<field class="oe_inline o_form_label text-uppercase" name="account_peppol_edi_mode"/>)
                             </span>
@@ -19,22 +19,30 @@
                         </div>
                         <!-- Info in case of receiver/smp_registration. -->
                         <div invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('receiver', 'smp_registration')">
-                            You are sending and receiving your e-invoices via Odoo with this Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.
+                            Your Peppol ID <field name="account_peppol_edi_identification" class="oe_inline o_form_label" readonly="1"/>.
                             <span class="ps-2" invisible="account_peppol_edi_mode == 'prod'">
                                 (<field class="oe_inline o_form_label text-uppercase" name="account_peppol_edi_mode"/>)
                             </span>
                             <div invisible="account_peppol_proxy_state != 'smp_registration'">
                                 Your registration should be activated within a day.
                             </div>
-                            <div invisible="account_peppol_proxy_state not in ('smp_registration', 'receiver')" class="mt-4">
-                                <div class="row" name="peppol_journal_config">
-                                    <label string="Incoming Invoices Journal"
-                                           for="account_peppol_purchase_journal_id"
-                                           class="col-lg-3"/>
-                                    <field name="account_peppol_purchase_journal_id"
-                                           required="account_peppol_proxy_state in ('smp_registration', 'receiver')"/>
-                                </div>
+                        </div>
+                        <div class="row mt-1"
+                            invisible="peppol_use_parent_company or account_peppol_proxy_state == 'not_registered'">
+                            <label string="Peppol Contact Email"
+                                for="account_peppol_contact_email"
+                                class="col-lg-5 o_light_label"/>
+                            <field name="account_peppol_contact_email"
+                                    required="account_peppol_proxy_state in ('sender', 'smp_registration', 'receiver')"/>
+                        </div>
+                        <div class="o_setting_right_pane" id="peppol_participation_role_config" company_dependent="1"
+                            invisible="not peppol_participation_role">
+                            <div class="mb-2">
+                                <span class="o_form_label">
+                                    <label string="Peppol Participation Role" for="peppol_participation_role"/>
+                                </span>
                             </div>
+                            <field name="peppol_participation_role" widget="radio"/>
                         </div>
                         <!-- Info in case of rejected. -->
                         <div invisible="peppol_use_parent_company or account_peppol_proxy_state != 'rejected'">
@@ -48,11 +56,17 @@
 
                         <div class="d-flex gap-1 action_buttons mt-2"
                              invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')">
+                            <!-- Deprecated button for advanced configuration -->
                             <button string="Advanced Configuration"
                                 icon="oi-arrow-right"
                                 name="button_open_peppol_config_wizard"
                                 type="object"
-                                class="btn-link"/>
+                                class="btn-link"
+                                invisible="True"/>
+                            <button string="Disconnect Peppol"
+                                    name="button_peppol_deregister"
+                                    type="object"
+                                    class="btn-primary me-1"/>
                         </div>
                         <div class="d-flex gap-1 action_buttons" colspan="3">
                             <!-- Not yet registered on Peppol -->
@@ -65,8 +79,8 @@
                                         string="Activate Electronic Invoicing"
                                         class="oe_highlight mt-2"/>
                             </div>
-                            <!-- Registered on Peppol -->
-                            <div invisible="peppol_use_parent_company or account_peppol_proxy_state not in ('sender', 'smp_registration', 'receiver')" class="mt-3">
+                            <!-- deprecated Registered on Peppol -->
+                            <div invisible="True" class="mt-3">
                                 <button string="Register with Odoo"
                                         name="button_peppol_register_sender_as_receiver"
                                         type="object"
@@ -113,6 +127,18 @@
                         </div>
                     </div>
                 </div>
+                <setting
+                    invisible="account_is_token_out_of_sync or peppol_use_parent_company or peppol_participation_role != 'sending_and_receiving'">
+                    <div class="row" name="peppol_journal_config">
+                        <label string="Incoming Accounting Journal"
+                            for="account_peppol_purchase_journal_id"
+                            class="col-lg-5"/>
+                        <field name="account_peppol_purchase_journal_id"
+                            class="col-lg-7"
+                            required="account_peppol_proxy_state in ('smp_registration', 'receiver')
+                                        and peppol_participation_role != 'sending_only'"/>
+                    </div>
+                </setting>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
In this commit:
- Deprecate the Peppol configuration wizard.
- Move the Peppol contact email field to Settings.
- Replace the wizard button with a radio selection for the Peppol registration type.
- Simplify the overall Peppol settings user experience.

Task-5438539
Co-authored: [Soham Zadafiya (soza)](soza@odoo.com)
