### PR TITLE
[IMP] mail,calendar: add activities in attendee calendar

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -69,4 +69,4 @@ class MailActivity(models.Model):
 
     def _store_activity_fields(self, res: Store.FieldList):
         super()._store_activity_fields(res)
-        res.attr("calendar_event_id")
+        res.extend(["calendar_event_id", "res_name"])

--- a/addons/calendar/models/res_users_settings.py
+++ b/addons/calendar/models/res_users_settings.py
@@ -14,6 +14,7 @@ class ResUsersSettings(models.Model):
         'Calendar Default Privacy', default='public', required=True,
         store=True, readonly=False, help="Default privacy setting for whom the calendar events will be visible."
     )
+    calendar_show_activities = fields.Boolean(string='Show Activities in Calendar', default=True)
 
     @api.model
     def _get_fields_blacklist(self):

--- a/addons/calendar/static/src/core/web/activity_list_popover_item_patch.js
+++ b/addons/calendar/static/src/core/web/activity_list_popover_item_patch.js
@@ -6,6 +6,10 @@ patch(ActivityListPopoverItem.prototype, {
         return super.hasEditButton && !this.props.activity.calendar_event_id;
     },
 
+    get hasRescheduleMeetingButton() {
+        return this.props.activity.calendar_event_id;
+    },
+
     async onClickReschedule() {
         await this.props.activity.rescheduleMeeting();
     },

--- a/addons/calendar/static/src/core/web/activity_list_popover_item_patch.xml
+++ b/addons/calendar/static/src/core/web/activity_list_popover_item_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ActivityListPopoverItem" t-inherit-mode="extension">
         <xpath expr="//button[hasclass('o-mail-ActivityListPopoverItem-editbtn')]" position="after">
-            <button t-if="this.props.activity.calendar_event_id" class="o-mail-ActivityListPopoverItem-editbtn btn btn-sm btn-success btn-link" t-on-click="this.onClickReschedule">
+            <button t-if="this.hasRescheduleMeetingButton" class="o-mail-ActivityListPopoverItem-editbtn btn btn-sm btn-success btn-link" t-on-click="this.onClickReschedule">
                 <i class="fa fa-calendar"/>
             </button>
         </xpath>

--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -25,6 +25,25 @@
     }
 }
 
+.o_cw_activity_popover {
+    div:first-child {
+        // Remove popover focus outline.
+        // NB: On open, popover auto-focus the first tabable element (cf useActiveElement hook).
+        //     tabindex="0" has been added to the first div wrapper to make it the first tabable element.
+        //     This prevents having, on popover open, a weird auto-focus style on the first button/link.
+        outline: none;
+    }
+    .o-mail-ActivityListPopoverItem > :first-child .btn-link {
+        // Adjust spacings to prevent buttons box-shadow from overflowing the item container
+        width: 23px;
+        margin: map-get($spacers, 1);
+        padding-right: map-get($spacers, 1);
+        padding-left: map-get($spacers, 1);
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}
+
 .o_field_many2manyattendeeexpandable .o_field_tags {
     flex-direction: column;
 
@@ -76,6 +95,18 @@
     &.o_attendee_status_declined, &.o_event_striked {
         .fc-event-main {
             text-decoration: line-through;
+        }
+    }
+
+    &.o_activity_event {
+        // For the user activity events, use the user color with
+        // a slight change so that activities can be spotted
+        // more easily in the calendar view.
+        @for $i from 1 through length($o-colors-complete) {
+            $color: nth($o-colors-complete, $i);
+            &.o_calendar_color_#{$i - 1} {
+                --fc-event-bg-color: #{mix($o-white, $color, 80%)};
+            }
         }
     }
 }

