### PR TITLE
[FIX] html_builder, website: fix add item button traceback

### DIFF
--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -110,7 +110,9 @@ export class CloneItemAction extends BuilderAction {
     static dependencies = ["clone", "history"];
     async apply({ editingElement, params: { mainParam: itemSelector }, value: position }) {
         const itemEl = editingElement.querySelector(itemSelector);
-        await this.dependencies.clone.cloneElement(itemEl, { position, scrollToClone: true });
-        this.dependencies.history.addStep();
+        if (itemEl) {
+            await this.dependencies.clone.cloneElement(itemEl, { position, scrollToClone: true });
+            this.dependencies.history.addStep();
+        }
     }
 }

--- a/addons/website/static/src/builder/plugins/options/faq_horizontal_option.xml
+++ b/addons/website/static/src/builder/plugins/options/faq_horizontal_option.xml
@@ -7,7 +7,8 @@
             action="'addItem'"
             actionParam="'.s_faq_horizontal_entry:last-of-type'"
             preview="false"
-            className="'o_we_bg_success'">
+            className="'o_we_bg_success'"
+            applyTo="':scope > :has(.s_faq_horizontal_entry)'">
             Add New
         </BuilderButton>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/timeline_list_option.xml
+++ b/addons/website/static/src/builder/plugins/options/timeline_list_option.xml
@@ -8,7 +8,8 @@
             actionParam="'.s_timeline_list_row'"
             actionValue="'beforebegin'"
             preview="false"
-            className="'o_we_bg_brand_primary'">
+            className="'o_we_bg_brand_primary'"
+            applyTo="':scope > :has(.s_timeline_list_row)'">
             Add New
         </BuilderButton>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/timeline_option.xml
+++ b/addons/website/static/src/builder/plugins/options/timeline_option.xml
@@ -8,7 +8,8 @@
             actionParam="'.s_timeline_row'"
             actionValue="'beforebegin'"
             preview="false"
-            className="'o_we_bg_brand_primary'">
+            className="'o_we_bg_brand_primary'"
+            applyTo="':scope > :has(.s_timeline_row)'">
             Add Date
         </BuilderButton>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/timeline_images_option.xml
+++ b/addons/website/static/src/builder/plugins/timeline_images_option.xml
@@ -8,7 +8,8 @@
             actionParam="'.s_timeline_images_row'"
             actionValue="'beforebegin'"
             preview="false"
-            className="'o_we_bg_brand_primary'">
+            className="'o_we_bg_brand_primary'"
+            applyTo="':scope > :has(.s_timeline_images_row)'">
             Add Date
         </BuilderButton>
     </BuilderRow>


### PR DESCRIPTION
Steps to reproduce:

- Drag and drop a "Topics List" snippet onto a web page.
- Remove all "Topic" items from the snippet so that none remain.
- Click the "Add New" button.
- A traceback occurs.

This bug is caused by the fact that the "Add item" option is defined in the "Options" section of the parent element of the topics. As a result, the option button remains visible even when no topics exist anymore.

Clicking it then triggers a traceback because the option attempts to duplicate an element that does not exist.

In this commit, we fix the issue by adding an "applyTo" on the option, targeting the topics, so that the "Add New" button no longer appears when no topic is present.

Note that the same bug exists for other snippets, and this commit fixes them as well.

task-5462596
