### PR TITLE
[REF] test_mail, various: cleanup tracking tests

### DIFF
--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -4,6 +4,7 @@
 from . import test_crm_activity
 from . import test_crm_lead
 from . import test_crm_lead_assignment
+from . import test_crm_lead_duration_mixin
 from . import test_crm_lead_notification
 from . import test_crm_lead_convert
 from . import test_crm_lead_convert_mass

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -9,7 +9,6 @@ from odoo import fields
 from odoo.addons.base.tests.test_format_address_mixin import FormatAddressCase
 from odoo.addons.crm.models.crm_lead import PARTNER_FIELDS_TO_SYNC, PARTNER_ADDRESS_FIELDS_TO_SYNC
 from odoo.addons.crm.tests.common import TestCrmCommon, INCOMING_EMAIL
-from odoo.addons.mail.tests.common_tracking import MailTrackingDurationMixinCase
 from odoo.addons.phone_validation.tools.phone_validation import phone_format
 from odoo.exceptions import UserError
 from odoo.tests import Form, tagged, users
@@ -1159,21 +1158,3 @@ class TestLeadFormTools(FormatAddressCase):
     def test_address_view(self):
         self.env.company.country_id = self.env.ref('base.us')
         self.assertAddressView('crm.lead')
-
-
-@tagged('lead_internals', 'is_query_count')
-@tagged('at_install', '-post_install')  # LEGACY at_install
-class TestCrmLeadMailTrackingDuration(MailTrackingDurationMixinCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass('crm.lead')
-
-    def test_crm_lead_mail_tracking_duration(self):
-        self._test_record_duration_tracking()
-
-    def test_crm_lead_mail_tracking_duration_batch(self):
-        self._test_record_duration_tracking_batch()
-
-    def test_crm_lead_queries_batch_mail_tracking_duration(self):
-        self._test_queries_batch_duration_tracking()

--- a/addons/crm/tests/test_crm_lead_duration_mixin.py
+++ b/addons/crm/tests/test_crm_lead_duration_mixin.py
@@ -1,0 +1,16 @@
+from odoo.addons.mail.tests.common_tracking import MailTrackingDurationMixinCase
+from odoo.tests import tagged
+
+
+@tagged('is_query_count', 'mail_track')
+class TestCrmLeadMailTrackingDuration(MailTrackingDurationMixinCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass('crm.lead')
+
+    def test_crm_lead_mail_tracking_duration(self):
+        self._test_record_duration_tracking()
+
+    def test_crm_lead_queries_batch_mail_tracking_duration(self):
+        self._test_queries_batch_duration_tracking()

--- a/addons/l10n_de/tests/test_audit_trail.py
+++ b/addons/l10n_de/tests/test_audit_trail.py
@@ -3,7 +3,7 @@ from odoo.exceptions import UserError
 from odoo.tests.common import tagged
 
 
-@tagged('post_install_l10n', 'post_install', '-at_install')
+@tagged('post_install_l10n', 'post_install', '-at_install', 'mail_track')
 class TestAuditTrailDE(AccountTestInvoicingHttpCommon):
     @classmethod
     @AccountTestInvoicingCommon.setup_chart_template('de_skr03')

--- a/addons/mail/models/mail_tracking_duration_mixin.py
+++ b/addons/mail/models/mail_tracking_duration_mixin.py
@@ -113,9 +113,8 @@ class MailTrackingDurationMixin(models.AbstractModel):
         # add "fake" tracking for time spent in the current value
         trackings.append({
             'create_date': self.env.cr.now(),
-            'old_value_integer': self[self._track_duration_field].id,
+            'old_value_integer': self[self._track_duration_field].id or 0,
         })
-
         for tracking in trackings:
             json[tracking['old_value_integer']] += int((tracking['create_date'] - previous_date).total_seconds())
             previous_date = tracking['create_date']

--- a/addons/mail/tests/common_tracking.py
+++ b/addons/mail/tests/common_tracking.py
@@ -8,179 +8,110 @@ from odoo.addons.mail.tests.common import MailCommon
 class MailTrackingDurationMixinCase(MailCommon):
 
     @classmethod
-    def setUpClass(cls, tested_model, model_fields=None):
-
+    def setUpClass(cls, test_model_name):
         super().setUpClass()
-        if model_fields:
-            for field in model_fields:
-                if model_fields[field] == 'create':
-                    model_fields[field] = cls.env[tested_model][field].create({'name': 'test'}).id
+        cls._prepare_duration_setup(test_model_name)
 
-        stage_1_values = {'name': 'Stage 1'}
-        stage_2_values = {'name': 'Stage 2'}
-        stage_3_values = {'name': 'Stage 3'}
-        stage_4_values = {'name': 'Stage 4'}
-        cls.track_duration_field = cls.env[tested_model]._track_duration_field
+        cls.test_model_name = test_model_name
+        TestModel = cls.env[test_model_name]
+        cls.test_stage_model_name = TestModel[TestModel._track_duration_field]._name
+        cls.track_duration_field = cls.env[test_model_name]._track_duration_field
 
-        stage_model = cls.env[tested_model][cls.track_duration_field]
-        cls.stage_1 = stage_model.create(stage_1_values)
-        cls.stage_2 = stage_model.create(stage_2_values)
-        cls.stage_3 = stage_model.create(stage_3_values)
-        cls.stage_4 = stage_model.create(stage_4_values)
-
-        record_values = {'name': 'test record', cls.track_duration_field: cls.stage_1.id}
-        if model_fields:
-            record_values.update(model_fields)
-
+        cls.stage_1, cls.stage_2, cls.stage_3, cls.stage_4, cls.stage_5 = cls._create_stages(
+            test_model_name, count=5,
+        )
         cls.mock_start_time = datetime(2023, 2, 15, 12, 0, 0)
-
         with patch.object(cls.env.cr, 'now', return_value=cls.mock_start_time):
-            cls.rec_1, cls.rec_2, cls.rec_3, cls.rec_4 = cls.env[tested_model].create(
-                [record_values for i in range(4)])
-        cls.flush_tracking(cls)
+            cls.rec_1, cls.rec_2, cls.rec_3, cls.rec_4, cls.rec_5 = cls._create_records(
+                test_model_name, count=5,
+                record_vals={
+                    cls.track_duration_field: cls.stage_1.id,
+                }
+            )
+            cls.flush_tracking(cls)
 
-    def _update_duration_tracking(self, record_to_tracking_dic, minutes, new_stage=False):
-        """
-        Updates the mock duration_tracking field for multiple records based on the provided minutes.
-        If new_stage is defined, the stage of the records is updated as well.
+    @classmethod
+    def _prepare_duration_setup(cls, test_model_name):
+        return
 
-        Args:
-            record_to_tracking_dic (list): A list of tuples mapping records to their respective tracking dictionaries.
-            minutes (int): The number of minutes to be added to the duration tracking, which will be converted to seconds.
-            new_stage (int, optional): Indicated the new stage to be set for the records. Defaults to False.
-        """
-        for record, tracking_dic in record_to_tracking_dic:
-            tracking_dic[str(record[self.track_duration_field].id)] += minutes * 60
-            if new_stage:
-                tracking_dic[str(new_stage.id)] += 0
+    @classmethod
+    def _create_stages(cls, test_model_name, count=5, stage_vals=None):
+        return cls.env[cls.test_stage_model_name].create([
+            {
+                'name': f'Stage {idx}',
+                **(stage_vals or {}),
+            }
+            for idx in range(count)
+        ])
+
+    @classmethod
+    def _create_records(cls, test_model_name, count=5, record_vals=None):
+        return cls.env[test_model_name].create([
+            {
+                'name': 'Test Record {idx}',
+                **(record_vals or {}),
+            }
+            for idx in range(count)
+        ])
+
+    def _update_mock_timing(self, records, records_trackings, minutes, new_stage=False):
+        """ Updates the mock duration_tracking field for multiple records based
+        on the provided minutes. If new_stage is given, the stage of the
+        records is updated as well. """
+        self.assertEqual(len(records), len(records_trackings))
+        for record, tracking_dict in records_trackings.items():
+            tracking_dict[str(record[self.track_duration_field].id) if record[self.track_duration_field].id else '0'] += minutes * 60
+            if new_stage is not False:
+                tracking_dict[str(new_stage.id) if new_stage.id else '0'] += 0
                 record[self.track_duration_field] = new_stage
                 self.flush_tracking()
 
-    def assertTrackingDuration(self, records, record_to_tracking_dic):
-        """
-        Asserts whether for multiple records their duration_tracking is equal to a dictionary
+        # check computed value matches mock stored values
+        self.assertTrackingDuration(records, records_trackings)
 
-        Args:
-            records (recordset): all the records that need to be asserted
-            record_to_tracking_dic (list): A list of tuples mapping records to their respective tracking dictionaries.
-        """
-        records._compute_duration_tracking()
-        for record, tracking_dic in record_to_tracking_dic:
-            self.assertDictEqual(dict(tracking_dic), record.duration_tracking)
+    def assertTrackingDuration(self, records, records_trackings):
+        """ Assert content of records's duration_tracking value. """
+        records.invalidate_recordset(fnames=['duration_tracking'])
+        for record in records:
+            tracking_dict = records_trackings[record]
+            self.assertDictEqual(record.duration_tracking, dict(tracking_dict))
 
     def _test_record_duration_tracking(self):
-        """
-        Moves a record's many2one field through several values and asserts the duration spent in that value each time
-        """
+        """ Moves a record's many2one field through several values and asserts
+        the duration spent in that value each time.
 
+        Total time: 1: 5+ // 2: 10+50+55+ // 3: 50+20+ // 4: 20+200 // No: 30"""
         with patch.object(self.env.cr, 'now', return_value=self.mock_start_time) as now:
+            records = (self.rec_1 + self.rec_2).with_env(self.env)
+            records_trackings = {record: defaultdict(lambda: 0) for record in records}
 
-            track_duration_tracking = defaultdict(lambda: 0)
-            record = self.rec_1
+            for additional_time, stage in [
+                (5, self.stage_2),
+                (10, False),
+                (50, self.stage_3),
+                (50, self.stage_4),
+                (20, self.stage_2),
+                (55, self.stage_4),
+                (200, self.env[self.test_stage_model_name]),
+                (30, self.stage_3),
+                (20, False),
+            ]:
+                with self.subTest(additional_time=additional_time, stage=stage):
+                    now.return_value += timedelta(minutes=additional_time)
+                    self._update_mock_timing(records, records_trackings, additional_time, new_stage=stage)
+            for record in records:
+                self.assertDictEqual(
+                    record.duration_tracking, {
+                        '0': 30 * 60,  # no stage tracking
+                        str(self.stage_1.id): 5 * 60,
+                        str(self.stage_2.id): 115 * 60,
+                        str(self.stage_3.id): 70 * 60,
+                        str(self.stage_4.id): 220 * 60,
+                    }
+                )
 
-            minutes = 5
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes, self.stage_2)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-            minutes = 100
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-            minutes = 5000
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes, self.stage_3)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-            minutes = 5000
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes, self.stage_4)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-            minutes = 20
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes, self.stage_2)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-            minutes = 55
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes, self.stage_4)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-            minutes = 200
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-            minutes = 300
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking([(record, track_duration_tracking)], minutes, self.stage_3)
-            self.assertTrackingDuration(record, [(record, track_duration_tracking)])
-
-    def _test_record_duration_tracking_batch(self):
-        """
-        Moves for a batch of records many2one field through several values and asserts the duration
-        spent in that value each time.
-        """
-
-        with patch.object(self.env.cr, 'now', return_value=self.mock_start_time) as now:
-
-            track_duration_tracking1 = defaultdict(lambda: 0)
-            track_duration_tracking2 = defaultdict(lambda: 0)
-            track_duration_tracking3 = defaultdict(lambda: 0)
-            batch = self.rec_1 | self.rec_2 | self.rec_3
-            record_to_tracking_dic = [
-                (self.rec_1, track_duration_tracking1),
-                (self.rec_2, track_duration_tracking2),
-                (self.rec_3, track_duration_tracking3)
-            ]
-
-            minutes = 5
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes, self.stage_2)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-            minutes = 100
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-            minutes = 5000
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes, self.stage_3)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-            minutes = 5000
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes, self.stage_4)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-            minutes = 20
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes, self.stage_2)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-            minutes = 55
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes, self.stage_4)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-            minutes = 200
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-            minutes = 300
-            now.return_value += timedelta(minutes=minutes)
-            self._update_duration_tracking(record_to_tracking_dic, minutes, self.stage_3)
-            self.assertTrackingDuration(batch, record_to_tracking_dic)
-
-    def _test_queries_batch_duration_tracking(self):
-        """
-        The MailTrackingDuration mixin is only supposed to add 3 queries
-        """
-
+    def _test_queries_batch_duration_tracking(self, query_count=2):
+        """ The MailTrackingDuration mixin is only supposed to add 3 queries """
         batch = self.rec_1 | self.rec_2 | self.rec_3 | self.rec_4
         batch[self.track_duration_field] = self.stage_2.id
         self.flush_tracking()
