### PR TITLE
[FIX] mail: do not show message actions on right-click on link

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -467,6 +467,13 @@ export class Message extends Component {
             // Mobile OS long press is handled with useLongPress()
             return;
         }
+        if (ev.target.tagName === "A") {
+            return;
+        }
+        this.showRightClickMessageActions(ev);
+    }
+
+    showRightClickMessageActions(ev) {
         const el = this.rightClickAnchor.el;
         el.style.left = ev.clientX + "px";
         el.style.top = ev.clientY + "px";

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -53,6 +53,7 @@ import {
 import { makeRecordFieldLocalId } from "@mail/model/misc";
 import { Settings } from "@mail/core/common/settings_model";
 import { toRawValue } from "@mail/utils/common/local_storage";
+import { Message } from "@mail/core/common/message";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -812,6 +813,16 @@ test("rendering of inbox message", async () => {
 test("Can right-click on message to opens message actions dropdown", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Refactoring" });
+    patchWithCleanup(Message.prototype, {
+        onContextMenu() {
+            expect.step("Message.onContextMenu");
+            super.onContextMenu(...arguments);
+        },
+        showRightClickMessageActions() {
+            expect.step("Message.showRightClickMessageActions");
+            super.showRightClickMessageActions(...arguments);
+        },
+    });
     const [messageId_1, messageId_2] = pyEnv["mail.message"].create([
         {
             body: "message-body-1",
@@ -820,7 +831,7 @@ test("Can right-click on message to opens message actions dropdown", async () =>
             res_id: partnerId,
         },
         {
-            body: "msg-body-2",
+            body: "msg-body-2 <a href='#'>Test link</a>",
             model: "res.partner",
             needaction: true,
             res_id: partnerId,
@@ -844,6 +855,8 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message", { count: 2 });
     await rightClick(".o-mail-Message:eq(0)");
+    await animationFrame();
+    await expect.waitForSteps(["Message.onContextMenu", "Message.showRightClickMessageActions"]);
     await contains(".o-dropdown-item", { count: 6 });
     await contains(".o-dropdown-item:contains('Add a Reaction')");
     await contains(".o-dropdown-item:contains('Add Star')");
@@ -853,6 +866,13 @@ test("Can right-click on message to opens message actions dropdown", async () =>
     await contains(".o-dropdown-item:contains('Copy Text')");
     await contains(".o-mail-Message:eq(0).o-selected");
     await contains(".o-mail-Message:eq(1):not(.o-selected)");
+    // Test inner-link in body of message doesn't trigger showing of message actions
+    await click(".o-mail-Thread");
+    await contains(".o-dropdown-item", { count: 0 });
+    await rightClick(".o-mail-Message-body:eq(1) a");
+    await expect.waitForSteps(["Message.onContextMenu"]);
+    await animationFrame();
+    expect.verifySteps([]);
 });
 
 test("Can add reaction from right-click on message", async () => {


### PR DESCRIPTION
Before this commit, when right-clicking on a link in a message body, this was showing the list of message actions in dropdown.

This is a problem because right-click on link has features like "Open link" / "Copy link" and so on. They were over-shadowed by the right-click on message for showing of message actions.

This commit prevent the showing of message actions in dropdown from right-click in links in message body, so that the browser context menu is open instead in that scenario, showing features like "Open link" and "Copy link".