### PR TITLE
[FIX] project_timesheet_holidays: Exclude archived employees from time-off 

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -68,9 +68,10 @@ class Holidays(models.Model):
         """
         vals_list = []
         leave_ids = []
-        calendar_leaves_data = self.env['resource.calendar.leaves']._read_group([('holiday_id', 'in', self.ids)], ['holiday_id'], ['id:array_agg'])
+        leaves_with_active_employee = self.filtered(lambda l: l.employee_id.active)
+        calendar_leaves_data = self.env['resource.calendar.leaves']._read_group([('holiday_id', 'in', leaves_with_active_employee.ids)], ['holiday_id'], ['id:array_agg'])
         mapped_calendar_leaves = {leave: calendar_leave_ids[0] for leave, calendar_leave_ids in calendar_leaves_data}
-        for leave in self:
+        for leave in leaves_with_active_employee:
             if leave.holiday_type != 'employee' or not leave.holiday_status_id.timesheet_generate:
                 continue
 

--- a/addons/project_timesheet_holidays/tests/test_employee.py
+++ b/addons/project_timesheet_holidays/tests/test_employee.py
@@ -120,3 +120,44 @@ class TestEmployee(TransactionCase):
         self.assertEqual(len(timesheet), 1, 'A timesheet should have been created for the global leave of the employee')
         self.assertEqual(str(timesheet.date), '2020-01-01', 'The timesheet should be created for the correct date')
         self.assertEqual(timesheet.unit_amount, 8, 'The timesheet should be created for the correct duration')
+
+    @freeze_time('2020-01-01')
+    def test_timesheet_inactive_employee(self):
+        """ Test if the timesheets representing the time off of this employee,
+            are correctly generated once the employee is set to inactive
+        """
+        employee = self.env['hr.employee'].create({
+            'name': 'Test Employee',
+            'resource_calendar_id': self.company.resource_calendar_id.id,
+            'company_id': self.company.id,
+        })
+        old_timesheet_count = len(self.env['account.analytic.line'].search([
+            ('employee_id', '=', employee.id)]))
+        generic_time_off_type = self.env['hr.leave.type'].create({
+            'name': 'Generic Time Off',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'both',
+            'company_id': self.company.id,
+        })
+        leave = self.env['hr.leave'].create({
+            'employee_id': employee.id,
+            'state': 'confirm',
+            'holiday_type': 'employee',
+            'holiday_status_id': generic_time_off_type.id,
+            'request_date_from': '2020-01-02 08:00:00',
+            'request_date_to': '2020-01-07 17:00:00',
+        })
+        leave.action_validate()
+        timesheets = self.env['account.analytic.line'].search([
+            ('employee_id', '=', employee.id)])
+        self.assertEqual(len(timesheets), old_timesheet_count + 4, "4 new Timesheets should be generated for timeoff that doesn't fall on a week-end")
+
+        employee.write({'active': False})  # Archiveing an employee will delete the timesheet related to its future holidays, this will change the number of timesheets
+        old_timesheet_count = len(self.env['account.analytic.line'].search([
+            ('employee_id', '=', employee.id)]))
+
+        leave._generate_timesheets()
+        self.assertTrue(timesheets, "Timesheet should not have been regenerated and therefore old timesheet shouldn't be deleted")
+        timesheets = self.env['account.analytic.line'].search([
+            ('employee_id', '=', employee.id)])
+        self.assertEqual(len(timesheets), old_timesheet_count, "New timesheets should not have been generated due to employee being inactive/archived")


### PR DESCRIPTION
[FIX] project_timesheet_holidays: Exclude archived employees from time-off 

# Description of the issue/feature this PR addresses:
## Steps to Reproduce:
1. Create a time off for Employee A (it should affect the timesheets).
2. Create a new public holiday (global time off) that overlaps with Employee A’s time off.
3. Archive Employee A.
4. Delete the public holiday created in step 2.
5. An error related to timesheet generation appears.

## Expected Behavior:
- The public holiday / global time off should be deleted without any error.

# Desired behavior after PR is merged:
## Fix (Implemented):
When regenerating timesheets due to changes in holidays or time off, leaves related to archived employees should not be taken into account. A check was added inside the `_generate_timesheets` function in `project_timesheet_holidays/models/hr_holidays.py` to exclude leaves belonging to archived employees.

## Alternative Fix (Not Implemented):
Instead of filtering out leaves linked to archived employees, we could delete those leaves when an employee is archived. However, this approach is not ideal, as archived employees may be reactivated later and would still need their previously requested time off to be preserved.

 ## Version:
 This bug appears in both version 17.0 and 19.0. I assumed that it also appears in 18.0  but didn't directly test

## Task:

[5474038](https://www.odoo.com/odoo/project/4105/tasks/5474038)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
