### PR TITLE
[FIX] {purchase,sale_purchase}_stock: avoid overcounting of monthly demand

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -141,10 +141,14 @@ class ProductProduct(models.Model):
             (We don't include returns in demand estimation - they come back on hand)
         """
         warehouse_id = self.env.context.get('warehouse_id')
+        non_return_moves_domain = ['!', ('move_dest_ids.origin_returned_move_id', '=', False)]
         if not warehouse_id:
-            return Domain.OR([
-                [('location_dest_usage', 'in', ['customer', 'production'])],
-                [('location_final_id.usage', 'in', ['customer', 'production'])],
+            return Domain.AND([
+                Domain.OR([
+                    [('location_dest_usage', 'in', ['customer', 'production'])],
+                    [('location_final_id.usage', 'in', ['customer', 'production'])],
+                ]),
+                non_return_moves_domain,
             ])
         else:
             return Domain.AND([
@@ -153,7 +157,8 @@ class ProductProduct(models.Model):
                     [('location_dest_id.warehouse_id', '!=', warehouse_id)],
                     [('location_final_id.warehouse_id', '!=', warehouse_id)]
                 ]),  # includes moves going to customer or production
-                [('location_dest_id.usage', '!=', 'inventory')]  # exclude scrap
+                [('location_dest_id.usage', '!=', 'inventory')],  # exclude scrap
+                non_return_moves_domain,
             ])
 
     def _get_quantity_in_progress(self, location_ids=False, warehouse_ids=False):

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -2,9 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
+from dateutil.relativedelta import relativedelta
 
 from odoo import Command, fields
-from odoo.tests import Form, TransactionCase
+from odoo.tests import Form, TransactionCase, freeze_time
 
 
 class TestSalePurchaseStockFlow(TransactionCase):
@@ -558,3 +559,26 @@ class TestSalePurchaseStockFlow(TransactionCase):
         sale_order.action_confirm()
         purchase_order = sale_order._get_purchase_orders()
         self.assertEqual(purchase_order.order_line.analytic_distribution, {str(analytic_account.id): 100})
+
+    def test_product_monthly_demand(self):
+        """
+        Test monthly demand is counted once in a multi-step delivery flow.
+        """
+        self.warehouse.delivery_steps = 'pick_pack_ship'
+        with freeze_time(fields.Datetime.now() - relativedelta(days=1)):
+            so = self.env['sale.order'].create({
+                'partner_id': self.customer.id,
+                'warehouse_id': self.warehouse.id,
+                'order_line': [Command.create({
+                    'product_id': self.mto_product.id,
+                    'product_uom_qty': 10,
+                })],
+            })
+            so.action_confirm()
+            so.picking_ids[0].move_ids.quantity = 10
+            so.picking_ids[0].button_validate()
+            so.picking_ids[1].move_ids.quantity = 10
+            so.picking_ids[1].button_validate()
+            so.picking_ids[2].move_ids.quantity = 10
+            so.picking_ids[2].button_validate()
+        self.assertEqual(self.mto_product.monthly_demand, 10.0)


### PR DESCRIPTION
**Steps to reproduce:**
* Install *purchase_stock* and *sale_management* module.
* Go to *Inventory > Configuration > Settings*. Enable *Multi-Step Routes*.
* Go to *Inventory > Configuration > Warehouses*.
* Set the warehouse delivery flow to *Pick + Pack + Ship (3 steps)*.
* Create a new product. Under the *Purchase* tab, add a vendor.
* Create a sales order for this product with some quantity.
* Confirm the sales order. Validate all three generated transfers (*Pick*, *Pack*, *Ship*).
* Create a purchase order for the same vendor.
* In the purchase order line, click *Catalog* and search for the product.

**Observed behavior:**
* In the catalog view, the *Monthly Demand* is shown as *3x* 
the original sales order quantity instead of the actual demand.

**Cause:**
* *Monthly Demand* is a computed field using `_compute_monthly_demand`, 
which relies on `_get_monthly_demand_moves_location_domain()`.
* In a 3-step delivery flow, all related moves have a final location with usage set to *customer*.
* The domain condition: `('location_final_id.usage', 'in', ['customer', 'production'])`
counts all intermediate pickings.
* Additionally, the fallback condition: `[('location_final_id.warehouse_id', '!=', warehouse_id)]`
is always true because *customer* locations are not linked to a warehouse.
* As a result, all three pickings are counted, inflating the demand. See: https://github.com/odoo/odoo/blob/6bbaea728dbcba49776e813c70dff649d041bdc9/addons/purchase_stock/models/product.py#L144-L157

**Fix:**
* Prevent counting intermediate pickings in 3-step delivery by 
restricting the domain to moves with `move_dest_ids = False`,
ensuring only the final move is considered for monthly demand computation.

---

opw-5453991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
