### PR TITLE
[IMP] website_sale_mrp: Subtract qty from kits

### DIFF
--- a/addons/website_sale_mrp/models/sale_order.py
+++ b/addons/website_sale_mrp/models/sale_order.py
@@ -58,3 +58,7 @@ class SaleOrder(models.Model):
                 max_free_kit_qty = min(max_free_kit_qty, (component.free_qty - unavailable_component_qty) // qty_per_kit[component])
             unavailable_qty += free_qty - max_free_kit_qty
         return unavailable_qty
+
+    def _get_cart_and_free_qty(self, product, line=None):
+        cart_qty, free_qty = super()._get_cart_and_free_qty(product, line)
+        return cart_qty, free_qty - self._get_unavailable_quantity_from_kits(product)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a product with a kit was added to the website cart, the quantities of the
kit components were not deducted from stock calculations. As a result, customers
could add the same product again without the kit, even though the available stock
should have been reduced.

Current behavior before PR:
Adding a product with a kit to the cart does not subtract the quantities of the
kit components. This allows customers to add the same product without the kit
regardless of actual stock availability.

Desired behavior after PR is merged:
When a product with a kit is added to the cart, the quantities of the kit
components are correctly deducted from stock calculations, preventing customers
from adding the same product without the kit when stock limits are reached.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
