### PR TITLE
[FIX] im_livechat: smaller size of looking for help timers

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
@@ -4,7 +4,7 @@
         <xpath expr="//*[@t-ref='displayNameAdditionalContent']" position="inside">
             <t t-if="channel.livechat_status === 'need_help'">
                 <i t-if="channel.matchesSelfExpertise" class="fa fa-star o-mail-starred me-2" role="image" title="Relevant to your expertise"/>
-                <span t-if="helpState.text" class="o-livechat-LookingForHelp-timer text-muted fw-normal" t-esc="helpState.text"/>
+                <span t-if="helpState.text" class="o-livechat-LookingForHelp-timer text-muted fw-normal smaller" t-esc="helpState.text"/>
             </t>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-itemName')]" position="inside">


### PR DESCRIPTION
Timers on "looking for help" live chat conversations on discuss sidebar were slightly too big. This commit reduces the size to make the overal text content of a discuss item more balanced.

Before / After
<img width="296" height="100" alt="Screenshot 2026-01-16 at 16 58 50" src="https://github.com/user-attachments/assets/32d8e304-c00f-4d2f-bcb9-3b58be7f01c4" /> <img width="298" height="99" alt="Screenshot 2026-01-16 at 16 58 57" src="https://github.com/user-attachments/assets/2cc6fff7-8613-4b56-b44c-22ad72738286" />
