### PR TITLE
[FIX] test_discuss_full: correct init_store_data tz assertion

### DIFF
--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -187,6 +187,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             {'name': 'test14', 'login': 'test14'},
             {'name': 'test15', 'login': 'test15'},
         ])
+        self.env.ref("base.partner_root").tz = "Europe/Brussels"
         self.employees = self.env['hr.employee'].create([{
             'user_id': user.id,
         } for user in self.users])
@@ -397,7 +398,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "is_company": False,
                     "main_user_id": self.user_root.id,
                     "name": "OdooBot",
-                    "tz": False,
+                    "tz": "Europe/Brussels",
                     "write_date": fields.Datetime.to_string(self.user_root.partner_id.write_date),
                 },
                 {


### PR DESCRIPTION
This commit fixes a failing assert in `test_10_init_store_data`.
The test fails since [1] due to asserting the value of the OdooBot time zone as False.
This commit explicitely sets the time zone of the OdooBot partner record and asserts it.

[1] https://github.com/odoo/odoo/pull/210094

runbot-237777