### PR TITLE
[FIX] iot_drivers: fix concurrent USB printer access

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -11,7 +11,7 @@ import pywintypes
 import ghostscript
 
 from odoo.addons.iot_drivers.controllers.proxy import proxy_drivers
-from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import PrinterDriverBase
+from odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base import EscposNotAvailableError, PrinterDriverBase
 from odoo.addons.iot_drivers.tools import helpers
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.addons.iot_drivers.iot_handlers.interfaces.printer_interface_W import win32print_lock
@@ -64,9 +64,12 @@ class PrinterDriver(PrinterDriverBase):
         super().disconnect()
 
     def print_raw(self, data, action_unique_id=None):
-        if not self.check_printer_status(action_unique_id):
-            _logger.warning("Printer %s is not ready, aborting raw print", self.device_name)
-            raise Exception("Printer not ready")
+        if self.escpos_device:
+            try:
+                return self.print_raw_escpos(data, action_unique_id)
+            except EscposNotAvailableError:
+                _logger.warning("Failed to print via python-escpos, falling back to Windows printing")
+
         job_id = False
         page_started = False
         try:

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from base64 import b64decode
+import threading
 from escpos.escpos import EscposIO
 import escpos.printer
 import escpos.exceptions
@@ -37,6 +38,10 @@ def _read_escpos_with_retry(self):
 escpos.printer.Usb._read = _read_escpos_with_retry
 
 
+class EscposNotAvailableError(RuntimeError):
+    pass
+
+
 class PrinterDriverBase(Driver, ABC):
     connection_type = 'printer'
     job_timeout_seconds = 30
@@ -63,6 +68,7 @@ class PrinterDriverBase(Driver, ABC):
         self.job_ids = []
         self.job_action_ids = {}
         self.escpos_device = None
+        self.escpos_lock = threading.Lock()
 
         self._actions.update({
             'cashbox': self.open_cashbox,
@@ -228,26 +234,29 @@ class PrinterDriverBase(Driver, ABC):
         for drawer in commands['drawers']:
             self.print_raw(drawer, action_unique_id=data.get("action_unique_id"))
 
-    def check_printer_status(self, action_unique_id=None):
+    def print_raw_escpos(self, data, action_unique_id=None):
         if not self.escpos_device:
-            return True
+            raise EscposNotAvailableError
         try:
-            with EscposIO(self.escpos_device, autocut=False) as esc:
+            with self.escpos_lock, EscposIO(self.escpos_device, autocut=False) as esc:
                 esc.printer.open()
                 if not esc.printer.is_online():
+                    _logger.warning("Printer %s is not ready, aborting raw print", self.device_name)
                     self.send_status(status='error', message='ERROR_OFFLINE', action_unique_id=action_unique_id)
                     return False
                 paper_status = esc.printer.paper_status()
                 if paper_status == 0:
+                    _logger.warning("Printer %s has no paper, aborting raw print", self.device_name)
                     self.send_status(status='error', message='ERROR_NO_PAPER', action_unique_id=action_unique_id)
                     return False
                 elif paper_status == 1:
                     self.send_status(status='warning', message='WARNING_LOW_PAPER')
+                esc.printer._raw(data)
+            self.send_status(status='success')
+            return True
         except (escpos.exceptions.Error, OSError, AssertionError, TypeError):
             self.escpos_device = None
-            _logger.warning("Failed to query ESC/POS status")
-
-        return True
+            raise EscposNotAvailableError
 
     def run(self):
         while True:


### PR DESCRIPTION
When printing many receipts quickly using a USB printer, this error was occasinally occuring:

```
WARNING ? odoo.addons.iot_drivers.iot_handlers.drivers.printer_driver_base: Failed to query ESC/POS status
ERROR   ? root: Could not set configuration: [Errno 16] Resource busy
```

This would cause `python-escpos` to be disabled and fallback to just CUPS printing.

The issue was caused by two threads trying to access the printer at the same time, which could happen in two ways:
- IoT thread with `python-escpos` and CUPS try to access the printer at the same time.
- Two IoT threads with `python-escpos` try to access the printer at the same time (this can happen if two receipt actions are received at the same time).

Both of these scenarios should now prevented:
- Now, if we are using `python-escpos`, we also use it to print the receipt as well as checking the status. CUPS is never used so there should be no interference from it.
- We now have an `escpos_lock` (per printer, not global) that is acquired when accessing the printer via `python-escpos`. This ensures that different threads cannot both try to access the printer at the same time.

task-5490942

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