--- a/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_common_renderer.js
+++ b/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_common_renderer.js
@@ -1,0 +1,134 @@
+import { AttendeeCalendarActivityListPopover } from "@calendar/views/attendee_calendar/activity/attendee_calendar_activity_list_popover";
+import { AttendeeCalendarCommonRenderer } from "@calendar/views/attendee_calendar/common/attendee_calendar_common_renderer";
+import { patch } from "@web/core/utils/patch";
+import { renderToFragment } from "@web/core/utils/render";
+import { useCalendarPopover } from "@web/views/calendar/hooks/calendar_popover_hook";
+import { useService } from "@web/core/utils/hooks";
+
+/**
+ * Render the pending user activities in the Attendee Calendar day, week and month views.
+ *
+ * Done using a patch to prevent loading this feature and its mail components/store service in POS
+ * (only POS module concerned/using the attendee calendar view : 'pos_appointment').
+ */
+patch(AttendeeCalendarCommonRenderer, {
+    activityTemplate: "calendar.AttendeeCalendarCommonRenderer.activity",
+});
+patch(AttendeeCalendarCommonRenderer.prototype, {
+    /**
+     * @override
+     */
+    setup() {
+        super.setup(...arguments);
+        this.notification = useService("notification");
+        this.orm = useService("orm");
+        this.activityListPopover = useCalendarPopover(AttendeeCalendarActivityListPopover);
+    },
+
+    /**
+     * @override
+     * Make sure the activities are set before any other event.
+     */
+    get options() {
+        const defaultEventOrder = "start,-duration,allDay,title"; // (cf full calendar library BASE_OPTION_DEFAULTS)
+        return {
+            ...super.options,
+            eventOrder: "isActivity," + defaultEventOrder,
+        };
+    },
+
+    /**
+     * @override
+     */
+    eventClassNames({ el, event }) {
+        if (!event.extendedProps?.isActivity) {
+            return super.eventClassNames({ el, event });
+        }
+        const record = this.props.model.activities[event.id];
+        return [
+            "o_event",
+            "o_activity_event",
+            "o_event_allday",
+            ...(record ? [`o_calendar_color_${record.colorIndex}`] : []),
+        ];
+    },
+
+    /**
+     * @override
+     * Adding activity events to the displayed Full Calendar events.
+     */
+    mapRecordsToEvents() {
+        const events = super.mapRecordsToEvents();
+        if (!this.props.model.showActivities) {
+            return events;
+        }
+        const activityEvents = Object.values(this.props.model.activities).map((r) => {
+            const event = this.convertRecordToEvent(r);
+            return {
+                ...event,
+                editable: false, // (no drag & drop, no time extension, ...)
+                isActivity: true,
+            };
+        });
+        return events.concat(activityEvents);
+    },
+
+    /**
+     * @override
+     * Open activity list popover on event click.
+     */
+    onClick(info) {
+        const activityEvent = info.event.extendedProps?.isActivity
+            ? this.props.model.activities[info.event.id]
+            : false;
+        if (!activityEvent) {
+            return super.onClick(info);
+        }
+        this.activityListPopover.open(
+            info.el,
+            {
+                activityIds: activityEvent.rawRecord.map((a) => a.id),
+                model: this.props.model,
+                onActivityChanged: () => {
+                    this.props.model.load();
+                },
+                onViewMeeting: (eventId) => {
+                    const el = document.querySelector(`.fc-event[data-event-id="${eventId}"]`);
+                    const record = this.props.model.records[eventId];
+                    if (el && record) {
+                        this.activityListPopover.close();
+                        this.openPopover(el, record);
+                    }
+                },
+            },
+            `o_cw_popover o_cw_activity_popover card o_calendar_color_${activityEvent.colorIndex}`
+        );
+    },
+
+    /**
+     * @override
+     * Do not handle double clicks for activities.
+     */
+    onDblClick(info) {
+        if (!info.event.extendedProps?.isActivity) {
+            super.onDblClick(info);
+        }
+    },
+
+    /**
+     * @override
+     * Render activity events with a custom template.
+     */
+    onEventContent(arg) {
+        const { event } = arg;
+        if (!event.extendedProps?.isActivity) {
+            return super.onEventContent(arg);
+        }
+        const activityEvent = this.props.model.activities[event.id];
+        if (activityEvent) {
+            const fragment = renderToFragment(this.constructor.activityTemplate, activityEvent);
+            return { domNodes: fragment.children };
+        }
+        return true;
+    },
+});

--- a/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_common_renderer.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_common_renderer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="calendar.AttendeeCalendarCommonRenderer.activity">
+        <div class="d-flex flex-nowrap align-items-center">
+            <i class="fa fa-clock-o fs-6 me-1"/>
+            <span class="text-truncate" t-out="this.title" t-att-title="this.title"/>
+        </div>
+    </t>
+</templates>

--- a/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover.js
+++ b/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover.js
@@ -1,0 +1,72 @@
+import { AttendeeCalendarActivityListPopoverItem } from "@calendar/views/attendee_calendar/activity/attendee_calendar_activity_list_popover_item";
+import { Dialog } from "@web/core/dialog/dialog";
+import { useService } from "@web/core/utils/hooks";
+
+import { Component, onWillStart } from "@odoo/owl";
+
+/**
+ * @typedef {Object} Props
+ * @property {number[]} activityIds
+ * @property {Object} model
+ * @property {function} close
+ * @property {function} onActivityChanged
+ * @extends {Component<Props, Env>}
+ *
+ * Highly inspired from the "ActivityListPopover" mail component.
+ * Instead of managing the activities for a specific record (or specific selected records),
+ * this component "activityIds" props refers to the user pending activities for a specific date.
+ */
+export class AttendeeCalendarActivityListPopover extends Component {
+    static components = { Dialog, AttendeeCalendarActivityListPopoverItem };
+    static props = ["activityIds", "model", "close", "onActivityChanged", "onViewMeeting"];
+    static template = "calendar.AttendeeCalendarActivityListPopover";
+
+    setup() {
+        super.setup();
+        this.action = useService("action");
+        this.orm = useService("orm");
+        this.store = useService("mail.store");
+        this.limit = this.env.isSmall ? false : 5;
+
+        onWillStart(async () => {
+            const data = await this.orm.silent.call("mail.activity", "activity_format", [
+                this.props.activityIds,
+            ]);
+            this.store.insert(data);
+        });
+    }
+
+    /**
+     * Fetch the activities from the store.
+     * Each activity is an Activity js Record.
+     */
+    get activities() {
+        /** @type {import("models").Activity[]} */
+        return (this.limit ? this.props.activityIds.slice(0, this.limit) : this.props.activityIds)
+            .map((id) => this.store["mail.activity"].get(id))
+            .filter(Boolean); // Do not consider activities removed from the store
+    }
+
+    /**
+     * Open the mail.activity views with the current popover activities.
+     */
+    async onClickViewAll() {
+        const action = await this.action.loadAction("mail.mail_activity_action_my");
+        action.context = { force_search_count: 1 }; // remove default search
+        action.domain = [["id", "in", this.props.activityIds]];
+        this.props.close();
+        this.action.doAction(action);
+    }
+
+    /**
+     * When an activity is removed from the popover (marked done, rescheduled, on file uploaded),
+     * remove the activity id from the props to update the template and
+     * automatically close the popover when there's no activity left.
+     */
+    onRemoveActivityItem(activityId) {
+        this.props.activityIds = this.props.activityIds.filter((id) => id !== activityId);
+        if (!this.props.activityIds.length) {
+            this.props.close();
+        }
+    }
+}

