### PR TITLE
[FIX] website: keep carousel preview height in snippet dialog

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -261,6 +261,10 @@ export class AddSnippetDialog extends Component {
                         || !!snippet.baseBody.querySelector(".parallax");
                     snippetLabel = hasParallax ? _t("Parallax") : "";
                 }
+                if (snippet.isCustom && !snippetLabel && originalSnippet?.label
+                    && originalSnippet.label !== "Parallax") {
+                    snippetLabel = originalSnippet.label;
+                }
                 if (snippetLabel) {
                     snippetPreviewWrapEl.dataset.label = snippetLabel;
                 }

--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -93,7 +93,10 @@ export class CarouselSlider extends Interaction {
         for (const itemEl of this.el.querySelectorAll(".carousel-item")) {
             const isActive = itemEl.classList.contains("active");
             itemEl.classList.add("active");
-            const height = itemEl.getBoundingClientRect().height;
+            // We must use "offsetHeight" instead of "getBoundingClientRect()"
+            // otherwise it is not correct in the snippet dialog because of
+            // the "transform: scale" on "o_snippets_preview_row" elements.
+            const height = itemEl.offsetHeight;
             if (height > this.maxHeight || this.maxHeight === undefined) {
                 this.maxHeight = height;
             }

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -16,7 +16,11 @@ registerWebsitePreviewTour('snippet_cache_across_websites', {
     },
     {
         content: "Ensure custom snippet preview appeared in the dialog",
-        trigger: ":iframe .o_snippet_preview_wrap[data-snippet-id^='s_text_block_'] section[data-name='custom_snippet_test']",
+        trigger: ":iframe .o_snippet_preview_wrap[data-snippet-id^='s_carousel_'] section[data-name='custom_snippet_test']",
+    },
+    {
+        content: "Ensure custom snippet preview shows the base label",
+        trigger: ":iframe .o_snippet_preview_wrap[data-snippet-id^='s_carousel_'][data-label='Carousel']",
     },
     {
         content: "Close the 'add snippet' dialog",

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -528,12 +528,16 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.env['ir.ui.view'].with_context(website_id=default_website.id).save_snippet(
             name='custom_snippet_test',
             arch="""
-                <section class="s_text_block" data-snippet="s_text_block">
-                    <div class="custom_snippet_website_1">Custom Snippet Website 1</div>
+                <section class="s_carousel carousel slide" data-snippet="s_carousel">
+                    <div class="carousel-inner">
+                        <div class="carousel-item active">
+                            <div class="custom_snippet_website_1">Custom Snippet Website 1</div>
+                        </div>
+                    </div>
                 </section>
             """,
             thumbnail_url='/website/static/src/img/snippets_thumbs/s_text_block.svg',
-            snippet_key='s_text_block',
+            snippet_key='s_carousel',
             template_key='website.snippets')
         self.start_tour('/@/', 'snippet_cache_across_websites', login='admin', cookies={
             'websiteIdMapping': json.dumps({'Test Website': website.id})


### PR DESCRIPTION
Steps to reproduce:

- Open the website editor.
- Add a carousel snippet to a page.
- Remove content from the first slide so it is shorter.
- Save the carousel as a custom snippet.
- Open the snippet dialog and locate the custom snippet. => The preview height is too small.

Before this commit, the preview height was computed from the scaled size, so shorter slides made the preview min-height too low.

After this commit, the preview height uses the layout size so the min-height stays consistent with other slides.

----------

Steps to reproduce:
- Open the website editor.
- Open the snippet dialog and resize the window.
=> The parallax preview background shifts to the left.
- Save a snippet with a parallax zoom in/out effect as a custom snippet.
- Open the snippet dialog and locate the custom snippet.
=> The preview shows a top to bottom effect instead of zoom.

Before this commit, resizing the snippet dialog could offset the
parallax background to the left, and zoom previews looked like top to
bottom effects.

After this commit, the preview keeps the background aligned and shows
zoom in/out effects for custom snippets.

Fixed parallax is still not previewed because it would require an
oversized background in the dialog.

----------

Steps to reproduce:

- Open the website editor.
- Save a "Carousel" snippet as a custom snippet.
- Open the snippet dialog.
=> The custom snippet shows no label.

Before this commit, custom previews dropped the base label so the dialog
showed no tag for custom snippets.

After this commit, custom previews reuse the base label.

task-5156137

**To see/test the bug, the change made in https://github.com/odoo/odoo/pull/244251 must be present**