### PR TITLE
[FIX] web: onItemSelected

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -342,7 +342,8 @@ export class SelectMenu extends Component {
         } else if (!this.selectedChoice || this.selectedChoice.value !== value) {
             this.props.onSelect(value);
             if (this.inputRef.el) {
-                this.inputRef.el.value = this.state.choices.find((c) => c.value === value).label;
+                const label = this.state.choices.find((c) => c.value === value)?.label ?? "";
+                this.inputRef.el.value = label;
             }
         }
         this.state.searchValue = null;

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -145,6 +145,55 @@ test("Selecting a choice calls onSelect and the displayed value is updated", asy
     expect.verifySteps(["world"]);
 });
 
+test.tags("desktop");
+test.debug("Can be rendered 2", async () => {
+    class MyParent extends Component {
+        static props = ["*"];
+        static components = { SelectMenu };
+        static template = xml`
+            <SelectMenu
+                groups="state.groups"
+                choices="state.choices"
+                value="state.value"
+                onSelect.bind="onSelect"
+            />
+        `;
+        setup() {
+            this.state = useState({
+                value: "world",
+                choices: [{ label: "Hello", value: "hello" }],
+                groups: [
+                    {
+                        label: "Group A",
+                        choices: [{ label: "World", value: "world" }],
+                    },
+                ],
+            });
+        }
+
+        async onSelect(value) {
+            expect.step(value);
+            this.state.choices = [];
+            this.state.groups = [];
+            delete MyParent.state;
+        }
+    }
+    await mountSingleApp(MyParent);
+
+    expect(".o_select_menu").toHaveCount(1);
+    expect(".o_select_menu_toggler").toHaveCount(1);
+
+    await click(".o_select_menu_toggler");
+    await click(".o-dropdown-item");
+    // expect(".o_select_menu_menu").toHaveCount(0);
+    // expect(".o_select_menu_item").toHaveCount(0);
+    // await animationFrame();
+
+    // expect(".o_select_menu_menu").toHaveCount(1);
+    // expect(".o_select_menu_item").toHaveCount(2);
+    // expect(queryAllTexts(".o_select_menu_item")).toEqual(["Hello", "World"]);
+});
+
 test("Close dropdown on click outside", async () => {
     await mountSingleApp(Parent);
 


### PR DESCRIPTION
With this commit, we fix the scenario where onItemSelected can be called but state.choices can still be empty.

runbot-error-id~234527

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
