### PR TITLE
[IMP] point_of_sale: optimize getPrice pricelist computation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/product_template_accounting.js
@@ -89,24 +89,43 @@ export class ProductTemplateAccounting extends Base {
             quantity = related_lines.reduce((sum, line) => sum + line.getQuantity(), 0);
         }
 
-        const tmplRules = (productTmpl.backLink("<-product.pricelist.item.product_tmpl_id") || [])
-            .filter((rule) => rule.pricelist_id.id === pricelist.id && !rule.product_id)
-            .sort((a, b) => b.min_quantity - a.min_quantity);
-        const productRules = (product?.backLink?.("<-product.pricelist.item.product_id") || [])
-            .filter((rule) => rule.pricelist_id.id === pricelist.id)
-            .sort((a, b) => b.min_quantity - a.min_quantity);
+        let rule = null;
 
-        const tmplRulesSet = new Set(tmplRules.map((rule) => rule.id));
-        const productRulesSet = new Set(productRules.map((rule) => rule.id));
-        const generalRulesIds = pricelist.getGeneralRulesIdsByCategories(this.parentCategories);
-        const rules = this.models["product.pricelist.item"]
-            .readMany([...productRulesSet, ...tmplRulesSet, ...generalRulesIds])
-            .filter((r) => !r.min_quantity || r.min_quantity <= quantity);
+        // 1. Variant Rules
+        if (product) {
+            const productRules = pricelist.getRulesByProductId(product.id);
+            rule = pricelist.findBestRule(productRules, quantity);
+        }
 
-        const rule = rules.length && rules[0];
+        // 2. Template Rules
+        if (!rule) {
+            const tmplRules = pricelist.getRulesByTmplId(productTmpl.id);
+            rule = pricelist.findBestRule(tmplRules, quantity);
+        }
+
+        // 3. Category Rules
+        if (!rule) {
+            const categoryRulesIds = pricelist.getCategoryRulesIds(this.parentCategories);
+            if (categoryRulesIds.length > 0) {
+                const categoryRules =
+                    this.models["product.pricelist.item"].readMany(categoryRulesIds);
+                rule = pricelist.findBestRule(categoryRules, quantity);
+            }
+        }
+
+        // 4. Global Rules
+        if (!rule) {
+            const globalRulesIds = pricelist.getGlobalRulesIds();
+            if (globalRulesIds.length > 0) {
+                const globalRules = this.models["product.pricelist.item"].readMany(globalRulesIds);
+                rule = pricelist.findBestRule(globalRules, quantity);
+            }
+        }
+
         if (!rule) {
             return price;
         }
