### PR TITLE
[FIX] mail: make message read / search symmetric

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -184,6 +184,7 @@ class ThreadController(http.Controller):
                     )
                 ),
             ).ids
+        res.setdefault("message_type", "comment")
         return res
 
     @http.route("/mail/message/post", methods=["POST"], type="jsonrpc", auth="public")

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timedelta
 from dateutil.relativedelta import MO, relativedelta
 
 from odoo import api, fields, models, _
-from odoo.exceptions import AccessError, MissingError
+from odoo.exceptions import AccessError
 from odoo.fields import Domain
 from odoo.tools import is_html_empty
 from odoo.tools.misc import clean_context, get_lang, groupby
@@ -243,19 +243,9 @@ class MailActivity(models.Model):
                 forbidden_ids.append(activity.id)
 
         for doc_model, docid_actids in model_docid_actids.items():
-            documents = self.env[doc_model].browse(docid_actids)
-            doc_operation = getattr(
-                documents, '_mail_post_access', 'read' if operation == 'read' else 'write'
-            )
-            try:
-                doc_result = documents._check_access(doc_operation)
-            except MissingError:
-                existing = documents.exists()
-                forbidden_ids.extend((documents - existing).ids)
-                doc_result = existing._check_access(doc_operation)
-            if doc_result:
-                for document in doc_result[0]:
-                    forbidden_ids.extend(docid_actids[document.id])
+            allowed = self.env['mail.message']._filter_records_for_message_operation(doc_model, docid_actids, operation)
+            for document_id in [doc_id for doc_id in docid_actids if doc_id not in allowed.ids]:
+                forbidden_ids.extend(docid_actids[document_id])
 
         if forbidden_ids:
             forbidden = self.browse(forbidden_ids)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -328,14 +328,18 @@ class MailMessage(models.Model):
         ids uid could not see according to our custom rules. Please refer to
         _check_access() for more details about those rules.
 
-        Non employees users see only message with subtype (aka do not see
-        internal logs).
+        Non employees users see only message with subtype, and cannot see
+        internal messages, either coming from message 'is_internal' flag,
+        subtype 'internal' flag, or being pure logs (no subtype). See
+        `_get_search_domain_share` which generates the domain.
 
         After having received ids of a classic search, keep only:
         - if author_id == pid, uid is the author, OR
         - uid belongs to a notified channel, OR
         - uid is in the specified recipients, OR
-        - uid has a notification on the message
+        - uid has a notification on the message, OR
+        - uid has acces to the message linked document for messages that are not
+          'user_notification'
         - otherwise: remove the id
         """
         # Rules do not apply to administrator
@@ -406,7 +410,7 @@ class MailMessage(models.Model):
     def _find_allowed_doc_ids(self, model_ids):
         """ Filter out message user cannot read due to missing document access.
 
