### PR TITLE
[FIX] html_builder: switch tooltip icon in RTL

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -1,4 +1,5 @@
 import { Component, onMounted, useEffect, useRef, useState } from "@odoo/owl";
+import { localization } from "@web/core/l10n/localization";
 import { useTransition } from "@web/core/transition";
 import { uniqueId } from "@web/core/utils/functions";
 import { useService } from "@web/core/utils/hooks";
@@ -36,6 +37,7 @@ export class BuilderRow extends Component {
             expanded: this.props.expand,
         });
         this.hasTooltip = this.props.tooltip ? true : undefined;
+        this.isBackendRTL = localization.direction === "rtl";
 
         if (this.props.slots.collapse) {
             useVisibilityObserver("collapse-content", useApplyVisibility("collapse"));

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.xml
@@ -38,7 +38,7 @@
                     >
 
                     <span class="text-nowrap text-truncate" t-out="props.label" t-ref="label"/>
-                    <i t-if="state.tooltip" class="fa fa-question icon-sup"/>
+                    <i t-if="props.tooltip" class="fa fa-question icon-sup" t-att-class="this.isBackendRTL ? 'fa-flip-horizontal' : ''"/>
                 </div>
                 <div
                     class="hb-row-content d-flex"


### PR DESCRIPTION
Among other things, commit [0aba7f3] added a `?` icon on builder options with a tooltip. However:

- since [94e17fd], the key `state.tooltip` was removed from the BuilderRow component (to use `props.tooltip` directly), but the XML wasn't properly adapted in 19.0.
- the icon isn't mirrored in RTL languages.

This commit fixes both issues.

[0aba7f3]: https://github.com/odoo/odoo/commit/0aba7f383c86dec00e9fc6d324a5bfdec7a19707
[94e17fd]: https://github.com/odoo/odoo/commit/94e17fd9845486a959f2544e1b26199abc96a56a

task-5109547