### PR TITLE
[FIX] crm: prevent error when marking lead as won without a valid stage

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1248,7 +1248,7 @@ class CrmLead(models.Model):
         # use duration tracking field to determine if the task jumped from first to last stage
         # only takes into accounts stages on which the lead has spent at least a minute,
         # to only account for valid stage movements
-        elif len(stage_ids := [int(stage_id) for stage_id, duration in self.duration_tracking.items() if duration >= 60]) == 1:
+        elif len(stage_ids := [int(stage_id) for stage_id, duration in self.duration_tracking.items() if str(stage_id).isdigit() and duration >= 60]) == 1:
             first_stage = self.env['crm.stage'].search([
                 '|', ('team_ids', 'in', False), ('team_ids', 'in', self.team_id.id),
             ], order='sequence ASC', limit=1)


### PR DESCRIPTION
An error occurs when marking a lead as Won while it does not belong to any valid CRM stage.

**Steps to Reproduce:**
1. Install **CRM** module.
2. Create a new user.
3. Delete all the default crm stages.
4. Create a lead **older than 31 days** with no stage assigned (change system date if required).
5. Assign the new user as **Salesperson** and set **Expected Revenue = 0**.
6. Mark the lead as **Won**.

**Error:**
`ValueError - invalid literal for int() with base 10: 'false'`

**Cause:**
When a lead does not belong to a valid stage, the `stage_id` become False. When it tries to cast `stage_id` to an integer, an error will be raised.

**Fix:**
This commit ensures only valid numerical stage ids are processed.

sentry-7193424787