### PR TITLE
[FIX] hr_holidays : Create allocation with same number of hours

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -788,7 +788,8 @@ class HolidaysAllocation(models.Model):
             'holiday_type': 'employee',
             'holiday_status_id': self.holiday_status_id.id,
             'notes': self.notes,
-            'number_of_days': self.number_of_days,
+            'number_of_days': (self.number_of_hours_display / employee.resource_calendar_id.hours_per_day)
+                                if self.type_request_unit == 'hour' and employee.resource_calendar_id else self.number_of_days,
             'parent_id': self.id,
             'employee_id': employee.id,
             'employee_ids': [(6, 0, [employee.id])],


### PR DESCRIPTION
### Steps to reproduce:
	- Create two employees with two different working schedule
	- Create a multi employee allocation for the created employees with 40 hours
	- Validate the allocation you created
	- Notice the number of hours is differenc between the two allocations

### Cause:
When validating the multi employee allocation and while creating the children allocations we compute the number_of_hours_display and since we calculate it with number of days * hours per day it will result into two different values for the number of hours as the hours per day is different for each working schedule.

### Fix:
To fix this we check if the allocation is an hourly one we change the number of days depending on the number of hours that we already got from the parent allocation. So when computing the number of hours for the children allocations we get the same value

opw-5232797