### PR TITLE
[FIX] hr_recruitment: prevent showing jobs from different company than applicant belongs

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -19,7 +19,7 @@ class HrDepartment(models.Model):
     name = fields.Char('Department Name', required=True, translate=True)
     complete_name = fields.Char('Complete Name', compute='_compute_complete_name', recursive=True, search='_search_complete_name')
     active = fields.Boolean('Active', default=True)
-    company_id = fields.Many2one('res.company', string='Company', index=True, default=lambda self: self.env.company)
+    company_id = fields.Many2one('res.company', string='Company', compute="_compute_company_id", store=True, recursive=True, index=True, readonly=False, tracking=True, default=lambda self: self.env.company)
     parent_id = fields.Many2one('hr.department', string='Parent Department', index=True, check_company=True)
     child_ids = fields.One2many('hr.department', 'parent_id', string='Child Departments')
     manager_id = fields.Many2one('hr.employee', string='Manager', tracking=True, domain="['|', ('company_id', '=', False), ('company_id', 'in', allowed_company_ids)]")
@@ -120,6 +120,11 @@ class HrDepartment(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         return super(HrDepartment, self.with_context(mail_create_nosubscribe=True)).create(vals_list)
+
+    @api.depends('parent_id', 'parent_id.company_id')
+    def _compute_company_id(self):
+        if self.parent_id and self.parent_id.company_id:
+            self.company_id = self.parent_id.company_id
 
     def write(self, vals):
         """ If updating manager of a department, we need to update all the employees

--- a/addons/hr/tests/test_hr_department.py
+++ b/addons/hr/tests/test_hr_department.py
@@ -23,3 +23,40 @@ class TestHrDepartment(TestMultiCompany):
         self.department._compute_total_employee()
         employee_count = self.department.total_employee  # should count all 3 employees
         self.assertEqual(employee_count, 3)
+
+    def test_department_company_id(self):
+        """
+        When the parent exists and parent's company changes to non-empty company, the child's company must be equalized to the same company
+        If the parent's company changes to empty, the child's company should not get affected
+        """
+
+        self.parent_department = self.env['hr.department'].create({
+            'name': 'parent of the test department',
+            'company_id': self.company_a.id,
+        })
+        self.department.company_id = self.company_b.id
+        self.assertTrue(self.department.company_id == self.company_b)
+        self.department.parent_id = self.parent_department.id
+        self.assertTrue(self.department.company_id == self.company_a)
+        self.parent_department.company_id = self.company_b
+        self.assertTrue(self.department.company_id == self.company_b)
+        self.parent_department.company_id = False
+
+        # Child's company should not change
+
+        self.assertTrue(self.department.company_id == self.company_b)
+
+        self.parents_parent_department = self.env['hr.department'].create({
+            'name': 'grandparent of test department',
+            'company_id': False,
+        })
+        self.parent_department.parent_id = self.parents_parent_department.id
+
+        #   Since the company of grandparent is False, it will not affect childs.
+
+        self.assertFalse(self.parent_department.company_id)
+        self.assertTrue(self.department.company_id == self.company_b)
+
+        self.parents_parent_department.company_id = self.company_a.id
+        self.assertTrue(self.parent_department.company_id == self.company_a)
+        self.assertTrue(self.department.company_id == self.company_a)

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -91,7 +91,7 @@ class HrApplicant(models.Model):
     date_open = fields.Datetime("Assigned", readonly=True)
     date_last_stage_update = fields.Datetime("Last Stage Update", index=True, default=fields.Datetime.now)
     priority = fields.Selection(AVAILABLE_PRIORITIES, "Evaluation", default='0')
-    job_id = fields.Many2one('hr.job', "Job Position", domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", tracking=True, index=True, copy=False)
+    job_id = fields.Many2one('hr.job', "Job Position", domain="company_id and [('company_id', '=', company_id)] or []", tracking=True, index=True, copy=False)
     salary_proposed_extra = fields.Char("Proposed Salary Extra", help="Salary Proposed by the Organisation, extra advantages", tracking=True, groups="hr_recruitment.group_hr_recruitment_user")
     salary_expected_extra = fields.Char("Expected Salary Extra", help="Salary Expected by Applicant, extra advantages", tracking=True, groups="hr_recruitment.group_hr_recruitment_user")
     salary_proposed = fields.Float("Proposed", aggregator="avg", help="Salary Proposed by the Organisation", tracking=True, groups="hr_recruitment.group_hr_recruitment_user")


### PR DESCRIPTION
[FIX] hr_recruitment: prevent showing jobs from different company than applicant belongs

Bug production steps: Select My Belgium Company -> Recruitment -> Applications -> All applications -> Create new application -> In the job position field, many jobs can be seen that are belong to other companies from applicant company
Bug cause: In the previous domain for job_ids, it should be either False (can belongs to many companies) or should be the company that our applicant belongs to.
Bug solution: Convert the domain such that it only lists the jobs that the job company and applicant company are same.

Also, company_id field made visible when >= 2 companies are selected in the environment.

task - 5498859

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
