### PR TITLE
[IMP] pos_self_order: sort products by sequence

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -23,7 +23,7 @@ class ProductTemplate(models.Model):
             domain,
             fields,
             limit=config.get_limited_product_count(),
-            order='sequence,default_code,name',
+            order='is_favorite DESC,pos_sequence,name',
             load=False
         )
 
@@ -32,7 +32,7 @@ class ProductTemplate(models.Model):
             [("id", 'in', combo_products.combo_ids.combo_item_ids.product_id.product_tmpl_id.ids), ("id", "not in", [p['id'] for p in products])],
             fields,
             limit=config.get_limited_product_count(),
-            order='sequence,default_code,name',
+            order='is_favorite DESC,pos_sequence,name',
             load=False
         )
         products.extend(combo_products_choice)

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -120,3 +120,16 @@ registry.category("web_tour.tours").add("kiosk_order_pos_closed", {
         Utils.checkIsNoBtn("Add to cart"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_self_order_products_sorting_order", {
+    steps: () => [
+        LandingPage.isClosed(),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Test-Takeout"),
+        ProductPage.checkNthProduct(1, "Free"),
+        ProductPage.checkNthProduct(2, "Desk Organizer"),
+        ProductPage.checkNthProduct(3, "Ketchup"),
+        ProductPage.checkNthProduct(4, "Fanta"),
+        ProductPage.checkNthProduct(5, "Coca-Cola"),
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -203,3 +203,10 @@ export function isProductDisplayed(productName) {
         trigger: `.o_self_product_box span:contains("${productName}")`,
     };
 }
+
+export function checkNthProduct(n, name) {
+    return {
+        content: `Product ${n} should be ${name}`,
+        trigger: `.product_list .o_self_product_box:nth-child(${n}) span:contains('${name}')`,
+    };
+}

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -104,3 +104,25 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
             'self_ordering_mode': 'mobile',
         })
         self.start_tour(self.pos_config._get_self_order_route(floor.table_ids[0].id), "test_self_order_product_availability")
+
+    def test_self_order_products_sorting_order(self):
+        """Test self order products sorting order should follow: favorite, pos_sequence, name"""
+
+        products_data = [
+            # product, is_favorite, pos_sequence
+            (self.cola, False, 20),
+            (self.desk_organizer, True, 20),
+            (self.ketchup, False, 5),
+            (self.fanta, False, 10),
+            (self.free, True, 10),
+        ]
+
+        for product, is_favorite, pos_sequence in products_data:
+            product.write({
+                'is_favorite': is_favorite,
+                'pos_sequence': pos_sequence
+            })
+
+        for mode in ('mobile', 'kiosk', 'consultation'):
+            self.pos_config.write({'self_ordering_mode': mode})
+            self.start_tour(self.pos_config._get_self_order_route(), 'test_self_order_products_sorting_order')


### PR DESCRIPTION
In this commit:
===============
- Products in Self Order are now sorted by favorite products first, then
pos sequence, and finally by name, ensuring the same behavior as the pos config.

Task: 5480181




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
