### PR TITLE
[FIX] website_forum: fix wrong props passed to WebsiteForumTagsWrapper

### DIFF
--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -135,7 +135,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
 
             await attachComponent(this, selectMenuWrapperEl, WebsiteForumTagsWrapper, {
                 defaulValue: defaulValue,
-                disabled: isReadOnly,
+                isReadOnly: isReadOnly,
             });
         }
 


### PR DESCRIPTION
Following rewrite in odoo/odoo@33206fd1941ae, this commit update passed props (`disabled` -> `isReadOnly`) to avoid a crash when creating a new forum post while being in debug mode:

`OwlError: Invalid props for component 'WebsiteForumTagsWrapper': unknown key 'disabled'`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
