### PR TITLE
[FIX] point_of_sale: create order for cash move with correct values

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -64,10 +64,10 @@ export class CashMovePopup extends Component {
             "CASH_DRAWER_ACTION"
         );
         const order = this.pos.models["pos.order"].create({
-            session_id: this.session,
-            company_id: this.company,
+            session_id: this.pos.session,
+            company_id: this.pos.company,
             config_id: this.pos.config,
-            user_id: this.user,
+            user_id: this.pos.user,
             ticket_code: "",
             tracking_number: "",
             sequence_number: 0,


### PR DESCRIPTION
Before this commit, the order for cash moves was created without setting the session_id, company_id, and user_id fields.

opw-5500966

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
