### PR TITLE
[FIX] website_sale: Prevent replacing category snippet

### DIFF
--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_category_options.xml
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_category_options.xml
@@ -7,7 +7,7 @@
     >
         <BuilderRow id="template_opt_row" position="replace"/>
         <BuilderRow id="number_of_records_opt_row" position="replace"/>
-        <BuilderRow id="filter_opt_row" position="after">
+        <BuilderRow id="filter_opt_row" position="replace">
             <BuilderRow label.translate="Columns">
                 <BuilderRange dataAttributeAction="'columns'" min="2" max="5"/>
             </BuilderRow>


### PR DESCRIPTION
Steps to reproduce:
====================
1- Go to any product and in the tab Sales add some accessory products
2- Go to the website and edit a page
3- Add a category list block
4- Change category list filter to "Accessories for product"
5- Save

-> The block is empty

Cause:
======
The category snippet was meant to be used only for categories.
The problem is that its possible to change from "Categories List" to anything else.
When the user makes the choice to add a categories snippet he shouldn't be able to change the content of the snippet from categories to products, blogs, etc..

Solution:
==========
Prevent replacing the category snippet to anything else.

opw-5497284