### PR TITLE
[FIX] account: apply tax when tax fiscal position is set to all

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -154,7 +154,7 @@ class AccountFiscalPosition(models.Model):
     def map_tax(self, taxes):
         if not self:
             return taxes
-        if not self.tax_ids:  # empty fiscal positions (like those created by tax units) remove all taxes
+        if not self.tax_ids and taxes.fiscal_position_ids:  # empty fiscal positions (like those created by tax units) remove all taxes
             return self.env['account.tax']
         return self.env['account.tax'].browse(unique(
             tax_id


### PR DESCRIPTION
### Issue:
No tax will be applied if in taxes, fiscal position is set to all.

#### Steps to reproduce:
1- Create a tax, and in the tax form, leave `Fiscal Position` field blank, which in this case `all` will be shown in placeholder.
2- Set Domestic FP to be applied automatically, and set the country to `US`.
3- Create a Partner with `US` country_id.
4- Create a product, and apply the created tax to sale taxes.
5- Create a SO with created partner and the created product.
6- As you see, the tax is not applied to the line, while if you check SO's fiscal position, it is set to Domestic.

Expected: As tax's fp is set to all, we expect this tax being applied with Domestic fp.

### Cause:
In this line, if no `tax_ids` is set, it means fp has not tax_ids:
https://github.com/odoo/odoo/blob/0c3ae7f78d313885984c99a4e57485d9660dd974/addons/account/models/partner.py#L154-L158

However, this might also mean the tax has no fp because `fp.tax_ids` is a Many2Many relation.

In the forms, `tax.fiscal_position_ids` being empty is shown as `all` in the placeholder, which means when no tax applied to fp, we expect all taxes to be mapped.

### Fix:
This can be fixed by making sure the fp.tax_ids is not empty because there is no `tax.fiscal_position_ids` set.

### Remark:
In this fix we rename `TestInvoiceTaxes._create_invoice` to `_create_invoice_taxes_per_line` to avoid override of `AccountTestInvoicingCommon._create_invoice`. This is already done on saas-19.1+.

opw-5463245
