### PR TITLE
[FIX] website_sale: fix combination issue with multi-attribute and an archived variant

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -820,7 +820,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                             and ptav.product_attribute_value_id.id in attribute_value_ids
                         )
                     )[:1]
-                ) or ptal.product_template_value_ids[:1]
+                ) or ptal.product_template_value_ids.filtered('ptav_active')[:1]
             )
             combination_info = product._get_combination_info(
                 combination=request.env['product.template.attribute.value'].concat(combination)

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -432,3 +432,57 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             }),
         ]
         self.start_tour('/shop', 'website_sale_product_configurator_strikethrough_price')
+
+    def test_get_product_combination_multi_attribute_with_archived_variant_and_inactive_ptav(self):
+        """
+        This test covers a case where a product has multiple attributes and one
+        of the attribute values corresponds to an archived variant, with its
+        ptav_active set to False.
+
+        In this scenario, a valid combination should still be possible, and the
+        resulting combination product must not be the archived variant.
+        """
+        attribute_single = self.env['product.attribute'].create({
+            'name': "attribute single",
+            'value_ids': [
+                Command.create({
+                    'name': "single",
+                }),
+            ],
+        })
+        attribute_multi = self.env['product.attribute'].create({
+            'name': "attribute multi",
+            'value_ids': [
+                Command.create({'name': "first"}),
+                Command.create({'name': "second"}),
+                Command.create({'name': "third"}),
+            ],
+        })
+        main_product = self.env['product.template'].create({
+            'name': "Main product",
+            'website_published': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute_single.id,
+                    'value_ids': [Command.set(attribute_single.value_ids.ids)],
+                }),
+                Command.create({
+                    'attribute_id': attribute_multi.id,
+                    'value_ids': [Command.set(attribute_multi.value_ids.ids)],
+                }),
+            ],
+        })
+        main_product.product_variant_ids.filtered(
+            lambda product: product.product_template_attribute_value_ids[1].name == 'first',
+        ).action_archive()
+        main_product.attribute_line_ids[1].product_template_value_ids[0].ptav_active = False
+        with MockRequest(self.env, website=self.website):
+            product_values = self.pc_controller._prepare_product_values(
+                main_product,
+                self.env['product.public.category'],
+                attribute_values=str(attribute_single.value_ids.id),
+            )
+        is_combination_possible = product_values['combination_info']['is_combination_possible']
+        combination_product_id = product_values['combination_info']['product_id']
+        self.assertTrue(is_combination_possible)
+        self.assertTrue(self.env['product.product'].browse(combination_product_id).active)


### PR DESCRIPTION
### Issue:
When a product has multiple attributes and one variant is archived, the product page may appear grayed out and the product cannot be added to the cart.

#### Steps to reproduce (with demo data):
1- Create a product with two attributes:
   - attribute with 3 values
   - Brand: Adidas

2- Save product to generate variants. Publish the product.
3- From variant list, archive the first variant
4- Back in product page, from attributes & variants tab, remove
   the first value. This sets `ptav_active` to False.
5- Navigate to website shop page, and add the Brand Adidas to filter
6- This should show the created product active.
7- Open the product. You will see the product is grayed out and it's
   shown inactive and cannot add it to the cart.

### Cause:
In this scenario, `attribute_value_ids` only contains values from the single-value attribute:
https://github.com/odoo/odoo/blob/da88d0a72bf4c0ec6887e53d35bf4c28b68a6a2b/addons/website_sale/controllers/main.py#L814-L824

For the multi-value attribute, no ptav matches `attribute_value_ids`, so the code falls back to selecting the first ptav: https://github.com/odoo/odoo/blob/da88d0a72bf4c0ec6887e53d35bf4c28b68a6a2b/addons/website_sale/controllers/main.py#L823

If this ptav corresponds to an archived variant, the resulting combination resolves to an inactive product.

### Fix:
Ensure the fallback logic only considers active ptavs, preventing archived variants with prav inactive from being selected.

opw-5352224

