### PR TITLE
Increase z index of list view filter button

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -45,7 +45,7 @@
                             <th t-else="" t-on-keydown="(ev) => this.onCellKeydown(ev)" t-att-class="{'o_list_button w-print-0 p-print-0': column.type === 'button_group'}"/>
                         </t>
                         <th t-if="hasOpenFormViewColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_open_form_view w-print-0 p-print-0"/>
-                        <th t-if="hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0">
+                        <th t-if="hasActionsColumn" t-on-keydown="(ev) => this.onCellKeydown(ev)" class="o_list_controller o_list_actions_header w-print-0 p-print-0 position-sticky end-0 z-2">
                             <div t-if="displayOptionalFields or hasOptionalOpenFormViewColumn" class="o_optional_columns_dropdown d-print-none text-center border-top-0">
                                 <Dropdown position="'bottom-end'">
                                     <button class="btn p-0" tabindex="-1">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: The filter button in lists views appear under the column resize handle, meaning that the handle can be grabbed accidentally when trying to click the filter button.

Layering the button above the handle makes it more consistent to click.


Video showing before/after behavior: https://drive.google.com/file/d/1Tmj-qX3nxsoG-QfO4LpGdp0adAfC69J5/view?usp=sharing

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
