### PR TITLE
[FIX] mrp{,_account}, stock_account: avoid valuating kit products

### DIFF
--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -160,5 +160,9 @@
                 </xpath>
             </field>
         </record>
+
+        <record model="ir.actions.act_window" id="stock.action_product_stock_view">
+            <field name="domain">[('is_storable', '=', True), ('is_kits','=', False)]</field>
+        </record>
     </data>
 </odoo>

--- a/addons/mrp_account/models/__init__.py
+++ b/addons/mrp_account/models/__init__.py
@@ -6,3 +6,4 @@ from . import mrp_production
 from . import product
 from . import stock_move
 from . import account_move
+from . import res_company

--- a/addons/mrp_account/models/res_company.py
+++ b/addons/mrp_account/models/res_company.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    def _get_valuation_product_domain(self):
+        return super()._get_valuation_product_domain() + [('is_kits', '=', False)]

--- a/addons/mrp_account/tests/test_valuation_layers.py
+++ b/addons/mrp_account/tests/test_valuation_layers.py
@@ -335,3 +335,15 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         comp_move = mo.unbuild_ids.produce_line_ids.filtered(lambda move: move.product_id.id == self.glass.id)
         with Form(comp_move.move_line_ids[0]) as form:
             form.quantity = 0
+
+    def test_kit_product_valuation(self):
+        """
+        Verify that kit products are excluded from inventory valuation
+        and have no effect on valuation upon price change.
+        """
+        self.assertRecordValues(self.table_head, [{'standard_price': 300, 'total_value': 300}])
+        self.assertTrue(self.table_head not in self.env.company._get_accounts_by_product())
+        old_stock_value = sum(self.env.company.stock_value().values())
+        self.table_head.action_bom_cost()
+        self.assertRecordValues(self.table_head, [{'standard_price': 468.75, 'total_value': 468.75}])
+        self.assertEqual(old_stock_value, sum(self.env.company.stock_value().values()))

--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -141,9 +141,12 @@ class ResCompany(models.Model):
         for company in companies:
             company.action_close_stock_valuation(auto_post=True)
 
+    def _get_valuation_product_domain(self):
+        return [('is_storable', '=', True)]
+
     def _get_accounts_by_product(self, products=None):
         if not products:
-            products = self.env['product.product'].with_company(self).search([('is_storable', '=', True)])
+            products = self.env['product.product'].with_company(self).search(self._get_valuation_product_domain())
 
         accounts_by_product = {}
         for product in products:


### PR DESCRIPTION
Currently, when a user creates a kit, the price of the kit itself is included in stock valuation.

## Steps to produce:
* Install `mrp_account` without demo data.
* Create a product with inventory tracking enabled.
* Create a BoM of type kit for that product.
* Add component products with a defined cost and on-hand quantity greater than 0 to the BoM.
* Recompute the kit product’s cost from its BoM on the product page.
* Go to Inventory > Reporting > Stock.

## Observed Behavior:
The cost of the kit is currently being included in the stock valuation.

For example, consider a kit product called **“Computer”** that is composed of the
following components:
| Product | Quantity | Cost |
|--------|--------|--------|
| CPU | 1 | $300 |
| Motherboard | 1 | $300 | 

The total cost of the Computer kit is therefore $600. Since the Computer is made up of the CPU and Motherboard, the total inventory value should be $600. However, the system is currently calculating the total inventory value as $1,200
, which is incorrect because it is counting both the kit and its components.

## Root cause:
This behavior started after the refactor in [1], where the `_compute_value_svl`
function was replaced by the `compute_value` function to calculate both average and total value for 
inventory valuation.

With this change, the new compute function in [2] now also includes kit products when calculating inventory valuation based on their costing method.

In earlier versions, this did not occur because `_compute_value_svl` depended on valuation layer groups. Kit products were excluded at [3] through the  `_get_valuation_layer_groups()` call, as illustrated in image [4].

[2]-
https://github.com/odoo/odoo/blob/1b9937a702fbeb47cd6d42d8119cead5828fd3fe/addons/stock_account/models/product.py#L139-L169 
[3]-
https://github.com/odoo/odoo/blob/a9d2e54201173d1d2d5ab97de0904d63a4b6b82b/addons/stock_account/models/product.py#L284

## Solution:
To ensure correct total inventory valuation, kit products should be excluded from valuation and only their individual components should be calculated.

This can be achieved by modifying the domains used in 'action_product_stock_view` and `_get_accounts_by_product`
to exclude the kits so that the kit products get filtered out, allowing the report to consider only its components.

**Before:**
<img width="1857" height="938" alt="image" src="https://github.com/user-attachments/assets/bbd4eb94-ba1a-429a-a61c-afbe33729ac0" />

**After:**
<img width="1915" height="883" alt="image" src="https://github.com/user-attachments/assets/c93d55c8-8197-4e57-9f87-b2159fe67d87" />

[1]:
https://github.com/odoo/odoo/pull/222169/commits/6e694b79b8892d693117f6c79df1a2d3a4759f4f 
[4]:
https://drive.google.com/file/d/1g4BzGscCW2K0rf5iDKrq-psYRlKhYkDP/view?usp=sharing

opw-5462515