-        :param dict model_ids: dictionary like {
+        :param dict model_ids: dictionary giving messages IDs per model / doc ids {
             'document_model_name': {
                 'document_id_1': set(message IDs),
                 'document_id_2': set(message IDs),

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -618,21 +618,6 @@ class MailMessage(models.Model):
             if not messages_to_check:
                 return forbidden
 
-            # Recipients condition for create (message_follower_ids)
-            for model, docid_msgids in model_docid_msgids.items():
-                domain = [
-                    ('res_model', '=', model),
-                    ('res_id', 'in', list(docid_msgids)),
-                    ('partner_id', '=', self.env.user.partner_id.id),
-                ]
-                followers = self.env['mail.followers'].sudo().search_fetch(domain, ['res_id'])
-                for follower in followers:
-                    for mid in docid_msgids[follower.res_id]:
-                        messages_to_check.pop(mid)
-
-            if not messages_to_check:
-                return forbidden
-
         forbidden += self.browse(messages_to_check)
         return forbidden
 

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -466,8 +466,8 @@ class MailMessage(models.Model):
                 - uid has write or create access on the related document
                 - otherwise: raise
 
-        Specific case: non employee users see only messages with subtype (aka do
-        not see internal logs).
+        Specific case: non employee users cannot see internal messages (aka logs):
+        'is_internal' flag on message, 'internal' flag on subtype.
         """
         result = super()._check_access(operation)
         if not self:
@@ -490,14 +490,16 @@ class MailMessage(models.Model):
 
         # Non employees see only messages with a subtype (aka, not internal logs)
         if not self.env.user._is_internal():
+            message_type_condition = ''
+            if operation in ('create', 'read'):
+                message_type_condition = "message.message_type = 'comment' AND"
             rows = self.env.execute_query(SQL(
                 ''' SELECT message.id
                     FROM "mail_message" AS message
                     LEFT JOIN "mail_message_subtype" as subtype ON message.subtype_id = subtype.id
-                    WHERE message.id = ANY (%s)
-                        AND message.message_type = 'comment'
+                    WHERE %s message.id = ANY (%%s)
                         AND (message.is_internal IS TRUE OR message.subtype_id IS NULL OR subtype.internal IS TRUE)
-                ''',
+                ''' % message_type_condition,
                 self.ids,
             ))
             if rows:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -406,6 +406,27 @@ class MailMessage(models.Model):
     def _get_search_domain_share(self):
         return Domain(['&', '&', ('is_internal', '=', False), ('subtype_id', '!=', False), ('subtype_id.internal', '=', False)])
 
+    def _filter_records_for_message_operation(self, doc_model, doc_res_ids, operation):
+        """ Helper returning records on which 'operation' on mail.message is
+        allowed, based on '_get_mail_message_access' behavior and potential
+        model override. """
+        documents_all = self.env[doc_model].with_context(active_test=False).browse(doc_res_ids)
+        operation_res_ids = documents_all._mail_group_by_operation_for_mail_message_operation(operation)
+
+        # group documents per operation to check, based on mail.message access
+        # note that some ids may be filtered out if (e.g. group limitation, ...)
+        forbidden_doc_ids = set()
+        allowed_ids = []
+        for record_operation, records in operation_res_ids.items():
+            operation_result = records._check_access(record_operation)
+            # keepr actually returned records for the opration, that are not forbidden
+            allowed_ids += [
+                record.id for record in records
+                if record.id not in (operation_result or [[self.env[doc_model]]])[0]._ids
+            ]
+
+        return self.env[doc_model].browse(allowed_ids)
+
     @api.model
     def _find_allowed_doc_ids(self, model_ids):
         """ Filter out message user cannot read due to missing document access.
@@ -426,17 +447,7 @@ class MailMessage(models.Model):
         for doc_model, doc_dict in model_ids.items():
             if not IrModelAccess.check(doc_model, 'read', False):
                 continue
-            records_all = self.env[doc_model].with_context(active_test=False).search([('id', 'in', list(doc_dict))])
-            allowed_documents = self.env[doc_model]
-            # _mail_group_by_operation_for_mail_message_operation set prefetch to records_all.ids
-            # hence should be good, no need to force it again
-            operation_res_ids = records_all._mail_group_by_operation_for_mail_message_operation('read')
-            # filter for each operation
-            for record_operation, records in operation_res_ids.items():
-                if record_operation == "read":  # already implied by 'search'
-                    allowed_documents += records
-                else:
-                    allowed_documents += records._filtered_access(record_operation)
+            allowed_documents = self._filter_records_for_message_operation(doc_model, list(doc_dict), 'read')
             allowed_ids |= {
                 msg_id for document_id in allowed_documents.ids for msg_id in doc_dict[document_id]
             }
@@ -584,15 +595,10 @@ class MailMessage(models.Model):
                 model_docid_msgids[message['model']][message['res_id']].append(mid)
 
         for model, docid_msgids in model_docid_msgids.items():
-            documents = self.env[model].browse(docid_msgids)
-            # group documents per operation to check, based on mail.message access
-            # note that some ids may be filtered out if (e.g. group limitation, ...)
-            operation_res_ids = documents._mail_group_by_operation_for_mail_message_operation(operation)
-            for record_operation, records in operation_res_ids.items():
-                check_result = records._check_access(record_operation)
-                forbidden_doc_ids = set(check_result[0]._ids) if check_result else set()
-                for res_id in (r.id for r in records if r.id not in forbidden_doc_ids):
-                    for mid in docid_msgids[res_id]:
+            allowed = self._filter_records_for_message_operation(model, docid_msgids, operation)
+            for doc_id, msg_ids in docid_msgids.items():
+                if doc_id in allowed.ids:
+                    for mid in msg_ids:
                         messages_to_check.pop(mid)
 
         if not messages_to_check:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -786,6 +786,12 @@ class MailMessage(models.Model):
         self.check_access('read')
         return super().read(fields=fields, load=load)
 
+    def copy_data(self, default=None):
+        """ Make is symmetric to read, to avoid spurious issues with recordsets
+        differences. """
+        self.check_access('read')
+        return super().copy_data(default=default)
+
     def fetch(self, field_names=None):
         # This freaky hack is aimed at reading data without the overhead of
         # checking that "self" is accessible, which is already done above in

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -415,14 +415,20 @@ class MailMessage(models.Model):
 
         # group documents per operation to check, based on mail.message access
         # note that some ids may be filtered out if (e.g. group limitation, ...)
-        forbidden_doc_ids = set()
         allowed_ids = []
         for record_operation, records in operation_res_ids.items():
-            operation_result = records._check_access(record_operation)
-            # keepr actually returned records for the opration, that are not forbidden
+            forbidden_doc_ids = set()
+            try:
+                operation_result = records._check_access(record_operation)
+            except MissingError:
+                existing = records.exists()
+                forbidden_doc_ids = set((records - existing).ids)
+                operation_result = existing._check_access(record_operation)
+            forbidden_doc_ids |= set((operation_result or [self.env[doc_model]])[0]._ids)
+            # keep actually returned records for the opration, that are not forbidden
             allowed_ids += [
                 record.id for record in records
-                if record.id not in (operation_result or [[self.env[doc_model]]])[0]._ids
+                if record.id not in forbidden_doc_ids
             ]
 
         return self.env[doc_model].browse(allowed_ids)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -5044,7 +5044,7 @@ class MailThread(models.AbstractModel):
         if res.is_for_current_user():
             res.attr("hasReadAccess", lambda t: t.sudo(False).has_access("read"))
             res.attr("hasWriteAccess", lambda t: t.sudo(False).has_access("write"))
-            res.attr("canPostOnReadonly", self._mail_post_access == "read")
+            res.attr("canPostOnReadonly", self._mail_get_operation_for_mail_message_operation('create').get(self) == "read")
         if "activities" in request_list and isinstance(self, self.env.registry["mail.activity.mixin"]):
             res.many(
                 "activities",

--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -13,16 +13,18 @@
                         'btn-primary': state.composerType !== 'note',
                         'btn-secondary': state.composerType === 'note',
                         'active': state.composerType === 'message',
-                    }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
+                    }" t-att-disabled="!state.thread.canPostMessage and props.threadId" data-hotkey="m" t-on-click="() => this.toggleComposer('message')">
                         Send message
                     </button>
                     <button class="o-mail-Chatter-logNote btn text-nowrap my-2" t-att-class="{
                         'btn-primary active': state.composerType === 'note',
                         'btn-secondary': state.composerType !== 'note',
-                    }" t-att-disabled="!state.thread.hasWriteAccess and !(state.thread.hasReadAccess and state.thread.canPostOnReadonly) and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
+                    }" t-att-disabled="!state.thread.canPostMessage and props.threadId and props.threadId" data-hotkey="shift+m" t-on-click="() => this.toggleComposer('note')">
                         Log note
                     </button>
-                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap my-2" data-hotkey="shift+a" t-on-click="scheduleActivity">
+                    <button t-if="props.has_activities" class="o-mail-Chatter-activity btn btn-secondary text-nowrap my-2"
+                            t-att-disabled="!state.thread.canPostMessage and props.threadId"
+                            data-hotkey="shift+a" t-on-click="scheduleActivity">
                         <span>Activity</span>
                     </button>
                 </div>
