### PR TITLE
[FIX] hr_work_entry_holidays: Error when writing contract with multiple leaves

### DIFF
--- a/addons/hr_work_entry_holidays/models/hr_contract.py
+++ b/addons/hr_work_entry_holidays/models/hr_contract.py
@@ -92,6 +92,7 @@ class HrContract(models.Model):
         all_new_leave_origin = []
         all_new_leave_vals = []
         leaves_state = {}
+        vals_calendar = self.env['resource.calendar'].browse(vals.get('resource_calendar_id', False))
         # In case a validation error is thrown due to holiday creation with the new resource calendar (which can
         # increase their duration), we catch this error to display a more meaningful error message.
         try:
@@ -110,14 +111,16 @@ class HrContract(models.Model):
                                   ('state', '!=', 'draft'),
                              ('kanban_state', '=', 'done'),
                     ]).sorted(key=lambda c: {'open': 1, 'close': 2, 'draft': 3, 'cancel': 4}[c.state])
-                    if len(overlapping_contracts.resource_calendar_id) <= 1:
-                        super(HrContract, contract).write(vals)
-                        if overlapping_contracts and leave.resource_calendar_id != overlapping_contracts[0].resource_calendar_id:
-                            leave.resource_calendar_id = overlapping_contracts[0].resource_calendar_id
-                            if not leave.request_unit_hours:
-                                leave.with_context(leave_skip_date_check=True, leave_skip_state_check=True)._compute_date_from_to()
-                                if leave.state == 'validate':
-                                    leave._validate_leave_request()
+                    all_calendars = overlapping_contracts.resource_calendar_id if not vals_calendar else (overlapping_contracts - self).resource_calendar_id | vals_calendar
+                    if len(all_calendars) <= 1:
+                        if overlapping_contracts:
+                            new_calendar = vals_calendar or overlapping_contracts[0].resource_calendar_id
+                            if leave.resource_calendar_id != new_calendar:
+                                leave.resource_calendar_id = new_calendar
+                                if not leave.request_unit_hours:
+                                    leave.with_context(leave_skip_date_check=True, leave_skip_state_check=True)._compute_date_from_to()
+                                    if leave.state == 'validate':
+                                        leave._validate_leave_request()
                         continue
                     if leave.id not in leaves_state:
                         leaves_state[leave.id] = leave.state

--- a/addons/hr_work_entry_holidays/tests/test_multi_contract.py
+++ b/addons/hr_work_entry_holidays/tests/test_multi_contract.py
@@ -146,6 +146,11 @@ class TestWorkEntryHolidaysMultiContract(TestWorkEntryHolidaysBase):
         self.assertEqual(leave.state, 'validate')
 
         self.contract_cdi.date_end = date(2022, 6, 15)
+        # create another leave to ensure that we only write the state
+        # to the contract after ensuring that overlapped leaves are
+        # splitted correctly and not with other leaves while looping
+        no_overlap_leave = self.create_leave(date(2022, 7, 5), date(2022, 7, 10))
+        no_overlap_leave.action_approve()
         new_contract_cdi = self.env['hr.contract'].create({
             'date_start': date(2022, 6, 16),
             'name': 'New Contract for Jules',
@@ -158,7 +163,7 @@ class TestWorkEntryHolidaysMultiContract(TestWorkEntryHolidaysBase):
         new_contract_cdi.state = 'open'
 
         leaves = self.env['hr.leave'].search([('employee_id', '=', self.jules_emp.id)])
-        self.assertEqual(len(leaves), 3)
+        self.assertEqual(len(leaves), 4)
         self.assertEqual(leave.state, 'refuse')
 
         first_leave = leaves.filtered(lambda l: l.date_from.day == 1 and l.date_to.day == 15)

--- a/addons/hr_work_entry_holidays/tests/test_multi_contract.py
+++ b/addons/hr_work_entry_holidays/tests/test_multi_contract.py
@@ -146,6 +146,11 @@ class TestWorkEntryHolidaysMultiContract(TestWorkEntryHolidaysBase):
         self.assertEqual(leave.state, 'validate')
 
         self.contract_cdi.date_end = date(2022, 6, 15)
+        # create another leave to ensure that we only write the state
+        # to the contract after ensuring that overlapped leaves are
+        # split correctly and not with other leaves while looping
+        no_overlap_leave = self.create_leave(date(2022, 7, 5), date(2022, 7, 10))
+        no_overlap_leave.action_approve()
         new_contract_cdi = self.env['hr.contract'].create({
             'date_start': date(2022, 6, 16),
             'name': 'New Contract for Jules',
@@ -158,7 +163,7 @@ class TestWorkEntryHolidaysMultiContract(TestWorkEntryHolidaysBase):
         new_contract_cdi.state = 'open'
 
         leaves = self.env['hr.leave'].search([('employee_id', '=', self.jules_emp.id)])
-        self.assertEqual(len(leaves), 3)
+        self.assertEqual(len(leaves), 4)
         self.assertEqual(leave.state, 'refuse')
 
         first_leave = leaves.filtered(lambda l: l.date_from.day == 1 and l.date_to.day == 15)


### PR DESCRIPTION
Issue: when you change in a contract for an employee with multiple leaves and one of them is overlapping multiple contracts, you get a validation error which shouldn't be the case

Steps to reproduce:
- create an employee with a contract ending on a day x
- create 2 leaves for the employee one from x-5 to x+5 and the second from x+10 to x+15 and approve them
- create another contract with a different calendar for the employee starting on a day x+1
- when you move the second contract to the running state, you get a validation error but you shouldn't and the operation should be done normally

Fix:
- ensured that the write of vals in contract is only done after refusing leaves that span multiple contracts
- changed the employee in `test_leave_change_working_schedule` and ensured that all timezones are in Europe/Brussels (jules_emp's tz was changing between UTC and Europe/Brussels depending on demo data which caused a runbot error)
- created another leave in `test_leave_multi_contracts_split` to ensure that the split works correctly with more than one leave

task-id: 5499527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
