### PR TITLE
[FIX] iot_drivers: fix escpos USB read patch

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -30,6 +30,7 @@ def _read_escpos_with_retry(self):
 
         time.sleep(0.05)
         _logger.debug("Read attempt %s failed", attempt)
+    return b""
 
 
 # Monkeypatch the USB printer read method with our retrying version


### PR DESCRIPTION
When using the `python-escpos` library with a USB printer, we had to patch the read method to retry due to the result not always being immediately available. However, in the case where all the retries are exhausted, it currently returns `None`, whereas the library always expects a `bytes` result.

This commit fixes the issue by returning `b""` when no result can be read. This prevents the `python-escpos` functionality from being disabled when the printer lid is open.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
