### PR TITLE
[FIX] iot_box_image: pin compatible aiortc version on windows

### DIFF
--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -3,7 +3,7 @@ gatt; sys_platform == "linux" and "rpi" in platform_release
 /home/pi/odoo/addons/iot_box_image/configuration/aiortc-1.4.0-py3-none-any.whl; sys_platform == "linux" and "rpi" in platform_release and python_version <= '3.11'
 
 # The following requirements are needed only on Windows Virtual IoT:
-aiortc; sys_platform == "win32"
+aiortc==1.10.1; sys_platform == "win32"
 ghostscript==0.7; sys_platform == "win32"
 decorator; sys_platform == "win32"
 


### PR DESCRIPTION
Before this commit, WebRTC communication was broken on the Virtual IoT due to using too new of a version of the `aiortc` package, which isn't compatible with the version of `pyopenssl` being used.

This commit fixes the issue by pinning the version to `1.10.1`, which is the last version to support `pyopenssl` v24.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