@@ -192,5 +123,5 @@ class MailTrackingDurationMixinCase(MailCommon):
         self.flush_tracking()
         batch[self.track_duration_field] = self.stage_2.id
 
-        with self.assertQueryCount(2):
+        with self.assertQueryCount(query_count):
             batch._compute_duration_tracking()

--- a/addons/project/tests/test_project_task_mail_tracking_duration.py
+++ b/addons/project/tests/test_project_task_mail_tracking_duration.py
@@ -11,13 +11,23 @@ class TestProjectTaskMailTrackingDuration(MailTrackingDurationMixinCase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass('project.task', {'project_id': 'create'})
+        super().setUpClass('project.task')
+
+    @classmethod
+    def _prepare_duration_setup(cls, test_model_name):
+        if test_model_name == 'project.task':
+            cls.test_project = cls.env['project.project'].create({'name': 'Test Project'})
+        return super()._prepare_duration_setup
+
+    @classmethod
+    def _create_records(cls, test_model_name, count=5, record_vals=None):
+        if test_model_name == 'project.task':
+            record_vals = record_vals or {}
+            record_vals['project_id'] = cls.test_project.id
+        return super()._create_records(test_model_name, count=count, record_vals=record_vals)
 
     def test_project_task_mail_tracking_duration(self):
         self._test_record_duration_tracking()
-
-    def test_project_task_mail_tracking_duration_batch(self):
-        self._test_record_duration_tracking_batch()
 
     def test_project_task_queries_batch_mail_tracking_duration(self):
         self._test_queries_batch_duration_tracking()

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -333,12 +333,6 @@ class TestAccountMove(TestStockValuationCommon):
             closing._post()
             # Second flush to post the tracking values
             self.env.cr.flush()
-            # Update the tracking value create_date since it used the cursor one and not the frozen time
-            am_state_field = self.env['ir.model.fields'].search(
-                [('model', '=', 'account.move'), ('name', '=', 'state')], limit=1)
-            state_tracking = closing.message_ids.tracking_value_ids.filtered(
-                lambda t: t.field_id == am_state_field)
-            state_tracking.create_date = fields.Datetime.now()
             self.assertRecordValues(closing.line_ids, [
                 {'account_id': self.account_inventory.id, 'debit': 0.0, 'credit': 100.0},
                 {'account_id': self.account_stock_valuation.id, 'debit': 100.0, 'credit': 0.0},

--- a/addons/test_mail/data/mail_template_data.xml
+++ b/addons/test_mail/data/mail_template_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="mail_test_ticket_tracking_tpl" model="mail.template">
         <field name="name">Mail Test Full: Tracking Template</field>
-        <field name="subject">Test Template</field>
+        <field name="subject">Test Template on {{ object.name }}</field>
         <field name="partner_to">{{ object.customer_id.id }}</field>
         <field name="use_default_to" eval="False"/>
         <field name="body_html" type="html"><p>Hello <t t-out="object.name or ''"/></p></field>

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -99,6 +99,34 @@ class MailTestLang(models.Model):
 # ------------------------------------------------------------
 
 
+class MailTestTrack(models.Model):
+    """ This model can be used in tests when automatic subscription and simple
+    tracking is necessary. Most features are present in a simple way. """
+    _description = 'Standard Tracked Model'
+    _name = "mail.test.track"
+    _inherit = ['mail.thread']
+
+    name = fields.Char()
+    email_from = fields.Char()
+    user_id = fields.Many2one('res.users', 'Responsible', tracking=True)
+    container_id = fields.Many2one('mail.test.container', tracking=True)
+    company_id = fields.Many2one('res.company')
+    track_fields_tofilter = fields.Char()  # comma-separated list of field names
+    track_enable_default_log = fields.Boolean(default=False)
+    parent_id = fields.Many2one('mail.test.track', string='Parent')
+
+    def _track_filter_for_display(self, tracking_values):
+        values = super()._track_filter_for_display(tracking_values)
+        filtered_fields = set(self.track_fields_tofilter.split(',') if self.track_fields_tofilter else '')
+        return values.filtered(lambda val: val.field_id.name not in filtered_fields)
+
+    def _track_get_default_log_message(self, changes):
+        filtered_fields = set(self.track_fields_tofilter.split(',') if self.track_fields_tofilter else '')
+        if self.track_enable_default_log and not all(change in filtered_fields for change in changes):
+            return f'There was a change on {self.name} for fields "{",".join(changes)}"'
+        return super()._track_get_default_log_message(changes)
+
+
 class MailTestTrackAllM2m(models.Model):
     _description = 'Sub-model: pseudo tags for tracking'
     _name = "mail.test.track.all.m2m"
@@ -120,6 +148,7 @@ class MailTestTrackAllPropertiesParent(models.Model):
     _description = 'Properties Parent'
     _name = "mail.test.track.all.properties.parent"
 
+    name = fields.Char()
     definition_properties = fields.PropertiesDefinition()
 
 

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -201,14 +201,32 @@ class MailTestTrackCompute(models.Model):
 class MailTestTrackDurationMixin(models.Model):
     _description = 'Fake model to test the mixin mail.tracking.duration.mixin'
     _name = "mail.test.track.duration.mixin"
-    _track_duration_field = 'customer_id'
+    _track_duration_field = 'stage_id'
     _inherit = ['mail.tracking.duration.mixin']
 
     name = fields.Char()
     customer_id = fields.Many2one('res.partner', 'Customer', tracking=True)
+    stage_id = fields.Many2one(
+        'mail.test.track.duration.mixin.stage', compute='_compute_stage_id',
+        readonly=False, store=True, tracking=True,
+    )
+
+    @api.depends('name')
+    def _compute_stage_id(self):
+        default = self.env['mail.test.track.duration.mixin.stage'].search([], limit=1)
+        for duration_track in self.filtered(lambda t: not t.stage_id):
+            duration_track.stage_id = default.id
 
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
+
+
+class MailTestTrackDurationMixinStage(models.Model):
+    _description = 'Fake stage model for duration mixin'
+    _name = "mail.test.track.duration.mixin.stage"
+
+    name = fields.Char()
+    fold = fields.Boolean(default=False)
 
 
 class MailTestTrackGroups(models.Model):

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -146,34 +146,6 @@ class MailTestGatewayGroups(models.Model):
         return ['customer_id']
 
 
-class MailTestTrack(models.Model):
-    """ This model can be used in tests when automatic subscription and simple
-    tracking is necessary. Most features are present in a simple way. """
-    _description = 'Standard Chatter Model'
-    _name = "mail.test.track"
-    _inherit = ['mail.thread']
-
-    name = fields.Char()
-    email_from = fields.Char()
-    user_id = fields.Many2one('res.users', 'Responsible', tracking=True)
-    container_id = fields.Many2one('mail.test.container', tracking=True)
-    company_id = fields.Many2one('res.company')
-    track_fields_tofilter = fields.Char()  # comma-separated list of field names
-    track_enable_default_log = fields.Boolean(default=False)
-    parent_id = fields.Many2one('mail.test.track', string='Parent')
-
-    def _track_filter_for_display(self, tracking_values):
-        values = super()._track_filter_for_display(tracking_values)
-        filtered_fields = set(self.track_fields_tofilter.split(',') if self.track_fields_tofilter else '')
-        return values.filtered(lambda val: val.field_id.name not in filtered_fields)
-
-    def _track_get_default_log_message(self, changes):
-        filtered_fields = set(self.track_fields_tofilter.split(',') if self.track_fields_tofilter else '')
-        if self.track_enable_default_log and not all(change in filtered_fields for change in changes):
-            return f'There was a change on {self.name} for fields "{",".join(changes)}"'
-        return super()._track_get_default_log_message(changes)
-
-
 class MailTestActivity(models.Model):
     """ This model can be used to test activities in addition to simple chatter
     features. """

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -66,9 +66,10 @@ access_mail_test_rotting_resource,mail.test.rotting.resource,model_mail_test_rot
 access_mail_test_rotting_stage,mail.test.rotting.stage,model_mail_test_rotting_stage,base.group_user,1,1,1,1
 access_mail_test_thread_customer_user,mail.test.thread.customer.user,model_mail_test_thread_customer,base.group_user,1,1,1,1
 access_mail_test_track_all,mail.test.track.all,model_mail_test_track_all,base.group_user,1,1,1,1
-access_mail_test_track_all_properties_parent,access_mail_test_track_all_properties_parent,model_mail_test_track_all_properties_parent,base.group_user,1,0,0,0
 access_mail_test_track_all_m2m,mail.test.track.all.m2m,model_mail_test_track_all_m2m,base.group_user,1,1,1,1
 access_mail_test_track_all_o2m,mail.test.track.all.o2m,model_mail_test_track_all_o2m,base.group_user,1,1,1,1
+access_mail_test_track_all_properties_parent,access_mail_test_track_all_properties_parent,model_mail_test_track_all_properties_parent,base.group_user,1,0,0,0
+access_mail_test_track_all_properties_parent_system,access_mail_test_track_all_properties_parent_system,model_mail_test_track_all_properties_parent,base.group_user,1,1,1,1
 access_mail_test_track_compute,mail.test.track.compute,model_mail_test_track_compute,base.group_user,1,1,1,1
 access_mail_test_track_groups,mail.test.track.groups,model_mail_test_track_groups,base.group_user,1,1,1,1
 access_mail_test_track_monetary,mail.test.track.monetary,model_mail_test_track_monetary,base.group_user,1,1,1,1

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -76,4 +76,6 @@ access_mail_test_track_monetary,mail.test.track.monetary,model_mail_test_track_m
 access_mail_test_track_selection_portal,mail.test.track.selection.portal,model_mail_test_track_selection,base.group_portal,0,0,0,0
 access_mail_test_track_selection_user,mail.test.track.selection.user,model_mail_test_track_selection,base.group_user,1,1,1,1
 access_mail_test_properties_user,mail.test.properties.user,model_mail_test_properties,base.group_user,1,1,1,1
+access_mail_test_track_duration_mixin_portal,mail.test.track.duration.mixin.portal,model_mail_test_track_duration_mixin,base.group_portal,1,1,0,0
 access_mail_test_track_duration_mixin,mail.test.track.duration.mixin,model_mail_test_track_duration_mixin,base.group_user,1,1,1,1
+access_mail_test_track_duration_mixin_stage,mail.test.track.duration.mixin.stage,model_mail_test_track_duration_mixin_stage,base.group_user,1,1,1,1

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -808,6 +808,18 @@ class TestMailMessageAccess(MessageAccessCommon):
             res_id=self.record_public.id,
             subtype_id=self.ref('mail.mt_comment'),
         ))
+        msg_record_public_with_tracking = self.env['mail.message'].create(dict(base_msg_vals,
+            body='Public Comment with Trackings',
+            message_type='notification',
+            model=self.record_public._name,
+            res_id=self.record_public.id,
+            subtype_id=self.ref('mail.mt_comment'),
+            tracking_value_ids=[(0, 0, {
+                'field_id': self.env['ir.model.fields']._get('mail.test.access', 'name').id,
+                'new_value_char': 'Tracked',
+                'old_value_char': False,
+            })],
+        ))
         msg_record_public_internal = self.env['mail.message'].create(dict(base_msg_vals,
             body='Internal Comment on Public',
             is_internal=True,
@@ -824,13 +836,13 @@ class TestMailMessageAccess(MessageAccessCommon):
             (self.user_admin, []),
         ], [
             # public: record with access
-            msg_record_public,
+            msg_record_public + msg_record_public_with_tracking,
             # portal: mentionned + record with access, if published
-            msgs[0] + msgs[3] + msg_record_portal + msg_record_public,
+            msgs[0] + msgs[3] + msg_record_portal + msg_record_public + msg_record_public_with_tracking,
             # employee
-            msgs[1:6] + msg_record_portal + msg_record_portal_internal + msg_record_public + msg_record_public_internal,
+            msgs[1:6] + msg_record_portal + msg_record_portal_internal + msg_record_public + msg_record_public_with_tracking + msg_record_public_internal,
             msgs[1:6] + msg_record_portal_internal + msg_record_public_internal,
-            msgs[1:] + msg_record_admin + msg_record_portal + msg_record_portal_internal + msg_record_public + msg_record_public_internal,
+            msgs[1:] + msg_record_admin + msg_record_portal + msg_record_portal_internal + msg_record_public + msg_record_public_with_tracking + msg_record_public_internal,
         ]):
             with self.subTest(test_user=test_user.name, add_domain=add_domain):
                 self.env.invalidate_all()

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1279,14 +1279,26 @@ class TestMailAPIPerformance(BaseMailPerformance):
             })
 
         # write template message (sent to customer, mass mailing kept for history)
