### PR TITLE
[FIX] mail: fix traceback when opening chatter in documents

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -37,7 +37,10 @@ export class Attachment extends FileModelMixin(Record) {
             if (
                 this.isPdf &&
                 !this.has_thumbnail &&
-                (this.store.self.main_user_id?.share === false || this.ownership_token)
+                (this.ownership_token ||
+                    // If related to a record, must have write access to it
+                    ((!this.thread || this.thread.hasWriteAccess) &&
+                        this.store.self.main_user_id?.share === false))
             ) {
                 this.setPdfThumbnail();
             }


### PR DESCRIPTION
How to reproduce:
- Install documents
- Create a folder at the root (company) not shared to anyone (including internal user)
- Open that folder and ensure the chatter is closed
- Upload a document in it and share it with Marc Demo with view access
- Connect with Marc Demo, click on that shared document and open the chatter You get an error because the client try to update the thumbnail of the attachment for the chatter but the user has only view access to it.

The user doesn't have write access to the attachment because it is linked to a document with only read access. To solve the problem, we modify the check that trigger the thumbnail update to also check that the user has access to the related record.

Task-5360962