### PR TITLE
[FIX] mail: enable other views when opening records

### DIFF
--- a/addons/mail/static/src/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/core/web/thread_model_patch.js
@@ -75,15 +75,18 @@ patch(Thread.prototype, {
             return;
         }
         if (this.model !== "discuss.channel") {
-            this.store.env.services.action.doAction({
-                type: "ir.actions.act_window",
-                res_id: this.id,
-                res_model: this.model,
-                views: [[false, "form"]],
-            });
+            this.store.env.services.action.doAction(this.openRecordActionRequest);
             return;
         }
         super.open();
+    },
+    get openRecordActionRequest() {
+        return {
+            type: "ir.actions.act_window",
+            res_id: this.id,
+            res_model: this.model,
+            views: [[false, "form"]],
+        };
     },
     async unpin() {
         const chatWindow = this.store.ChatWindow.get({ thread: this });


### PR DESCRIPTION
Records of some models may not want to be shown in their form
view by default. See related ENT PR for documents.

We re-export to avoid patching order issues. In particular,
this makes sure that if we are in the webclient, the chat
window is opened before executing the "real" open.

Task-5386466