### PR TITLE
[IMP] mail: show explicit error of fetch message in message list

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -82,6 +82,7 @@
         <div class="o-mail-Thread-error">
             An error occurred while fetching messages.
         </div>
+        <span t-if="props.thread.hasLoadingFailedError" class="o-xsmaller text-muted" t-esc="props.thread.hasLoadingFailedError"/>
         <button class="btn btn-link" t-on-click="onClickLoadOlder">
             Click here to retry
         </button>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -197,6 +197,8 @@ export class Thread extends Record {
     /** @type {String|undefined} */
     primary_email_field;
     hasLoadingFailed = false;
+    /** @type {Error} */
+    hasLoadingFailedError;
     canPostOnReadonly;
     /** @type {Boolean} */
     is_editable;
@@ -380,9 +382,11 @@ export class Thread extends Record {
         let res;
         try {
             res = await this.fetchMessagesData({ after, around, before });
+            this.hasLoadingFailedCause = undefined;
             this.hasLoadingFailed = false;
         } catch (e) {
             this.hasLoadingFailed = true;
+            this.hasLoadingFailedError = e;
             this.isLoaded = true;
             this.status = "ready";
             throw e;


### PR DESCRIPTION
Before this commit, when message list failed to load, it just displays a "Ann error occurred" generic message with a retry button.

This assumes that error happens rarely and when so this is temporarily. However some errors are persistent and it's frustrating to have no clue on why there's error or what may have caused it.

This commit shows the `Error.toString()` from fetch message RPC failure on UI, so that there's a clue on the reason the fetch of messages failed.

Before / After
<img width="322" height="78" alt="Screenshot 2026-01-15 at 18 18 31" src="https://github.com/user-attachments/assets/81873d16-c489-4be8-b2de-64f7dec2215e" /> <img width="347" height="91" alt="Screenshot 2026-01-15 at 18 17 44" src="https://github.com/user-attachments/assets/90bc09e6-99a8-4722-92d0-f972aee20b36" />
