### PR TITLE
[FIX] repair: fix error when product is missing on move lines

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -285,7 +285,15 @@ class Repair(models.Model):
         # Force to prefetch more than 1000 by 1000
         all_moves._fields['forecast_availability'].compute_value(all_moves)
         for repair in repairs:
-            if any(float_compare(move.forecast_availability, move.product_qty, precision_rounding=move.product_id.uom_id.rounding) < 0 for move in repair.move_ids):
+            if any(
+                move.product_id
+                and float_compare(
+                    move.forecast_availability,
+                    move.product_qty,
+                    precision_rounding=move.product_id.uom_id.rounding
+                ) < 0
+                for move in repair.move_ids
+            ):
                 repair.parts_availability = _('Not Available')
                 repair.parts_availability_state = 'late'
                 continue


### PR DESCRIPTION
An error occurs when the product is not set in the repair move line, and the Scheduled Date is being updated.

**Steps to Reproduce:**
- Install the **Repairs** module.
- Create a new **Repair Orders**.
- Add a product and confirm the repair.
- In the **Parts** tab, **add a new line** and change the **demanded** quantity without selecting a product.
- Update the **Scheduled Date**.

**Error:**
`AssertionError: precision_rounding must be positive, got 0.0`
`ValueError: Expected singleton: uom.uom()` (v19.0)

When the move line has no `product_id`, its Unit of Measure (uom_id) is also empty. Updating the scheduled date triggers a computation, which leads to the error.