### PR TITLE
[FIX] mail: run sanitize for mail.catchall.domain.allowed

### DIFF
--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -47,15 +47,54 @@ class TestMailAlias(TestMailAliasCommon):
             with self.assertRaises(exceptions.ValidationError):
                 self.env['ir.config_parameter'].set_param('mail.catchall.domain.allowed', value)
 
-        for value, expected in [
+        test_cases = [
             ('', False),
             ('hello.com', 'hello.com'),
             ('hello.com,,', 'hello.com'),
             ('hello.com,bonjour.com', 'hello.com,bonjour.com'),
             ('hello.COM, BONJOUR.com', 'hello.com,bonjour.com'),
-        ]:
-            self.env['ir.config_parameter'].set_param('mail.catchall.domain.allowed', value)
-            self.assertEqual(self.env['ir.config_parameter'].get_param('mail.catchall.domain.allowed'), expected)
+        ]
+        for value, expected in test_cases:
+            with self.subTest(value=value):
+                self.env['ir.config_parameter'].set_param('mail.catchall.domain.allowed', value)
+                self.assertEqual(self.env['ir.config_parameter'].get_param('mail.catchall.domain.allowed'), expected)
+
+        # test create and write sanitization
+        for value, expected in test_cases:
+            with self.subTest(value=value):
+                self.env["ir.config_parameter"].search([
+                    ("key", "=", "mail.catchall.domain.allowed")
+                ]).unlink()
+                self.env["ir.config_parameter"].create({
+                    "key": "mail.catchall.domain.allowed",
+                    "value": value,
+                })
+                # check after create
+                self.assertEqual(
+                    self.env["ir.config_parameter"].get_param(
+                        "mail.catchall.domain.allowed"
+                    ),
+                    expected,
+                )
+
+                icp_record = self.env["ir.config_parameter"].search([
+                    ("key", "=", "mail.catchall.domain.allowed")
+                ])
+                icp_record.write({
+                        "key": "mail.catchall.domain.allowed",
+                        "value": "randomPlaceHolder",
+                    })
+                icp_record.write({
+                        "key": "mail.catchall.domain.allowed",
+                        "value": value,
+                    })
+                # check after write
+                self.assertEqual(
+                    self.env["ir.config_parameter"].get_param(
+                        "mail.catchall.domain.allowed"
+                    ),
+                    expected,
+                )
 
     @users('erp_manager')
     def test_alias_domain_company_check(self):


### PR DESCRIPTION
Since its introduction (https://github.com/odoo/odoo/pull/76734), the "mail.catchall.domain.allowed" system parameter is normally sanitized by `_sanitize_allowed_domains` when using `set_param`.

But the method is not run when the system parameter is created manually, for example through the UI, because the current conditional logic is not triggered for write and create call.

This can be an issue if for example the use submits this value: "domain1.com, domain2.com,domain3.com"

The comma seperated list will only be split by ',', meaning that the second element is " domain2.com" (space character in front). As such, that domain will not be used as expected, since most flows using that data will end up comparing "domain2.com" vs " domain2.com", and not considering it a match.

Before this fix:
Create new record in System parameters with
key = "mail.catchall.domain.allowed"
value = "domain1.com, domain2.com,domain3.com"
-> after save, value == "domain1.com, domain2.com,domain3.com"

After this fix:
-> after save, value == "domain1.com,domain2.com,domain3.com"

OPW-5505414

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