--- a/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="calendar.AttendeeCalendarActivityListPopover">
+        <t t-if="env.isSmall">
+            <Dialog title.translate="Activities" withBodyPadding="false">
+                <t t-call="calendar.AttendeeCalendarActivityListPopover.popover"/>
+            </Dialog>
+        </t>
+        <t t-else="">
+            <t t-call="calendar.AttendeeCalendarActivityListPopover.popover"/>
+        </t>
+    </t>
+
+    <t t-name="calendar.AttendeeCalendarActivityListPopover.popover">
+        <!-- tabindex="0" needed to prevent having a weird auto-focus style
+            on the first button/link of the popover while still auto-focusing the popover. -->
+        <div tabindex="0" class="d-flex flex-column h-100">
+            <div class="overflow-y-auto d-flex flex-column flex-grow-1">
+                <AttendeeCalendarActivityListPopoverItem
+                    t-foreach="this.activities" t-as="activity" t-key="activity.id"
+                    activity="activity"
+                    onActivityChanged="this.props.onActivityChanged"
+                    onClickDoneAndScheduleNext="this.props.close"
+                    onClickEditActivityButton="this.props.close"
+                    onRemoveActivityItem.bind="this.onRemoveActivityItem"
+                    onViewMeeting.bind="this.props.onViewMeeting"/>
+            </div>
+            <button t-if="this.limit and this.props.activityIds.length > this.limit"
+                class="btn btn-secondary p-3 text-center text-primary border-top"
+                t-on-click="this.onClickViewAll">
+                ...and <t t-out="this.props.activityIds.length - this.limit"/> more
+            </button>
+        </div>
+    </t>
+</templates>

--- a/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover_item.js
+++ b/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover_item.js
@@ -1,0 +1,109 @@
+import { ActivityListPopoverItem } from "@mail/core/web/activity_list_popover_item";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { useService } from "@web/core/utils/hooks";
+
+const { DateTime } = luxon;
+
+export class AttendeeCalendarActivityListPopoverItem extends ActivityListPopoverItem {
+    static components = {
+        ...ActivityListPopoverItem.components,
+        Dropdown,
+        DropdownItem,
+    };
+    static template = "calendar.AttendeeCalendarActivityListPopoverItem";
+    static props = [...ActivityListPopoverItem.props, "onRemoveActivityItem", "onViewMeeting"];
+
+    setup() {
+        super.setup(...arguments);
+        this.action = useService("action");
+        this.orm = useService("orm");
+        const today = DateTime.now().startOf("day");
+        this.targetDays = {
+            today: {
+                day: today,
+                actionName: "action_reschedule_today",
+            },
+            tomorrow: {
+                day: today.plus({ days: 1 }),
+                actionName: "action_reschedule_tomorrow",
+            },
+            nextWeek: {
+                day: today.plus({ weeks: 1 }).startOf("week"),
+                actionName: "action_reschedule_nextweek",
+            },
+        };
+    }
+
+    get hasCancelButton() {
+        return false;
+    }
+
+    /**
+     * Remove the “Reschedule Meeting” button, as this component is already
+     * in the calendar view (no need for the action redirection) and provides its own
+     * “Reschedule Activity” dropdown which automatically updates the activity
+     * and its related meeting.
+     */
+    get hasRescheduleMeetingButton() {
+        return false;
+    }
+
+    get hasViewMeetingButton() {
+        return this.props.activity.calendar_event_id;
+    }
+
+    /**
+     * Remove the activity from the list when marking it as done.
+     */
+    onClickDone() {
+        this.props.activity.remove();
+        this.props.onRemoveActivityItem(this.props.activity.id);
+    }
+
+    /**
+     * Open the activity related record form view if user has access,
+     * else open the activity form view.
+     * In current window on click, in new window on middle click.
+     */
+    async onClickOpenRelatedRecord(ev, isMiddleClick) {
+        const action = await this.orm.call("mail.activity", "action_open_document", [
+            this.props.activity.id,
+        ]);
+        this.action.doAction(action, {
+            newWindow: isMiddleClick,
+        });
+    }
+
+    /**
+     * Remove the activity from the list when uploading a document
+     * (i.e. when an activity of type Document is marked as done).
+     */
+    async onFileUploaded(data) {
+        await super.onFileUploaded(data);
+        this.props.activity.remove();
+        this.props.onRemoveActivityItem(this.props.activity.id);
+    }
+
+    /**
+     * Reschedule the activity to a specific date.
+     * @param {Object} targetDay
+     */
+    onRescheduleActivity(targetDay) {
+        // Do nothing if rescheduled on same date.
+        if (targetDay.day.hasSame(this.props.activity.date_deadline, "day")) {
+            return;
+        }
+        this.action.doActionButton({
+            type: "object",
+            name: targetDay.actionName,
+            resModel: "mail.activity",
+            resId: this.props.activity.id,
+            onClose: () => {
+                this.props.activity.remove();
+                this.props.onRemoveActivityItem(this.props.activity.id);
+                this.props.onActivityChanged?.();
+            },
+        });
+    }
+}