-        self.assertEqual(rec1.message_ids[0].subtype_id, self.env['mail.message.subtype'])
-        self.assertEqual(rec1.message_ids[0].subject, 'Test Template')
+        self.assertMessageFields(
+            rec1.message_ids[0], {
+                'subject': f'Test Template on {rec1.name}',
+                'subtype_id': self.env['mail.message.subtype'],
+            }
+        )
         # write tracking message
-        self.assertEqual(rec1.message_ids[1].subtype_id, self.env.ref('mail.mt_note'))
-        self.assertEqual(rec1.message_ids[1].notified_partner_ids, self.env['res.partner'])
+        self.assertMessageFields(
+            rec1.message_ids[1], {
+                'notified_partner_ids': self.env['res.partner'],
+                'subtype_id': self.env.ref('mail.mt_note'),
+            }
+        )
         # creation message
-        self.assertEqual(rec1.message_ids[2].subtype_id, self.env.ref('test_mail.st_mail_test_ticket_container_upd'))
-        self.assertEqual(rec1.message_ids[2].notified_partner_ids, self.partners | self.user_portal.partner_id)
+        self.assertMessageFields(
+            rec1.message_ids[2], {
+                'notified_partner_ids': self.partners | self.user_portal.partner_id,
+                'subtype_id': self.env.ref('test_mail.st_mail_test_ticket_container_upd'),
+            }
+        )
         self.assertEqual(len(rec1.message_ids), 3)
 
 


### PR DESCRIPTION
Use higher level helper for message content check, including tracking
values. That way all checks are globally hidden in tools and it is
easier to update / adapt tests if somehow modeling of tracking values
change (yay).

Add tests for creation, which currently generates no tracking message.

Remove some duplicated / useless test or test parts when possible.

Batch-ize some tests, just to cover tracking when creating or updating
records in batch.

Update a bit duration mixin tests, trying to make them easier to
update if model has to change (yay).

Task-5503121
Prepares Task-3645865