### PR TITLE
[FIX] mail: fix discuss typing test fails 'Demo is typing...' Found 0

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -100,13 +100,17 @@ export class ChannelMember extends Record {
                 this.isTyping = false;
             }
             if (this.isTyping) {
-                this.typingTimeoutId = browser.setTimeout(
-                    () => (this.isTyping = false),
-                    Store.OTHER_LONG_TYPING
-                );
+                this.registerTypingTimeout();
             }
         },
     });
+    /** To be patched in test, to detect when this timeout is registered. */
+    registerTypingTimeout() {
+        this.typingTimeoutId = browser.setTimeout(
+            () => (this.isTyping = false),
+            Store.OTHER_LONG_TYPING
+        );
+    }
     channelAsTyping = fields.One("discuss.channel", {
         compute() {
             return this.isTyping ? this.channel_id : undefined;


### PR DESCRIPTION
Backport of odoo/odoo#243138

Before this commit, the following discuss typing HOOT tests were failing non-deterministically:

```
[text composer] other member typing status "is typing" refreshes of assuming no longer typing
other member typing status "is typing" refreshes of assuming no longer typing
```

This happens because these tests advance time for 10 to 60 seconds to assert presence of "Demo is typing..." text. The text relies on 2 asynchonous pieces of code:

1. a bus notification that the server returns `is_typing_dt` when someone explicitly notifies start or stop typing
2. a client-side internal timeout `typingTimeoutId` for long typing of more than 60 seconds (it expects receiving a is_typing: true in the mean time if the member is still actually typing)

The test had no control over these 2 asynchronous pieces of code. This is a problem because HOOT tests show extreme condition where bus notifications come much later than RPC returns, and also simulation of passing of time with `advanceTime()` acts as a jump to the future and consumes all registered timeouts.

The bus notification problem can mistakenly have it consumed way later than a long typing with simulated advanced time of test. This commit fixes the issue by awaiting the notification `notify_typing`.

`advanceTime()` that jumps to future and consumes timeout can mistakenly register and consume timeouts in the wrong order. We can't know for sure when the timeout is consumed so we cannot reliably provide a specific value to `advanceTime()`. This commit fixes it by patching a dedicated function that registers the timeout, so that the test can patch and asynchronously step when the long typing timeout is registered, also ensuring proper awaiting to simulate advance of time in a reliable way.

This commit also fixes an issue with recent PR [1] were `Demo is typing... { count: 0 }` were mistakenly turned into `Demo is typing...`. Diff in PR was big so some mistakes were expected!

Fixes runbot-error-237516

[1]: https://github.com/odoo/odoo/pull/238887
