### PR TITLE
[FIX] pos_razorpay: prevent sudo attribute error during Razorpay request

### DIFF
--- a/addons/pos_razorpay/models/razorpay_pos_request.py
+++ b/addons/pos_razorpay/models/razorpay_pos_request.py
@@ -57,5 +57,5 @@ class RazorpayPosRequest:
     def _razorpay_get_payment_status_request_body(self):
         return {
             'username': self.razorpay_username,
-            'appKey': self.sudo().razorpay_api_key,
+            'appKey': self.razorpay_api_key,
         }


### PR DESCRIPTION
Steps:

- Configure a Razorpay payment method in POS with Indian localization.
- Open a POS session and process an order.
- Start the Razorpay transaction.

Issue:

- An error pop-up is shown: 'RazorpayPosRequest' object has no attribute 'sudo'.

Cause:

- The code attempts to call sudo() on RazorpayPosRequest, which is not a model and does not support sudo.

Fix:

- Remove the unnecessary sudo() access from RazorpayPosRequest.

Task-5501634
