### PR TITLE
[FIX] sale: prevent payment when so is expired

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -417,6 +417,9 @@ class PaymentPortal(payment_portal.PaymentPortal):
             ):
                 raise ValidationError(_("The provided parameters are invalid."))
 
+            if order_sudo.is_expired:
+                raise ValidationError(_("The sale order has expired."))
+
             kwargs.update({
                 # To display on the payment form; will be later overwritten when creating the tx.
                 'reference': order_sudo.name,

--- a/addons/sale/wizard/payment_link_wizard.py
+++ b/addons/sale/wizard/payment_link_wizard.py
@@ -29,6 +29,13 @@ class PaymentLinkWizard(models.TransientModel):
                         amount=format_amount(wizard.env, remaining_amount, wizard.currency_id),
                     )
 
+    def _compute_warning_message(self):
+        super()._compute_warning_message()
+        for wizard in self.filtered(lambda w: w.res_model == 'sale.order'):
+            sale_order = self.env['sale.order'].browse(self.res_id)
+            if sale_order.is_expired:
+                wizard.warning_message = _("The sale order has expired.")
+
     def _get_additional_link_values(self):
         """ Override of `payment` to add `sale_order_id` to the payment link values.
 


### PR DESCRIPTION
## Issue:
Payment link should expire if payment is expired.

#### Steps to reproduce:
1- Create a new quotation.
2- Set the expiry date in the past.
3- Open the action menu and generate a payment link.
4- Open the payment link and pay.

Expected result: The payment should fail if the so is expired.

opw-5478691
