### PR TITLE
[FIX] l10n_hr_edi: Minor UI, API and error handling fixes

### DIFF
--- a/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
+++ b/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
@@ -34,6 +34,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                                     'cbc:ID': {},
                                     'cbc:Name': {},
                                     'cbc:Percent': {},
+                                    'cbc:TaxExemptionReason': {},
                                     'hrextac:HRTaxScheme': {
                                         'cbc:ID': {},
                                     }
@@ -178,6 +179,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                     'cbc:ID': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:ID'],
                     'cbc:Name': hr_tax_name,
                     'cbc:Percent': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:Percent'],
+                    'cbc:TaxExemptionReason': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:TaxExemptionReason'],
                     'hrextac:HRTaxScheme': tax_subtotals[i]['cac:TaxCategory'][0]['cac:TaxScheme'] if hr_tax_name['_text'] != "HR:POVNAK" else {'_text': "OTH"},
                 }
             }
@@ -329,6 +331,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
             'cbc:ID': {'_text': tax_category['tax_category_code']},
             'cbc:Name': {'_text': tax_category.get('name')},
             'cbc:Percent': {'_text': tax_category['percent']},
+            'cbc:TaxExemptionReason': {'_text': tax_category.get('tax_exemption_reason')},
             'cac:TaxScheme': {
                 'cbc:ID': {'_text': tax_category['scheme_id']},
             }

--- a/addons/l10n_hr_edi/models/account_move.py
+++ b/addons/l10n_hr_edi/models/account_move.py
@@ -177,9 +177,18 @@ class AccountMove(models.Model):
             if move.country_code == 'HR' and move.is_sale_document():
                 if not move.l10n_hr_fiscal_user_id:
                     move.l10n_hr_fiscal_user_id = move.env.user.partner_id
-            if move.company_id.country_code == 'HR' and move.is_purchase_document() and move.l10n_hr_business_document_status == '1':
-                raise UserError(self.env._("This vendor bill is already rejected according to the Tax Authority."))
-        return super()._post(soft)
+            if move.l10n_hr_mer_document_eid and move.is_purchase_document():
+                if move.l10n_hr_business_document_status == '1':
+                    raise UserError(self.env._("This vendor bill is already rejected according to the Tax Authority."))
+                elif move.l10n_hr_business_document_status in ('4', '99'):
+                    _mer_api_update_document_process_status(
+                        move.company_id,
+                        move.l10n_hr_mer_document_eid,
+                        0,
+                    )
+                    move.l10n_hr_edi_addendum_id.business_document_status = '0'
+                    _logger.info("Document eID %s reported as approved by recepient.", move.l10n_hr_mer_document_eid)
+        return super()._post(soft=soft)
 
     def l10n_hr_edi_mer_action_reject(self):
         self.ensure_one()

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption.xml
@@ -13,6 +13,7 @@
                 <cbc:ID>K</cbc:ID>
                 <cbc:Name>HR:K</cbc:Name>
                 <cbc:Percent>0.0</cbc:Percent>
+                <cbc:TaxExemptionReason>Exempt from VAT due to delivery within the EU</cbc:TaxExemptionReason>
                 <hrextac:HRTaxScheme>
                   <cbc:ID>VAT</cbc:ID>
                 </hrextac:HRTaxScheme>
@@ -171,6 +172,7 @@
         <cbc:ID>K</cbc:ID>
         <cbc:Name>HR:K</cbc:Name>
         <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt from VAT due to delivery within the EU</cbc:TaxExemptionReason>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>

--- a/addons/l10n_hr_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_hr_edi/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//block[@id='peppol']" position="after">
                 <block title="MojEracun E-Invoicing" id="mojeracun" invisible="country_code != 'HR'">
-                    <setting string="Service credentials">
+                    <setting string="Service credentials" company_dependent="1">
                         <span class="text-muted">Requires registration on <a href="https://portal.moj-eracun.hr/">MojEracun portal</a></span>
                         <div class="mt-4">
                             <div class="row">
@@ -22,7 +22,7 @@
                                 <label string="Company ID (OIB or GIN)" for="l10n_hr_mer_company_ident" class="col-lg-6 o_light_label"/>
                                 <field name="l10n_hr_mer_company_ident"/>
                             </div>
-                            <div class="row">
+                            <div class="row" title="If you have not used Company BU/PJ for registering on MojEracun, leave this field blank.">
                                 <label string="Company Business Unit (PJ)" for="l10n_hr_mer_company_bu" class="col-lg-6 o_light_label"/>
                                 <field name="l10n_hr_mer_company_bu"/>
                             </div>
@@ -32,7 +32,7 @@
                             </div>
                         </div>
                     </setting>
-                    <setting string="Current status">
+                    <setting string="Current status" company_dependent="1">
                         <div class="mt-4">
                             <field name="l10n_hr_mer_connection_state"/>
                         </div>


### PR DESCRIPTION
- Adjusting error handling for receiving an empty response from MER for a document fiscalization status.
- Adding additional checks for running multi-company-wide MER API methods.
- Adjusting how approval API call is handled when confirming a bill.
- Adding a tooltip about Company BU in MER settings and missing "company dependent" indicators for the credentials.
Continuation of task-4925745
Related to opw-5477846

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
