### PR TITLE
popup backdrop vs hide/show (class trick)

### DIFF
--- a/addons/website/static/src/builder/plugins/popup_visibility.edit.scss
+++ b/addons/website/static/src/builder/plugins/popup_visibility.edit.scss
@@ -1,0 +1,6 @@
+.o_force_show_popup_modal {
+    display: block !important;
+}
+.o_force_hide_popup_modal {
+    display: none !important;
+}


### PR DESCRIPTION
Steps to reproduce in 18.4:
- Add a popup on the page
- Click on the popup
- Change the backdrop color
- Hide the popup by clicking on its entry in "Invisible Elements"
- Undo
- Redo
- Bug: The popup disappears

Steps to reproduce in 19.0:
- Add a popup on the page
- Click on the popup
- Hover a color in the colorpicker of the backdrop option of the popup
- Stop hovering the color
- Bug: The popup disappears
