### PR TITLE
[IMP] account,point_of_sale: Modified payment widget and exchange diff account

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -660,6 +660,7 @@ class AccountPartialReconcile(models.Model):
 
         # Reconcile the tax lines being on a reconcile tax basis transfer account.
         reconciliation_plan = []
+        exchange_account_per_move = self.env.context.get('exchange_account_per_move', {})
         for lines, move_index, sequence in to_reconcile_after:
 
             # In expenses, all move lines are created manually without any grouping on tax lines.
@@ -675,6 +676,7 @@ class AccountPartialReconcile(models.Model):
                 continue
 
             reconciliation_plan.append(counterpart_line + lines)
+            exchange_account_per_move[moves[move_index]] = exchange_account_per_move.get(lines.move_id)
 
         # passing add_caba_vals in the context to make sure that any exchange diff that would be created for
         # this cash basis move would set the field draft_caba_move_vals accordingly on the partial

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -41,19 +41,11 @@
                             <td>
                                <a role="button" tabindex="0" class="js_payment_info fa fa-info-circle" t-att-index="line_index" style="margin-right:5px;" aria-label="Info" title="Journal Entry Info" data-bs-toggle="tooltip" t-on-click.stop="(ev) => this.onInfoClick(ev, line)"></a>
                             </td>
-                            <td t-if="!line.is_exchange">
+                            <td>
                                 <i class="o_field_widget text-start o_payment_label">
                                     <t t-if="line.is_refund">Reversed on </t>
                                     <t t-else="">Paid on </t>
                                     <t t-out="line.formattedDate"></t>
-                                </i>
-                            </td>
-                            <td t-if="line.is_exchange" colspan="2">
-                                <i class="o_field_widget text-start text-muted text-start">
-                                    <span class="oe_form_field oe_form_field_float oe_form_field_monetary fw-bold">
-                                        <t t-out="line.amount_formatted"/>
-                                    </span>
-                                    <span> Exchange Difference</span>
                                 </i>
                             </td>
                         </t>
@@ -64,6 +56,19 @@
                         </td>
                         </tr>
                     </t>
+                    <tr t-if="info.exchangeInfo?.line_ids and info.exchangeInfo.line_ids.length">
+                        <td>
+                            <a role="button" tabindex="0" class="js_exchange_info fa fa-info-circle" style="margin-right:5px;" t-on-click.stop="() => this.onExchangeInfoClick(info.exchangeInfo.line_ids)"></a>
+                        </td>
+                        <td colspan="2">
+                            <i class="o_field_widget text-start text-muted text-start">
+                                <span class="oe_form_field oe_form_field_float oe_form_field_monetary fw-bold exchange_amount">
+                                    <t t-out="info.exchangeInfo.exchange_amount_formatted"/>
+                                </span>
+                                <span class="ps-2 exchange_label" t-out="info.exchangeInfo.label" />
+                            </i>
+                        </td>
+                    </tr>
                 </table>
             </div>
         </div>
@@ -111,7 +116,7 @@
                         </tr>
                     </table>
                 </div>
-                <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" t-if="!props.is_exchange" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onRemoveMoveReconcile(props.move_id, props.partial_id)">Unreconcile</button>
+                <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onRemoveMoveReconcile(props.move_id, props.partial_id)">Unreconcile</button>
                 <button class="btn btn-sm btn-secondary js_open_payment float-end" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onOpenMove(props.move_id)">View</button>
             </div>
         </div>

--- a/addons/account/static/src/components/account_payment_field/account_payment_field.js
+++ b/addons/account/static/src/components/account_payment_field/account_payment_field.js
@@ -31,7 +31,9 @@ export class AccountPaymentField extends Component {
             outstanding: false,
             title: "",
             move_id: this.props.record.resId,
+            exchange_info: {},
         };