--- a/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover_item.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_list_popover_item.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="calendar.AttendeeCalendarActivityListPopoverItem" t-inherit="mail.ActivityListPopoverItem" t-inherit-mode="primary">
+        <xpath expr="//span[hasclass('o-mail-ActivityListPopoverItem-name')]" position="replace">
+            <div class="d-flex flex-column text-truncate flex-grow-1 flex-basis-0">
+                <span class="o-mail-ActivityListPopoverItem-name d-flex flex-nowrap align-items-center">
+                    <i t-attf-class="fa {{this.props.activity.icon}} fa-fw lh-base me-1"/>
+                    <b t-if="this.props.activity.summary" class="fw-normal text-900 text-truncate" t-out="this.props.activity.summary"/>
+                    <b t-elif="this.props.activity.activity_type_id?.name" class="fw-normal text-900 text-truncate" t-out="this.props.activity.activity_type_id.name"/>
+                </span>
+                <span
+                    t-if="this.props.activity.res_name"
+                    class="text-action cursor-pointer text-truncate w-100 align-self-start small"
+                    t-custom-click.stop="(ev, isMiddleClick) => this.onClickOpenRelatedRecord(ev, isMiddleClick)"
+                    t-out="this.props.activity.res_name"/>
+            </div>
+            <Dropdown>
+                <button class="o-mail-ActivityListPopoverItem-reschedulebtn btn btn-sm btn-info btn-link" type="button" title="Reschedule" aria-label="Reschedule">
+                    <i class="fa fa-calendar o_button_icon"/>
+                </button>
+                <t t-set-slot="content">
+                    <DropdownItem onSelected="() => this.onRescheduleActivity(this.targetDays.today)">
+                        <div class="d-flex justify-content-between">
+                            <span>
+                                <i class="oi oi-schedule-today me-1"/> Today
+                            </span>
+                            <span t-out="this.targetDays.today.day.weekdayShort" class="ms-2 text-muted"/>
+                        </div>
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.onRescheduleActivity(this.targetDays.tomorrow)">
+                        <div class="d-flex justify-content-between">
+                            <span>
+                                <i class="oi oi-schedule-tomorrow me-1"/> Tomorrow
+                            </span>
+                            <span t-out="this.targetDays.tomorrow.day.weekdayShort" class="ms-2 text-muted"/>
+                        </div>
+                    </DropdownItem>
+                    <DropdownItem onSelected="() => this.onRescheduleActivity(this.targetDays.nextWeek)">
+                        <div class="d-flex justify-content-between">
+                            <span>
+                                <i class="oi oi-schedule-later me-1"/> Next Week
+                            </span>
+                            <span t-out="this.targetDays.nextWeek.day.weekdayShort" class="ms-2 text-muted"/>
+                        </div>
+                    </DropdownItem>
+                </t>
+            </Dropdown>
+        </xpath>
+        <xpath expr="//div[hasclass('o-mail-ActivityListPopoverItem-user')]" position="replace"/>
+        <xpath expr="//ActivityMarkAsDone" position="attributes">
+            <attribute name="onClickDone.bind">this.onClickDone</attribute>
+        </xpath>
+        <xpath expr="//button[hasclass('o-mail-ActivityListPopoverItem-editbtn')]" position="after">
+            <button t-if="this.hasViewMeetingButton"
+                title="View Meeting" aria-label="View Meeting"
+                class="o-mail-ActivityListPopoverItem-viewmeetingbtn btn btn-sm btn-success btn-link"
+                t-on-click="() => this.props.onViewMeeting(this.props.activity.calendar_event_id)">
+                <i class="fa fa-eye"/>
+            </button>
+        </xpath>
+    </t>
+</templates>

