### PR TITLE
[FIX] l10n_nl: correct NL Domestic fiscal position definition

### DIFF
--- a/addons/l10n_nl/data/template/account.fiscal.position-nl.csv
+++ b/addons/l10n_nl/data/template/account.fiscal.position-nl.csv
@@ -1,6 +1,5 @@
 "id","sequence","name","auto_apply","vat_required","country_id","country_group_id","account_ids/account_src_id","account_ids/account_dest_id","name@nl","name@de"
-"l10n_nl_domestic_fiscal_position","10","NL Domestic","1","","base.nl","l10n_nl.mainland_nl","","","Binnenland","Inländische"
-"fiscal_position_template_national","20","Domestic","1","","","l10n_nl.mainland_nl","","","Binnenland","Inländische"
+"l10n_nl_domestic_fiscal_position","10","NL Domestic","1","","","l10n_nl.mainland_nl","","","Binnenland","Inländische"
 "fiscal_position_template_transferred","","VAT reverse charge","","","","","","","BTW verlegd","Umkehrung der Steuerschuldnerschaft"
 "fiscal_position_template_eu_private","40","EU private B2C","1","","","account.europe_vat","","","",""
 "fiscal_position_template_eu","30","EU intra B2B","1","1","","account.europe_vat","","","",""


### PR DESCRIPTION
Installing the Netherlands localisation creates two Domestic fiscal positions, both incorrectly configured. This commit removes the empty duplicate fiscal position and properly defines the NL Domestic fiscal position by setting the Country Group, leaving Country empty, and disabling VAT requirement.

task-5489829
