### PR TITLE
[FIX] pos_restaurant: fix close closePrintingWarning

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/utils/chrome.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/chrome.js
@@ -1,5 +1,3 @@
-import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
-
 export function isTabActive(tabText) {
     return [
         {
@@ -12,8 +10,10 @@ export function isTabActive(tabText) {
 export function closePrintingWarning() {
     return [
         {
-            ...Dialog.confirm(),
+            trigger: `.modal:has(.modal-header:contains(printing failed)) .modal-footer .btn-primary:contains(continue)`,
             content: "acknowledge printing error ( because we don't have printer in the test. )",
+            run: "click",
+            timeout: 30000,
         },
     ];
 }


### PR DESCRIPTION
Before this commit, the function closePrintingWarning use Dialog.confirm() that is a generic function to close a dialog by clicking on .btn-primary.
This function can thus close an other unwanted modal (because warning can take a very long time to appears).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
