### PR TITLE
[IMP] hr: allow HR user to archive unused departure reason

### DIFF
--- a/addons/hr/models/hr_departure_reason.py
+++ b/addons/hr/models/hr_departure_reason.py
@@ -9,6 +9,7 @@ class HrDepartureReason(models.Model):
     _description = "Departure Reason"
     _order = "sequence"
 
+    active = fields.Boolean(default=True)
     sequence = fields.Integer("Sequence", default=10)
     name = fields.Char(string="Reason", required=True, translate=True)
     country_id = fields.Many2one('res.country', string='Country', default=lambda self: self.env.company.country_id)


### PR DESCRIPTION
An HR user has currently no way to prevent use of specific /deprecated departure reason other than specifying it in the name.

This commit an active field on `hr.departure.reason` so that an HR user can archive departure reasons that should not be used (as he can't delete them if they are referenced at least once).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
