### PR TITLE
[FIX] pos_self_order: format amount in emails

### DIFF
--- a/addons/pos_self_order/data/mail_template_data.xml
+++ b/addons/pos_self_order/data/mail_template_data.xml
@@ -22,7 +22,7 @@
                         <t t-else="">Hello,</t>
                     </div>
                     <br/>
-                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="object.amount_total">$xx.xx</t> has been confirmed. <span t-if="object.preset_time">It will be ready at <t t-out="format_time(time=object.preset_time, tz=tz, time_format='short', lang_code=lg)">12:00 pm</t></span></div>
+                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="format_amount(object.amount_total,object.currency_id)">$xx.xx</t> has been confirmed. <span t-if="object.preset_time">It will be ready at <t t-out="format_time(time=object.preset_time, tz=tz, time_format='short', lang_code=lg)">12:00 pm</t></span></div>
                     <br/>
                     <div>Thank you,</div>
                     <br/>
@@ -62,7 +62,7 @@
                         <t t-else="">Hello,</t>
                     </div>
                     <br/>
-                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="object.amount_total">$xx.xx</t> has been confirmed. <span t-if="object.preset_time or client.street">It will be ready</span> <span t-if="object.preset_time">at <t t-out="format_time(time=object.preset_time, tz=tz, time_format='short', lang_code=lg)">12:00 pm</t></span> <span t-if="client.street">at <t t-out="street">street</t>, <t t-out="state">state</t>, <t t-out="client.zip or ''">zip</t>, <t t-out="city">city</t>, <t t-out="country">country</t></span></div>
+                    <div>Your order <t t-out="object.tracking_number">...</t> amounting in <t t-out="format_amount(object.amount_total,object.currency_id)">$xx.xx</t> has been confirmed. <span t-if="object.preset_time or client.street">It will be ready</span> <span t-if="object.preset_time">at <t t-out="format_time(time=object.preset_time, tz=tz, time_format='short', lang_code=lg)">12:00 pm</t></span> <span t-if="client.street">at <t t-out="street">street</t>, <t t-out="state">state</t>, <t t-out="client.zip or ''">zip</t>, <t t-out="city">city</t>, <t t-out="country">country</t></span></div>
                     <br/>
                     <div>Thank you,</div>
                     <br/>


### PR DESCRIPTION
**Problem:**
POS self-order confirmation emails (delivery and takeout) display the order amount without the currency symbol and proper formatting.

**Steps to reproduce:**
1. Create a POS self-order with delivery or takeout
2. Preview or send the confirmation email
3. Observe the amount displays without currency symbol or formatting

**Current behavior:**
Email shows amount as a plain number (e.g., "2.0") without currency symbol or locale-specific formatting.

**Expected behavior:**
Email should display amount with currency symbol and proper formatting based on user's locale (e.g., "2,00€", "$2.00", etc.).

**Cause of the issue:**
The email templates used direct field output `t-out="object.amount_total"` which renders only the numeric value without any formatting. This bypasses Odoo's standard currency formatting that handles both the symbol and locale-specific decimal/thousand separators.

**Fix:**
Use the `format_amount()` helper function which properly formats monetary values with currency symbols and locale-appropriate separators. The function takes the amount and currency as parameters and returns the fully formatted string respecting the user's language settings.

opw-5485801
