### PR TITLE
[REV] spreadsheet_dashboard: etag computation revert

### DIFF
--- a/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
+++ b/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
@@ -1,9 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import werkzeug.http
-
 from odoo import http
-from odoo.http import request, HTTPStatus
+from odoo.http import request
 
 
 class DashboardDataRoute(http.Controller):
@@ -24,18 +22,9 @@ class DashboardDataRoute(http.Controller):
                     'snapshot': sample_data,
                     'is_sample': True,
                 })
-        etag = dashboard._get_dashboard_etag()
-        modified = werkzeug.http.is_resource_modified(
-            request.httprequest.environ,
-            etag=etag,
-        )
-        if not modified:
-            return request.make_response('', headers=[('ETag', etag), ('Cache-Control', 'no-cache, private')], status=HTTPStatus.NOT_MODIFIED)
         body = dashboard._get_serialized_readonly_dashboard()
         headers = [
             ('Content-Length', len(body)),
-            ('Cache-Control', 'no-cache, private'),
-            ('ETag', etag),
             ('Content-Type', 'application/json; charset=utf-8'),
         ]
         return request.make_response(body, headers)

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -1,9 +1,7 @@
 import json
-import werkzeug.http
 
 from odoo import Command, _, api, fields, models
 from odoo.tools import file_open
-from odoo.addons.spreadsheet.utils.json import extend_serialized_json
 
 
 class SpreadsheetDashboard(models.Model):
@@ -46,34 +44,17 @@ class SpreadsheetDashboard(models.Model):
         else:
             self.sudo().favorite_user_ids = [Command.link(current_user_id)]
 
-    def _get_dashboard_etag(self):
-        serialized_metadata = self._get_serialized_dashboard_metadata()
-        user_locale_code = self.env.user.lang or "en_US"
-        etag_data = "%s-%s-%s" % (serialized_metadata,
-                                  self.env.uid, user_locale_code)
-        return '"%s"' % werkzeug.http.generate_etag(etag_data.encode("utf-8"))
-
-    def _get_serialized_dashboard_metadata(self):
-        default_currency = self.env['res.currency'].get_company_currency_for_spreadsheet()
-        return json.dumps(
-            dict(
-                default_currency=default_currency,
-                translation_namespace=self._get_dashboard_translation_namespace(),
-            ),
-            ensure_ascii=False,
-            sort_keys=True,
-        )
-
     def _get_serialized_readonly_dashboard(self):
         snapshot = json.loads(self.spreadsheet_data)
         user_locale = self.env['res.lang']._get_user_spreadsheet_locale()
         snapshot.setdefault('settings', {})['locale'] = user_locale
-        serialized_metadata = self._get_serialized_dashboard_metadata()
-        return extend_serialized_json(
-            serialized_metadata,
-            [('snapshot', json.dumps(snapshot, ensure_ascii=False)),
-             ('revisions', '[]')],
-        )
+        default_currency = self.env['res.currency'].get_company_currency_for_spreadsheet()
+        return json.dumps({
+            'snapshot': snapshot,
+            'revisions': [],
+            'default_currency': default_currency,
+            'translation_namespace': self._get_dashboard_translation_namespace(),
+        })
 
     def _get_sample_dashboard(self):
         try:


### PR DESCRIPTION
This reverts commit 3b014027cb785a2c567ec94fd14ae24f39f92783. We already had many issues (and probably a lot more to come) with etag computation in spreadsheets, the ratio cost/benefit is not worth it. This reverts the etag computation in spreadsheet dashboards.

Task: 5504270

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
