### PR TITLE
[FIX] hr: fix JS error by adding explicit views to action

### DIFF
--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -26,6 +26,7 @@ class ResPartner(models.Model):
                 'type': 'ir.actions.act_window',
                 'res_model': 'hr.employee',
                 'view_mode': 'kanban',
+                'views': [(False, 'kanban')],
                 'domain': [('id', 'in', self.employee_ids.ids),
                            ('company_id', 'in', self.env.companies.ids)],
             }
@@ -35,6 +36,7 @@ class ResPartner(models.Model):
             'res_model': 'hr.employee',
             'res_id': self.employee_ids.filtered(lambda e: e.company_id in self.env.companies).id,
             'view_mode': 'form',
+            'views': [(False, 'form')],
         }
 
     def _get_all_addr(self):


### PR DESCRIPTION
The frontend action service requires the 'views' field to be present in the action dictionary.

Without it, `_preprocessAction` fails when trying to access `action.views`[1], causing a client-side crash. This commit ensures `views` is defined alongside `view_mode`.

[1]: https://github.com/odoo/odoo/blob/3c5e2be7eb3b22b1d5eb28c1eae37fe61dabcd46/addons/web/static/src/webclient/actions/action_service.js#L442

Task-[5368166](https://www.odoo.com/odoo/5778/tasks/5368166)
Ent PR odoo/enterprise#102547




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
