### PR TITLE
[FIX] point_of_sale: show default_code in product display name

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -8,7 +8,7 @@
                         t-att-style="props.productTemplate.is_favorite ? 'color: #f3cc00;' : ''"
                         role="img"/>
                 </button>
-                <h3 class="section-title" t-out="props.productTemplate.display_name + ' | ' + env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)"/>
+                <h3 class="section-title" t-out="props.productTemplate.displayName + ' | ' + env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)"/>
                 <button type="button" class="btn-close mb-2" aria-label="Close" tabindex="-1" t-on-click="props.close"/>
             </t>
             <div class="section-public-description mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.productTemplate.productDescriptionMarkup">

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -139,5 +139,11 @@ export class ProductTemplate extends ProductTemplateAccounting {
             .filter(Boolean)
             .join(" ");
     }
+
+    get displayName() {
+        return this.default_code
+            ? `[${this.default_code}] ${this.display_name}`
+            : this.display_name;
+    }
 }
 registry.category("pos_available_models").add(ProductTemplate.pythonModel, ProductTemplate);


### PR DESCRIPTION
This commit adds the default_code (internal reference) to the display name of the product in the product info popup.

opw-5493827

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
