### PR TITLE
[FIX] mail: align thumbnail in video link preview overlay

### DIFF
--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -55,7 +55,7 @@
         <div class="o-mail-LinkPreviewVideo card position-relative w-100 mb-2 rounded bg-view shadow-sm overflow-hidden" t-att-data-provider="props.linkPreview.videoProvider" t-att-class="{ 'me-2': env.inChatter, 'o-mail-LinkPreviewVideo-embed': props.linkPreview.videoURL, 'o-mail-LinkPreviewVideo-started': state.startVideo }" t-attf-class="{{ className }}">
             <div class="row g-0 flex-row-reverse">
                 <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !props.linkPreview.og_description }">
-                    <div class="d-flex flex-column gap-1 px-3 py-2 bg-view">
+                    <div class="d-flex flex-column gap-1 px-3 py-1 bg-view">
                         <p t-if="props.linkPreview.og_site_name" class="mb-0 card-text text-muted smaller overflow-hidden" t-out="props.linkPreview.og_site_name"></p>
                         <h6 class="o-mail-LinkPreviewVideo-title card-title mb-0 me-2" t-attf-class="{{ props.linkPreview.og_description ? 'text-truncate' : 'o-mail-LinkPreviewVideo-hasDescription overflow-hidden' }}">
                             <a t-att-href="props.linkPreview.source_url" target="_blank" t-esc="props.linkPreview.og_title"/>
@@ -67,9 +67,9 @@
                     <a t-att-href="props.linkPreview.source_url" target="_blank"><t t-call="mail.LinkPreviewVideo.preview"/></a>
                 </div>
             </div>
-            <div t-if="props.linkPreview.videoURL" class="o-mail-LinkPreviewVideo-container">
+            <div t-if="props.linkPreview.videoURL" class="o-mail-LinkPreviewVideo-container mx-3 mb-2">
                 <div t-if="!state.videoLoaded" class="o-mail-LinkPreviewVideo-videoWrap h-100 w-100" t-on-click="() => state.startVideo = true"><t t-call="mail.LinkPreviewVideo.preview"/></div>
-                <iframe t-if="state.startVideo" t-att-src="props.linkPreview.videoURL" class="h-100 w-100" t-att-class="{'d-none': !state.videoLoaded}" allow="autoplay" frameborder="0" allowFullScreen="true" t-ref="video"/>
+                <iframe t-if="state.startVideo" t-att-src="props.linkPreview.videoURL" class="h-100 w-100 rounded" t-att-class="{'d-none': !state.videoLoaded}" allow="autoplay" frameborder="0" allowFullScreen="true" t-ref="video"/>
             </div>
             <t t-if="props.deletable" t-call="mail.LinkPreview.aside">
                 <t t-set="className" t-value="'fa fa-stack p-0 opacity-75 opacity-100-hover'"/>
@@ -86,8 +86,8 @@
     </t>
 
     <t t-name="mail.LinkPreviewVideo.preview">
-        <div  class="o-mail-LinkPreviewVideo-overlay position-relative h-100 rounded-bottom" t-att-class="{'bg-dark': !props.linkPreview.og_image}">
-            <img t-if="props.linkPreview.og_image" class="img-fluid h-100 o_object_fit_cover" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
+        <div class="o-mail-LinkPreviewVideo-overlay position-relative h-100 rounded-bottom" t-att-class="{'bg-dark': !props.linkPreview.og_image}">
+            <img t-if="props.linkPreview.og_image" class="img-fluid h-100 w-100 o_object_fit_cover rounded" t-att-src="props.linkPreview.og_image" t-att-alt="props.linkPreview.og_title" t-on-load="onImageLoaded"/>
             <i t-elif="props.linkPreview.videoURL" class="fa fa-television fa-8x position-absolute top-50 start-50 translate-middle"/>
             <span t-else="" class="d-flex align-items-center justify-content-center w-100 h-100 bg-100 text-300">
                 <i class="fa fa-camera fa-2x"/>


### PR DESCRIPTION
**Purpose of this PR:**

Before this commit, video thumbnails from youtube left blank spaces in the container, creating inconsistent layouts across different video links.

After this commit, thumbnails consistently fill the entire container, ensuring uniform appearance for all video link previews.

**Before/After:**
<img width="533" height="407" alt="image" src="https://github.com/user-attachments/assets/ce2ba872-27b7-4be5-9d85-fbbe6f272e14" />
<img width="481" height="386" alt="image" src="https://github.com/user-attachments/assets/523f5d16-2983-49c1-9dcc-01adb4284e56" />

task-5424534