### PR TITLE
[FIX] web: Make Popover animation timing consistent in tests

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -130,6 +130,8 @@ export class Popover extends Component {
         this.popoverRef = useRef("ref");
         this.position = usePosition("ref", () => this.props.target, this.positioningOptions);
 
+        this.animationDone = !this.props.animation;
+
         const resizeObserver = new ResizeObserver(() => {
             if (!this.props.fixedPosition && this.animationDone) {
                 this.position.unlock();


### PR DESCRIPTION
This commit fixes two things;

1. Because the popover had his animation enabled in tests, it could on very rare occasion end too fast and call it's finished callback, triggering extra repositionning (and thus extra expect.steps).

2. The ResizeObserver could never trigger if there where no animations, it now can but some tests had to be adapted.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