@@ -82,7 +84,7 @@
                         />
                         <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                             <t t-set-slot="toggler">
-                                <button class="btn btn-link px-1" type="button" t-att-disabled="!state.thread.hasWriteAccess">
+                                <button class="btn btn-link px-1" type="button" t-att-disabled="!state.thread.canPostMessage">
                                     <i class="fa fa-plus-square"/>
                                     Attach files
                                 </button>
@@ -152,7 +154,8 @@
 </t>
 
 <t t-name="mail.Chatter.attachFiles">
-    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
+    <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-on-click="onClickAddAttachments"
+            t-att-disabled="state.isSearchOpen || (!state.thread.canPostMessage and attachments.length === 0)">
         <i class="fa fa-paperclip fa-lg fa-fw"/>
         <sup t-if="attachments.length > 0" t-esc="attachments.length"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -267,6 +267,10 @@ export class Thread extends Record {
         return attachments;
     }
 
+    get canPostMessage() {
+        return this.hasWriteAccess || (this.hasReadAccess && this.canPostOnReadonly);
+    }
+
     get isUnread() {
         return this.needactionMessages.length > 0;
     }

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -38,7 +38,7 @@ class MailTestAccessCusto(models.Model):
     or partner which have their own set of ACLs. """
     _description = 'Mail Access Test with Custo'
     _name = 'mail.test.access.custo'
-    _inherit = ['mail.thread.blacklist']
+    _inherit = ['mail.thread.blacklist', 'mail.activity.mixin']
     _mail_post_access = 'write'  # default value but ease mock
     _order = 'id DESC'
     _primary_email = 'email_from'

--- a/addons/test_mail/models/mail_test_access.py
+++ b/addons/test_mail/models/mail_test_access.py
@@ -48,13 +48,14 @@ class MailTestAccessCusto(models.Model):
     phone = fields.Char()
     customer_id = fields.Many2one('res.partner', 'Customer')
     is_locked = fields.Boolean()
+    is_readonly = fields.Boolean()
 
     def _mail_get_partner_fields(self, introspect_fields=False):
         return ['customer_id']
 
     def _mail_get_operation_for_mail_message_operation(self, message_operation):
         # customize message creation: only unlocked, except admins
-        if message_operation == "create":
+        if message_operation == "create" and not self.env.user._is_admin():
             return dict.fromkeys(self.filtered(lambda r: not r.is_locked), 'read')
         # customize read: read access on unlocked, write access on locked
         elif message_operation == "read":

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -231,9 +231,9 @@ class MailTestMultiCompany(models.Model):
 class MailTestMultiCompanyRead(models.Model):
     """ Just mail.test.simple, but multi company and supporting posting
     even if the user has no write access. """
-    _description = 'Simple Chatter Model'
-    _name = "mail.test.multi.company.read"
-    _inherit = ['mail.test.multi.company']
+    _description = 'Simple Chatter Model '
+    _name = 'mail.test.multi.company.read'
+    _inherit = ['mail.test.multi.company', 'mail.activity.mixin']
     _mail_post_access = 'read'
 
 

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -65,15 +65,25 @@
         <field name="groups" eval="[(4, ref('base.group_system'))]"/>
     </record>
 
-    <!-- mail.test.access.custo -->
-    <record id="ir_rule_mail_test_access_custo_update_internal" model="ir.rule">
-        <field name="name">Internal: write/unlink unlocked</field>
+    <!-- MAIL.TEST.ACCESS.CUSTO -->
+    <record id="ir_rule_mail_test_access_custo_portal_read" model="ir.rule">
+        <field name="name">Portal: read unlocked</field>
         <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
         <field name="domain_force">[('is_locked', '=', False)]</field>
-        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+    <record id="ir_rule_mail_test_access_custo_update" model="ir.rule">
+        <field name="name">Internal: create/write/unlink unlocked and not readonly</field>
+        <field name="model_id" ref="test_mail.model_mail_test_access_custo"/>
+        <field name="domain_force">[('is_readonly', '=', False), ('is_locked', '=', False)]</field>
+        <field name="groups" eval="[(4, ref('base.group_user')), (4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="False"/>
         <field name="perm_write" eval="True"/>
-        <field name="perm_create" eval="False"/>
+        <field name="perm_create" eval="True"/>
         <field name="perm_unlink" eval="True"/>
     </record>
     <record id="ir_rule_mail_test_access_custo_update_admin" model="ir.rule">

--- a/addons/test_mail/static/tests/chatter.test.js
+++ b/addons/test_mail/static/tests/chatter.test.js
@@ -56,10 +56,11 @@ test("Send message button activation (access rights dependent)", async () => {
     await start();
     const simpleId = pyEnv["mail.test.multi.company"].create({ name: "Test MC Simple" });
     const simpleMcId = pyEnv["mail.test.multi.company.read"].create({
-        name: "Test MC Readonly",
+        name: "Test MC Readonly with Activities",
     });
     async function assertSendButton(
         enabled,
+        activities,
         msg,
         model = null,
         resId = null,
@@ -73,12 +74,23 @@ test("Send message button activation (access rights dependent)", async () => {
         }
         if (enabled) {
             await contains(".o-mail-Chatter-topbar button:enabled", { text: "Send message" });
+            await contains(".o-mail-Chatter-topbar button:enabled", { text: "Log note" });
+            if (activities) {
+                await contains(".o-mail-Chatter-topbar button:enabled", { text: "Activity" });
+
+            }
         } else {
             await contains(".o-mail-Chatter-topbar button:disabled", { text: "Send message" });
+            await contains(".o-mail-Chatter-topbar button:disabled", { text: "Log note" });
+            if (activities) {
+                await contains(".o-mail-Chatter-topbar button:disabled", { text: "Activity" });
+
+            }
         }
     }
     await assertSendButton(
         true,
+        false,
         "Record, all rights",
         "mail.test.multi.company",
         simpleId,
@@ -86,6 +98,7 @@ test("Send message button activation (access rights dependent)", async () => {
         true
     );
     await assertSendButton(
+        true,
         true,
         "Record, all rights",
         "mail.test.multi.company.read",
@@ -95,6 +108,7 @@ test("Send message button activation (access rights dependent)", async () => {
     );
     await assertSendButton(
         false,
+        false,
         "Record, no write access",
         "mail.test.multi.company",
         simpleId,
@@ -102,16 +116,17 @@ test("Send message button activation (access rights dependent)", async () => {
     );
     await assertSendButton(
         true,
+        true,
         "Record, read access but model accept post with read only access",
         "mail.test.multi.company.read",
         simpleMcId,
         true
     );
-    await assertSendButton(false, "Record, no rights", "mail.test.multi.company", simpleId);
-    await assertSendButton(false, "Record, no rights", "mail.test.multi.company.read", simpleMcId);
+    await assertSendButton(false, false, "Record, no rights", "mail.test.multi.company", simpleId);
+    await assertSendButton(false, true, "Record, no rights", "mail.test.multi.company.read", simpleMcId);
     // Note that rights have no impact on send button for draft record (chatter.isTemporary=true)
-    await assertSendButton(true, "Draft record", "mail.test.multi.company");
-    await assertSendButton(true, "Draft record", "mail.test.multi.company.read");
+    await assertSendButton(true, false, "Draft record", "mail.test.multi.company");
+    await assertSendButton(true, true, "Draft record", "mail.test.multi.company.read");
 });
 
 test("basic chatter rendering with a model without activities", async () => {

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -161,7 +161,7 @@ class TestMailMessageAccess(MessageAccessCommon):
             (self.record_admin, {}, True, 'No access on record (and not notified on first message)'),
             (record_admin_fol, {
                 'reply_to': 'avoid.catchall@my.test.com',  # otherwise crashes
-            }, False, 'Followers > no access on record'),
+            }, True, 'No access on record > followers'),
             # parent based
             (self.record_admin, {  # note: force reply_to normally computed by message_post avoiding ACLs issues
                 'parent_id': admin_msg.id,
@@ -283,7 +283,7 @@ class TestMailMessageAccess(MessageAccessCommon):
             (self.record_internal, {}, True, 'No R/W Access on record'),
             (record_admin_fol, {
                 'reply_to': 'avoid.catchall@my.test.com',  # otherwise crashes
-            }, False, 'Followers > no access on record'),
+            }, True, 'No access on record > followers'),
             # parent based
             (self.record_admin, {
                 'parent_id': admin_msg.id,

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -774,7 +774,7 @@ class TestMailMessageAccess(MessageAccessCommon):
         """ Test '_mail_get_operation_for_mail_message_operation' support in search """
         records = self.env['mail.test.access.custo'].with_user(self.user_admin).create([
             {'name': 'Open'},
-            {'name': 'Open (other)'},
+            {'name': 'Open RO', 'is_readonly': True},  # internal can read thus search
             {'name': 'Soonish Locked'},
         ])
         messages_all = self.env['mail.message'].sudo()
@@ -795,18 +795,19 @@ class TestMailMessageAccess(MessageAccessCommon):
         ])
         self.assertEqual(found_por, messages_all)
 
-        # lock -> see '_mail_get_operation_for_mail_message_operation', which is not supported currently
-        # in the search, making it inconsistent with 'read'
+        # lock -> locked records need 'write' access, as defined in '_get_mail_message_access'
+        # hence messages are out of search, symmetrical to reading therm
         records[2].write({'is_locked': True, 'name': 'Locked !'})
+        records[2].flush_recordset()
         found_emp = self.env['mail.message'].with_user(self.user_employee).search([
             ('body', 'ilike', 'AnchorForSearch')
         ])
-        self.assertEqual(found_emp, messages_all.filtered(lambda m: m.res_id != records[2].id), 'FIXME: should filter like read')
+        self.assertEqual(found_emp, messages_all.filtered(lambda m: m.res_id != records[2].id), 'Should filter like read')
         found_emp.read(['subject'])
         found_por = self.env['mail.message'].with_user(self.user_portal).search([
             ('body', 'ilike', 'AnchorForSearch')
         ])
-        self.assertEqual(found_por, messages_all.filtered(lambda m: m.res_id != records[2].id), 'FIXME: should filter like read')
+        self.assertEqual(found_por, messages_all.filtered(lambda m: m.res_id != records[2].id), 'Should filter like read')
         found_por.read(['subject'])
 
 

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -156,6 +156,7 @@ class TestMailMessageAccess(MessageAccessCommon):
             (self.env["mail.test.access"], {}, False, 'Private message like is ok'),
             # document based
             (self.record_internal, {}, False, 'W Access on record'),
+            (self.record_internal, {'message_type': 'notification'}, False, 'W Access on record, notification does not change anything'),
             (self.record_internal_ro, {}, True, 'No W Access on record'),
             (self.record_admin, {}, True, 'No access on record (and not notified on first message)'),
             (record_admin_fol, {
@@ -167,26 +168,30 @@ class TestMailMessageAccess(MessageAccessCommon):
             }, False, 'No access on record but reply to notified parent'),
         ]:
             with self.subTest(record=record, msg_vals=msg_vals, reason=reason):
+                final_vals = dict(
+                    {
+                        'body': 'Test',
+                        'message_type': 'comment',
+                        'subtype_id': self.env.ref('mail.mt_comment').id,
+                    }, **msg_vals
+                )
                 if should_crash:
                     with self.assertRaises(AccessError):
                         self.env['mail.message'].with_user(self.user_employee).create({
                             'model': record._name if record else False,
                             'res_id': record.id if record else False,
-                            'body': 'Test',
-                            **msg_vals,
+                            **final_vals,
                         })
                     if record:
                         with self.assertRaises(AccessError):
                             record.with_user(self.user_employee).message_post(
-                                body='Test',
-                                subtype_id=self.env.ref('mail.mt_comment').id,
+                                **final_vals,
                             )
                 else:
                     _message = self.env['mail.message'].with_user(self.user_employee).create({
                         'model': record._name if record else False,
                         'res_id': record.id if record else False,
-                        'body': 'Test',
-                        **msg_vals,
+                        **final_vals,
                     })
                     if record:
                         # TDE note: due to parent_id flattening, doing message_post
@@ -196,24 +201,38 @@ class TestMailMessageAccess(MessageAccessCommon):
                         if record == self.record_admin and 'parent_id' in msg_vals:
                             continue
                         record.with_user(self.user_employee).message_post(
-                            body='Test',
-                            subtype_id=self.env.ref('mail.mt_comment').id,
-                            **msg_vals,
+                            **final_vals,
                         )
 
     def test_access_create_customized(self):
         """ Test '_mail_get_operation_for_mail_message_operation' support """
         record = self.env['mail.test.access.custo'].with_user(self.user_employee).create({'name': 'Open'})
         for user in self.user_employee + self.user_portal:
-            _message = record.message_post(
-                body='A message',
-                subtype_id=self.env.ref('mail.mt_comment').id,
-            )
-        # lock -> see '_mail_get_operation_for_mail_message_operation'
+            with self.subTest(user_name=user.name):
+                _message = record.with_user(user).message_post(
+                    body='A message',
+                    subtype_id=self.env.ref('mail.mt_comment').id,
+                )
+        # lock -> see '_get_mail_message_access'
         record.write({'is_locked': True})
+        record.invalidate_model()
         for user in self.user_employee + self.user_portal:
-            with self.assertRaises(AccessError):
-                _message_portal = record.with_user(self.user_portal).message_post(
+            with self.subTest(user_name=user.name):
+                with self.assertRaises(AccessError):
+                    _message = record.with_user(user).message_post(
+                        body='Another portal message',
+                        subtype_id=self.env.ref('mail.mt_comment').id,
+                    )
+        # readonly -> "read" access sufficient on unlocked records, see '_get_mail_message_access'
+        record.sudo().write({'is_locked': False, 'is_readonly': True})
+        record.invalidate_model()
+        for user in self.user_employee + self.user_portal:
+            with self.subTest(user_name=user.name):
+                # cannot write
+                with self.assertRaises(AccessError):
+                    record.with_user(user).write({'name': 'Can Update'})
+                # can post
+                _message = record.with_user(user).message_post(
                     body='Another portal message',
                     subtype_id=self.env.ref('mail.mt_comment').id,
                 )
@@ -441,21 +460,30 @@ class TestMailMessageAccess(MessageAccessCommon):
         """ Test '_mail_get_operation_for_mail_message_operation' support """
         records = self.env['mail.test.access.custo'].with_user(self.user_admin).create([
             {'name': 'Open'},
+            {'name': 'Open RO', 'is_readonly': True},
             {'is_locked': True, 'name': 'Locked'},
         ])
         messages_all = self.env['mail.message']
         for record in records:
             messages_all += record.with_user(self.user_admin).message_post(
-                body=f'AnchorForTest / A message from {self.user_admin.name}',
+                body=f'AnchorForTest / A message from {self.user_admin.name} on {record.name}',
                 subtype_id=self.env.ref('mail.mt_comment').id,
             )
-        # lock -> see '_mail_get_operation_for_mail_message_operation', cannot read locked message
+        # lock -> see '_get_mail_message_access', cannot read locked message
         # without write access, with is not granted for employees
-        with self.assertRaises(AccessError):  # write access not granted on locked
+        with self.assertRaises(AccessError):  # write access not granted on locked -> cannot read message
+            messages_all[2].with_user(self.user_employee).read(['subject'])
+        with self.assertRaises(AccessError):  # also working in case of batch ok / not ok
             messages_all.with_user(self.user_employee).read(['subject'])
         messages_all[0].with_user(self.user_employee).read(['subject'])
+        messages_all[1].with_user(self.user_employee).read(['subject'])  # can read message of readonly
+
+        with self.assertRaises(AccessError):  # fetch should be symmetric to read
+            _message = messages_all[2].with_user(self.user_employee).copy_data()
+
         with self.assertRaises(AccessError):  # no write access at all
             messages_all.with_user(self.user_portal).read(['subject'])
+        messages_all.with_user(self.user_admin).read(['subject'])
 
     def test_access_read_portal(self):
         """ Read access check for portal users """

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -35,6 +35,13 @@ class MessageAccessCommon(MailCommon):
             name='Chell Gladys',
         )
 
+        cls.test_subtype_access_internal = cls.env['mail.message.subtype'].create([
+            {
+                'internal': True,
+                'name': 'Test Internal',
+            },
+        ])
+
         (
             cls.record_public, cls.record_portal, cls.record_portal_ro,
             cls.record_followers,
@@ -290,7 +297,10 @@ class TestMailMessageAccess(MessageAccessCommon):
             }, False, 'No access on record but reply to notified parent'),
             # internal = forbidden (internal users only)
             (self.record_portal, {'is_internal': True}, True, 'Internal subtype always forbidden'),
+            (self.record_portal, {'is_internal': True, 'message_type': 'notification'}, False, 'Automatic log accepted'),
             (self.record_portal, {'subtype_id': self.env.ref('mail.mt_note').id}, True, 'Internal flag always forbidden'),
+            (self.record_portal, {'subtype_id': self.test_subtype_access_internal.id}, True, 'Internal flag (custom subtype) always forbidden'),
+            (self.record_portal, {'message_type': 'notification', 'subtype_id': self.test_subtype_access_internal.id}, False, 'Automatic log accepted'),
             (self.record_portal, {'subtype_id': False}, True, 'No subtype = internal = always forbidden'),
         ]:
             with self.subTest(record=record, msg_vals=msg_vals, reason=reason):
@@ -300,6 +310,7 @@ class TestMailMessageAccess(MessageAccessCommon):
                             'model': record._name if record else False,
                             'res_id': record.id if record else False,
                             'body': 'Test',
+                            'message_type': 'comment',
                             'subtype_id': self.env.ref('mail.mt_comment').id,
                             **msg_vals,
                         })
@@ -308,6 +319,7 @@ class TestMailMessageAccess(MessageAccessCommon):
                         'model': record._name if record else False,
                         'res_id': record.id if record else False,
                         'body': 'Test',
+                        'message_type': 'comment',
                         'subtype_id': self.env.ref('mail.mt_comment').id,
                         **msg_vals,
                     })
@@ -504,14 +516,29 @@ class TestMailMessageAccess(MessageAccessCommon):
             # forbidden
             (self.record_portal.message_ids[0], {
                 'subtype_id': self.env.ref('mail.mt_note').id,
-            }, True, 'Note cannot be read by portal users'),
+            }, True, 'Note (comment) cannot be read by portal users'),
+            (self.record_portal.message_ids[0], {
+                'subtype_id': self.test_subtype_access_internal.id,
+            }, True, 'Internal subtype (comment) cannot be read by portal users'),
+            (self.record_portal.message_ids[0], {
+                'message_type': 'email_outgoing',
+                'subtype_id': self.env.ref('mail.mt_note').id,
+            }, False, 'Note (email_outgoing) can be read by portal users'),
             (self.record_portal.message_ids[0], {
                 'is_internal': True,
-            }, True, 'Internal message cannot be read by portal users'),
+            }, True, 'Internal message (comment) cannot be read by portal users'),
+            (self.record_portal.message_ids[0], {
+                'is_internal': True,
+                'message_type': 'notification',
+            }, False, 'Internal message (notification) can be read by portal users'),
+            (self.record_portal.message_ids[0], {
+                'message_type': 'user_notification',
+            }, True, 'User notifications for other people can never be read by portal users'),
         ]:
             original_vals = {
                 'author_id': msg.author_id.id,
                 'is_internal': False,
+                'message_type': msg.message_type,
                 'notification_ids': [(6, 0, {})],
                 'parent_id': msg.parent_id.id,
                 'subtype_id': self.env.ref('mail.mt_comment').id,
@@ -519,6 +546,8 @@ class TestMailMessageAccess(MessageAccessCommon):
             with self.subTest(msg=msg, reason=reason):
                 if msg_vals:
                     msg.write(msg_vals)
+
+                self.env.invalidate_all()
                 if should_crash:
                     with self.assertRaises(AccessError):
                         msg.with_user(self.user_portal).read(['body'])
@@ -526,6 +555,7 @@ class TestMailMessageAccess(MessageAccessCommon):
                     msg.with_user(self.user_portal).read(['body'])
                 if msg_vals:
                     msg.write(original_vals)
+                    self.env.invalidate_all()
 
     def test_access_read_public(self):
         """ Read access check for public users """
@@ -554,6 +584,7 @@ class TestMailMessageAccess(MessageAccessCommon):
             original_vals = {
                 'author_id': msg.author_id.id,
                 'is_internal': False,
+                'message_type': msg.message_type,
                 'notification_ids': [(6, 0, {})],
                 'parent_id': msg.parent_id.id,
                 'subtype_id': self.env.ref('mail.mt_comment').id,
@@ -561,6 +592,8 @@ class TestMailMessageAccess(MessageAccessCommon):
             with self.subTest(msg=msg, reason=reason):
                 if msg_vals:
                     msg.write(msg_vals)
+
+                self.env.invalidate_all()
                 if should_crash:
                     with self.assertRaises(AccessError):
                         msg.with_user(self.user_public).read(['body'])
@@ -568,6 +601,7 @@ class TestMailMessageAccess(MessageAccessCommon):
                     msg.with_user(self.user_public).read(['body'])
                 if msg_vals:
                     msg.write(original_vals)
+                    self.env.invalidate_all()
 
     # ------------------------------------------------------------
     # UNLINK
@@ -746,8 +780,22 @@ class TestMailMessageAccess(MessageAccessCommon):
             res_id=self.record_portal.id,
             subtype_id=self.ref('mail.mt_comment'),
         ))
+        msg_record_portal_internal = self.env['mail.message'].create(dict(base_msg_vals,
+            body='Internal Comment on Portal',
+            is_internal=True,
+            model=self.record_portal._name,
+            res_id=self.record_portal.id,
+            subtype_id=self.ref('mail.mt_comment'),
+        ))
         msg_record_public = self.env['mail.message'].create(dict(base_msg_vals,
             body='Public Comment',
+            model=self.record_public._name,
+            res_id=self.record_public.id,
+            subtype_id=self.ref('mail.mt_comment'),
+        ))
+        msg_record_public_internal = self.env['mail.message'].create(dict(base_msg_vals,
+            body='Internal Comment on Public',
+            is_internal=True,
             model=self.record_public._name,
             res_id=self.record_public.id,
             subtype_id=self.ref('mail.mt_comment'),
@@ -760,13 +808,17 @@ class TestMailMessageAccess(MessageAccessCommon):
             (self.user_employee, [('body', 'ilike', 'Internal')]),
             (self.user_admin, []),
         ], [
+            # public: record with access
             msg_record_public,
+            # portal: mentionned + record with access, if published
             msgs[0] + msgs[3] + msg_record_portal + msg_record_public,
-            msgs[1:6] + msg_record_portal + msg_record_public,
-            msgs[1:6],
-            msgs[1:] + msg_record_admin + msg_record_portal + msg_record_public
+            # employee
+            msgs[1:6] + msg_record_portal + msg_record_portal_internal + msg_record_public + msg_record_public_internal,
+            msgs[1:6] + msg_record_portal_internal + msg_record_public_internal,
+            msgs[1:] + msg_record_admin + msg_record_portal + msg_record_portal_internal + msg_record_public + msg_record_public_internal,
         ]):
             with self.subTest(test_user=test_user.name, add_domain=add_domain):
+                self.env.invalidate_all()
                 domain = [('subject', 'like', '_ZTest')] + add_domain
                 self.assertEqual(self.env['mail.message'].with_user(test_user).search(domain), exp_messages)
 

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -312,10 +312,10 @@ class TestMailMessageAccess(MessageAccessCommon):
             }, False, 'No access on record but reply to notified parent'),
             # internal = forbidden (internal users only)
             (self.record_portal, {'is_internal': True}, True, 'Internal subtype always forbidden'),
-            (self.record_portal, {'is_internal': True, 'message_type': 'notification'}, False, 'Automatic log accepted'),
+            (self.record_portal, {'is_internal': True, 'message_type': 'notification'}, True, 'Automatic log not accepted'),
             (self.record_portal, {'subtype_id': self.env.ref('mail.mt_note').id}, True, 'Internal flag always forbidden'),
             (self.record_portal, {'subtype_id': self.test_subtype_access_internal.id}, True, 'Internal flag (custom subtype) always forbidden'),
-            (self.record_portal, {'message_type': 'notification', 'subtype_id': self.test_subtype_access_internal.id}, False, 'Automatic log accepted'),
+            (self.record_portal, {'message_type': 'notification', 'subtype_id': self.test_subtype_access_internal.id}, True, 'Automatic log not accepted'),
             (self.record_portal, {'subtype_id': False}, True, 'No subtype = internal = always forbidden'),
         ]:
             with self.subTest(record=record, msg_vals=msg_vals, reason=reason):
@@ -538,14 +538,14 @@ class TestMailMessageAccess(MessageAccessCommon):
             (self.record_portal.message_ids[0], {
                 'message_type': 'email_outgoing',
                 'subtype_id': self.env.ref('mail.mt_note').id,
-            }, False, 'Note (email_outgoing) can be read by portal users'),
+            }, True, 'Note (email_outgoing) cannot be read by portal users'),
             (self.record_portal.message_ids[0], {
                 'is_internal': True,
             }, True, 'Internal message (comment) cannot be read by portal users'),
             (self.record_portal.message_ids[0], {
                 'is_internal': True,
                 'message_type': 'notification',
-            }, False, 'Internal message (notification) can be read by portal users'),
+            }, True, 'Internal message (notification) cannot be read by portal users'),
             (self.record_portal.message_ids[0], {
                 'message_type': 'user_notification',
             }, True, 'User notifications for other people can never be read by portal users'),

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -7,10 +7,10 @@ from odoo.addons.test_mail.models.mail_test_access import MailTestAccess
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.exceptions import AccessError
 from odoo.tools import mute_logger
-from odoo.tests import tagged
+from odoo.tests import HttpCase, tagged
 
 
-class MessageAccessCommon(MailCommon):
+class MessageAccessCommon(MailCommon, HttpCase):
 
     @classmethod
     def setUpClass(cls):
@@ -217,6 +217,7 @@ class TestMailMessageAccess(MessageAccessCommon):
         for user in self.user_employee + self.user_portal:
             with self.subTest(user_name=user.name):
                 _message = record.with_user(user).message_post(
+                    # attachments=[('Attachment', b'My attachment')],  # TDE FIXME: incoherency between message and attachment check
                     body='A message',
                     subtype_id=self.env.ref('mail.mt_comment').id,
                 )
@@ -240,9 +241,23 @@ class TestMailMessageAccess(MessageAccessCommon):
                     record.with_user(user).write({'name': 'Can Update'})
                 # can post
                 _message = record.with_user(user).message_post(
+                    # attachments=[('Attachment', b'My attachment')],  # TDE FIXME: incoherency between message and attachment check
                     body='Another portal message',
                     subtype_id=self.env.ref('mail.mt_comment').id,
                 )
+                # controller check
+                self.authenticate(user.login, user.login)
+                res = self.make_jsonrpc_request(
+                    route="/mail/message/post",
+                    params={
+                        'thread_model': record._name,
+                        'thread_id': record.id,
+                        'post_data': {
+                            'body': "Test",
+                        },
+                    },
+                )
+                self.assertEqual(len(res['store_data']['mail.message']), 1)
 
     def test_access_create_mail_post_access(self):
         """ Test 'mail_post_access' support that allows creating a message with

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -8,11 +8,12 @@ from unittest.mock import patch
 from werkzeug.urls import url_parse
 
 from odoo.addons.mail.models.mail_message import MailMessage
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.addons.test_mail.models.test_mail_corner_case_models import MailTestMultiCompanyWithActivity
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.exceptions import AccessError
 from odoo.tests import tagged, users, HttpCase
