### PR TITLE
[FIX] point_of_sale: rounding of tax base amounts in reports before sum

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -387,7 +387,7 @@ class ReportPoint_Of_SaleReport_Saledetails(models.AbstractModel):
                 base_amounts[tax['id']] = tax['base']
 
             for tax_id, base_amount in base_amounts.items():
-                taxes['taxes'][tax_id]['base_amount'] += base_amount
+                taxes['taxes'][tax_id]['base_amount'] += currency.round(base_amount)
         else:
             taxes['taxes'].setdefault(0, {'name': _('No Taxes'), 'tax_amount': 0.0, 'base_amount': 0.0})
             taxes['taxes'][0]['base_amount'] += line.price_subtotal_incl


### PR DESCRIPTION
Before this commit, the total base amounts of taxes might be different from summing the base amounts of each line, due to rounding issues.

opw-5408201

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
