### PR TITLE
[FIX] mail: allow starring persistent messages without thread

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -433,7 +433,6 @@ export class Message extends Record {
         return Boolean(
             !this.is_transient &&
                 !this.isPending &&
-                this.thread &&
                 this.store.self.type === "partner" &&
                 this.store.self.isInternalUser &&
                 this.persistent

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1002,6 +1002,26 @@ test("toggle_star message", async () => {
     await contains(".o-mail-Message [title='Mark as Todo']" + " i.fa-star-o");
 });
 
+test("can star a persistent message without thread", async () => {
+    const pyEnv = await startServer();
+    const messageId = pyEnv["mail.message"].create({
+        body: "Test",
+        message_type: "user_notification",
+        needaction: true,
+    });
+    pyEnv["mail.notification"].create({
+        mail_message_id: messageId,
+        notification_status: "sent",
+        notification_type: "inbox",
+        res_partner_id: serverState.partnerId,
+    });
+    await start();
+    await openDiscuss();
+    await contains(".o-mail-Message:not([data-starred]):contains('Test')");
+    await click(".o-mail-Message:contains('Test') [title='Mark as Todo']");
+    await contains(".o-mail-Message[data-starred]:contains('Test')");
+});
+
 test("Name of message author is only displayed in chat window for partners others than the current user", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ channel_type: "channel" });


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Starring a message should depend on whether the message is persistent and 
whether the current user is allowed to star it, not on whether the message is 
attached to a thread.

**Current behavior before PR:**

Some persistent messages (such as user notifications) can be displayed in Inbox 
without an associated thread. In such cases, the star action was unavailable 
even though the message itself was valid and persistent.

**Desired behavior after PR is merged:**

This change removes the dependency on thread presence when determining 
whether a message can be starred. As a result, users can now star persistent messages 
without a thread, including Inbox notifications such as sign requests.

task-[5473438](https://www.odoo.com/odoo/project/1519/tasks/5473438)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
