### PR TITLE
[FIX] pos_self_order: Fix combo choice product template in self order

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -4,7 +4,7 @@ import { AttributeSelectionHelper } from "./attribute_selection_helper";
 
 export class AttributeSelection extends Component {
     static template = "pos_self_order.AttributeSelection";
-    static props = ["productTemplate", "onSelection?"];
+    static props = ["productTemplate", "onSelection?", "isCombo?"];
 
     setup() {
         this.selfOrder = useSelfOrder();
@@ -25,9 +25,17 @@ export class AttributeSelection extends Component {
     }
 
     availableAttributeValue(attribute) {
-        return this.selfOrder.config.self_ordering_mode === "kiosk"
-            ? attribute.product_template_value_ids.filter((a) => !a.is_custom)
-            : attribute.product_template_value_ids;
+        const isKiosk = this.selfOrder.kioskMode;
+        const isNoVariantCreation = attribute.attribute_id.create_variant === "no_variant";
+        return attribute.product_template_value_ids.filter((a) => {
+            if (isKiosk && a.is_custom) {
+                return false;
+            }
+            if (this.props.isCombo) {
+                return isNoVariantCreation;
+            }
+            return true;
+        });
     }
 
     getCustomSelectedValue(attribute) {

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -1,36 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.AttributeSelection">
-         <t t-foreach="props.productTemplate.attribute_line_ids" t-as="attribute" t-key="attribute.id">
-             <h2 class="text-start py-3 m-0 d-flex align-items-center" t-att-id="attribute.attribute_id.id">
-                 <t t-out="attribute.attribute_id.name"/>
-                 <span t-if="attribute.attribute_id.display_type !== 'multi'" class="badge smaller rounded-pill bg-danger text-white ms-2">Required</span>
-             </h2>
-             <div class="self_order_attribute_selection row pb-3">
-                <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
-                    <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>
-                    <div class="d-flex col-12 col-md-6 col-lg-4 position-relative">
-                        <button
-                            t-on-click="() => this.selectAttribute(attribute, value)" style="min-height:105px;"
-                            role="button" class="btn btn-light px-3 px-sm-3 py-3 py-sm-3 w-100 d-flex flex-column align-items-start align-items-md-center text-start text-md-center justify-content-center gap-0 border-2 shadow-sm rounded-4"
-                            t-attf-class="{{ valueSelected ? 'border-primary': 'border-transparent' }}">
-                            <div class="d-flex d-inline-flex justify-content-between w-100 align-items-center gap-1">
-                                <div class="text-center d-flex flex-column gap-2 align-items-center w-100">
-                                    <span t-esc="value.name" class="fs-4"/>
+        <t t-foreach="props.productTemplate.attribute_line_ids" t-as="attribute" t-key="attribute.id">
+            <t t-set="availableValues" t-value="availableAttributeValue(attribute)"/>
+            <t t-if="availableValues.length">
+                <h2 class="text-start py-3 m-0 d-flex align-items-center" t-att-id="attribute.attribute_id.id">
+                    <t t-out="attribute.attribute_id.name"/>
+                    <span t-if="attribute.attribute_id.display_type !== 'multi'" class="badge smaller rounded-pill bg-danger text-white ms-2">Required</span>
+                </h2>
+                <div class="self_order_attribute_selection row pb-3">
+                    <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
+                        <t t-set="valueSelected" t-value="isValueSelected(attribute,value)"/>
+                        <div class="d-flex col-12 col-md-6 col-lg-4 position-relative">
+                            <button
+                                t-on-click="() => this.selectAttribute(attribute, value)" style="min-height:105px;"
+                                role="button" class="btn btn-light px-3 px-sm-3 py-3 py-sm-3 w-100 d-flex flex-column align-items-start align-items-md-center text-start text-md-center justify-content-center gap-0 border-2 shadow-sm rounded-4"
+                                t-attf-class="{{ valueSelected ? 'border-primary': 'border-transparent' }}">
+                                <div class="d-flex d-inline-flex justify-content-between w-100 align-items-center gap-1">
+                                    <div class="text-center d-flex flex-column gap-2 align-items-center w-100">
+                                        <span t-esc="value.name" class="fs-4"/>
+                                    </div>
+                                    <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)"
+                                        class="d-block position-absolute badge top-0 end-0 me-3 mt-3 rounded-3 text-bg-primary fw-medium" />
+                                    <img  t-if="value.image" t-attf-src="data:image/png;base64,{{value.image}}" class="img-fluid rounded-4" style="max-height:70px; max-width:70px"/>
+                                    <div t-if="value.html_color and !value.image" t-attf-style="min-height: 25px; min-width: 25px; background-color: {{value.html_color}}" class="rounded-5"/> 
                                 </div>
-                                <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)"
-                                    class="d-block position-absolute badge top-0 end-0 me-3 mt-3 rounded-3 text-bg-primary fw-medium" />
-                                <img  t-if="value.image" t-attf-src="data:image/png;base64,{{value.image}}" class="img-fluid rounded-4" style="max-height:70px; max-width:70px"/>
-                                <div t-if="value.html_color and !value.image" t-attf-style="min-height: 25px; min-width: 25px; background-color: {{value.html_color}}" class="rounded-5"/> 
-                            </div>
-                        </button>
+                            </button>
+                        </div>
+                    </t>
+                    <t t-set="customValue" t-value="getCustomSelectedValue(attribute)"/>
+                    <div t-if="customValue">
+                        <input type="text" t-model="selectedValues.getCustomValue(attribute,customValue).custom_value" class="form-control px-3 py-3 rounded-4 bg-white shadow-sm mt-2" t-ref="customValueInput" placeholder="Enter your custom value" />
                     </div>
-                </t>
-                 <t t-set="customValue" t-value="getCustomSelectedValue(attribute)"/>
-                 <div t-if="customValue">
-                     <input type="text" t-model="selectedValues.getCustomValue(attribute,customValue).custom_value" class="form-control px-3 py-3 rounded-4 bg-white shadow-sm mt-2" t-ref="customValueInput" placeholder="Enter your custom value" />
-                 </div>
-            </div>
-          </t>
+                </div>
+            </t>
+        </t>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.js
+++ b/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.js
@@ -1,6 +1,7 @@
 import { Component } from "@odoo/owl";
 import { ProductInfoPopup } from "../product_info_popup/product_info_popup";
 import { useService } from "@web/core/utils/hooks";
+import { formatProductName } from "../../utils";
 
 export class ProductNameWidget extends Component {
     static template = "pos_self_order.ProductNameWidget";
@@ -13,5 +14,9 @@ export class ProductNameWidget extends Component {
         this.dialog.add(ProductInfoPopup, {
             productTemplate: this.props.product,
         });
+    }
+
+    formatProductName(product) {
+        return formatProductName(product);
     }
 }

--- a/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.xml
+++ b/addons/pos_self_order/static/src/app/components/product_name_widget/product_name_widget.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_self_order.ProductNameWidget">
        <div class="self_order_product_name d-inline-block">
            <t t-set="product" t-value="props.product"/>
-           <span t-esc="product.name" class="align-middle fs-4 fw-bold text-break"/>
+           <span t-esc="formatProductName(product)" class="align-middle fs-4 fw-bold text-break"/>
            <div t-if="product.public_description or product.product_tag_ids.length > 0"
                 class="product_info_icon d-inline-flex justify-content-center align-items-center border border-dark rounded-circle text-center"
                 t-on-click.stop="()=>this.displayProductInfo()">

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -9,6 +9,7 @@ import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 import { OrderReceipt } from "@point_of_sale/app/screens/receipt_screen/receipt/order_receipt";
 import { CancelPopup } from "@pos_self_order/app/components/cancel_popup/cancel_popup";
 import { _t } from "@web/core/l10n/translation";
+import { formatProductName } from "../../utils";
 
 export class CartPage extends Component {
     static template = "pos_self_order.CartPage";
@@ -261,6 +262,10 @@ export class CartPage extends Component {
     }
     get displayTaxes() {
         return !this.selfOrder.isTaxesIncludedInPrice();
+    }
+
+    formatProductName(product) {
+        return formatProductName(product);
     }
 
     /*

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -33,7 +33,7 @@
                                         <div t-foreach="line.combo_line_ids" t-as="cline" t-key="cline.uuid" class="ps-3 mb-2">
                                             <t t-set="c_qty" t-value="cline.qty / line.qty"/>
                                             <span t-if="(c_qty &gt; 1)"><t t-esc="c_qty"/>x </span>
-                                            <t t-esc="cline.product_id.name"/>
+                                            <t t-esc="formatProductName(cline.product_id)"/>
                                             <div t-foreach="cline.attribute_value_ids" t-as="attrVal" t-key="attrVal.id" class="ps-3 mt-1 text-muted">
                                                 <t t-esc="attrVal.attribute_id.name" />:
                                                 <t t-esc="attrVal.name" />

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -6,6 +6,7 @@ import { ProductNameWidget } from "@pos_self_order/app/components/product_name_w
 import { ComboStepper } from "@pos_self_order/app/components/combo_stepper/combo_stepper";
 import { computeTotalComboPrice } from "../../services/card_utils";
 import { useScrollShadow } from "../../utils/scroll_shadow_hook";
+import { formatProductName } from "../../utils";
 
 export class ComboPage extends Component {
     static template = "pos_self_order.ComboPage";
@@ -124,12 +125,20 @@ export class ComboPage extends Component {
         const selection = (selectedItems[item.id] ||= { item });
         selection.item = item;
         selection.qty = 1;
-
-        if (product.attribute_line_ids.length > 0) {
+        if (this.hasAttribute(product)) {
             this.currentChoiceState.displayAttributesOfItem = item;
         } else if (!this.hasMultiItemSelection) {
             this.next();
         }
+    }
+
+    hasAttribute(product) {
+        return (
+            product.attribute_line_ids.length > 0 &&
+            product.attribute_line_ids.some(
+                (line) => line.attribute_id?.create_variant === "no_variant"
+            )
+        );
     }
 
     getSelectedItems(choiceState = undefined) {
@@ -216,13 +225,17 @@ export class ComboPage extends Component {
         const product = comboItem.product_id;
         const selection = this.state.selectedValues[product.id];
 
-        if (product.attribute_line_ids.length === 0) {
+        const attributeLines = product.attribute_line_ids.filter(
+            (line) => line.attribute_id?.create_variant === "no_variant"
+        );
+
+        if (attributeLines.length === 0) {
             return false;
         }
         if (!selection) {
             return true;
         }
-        return Boolean(selection.getMissingAttributeValue(product.attribute_line_ids));
+        return Boolean(selection.getMissingAttributeValue(attributeLines));
     }
 
     changeQuantity(increase) {
@@ -295,9 +308,7 @@ export class ComboPage extends Component {
         } else if (!isAttributeSelection && !hasMultiItemSelection) {
             const selectedItem = this.getSelectedItems()[0];
             if (selectedItem) {
-                // Display attributes of the selected item, if any are available
-                const hasAttributes = selectedItem.item.product_id.attribute_line_ids.length > 0;
-                if (hasAttributes) {
+                if (this.hasAttribute(selectedItem.item.product_id)) {
                     this.currentChoiceState.displayAttributesOfItem = selectedItem.item;
                     newSectionDisplayed = true;
                 }
@@ -460,6 +471,10 @@ export class ComboPage extends Component {
         document
             .getElementById(missingAttribute?.attribute_id?.id)
             ?.scrollIntoView({ behavior: "smooth" });
+    }
+
+    formatProductName(product) {
+        return formatProductName(product);
     }
 
     /*

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -103,13 +103,13 @@
                                 <img class="object-fit-cover" t-attf-src="/web/image/product.product/{{ product.id }}/image_512?unique=#{product.write_date}"  loading="lazy"/>
                             </div>
                             <div class="o_self_variant_description d-flex flex-column justify-content-center">
-                                <h2 t-esc="product.name" class="mb-0 text-white"/>
+                                <h2 t-esc="formatProductName(product)" class="mb-0 text-white"/>
                                 <span t-if="product.public_description" t-out="product.productDescriptionMarkup" class="product-description mt-1"/>
                             </div>
                         </div>
                         <!-- Attributes -->
                         <div class="">
-                            <AttributeSelection t-if="product.attribute_line_ids.length" productTemplate="product" onSelection="onAttributeSelection" />
+                            <AttributeSelection t-if="product.attribute_line_ids.length" productTemplate="product" onSelection="onAttributeSelection" isCombo="true"/>
                         </div>
                         <t t-if="hasMissingAttributeValues(currentChoiceState.displayAttributesOfItem) and shouldShowMissingDetails()" t-call="pos_self_order.MissingRequiredDetails" />
                     </div>
@@ -129,7 +129,8 @@
                                         </div>
                                         <div class="d-flex flex-column gap-1">
                                             <div class="fs-4 fw-bold text-break">
-                                                <span t-if="item_qty &gt; 1" class="fw-normal"><t t-esc="item_qty"/>x </span><t t-esc="product.name"/>
+                                                <span t-if="item_qty &gt; 1" class="fw-normal"><t t-esc="item_qty"/>x </span>
+                                                <span t-esc="formatProductName(product)"/>
                                             </div>
                                             <div class="text-muted fw-medium" t-foreach="attributes" t-as="attrVal" t-key="attrVal.attribute_line_id.id">
                                                 <t t-esc="attrVal.attribute_line_id.attribute_id.name" />:

--- a/addons/pos_self_order/static/src/app/utils.js
+++ b/addons/pos_self_order/static/src/app/utils.js
@@ -11,3 +11,8 @@ export const attributeFlatter = (attribute) =>
         })
         .flat()
         .map((v) => parseInt(v));
+
+export const formatProductName = (product) => {
+    const attributes = product.product_template_attribute_value_ids?.map((v) => v.name).join(",");
+    return attributes ? `${product.name} (${attributes})` : product.name;
+};

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -3,6 +3,7 @@ import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
+import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
     steps: () => [
@@ -69,5 +70,25 @@ registry.category("web_tour.tours").add("self_combo_selector_category", {
         Utils.clickBtn("Order"),
         Utils.clickBtn("Ok"),
         Utils.checkIsNoBtn("Order Now"),
+    ],
+});
+
+registry.category("web_tour.tours").add("test_product_dont_display_all_variants", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-In"),
+        ProductPage.clickCategory("Uncategorised"),
+        ProductPage.clickProduct("Meal Combo"),
+        ProductPage.clickComboProduct("Coke always never"),
+        Utils.clickBtn("Red"),
+        Utils.clickBtn("Next"),
+        Utils.clickBtn("Add to cart"),
+        ProductPage.clickProduct("Meal Combo"),
+        ProductPage.clickComboProduct("Coke always only"),
+        Utils.clickBtn("Add to cart"),
+        ProductPage.clickProduct("Meal Combo"),
+        ProductPage.clickComboProduct("Coke never only"),
+        Utils.clickBtn("Red"),
+        Utils.clickBtn("Add to cart"),
     ],
 });


### PR DESCRIPTION
Before the fix, when we set a product variant as combo choice. In self/kiosk, we'll see the product template instead of the product itself. And we need to configure it again. It occured because for all of the products in the kiosk/self, we display the product template.

The expected behavior if we set a product variant as combo choice is to have the product variant in the combo directly without having to reconfigure it.

The bug occurs only since 19.0 because a fix was already done from 18.3 to 18.4 in this pr : #219908 but the fwport for 19.0 has never been merged.

task: 5493798

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
