### PR TITLE
[FIX] website_sale_comparison: hide single custom value attribute

### DIFF
--- a/addons/website_sale_comparison/models/product_template_attribute_line.py
+++ b/addons/website_sale_comparison/models/product_template_attribute_line.py
@@ -26,3 +26,20 @@ class ProductTemplateAttributeLine(models.Model):
         for ptal in self:
             categories[ptal.attribute_id.category_id] |= ptal
         return categories
+
+    def _prepare_categories_for_display_in_specs_table(self):
+        """
+         Prepare attribute categories for display in a specs table.
+
+        Filters out attribute lines that have a single value and whose value is
+        marked as custom, then call _prepare_categories_for_display to group
+        the remaining attribute lines by category.
+
+        :return: OrderedDict [{
+        product.attribute.category: [product.template.attribute.line]
+        }]
+        """
+        filtered_self = self - self.filtered(
+            lambda ptal: len(ptal.value_ids) == 1 and ptal.value_ids.is_custom
+        )
+        return filtered_self._prepare_categories_for_display()

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -254,3 +254,50 @@ class TestWebsiteSaleComparisonUi(HttpCase):
                 ]))
             ])),
         ]))
+
+    def test_single_value_attribute_specifications(self):
+        """Test that attribute with single custom value shouldn't be displayed in specifications
+        or single value attributes.
+        The attribute with 'multi type single value' attribute should be displayed in specs table
+        but not in single value attributes."""
+        custom_attribute = self.env['product.attribute'].create([{
+            'name': 'Write here',
+            'value_ids': [
+                Command.create({
+                    'name': 'Custom',
+                    'is_custom': True,
+                }),
+            ],
+        }])
+        multi_attribute = self.env['product.attribute'].create([{
+            'name': 'multi',
+            'display_type': 'multi',
+            'create_variant': 'no_variant',
+            'value_ids': [
+                Command.create({
+                    'name': 'multi type single value',
+                }),
+            ],
+        }])
+        product = self.env['product.template'].create([{
+            'name': 'T-Shirt',
+            'is_published': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': custom_attribute.id,
+                    'value_ids': custom_attribute.value_ids,
+                }),
+                Command.create({
+                    'attribute_id': multi_attribute.id,
+                    'value_ids': multi_attribute.value_ids,
+                }),
+            ],
+        }])
+
+        self.assertFalse(product.attribute_line_ids._prepare_single_value_for_display())
+        single_value_including_multi_type = product.attribute_line_ids._prepare_single_value_including_multi_type_for_display()
+        self.assertIn(multi_attribute.attribute_line_ids, single_value_including_multi_type.values())
+
+        categories = product.attribute_line_ids._prepare_categories_for_display_in_specs_table()
+        self.assertNotIn(custom_attribute.attribute_line_ids, categories.values())
+        self.assertIn(multi_attribute.attribute_line_ids, categories.values())

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -39,7 +39,7 @@
     <template id="product_attributes_body" inherit_id="website_sale.product" name="Product attributes table">
         <xpath expr="//div[@id='product_attributes_simple']" position="replace"/>
         <xpath expr="//div[@id='product_full_description']" position="after">
-            <t t-set="attrib_categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
+            <t t-set="attrib_categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display_in_specs_table()"/>
             <t t-if="attrib_categories">
                 <section class="pt32 pb32" id="product_full_spec">
                     <div class="container">
@@ -89,7 +89,7 @@
         active="False"
     >
         <xpath expr="//div[@id='more_information_accordion_item']" position="before">
-            <t t-if="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()">
+            <t t-if="product.valid_product_template_attribute_line_ids._prepare_categories_for_display_in_specs_table()">
                 <t t-foreach="attrib_categories" t-as="category">
                     <div class="accordion-item">
                         <div class="accordion-header my-0 h6">
@@ -152,7 +152,7 @@
             </tr>
             <t
                 t-set="single_value_attributes"
-                t-value="attrib_categories[category]._prepare_single_value_for_display()"
+                t-value="attrib_categories[category]._prepare_single_value_including_multi_type_for_display()"
             />
             <tr t-foreach="single_value_attributes" t-as="attribute">
                 <t


### PR DESCRIPTION
### Issue:
Due to this bug, an attribute with a single custom value will be shown in specifications and single value attributes.

#### Steps to reproduce:
1- Create a product. Add a `Free text` attribute.
2- Navigate to product page on the website.
3- From website editor, style tab, switch `specification` style.
4- With specification style set to `None`, you can see this attribute
   in single value attributes list.
5- With other 2 styles you can see this attributes in specifications.

Expected: In both steps 4 and 5, this attributes shouldn't be displayed there because it is already displayed in main attributes where you can set the value.

Initially fix was to filter `ProductTemplateAttributeLine` in `_prepare_single_value_for_display`, however it would cause
empty specification sections.

To avoid that we also need to filter out single custom value attributes in `_prepare_categories_for_display`.

opw-5484721
