### PR TITLE
[IMP] base: add memoization cache for template QWeb compilation

### DIFF
--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -173,9 +173,15 @@ registerWebsitePreviewTour(
             trigger: ':iframe html[lang*="en"]',
         },
         {
+            trigger: ':iframe .js_language_selector > button:contains(English)',
+        },
+        {
             content: "click on Parseltongue version",
             trigger: ':iframe .js_language_selector a[data-url_code="pa_GB"]',
             run: "click",
+        },
+        {
+            trigger: ':iframe .js_language_selector > button:contains(Parseltongue)',
         },
         {
             content: "edit",
@@ -205,6 +211,9 @@ registerWebsitePreviewTour(
         {
             content: "Check that the generic 'Translation' option is always visible",
             trigger: ".o_customize_tab .options-container [data-label='Translate to']",
+        },
+        {
+            trigger: ':iframe .js_language_selector > button:contains(Parseltongue)',
         },
         {
             content: "translate text",
@@ -290,9 +299,28 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
+            trigger: ':iframe .js_language_selector > button:contains(English)',
+        },
+        {
+            content: "check: default value translation",
+            trigger: ':iframe input[placeholder="test translate placeholder"]',
+        },
+        {
             content: "Check body",
             trigger:
                 ":iframe body:not(:has(#wrap p font:first:text(paragraphs <b>describing</b>)))",
+        },
+        {
+            content: "return to Parseltongue version",
+            trigger: ':iframe .js_language_selector a[data-url_code="pa_GB"]',
+            run: "click",
+        },
+        {
+            content: "check: placeholder translation",
+            trigger: ':iframe input[placeholder="test Parseltongue placeholder"]',
+        },
+        {
+            trigger: ':iframe .js_language_selector > button:contains(Parseltongue)',
         },
         ...clickOnEditAndWaitEditModeInTranslatedPage(),
         {

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -506,6 +506,39 @@ class TestQwebDataSnippet(TransactionCase):
         rendered = self._render_snippet('website.s_c')
         self.assertEqual(self._normalize_xml(rendered), self._normalize_xml(expected_output))
 
+        # test that they are no wrong information in cache
+        rendered = self._render_snippet('website.s_c')
+        self.assertEqual(self._normalize_xml(rendered), self._normalize_xml(expected_output))
+
+    def test_t_snippet_call_root_unalter_cache(self):
+        noise = self.env['ir.ui.view'].create({
+            'name': 't-snippet-call_website.s_c',
+            'type': 'qweb',
+            'arch': '''
+                <t t-snippet-call="website.s_c"/>
+            '''
+        })
+        template = self.env['ir.ui.view'].create({
+            'name': 't-snippet-call_website.s_b',
+            'type': 'qweb',
+            'arch': '''
+                <t t-snippet-call="website.s_b"/>
+            '''
+        })
+
+        expected_output = '''
+            <section class="foo" data-snippet="s_b">
+                <section class="hello" data-snippet="s_a">
+                    <article>
+                        <span>Hello</span>
+                    </article>
+                </section>
+            </section>
+        '''
+        self.env['ir.qweb']._render(noise.id)
+        rendered = self.env['ir.qweb']._render(template.id)
+        self.assertEqual(self._normalize_xml(rendered), self._normalize_xml(expected_output))
+
     def test_t_snippet_call_as_snippet_root(self):
         expected_output = '''
             <section class="hello" data-snippet="s_a">

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -55,6 +55,7 @@ _REGISTRY_CACHES = {
     'assets': 512,
     'stable': 1024,
     'templates': 1024,
+    'template_code': 1024,
     'routing': 1024,  # 2 entries per website
     'routing.rewrites': 8192,  # url_rewrite entries
     'templates.cached_values': 2048, # arbitrary


### PR DESCRIPTION
Introduced a new cache layer based on view IDs and write dates to optimize QWeb template compilation and inheritance combining.

We observed a much higher rate of cache invalidations than expected, mainly due to users frequently saving work-in-progress during template editing and translation. Previously, invalidations triggered a full re-compilation of all templates, significantly impacting performance.

Now, when a cache invalidation occurs, the system performs a batch check of IDs and write dates. Re-compilation is only triggered for the specific views that were modified, drastically reducing the performance overhead and improving the cache hit rate.