+
         for (const [key, value] of Object.entries(info.content)) {
             value.index = key;
             value.amount_formatted = formatMonetary(value.amount, {
@@ -41,9 +43,11 @@ export class AccountPaymentField extends Component {
                 // value.date is a string, parse to date and format to the users date format
                 value.formattedDate = formatDate(deserializeDate(value.date))
             }
-        }
+        };
+
         return {
             lines: info.content,
+            exchangeInfo: info.exchange_info,
             outstanding: info.outstanding,
             title: info.title,
             moveId: info.move_id,
@@ -57,6 +61,11 @@ export class AccountPaymentField extends Component {
             _onRemoveMoveReconcile: this.removeMoveReconcile.bind(this),
             _onOpenMove: this.openMove.bind(this),
         });
+    }
+
+    async onExchangeInfoClick(lineIds) {
+        const action = await this.orm.call(this.props.record.resModel, 'action_open_exchange_items', [lineIds], {});
+        this.action.doAction(action);
     }
 
     async assignOutstandingCredit(moveId, id) {

--- a/addons/account/static/tests/tours/invoice_payment_widget_tests.js
+++ b/addons/account/static/tests/tours/invoice_payment_widget_tests.js
@@ -1,0 +1,68 @@
+import { accountTourSteps } from "@account/js/tours/account";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('invoice_payments_widget_exchange_tour', {
+    url: "/odoo",
+    steps: () => [
+    ...accountTourSteps.goToAccountMenu("Go to Invoicing"),
+    {
+        content: "Go to Customers",
+        trigger: 'span:contains("Customers")',
+        run: "click",
+    },
+    {
+        content: "Go to Invoices",
+        trigger: 'a:contains("Invoices")',
+        run: "click",
+    },
+    {
+        trigger: ".o_breadcrumb .text-truncate:contains(Invoices)",
+    },
+    {
+        content: "Open first invoice",
+        trigger: 'div.o_list_renderer table.o_list_table tbody tr.o_data_row:last > td.o_data_cell[name="name"]',
+        run: "click",
+    },
+    {
+        content: "Check payment widget is shown",
+        trigger: 'div.o_field_widget.o_field_payment[name="invoice_payments_widget"]',
+    },
+    {
+        content: "Check payment widget total exchange amount",
+        trigger: 'div.o_field_widget.o_field_payment[name="invoice_payments_widget"] tr:last > td:last > i.o_field_widget span.exchange_amount:contains($ 150.00)',
+    },
+    {
+        content: "Check payment widget total exchange is loss",
+        trigger: 'div.o_field_widget.o_field_payment[name="invoice_payments_widget"] tr:last > td:last > i.o_field_widget span.exchange_label:contains(Exchange Loss)',
+    },
+    {
+        content: "Go to next invoice",
+        trigger: 'nav.o_pager button.o_pager_next',
+        run: "click",
+    },
+    {
+        content: "Check payment widget is shown",
+        trigger: 'div.o_field_widget.o_field_payment[name="invoice_payments_widget"]',
+    },
+    {
+        content: "Check payment widget total exchange amount",
+        trigger: 'div.o_field_widget.o_field_payment[name="invoice_payments_widget"] tr:last > td:last > i.o_field_widget span.exchange_amount:contains($ 50.00)',
+    },
+    {
+        content: "Check payment widget total exchange is loss",
+        trigger: 'div.o_field_widget.o_field_payment[name="invoice_payments_widget"] tr:last > td:last > i.o_field_widget span.exchange_label:contains(Exchange Profit)',
+    },
+    {
+        content: "Go to exchange line list view",
+        trigger: 'a.js_exchange_info',
+        run: "click",
+    },
+    {
+        content: "Reconciled journal items are shown",
+        trigger: '.o_breadcrumb .text-truncate:contains(Journal Items)',
+    },
+    {
+        content: "Open exchange move",
+        trigger: 'div.o_list_renderer table.o_list_table tbody tr.o_data_row:last > td.o_data_cell[name="move_name"] div[name="move_name"] a:contains(EXCH)',
+    },
+]});

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -992,19 +992,30 @@ class AccountTestInvoicingCommon(ProductCommon):
             current_amounts = {}
         self.assertDictEqual(current_amounts, expected_amounts)
 
-    def assert_invoice_outstanding_reconciled_widget(self, invoice, expected_amounts):
+    def assert_invoice_outstanding_reconciled_widget(self, invoice, expected_amounts, expected_exchange_info=None):
         """ Check the outstanding widget after the reconciliation.
-        :param invoice:             An invoice.
-        :param expected_amounts:    A map <move_id> -> <amount>
+        :param invoice:                     An invoice.
+        :param expected_amounts:            A map <move_id> -> <amount>
+        :param expected_exchange_info:      (Optional) Dictionary containing:
+            line_ids            List of Reconciled exchange IDs (integers)
+            exchange_amount     Total exchange amount
         """
         invoice.invalidate_recordset(['invoice_payments_widget'])
         widget_vals = invoice.invoice_payments_widget
 
         if widget_vals:
             current_amounts = {vals['move_id']: vals['amount'] for vals in widget_vals['content']}
+            expected_exchange_info = expected_exchange_info or {'line_ids': [], 'exchange_amount': 0.0}
+            current_exchange_info = {
+                'line_ids': widget_vals['exchange_info']['line_ids'],
+                'exchange_amount': widget_vals['exchange_info']['exchange_amount'],
+            }
         else:
             current_amounts = {}
+            current_exchange_info = {}
+
         self.assertDictEqual(current_amounts, expected_amounts)
+        self.assertDictEqual(current_exchange_info, expected_exchange_info or {})
 
     def _assert_tax_totals_summary(self, tax_totals, expected_results, soft_checking=False):
         """ Assert the tax totals.

--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -535,7 +535,7 @@ class AccountMove(models.Model):
         if is_allowance:
             # Check if the credit note has exchange difference, we need to add it to the sale amount
             reconciled_partials = self._get_all_reconciled_invoice_partials()
-            exchange_difference = sum(item["amount"] for item in reconciled_partials if item.get("is_exchange"))
+            exchange_difference = sum(item["amount"] for item in reconciled_partials if item.get("is_exchange") and not item.get('is_caba'))
             if exchange_difference and self.l10n_tw_edi_is_b2b and tax_type != "4":
                 tax_rate = abs(self.amount_untaxed_signed) / abs(self.amount_total_signed)
                 exchange_difference = self.company_id.currency_id.round(exchange_difference * tax_rate)  # Use untaxed amount for B2B and non special type credit notes


### PR DESCRIPTION
This PR targets two things:
- Improve the visualization of the exchanges on the payment widget
- Match the exchange account when an exchange entry is created for both caba and payment
reconciliations with an invoice

The invoice payment widget was modified to now show the total amount of exchange instead
of showing each exchange move separately and if it is gain or loss. It is possible to click on button to go and see 
the list of exchange. Also, now the exchange moves coming from CABA entries are also considered

Also, when a reconciliation with an invoice with caba taxes, has exchange difference. The exchange moves
created will share the same account

target: master
task-4814793