+from odoo.tests.common import JsonRpcException
 from odoo.tools import mute_logger
 
 
@@ -57,6 +58,15 @@ class TestMailMCCommon(MailCommon, TestRecipients):
             'author_id': cls.partner_1.id,
             'message_id': '<123456-openerp-%s-mail.test.gateway@%s>' % (cls.test_record.id, socket.gethostname()),
         })
+
+        cls._create_portal_user()
+        cls.user_portal_c2 = mail_new_test_user(
+            cls.env,
+            groups='base.group_portal',
+            login='portal_user_c2',
+            company_id=cls.company_2.id,
+            name="Portal User C2",
+        )
 
     def setUp(self):
         super().setUp()
@@ -260,7 +270,75 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
 
 
 @tagged('-at_install', 'post_install', 'multi_company', 'mail_controller')
-class TestMultiCompanyRedirect(MailCommon, HttpCase):
+class TestMultiCompanyControllers(TestMailMCCommon, HttpCase):
+
+    @mute_logger('odoo.http')
+    def test_mail_thread_data(self):
+        """ Test returned thread data, in MC environment, to test notably MC
+        access issues on partner, ACL support, ... """
+        customer_c3 = self.env["res.partner"].create({
+            "company_id": self.company_3.id,
+            "name": "C3 Customer",
+        })
+        record = self.env["mail.test.multi.company.read"].with_user(self.user_employee_c2).create({
+            "company_id": self.user_employee_c2.company_id.id,
+            "name": "Multi Company Record",
+        })
+        self.assertEqual(record.company_id, self.company_2)
+
+        record.message_subscribe(partner_ids=customer_c3.ids)
+        with self.assertRaises(AccessError):
+            customer_c3.with_user(self.user_employee_c2).check_access("read")
+
+        self.authenticate(self.user_employee_c2.login, self.user_employee_c2.login)
+        result = self.make_jsonrpc_request(
+            "/mail/data", {"fetch_params": [["mail.thread", {
+                "thread_id": record.id,
+                "thread_model": record._name,
+                "request_list": ["followers"],
+            }]]},
+        )
+        self.assertEqual(len(result["mail.followers"]), 2)
+        self.assertEqual(result["mail.followers"][1]["partner_id"], customer_c3.id)
+        self.assertEqual(result["mail.thread"][0]["followersCount"], 2)
+        self.assertTrue(result["mail.thread"][0]["hasWriteAccess"])
+        self.assertTrue(result["mail.thread"][0]["hasReadAccess"])
+        self.assertTrue(result["mail.thread"][0]["canPostOnReadonly"])
+
+        # check read / write / post access info
+        for test_user, (has_w, has_r, can_post) in zip(
+            (self.user_portal, self.user_portal_c2, self.user_employee, self.user_admin),
+            (
+                (False, True, True),  # currently not really supported actually, should go through portal controllers
+                (False, True, True),  # currently not really supported actually, should go through portal controllers
+                (False, True, True),
+                (True, True, True),
+            ),
+        ):
+            with self.subTest(user_name=test_user.name):
+                self.authenticate(test_user.login, test_user.login)
+                # crash if calling using portal users -> dedicated portal routes currently
+                if test_user in self.user_portal + self.user_portal_c2:
+                    with self.assertRaises(JsonRpcException):
+                        result = self.make_jsonrpc_request(
+                            "/mail/data", {"fetch_params": [["mail.thread", {
+                                "thread_id": record.id,
+                                "thread_model": record._name,
+                                "request_list": ["followers"],
+                            }]]},
+                        )
+                else:
+                    result = self.make_jsonrpc_request(
+                        "/mail/data", {"fetch_params": [["mail.thread", {
+                            "thread_id": record.id,
+                            "thread_model": record._name,
+                            "request_list": ["followers"],
+                        }]]},
+                    )
+                    self.assertEqual(result["mail.thread"][0]["followersCount"], 2)
+                    self.assertEqual(result["mail.thread"][0]["hasWriteAccess"], has_w)
+                    self.assertEqual(result["mail.thread"][0]["hasReadAccess"], has_r)
+                    self.assertEqual(result["mail.thread"][0]["canPostOnReadonly"], can_post)
 
     def test_redirect_to_records(self):
         """ Test mail/view redirection in MC environment, notably cids being
@@ -381,33 +459,3 @@ class TestMultiCompanyRedirect(MailCommon, HttpCase):
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertNotIn('cids', response.request._cookies)
-
-
-@tagged("-at_install", "post_install", "multi_company", "mail_controller")
-class TestMultiCompanyThreadData(MailCommon, HttpCase):
-
-    def test_mail_thread_data_follower(self):
-        partner_portal = self.env["res.partner"].create(
-            {"company_id": self.company_3.id, "name": "portal partner"}
-        )
-        record = self.env["mail.test.multi.company"].create({"name": "Multi Company Record"})
-        record.message_subscribe(partner_ids=partner_portal.ids)
-        self.assertFalse(partner_portal.with_user(self.user_employee_c2).has_access("read"))
-        self.authenticate(self.user_employee_c2.login, self.user_employee_c2.login)
-        data = self.make_jsonrpc_request(
-            "/mail/data",
-            {
-                "fetch_params": [
-                    [
-                        "mail.thread",
-                        {
-                            "thread_id": record.id,
-                            "thread_model": "mail.test.multi.company",
-                            "request_list": ["followers"],
-                        },
-                    ]
-                ]
-            },
-        )
-        self.assertEqual(len(data["mail.followers"]), 1)
-        self.assertEqual(data["mail.followers"][0]["partner_id"], partner_portal.id)

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -612,6 +612,13 @@ class SlideChannel(models.Model):
     def _mail_get_partner_fields(self, introspect_fields=False):
         return []
 
+    def _mail_get_operation_for_mail_message_operation(self, message_operation):
+        # posting messages on channels user is a member requires only read access
+        is_member = self.filtered('is_member') if message_operation == "create" else self.browse()
+        result = super(SlideChannel, self - is_member)._mail_get_operation_for_mail_message_operation(message_operation)
+        result.update(dict.fromkeys(is_member, 'read'))
+        return result
+
     # ---------------------------------------------------------
     # Business / Actions
     # ---------------------------------------------------------


### PR DESCRIPTION
Message access is notably based on related document, given their
(model, res_id) pair. Model may customize the required access on
it in order to access their message. For example, you generally
need write access to create a message (post) but on some models
you can post when you can read. Calendar events message access depends
on calendar privacy settings.

This is controlled via '_get_mail_message_access'. However currently
it is "globally called", for all documents. It should be done on a
per-document basis, as each document could define different access
check.

Keep code somewhat optimized by doing access checks in batch for a
given operation.

Make _search and read symmetric. Reading documents should be allowed
on search results, and search results should match what is available
for reading.

Portal users have some specific domains applied when accessing
messages, see notably odoo/odoo@9cd9aaaa174ae1f2a0af12143a34eb4682ea6f59 (but also check for
'website_message_ids' domain, mail controllers, ...). However there
are still some cases where search and read are not coherent with
portal users. This is not really annoying as most messages are accessed
using sudo and correctly tailored domains via controllers but let
us try to have a more correct code.

Fix discuss display of chatter-related buttons
* not taking into account '_get_mail_message_access' to check if
  user has right to post (generally used to indicate users can
  post on readonly records, but not limited to that);
* not adding the same check on Activities button as on Send message
  and Log note. We consider generally that rights should be aligned
  and UX should match that behavior;
* not adding the same check on attachments buttons, currently limited
  to write access (or always accessible). This is a preliminary work
  for attachments, further fixes are probably incoming;

Mainly a backport of master improvement done at https://github.com/odoo/odoo/pull/214705 .

Task-5138368
opw-4785878

Forward-Port-Of: odoo/odoo#244129
Forward-Port-Of: odoo/odoo#233725