--- a/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/activity/attendee_calendar_activity_model.js
@@ -1,0 +1,117 @@
+import { AttendeeCalendarModel } from "@calendar/views/attendee_calendar/attendee_calendar_model";
+import { deserializeDate, serializeDate } from "@web/core/l10n/dates";
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+import { user } from "@web/core/user";
+
+/**
+ * Load the pending user activities in the Attendee Calendar model.
+ * Can be activated/deactivated using the "userActivitiesEnabled" getter.
+ *
+ * Done using a patch to prevent loading this feature and its mail components/store service in POS
+ * (only POS module concerned/using the attendee calendar view : 'pos_appointment').
+ */
+patch(AttendeeCalendarModel.prototype, {
+    /**
+     * User pending activities data.
+     */
+    get activities() {
+        return this.data.activities;
+    },
+
+    /**
+     * Whether or not to show the activities in the attendee calendar.
+     * User preference controlled using a filter in the calendar side bar.
+     */
+    get showActivities() {
+        return user.settings.calendar_show_activities;
+    },
+
+    /**
+     * Override to control whether or not the current user can see and manage
+     * their activities directly from the attendee calendar.
+     * Activate/Deactivate the feature.
+     **/
+    get userActivitiesEnabled() {
+        return true;
+    },
+
+    /**
+     * Initialize a Full Calendar library event with the activities for the day.
+     */
+    normalizeActivityEventRecord(day, activities) {
+        const event = {
+            id: `activity-event-${day.toISODate()}`,
+            colorIndex: user.partnerId || 0,
+            duration: 1,
+            start: day,
+            // "end" needed even for all day events to represent it on the calendar.
+            end: day.plus({ hours: 1 }),
+            isActivity: true,
+            isAllDay: true,
+            resModel: "mail.activity",
+            rawRecord: activities,
+        };
+        if (this.env.isSmall) {
+            event.title = activities.length;
+        } else if (activities.length > 1) {
+            event.title = _t("%s pending activities", activities.length);
+        } else {
+            event.title = activities[0].display_name;
+        }
+        return event;
+    },
+
+    /**
+     * Update the model activity data with the user pending activities.
+     */
+    async updateActivityData(data) {
+        if (!this.userActivitiesEnabled || !this.showActivities || this.meta.scale === "year") {
+            data.activities = {};
+            return;
+        }
+        // Retrieves user pending activities for the current calendar date range
+        // Done activities are archived and therefore excluded by default.
+        const activities = await this.orm.webSearchRead(
+            "mail.activity",
+            [
+                ["date_deadline", ">=", serializeDate(data.range.start)],
+                ["date_deadline", "<=", serializeDate(data.range.end)],
+                ["user_id", "=", user.userId],
+            ],
+            {
+                specification: {
+                    date_deadline: {},
+                    display_name: {},
+                },
+            }
+        );
+        if (!activities.length) {
+            data.activities = {};
+            return;
+        }
+        // Create activity events
+        const activitiesPerDueDate = activities.records.reduce((acc, activity) => {
+            const key = activity.date_deadline;
+            (acc[key] ||= []).push(activity);
+            return acc;
+        }, {});
+        const activityEvents = {};
+        for (const [date, activities] of Object.entries(activitiesPerDueDate)) {
+            const activityEvent = this.normalizeActivityEventRecord(
+                deserializeDate(date),
+                activities
+            );
+            activityEvents[activityEvent.id] = activityEvent;
+        }
+        data.activities = activityEvents;
+    },
+
+    /**
+     * @override
+     */
+    async updateData(data) {
+        await super.updateData(...arguments);
+        await this.updateActivityData(data);
+    },
+});

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.js
@@ -1,4 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
+import { AttendeeCalendarSidePanel } from "@calendar/views/attendee_calendar/side_panel/attendee_calendar_side_panel";
 import { CalendarController } from "@web/views/calendar/calendar_controller";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
