### PR TITLE
[FIX] pos_loyalty: fix traceback with customer and configurable product

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -423,6 +423,9 @@ patch(PosStore.prototype, {
         }
 
         const result = await super.addLineToCurrentOrder(vals, opt, configure);
+        if (!result) {
+            return;
+        }
 
         const rewardsToApply = [];
         for (const reward of potentialRewards) {

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -6,6 +6,7 @@ import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selecti
 import { registry } from "@web/core/registry";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
+import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
     steps: () =>
@@ -280,7 +281,11 @@ registry.category("web_tour.tours").add("test_loyalty_reward_with_variant", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-
+            ProductScreen.clickPartnerButton(),
+            PartnerList.searchCustomerValue("Test Partner", true),
+            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            Dialog.discard(),
             ProductScreen.clickDisplayedProduct("Test Product"),
             ProductConfiguratorPopup.pickRadio("Value 1"),
             Dialog.confirm(),


### PR DESCRIPTION
Steps to reproduce:
=
- Open a PoS with pos_loyalty
- Set a customer
- Open a configurable product
- Click `Discard` button or press `ESC` key

Issue:
=
- A traceback occurs with the error: `TypeError: Cannot read properties of undefined (reading 'product_id')`

Reason:
=
- When a configurable product is discarded during variant selection, the flow continues and attempts to process an undefined product.

Fix:
=
- Ensure if adding a configurable product is discarded while selecting variant it should not p[roccess futher.

task-5481204
