### PR TITLE
[IMP] core,*: make 'Product Price' a minimum precision

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -356,7 +356,7 @@ class AccountMoveLine(models.Model):
     price_unit = fields.Float(
         string='Unit Price',
         compute="_compute_price_unit", store=True, readonly=False, precompute=True,
-        digits='Product Price',
+        min_display_digits='Product Price',
     )
     price_subtotal = fields.Monetary(
         string='Subtotal',

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1050,7 +1050,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
+                'price_unit': 0.045,
                 'price_subtotal': 0.005,
                 'price_total': 0.006,
                 'currency_id': self.other_currency.id,
@@ -1099,11 +1099,11 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
-                'price_subtotal': 0.01,
-                'price_total': 0.01,
-                'amount_currency': 0.01,
-                'debit': 0.01,
+                'price_unit': 0.045,
+                'price_subtotal': 0.0,
+                'price_total': 0.0,
+                'amount_currency': 0.0,
+                'debit': 0.0,
             },
             self.product_line_vals_2,
             {
@@ -1114,17 +1114,17 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
             self.tax_line_vals_2,
             {
                 **self.term_line_vals_1,
-                'amount_currency': -208.01,
-                'credit': 208.01,
+                'amount_currency': -208.0,
+                'credit': 208.0,
                 'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
             'currency_id': self.company_data['currency'].id,
             'date': fields.Date.from_string('2016-01-01'),
-            'amount_untaxed': 160.01,
+            'amount_untaxed': 160.0,
             'amount_tax': 48.0,
-            'amount_total': 208.01,
+            'amount_total': 208.0,
         })
 
     def test_in_invoice_onchange_past_invoice_1(self):

--- a/addons/account/tests/test_account_move_in_refund.py
+++ b/addons/account/tests/test_account_move_in_refund.py
@@ -703,7 +703,7 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
+                'price_unit': 0.045,
                 'price_subtotal': 0.005,
                 'price_total': 0.006,
                 'currency_id': self.other_currency.id,
@@ -754,11 +754,11 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
-                'price_subtotal': 0.01,
-                'price_total': 0.01,
-                'amount_currency': -0.01,
-                'credit': 0.01,
+                'price_unit': 0.045,
+                'price_subtotal': 0.0,
+                'price_total': 0.0,
+                'amount_currency': -0.0,
+                'credit': 0.0,
             },
             self.product_line_vals_2,
             {
@@ -769,8 +769,8 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             self.tax_line_vals_2,
             {
                 **self.term_line_vals_1,
-                'amount_currency': 208.01,
-                'debit': 208.01,
+                'amount_currency': 208.0,
+                'debit': 208.0,
                 'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
@@ -778,9 +778,9 @@ class TestAccountMoveInRefundOnchanges(AccountTestInvoicingCommon):
             'currency_id': self.company_data['currency'].id,
             'date': fields.Date.from_string('2016-01-01'),
             'invoice_date': fields.Date.from_string('2016-01-01'),
-            'amount_untaxed': 160.01,
+            'amount_untaxed': 160.0,
             'amount_tax': 48.0,
-            'amount_total': 208.01,
+            'amount_total': 208.0,
         })
 
     def test_in_refund_onchange_past_invoice_1(self):

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -350,11 +350,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'amount_total': 2760.0,
         })
 
-        # Check rounding.
-        decimal_precision_name = self.env['account.move.line']._fields['price_unit']._digits
-        decimal_precision = self.env['decimal.precision'].search([('name', '=', decimal_precision_name)])
-        decimal_precision.digits = 4
-
         product.lst_price = 90.0034
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -371,7 +366,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             ],
         })
         self.assertRecordValues(invoice.invoice_line_ids, [{
-            'price_unit': 163.6425, # 90.0034 / 1.10 * 2
+            'price_unit': 163.64254545454546,  # 90.0034 / 1.10 * 2
             'tax_ids': tax_price_exclude.ids,
             'price_subtotal': 163.643,
             'price_total': 188.189,
@@ -780,13 +775,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         ''' Seek for rounding issue on the price_subtotal when dealing with a price_unit having more digits than the
         foreign currency one.
         '''
-        decimal_precision_name = self.env['account.move.line']._fields['price_unit']._digits
-        decimal_precision = self.env['decimal.precision'].search([('name', '=', decimal_precision_name)])
-
-        self.assertTrue(decimal_precision, "Decimal precision '%s' not found" % decimal_precision_name)
-
         self.other_currency.rounding = 0.01
-        decimal_precision.digits = 4
 
         def check_invoice_values(invoice):
             self.assertInvoiceValues(invoice, [
@@ -1633,7 +1622,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
+                'price_unit': 0.045,
                 'price_subtotal': 0.005,
                 'price_total': 0.006,
                 'currency_id': self.other_currency.id,
@@ -1683,11 +1672,11 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
-                'price_subtotal': 0.01,
-                'price_total': 0.01,
-                'amount_currency': -0.01,
-                'credit': 0.01,
+                'price_unit': 0.045,
+                'price_subtotal': 0.0,
+                'price_total': 0.0,
+                'amount_currency': -0.0,
+                'credit': 0.0,
             },
             self.product_line_vals_2,
             {
@@ -1698,17 +1687,17 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             self.tax_line_vals_2,
             {
                 **self.term_line_vals_1,
-                'amount_currency': 260.01,
-                'debit': 260.01,
+                'amount_currency': 260.0,
+                'debit': 260.0,
                 'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
             'currency_id': self.company_data['currency'].id,
             'date': fields.Date.from_string('2016-01-01'),
-            'amount_untaxed': 200.01,
+            'amount_untaxed': 200.0,
             'amount_tax': 60.0,
-            'amount_total': 260.01,
+            'amount_total': 260.0,
         })
 
     def test_out_invoice_line_tax_fixed_price_include_free_product(self):

--- a/addons/account/tests/test_account_move_out_refund.py
+++ b/addons/account/tests/test_account_move_out_refund.py
@@ -686,7 +686,7 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
+                'price_unit': 0.045,
                 'price_subtotal': 0.005,
                 'price_total': 0.006,
                 'currency_id': self.other_currency.id,
@@ -736,11 +736,11 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             {
                 **self.product_line_vals_1,
                 'quantity': 0.1,
-                'price_unit': 0.05,
-                'price_subtotal': 0.01,
-                'price_total': 0.01,
-                'amount_currency': 0.01,
-                'debit': 0.01,
+                'price_unit': 0.045,
+                'price_subtotal': 0.0,
+                'price_total': 0.0,
+                'amount_currency': 0.0,
+                'debit': 0.0,
             },
             self.product_line_vals_2,
             {
@@ -751,17 +751,17 @@ class TestAccountMoveOutRefundOnchanges(AccountTestInvoicingCommon):
             self.tax_line_vals_2,
             {
                 **self.term_line_vals_1,
-                'amount_currency': -260.01,
-                'credit': 260.01,
+                'amount_currency': -260.0,
+                'credit': 260.0,
                 'date_maturity': fields.Date.from_string('2016-01-01'),
             },
         ], {
             **self.move_vals,
             'currency_id': self.company_data['currency'].id,
             'date': fields.Date.from_string('2016-01-01'),
-            'amount_untaxed': 200.01,
+            'amount_untaxed': 200.0,
             'amount_tax': 60.0,
-            'amount_total': 260.01,
+            'amount_total': 260.0,
         })
 
     def test_out_refund_create_1(self):

--- a/addons/delivery/models/delivery_price_rule.py
+++ b/addons/delivery/models/delivery_price_rule.py
@@ -46,8 +46,8 @@ class PriceRule(models.Model):
     variable = fields.Selection(selection=VARIABLE_SELECTION, required=True, default='quantity')
     operator = fields.Selection([('==', '='), ('<=', '<='), ('<', '<'), ('>=', '>='), ('>', '>')], required=True, default='<=')
     max_value = fields.Float('Maximum Value', required=True)
-    list_base_price = fields.Float(string='Sale Base Price', digits='Product Price', required=True, default=0.0)
-    list_price = fields.Float('Sale Price', digits='Product Price', required=True, default=0.0)
+    list_base_price = fields.Float(string='Sale Base Price', min_display_digits='Product Price', required=True, default=0.0)
+    list_price = fields.Float('Sale Price', min_display_digits='Product Price', required=True, default=0.0)
     variable_factor = fields.Selection(
         selection=VARIABLE_SELECTION, string="Variable Factor", required=True, default='weight'
     )

--- a/addons/event_booth_sale/models/event_booth_category.py
+++ b/addons/event_booth_sale/models/event_booth_category.py
@@ -20,15 +20,15 @@ class EventBoothCategory(models.Model):
         domain=[('service_tracking', '=', 'event_booth')], default=_default_product_id,
         groups="event.group_event_registration_desk")
     price = fields.Float(
-        string='Price', compute='_compute_price', digits='Product Price', readonly=False,
+        string='Price', compute='_compute_price', min_display_digits='Product Price', readonly=False,
         store=True, groups="event.group_event_registration_desk")
     price_incl = fields.Float(
-        string='Price incl', compute='_compute_price_incl', digits='Product Price', readonly=False,
+        string='Price incl', compute='_compute_price_incl', min_display_digits='Product Price', readonly=False,
         groups="event.group_event_registration_desk")
     currency_id = fields.Many2one(related='product_id.currency_id', groups="event.group_event_registration_desk")
     price_reduce = fields.Float(
         string='Price Reduce', compute='_compute_price_reduce',
-        compute_sudo=True, digits='Product Price', groups="event.group_event_registration_desk")
+        compute_sudo=True, min_display_digits='Product Price', groups="event.group_event_registration_desk")
     price_reduce_taxinc = fields.Float(
         string='Price Reduce Tax inc', compute='_compute_price_reduce_taxinc',
         compute_sudo=True

--- a/addons/event_product/models/event_event_ticket.py
+++ b/addons/event_product/models/event_event_ticket.py
@@ -11,7 +11,7 @@ class EventTicket(models.Model):
         compute_sudo=True)
     price_incl = fields.Float(
         string='Price include', compute='_compute_price_incl',
-        digits='Product Price', readonly=False, compute_sudo=True)
+        min_display_digits='Product Price', readonly=False, compute_sudo=True)
 
     @api.depends('product_id.active')
     def _compute_sale_available(self):

