### PR TITLE
[FIX] mail: avoid access error when archiving channel as non admin

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -493,7 +493,8 @@ class DiscussChannel(models.Model):
             if channels_to_check := self.filtered(lambda channel: channel.active != vals["active"]):
                 if failing_channels := channels_to_check.filtered(
                     lambda channel: channel.channel_type in ["channel", "group"]
-                    and channel.self_member_id.channel_role != "owner"
+                    # sudo: discuss.channel.member - allow reading channel_role for access checks
+                    and channel.self_member_id.sudo().channel_role != "owner"
                     and not self.env.user.has_group("base.group_system")
                 ):
                     raise UserError(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -61,6 +61,12 @@ class TestChannelInternals(MailCommon, HttpCase):
             len(channels.filtered(lambda c: c.self_member_id.sudo().channel_role == "owner")), 3
         )
 
+    @users("employee")
+    def test_channel_archive_as_employee(self):
+        channel = self.env["discuss.channel"].create({"name": "Archive Access Test"})
+        channel.write({"active": False})
+        self.assertFalse(channel.active)
+
     @users('employee')
     @freeze_time("2020-03-22 10:42:06")
     def test_channel_members(self):


### PR DESCRIPTION
**Purpose of this PR:-**
 
Allow users to archive channels using `sudo` so the action is not blocked by missing discuss role access  error.

task-5478832

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
