### PR TITLE
[FIX] l10n_vn_edi_viettel: prevent itemName from being concatenated in SInvoice

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -3,6 +3,7 @@
 import base64
 import io
 import re
+import textwrap
 import time
 import uuid
 import zipfile
@@ -694,9 +695,10 @@ class AccountMove(models.Model):
         for line in self.invoice_line_ids.filtered(lambda ln: ln.display_type == 'product'):
             # For credit notes amount, we send negative values (reduces the amount of the original invoice)
             sign = 1 if self.move_type == 'out_invoice' else -1
+            item_name = line.name.replace('\n', ' ')
             item_information = {
                 'itemCode': line.product_id.code or '',
-                'itemName': line.name,
+                'itemName': textwrap.shorten(item_name, width=500, placeholder='...'),
                 'unitName': line.product_uom_id.name or 'Units',
                 'unitPrice': line.price_unit * sign,
                 'quantity': line.quantity,


### PR DESCRIPTION
Before:
SInvoice was stripping newlines from the `itemName` field. Since we were directly using `line.name` (which contains a `\n` between product name and description), the content ended up concatenated without any separation.

After:
Now we replace the newline with a space before sending the value, so the name
and description remain readable once processed by SInvoice and set
limit to 500 characters as per API specs.

task-5498120