### PR TITLE
[FIX] html_builder: Prevent dropping image in invalid locations

### DIFF
--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -143,7 +143,7 @@ export class DisableSnippetsPlugin extends Plugin {
                 dropAreaEls.push(
                     ...this.dependencies.dropzone.getSelectorSiblings(editableAreaEls, rootEl, {
                         selector: dropNear,
-                        excludeNearParent,
+                        excludeParent: excludeNearParent,
                     })
                 );
             }

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -115,7 +115,7 @@ export class DropZonePlugin extends Plugin {
                     selectorSiblings.push(
                         ...this.getSelectorSiblings(editableAreaEls, rootEl, {
                             selector: dropNear,
-                            excludeNearParent,
+                            excludeParent: excludeNearParent,
                         })
                     );
                 }

--- a/addons/html_builder/static/tests/drop_zone.test.js
+++ b/addons/html_builder/static/tests/drop_zone.test.js
@@ -37,3 +37,29 @@ test("drop beside dropzone inserts the snippet", async () => {
     </div>
 </section>`);
 });
+
+test("snippets cannot be dropped next to elements inside excluded parent", async () => {
+    const snippetContent = [
+        `<div name="Image" data-oe-thumbnail="image.svg" data-snippet="s_image">
+            <img src="/web/image/test.png" data-snippet="s_image" alt="Test Image"/>
+        </div>`,
+    ];
+    const dropzoneSelectors = [
+        {
+            selector: "img",
+            dropNear: "p, h1",
+            excludeNearParent: ".second-div",
+        },
+    ];
+    await setupHTMLBuilder(
+        `<div class="first-div"><h1>Title</h1><p>Paragraph</p></div>
+        <div class="second-div"><h1>Title</h1><p>Paragraph</p></div>`,
+        { snippetContent, dropzoneSelectors }
+    );
+
+    await contains(".o-snippets-menu .o_snippet_thumbnail[data-snippet='s_image']").drag();
+    // Should have 3 dropzones in first-div (not excluded)
+    expect(":iframe .first-div .oe_drop_zone").toHaveCount(3);
+    // Should have no dropzones in second-div (excluded by excludeNearParent)
+    expect(":iframe .second-div .oe_drop_zone").toHaveCount(0);
+});

--- a/addons/website/static/tests/builder/website_builder/button_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/button_option.test.js
@@ -39,11 +39,11 @@ test("Drag & drop a 'Button' snippet in a <div> should put it inside a <p>", asy
 
 test("Drag & drop a 'Button' snippet should align the button style with the button before it", async () => {
     const { getEditableContent } = await setupWebsiteBuilder(
-        `<a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a>`
+        `<div><a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a></div>`
     );
     const contentEl = getEditableContent();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a>`
+        `<div class="o-paragraph"><a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a></div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").not.toBeEnabled();
 
@@ -61,20 +61,20 @@ test("Drag & drop a 'Button' snippet should align the button style with the butt
     await drop(getDragHelper());
     await waitForEndOfOperation();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary mb-2" style="line-height: 50px;"> ButtonStyled </a> <a class="btn mb-2 btn-fill-secondary" href="#"> Button </a>`
+        `<div class="o-paragraph"><a href="http://test.com" class="btn btn-fill-secondary mb-2" style="line-height: 50px;"> ButtonStyled </a> <a class="btn mb-2 btn-fill-secondary" href="#"> Button </a></div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").toBeEnabled();
 });
 
 test("Drag & drop a 'Button' snippet over a dropzone should preview it correctly", async () => {
     const { getEditableContent } = await setupWebsiteBuilder(
-        `<a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
-         <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p>`
+        `<div><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
+         <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p></div>`
     );
     const contentEl = getEditableContent();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
-         <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p>`
+        `<div><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
+         <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p></div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").not.toBeEnabled();
 
@@ -98,9 +98,9 @@ test("Drag & drop a 'Button' snippet over a dropzone should preview it correctly
     await drop(getDragHelper());
     await waitForEndOfOperation();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled </a>
+        `<div><a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled </a>
          <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled in a p </a></p>
-         <p><a class="btn btn-primary" href="#"> Button </a></p>`
+         <p><a class="btn btn-primary" href="#"> Button </a></p></div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").toBeEnabled();
 });


### PR DESCRIPTION
Steps to reproduce the issue:
=================================

1. Go to Website > Products and edit a product.
2. In the product description, add a header using the editor.
3. You can now drop an image in that place, so drop it.
4. Click on the image and try to add an anchor for it.

-> Traceback

Cause:
======

The reason an image can be dropped in that location is because the editor
added an adjacent element, such as a `<p>` or `<h1>`, which is considered
a valid drop zone by the drop zone plugin. However, when trying to
create a link, the parent element checks if it is valid to have an
anchor, but then when adding an anchor the element text is undefined,
causing a traceback.

Why can an image be dropped in that location after adding the editor?
The bug was due to passing `excludeNearParent` as a property name instead
of `excludeParent` to the `getSelectorSiblings` function, which always
evaluated to false. So it allowed dropping images in invalid locations.

Solution:
=========
Pass the correct property name.

Impact:
=======
This fix enforces the intended dropzone behavior where content snippets
(like images, buttons with `.o_snippet_drop_in_only`) cannot create
dropzones next to elements that are direct children of `.oe_structure`
containers.

Test Changes Required:
=======================
The button tests were failing after the fix because they were testing
buttons as direct children of
`<div id="wrap" class="oe_structure oe_empty">`. This was only working
before due to the bug - `excludeNearParent` was being ignored.

The fix wraps the test buttons in a `<div>` container,
making them children of a child of `.oe_structure` rather than
direct children.

opw-5489444

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
