### PR TITLE
[FIX] mrp, *: correctly link move lines to receipt picking

### DIFF
--- a/addons/mrp/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 
 
 class MrpProductionSerials(models.TransientModel):
@@ -50,6 +51,8 @@ class MrpProductionSerials(models.TransientModel):
 
     def action_apply(self):
         self.ensure_one()
+        if not self.serial_numbers:
+            raise UserError(self.env._("There is no serial numbers to apply."))
         lots = list(filter(lambda serial_number: len(serial_number.strip()) > 0, self.serial_numbers.split('\n'))) if self.serial_numbers else []
         existing_lots = self.env['stock.lot'].search([
             '|', ('company_id', '=', False), ('company_id', '=', self.production_id.company_id.id),

--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -129,6 +129,7 @@ class MrpProduction(models.Model):
                 'product_id': move.product_id.id,
                 'move_id': move.id,
                 'quantity': 1,
+                'picking_id': move.picking_id.id,
                 'lot_id': False,
             })
         return move.action_show_subcontract_details(lot_id=False)

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1630,3 +1630,30 @@ class TestSubcontractingSerialMassReceipt(TransactionCase):
             {'name': '03-02-0000002'},
         ])
         self.assertEqual(self.finished.next_serial, '0000003')
+
+    def test_subcontract_move_lines_are_linked_to_picking(self):
+        """Test to ensure that when we generate mass serial numbers for a
+        subcontracting order, the created move lines are linked to the picking."""
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': warehouse.in_type_id.id,
+            'partner_id': self.subcontractor.id,
+            'move_ids': [Command.create({
+                'product_id': self.finished.id,
+                'product_uom_qty': 3,
+            })],
+        })
+        receipt.action_confirm()
+        mo = self.env['mrp.production'].browse(receipt.move_ids.action_show_subcontract_details()['res_id'])
+
+        self.finished.lot_sequence_id.number_next_actual = 1
+        wizard = Form.from_action(self.env, mo.action_generate_serial()).save()
+        wizard.action_generate_serial_numbers()
+        wizard.action_apply()
+        self.assertRecordValues(mo._get_subcontract_move().lot_ids, [
+            {'name': '0000001'},
+            {'name': '0000002'},
+            {'name': '0000003'},
+        ])
+        receipt.button_validate()
+        self.assertEqual(receipt.move_line_ids.lot_id, mo._get_subcontract_move().lot_ids)

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1633,7 +1633,10 @@ class TestSubcontractingSerialMassReceipt(TransactionCase):
 
     def test_subcontract_move_lines_are_linked_to_picking(self):
         """Test to ensure that when we generate mass serial numbers for a
-        subcontracting order, the created move lines are linked to the picking."""
+        subcontracting order, the created move lines are linked to the picking.
+
+        Also ensure that applying the serial number generation wizard without
+        generating any lot/serial numbers raises a UserError."""
         warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         receipt = self.env['stock.picking'].create({
             'picking_type_id': warehouse.in_type_id.id,
@@ -1648,6 +1651,9 @@ class TestSubcontractingSerialMassReceipt(TransactionCase):
 
         self.finished.lot_sequence_id.number_next_actual = 1
         wizard = Form.from_action(self.env, mo.action_generate_serial()).save()
+        # Applying the wizard without generating any lot/serial numbers should raise a UserError.
+        with self.assertRaises(UserError):
+            wizard.action_apply()
         wizard.action_generate_serial_numbers()
         wizard.action_apply()
         self.assertRecordValues(mo._get_subcontract_move().lot_ids, [

--- a/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
@@ -9,7 +9,7 @@ class MrpProductionSerials(models.TransientModel):
     def action_apply(self):
         self.ensure_one()
         sbc_move = self.production_id._get_subcontract_move()
-        if not sbc_move:
+        if not sbc_move or not self.serial_numbers:
             return super().action_apply()
 
         lots = list(filter(lambda serial_number: len(serial_number.strip()) > 0, self.serial_numbers.split('\n'))) if self.serial_numbers else []

--- a/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
@@ -35,12 +35,14 @@ class MrpProductionSerials(models.TransientModel):
             'lot_producing_ids': all_lots[0],
             'product_qty': 1,
         })
+        picking = sbc_move.picking_id
         sbc_move.move_line_ids.create([
             {
                 'product_id': lot.product_id.id,
                 'lot_id': lot.id,
                 'move_id': sbc_move.id,
+                'picking_id': picking.id,
                 'quantity': 1,
             } for lot in all_lots[1:]
         ])
-        return sbc_move.picking_id.action_show_subcontract_details()
+        return picking.action_show_subcontract_details()


### PR DESCRIPTION
*: mrp_subcontracting

Issue:
---------------------------------
When subcontracting a lot/serial-tracked product and generating multiple subcontracting MOs by generating SN numbers or the "Create New Production" action, only the `first serial number line` appears in the "Move" detail operations smart button.
Although all move lines are correctly created on the move, this behaviour is confusing for the user.

Steps to reproduce:
---------------------------------
1. Install the `mrp_subcontracting_purchase` module.
2. Create a serial-tracked product and its subcontracting BoM.
3. Create a PO with a subcontracting vendor and a product quantity greater than 1.
4. Confirm the PO and validate the resupply.
5. Open the receipt and click on the "Subcontracting Production" smart button.
6. Generate serial numbers for the product.
7. Validate the receipt and open the "Move" detail operations smart button.
8. Only one line (the first serial number) is shown, while the move actually contains all move lines.

Cause:
---------------------------------
When serial numbers are generated from the subcontracting MO view, or when a new MO is created using the "Create New Production" action introduced in [PR](https://github.com/odoo/odoo/pull/218377), new move lines are created without setting the `picking_id`.
As a result, these move lines are linked to the stock move but not directly to the picking.
Since the "Move" detail operations smart button relies on the picking’s `move_line_ids`, the newly created move lines are not displayed.

With this commit:
---------------------------------
The `picking_id` is now set on newly created move lines. This ensures that all move lines are directly linked to the picking, allowing the "Move" detail operations smart button to display all serial/lot lines correctly and improving traceability for the user.

And also When working with a subcontracting order, if the user opens the lot/serial number generation wizard from the subcontracting production and directly clicks 'Apply' without creating or assigning any lot/serial number, Odoo raises the following traceback:
`IndexError: tuple index out of range`
This issue has also been fixed here.