--- a/addons/event_product/models/event_type_ticket.py
+++ b/addons/event_product/models/event_type_ticket.py
@@ -23,10 +23,10 @@ class EventTemplateTicket(models.Model):
     currency_id = fields.Many2one(related="product_id.currency_id", string="Currency")
     price = fields.Float(
         string='Price', compute='_compute_price',
-        digits='Product Price', readonly=False, store=True)
+        min_display_digits='Product Price', readonly=False, store=True)
     price_reduce = fields.Float(
         string="Price Reduce", compute="_compute_price_reduce",
-        compute_sudo=True, digits='Product Price')
+        compute_sudo=True, min_display_digits='Product Price')
 
     @api.depends('product_id')
     def _compute_price(self):

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -144,7 +144,7 @@ class HrExpense(models.Model):
         string="Unit Price",
         compute='_compute_price_unit', precompute=True, store=True, required=True, readonly=True,
         copy=True,
-        digits='Product Price',
+        min_display_digits='Product Price',
     )
     currency_id = fields.Many2one(
         comodel_name='res.currency',

--- a/addons/l10n_gcc_invoice/models/account_move.py
+++ b/addons/l10n_gcc_invoice/models/account_move.py
@@ -68,7 +68,7 @@ class AccountMove(models.Model):
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    l10n_gcc_invoice_tax_amount = fields.Float(string='Tax Amount', compute='_compute_tax_amount', digits='Product Price')
+    l10n_gcc_invoice_tax_amount = fields.Float(string='Tax Amount', compute='_compute_tax_amount', min_display_digits='Product Price')
     l10n_gcc_line_name = fields.Char(compute='_compute_l10n_gcc_line_name')
 
     @api.depends('price_subtotal', 'price_total')

--- a/addons/membership/models/membership.py
+++ b/addons/membership/models/membership.py
@@ -28,7 +28,7 @@ class MembershipLine(models.Model):
     date = fields.Date(string='Join Date',
         help="Date on which member has joined the membership")
     member_price = fields.Float(string='Membership Fee',
-        digits='Product Price', required=True,
+        min_display_digits='Product Price', required=True,
         help='Amount for the membership')
     account_invoice_line = fields.Many2one('account.move.line', string='Account Invoice line', readonly=True, ondelete='cascade')
     account_invoice_id = fields.Many2one('account.move', related='account_invoice_line.move_id', string='Invoice', readonly=True)

--- a/addons/membership/wizard/membership_invoice.py
+++ b/addons/membership/wizard/membership_invoice.py
@@ -9,7 +9,7 @@ class MembershipInvoice(models.TransientModel):
     _description = "Membership Invoice"
 
     product_id = fields.Many2one('product.product', string='Membership', required=True)
-    member_price = fields.Float(string='Member Price', digits='Product Price', required=True)
+    member_price = fields.Float(string='Member Price', min_display_digits='Product Price', required=True)
 
     @api.onchange('product_id')
     def onchange_product(self):

--- a/addons/mrp_account/tests/test_bom_price.py
+++ b/addons/mrp_account/tests/test_bom_price.py
@@ -253,4 +253,4 @@ class TestBomPrice(TestBomPriceCommon):
         self.dining_table.button_bom_cost()
         self.assertEqual(self.dining_table.standard_price, 137.5, "After computing price from BoM price should be 137.5")
         scrap_wood.button_bom_cost()
-        self.assertEqual(scrap_wood.standard_price, 20.63, "After computing price from BoM price should be 20.63")
+        self.assertAlmostEqual(scrap_wood.standard_price, 20.625, msg="After computing price from BoM price should be 20.63")

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1392,7 +1392,7 @@ class PosOrderLine(models.Model):
     ], string='Price Type', default='original')
     margin = fields.Monetary(string="Margin", compute='_compute_margin')
     margin_percent = fields.Float(string="Margin (%)", compute='_compute_margin', digits=(12, 4))
-    total_cost = fields.Float(string='Total cost', digits='Product Price', readonly=True)
+    total_cost = fields.Float(string='Total cost', min_display_digits='Product Price', readonly=True)
     is_total_cost_computed = fields.Boolean(help="Allows to know if the total cost has already been computed or not")
     discount = fields.Float(string='Discount (%)', digits=0, default=0.0)
     order_id = fields.Many2one('pos.order', string='Order Ref', ondelete='cascade', required=True, index=True)

--- a/addons/product/models/product_combo.py
+++ b/addons/product/models/product_combo.py
@@ -25,7 +25,7 @@ class ProductCombo(models.Model):
              " prorate the price of this combo with respect to the other combos in a combo product."
              " This heuristic ensures that whatever product the user chooses in a combo, it will"
              " always be the same price.",
-        digits='Product Price',
+        min_display_digits='Product Price',
         compute='_compute_base_price',
     )
 

