### PR TITLE
[IMP] core: support JSON serialization of dataclasses

### DIFF
--- a/odoo/tools/json.py
+++ b/odoo/tools/json.py
@@ -72,4 +72,6 @@ def json_default(obj):
         return obj.decode()
     if isinstance(obj, fields.Domain):
         return list(obj)
+    if (as_dict_func := getattr(obj, 'as_dict', None)) and callable(as_dict_func):
+        return as_dict_func()
     return str(obj)


### PR DESCRIPTION
To reduce the memory footprint of accounting reports, we now use different data structures for lines, columns, etc. These structures are sent to the web client and therefore need to be JSON-serializable.

This change allows dataclasses to be returned directly; they are now automatically converted to dictionaries.

task-5404869
