### PR TITLE
[FIX] sale_stock: handle non-picking reservations in forecasted view

### DIFF
--- a/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
+++ b/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
@@ -23,10 +23,10 @@
         </xpath>
         <xpath expr="//td[@name='usedby_cell']" position="inside">
             <span t-if="line.move_out and line.move_out.picking_id and line.move_out.picking_id.sale_id" t-out="' - ' + line.move_out.picking_id.sale_id.partner_id.display_name"/>
-            <t t-if="line.reservation and (line.document_out._name != 'stock.picking' or line.document_out.id != line.reservation.id)">
+            <t t-if="line.reservation and (line.document_out._name != line.reservation._name or line.document_out.id != line.reservation.id)">
                 <span t-out="' - '"/>
                 <a t-if="line.reservation" t-out="line.reservation.name" href="#" class="fw-bold"
-                    t-on-click.prevent="() => this.props.openView('stock.picking', 'form', line.reservation.id)"/>
+                    t-on-click.prevent="() => this.props.openView(line.reservation._name, 'form', line.reservation.id)"/>
             </t>
             <span t-if="line.document_out and line.is_matched and line.document_out._name === 'sale.order'" t-out="' (Your SO)'"/>
         </xpath>


### PR DESCRIPTION
**Issue:**
The forecasted inventory view assumed that line.reservation was always a `stock.picking`. In manufacturing flows, the reservation can be an `mrp.production`, which caused incorrect navigation to a `stock.picking` record.

Fix this by comparing both model and id when checking if the reservation differs from the outgoing document, and by opening the reservation using its actual model. This ensures the correct document is shown and avoids duplicate or invalid links in the "Used by" column.

**Steps to reproduce:**
- Create a v19 db with sale,mrp,sale_stock with `--demo-true`.
- Go to products -> search for 'FURN_0269' product and open form view.
- open forecasted smart button for forecasted reeport.
- check the used by column for mrp reservation
   - i.e,: `WH/MO/00001 - WH/MO/00001` appears twice.
   - clicking on first, opens correct record of `mrp.production` where the units is reserved.
   - clicking on the second, navigate to false record of `stock.picking` by taking the id of `mrp.produciton` as the reserve is having `_name: "mrp.production"`

**Screenshots from UI:**
- Product page:

<img width="1253" height="572" alt="stock_1" src="https://github.com/user-attachments/assets/13cd7f0a-34b0-48ea-a8d5-5337cbf9f5a5" />

- Forecasted report for that product:

<img width="1908" height="994" alt="stock_2" src="https://github.com/user-attachments/assets/ce0af8a3-9f37-469c-8119-36b6e7be9c4a" />

- Clicking on First `WH/MO/00001` button:

<img width="1265" height="568" alt="stock_3" src="https://github.com/user-attachments/assets/a8cb8a08-5c24-45f7-ad2e-5e3987f9ee70" />

- Clicking on second `WH/MO/00001` button, navigating to incorrect `stock.picking` by taking id of `mrp.production` even though there is no picking avaiable:

<img width="1264" height="519" alt="stock_4" src="https://github.com/user-attachments/assets/3a2d1613-ccbb-4994-898c-c885690c507e" />


**Final view Before and After the Fix:**
- For final view, In order to check the reservation done by `stock.picking`, I have created a `sale.order` having delivery for the same product to showcase both of them are working.

- **Before Fix:**
<img width="1907" height="994" alt="stock_5" src="https://github.com/user-attachments/assets/4441910e-348b-4270-ab1b-db903b334c97" />

- **After Fix:**
<img width="1905" height="940" alt="stock_66" src="https://github.com/user-attachments/assets/ba288e6b-b2c9-47ed-b752-233ff876fb55" />


opw-[5481220](https://www.odoo.com/odoo/70/tasks/5481220?debug=1)
upg-[3804157](https://upgrade.odoo.com/odoo/upgrade.request/3804157?debug=1)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