--- a/addons/product/models/product_combo_item.py
+++ b/addons/product/models/product_combo_item.py
@@ -22,10 +22,10 @@ class ProductComboItem(models.Model):
     currency_id = fields.Many2one(comodel_name='res.currency', related='product_id.currency_id')
     lst_price = fields.Float(
         string="Original Price",
-        digits='Product Price',
+        min_display_digits='Product Price',
         related='product_id.lst_price',
     )
-    extra_price = fields.Float(string="Extra Price", digits='Product Price', default=0.0)
+    extra_price = fields.Float(string="Extra Price", min_display_digits='Product Price', default=0.0)
 
     @api.constrains('product_id')
     def _check_product_id_no_combo(self):

--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -108,7 +108,7 @@ class PricelistItem(models.Model):
              " in order to show discount to customer.",
         index=True, default='fixed', required=True)
 
-    fixed_price = fields.Float(string="Fixed Price", digits='Product Price')
+    fixed_price = fields.Float(string="Fixed Price", min_display_digits='Product Price')
     percent_price = fields.Float(
         string="Percentage Price",
         help="You can apply a mark-up by setting a negative discount.")
@@ -120,13 +120,13 @@ class PricelistItem(models.Model):
         help="You can apply a mark-up by setting a negative discount.")
     price_round = fields.Float(
         string="Price Rounding",
-        digits='Product Price',
+        min_display_digits='Product Price',
         help="Sets the price so that it is a multiple of this value.\n"
              "Rounding is applied after the discount and before the surcharge.\n"
              "To have prices that end in 9.99, round off to 10.00 and set an extra at -0.01")
     price_surcharge = fields.Float(
         string="Extra Fee",
-        digits='Product Price',
+        min_display_digits='Product Price',
         help="Specify the fixed amount to add or subtract (if negative) to the amount calculated with the discount.")
 
     price_markup = fields.Float(
@@ -139,11 +139,11 @@ class PricelistItem(models.Model):
 
     price_min_margin = fields.Float(
         string="Min. Price Margin",
-        digits='Product Price',
+        min_display_digits='Product Price',
         help="Specify the minimum amount of margin over the base price.")
     price_max_margin = fields.Float(
         string="Max. Price Margin",
-        digits='Product Price',
+        min_display_digits='Product Price',
         help="Specify the maximum amount of margin over the base price.")
 
     # functional fields used for usability purposes

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -24,12 +24,12 @@ class ProductProduct(models.Model):
     # price_extra: catalog extra value only, sum of variant extra attributes
     price_extra = fields.Float(
         'Variant Price Extra', compute='_compute_product_price_extra',
-        digits='Product Price',
+        min_display_digits='Product Price',
         help="This is the sum of the extra price of all attributes")
     # lst_price: catalog value + extra, context dependent (uom)
     lst_price = fields.Float(
         'Sales Price', compute='_compute_product_lst_price',
-        digits='Product Price', inverse='_set_product_lst_price',
+        min_display_digits='Product Price', inverse='_set_product_lst_price',
         help="The sale price is managed from the product template. Click on the 'Configure Variants' button to set the extra attribute prices.")
 
     default_code = fields.Char('Internal Reference', index=True)
@@ -53,7 +53,7 @@ class ProductProduct(models.Model):
 
     standard_price = fields.Float(
         'Cost', company_dependent=True,
-        digits='Product Price',
+        min_display_digits='Product Price',
         groups="base.group_user",
         help="""Value of the product (automatically computed in AVCO).
         Used to value the product when the purchase cost is not known (e.g. inventory adjustment).

--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -37,7 +37,7 @@ class SupplierInfo(models.Model):
         'Quantity', default=0.0, required=True, digits="Product Unit of Measure",
         help="The quantity to purchase from this vendor to benefit from the price, expressed in the vendor Product Unit of Measure if not any, in the default unit of measure of the product otherwise.")
     price = fields.Float(
-        'Price', default=0.0, digits='Product Price',
+        'Price', default=0.0, min_display_digits='Product Price',
         required=True, help="The price to purchase a product")
     price_discounted = fields.Float('Discounted Price', compute='_compute_price_discounted')
     company_id = fields.Many2one(

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -93,14 +93,14 @@ class ProductTemplate(models.Model):
     # list_price: catalog price, user defined
     list_price = fields.Float(
         'Sales Price', default=1.0,
-        digits='Product Price',
+        min_display_digits='Product Price',
         tracking=True,
         help="Price at which the product is sold to customers.",
     )
     standard_price = fields.Float(
         'Cost', compute='_compute_standard_price',
         inverse='_set_standard_price', search='_search_standard_price',
-        digits='Product Price', groups="base.group_user",
+        min_display_digits='Product Price', groups="base.group_user",
         help="""Value of the product (automatically computed in AVCO).
         Used to value the product when the purchase cost is not known (e.g. inventory adjustment).
         Used to compute margins on sale orders.""")

--- a/addons/product/models/product_template_attribute_value.py
+++ b/addons/product/models/product_template_attribute_value.py
@@ -35,7 +35,7 @@ class ProductTemplateAttributeValue(models.Model):
     price_extra = fields.Float(
         string="Extra Price",
         default=0.0,
-        digits='Product Price',
+        min_display_digits='Product Price',
         help="Extra price for the variant with this attribute value on sale price."
             " eg. 200 price extra, 1000 + 200 = 1200.")
     currency_id = fields.Many2one(related='attribute_line_id.product_tmpl_id.currency_id')

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -36,7 +36,7 @@ class PurchaseOrderLine(models.Model):
     product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)], change_default=True, index='btree_not_null', ondelete='restrict')
     product_type = fields.Selection(related='product_id.type', readonly=True)
     price_unit = fields.Float(
-        string='Unit Price', required=True, digits='Product Price', aggregator='avg',
+        string='Unit Price', required=True, min_display_digits='Product Price', aggregator='avg',
         compute="_compute_price_unit_and_date_planned_and_name", readonly=False, store=True)
     price_unit_discounted = fields.Float('Unit Price (Discounted)', compute='_compute_price_unit_discounted')
 

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -515,19 +515,22 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
         ])
         receipt = purchase_order.picking_ids
         receipt.button_validate()
-        self.assertRecordValues(components.stock_valuation_layer_ids.sorted(lambda l: l.product_id.id), [
-            {'product_id': component01.id, 'unit_cost':  33.3},
-            {'product_id': component02.id, 'unit_cost': 100.0},
-            {'product_id': component02.id, 'unit_cost': 150.0},
-            {'product_id': component02.id, 'unit_cost':  33.3},
-            {'product_id': component03.id, 'unit_cost': 150.0},
-            {'product_id': component03.id, 'unit_cost':  33.4},
-            {'product_id': component04.id, 'unit_cost': 150.0},
-            {'product_id': component04.id, 'unit_cost': 100.0},
-            {'product_id': component05.id, 'unit_cost': 150.0},
-            {'product_id': component05.id, 'unit_cost': 100.0},
-            {'product_id': component05.id, 'unit_cost': 0.0},
+        svls_ordered = components.stock_valuation_layer_ids.sorted(lambda l: l.product_id.id)
+        self.assertRecordValues(svls_ordered, [
+            {'product_id': component01.id},
+            {'product_id': component02.id},
+            {'product_id': component02.id},
+            {'product_id': component02.id},
+            {'product_id': component03.id},
+            {'product_id': component03.id},
+            {'product_id': component04.id},
+            {'product_id': component04.id},
+            {'product_id': component05.id},
+            {'product_id': component05.id},
+            {'product_id': component05.id},
         ])
+        for svl, expected_unit_cost in zip(svls_ordered, [33.3, 100.0, 150.0, 33.3, 150.0, 33.4, 150.0, 100.0, 150.0, 100.0, 0.0]):
+            self.assertAlmostEqual(svl.unit_cost, expected_unit_cost)
 
     def test_kit_bom_cost_share_constraint_with_variants(self):
         """

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1271,8 +1271,8 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         # The standard price of the component is updated to $10 because the kit cost
         # is $60, there are 6 units of different components used in this BoM, and since
         # the cost_share is equal, 60/6 = $10.
-        self.assertEqual(self.component_a.standard_price, 10)
-        self.assertEqual(lot_a.standard_price, 10)
+        self.assertAlmostEqual(self.component_a.standard_price, 9.99899999)
+        self.assertAlmostEqual(lot_a.standard_price, 9.99899999)
         self.assertEqual(lot_a.quantity_svl, 4)
         self.assertEqual(lot_a.value_svl, 40)
 

--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -175,7 +175,7 @@ class PurchaseRequisitionLine(models.Model):
     product_qty = fields.Float(string='Quantity', digits='Product Unit of Measure')
     product_description_variants = fields.Char('Description')
     price_unit = fields.Float(
-        string='Unit Price', digits='Product Price', default=0.0,
+        string='Unit Price', min_display_digits='Product Price', default=0.0,
         compute="_compute_price_unit", readonly=False, store=True)
     qty_ordered = fields.Float(compute='_compute_ordered_qty', string='Ordered')
     requisition_id = fields.Many2one('purchase.requisition', required=True, string='Purchase Agreement', ondelete='cascade')

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -744,4 +744,5 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
         bill.invoice_date = fields.Date.today()
         bill.action_post()
         svls = self.env['stock.valuation.layer'].search([])
-        self.assertRecordValues(svls, [{'value': 4809.92, 'remaining_value': 4809.92, 'unit_cost': 0.875}])
+        self.assertRecordValues(svls, [{'value': 4809.92, 'remaining_value': 4809.92}])
+        self.assertAlmostEqual(svls.unit_cost, 0.87452999)

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -131,9 +131,7 @@ class TestStockValuation(TransactionCase):
         move.picked = True
         picking.button_validate()
 
-        self.assertEqual(move.stock_valuation_layer_ids.unit_cost,
-            last_po_id.currency_id.round(ap_price),
-            "Wrong Unit price")
+        self.assertAlmostEqual(move.stock_valuation_layer_ids.unit_cost, ap_price, msg="Wrong Unit price")
 
     def test_change_unit_cost_average_1(self):
         """ Confirm a purchase order and create the associated receipt, change the unit cost of the
@@ -1417,7 +1415,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
 
         picking.button_validate()
         # 5 Units received at rate 0.7 = 42.86
-        self.assertAlmostEqual(product_avg.standard_price, 42.86)
+        self.assertAlmostEqual(product_avg.standard_price, 42.8571429)
 
         today = date_invoice
         inv = self.env['account.move'].with_context(default_move_type='in_invoice').create({
@@ -1645,7 +1643,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             picking.button_validate()
             picking._action_done()  # Create Backorder
         # 5 Units received at rate 0.7 = 42.86
-        self.assertAlmostEqual(product_avg.standard_price, 42.86)
+        self.assertAlmostEqual(product_avg.standard_price, 42.8571429)
 
         with freeze_time(date_invoice):
             inv = self.env['account.move'].with_context(default_move_type='in_invoice').create({
@@ -1700,7 +1698,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             })
             inv1.action_post()
         # 5 Units invoiced at rate 2 (10) + 5 Units invoiced at rate 2.2 and unit price 40 (18.18) = 14.09
-        self.assertAlmostEqual(product_avg.standard_price, 14.09)
+        self.assertAlmostEqual(product_avg.standard_price, 14.091)
         ##########################
         #       Invoice 0        #
         ##########################

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -172,7 +172,7 @@ class SaleOrderLine(models.Model):
     price_unit = fields.Float(
         string="Unit Price",
         compute='_compute_price_unit',
-        digits='Product Price',
+        min_display_digits='Product Price',
         store=True, readonly=False, required=True, precompute=True)
     technical_price_unit = fields.Float()
 

--- a/addons/sale/tests/test_product_catalog.py
+++ b/addons/sale/tests/test_product_catalog.py
@@ -101,10 +101,8 @@ class TestProductCatalog(HttpCase, SaleCommon):
             catalog_context['product_catalog_currency_id'],
             self.empty_order.currency_id.id,
         )
-        self.assertEqual(
-            catalog_context['product_catalog_digits'],
-            (16, self.env['decimal.precision'].precision_get('Product Price')),
-        )
+        # Equal to false, as `price_unit` doesn't have a precision set.
+        self.assertFalse(catalog_context['product_catalog_digits'])
 
     def test_empty_order_data(self):
         self.check_catalog_data(self.products)

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -108,10 +108,8 @@ class TestSalePrices(SaleCommon):
                 'product_id': self.product.id,
             })
 
-            self.assertEqual(order_line.pricelist_item_id, pricelist_rule)
-            self.assertEqual(
-                order_line.price_unit,
-                self.product.lst_price)
+            self.assertAlmostEqual(order_line.pricelist_item_id, pricelist_rule)
+            self.assertAlmostEqual(order_line.price_unit, self.product.lst_price)
             self.assertEqual(order_line.discount, 10)
 
             # Create an order tomorrow, add line today, rule active today doesn't work
@@ -390,9 +388,9 @@ class TestSalePrices(SaleCommon):
             order_form.pricelist_id = pricelist_b
             with order_form.order_line.new() as line_form:
                 line_form.product_id = self.product
-                self.assertEqual(line_form.price_unit, 0.83)
+                self.assertAlmostEqual(line_form.price_unit, 0.825)
                 line_form.product_uom_qty = 1000
-                self.assertEqual(line_form.price_unit, 0.55)
+                self.assertAlmostEqual(line_form.price_unit, 0.55)
 
     def test_compute_price_unit_no_currency(self):
         new_order = self.env['sale.order'].new({

--- a/addons/sale/tests/test_sale_report.py
+++ b/addons/sale/tests/test_sale_report.py
@@ -102,11 +102,8 @@ class TestSaleReportCurrencyRate(SaleCommon):
                     # to the currency of the so company and then from it to the currency of the so
                     # pricelist.
                     price_for_so_company = self.product.list_price / expected_product_currency_rate
-                    expected_rounded_price = pricelist.currency_id.round(
-                        price_for_so_company * expected_so_currency_rate
-                    )
 
-                    expected_amount_total = qty * expected_rounded_price
+                    expected_amount_total = pricelist.currency_id.round(qty * price_for_so_company * expected_so_currency_rate)
                     self.assertAlmostEqual(order.currency_rate, expected_so_currency_rate)
                     self.assertAlmostEqual(order.amount_total, expected_amount_total)
 

--- a/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
+++ b/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
@@ -80,22 +80,6 @@ class TestExpenseMargin(TestExpenseCommon):
         expense_sheet.action_approve_expense_sheets()
         expense_sheet.action_sheet_move_post()
 
-        self.assertRecordValues(sale_order.order_line[1:], [
-            # Expense lines:
-            {
-                'purchase_price': 86.96,
-                'is_expense': True,
-            },
-            {
-                'purchase_price': 100.0,
-                'is_expense': True,
-            },
-            {
-                'purchase_price': 869.57,
-                'is_expense': True,
-            },
-            {
-                'purchase_price': 1000.0,
-                'is_expense': True,
-            },
-        ])
+        for line, expected_purchase_price in zip(sale_order.order_line[1:], [86.96, 100.0, 869.5666667, 1000.0]):
+            self.assertAlmostEqual(line.purchase_price, expected_purchase_price)
+            self.assertTrue(line.is_expense)

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -44,7 +44,7 @@ class SaleOrderOption(models.Model):
 
     price_unit = fields.Float(
         string="Unit Price",
-        digits='Product Price',
+        min_display_digits='Product Price',
         compute='_compute_price_unit',
         store=True, readonly=False,
         required=True, precompute=True)

--- a/addons/sale_margin/models/sale_order_line.py
+++ b/addons/sale_margin/models/sale_order_line.py
@@ -9,12 +9,12 @@ class SaleOrderLine(models.Model):
 
     margin = fields.Float(
         "Margin", compute='_compute_margin',
-        digits='Product Price', store=True, groups="base.group_user", precompute=True)
+        min_display_digits='Product Price', store=True, groups="base.group_user", precompute=True)
     margin_percent = fields.Float(
         "Margin (%)", compute='_compute_margin', store=True, groups="base.group_user", precompute=True)
     purchase_price = fields.Float(
         string="Cost", compute="_compute_purchase_price",
-        digits='Product Price', store=True, readonly=False, copy=False, precompute=True,
+        min_display_digits='Product Price', store=True, readonly=False, copy=False, precompute=True,
         groups="base.group_user")
 
     @api.depends('product_id', 'company_id', 'currency_id', 'product_uom')

--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -18,7 +18,7 @@ class StockLot(models.Model):
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'lot_id')
     standard_price = fields.Float(
         "Cost", company_dependent=True,
-        digits='Product Price', groups="base.group_user",
+        min_display_digits='Product Price', groups="base.group_user",
         help="""Value of the lot (automatically computed in AVCO).
         Used to value the product when the purchase cost is not known (e.g. inventory adjustment).
         Used to compute margins on sale orders."""

--- a/addons/stock_account/models/stock_valuation_layer.py
+++ b/addons/stock_account/models/stock_valuation_layer.py
@@ -26,7 +26,7 @@ class StockValuationLayer(models.Model):
     quantity = fields.Float('Quantity', readonly=True, digits='Product Unit of Measure')
     uom_id = fields.Many2one(related='product_id.uom_id', readonly=True, required=True)
     currency_id = fields.Many2one('res.currency', 'Currency', related='company_id.currency_id', readonly=True, required=True)
-    unit_cost = fields.Float('Unit Value', digits='Product Price', readonly=True, aggregator=None)
+    unit_cost = fields.Float('Unit Value', min_display_digits='Product Price', readonly=True, aggregator=None)
     value = fields.Monetary('Total Value', readonly=True)
     remaining_qty = fields.Float(readonly=True, digits='Product Unit of Measure')
     remaining_value = fields.Monetary('Remaining Value', readonly=True)

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -26,13 +26,13 @@ class TestLotValuation(TestStockValuationCommon):
         """ Lots have their own valuation """
         self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
         self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
-        self.assertEqual(self.product1.standard_price, 6.0)
+        self.assertAlmostEqual(self.product1.standard_price, 6.0)
         self.assertEqual(self.lot1.standard_price, 5)
         self._make_out_move(self.product1, 2, lot_ids=[self.lot1])
 
         # lot1 has a cost different than the product it self. So a out move should recompute the
         # product cost
-        self.assertEqual(self.product1.standard_price, 6.11)
+        self.assertAlmostEqual(self.product1.standard_price, 6.1111111)
         self.assertEqual(len(self.lot1.stock_valuation_layer_ids), 2)
         self.assertEqual(self.lot1.stock_valuation_layer_ids.mapped('lot_id'), self.lot1)
         self.assertEqual(self.lot1.value_svl, 15)
@@ -244,7 +244,7 @@ class TestLotValuation(TestStockValuationCommon):
 
         self.assertEqual(productA.value_svl, 156)
         self.assertEqual(productA.quantity_svl, 24)
-        self.assertEqual(productB.value_svl, 144.1)  # 144.1 because of multiplying quantity with rounded standard price
+        self.assertEqual(productB.value_svl, 144.0)
         self.assertEqual(productB.quantity_svl, 22)
 
         # 4 original + 1 empty stock + 2 for the lots
@@ -254,9 +254,9 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(lotA_1.quantity_svl, 7)
         self.assertEqual(lotA_2.value_svl, 110.5)
         self.assertEqual(lotA_2.quantity_svl, 17)
-        self.assertEqual(lotB_1.value_svl, 39.3)
+        self.assertEqual(lotB_1.value_svl, 39.27)
         self.assertEqual(lotB_1.quantity_svl, 6)
-        self.assertEqual(lotB_2.value_svl, 104.8)
+        self.assertEqual(lotB_2.value_svl, 104.73)
         self.assertEqual(lotB_2.quantity_svl, 16)
 
     def test_enforce_lot_receipt(self):
@@ -315,7 +315,7 @@ class TestLotValuation(TestStockValuationCommon):
         })
         self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1])
         self._make_in_move(self.product1, 10, 9, lot_ids=[self.lot2])
-        self.assertEqual(self.product1.standard_price, 7)
+        self.assertAlmostEqual(self.product1.standard_price, 7)
         inventory_quant = self.env['stock.quant'].create({
             'location_id': shelf1.id,
             'product_id': self.product1.id,
@@ -411,7 +411,7 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(self.lot1.quantity_svl, 3)
         self.assertEqual(self.lot1.standard_price, 10)
         # product cost should be updated al well
-        self.assertEqual(self.product1.standard_price, 6.94)
+        self.assertAlmostEqual(self.product1.standard_price, 6.94444445)
         # rest remains unchanged
         self.assertEqual(len(self.lot2.stock_valuation_layer_ids), 1)
         self.assertEqual(self.lot2.stock_valuation_layer_ids.mapped('lot_id'), self.lot2)
@@ -431,7 +431,7 @@ class TestLotValuation(TestStockValuationCommon):
         self._make_in_move(self.product1, 6, 7, lot_ids=[self.lot1])
         self.assertEqual(self.lot1.standard_price, 6.2)
         self.assertEqual(self.lot1.value_svl, 62)
-        self.assertEqual(self.product1.standard_price, 5.86)
+        self.assertAlmostEqual(self.product1.standard_price, 5.8571429)
 
         Form(self.env['stock.valuation.layer.revaluation'].with_context({
             'default_product_id': self.product1.id,
@@ -446,7 +446,7 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(self.lot1.standard_price, 7, "lot1 cost changed")
         self.assertEqual(self.lot1.value_svl, 70, "lot1 value changed")
         self.assertEqual(self.lot2.standard_price, 5, "lot2 cost remains unchanged")
-        self.assertEqual(self.product1.standard_price, 6.43, "product cost changed too")
+        self.assertAlmostEqual(self.product1.standard_price, 6.4314286, msg="product cost changed too")
 
     def test_average_manual_product_revaluation_with_lots(self):
         self.product1.categ_id.property_cost_method = 'average'
@@ -457,7 +457,7 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(self.lot1.value_svl, 62)
         self.assertEqual(self.lot2.standard_price, 5)
         self.assertEqual(self.lot2.value_svl, 20)
-        self.assertEqual(self.product1.standard_price, 5.86)
+        self.assertAlmostEqual(self.product1.standard_price, 5.8571429)
 
         Form(self.env['stock.valuation.layer.revaluation'].with_context({
             'default_product_id': self.product1.id,
@@ -472,7 +472,7 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(self.lot1.value_svl, 70, "lot1 value changed")
         self.assertEqual(self.lot2.standard_price, 5.8, "lot2 cost changed")
         self.assertEqual(self.lot2.value_svl, 23.2, "lot2 value changed")
-        self.assertEqual(self.product1.standard_price, 6.66, "product cost changed too")
+        self.assertAlmostEqual(self.product1.standard_price, 6.66, msg="product cost changed too")
 
     def test_lot_move_update_after_done(self):
         """validate a stock move. Edit the move line in done state."""
@@ -512,13 +512,13 @@ class TestLotValuation(TestStockValuationCommon):
             {'value': -20, 'lot_id': self.lot2.id, 'quantity': -4},
             {'value': 20, 'lot_id': self.lot3.id, 'quantity': 4},
         ])
-        self.assertEqual(self.product1.standard_price, 5)
+        self.assertAlmostEqual(self.product1.standard_price, 5)
 
         self._make_in_move(self.product1, 4, 4, create_picking=True, lot_ids=[self.lot3])
-        self.assertEqual(self.product1.standard_price, 4.67)
+        self.assertAlmostEqual(self.product1.standard_price, 4.6666667)
 
         move = self._make_out_move(self.product1, 3, create_picking=True, lot_ids=[self.lot1])
-        self.assertEqual(self.product1.standard_price, 4.56)
+        self.assertAlmostEqual(self.product1.standard_price, 4.5555556)
 
         quant = self.env['stock.quant'].search([
             ('lot_id', '=', self.lot3.id),
@@ -528,7 +528,7 @@ class TestLotValuation(TestStockValuationCommon):
         move.move_line_ids = [
             Command.update(move.move_line_ids.id, {'quant_id': quant.id}),
         ]
-        self.assertEqual(self.product1.standard_price, 4.72)
+        self.assertAlmostEqual(self.product1.standard_price, 4.7222222)
 
         self.assertRecordValues(move.stock_valuation_layer_ids, [
             {'value': -15, 'lot_id': self.lot1.id, 'quantity': -3},

--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -105,7 +105,7 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         revaluation_wizard.save().action_validate_revaluation()
 
         # Check standard price change
-        self.assertEqual(self.product1.standard_price, 1.33)
+        self.assertAlmostEqual(self.product1.standard_price, 1.3333333)
         self.assertEqual(self.product1.quantity_svl, 3)
 
         # Check the creation of stock.valuation.layer
@@ -144,21 +144,21 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         self.product1.write({'standard_price': 0.022})
         self._make_in_move(self.product1, 10000)
 
-        self.assertEqual(self.product1.standard_price, 0.02)
+        self.assertAlmostEqual(self.product1.standard_price, 0.022)
         self.assertEqual(self.product1.quantity_svl, 10000)
 
         layer = self.product1.stock_valuation_layer_ids
-        self.assertEqual(layer.value, 200)
+        self.assertEqual(layer.value, 220.0)
 
         # Second Move
         self.product1.write({'standard_price': 0.053})
 
-        self.assertEqual(self.product1.standard_price, 0.05)
+        self.assertEqual(self.product1.standard_price, 0.053)
         self.assertEqual(self.product1.quantity_svl, 10000)
 
         layers = self.product1.stock_valuation_layer_ids
-        self.assertEqual(layers[0].value, 200)
-        self.assertEqual(layers[1].value, 300)
+        self.assertEqual(layers[0].value, 220.0)
+        self.assertEqual(layers[1].value, 280.0)
 
     def test_stock_valuation_layer_revaluation_avco_rounding_5_digits(self):
         """
@@ -337,13 +337,13 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         self._make_in_move(self.product1, 67104, unit_cost=0.00952)
         self._make_in_move(self.product1, 898, unit_cost=0.00952)
 
-        self.assertEqual(self.product1.standard_price, 0.01)
+        self.assertAlmostEqual(self.product1.standard_price, 0.00952)
         revaluation_wizard = Form(self.env['stock.valuation.layer.revaluation'].with_context(context))
         revaluation_wizard.added_value = 636  # triggers the rounding problem
         revaluation_wizard.account_id = self.stock_valuation_account
         revaluation_wizard.save().action_validate_revaluation()
 
-        self.assertEqual(self.product1.standard_price, 0.02)
+        self.assertAlmostEqual(self.product1.standard_price, 0.0193527)
 
     def test_multi_company_fifo_svl_negative_revaluation(self):
         """

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2408,7 +2408,7 @@ class TestStockValuation(TestStockValuationBase):
         move2.picked = True
         move2._action_done()
 
-        self.assertAlmostEqual(self.product1.standard_price, 16.67)
+        self.assertAlmostEqual(self.product1.standard_price, 16.6666667)
         self.assertAlmostEqual(move2.stock_valuation_layer_ids.value, 200)
         self.assertAlmostEqual(self.product1.quantity_svl, 15)
         self.assertAlmostEqual(self.product1.value_svl, 250)
@@ -3091,14 +3091,14 @@ class TestStockValuation(TestStockValuationBase):
         self.assertRecordValues(
             amls,
             [
-                {'account_id': self.stock_input_account.id, 'debit': 240, 'credit': 0},
-                {'account_id': self.stock_valuation_account.id, 'debit': 0, 'credit': 240},
-                {'account_id': self.stock_valuation_account.id, 'debit': 239.97, 'credit': 0},
-                {'account_id': self.stock_input_account.id, 'debit': 0, 'credit': 239.97},
+                {'account_id': self.stock_input_account.id, 'debit': 240.0, 'credit': 0},
+                {'account_id': self.stock_valuation_account.id, 'debit': 0, 'credit': 240.0},
+                {'account_id': self.stock_valuation_account.id, 'debit': 240.0, 'credit': 0},
+                {'account_id': self.stock_input_account.id, 'debit': 0, 'credit': 240.0},
             ]
         )
 
-        self.assertEqual(self.product1.standard_price, 12.63)
+        self.assertAlmostEqual(self.product1.standard_price, 12.63157895)
 
     def test_change_cost_method_2(self):
         """ Change the cost method from FIFO to standard.
@@ -3176,12 +3176,12 @@ class TestStockValuation(TestStockValuationBase):
             [
                 {'account_id': self.stock_input_account.id, 'debit': 240, 'credit': 0},
                 {'account_id': self.stock_valuation_account.id, 'debit': 0, 'credit': 240},
-                {'account_id': self.stock_valuation_account.id, 'debit': 239.97, 'credit': 0},
-                {'account_id': self.stock_input_account.id, 'debit': 0, 'credit': 239.97},
+                {'account_id': self.stock_valuation_account.id, 'debit': 240.0, 'credit': 0},
+                {'account_id': self.stock_input_account.id, 'debit': 0, 'credit': 240.0},
             ]
         )
 
-        self.assertEqual(self.product1.standard_price, 12.63)
+        self.assertAlmostEqual(self.product1.standard_price, 12.63157895)
 
     def test_fifo_sublocation_valuation_1(self):
         """ Set the main stock as a view location. Receive 2 units of a

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -588,11 +588,9 @@ class TestStockValuationAVCO(TestStockValuationCommon):
 
         move_out = self._make_out_move(self.product1, 3, create_picking=True)
 
-        self.assertIn('Rounding Adjustment: -0.01', move_out.stock_valuation_layer_ids.description)
-
         self.assertEqual(self.product1.value_svl, 0)
         self.assertEqual(self.product1.quantity_svl, 0)
-        self.assertEqual(self.product1.standard_price, 1.00)
+        self.assertAlmostEqual(self.product1.standard_price, 1.00333333)
 
     def test_rounding_slv_2(self):
         self._make_in_move(self.product1, 1, unit_cost=1.02)
@@ -603,17 +601,15 @@ class TestStockValuationAVCO(TestStockValuationCommon):
 
         move_out = self._make_out_move(self.product1, 3, create_picking=True)
 
-        self.assertIn('Rounding Adjustment: +0.01', move_out.stock_valuation_layer_ids.description)
-
         self.assertEqual(self.product1.value_svl, 0)
         self.assertEqual(self.product1.quantity_svl, 0)
-        self.assertEqual(self.product1.standard_price, 1.01)
+        self.assertAlmostEqual(self.product1.standard_price, 1.00666666)
 
     def test_rounding_svl_3(self):
         self._make_in_move(self.product1, 1000, unit_cost=0.17)
         self._make_in_move(self.product1, 800, unit_cost=0.23)
 
-        self.assertEqual(self.product1.standard_price, 0.20)
+        self.assertAlmostEqual(self.product1.standard_price, 0.19666666)
 
         self._make_out_move(self.product1, 1000, create_picking=True)
         self._make_out_move(self.product1, 800, create_picking=True)
@@ -628,7 +624,7 @@ class TestStockValuationAVCO(TestStockValuationCommon):
         self.product1.categ_id.property_cost_method = 'average'
         self._make_in_move(self.product1, 2, unit_cost=4.63)
         self._make_in_move(self.product1, 5, unit_cost=3.04)
-        self.assertEqual(self.product1.standard_price, 3.49)
+        self.assertAlmostEqual(self.product1.standard_price, 3.4942857)
 
         for _ in range(70):
             self._make_out_move(self.product1, 0.1)
@@ -640,17 +636,17 @@ class TestStockValuationAVCO(TestStockValuationCommon):
         self.product1.categ_id.property_cost_method = 'average'
         self._make_in_move(self.product1, 10, unit_cost=16.83)
         self._make_in_move(self.product1, 10, unit_cost=20)
-        self.assertEqual(self.product1.standard_price, 18.42)
+        self.assertEqual(self.product1.standard_price, 18.415)
 
         self._make_out_move(self.product1, 10)
         out_move = self._make_out_move(self.product1, 9)
-        self.assertEqual(out_move.stock_valuation_layer_ids[0].value, -165.73)
+        self.assertEqual(out_move.stock_valuation_layer_ids[0].value, -165.74)
 
-        self.assertEqual(self.product1.value_svl, 18.42)
+        self.assertEqual(self.product1.value_svl, 18.41)
         self.assertEqual(self.product1.quantity_svl, 1)
 
         self._make_out_move(self.product1, 1)
-        self.assertEqual(self.product1.value_svl, 0)
+        self.assertEqual(self.product1.value_svl, -0.01)
         self.assertEqual(self.product1.quantity_svl, 0)
 
     def test_return_delivery_2(self):
@@ -1031,7 +1027,7 @@ class TestStockValuationChangeCostMethod(TestStockValuationCommon):
         move3 = self._make_out_move(self.product1, 1)
 
         self.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'
-        self.assertEqual(self.product1.value_svl, 289.94)
+        self.assertEqual(self.product1.value_svl, 290)
         self.assertEqual(self.product1.quantity_svl, 19)
 
     def test_fifo_to_avco(self):
@@ -1046,7 +1042,7 @@ class TestStockValuationChangeCostMethod(TestStockValuationCommon):
         move3 = self._make_out_move(self.product1, 1)
 
         self.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
-        self.assertEqual(self.product1.value_svl, 289.94)
+        self.assertEqual(self.product1.value_svl, 290)
         self.assertEqual(self.product1.quantity_svl, 19)
 
     def test_avco_to_standard(self):

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_rounding.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_rounding.py
@@ -263,7 +263,7 @@ class TestStockLandedCostsRounding(TestStockLandedCostsCommon):
         landed_costs.compute_landed_cost()
         landed_costs.button_validate()
 
-        self.assertEqual(self.product_a.standard_price, 7.47)
+        self.assertAlmostEqual(self.product_a.standard_price, 7.4742857)
 
         deliveries = self.env['stock.picking'].create([{
             'picking_type_id': self.warehouse.out_type_id.id,

--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -205,7 +205,7 @@ class TestStockValuationLCFIFO(TestStockValuationLCCommon):
 
         self.assertEqual(out_svl.value, -250)
         # 15 * 16.66
-        self.assertAlmostEqual(in_svl.value, 249.9)
+        self.assertAlmostEqual(in_svl.value, 250.0, 2)
 
     def test_rounding_1(self):
         """3@100, out 1, out 1, out 1"""

--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -31,13 +31,14 @@ export function getCurrency(id) {
  */
 export function formatCurrency(amount, currencyId, options = {}) {
     const currency = getCurrency(currencyId);
-    const digits = options.digits || (currency && currency.digits);
+
+    const digits = (options.digits !== undefined)? options.digits : (currency && currency.digits)
 
     let formattedAmount;
     if (options.humanReadable) {
         formattedAmount = humanNumber(amount, { decimals: digits ? digits[1] : 2 });
     } else {
-        formattedAmount = formatFloat(amount, { digits });
+        formattedAmount = formatFloat(amount, { digits, minDigits: options.minDigits});
     }
 
     if (!currency || options.noSymbol) {

--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -214,9 +214,14 @@ export function formatFloat(value, options = {}) {
     let precision;
     if (options.digits && options.digits[1] !== undefined) {
         precision = options.digits[1];
+    } else if (options.minDigits) {
+        // When no precision is set, 12 is chosen as the precision. It is high enough to keep it precise,
+        // but not too high in order to avoid rounding errors..
+        precision = 12;
     } else {
         precision = 2;
     }
+    const minPrecision = options.minDigits || precision;
     if (floatIsZero(value, precision)) {
         value = 0.0;
     }
@@ -228,8 +233,11 @@ export function formatFloat(value, options = {}) {
     const decimalPoint = "decimalPoint" in options ? options.decimalPoint : l10n.decimalPoint;
     const formatted = value.toFixed(precision).split(".");
     formatted[0] = insertThousandsSep(formatted[0], thousandsSep, grouping);
-    if (options.trailingZeros === false && formatted[1]) {
+    if (formatted[1]) {
         formatted[1] = formatted[1].replace(/0+$/, "");
+        if (options.trailingZeros !== false) {
+            formatted[1] = formatted[1].padEnd(minPrecision, "0");
+        }
     }
     return formatted[1] ? formatted.join(decimalPoint) : formatted[0];
 }

--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -16,6 +16,7 @@ export class FloatField extends Component {
         inputType: { type: String, optional: true },
         step: { type: Number, optional: true },
         digits: { type: Array, optional: true },
+        minDigits: {type: [Number, String], optional: true },
         placeholder: { type: String, optional: true },
         humanReadable: { type: Boolean, optional: true },
         decimals: { type: Number, optional: true },
@@ -60,6 +61,7 @@ export class FloatField extends Component {
         }
         const options = {
             digits: this.props.digits,
+            minDigits: this.props.minDigits,
             field: this.props.record.fields[this.props.name],
         };
         if (this.props.humanReadable && !this.state.hasFocus) {
@@ -94,6 +96,11 @@ export const floatField = {
         {
             label: _t("Digits"),
             name: "digits",
+            type: "digits",
+        },
+        {
+            label: _t("Minimum Digits"),
+            name: "minDigits",
             type: "digits",
         },
         {
@@ -141,6 +148,7 @@ export const floatField = {
             humanReadable: !!options.human_readable,
             step: options.step,
             digits,
+            minDigits: options.min_display_digits,
             placeholder: attrs.placeholder,
             decimals: options.decimals || 0,
         };

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -131,6 +131,9 @@ export function formatFloat(value, options = {}) {
     if (!options.digits && options.field) {
         options.digits = options.field.digits;
     }
+    if (!options.minDigits && options.field) {
+        options.minDigits = options.field.min_display_digits;
+    }
     return formatFloatNumber(value, options);
 }
 formatFloat.extractOptions = ({ attrs, options }) => {
@@ -142,9 +145,10 @@ formatFloat.extractOptions = ({ attrs, options }) => {
     } else if (options.digits) {
         digits = options.digits;
     }
+    const minDigits = options.minDigits;
     const humanReadable = !!options.human_readable;
     const decimals = options.decimals || 0;
-    return { decimals, digits, humanReadable };
+    return { decimals, digits, minDigits, humanReadable };
 };
 
 /**

--- a/addons/web/static/src/views/fields/monetary/monetary_field.js
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.js
@@ -84,6 +84,7 @@ export class MonetaryField extends Component {
         }
         return formatMonetary(this.value, {
             digits: this.currencyDigits,
+            minDigits: this.props.useFieldDigits && this.props.record.fields[this.props.name].min_display_digits,
             currencyId: this.currencyId,
             noSymbol: !this.props.readonly || this.props.hideSymbol,
         });

--- a/addons/web/static/tests/core/utils/numbers.test.js
+++ b/addons/web/static/tests/core/utils/numbers.test.js
@@ -331,7 +331,6 @@ describe("formatFloat", () => {
         expect(formatFloat(1.0045e22, options)).toBe("1.005e+22");
         expect(formatFloat(-1.0045e22, options)).toBe("-1.004e+22");
 
-        Object.assign(options, { humanReadable: false });
-        expect(formatFloat(-0.0000001, options)).toBe("0.00");
+        expect(formatFloat(-0.0000001, { digits: [16, 2], humanReadable: false })).toBe("0.00");
     });
 });

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2856,8 +2856,8 @@ class Model(models.AbstractModel):
         :rtype: list
         """
         return [
-            'change_default', 'context', 'currency_field', 'definition_record', 'definition_record_field', 'digits', 'domain', 'aggregator', 'groups',
-            'help', 'model_field', 'name', 'readonly', 'related', 'relation', 'relation_field', 'required', 'searchable', 'selection', 'size',
+            'change_default', 'context', 'currency_field', 'definition_record', 'definition_record_field', 'digits', 'min_display_digits', 'domain', 'aggregator',
+            'groups', 'help', 'model_field', 'name', 'readonly', 'related', 'relation', 'relation_field', 'required', 'searchable', 'selection', 'size',
             'sortable', 'store', 'string', 'translate', 'trim', 'type', 'groupable',
         ]
 

--- a/odoo/addons/base/tests/test_qweb_field.py
+++ b/odoo/addons/base/tests/test_qweb_field.py
@@ -58,6 +58,41 @@ class TestQwebFieldInteger(common.TransactionCase):
             "125.125k"
         )
 
