### PR TITLE
[IMP] payment_razorpay: make OAuth integration user-friendly

### DIFF
--- a/addons/payment_razorpay/const.py
+++ b/addons/payment_razorpay/const.py
@@ -100,6 +100,9 @@ SUPPORTED_CURRENCIES = [
     "ZAR",
 ]
 
+# The codes of the countries where OAuth is enabled
+OAUTH_SUPPORTED_COUNTRY_CODES = ["IN"]
+
 # The codes of the payment methods to activate when Razorpay is activated.
 DEFAULT_PAYMENT_METHOD_CODES = {
     # Primary payment methods.

--- a/addons/payment_razorpay/models/payment_provider.py
+++ b/addons/payment_razorpay/models/payment_provider.py
@@ -51,6 +51,7 @@ class PaymentProvider(models.Model):
     razorpay_access_token_expiry = fields.Datetime(
         string="Razorpay Access Token Expiry", copy=False, groups="base.group_system"
     )
+    razorpay_is_oauth_supported = fields.Boolean(compute="_compute_razorpay_is_oauth_supported")
 
     # === COMPUTE METHODS === #
 
@@ -72,6 +73,15 @@ class PaymentProvider(models.Model):
             )
         return supported_currencies
 
+    @api.depends("company_id.country_id")
+    def _compute_razorpay_is_oauth_supported(self):
+        self.razorpay_is_oauth_supported = False
+        for provider in self.filtered(lambda p: p.code == "razorpay"):
+            country_code = provider.company_id.country_id.code
+            provider.razorpay_is_oauth_supported = (
+                country_code in const.OAUTH_SUPPORTED_COUNTRY_CODES
+            )
+
     # === CONSTRAINT METHODS === #
 
     @api.constrains("state")
@@ -83,10 +93,18 @@ class PaymentProvider(models.Model):
         for provider in self.filtered(lambda p: p.code == "razorpay" and p.state != "disabled"):
             if not provider.razorpay_account_id:
                 if not provider.razorpay_key_id or not provider.razorpay_key_secret:
+                    if provider.razorpay_is_oauth_supported:
+                        raise ValidationError(
+                            _(
+                                "Razorpay credentials are missing. Please set the state back to"
+                                " 'Disabled' and click the \"Connect\" button to set up your"
+                                " account."
+                            )
+                        )
                     raise ValidationError(
                         _(
-                            'Razorpay credentials are missing. Click the "Connect" button to set'
-                            " up your account."
+                            "Razorpay credentials are missing. Please fill them to set up your"
+                            " account."
                         )
                     )
 
@@ -147,6 +165,7 @@ class PaymentProvider(models.Model):
             "razorpay_refresh_token": None,
             "razorpay_access_token": None,
             "razorpay_access_token_expiry": None,
+            "razorpay_webhook_secret": None,
         }
 
     def action_razorpay_create_webhook(self):

--- a/addons/payment_razorpay/views/payment_provider_views.xml
+++ b/addons/payment_razorpay/views/payment_provider_views.xml
@@ -7,39 +7,49 @@
         <field name="inherit_id" ref="payment.payment_provider_form"/>
         <field name="arch" type="xml">
             <group name="provider_credentials" position="before">
-                <div class="text-muted mb-2" invisible="not razorpay_account_id">
+                <div class="text-muted mb-2" invisible="not razorpay_account_id and not (razorpay_key_id and razorpay_key_secret)">
                     This provider is linked with your Razorpay account.
                 </div>
             </group>
+            <sheet position="before">
+                <header invisible="not razorpay_is_oauth_supported">
+                    <button
+                        name="action_start_onboarding"
+                        string="Connect"
+                        type="object"
+                        class="btn-primary"
+                        invisible="razorpay_account_id"
+                    />
+                    <button
+                        name="action_reset_credentials"
+                        string="Disconnect"
+                        confirm="Are you sure you want to disconnect?"
+                        type="object"
+                        class="btn-secondary"
+                        invisible="not razorpay_account_id"
+                    />
+                </header>
+            </sheet>
             <group name="provider_credentials" position='inside'>
                 <group
                     name="razorpay_credentials"
                     invisible="code != 'razorpay'"
-                    groups="base.group_no_one"
                 >
-                    <label for="razorpay_account_id"/>
-                    <div class="o_row">
-                        <field name="razorpay_account_id" string="Account ID" readonly="True"/>
-                        <button
-                            string="Reset Your Razorpay Account"
-                            type="object"
-                            name="action_reset_credentials"
-                            class="btn-secondary ms-2"
-                            confirm="Are you sure you want to disconnect?"
-                            invisible="not razorpay_account_id"
-                            readonly="True"
-                        />
-                    </div>
+                    <field name="razorpay_account_id"
+                        string="Account ID"
+                        invisible="not razorpay_is_oauth_supported"
+                        readonly="True"
+                    />
                     <field
                         name="razorpay_key_id"
                         string="Key Id"
-                        decoration-muted="razorpay_account_id"
+                        invisible="razorpay_is_oauth_supported and (not razorpay_key_id or not razorpay_key_secret)"
                     />
                     <field
                         name="razorpay_key_secret"
                         string="Key Secret"
                         password="True"
-                        decoration-muted="razorpay_account_id"
+                        invisible="razorpay_is_oauth_supported and (not razorpay_key_id or not razorpay_key_secret)"
                     />
                     <label for="razorpay_webhook_secret"/>
                     <div class="o_row">
@@ -47,6 +57,7 @@
                             name="razorpay_webhook_secret"
                             string="Webhook Secret"
                             password="True"
+                            readonly="razorpay_is_oauth_supported"
                         />
                         <button
                             string="Generate your webhook"
@@ -62,19 +73,11 @@
                 <div
                     class="alert alert-warning"
                     role="alert"
-                    invisible="code != 'razorpay' or not razorpay_key_id or razorpay_account_id"
+                    invisible="code != 'razorpay' or not razorpay_key_id or razorpay_account_id or not razorpay_is_oauth_supported"
                 >
                     You are currently connected to Razorpay through the credentials method, which is
-                    deprecated. Click the "Connect" button below to use the recommended OAuth
+                    deprecated. Click the "Connect" button above to use the recommended OAuth
                     method.
-                </div>
-                <div invisible="code != 'razorpay' or razorpay_account_id">
-                    <button
-                        string="Connect"
-                        type="object"
-                        name="action_start_onboarding"
-                        class="btn-primary"
-                    />
                 </div>
             </group>
             <field name="allow_tokenization" position="after">


### PR DESCRIPTION
After enabling Razorpay's OAuth for India, we moved the credential fields to debug mode. This makes it hard for users from regions where OAuth is not available to onboard their accounts, as the "Connect" button doesn't work for them and manual credential entry is hidden. Furthermore, in countries where OAuth is supported, we should strongly encourage users to change from manual credential entry to OAuth, while still supporting upgrades.

In this commit we adapt the form view of Razorpay to each user's situation, making the default onboarding method the most intuitive one. We hide/show/make readonly each of the fields as necessary. In particular:
For countries where OAuth is not supported:
- Show editable Key ID, Key Secret and Webhook Secret

For countries where OAuth is supported:

- Show Key ID and Key Secret only if they are filled, make them invisible if they are blank (to support upgrades, but push users to use OAuth)
- OAuth "Connect" button
- Show readonly AccountId and Webhook Secret



task-4766035