+
         if (rule.base === "pricelist") {
             if (rule.base_pricelist_id) {
                 price = this.getPrice(rule.base_pricelist_id, quantity, 0, true, variant);
@@ -118,10 +137,10 @@ export class ProductTemplateAccounting extends Base {
         if (rule.compute_price === "fixed") {
             price = rule.fixed_price;
         } else if (rule.compute_price === "percentage") {
-            price = price - price * (rule.percent_price / 100);
+            price = price - price * ((rule.percent_price || 0) / 100);
         } else {
             var price_limit = price;
-            price -= price * (rule.price_discount / 100);
+            price -= price * ((rule.price_discount || 0) / 100);
             if (rule.price_round) {
                 price = roundPrecision(price, rule.price_round);
             }

--- a/addons/point_of_sale/static/src/app/models/product_pricelist.js
+++ b/addons/point_of_sale/static/src/app/models/product_pricelist.js
@@ -7,6 +7,8 @@ export class ProductPricelist extends Base {
     setup() {
         super.setup(...arguments);
 
+        this.rulesByProductId = {};
+        this.rulesByTmplId = {};
         this.uiState = {
             generalRulesIdsByCateg: {},
             generalRulesIds: {},
@@ -15,10 +17,10 @@ export class ProductPricelist extends Base {
         // General rules can be computed only on starting since they
         // are loaded by default, if a new pricelist is created
         // after the POS is started, it will be computed during the setup
-        this.computeGeneralRulesByCateg();
+        this.computeRuleIndexes();
     }
 
-    getGeneralRulesIdsByCategories(categoryIds) {
+    getCategoryRulesIds(categoryIds) {
         const rules = {};
 
         for (const id of categoryIds) {
@@ -27,15 +29,47 @@ export class ProductPricelist extends Base {
             }
         }
 
-        Object.assign(rules, this.uiState.generalRulesIds);
         return Object.values(rules);
     }
 
-    computeGeneralRulesByCateg() {
-        for (const idx in this.item_ids) {
-            const index = parseInt(idx);
-            const item = this.item_ids[index];
-            if (item.product_id || item.product_tmpl_id) {
+    getGlobalRulesIds() {
+        return Object.values(this.uiState.generalRulesIds);
+    }
+
+    getRulesByProductId(productId) {
+        return this.rulesByProductId[productId] || [];
+    }
+
+    getRulesByTmplId(tmplId) {
+        return this.rulesByTmplId[tmplId] || [];
+    }
+
+    computeRuleIndexes() {
+        this.rulesByProductId = {};
+        this.rulesByTmplId = {};
+        this.uiState.generalRulesIdsByCateg = {};
+        this.uiState.generalRulesIds = {};
+
+        for (let i = 0; i < this.item_ids.length; i++) {
+            const item = this.item_ids[i];
+
+            // Index by product_id (variant rules)
+            if (item.product_id) {
+                const prodId = item.product_id.id;
+                if (!this.rulesByProductId[prodId]) {
+                    this.rulesByProductId[prodId] = [];
+                }
+                this.rulesByProductId[prodId].push(item);
+                continue;
+            }
+
+            // Index by product_tmpl_id (template rules)
+            if (item.product_tmpl_id) {
+                const tmplId = item.product_tmpl_id.id;
+                if (!this.rulesByTmplId[tmplId]) {
+                    this.rulesByTmplId[tmplId] = [];
+                }
+                this.rulesByTmplId[tmplId].push(item);
                 continue;
             }
 
@@ -44,12 +78,24 @@ export class ProductPricelist extends Base {
                     this.uiState.generalRulesIdsByCateg[item.categ_id.id] = {};
                 }
 
-                this.uiState.generalRulesIdsByCateg[item.categ_id.id][index] = item.id;
+                this.uiState.generalRulesIdsByCateg[item.categ_id.id][i] = item.id;
                 continue;
             }
 
-            this.uiState.generalRulesIds[index] = item.id;
+            this.uiState.generalRulesIds[i] = item.id;
         }
+    }
+
+    findBestRule(rules, quantity) {
+        let bestRule = null;
+        for (const rule of rules) {
+            if (!rule.min_quantity || rule.min_quantity <= quantity) {
+                if (!bestRule || rule.min_quantity > bestRule.min_quantity) {
+                    bestRule = rule;
+                }
+            }
+        }
+        return bestRule;
     }
 }
 

--- a/addons/point_of_sale/static/tests/unit/accounting/pricelist.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/pricelist.test.js
@@ -1,0 +1,150 @@
+import { test, expect } from "@odoo/hoot";
+import { setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+
+definePosModels();
+
+test("Pricelist: Precedence Rules (Variant > Template > Category > Global)", async () => {
+    const store = await setupPosEnv();
+    const pricelist = store.models["product.pricelist"].create({
+        name: "Test Pricelist",
+    });
+
+    const category = store.models["product.category"].create({ name: "Test Category" });
+    const productTemplate = store.models["product.template"].create({
+        name: "Test Template",
+        list_price: 100,
+        categ_id: category,
+    });
+    const product = store.models["product.product"].create({
+        product_tmpl_id: productTemplate,
+        lst_price: 100,
+    });
+
+    // 1. Global Rule
+    const globalRule = store.models["product.pricelist.item"].create({
+        pricelist_id: pricelist,
+        compute_price: "fixed",
+        fixed_price: 90,
+    });
+    pricelist.update({ item_ids: [globalRule] });
+    pricelist.computeRuleIndexes();
+    expect(product.getPrice(pricelist, 1, 0, false, product)).toBe(90);
+
+    // 2. Category Rule (should win over Global)
+    const categoryRule = store.models["product.pricelist.item"].create({
+        pricelist_id: pricelist,
+        categ_id: category,
+        compute_price: "fixed",
+        fixed_price: 80,
+    });
+    pricelist.update({ item_ids: [globalRule, categoryRule] });
+    pricelist.computeRuleIndexes();
+    expect(product.getPrice(pricelist, 1, 0, false, product)).toBe(80);
+
+    // 3. Template Rule (should win over Category)
+    const templateRule = store.models["product.pricelist.item"].create({
+        pricelist_id: pricelist,
+        product_tmpl_id: productTemplate,
+        compute_price: "fixed",
+        fixed_price: 70,
+    });
+    pricelist.update({ item_ids: [globalRule, categoryRule, templateRule] });
+    pricelist.computeRuleIndexes();
+    expect(product.getPrice(pricelist, 1, 0, false, product)).toBe(70);
+
+    // 4. Variant Rule (should win over Template)
+    const variantRule = store.models["product.pricelist.item"].create({
+        pricelist_id: pricelist,
+        product_id: product,
+        compute_price: "fixed",
+        fixed_price: 60,
+    });
+    pricelist.update({ item_ids: [globalRule, categoryRule, templateRule, variantRule] });
+    pricelist.computeRuleIndexes();
+    expect(product.getPrice(pricelist, 1, 0, false, product)).toBe(60);
+});
+
+test("Pricelist: Min Quantity logic", async () => {
+    const store = await setupPosEnv();
+    const pricelist = store.models["product.pricelist"].create({
+        name: "Qty Pricelist",
+    });
+
+    const productTemplate = store.models["product.template"].create({
+        name: "Qty Product",
+        list_price: 100,
+    });
+    const product = store.models["product.product"].create({
+        product_tmpl_id: productTemplate,
+        lst_price: 100,
+    });
+
+    const ruleSmall = store.models["product.pricelist.item"].create({
+        pricelist_id: pricelist,
+        product_id: product,
+        compute_price: "fixed",
+        fixed_price: 50,
+        min_quantity: 0,
+    });
+    const ruleLarge = store.models["product.pricelist.item"].create({
+        pricelist_id: pricelist,
+        product_id: product,
+        compute_price: "fixed",
+        fixed_price: 20,
+        min_quantity: 10,
+    });
+
+    pricelist.update({ item_ids: [ruleSmall, ruleLarge] });
+    pricelist.computeRuleIndexes();
+
+    // Qty 1 -> should use ruleSmall (50)
+    expect(product.getPrice(pricelist, 1, 0, false, product)).toBe(50);
+    // Qty 10 -> should use ruleLarge (20)
+    expect(product.getPrice(pricelist, 10, 0, false, product)).toBe(20);
+    // Qty 15 -> should use ruleLarge (20)
+    expect(product.getPrice(pricelist, 15, 0, false, product)).toBe(20);
+});
+
+test("Pricelist: Nested Pricelists (Pricelist of Pricelist)", async () => {
+    const store = await setupPosEnv();
+
+    // Base Pricelist: -10% discount
+    const basePricelist = store.models["product.pricelist"].create({
+        name: "Base Pricelist",
+    });
+    const baseRule = store.models["product.pricelist.item"].create({
+        pricelist_id: basePricelist,
+        compute_price: "percentage",
+        percent_price: 10,
+        base: "list_price",
+    });
+    basePricelist.update({ item_ids: [baseRule] });
+    basePricelist.computeRuleIndexes();
+
+    // Nested Pricelist: Base + another -5$ surcharge
+    const nestedPricelist = store.models["product.pricelist"].create({
+        name: "Nested Pricelist",
+    });
+    const nestedRule = store.models["product.pricelist.item"].create({
+        pricelist_id: nestedPricelist,
+        compute_price: "formula", // formula to use base + surcharge
+        base: "pricelist",
+        base_pricelist_id: basePricelist,
+        price_surcharge: 5,
+    });
+    nestedPricelist.update({ item_ids: [nestedRule] });
+    nestedPricelist.computeRuleIndexes();
+
+    const productTemplate = store.models["product.template"].create({
+        name: "Nested Test Product",
+        list_price: 100,
+    });
+    const product = store.models["product.product"].create({
+        product_tmpl_id: productTemplate,
+        lst_price: 100,
+    });
+
+    // Calculation: (100 - 10%) + 5 = 90 + 5 = 95
+    expect(product.getPrice(nestedPricelist, 1, 0, false, product)).toBe(95);
+});


### PR DESCRIPTION
The getPrice function in product_template_accounting.js was a
performance bottleneck when using large pricelists. This commit
introduces the following optimizations:
1. Pre-index pricelist rules by product_id and product_tmpl_id at
   load time in ProductPricelist.
2. Replace the sort() operation with a single-pass scan to find
   the best matching rule (highest min_quantity that satisfies the
   current quantity).
3. Apply sequential rule precedence (Variant → Template → General),
   stopping as soon as a valid rule is found.
4. Move rule mappings from uiState to direct properties in
   ProductPricelist to avoid useless reactivity.
5. Centralize rule selection logic in ProductPricelist for better
   responsibility separation.

task-id: 5965826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