+
+class TestQwebFieldFloatConverter(common.TransactionCase):
+    def value_to_html(self, value, options=None):
+        options = options or {}
+        return self.env['ir.qweb.field.float'].value_to_html(value, options)
+
+    def test_float_value_to_html_no_precision(self):
+        self.assertEqual(self.value_to_html(3), '3.0')
+        self.assertEqual(self.value_to_html(3.1), '3.1')
+        self.assertEqual(self.value_to_html(3.1231239), '3.123124')
+
+    def test_float_value_to_html_with_precision(self):
+        options = {'precision': 3}
+        self.assertEqual(self.value_to_html(3, options), '3.000')
+        self.assertEqual(self.value_to_html(3.1, options), '3.100')
+        self.assertEqual(self.value_to_html(3.123, options), '3.123')
+        self.assertEqual(self.value_to_html(3.1239, options), '3.124')
+
+    def test_float_value_to_html_with_min_precision(self):
+        options = {'min_precision': 3}
+        self.assertEqual(self.value_to_html(3, options), '3.000')
+        self.assertEqual(self.value_to_html(3.1, options), '3.100')
+        self.assertEqual(self.value_to_html(3.123, options), '3.123')
+        self.assertEqual(self.value_to_html(3.1239, options), '3.1239')
+        self.assertEqual(self.value_to_html(3.1231239, options), '3.123124')
+
+    def test_float_value_to_html_with_precision_and_min_precision(self):
+        options = {'min_precision': 3, 'precision': 4}
+        self.assertEqual(self.value_to_html(3, options), '3.000')
+        self.assertEqual(self.value_to_html(3.1, options), '3.100')
+        self.assertEqual(self.value_to_html(3.123, options), '3.123')
+        self.assertEqual(self.value_to_html(3.1239, options), '3.1239')
+        self.assertEqual(self.value_to_html(3.12349, options), '3.1235')
+
+
 class TestQwebFieldContact(common.TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1584,6 +1584,14 @@ class Float(Field[float]):
         :class:`~odoo.addons.base.models.decimal_precision.DecimalPrecision` record name.
     :type digits: tuple(int,int) or str
 
+    :param min_display_digits: An int or a string referencing a
+        :class:`~odoo.addons.base.models.decimal_precision.DecimalPrecision` record name.
+        Represents the minimum number of decimal digits to display in the UI.
+        So if it's equal to 3:
+        - `3.1` will be shown as `'3.100'`.
+        - `3.1234` will be shown as `'3.1234'`.
+    :type min_display_digits: int or str
+
     When a float is a quantity associated with an unit of measure, it is important
     to use the right tool to compare or round values with the correct precision.
 
@@ -1617,10 +1625,19 @@ class Float(Field[float]):
 
     type = 'float'
     _digits = None                      # digits argument passed to class initializer
+    _min_display_digits = None
     aggregator = 'sum'
 
-    def __init__(self, string: str | Sentinel = SENTINEL, digits: str | tuple[int, int] | None | Sentinel = SENTINEL, **kwargs):
-        super(Float, self).__init__(string=string, _digits=digits, **kwargs)
+    def __init__(
+        self,
+        string: str | Sentinel = SENTINEL,
+        digits: str | tuple[int, int] | typing.Literal[0, False] | Sentinel | None = SENTINEL,
+        min_display_digits: str | int | Sentinel | None = SENTINEL,
+        **kwargs,
+    ):
+        if digits is SENTINEL and min_display_digits is not SENTINEL:
+            digits = False
+        super().__init__(string=string, _digits=digits, _min_display_digits=min_display_digits, **kwargs)
 
     @property
     def _column_type(self):
@@ -1639,10 +1656,18 @@ class Float(Field[float]):
         else:
             return self._digits
 
+    def get_min_display_digits(self, env):
+        if isinstance(self._min_display_digits, str):
+            return env['decimal.precision'].precision_get(self._min_display_digits)
+        return self._min_display_digits
+
     _related__digits = property(attrgetter('_digits'))
 
     def _description_digits(self, env):
         return self.get_digits(env)
+
+    def _description_min_display_digits(self, env):
+        return self.get_min_display_digits(env)
 
     def convert_to_column(self, value, record, values=None, validate=True):
         value_float = value = float(value or 0.0)


### PR DESCRIPTION
Imported invoices can show different totals than what the original
document show.  This especially an issue for Peppol.
Because `price_unit` is rounded, by computing the total of a line with
`quantity * price_unit`, it may not be possible to obtain the same
total as the one from the original document.

To face this issue, the float fields related to "Product Price" don't
have a decimal precision set anymore.
To keep the UI clean, the precision set on "Product Price" is now
interpreted as a "minimal precision".
So if it set to 3, we'll see at least 3 digits.  If there's more, all
the digits are shown.
As so:
`4.0`     -> `'4.000'`
`4.23`    -> `'4.230'`
`4.235`   -> `'4.235'`
`4.2358`  -> `'4.23458'`

task-4895014