### PR TITLE
[FIX] hr_attendance :  Fix quantity overtime

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -332,12 +332,12 @@ class HrAttendanceOvertimeRule(models.Model):
         attendances = self.env['hr.attendance']
         for (a_start, a_stop, attendance) in attendance_intervals:
             attendances += attendance
-            intervals_attendance_by_attendance[attendance] = (Intervals([(a_start, a_stop, self.env['resource.calendar'])]) - schedule['lunch']) &\
+            intervals_attendance_by_attendance[attendance] = (Intervals([(a_start, a_stop, self.env['resource.calendar'])]) - (schedule['lunch'] - schedule['leave'])) &\
                 Intervals([(start, stop, self.env['resource.calendar'])])
             attendances_interval_without_lunch.extend(intervals_attendance_by_attendance[attendance]._items)
 
         if self.expected_hours_from_contract:
-            period_schedule = schedule['work'] & Intervals([(start, stop, self.env['resource.calendar'])])
+            period_schedule = (schedule['work'] - schedule['leave']) & Intervals([(start, stop, self.env['resource.calendar'])])
             expected_duration = sum_intervals(period_schedule)
 
         overtime_amount = sum_intervals(Intervals(attendances_interval_without_lunch)) - expected_duration
@@ -402,6 +402,7 @@ class HrAttendanceOvertimeRule(models.Model):
         undertime_by_employee_by_attendance = defaultdict(lambda: defaultdict(list))
         for employee, duration_and_amount_by_periods in attendances_by_periods_by_employee.items():
             schedule = schedule_by_employee['schedule'][employee]
+            schedule['leave'] = schedule_by_employee['leave'][employee]
             fully_flex_schedule = schedule_by_employee['fully_flexible'][employee]
             for day, attendance_interval in duration_and_amount_by_periods.items():
                 for rule in self:

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -291,7 +291,7 @@ class TestHolidaysOvertime(TransactionCase):
             })
 
         self.assertEqual(self.employee.total_overtime, 0, 'Should have 0 hours of overtime')
-        self.assertEqual(self.manager.total_overtime, 0, "Should have 0 hours of overtime (because the employee ruleset doesn't have any timing rule)")
+        self.assertEqual(self.manager.total_overtime, 9, "Should have 9 hours of overtime (because of the quantity rule)")
 
     def test_worked_leave_type_overtime(self):
         """ Test that an attendance during a worked time off doesn't count as overtime. """


### PR DESCRIPTION
This PR aims to fix how the overtime is being calculated with quantity based rules :
 - The expected _hours didn't take into account the leaves of the day , so if the user was on a leave, it would considered him absent ( give him negative overtime) , because he has no attendances that day.
 - if the employee took a whole day off, and decided to work on it, all the hours should be considered as overtime, the brake shouldn't be included 
 (ex : his normal work sched is morning (9h-12h) , break(12h-13h), afternoon(13-17h) , he's already getting paid for that time , so every single hour worked that day from 12am to 12 pm is added time , and there is no break in added time) 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
