### PR TITLE
[FIX] stock_account: compute correct avco report multiple pages

### DIFF
--- a/addons/stock_account/report/stock_avco_audit_report.py
+++ b/addons/stock_account/report/stock_avco_audit_report.py
@@ -88,13 +88,17 @@ WHERE
         self.env.cr.execute(query)
 
     def _compute_cumulative_fields(self):
+        total_records_grouped = self.env['stock.avco.report'].search(
+            [('product_id', 'in', self.product_id.mapped('id')), ('company_id', 'in', self.company_id.mapped('id'))]
+        ).grouped(lambda m: (m.product_id, m.company_id))
         for records in self.grouped(lambda m: (m.product_id, m.company_id)).values():
-            records = records.sorted('date, id')
+            current_page_records = records.sorted('date, id')
+            total_records = total_records_grouped.get((records.product_id, records.company_id)).sorted('date, id')
             added_value = 0.0
             total_value = 0.0
             total_quantity = 0.0
             avco = 0.0
-            for record in records:
+            for record in total_records:
                 if record.res_model_name == 'stock.move':
                     if record.quantity > 0:
                         added_value = record.value
@@ -109,10 +113,11 @@ WHERE
 
                 if total_quantity:
                     avco = total_value / total_quantity
-                record.added_value = added_value
-                record.total_value = total_value
-                record.total_quantity = total_quantity
-                record.avco_value = avco
+                if record in current_page_records:
+                    record.added_value = added_value
+                    record.total_value = total_value
+                    record.total_quantity = total_quantity
+                    record.avco_value = avco
 
     def _compute_justification(self):
         self.justification = False

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3111,3 +3111,24 @@ class TestStockValuation(TestStockValuationCommon):
         })
         self.assertEqual(self.product_avco.total_value, 2000)
         self.assertEqual(self.product_avco.standard_price, 20)
+
+    def test_avco_report_multiple_page(self):
+        # New prod to have clean avco report
+        prod_avco = self.env['product.product'].create({
+            "standard_price": 10.0,
+            "list_price": 20.0,
+            "uom_id": self.uom.id,
+            "is_storable": True,
+            'name': 'Avco Product',
+            'categ_id': self.category_avco.id,
+        })
+        recs = self.env['stock.avco.report'].search([('product_id', '=', prod_avco.id)]).sorted('date, id')
+        self.assertEqual(len(recs), 1)
+        self._make_in_move(prod_avco, 1, 10)
+        self._make_in_move(prod_avco, 1, 10)
+        self._make_in_move(prod_avco, 1, 10)
+        recs = self.env['stock.avco.report'].search([('product_id', '=', prod_avco.id)]).sorted('date, id')
+        self.assertEqual(len(recs), 4)
+        recs[-2:]._compute_cumulative_fields()
+        self.assertEqual(recs[-1].total_quantity, 3)
+        self.assertEqual(recs[-1].total_value, 30)


### PR DESCRIPTION
**Problem:**
when there is multiple pages for the avco reports
the total value and quantity are not correctly computed

**Steps to reproduce:**
- create an avco storable product with a cost of 10
- create and validate 3 in moves for a quantiy of 1 each
- navigate to Inventory/ Stock and search your product
- click on the unit cost
- (see how the total quantity is 3 and total value is 30)
- change the view to display only the first 2 records
(write 1-2/4 on the top write)

**Current behavior:**
the total quantity is now 2 and total value 20

**Expected behavior:**
it should still be 3 and 30

**Cause of the issue:**
inside _compute_cumulative_fields, we start with a 
total_value and total_quantity of 0, then those variables 
are increased or decreased by each record in records
https://github.com/odoo/odoo/blob/89cc95266fa0d9a0fd4caae9abe1effbfea1a41a/addons/stock_account/report/stock_avco_audit_report.py#L94-L104
but records is computed based on self which contains
the lines displayed on the view
https://github.com/odoo/odoo/blob/89cc95266fa0d9a0fd4caae9abe1effbfea1a41a/addons/stock_account/report/stock_avco_audit_report.py#L91

**fix**
I need to add an if statement to avoid writing on the records
not displayed on the view because this causes an access_error

opw-5421925