### PR TITLE
[IMP] l10n_ro: rename report name Tax Report (RO) to VAT report D300

### DIFF
--- a/addons/l10n_ro/data/account_tax_report_data.xml
+++ b/addons/l10n_ro/data/account_tax_report_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo auto_sequence="1">
     <record id="tax_report" model="account.report">
-        <field name="name">Tax Report</field>
+        <field name="name">VAT report D300</field>
         <field name="name@ro">Raport fiscal</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
         <field name="country_id" ref="base.ro"/>

--- a/addons/l10n_ro/models/__init__.py
+++ b/addons/l10n_ro/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_report
 from . import template_ro
 from . import res_partner

--- a/addons/l10n_ro/models/account_report.py
+++ b/addons/l10n_ro/models/account_report.py
@@ -1,0 +1,15 @@
+from odoo import models, api
+
+
+class AccountReport(models.Model):
+    _inherit = 'account.report'
+
+    @api.depends('name', 'country_id')
+    def _compute_display_name(self):
+        """Override to prevent automatic (RO) suffix for Romanian VAT report D300"""
+        for report in self:
+            # Check if this is the Romanian VAT D300 report
+            if report.country_id.code == 'RO' and 'D300' in (report.name or ''):
+                report.display_name = report.name
+            else:
+                super(AccountReport, report)._compute_display_name()


### PR DESCRIPTION
Rename the report and the name of the tax return for Romania from Tax Report (RO) to VAT report D300.

ent PR: https://github.com/odoo/enterprise/pull/104906

task-5423935

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
