### PR TITLE
[FIX] website_sale: fixing test

### DIFF
--- a/addons/website_sale/tests/test_main_controller.py
+++ b/addons/website_sale/tests/test_main_controller.py
@@ -28,6 +28,7 @@ class TestPaymentProviderVisibility(PaymentHttpCommon, SaleCommon):
         restricted_provider.write({'state': 'test', 'website_id': website_shop.id})
 
         url_so = self.sale_order.get_portal_url()
+        self.sale_order.require_payment = True
         portal_url = f"{website_portal.domain}{url_so}"
 
         with patch(


### PR DESCRIPTION
version: 17.0+e

Why ?
---------------

test_payment_provider_visibility_with_portal didn't pass on runbot because the sale order used doesn't reqire payment.

The fix
---------------

Force the sale order to require a payment.

runbot-237786

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
