### PR TITLE
[FIX] point_of_sale: prevent weird quantity changes

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -321,9 +321,9 @@ export class OrderSummary extends Component {
             }
         }
         const newLine = this.getNewLine();
-        const decreasedQuantity = current_saved_quantity - newQuantity;
-        if (decreasedQuantity != 0) {
-            newLine.setQuantity(-decreasedQuantity + newLine.getQuantity(), true);
+        const decreasedSavedQuantity = current_saved_quantity - newQuantity;
+        if (decreasedSavedQuantity != 0) {
+            newLine.setQuantity(newQuantity, true);
         }
         if (newLine !== selectedLine && selectedLine.uiState.savedQuantity != 0) {
             selectedLine.setQuantity(
@@ -331,7 +331,8 @@ export class OrderSummary extends Component {
                 Boolean(selectedLine.combo_line_ids?.length)
             );
         }
-        return decreasedQuantity;
+        selectedLine.order_id.updateSavedQuantity();
+        return decreasedSavedQuantity;
     }
     getNewLine() {
         let selectedLine = this.currentOrder.getSelectedOrderline();


### PR DESCRIPTION
Fix issue that was causing issue when changing multiple quantity of a saved order line:
- Now we properly set the new quantity instead of trying to calculate a delta quantity.
- We still get the decreased saved quantity (used to send to the blackbox).
- We now update the saved quantity on the order after changing the quantities.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
