### PR TITLE
[FIX] web_editor: fix carousel snippet height in snippet modal

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2946,7 +2946,9 @@ we-select.o_grid we-toggler {
             [data-snippet="s_carousel_intro"],
             [data-snippet="s_quotes_carousel_minimal"],
             [data-snippet="s_quotes_carousel"] {
-                height: 550px;
+                .carousel-inner {
+                    height: fit-content;
+                }
             }
             [data-snippet="s_three_columns"] .figure-img[style*="height:50vh"] {
                 /* In Travel theme. */


### PR DESCRIPTION
Steps to reproduce:

- Drag and drop a Carousel.
- Add content to the first slide of the carousel to make the snippet taller.
- Save the snippet as a custom snippet.
- Open the snippet dialog.
- Issue: The height of the preview for the saved snippet is forced to 550px, causing the snippet to be truncated.

After this commit, the height is no longer forced; it now adapts to the snippet content.

task-5156137