### PR TITLE
[FIX] website_slides: re-enable course comments

### DIFF
--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -4,8 +4,7 @@
 <!-- Slide: main template: detailed view -->
 <template id="slide_main" name="Slide Detailed View" track="1">
     <t t-set="body_classname" t-value="'o_wslides_body'"/>
-    <t t-call="website.layout"
-        can_access_channel="slide.channel_id.is_member or slide.channel_id.can_publish">
+    <t t-call="website.layout">
         <div id="wrap" class="wrap o_wslides_wrap">
             <t t-call="website.record_cover"
                 _record="slide.channel_id"
@@ -47,6 +46,7 @@
             </t>
             <div class="container o_wslides_lesson_main">
                 <div class="row">
+                    <t t-set="can_access_channel" t-value="slide.channel_id.is_member or slide.channel_id.can_publish"/>
                     <div t-attf-class="o_wslides_lesson_aside col-lg-3 #{'order-2' if slide.channel_id.channel_type == 'documentation' else ''}">
                         <t t-if="slide.channel_id.channel_type == 'training'" t-call="website_slides.slide_aside_training"/>
                         <t t-if="slide.channel_id.channel_type == 'documentation'" t-call="website_slides.slide_aside_documentation"/>


### PR DESCRIPTION
How to reproduce:
- Install website_slide with demo data
- Log in with admin and go on the public page
- Click on Courses -> Basics of Gardening -> Home Gardening -> Exit Fullscreen
- Click on the tab "Comments (0)" below Instead of being able to comment the course, you get the message "Join this Course to be the first to leave a comment." while you're already enrolled.

Cause: In odoo/odoo#232539 the variable "can_access_channel" has been set as a t-call parameter while it was used in the template.

Task-5495351