### PR TITLE
[IMP] core: add StoredTranslations for cache value

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -60,7 +60,7 @@ from .domains import Domain
 from .fields import Field, determine
 from .fields_misc import Id
 from .fields_temporal import Date, Datetime
-from .fields_textual import Char
+from .fields_textual import Char, StoredTranslations
 
 from .identifiers import NewId
 from .query import Query, TableSQL
@@ -2847,7 +2847,6 @@ class BaseModel(metaclass=MetaModel):
                 value=Json(translations),
                 id=self.id,
             ))
-            self.modified([field_name])
         else:
             old_values = field._get_stored_translations(self)
             if not old_values:
@@ -2890,7 +2889,7 @@ class BaseModel(metaclass=MetaModel):
                 _old_translations = {src: values[lang] for src, values in old_translation_dictionary.items() if lang in values}
                 _new_translations = {**_old_translations, **_translations}
                 new_values[lang] = field.convert_to_cache(field.translate(_new_translations.get, old_source_lang_value), self)
-            field._update_cache(self.with_context(prefetch_langs=True), new_values, dirty=True)
+            field._update_cache(self.with_context(prefetch_langs=True), StoredTranslations(new_values), dirty=True)
 
         # the following write is incharge of
         # 1. mark field as modified


### PR DESCRIPTION
Add new class StoredTranslations for cache value, which allows ORM to
know if it has already cached all translations for a record.

task-5499441

prepare to support `record.tranlated_field = {'en_US': 'en', 'fr_FR': 'fr'}`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
