### PR TITLE
[FIX] l10n_ro_edi_stock: access settings in Romanian language

### DIFF
--- a/addons/l10n_ro_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_ro_edi/views/res_config_settings_views.xml
@@ -36,7 +36,7 @@
                                                 Fill "Callback URL 1" with the following URL:
                                                 <br/><field name="l10n_ro_edi_callback_url" widget="text" class="w-100 text-success"/>
                                             </li>
-                                            <li>In "Serviciu", select the option "E-Factura"</li>
+                                            <li id="serviciu">In "Serviciu", select the option "E-Factura"</li>
                                             <li>Submit the form by clicking on "Generare Client ID"</li>
                                         </ul>
                                     </li>

--- a/addons/l10n_ro_edi_stock/views/res_config_settings_views.xml
+++ b/addons/l10n_ro_edi_stock/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <!-- Match the appropriate <li> by using contains() instead of matching the whole text() because we can't properly escape the double quotes in the text -->
-            <xpath expr="//block[@id='l10n_ro_edi_settings']//li[contains(text(), 'Serviciu') and contains(text(), 'select the option')]" position="replace">
+            <xpath expr="//block[@id='l10n_ro_edi_settings']//li//li[@id='serviciu']" position="replace">
                 <li>In "Serviciu", select the options "E-Factura" and "E-Transport"</li>
             </xpath>
         </field>


### PR DESCRIPTION
**Issue**:

When the module `l10n_ro_edi_stock` is installed and Romanian is the selected language, accessing the settings app causes a traceback.

**Steps to reproduce**:

- Install the module `l10n_ro_edi_stock`
- Select a Romanian company
- In Profile > My Preferences > select Romanian language
- Try to access the settings

-> A traceback occurs

**Cause**:

The error is caused by this XPath:

https://github.com/odoo/odoo/blob/2309fb56553e6ae9f89b6dd0947aba2f54408960/addons/l10n_ro_edi_stock/views/res_config_settings_views.xml#L9C13-L11C21

Specifically, the `'select the option'` part. The XPath tries to replace this line in the parent view:

https://github.com/odoo/odoo/blob/2309fb56553e6ae9f89b6dd0947aba2f54408960/addons/l10n_ro_edi/views/res_config_settings_views.xml#L39

but fails to find it because the source text has already been translated at that point, so `'select the option'` no longer matches:

https://github.com/odoo/odoo/blob/2309fb56553e6ae9f89b6dd0947aba2f54408960/odoo/tools/template_inheritance.py#L154

**Solution**

Only rely on strings that are translation-invariant.

opw-5490346
