### PR TITLE
[IMP] Preparation display: Merge same products in one orderline

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1934,8 +1934,17 @@ export class PosStore extends WithLazyGetterTrap {
             line.isCombo ||
             line.combo_parent_uuid ||
             this.models["product.product"].get(line.product_id).type == "combo";
-        const comboChanges = orderChange.new.filter(isPartOfCombo);
-        const normalChanges = orderChange.new.filter((line) => !isPartOfCombo(line));
+        const { comboChanges, normalChanges } = orderChange.new.reduce(
+            (acc, line) => {
+                if (isPartOfCombo(line)) {
+                    acc.comboChanges.push(line);
+                    return acc;
+                }
+                acc.normalChanges.push(line);
+                return acc;
+            },
+            { comboChanges: [], normalChanges: [] }
+        );
         normalChanges.sort((a, b) => {
             const sequenceA = a.pos_categ_sequence;
             const sequenceB = b.pos_categ_sequence;
@@ -2047,18 +2056,47 @@ export class PosStore extends WithLazyGetterTrap {
 
     async prepareReceiptGroupedData(data) {
         const dataChanges = data.changes?.data;
-        if (dataChanges && dataChanges.some((c) => c.group)) {
-            const groupedData = dataChanges.reduce((acc, c) => {
-                const { name = "", index = -1 } = c.group || {};
-                if (!acc[name]) {
-                    acc[name] = { name, index, data: [] };
+        if (dataChanges) {
+            if (dataChanges.some((c) => c.group)) {
+                const groupedData = dataChanges.reduce((acc, c) => {
+                    const { name = "", index = -1 } = c.group || {};
+                    if (!acc[name]) {
+                        acc[name] = { name, index, data: [] };
+                    }
+                    acc[name].data.push(c);
+                    return acc;
+                }, {});
+                data.changes.groupedData = Object.values(groupedData).sort(
+                    (a, b) => a.index - b.index
+                );
+                for (const group of data.changes.groupedData) {
+                    group.data = this.mergeComboOrderlines(group.data);
                 }
-                acc[name].data.push(c);
-                return acc;
-            }, {});
-            data.changes.groupedData = Object.values(groupedData).sort((a, b) => a.index - b.index);
+            } else {
+                data.changes.data = this.mergeComboOrderlines(dataChanges);
+            }
         }
         return data;
+    }
+
+    mergeComboOrderlines(dataChanges) {
+        const getExistingLineInCombo = (line, lines) =>
+            lines.find(
+                (l) =>
+                    l.combo_parent_uuid &&
+                    l.combo_parent_uuid == line.combo_parent_uuid &&
+                    l.product_id == line.product_id
+            );
+        const mergedChanges = [];
+        for (const change of dataChanges) {
+            const existingLine = getExistingLineInCombo(change, mergedChanges);
+            if (existingLine) {
+                existingLine.quantity += change.quantity;
+                continue;
+            }
+            mergedChanges.push(change);
+        }
+        return mergedChanges;
     }
 
     async printOrderChanges(data, printer) {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -744,6 +744,27 @@ registry.category("web_tour.tours").add("test_open_default_register_screen_confi
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_preparation_display_combo_merge_lines", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            checkPreparationTicketData([
+                { name: "Office Combo", qty: 1 },
+                { name: "Combo Product 2", qty: 2 },
+                { name: "Combo Product 4", qty: 1 },
+                { name: "Combo Product 6", qty: 1 },
+            ]),
+        ].flat(),
+});
+
 registry
     .category("web_tour.tours")
     .add(

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -677,6 +677,23 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_open_default_register_screen_config')
 
+    def test_preparation_display_combo_merge_lines(self):
+        setup_product_combo_items(self)
+        pos_printer = self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
+        self.pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set(pos_printer.ids)],
+        })
+        combo = self.env["product.combo"].search([("name", "=", "Desk Accessories Combo")], limit=1)
+        combo.write({"qty_max": 2})
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_preparation_display_combo_merge_lines')
+
     def test_fast_payment_validation_from_restaurant_product_screen_with_automatic_receipt_printing(self):
         self.env['pos.printer'].create({
                 'name': 'Printer',


### PR DESCRIPTION
When ordering a combo product, the POS will split the included products from the extra products in different orderlines. This is done because of the extra products have a different price/unit than the extra items.

But for the preparation display we don't care about different prices, so this PR will make the different orderlines of the same combo be merged in the preparation display if they target the same product.

Task-[5473387](https://www.odoo.com/odoo/project/1737/tasks/5473387) 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
