### PR TITLE
[FIX] website_forum: edit post reason only for website designers

### DIFF
--- a/addons/website_forum/security/ir.model.access.csv
+++ b/addons/website_forum/security/ir.model.access.csv
@@ -10,7 +10,8 @@ access_forum_post_vote_portal,orum.post.vote.portal,model_forum_post_vote,base.g
 access_forum_post_vote_user,forum.post.vote.user,model_forum_post_vote,base.group_user,1,1,1,1
 access_forum_post_reason_public,forum.post.reason.public,model_forum_post_reason,base.group_public,1,0,0,0
 access_forum_post_reason_portal,forum.post.reason.portal,model_forum_post_reason,base.group_portal,1,0,0,0
-access_forum_post_reason_user,forum.post.reason.user,model_forum_post_reason,base.group_user,1,1,1,1
+access_forum_post_reason_user,forum.post.reason.user,model_forum_post_reason,base.group_user,1,0,0,0
+access_forum_post_reason_website_designer,forum.post.reason.website.designer,model_forum_post_reason,website.group_website_designer,1,1,1,1
 access_forum_tag_public,forum.tag.public,model_forum_tag,base.group_public,1,0,1,0
 access_forum_tag_portal,forum.tag.portal,model_forum_tag,base.group_portal,1,0,1,0
 access_forum_tag_user,forum.tag.user,model_forum_tag,base.group_user,1,1,1,1


### PR DESCRIPTION
Members of group_website_designer don't have the rights permissions on 'forum.post.reason' records. This commit adds the neccessary ACL.

task-5499165

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr