### PR TITLE
[FIX] mail: do not notify busy users with inbox messages

### DIFF
--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -49,6 +49,9 @@ export class MailCoreWeb {
             if (message.thread && notifId > message.thread.message_needaction_counter_bus_id) {
                 message.thread.message_needaction_counter++;
             }
+            if (this.store.self_partner?.im_status?.includes("busy")) {
+                return;
+            }
             this.store.env.services["mail.out_of_focus"].notify(message);
         });
         this.busService.subscribe("mail.message/mark_as_read", (payload, { id: notifId }) => {


### PR DESCRIPTION
Users shouldn't be notified when they set their status as "do not disturb". It's already done for push notifications but inbox messages follow a different path.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
