### PR TITLE
[IMP] stock_account: make qty_available first column in report

### DIFF
--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -57,8 +57,10 @@
             <field name="inherit_id" ref="stock.product_product_stock_tree"/>
             <field name="arch" type="xml">
                 <field name="qty_available" position="before">
-                    <field name="company_currency_id" column_invisible="True"/>
                     <field name="cost_method" optional="hide"/>
+                </field>
+                <field name="free_qty" position="after">
+                    <field name="company_currency_id" column_invisible="True"/>
                     <field name="avg_cost"
                         string="Unit Cost" optional="show" widget='stock_action_field'
                         options="{


### PR DESCRIPTION
This commit keeps the On Hand and Free to Use columns to be the first columns in stock report after the product name.

Task-5474075