### PR TITLE
[FIX] hr_holidays: fix forecasted balance for hourly time off types

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -644,7 +644,7 @@ class HrLeaveAllocation(models.Model):
 
         fake_allocation = self.env['hr.leave.allocation'].with_context(default_date_from=accrual_date).new(origin=self)
         fake_allocation.sudo().with_context(default_date_from=accrual_date)._process_accrual_plans(accrual_date, log=False)
-        if self.holiday_status_id.request_unit in ['hour']:
+        if self.holiday_status_id.unit_of_measure in ['hour']:
             res = float_round(fake_allocation.number_of_hours_display - self.number_of_hours_display, precision_digits=2)
         else:
             res = round((fake_allocation.number_of_days - self.number_of_days), 2)

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -4,7 +4,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from psycopg2 import IntegrityError
 
-from odoo import Command
+from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import tagged, Form
 from odoo.exceptions import ValidationError
@@ -4528,3 +4528,64 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 allocation._update_accrual()
                 self.assert_remaining_leaves_equal(self.leave_type_day, remaining_leaves, self.employee_emp, test_date, digits=3)
                 self.assertAlmostEqual(allocation.expiring_carryover_days, expiring_days, 2, msg=f'Incorrect number of expiring days for {test_date}')
+
+    def test_get_future_leaves_on(self):
+        today = fields.Date.today()
+        future_date = today + relativedelta(months=1, day=15)
+
+        allocation_day = self.env['hr.leave.allocation'].create({
+            'name': 'Daily Accrual',
+            'holiday_status_id': self.leave_type_day.id,
+            'employee_id': self.employee_emp.id,
+            'allocation_type': 'accrual',
+            'accrual_plan_id': self.accrual_plan_start1.id,
+            'number_of_days': 1.0,
+            'date_from': today,
+        })
+
+        allocation_day._action_validate()
+
+        res_day = allocation_day._get_future_leaves_on(future_date)
+        self.assertEqual(res_day, 1.0, f"Expected 1.0 day increase, got {res_day}")
+
+        # Assuming an 8-hour workday, 2 days = 16.0 hours
+        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+            'name': '2 Days Every 1st of Month',
+            'accrued_gain_time': 'start',
+            'level_ids': [Command.create({
+                'added_value': 2,
+                'added_value_type': 'day',
+                'frequency': 'monthly',
+                'first_day': 1,
+                'action_with_unused_accruals': 'all',
+                'milestone_date': 'creation',
+            })]
+        })
+
+        start_date = date(2026, 1, 1)
+        future_date = date(2026, 2, 2)
+
+        leave_type_hour = self.env['hr.leave.type'].create({
+            'name': 'Hourly Leave Type',
+            'time_type': 'leave',
+            'requires_allocation': True,
+            'allocation_validation_type': 'hr',
+            'request_unit': 'day',
+            'unit_of_measure': 'hour',
+        })
+
+        allocation_hour = self.env['hr.leave.allocation'].create({
+            'name': 'Hourly Allocation with daily accrual',
+            'holiday_status_id': leave_type_hour.id,
+            'employee_id': self.employee_emp.id,
+            'allocation_type': 'accrual',
+            'accrual_plan_id': accrual_plan.id,
+            'number_of_hours_display': 0.0,
+            'date_from': start_date,
+        })
+        allocation_hour._action_validate()
+
+        # On Feb 1st, it should trigger the 16-hour (2 days) addition
+        res_hour = allocation_hour._get_future_leaves_on(future_date)
+
+        self.assertEqual(res_hour, 16.0, f"Expected 16.0 hours (2 days) increase, got {res_hour}")


### PR DESCRIPTION
Steps to Reproduce:
Create an accrual plan that accrues 2 days monthly, credited at the start of the month. Create a Time Off Type with the Unit of Measure set to Hours. Create an allocation request using the above Time Off Type and Accrual Plan. Open the Time Off dashboard:
a. The current available balance is displayed in hours and is correctly computed based on the employee’s working schedule. b. However, when checking the balance for a future date, the system incorrectly adds 2 hours instead of 16 hours (i.e., 2 days converted to hours based on the working schedule).

Bug cause:
The system incorrectly identified the unit of measure because it was still referencing the request_unit field, which defaults to 'day'. Following a recent refactor where request_unit was replaced by unit_of_measure to define Time Off Type units, this specific logic flow was left unupdated, causing it to be calculated in days instead of hours.

Solution:
Updated the future leaves calculation logic to use unit_of_measure instead of request_unit. This ensures that when a Time Off Type is configured in hours, accruals defined in days are correctly converted based on the employee's working schedule.

Task: 5498292

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
