### PR TITLE
popup backdrop vs hide/show

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -159,7 +159,7 @@ import { toggleClass } from "@html_editor/utils/dom";
  *      reverse: boolean,
  *    },
  *    options: { forNewStep: boolean }
- *  ) => void)[]} attribute_change_processors
+ *  ) => string)[]} attribute_change_processors
  * @typedef {((step: HistoryStep) => HistoryStep)[]} history_step_processors
  * @typedef {((node: Node, childTreesToSerialize: Tree[]) => Tree[])[]} serializable_descendants_processors
  * @typedef {((node: Node, attributeName: string, attributeValue: string) => boolean)[]} set_attribute_overrides

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -59,7 +59,7 @@ import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
 /**
  * Clean up DOM before taking into account for next history step remaining in
  * edit mode
- * @typedef {((root: EditorContext["editable"] | HTMLElement, stepState: "original"|"undo"|"redo"|"restore") => void)[]} normalize_handlers
+ * @typedef {((root: EditorContext["editable"] | HTMLElement, stepType?: "original"|"undo"|"redo"|"restore") => void)[]} normalize_handlers
  */
 
 /**

--- a/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
+++ b/addons/website/static/src/builder/plugins/edit_interaction_plugin.js
@@ -5,7 +5,7 @@ import { registry } from "@web/core/registry";
 /**
  * @typedef { Object } EditInteractionShared
  * @property { EditInteractionPlugin['restartInteractions'] } restartInteractions
- * @property { EditInteractionPlugin['stopInteractions'] } stopInteractions
+ * @property { EditInteractionPlugin['stopInteraction'] } stopInteraction
  */
 
 /**

--- a/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
@@ -20,6 +20,21 @@ export class PopupVisibilityPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         on_restore_containers_handlers: this.hidePopupsWithoutTarget.bind(this),
         on_reveal_target_handlers: this.hidePopupsWithoutTarget.bind(this),
+        attribute_change_processors: ({ target, attributeName, value, oldValue }) => {
+            // On hide/show of the popup, the `style` attribute of the modal in
+            // the popup is changed. This also happens with the option
+            // "Backdrop" on the popup. When reverting/re-applying steps that
+            // are supposed to change the option, we do not want to also change
+            // whether the popup is hidden of not. Here, we keep the `display`
+            // property in the `style` attribute unchanged when the history
+            // revert/re-apply a step that modified it.
+            if (attributeName === "style" && target.matches(".s_popup > .modal")) {
+                const re = /display: .*?;/;
+                const oldDisplay = oldValue.match(re)?.[0] ?? "";
+                value = re.test(value) ? value.replace(re, oldDisplay) : value + oldDisplay;
+            }
+            return value;
+        },
     };
 
     setup() {

--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -44,6 +44,24 @@ describe("Popup options: empty page before edit", () => {
         expect(":iframe .s_popup .modal").toHaveClass("show");
         expect(":iframe .s_popup .modal").toHaveStyle({ display: "block" });
     });
+
+    test("dropping the popup snippet then previewing background colors keep it visible", async () => {
+        await insertCategorySnippet({ group: "content", snippet: "s_popup" });
+        expect(".o_add_snippet_dialog").toHaveCount(0);
+        expect(":iframe .s_popup .modal").toHaveStyle({ display: "block" });
+        await contains(":iframe .s_popup .modal").click();
+        await contains("[data-label=Backdrop] button.o_we_color_preview").click();
+        await contains("button.o_color_button[data-color='#FFFF00']").hover();
+        expect(":iframe .s_popup .modal").toHaveStyle({
+            display: "block",
+            "background-color": "rgb(255, 255, 0)",
+        });
+        await contains("button.o_color_button[data-color='#FF0000']").hover();
+        expect(":iframe .s_popup .modal").toHaveStyle({
+            display: "block",
+            "background-color": "rgb(255, 0, 0)",
+        });
+    });
 });
 describe("Popup options: popup in page before edit", () => {
     let builder;
@@ -142,6 +160,37 @@ describe("Popup options: popup in page before edit", () => {
         await expectToTriggerEvent(":iframe .s_popup .modal", "shown.bs.modal", () => undo(editor));
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
+    });
+
+    test("changing background color of s_popup, then closing it, then undo, then redo keep it visible", async () => {
+        const editor = builder.getEditor();
+        await expectToTriggerEvent(":iframe .s_popup .modal", "shown.bs.modal", () =>
+            contains(".o_we_invisible_entry .fa-eye-slash").click()
+        );
+        await waitFor(":iframe .s_popup .modal", { visible: true });
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
+        expect(":iframe .s_popup .modal").toBeVisible();
+        await contains(":iframe .s_popup .modal").click();
+        await contains("[data-label=Backdrop] button.o_we_color_preview").click();
+        await contains("button.o_color_button[data-color='#FF0000']").click();
+        expect(":iframe .s_popup .modal").toHaveStyle({
+            display: "block",
+            "background-color": "rgb(255, 0, 0)",
+        });
+        await expectToTriggerEvent(":iframe .s_popup .modal", "hidden.bs.modal", () =>
+            contains(":iframe .s_popup div.js_close_popup").click()
+        );
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
+        expect(":iframe .s_popup .modal").not.toBeVisible();
+        expect(editor.shared.history.canUndo()).toBe(true);
+        await expectToTriggerEvent(":iframe .s_popup .modal", "shown.bs.modal", () => undo(editor));
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
+        expect(":iframe .s_popup .modal").toBeVisible();
+        redo(editor);
+        expect(":iframe .s_popup .modal").toHaveStyle({
+            display: "block",
+            "background-color": "rgb(255, 0, 0)",
+        });
     });
 
     test("undoing something on a target outside s_popup closes it", async () => {


### PR DESCRIPTION
Steps to reproduce in 18.4:
- Add a popup on the page
- Click on the popup
- Change the backdrop color
- Hide the popup by clicking on its entry in "Invisible Elements"
- Undo
- Redo
- Bug: The popup disappears

Steps to reproduce in 19.0:
- Add a popup on the page
- Click on the popup
- Hover a color in the colorpicker of the backdrop option of the popup
- Stop hovering the color
- Bug: The popup disappears
