### PR TITLE
[FIX] html_editor, website: close link popover on snippet remove

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -283,6 +283,7 @@ export class LinkPlugin extends Plugin {
         clean_for_save_handlers: ({ root }) => this.removeEmptyLinks(root),
         normalize_handlers: this.normalizeLink.bind(this),
         after_insert_handlers: this.handleAfterInsert.bind(this),
+        on_will_remove_handlers: () => this.closeLinkTools(),
 
         /** Overrides */
         split_element_block_overrides: this.handleSplitBlock.bind(this),

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -228,7 +228,7 @@ export class LinkPopover extends Component {
         useExternalListener(this.props.document, "pointerdown", onPointerDown);
         if (this.props.document !== document) {
             // Listen to pointerdown outside the iframe
-            useExternalListener(document, "pointerdown", onPointerDown, { capture: true });
+            useExternalListener(document, "pointerdown", onPointerDown);
         }
     }
 


### PR DESCRIPTION
Description of the issue this PR addresses:

- When removing a snippet, the link popover stayed open because its `pointerdown` handler didn’t trigger, leaving the popover visible even after its selected content element was removed.
- A previous fix used { capture: true } on the document `pointerdown` listener, but this also triggered when interacting with the link type `dropdown` and color picker, closing the popover triggers `applyCallback` and causing nested links to be created.

After this commit:

- Close the link popover from `on_will_remove_handlers` before the target element is removed from the DOM.
- This ensures the popover closes when removing the snippet.

task-5359000

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
