### PR TITLE
[FIX] l10n_sa_edi_pos: skip forced zatca invoice for settlement due on new flow

### DIFF
--- a/addons/l10n_sa_edi_pos/models/__init__.py
+++ b/addons/l10n_sa_edi_pos/models/__init__.py
@@ -2,3 +2,5 @@ from . import pos_config
 from . import account_edi_xml_ubl_21_zatca
 from . import account_move
 from . import pos_order
+from . import account_edi_format
+from . import account_move_send

--- a/addons/l10n_sa_edi_pos/models/account_edi_format.py
+++ b/addons/l10n_sa_edi_pos/models/account_edi_format.py
@@ -1,0 +1,29 @@
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountEdiFormat(models.Model):
+    _inherit = 'account.edi.format'
+
+    @api.model
+    def is_settlement_order(self, invoice):
+        """
+            Check if the invoice is linked to a POS settlement order
+            Only available when pos_settle_due module is installed
+        """
+        if not self.env['pos.order.line']._fields.get('settled_order_id'):
+            return False
+        return bool(invoice.pos_order_ids.lines.filtered('settled_order_id'))
+
+    def _get_move_applicability(self, move):
+        # EXTENDS account_edi
+        self.ensure_one()
+        if self.code != 'sa_zatca' or move.country_code != 'SA' or move.move_type not in ('out_invoice', 'out_refund'):
+            return super()._get_move_applicability(move)
+
+        if self.is_settlement_order(move):
+            return {}
+        return super()._get_move_applicability(move)

--- a/addons/l10n_sa_edi_pos/models/account_move_send.py
+++ b/addons/l10n_sa_edi_pos/models/account_move_send.py
@@ -1,0 +1,18 @@
+from odoo import api, models
+
+
+class AccountMoveSend(models.AbstractModel):
+    _inherit = 'account.move.send'
+
+    @api.model
+    def _move_has_pos_settlement(self, move):
+        return bool(move.pos_order_ids.lines.settled_order_id)
+
+    @api.model
+    def _is_sa_edi_applicable(self, move):
+        res = super()._is_sa_edi_applicable(move)
+        if not self.env['pos.order.line']._fields.get('settled_order_id'):
+            return res
+
+        # Currently we are blocking settle due and new purchase on the same order from the UI
+        return bool(move.pos_order_ids.lines.settled_order_id) and res

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -1,5 +1,5 @@
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { markup } from "@odoo/owl";
@@ -36,5 +36,18 @@ patch(PaymentScreen.prototype, {
                 body: message,
             });
         }
+    },
+
+    async validateOrder(isForceValidate) {
+        const order = this.currentOrder;
+        // the isSettleDueLine() is only available if enterprise:pos_settle_due module is installed
+        const settleLineCount = order.lines.filter((line) => line.isSettleDueLine?.()).length;
+        if (settleLineCount && settleLineCount !== order.lines.length) {
+            return this.dialog.add(AlertDialog, {
+                title: _t("Settling Due Error"),
+                body: _t("Settle due payment and new products cannot be in the same order."),
+            });
+        }
+        await super.validateOrder(...arguments);
     },
 });

--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_order.js
@@ -19,6 +19,11 @@ patch(PosOrder.prototype, {
     isInvoiceMandatoryForSA() {
         // Zatca enforces invoice, but for settlement due, invoices are not needed
         // Only applicable if enterprise:pos_settle_due module is installed
+        const settleDueLines = this.lines.filter((line) => line.isSettleDueLine());
+        // is_settling_account here represents account deposit
+        if (settleDueLines.length || this.is_settling_account) {
+            return false;
+        }
         return this.isSACompany() && !this.is_settling_account;
     },
 

--- a/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
+++ b/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
@@ -5,7 +5,7 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_settlement", {
+registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_deposit", {
     steps: () =>
         [
             Chrome.startPoS(),
@@ -24,7 +24,7 @@ registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_settleme
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("ZATCA_invoice_mandatory_if_not_settlement", {
+registry.category("web_tour.tours").add("ZATCA_invoice_mandatory_if_regular_order", {
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
+++ b/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
@@ -1,11 +1,11 @@
 from unittest.mock import patch
 
+from odoo.tests import tagged
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.l10n_sa_edi.tests.common import AccountEdiTestCommon
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
-
-from odoo.tests import tagged
 
 
 @tagged('post_install', '-at_install', 'post_install_l10n')
@@ -44,27 +44,29 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     @patch('odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices',
            new=lambda self: True)
-    def test_ZATCA_invoice_not_mandatory_if_settlement(self):
+    def test_ZATCA_invoice_not_mandatory_if_deposit(self):
         """
-        Tests that the invoice is  not mandatory in POS payment for ZATCA if it's a settlement.
+        Tests that the invoice is  not mandatory in POS payment for ZATCA if it's a deposit.
         """
+
         self.test_partner = self.env["res.partner"].create({"name": "AAA Partner"})
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
-            'ZATCA_invoice_not_mandatory_if_settlement',
-            login="pos_admin",
+            'ZATCA_invoice_not_mandatory_if_deposit',
+            login="pos_admin"
         )
 
     @patch('odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices',
            new=lambda self: True)
-    def test_ZATCA_invoice_mandatory_if_not_settlement(self):
+    def test_ZATCA_invoice_mandatory_if_regular_order(self):
         """
         Tests that the invoice is mandatory in POS payment for ZATCA.
         Also is by default checked.
         """
+
         self.test_partner = self.env["res.partner"].create({"name": "AAA Partner"})
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
-            'ZATCA_invoice_mandatory_if_not_settlement',
+            'ZATCA_invoice_mandatory_if_regular_order',
             login="pos_admin",
         )


### PR DESCRIPTION
# Description of the issue/feature this PR addresses

In Point of Sale with ZATCA enabled (l10n_sa_edi_pos), invoicing is enforced on all orders.
In 18.0, settlement and deposit flows were both correctly excluded from mandatory ZATCA invoicing using the is_settling_account flag.

From saas-18.2, the Settle Due flow was refactored to include a dedicated settlement product line. 
As a result, is_settling_account now only covers account deposit flows, and is no longer sufficient to identify Settle Due orders.

# Current behavior before PR

With ZATCA enabled on saas-18.2:

- Account deposit flows are still correctly excluded from mandatory invoicing using is_settling_account.
- Settle Due orders are no longer detected by this flag and are treated as standard sales because they now contain order lines.
- This causes ZATCA invoice enforcement to be applied to Settle Due orders, even though the original invoice was already reported.
- Additionally, mixed orders combining settlement lines and new sale items would require partial ZATCA reporting, which is not supported.

# Desired behavior after PR is merged

After this fix:

- ZATCA invoice enforcement is skipped for account deposit flows using the existing is_settling_account flag.
- Even if invoice is checked, the invoice is not sent to ZATCA
- Settle Due orders are correctly identified using the isSettleDueLine() check on order lines and excluded from mandatory ZATCA invoicing.
- Mixed settlement and sale orders are explicitly blocked for ZATCA to avoid inconsistent or partial reporting.

This restores the intended settlement behavior from 18.0 while adapting it to the refactored Settle Due flow in saas-18.2.

task-5144679
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