@@ -8,6 +9,7 @@ export class AttendeeCalendarController extends CalendarController {
     static template = "calendar.AttendeeCalendarController";
     static components = {
         ...AttendeeCalendarController.components,
+        CalendarSidePanel: AttendeeCalendarSidePanel,
         QuickCreateFormView: CalendarQuickCreate,
     };
 

--- a/addons/calendar/static/src/views/attendee_calendar/side_panel/attendee_calendar_side_panel.js
+++ b/addons/calendar/static/src/views/attendee_calendar/side_panel/attendee_calendar_side_panel.js
@@ -1,0 +1,37 @@
+import { CalendarSidePanel } from "@web/views/calendar/calendar_side_panel/calendar_side_panel";
+import { _t } from "@web/core/l10n/translation";
+import { user } from "@web/core/user";
+
+/**
+ * Add the possibility to display/hide the user pending activities from the attendee calendar
+ * by adding a filter in the calendar side panel.
+ */
+export class AttendeeCalendarSidePanel extends CalendarSidePanel {
+    static components = {
+        ...CalendarSidePanel.components,
+    };
+    static template = "calendar.AttendeeCalendarSidePanel";
+
+    setup() {
+        super.setup();
+        this.state.activityFilterChecked = this.showActivities;
+    }
+
+    get activityFilterName() {
+        return _t("My Activities");
+    }
+
+    get showActivities() {
+        return this.props.model.showActivities;
+    }
+
+    get showActivityFilter() {
+        return this.props.model.userActivitiesEnabled && this.props.model.scale !== "year";
+    }
+
+    async onToggleActivityFilter() {
+        this.state.activityFilterChecked = !this.state.activityFilterChecked;
+        await user.setUserSettings("calendar_show_activities", this.state.activityFilterChecked);
+        await this.props.model.load();
+    }
+}

--- a/addons/calendar/static/src/views/attendee_calendar/side_panel/attendee_calendar_side_panel.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/side_panel/attendee_calendar_side_panel.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="calendar.AttendeeCalendarSidePanel" t-inherit="web.CalendarSidePanel" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_calendar_sidepanel_content')]" position="inside">
+            <div t-if="this.showActivityFilter" class="o-checkbox form-check position-relative w-100 mt-3">
+                <input
+                    id="show_activities_checkbox"
+                    type="checkbox"
+                    class="form-check-input"
+                    t-att-checked="this.state.activityFilterChecked"
+                    t-on-change="this.onToggleActivityFilter"
+                />
+                <span class="d-block fw-bolder text-truncate w-100 cursor-pointer"
+                    t-on-click.prevent.stop="this.onToggleActivityFilter"
+                    t-out="this.activityFilterName"/>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/calendar/static/tests/attendee_calendar_views.test.js
+++ b/addons/calendar/static/tests/attendee_calendar_views.test.js
@@ -1,5 +1,5 @@
 import { defineCalendarModels } from "@calendar/../tests/calendar_test_helpers";
-import { beforeEach, expect, test } from "@odoo/hoot";
+import { beforeEach, expect, queryAllTexts, test } from "@odoo/hoot";
 import { mockDate } from "@odoo/hoot-mock";
 import {
     contains,
@@ -17,6 +17,7 @@ import {
     findDateColumn,
     findTimeRow,
 } from "@web/../tests/views/calendar/calendar_test_helpers";
+import { user } from "@web/core/user";
 
 defineCalendarModels();
 preloadBundle("web.fullcalendar_lib");
@@ -63,6 +64,7 @@ async function selectTimeStart(startDateTime) {
 beforeEach(async () => {
     mockDate("2016-12-12 08:00:00", 0);
     const { env: pyEnv } = await makeMockServer();
+    user.updateUserSettings("calendar_show_activities", true); // init show activities in calendar setting
     const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
         { name: "Partner 1" },
         { name: "Partner 2" },
@@ -93,6 +95,58 @@ beforeEach(async () => {
             stop: "2016-12-12 14:55:05",
             attendee_ids: [serverData.attendeeIds[0], serverData.attendeeIds[1]],
             partner_ids: [serverState.partnerId, partnerId_1],
+        },
+    ]);
+    // Create activities on different models
+    pyEnv["mail.activity"].create([
+        {
+            can_write: true,
+            date_deadline: "2016-12-11 00:00:00",
+            state: "overdue",
+            summary: "Activity 1",
+            user_id: user.userId,
+        },
+        {
+            can_write: true,
+            date_deadline: "2016-12-12 10:55:05",
+            state: "today",
+            summary: "Activity 2",
+            user_id: user.userId,
+        },
+        {
+            // Should have a res record link
+            can_write: true,
+            date_deadline: "2016-12-12 10:55:05",
+            res_id: partnerId_2,
+            res_model: "res.partner",
+            res_name: "Partner 2",
+            state: "today",
+            summary: "Activity 3",
+            user_id: user.userId,
+        },
+        {
+            // User id is not the current user, shouldn't appear
+            can_write: true,
+            date_deadline: "2016-12-12 10:55:05",
+            state: "today",
+            summary: "Activity 4",
+            user_id: user.userId + 1,
+        },
+        {
+            can_write: true,
+            date_deadline: "2016-12-13 00:00:00",
+            state: "planned",
+            summary: "Activity 5",
+            user_id: user.userId,
+        },
+        {
+            // Activity done (automatically archived), shouldn't appear
+            active: false,
+            can_write: true,
+            date_deadline: "2016-12-13 00:00:00",
+            state: "done",
+            summary: "Activity 6",
+            user_id: user.userId,
         },
     ]);
 });
@@ -144,4 +198,78 @@ test("Default duration rendering", async () => {
     expect("div[name='stop'] div").toHaveText("Dec 15, 6:15 PM", {
         message: "The duration should be 3.25 hours",
     });
+});
+
+test.tags("desktop");
+test("Activity events rendering and popover", async () => {
+    const pyEnv = MockServer.current.env;
+    onRpc("mail.activity", "action_reschedule_tomorrow", () => {
+        expect.step("action_reschedule_tomorrow");
+    });
+    onRpc("res.partner", "get_attendee_detail", () => []);
+    onRpc("/calendar/check_credentials", () => ({}));
+    onRpc("res.users", "check_synchronization_status", () => ({}));
+    onRpc("set_res_users_settings", (args) => {
+        if ("calendar_show_activities" in args.kwargs.new_settings) {
+            if (args.kwargs.new_settings.calendar_show_activities) {
+                expect.step("calendar_show_activities");
+            } else {
+                expect.step("calendar_hide_activities");
+            }
+        }
+        return args.kwargs.new_settings;
+    });
+    onRpc("mail.activity", "web_search_read", () => {
+        expect.step("calendar_fetch_activities");
+    });
+    await mountView({ type: "calendar", resModel: "calendar.event", arch });
+    expect.verifySteps(["calendar_fetch_activities"]);
+
+    // Check activity events rendering (3 activity events: overdue, today and planned)
+    // Done activities and other users activities are not displayed.
+    expect(".fc-event.o_activity_event").toHaveCount(3);
+    expect("td[data-date='2016-12-11'] .o_activity_event:contains('Activity 1')").toHaveCount(1);
+    expect(
+        "td[data-date='2016-12-12'] .o_activity_event:contains('2 pending activities')"
+    ).toHaveCount(1);
+    expect("td[data-date='2016-12-13'] .o_activity_event:contains('Activity 5')").toHaveCount(1);
+    // Check activity calendar side panel filter
+    expect(".o_calendar_sidepanel input#show_activities_checkbox").toHaveProperty("checked", true);
+    await contains(".o_calendar_sidepanel input#show_activities_checkbox").click(); // Hide activities
+    expect.verifySteps(["calendar_hide_activities"]); // Does not fetch activities
+    expect(".fc-event.o_activity_event").toHaveCount(0);
+    await contains(".o_calendar_sidepanel input#show_activities_checkbox").click(); // Show activities
+    expect.verifySteps(["calendar_show_activities", "calendar_fetch_activities"]);
+    expect(".fc-event.o_activity_event").toHaveCount(3);
+    // Check activity popover rendering
+    await clickEvent("activity-event-2016-12-12");
+    expect(queryAllTexts(".o-mail-ActivityListPopoverItem-name")).toEqual([
+        "Activity 2",
+        "Activity 3",
+    ]);
+    const a2_selector = ".o-mail-ActivityListPopoverItem:contains(Activity 2) ";
+    const a3_selector = ".o-mail-ActivityListPopoverItem:contains(Activity 3) ";
+    expect(a2_selector + ".text-action").toHaveCount(0); // no res record link
+    expect(a3_selector + ".text-action").toHaveText("Partner 2"); // res record link
+    // Check activity popover done and reschedule actions
+    await contains(a2_selector + ".o-mail-ActivityListPopoverItem-markAsDone").click();
+    expect(a2_selector + ".o-mail-ActivityMarkAsDone").toHaveCount(1);
+    await contains(a2_selector + "button:text(Done)").click(); // Activity 2 marked done
+    expect(a2_selector).toHaveCount(0);
+    expect.verifySteps(["calendar_fetch_activities"]);
+    await contains(a3_selector + ".o-mail-ActivityListPopoverItem-reschedulebtn").click();
+    await contains(".o_popover .o-dropdown-item:contains(Tomorrow)").click(); // Activity 3 rescheduled
+    expect.verifySteps(["action_reschedule_tomorrow", "calendar_fetch_activities"]);
+    expect(a3_selector).toHaveCount(0);
+    // Check activity popover auto closing (no activity left for the day) and calendar view update
+    expect(".o_cw_activity_popover").toHaveCount(0);
+    expect(".fc-event.o_activity_event").toHaveCount(2);
+    // Check activity records have been updated
+    // Activity 2: Archived and set done
+    // Activity 3: Rescheduled
+    const a2 = pyEnv["mail.activity"].browse(2)[0];
+    expect(a2.active).toBe(false);
+    expect(a2.state).toBe("done");
+    const a3 = pyEnv["mail.activity"].browse(3)[0];
+    expect(a3.date_deadline).toBe("2016-12-13");
 });

--- a/addons/calendar/static/tests/mock_server/mock_models/mail_activity.js
+++ b/addons/calendar/static/tests/mock_server/mock_models/mail_activity.js
@@ -1,5 +1,6 @@
 import { mailModels, openView } from "@mail/../tests/mail_test_helpers";
 import { fields } from "@web/../tests/web_test_helpers";
+import { serializeDate, today } from "@web/core/l10n/dates";
 
 export class MailActivity extends mailModels.MailActivity {
     name = fields.Char();
@@ -18,6 +19,9 @@ export class MailActivity extends mailModels.MailActivity {
             target: "current",
         };
     }
+    action_reschedule_tomorrow(ids) {
+        this.write(ids, { date_deadline: serializeDate(today().plus({ days: 1 })) });
+    }
     unlink_w_meeting() {
         const eventIds = this.map((act) => act.calendar_event_id);
         const res = this.unlink(arguments[0]);
@@ -29,10 +33,15 @@ export class MailActivity extends mailModels.MailActivity {
     _to_store(store) {
         super._to_store(...arguments);
         for (const activity of this) {
-            if (activity.calendar_event_id) {
-                store._add_record_fields(this.browse(activity.id), {
-                    calendar_event_id: activity.calendar_event_id,
-                });
+            const fieldsToStore = ["calendar_event_id", "res_name"];
+            const storeData = fieldsToStore.reduce((acc, key) => {
+                if (key in activity) {
+                    acc[key] = activity[key];
+                }
+                return acc;
+            }, {});
+            if (Object.keys(storeData).length) {
+                store._add_record_fields(this.browse(activity.id), storeData);
             }
         }
     }

--- a/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -34,17 +34,6 @@ patch(AttendeeCalendarCommonRenderer.prototype, {
 		return {
             ...super.options,
 			businessHours: this.props.model.workingHours,
-            eventOrder: function(event1, event2){
-                if (event1.extendedProps.worklocation){
-                    return -1;
-                } else {
-                    if(event2.extendedProps.worklocation){
-                        return 1;
-                    } else {
-                        return event1.start < event2.start ? -1 : 1;
-                    }
-                }
-            },
             dayCellDidMount: this.onDayCellDidMount,
         };
 	},

--- a/addons/mail/static/src/core/web/activity_list_popover_item.xml
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.xml
@@ -3,12 +3,14 @@
     <t t-name="mail.ActivityListPopoverItem">
         <div class="o-mail-ActivityListPopoverItem d-flex flex-column border-bottom py-2">
             <div class="overflow-auto d-flex align-items-baseline ms-3 me-1">
-                <t t-if="this.props.activity.summary">
-                    <b class="text-900 me-2 text-truncate flex-grow-1 flex-basis-0" t-out="this.props.activity.summary"/>
-                </t>
-                <t t-if="!this.props.activity.summary and this.props.activity.activity_type_id">
-                    <b class="text-900 me-2 text-truncate flex-grow-1" t-out="this.props.activity.activity_type_id[1]"/>
-                </t>
+                <span class="o-mail-ActivityListPopoverItem-name flex-grow-1 flex-basis-0 text-truncate">
+                    <t t-if="this.props.activity.summary">
+                        <b class="text-900 me-2 text-truncate" t-out="this.props.activity.summary"/>
+                    </t>
+                    <t t-if="!this.props.activity.summary and this.props.activity.activity_type_id">
+                        <b class="text-900 me-2 text-truncate" t-out="this.props.activity.activity_type_id[1]"/>
+                    </t>
+                </span>
                 <t t-if="this.props.activity.can_write">
                     <FileUploader t-if="this.hasFileUploader" onUploaded.bind="this.onFileUploaded">
                         <t t-set-slot="toggler">
@@ -25,7 +27,7 @@
                     <i class="fa fa-pencil"/>
                 </button>
             </div>
-            <div class="d-flex align-items-center flex-wrap mx-3">
+            <div class="o-mail-ActivityListPopoverItem-user d-flex align-items-center flex-wrap mx-3">
                 <img class="me-2 rounded object-fit-cover" t-if="this.props.activity.user_id?.partner_id" t-att-src="this.props.activity.user_id.partner_id.avatarUrl" style="max-width: 1.5rem; max-height: 1.5rem;"/>
                 <div class="mt-1">
                     <small t-if="this.props.activity.user_id" class="text-truncate" t-out="this.props.activity.user_id.name"/>

--- a/addons/mail/static/src/core/web/activity_markasdone_popover.js
+++ b/addons/mail/static/src/core/web/activity_markasdone_popover.js
@@ -7,6 +7,7 @@ export class ActivityMarkAsDone extends Component {
         "activity",
         "close?",
         "hasHeader?",
+        "onClickDone?",
         "onClickDoneAndScheduleNext?",
         "onActivityChanged",
     ];
@@ -41,6 +42,9 @@ export class ActivityMarkAsDone extends Component {
         });
         this.state.disableDoneButton = true;
         try {
+            if (this.props.onClickDone) {
+                this.props.onClickDone();
+            }
             await this.props.activity.markAsDone();
             this.props.onActivityChanged(thread);
             await thread.fetchNewMessages();

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -464,6 +464,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "self_user": self.users[0].id,
                 "show_livechat_category": True,
                 "settings": {
+                    "calendar_show_activities": True,
                     "channel_notifications": False,
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,
                     "livechat_expertise_ids": [],

--- a/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
+++ b/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
@@ -55,7 +55,7 @@
 
     <t t-name="web.CalendarFilterSection.filter">
         <div
-            class="o_calendar_filter_item o-checkbox form-check position-relative w-100 cursor-pointer"
+            class="o_calendar_filter_item o-checkbox form-check position-relative w-100"
             t-att-class="this.getFilterColor(filter)"
             t-att-data-value="filter.value"
         >
@@ -69,7 +69,7 @@
                 t-on-change="(ev) => this.onFilterInputChange(filter, ev)"
             />
             <label
-                class="d-flex align-items-center gap-1"
+                class="d-flex align-items-center gap-1 cursor-pointer"
                 t-attf-for="o_calendar_filter_item_{{this.filterId}}"
             >
                 <t t-if="this.section.hasAvatar and filter.hasAvatar">


### PR DESCRIPTION
Purpose
=======
Make it easy for the users to quickly visualize and handle
their activities via their calendar.

Specification
=============
In day, week and month view, for each day where activities are
scheduled for the current user, an activity event is displayed
at the top of the all day events section.
Those activity events can be hidden from the calendar via a saved filter
in the calendar side panel.

Clicking on an activity event will display a popover (a dialog on mobile)
containing a list of the day activities with, for each one:
- quick action buttons (done, upload document, edit, reschedule, ...)
- a link to their related record. On click, it opens the record form view if the
current user has access to it, else opens the activity form view.

In desktop, when there's more than 5 activities for the day, to handle them in batch,
a button is added at the bottom of the list opening the activity views with the
current popover activities.

NB:
Removing the calendar eventOrder method used to order worklocation events as:
- worklocations are inserted into the dom as HTML instead of considered
as full calendar events. They're not impacted by the order method.
- worklocations are inserted into the day header, separately from other events,
making the purpose of the order method obsolete.

Also improving the cursor pointer positioning on the calendar side panel filters,
as hovering between the filter input and the filter label displays a cursor pointer
but clicking doesn't do anything.
Making sure the cursor pointer is only displayed where the click event is handled.

Task-5428944

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
