### PR TITLE
[FIX] mail: ensure _find_aliases respects allowed domains for localpart aliases

### DIFF
--- a/addons/mail/models/mail_alias_domain.py
+++ b/addons/mail/models/mail_alias_domain.py
@@ -189,12 +189,15 @@ class MailAliasDomain(models.Model):
         if not filtered_emails:
             return filtered_emails
         all_domains = self.search([])
-        aliases = all_domains.mapped('bounce_email') + all_domains.mapped('catchall_email') + all_domains.mapped('default_from_email')
+        aliases = set(all_domains.mapped('bounce_email') +
+                    all_domains.mapped('catchall_email') +
+                    all_domains.mapped('default_from_email'))
 
-        catchall_domains_allowed = list(filter(None, (self.env["ir.config_parameter"].sudo().get_param(
-            "mail.catchall.domain.allowed") or '').split(',')))
+        # Get allowed domains and convert to a set for O(1) lookup
+        catchall_params = self.env["ir.config_parameter"].sudo().get_param("mail.catchall.domain.allowed") or ''
+        catchall_domains_allowed = set(filter(None, catchall_params.split(',')))
         if catchall_domains_allowed:
-            catchall_domains_allowed += all_domains.mapped('name')
+            catchall_domains_allowed.update(all_domains.mapped('name'))
             email_localparts_tocheck = [
                 email.partition('@')[0] for email in filtered_emails if (
                     email and email.partition('@')[2] in catchall_domains_allowed
@@ -209,15 +212,23 @@ class MailAliasDomain(models.Model):
             ('alias_full_name', 'in', filtered_emails),
             '&', ('alias_name', 'in', email_localparts_tocheck), ('alias_incoming_local', '=', True),
         ])
-        # global alias: email match
-        aliases += potential_aliases.filtered(lambda x: not x.alias_incoming_local).mapped('alias_full_name')
-        # compat-mode alias: left-part only (filter on allowed domains already done)
-        local_alias_names = potential_aliases.filtered(lambda x: x.alias_incoming_local).mapped('alias_name')
-        return [
-            email for email in filtered_emails if (
-                email in aliases or
-                email.partition('@')[0] in local_alias_names
-            )]
+        # Global aliases match by full name
+        aliases.update(potential_aliases.filtered(lambda x: not x.alias_incoming_local).mapped('alias_full_name'))
+
+        # Local aliases for validated local part + domain checking
+        local_alias_names = set(potential_aliases.filtered(lambda x: x.alias_incoming_local).mapped('alias_name'))
+
+        res = []
+        for email in filtered_emails:
+            if email in aliases:
+                res.append(email)
+                continue
+
+            local_part, _, domain = email.partition('@')
+            if local_part in local_alias_names and (not catchall_domains_allowed or domain in catchall_domains_allowed):
+                res.append(email)
+
+        return res
 
     @api.model
     def _migrate_icp_to_domain(self):

--- a/addons/mail/tests/test_mail_tools.py
+++ b/addons/mail/tests/test_mail_tools.py
@@ -101,6 +101,26 @@ class TestMailTools(MailCommon):
         self.assertEqual(found.email_normalized, 'test_no_localpart@gmail.com')
         self.assertEqual(found.name, 'Customer')
 
+        # test if ICP still works when passing a list of emails
+        test_list = [
+            '"Customer" <test_localpart@gmail.com>',
+            '"Customer" <test_localpart@tartopoils.com>',
+            '"Customer" <test_localpart@brutijus.com>',
+            '"Customer" <test_localpart@brutijus.fr.com>',
+        ]
+
+        found = self.env['mail.thread']._partner_find_from_emails_single(test_list, no_create=False)
+        self.assertEqual(
+            len(found),
+            2,
+            "Should have found 2 partners, as tartopoils.com and brutijus.com are limiting local part alias recognition, limiting alias conflict check to those domains",
+        )
+        self.assertEqual(
+            found.mapped("email_normalized"),
+            ["test_localpart@gmail.com", "test_localpart@brutijus.fr.com"],
+            "Found Partners have wrong normalized email addresses",
+        )
+
     @users('employee')
     def test_mail_find_partner_from_emails_followers(self):
         """ Test '_mail_find_partner_from_emails' when dealing with records on


### PR DESCRIPTION
The fix introduced in https://github.com/odoo/odoo/pull/216737 can lead to "over-eager" filtering when an external email address matches a localpart (left part) alias in a input email list contains internal emails (aliases to filter) AND external email addresses (should not be filtered).

The `_find_aliases` method is used to identify internal system emails (aliases, bounces, catchalls) to prevent mail loops and ensure correct recipient filtering during notification grouping.

Before this fix, when the `mail.catchall.domain.allowed` system parameter was set, the logic for local-part aliases (where `alias_incoming_local` is True) failed to correctly associate the local part with the allowed domains. This resulted in external email addressed being returned by the system, potentially leading to incorrect notification routing.

We now use a more robust approach:
- Pre-filter local parts based on the allowed domains to reduce DB load.
- Utilize Python Sets for O(1) lookups of static and local aliases
- Explicitly validate the (local_part, domain) combo during the final filtering.

Example Scenario:
- Config: mail.catchall.domain.allowed = "test1.com,test2.com"
- Alias: "info" (alias_incoming_local=True)
- Input: ["info@test1.com", "info@test3.com"]

### Output Before Fix:
["info@test1.com", "info@test3.com"]
(The function failed to recognize info@test3.com as an external alias to be ignored based on the `mail.catchall.domain.allowed` config)

### Output After Fix:
["info@test1.com"]
(Correctly identifies the internal alias tob filtered while ignoring the external one)


OPW-5469264
OPW-5504201

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
