### PR TITLE
[FIX] mail,website: offset chat hub with website editor panel

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -35,6 +35,7 @@ export class ChatHub extends Component {
         this.options = useDropdownState();
         this.more = useDropdownState();
         this.ref = useRef("bubbles");
+        this.root = useRef("root");
         this.position = useState({
             dragged: false,
             isDragging: false,

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -2,8 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatHub">
-    <div class="o-mail-ChatHub d-print-none">
-
+    <div class="o-mail-ChatHub d-print-none" t-ref="root">
         <t t-set="visibleChatWindows" t-value="chatHub.compact ? chatHub.opened.filter(({ bypassCompact }) => bypassCompact) : chatHub.opened "/>
         <t t-foreach="visibleChatWindows" t-as="cw" t-key="cw.localId">
             <ChatWindow chatWindow="cw" t-if="cw.canShow" right="chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2)"/>

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -3,6 +3,7 @@ import { fields, Record } from "@mail/model/export";
 
 import { Deferred, Mutex } from "@web/core/utils/concurrency";
 
+export const CHAT_HUB_DEFAULT_BUBBLE_START = 15; // same value as $o-mail-ChatHub-bubblesStart
 export const CHAT_HUB_KEY = "mail.ChatHub";
 const CHAT_HUB_COMPACT_LS = "mail.user_setting.chathub_compact";
 
@@ -15,7 +16,17 @@ const CHAT_HUB_COMPACT_LS = "mail.user_setting.chathub_compact";
 
 export class ChatHub extends Record {
     BUBBLE = 56; // same value as $o-mail-ChatHub-bubblesWidth
-    BUBBLE_START = 15; // same value as $o-mail-ChatHub-bubblesStart
+    recomputeBubbleStart = 0;
+    BUBBLE_START = fields.Attr(CHAT_HUB_DEFAULT_BUBBLE_START, {
+        /** @this {import("models").Chathub} */
+        compute() {
+            void this.recomputeBubbleStart;
+            return this.computeBubbleStart();
+        },
+    });
+    computeBubbleStart() {
+        return CHAT_HUB_DEFAULT_BUBBLE_START;
+    }
     BUBBLE_LIMIT = 7;
     BUBBLE_OUTER = 10; // same value as $o-mail-ChatHub-bubblesMargin
     WINDOW_GAP = 10; // for a single end, multiply by 2 for left and right together.

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -3,7 +3,7 @@ $o-mail-Avatar-sizeSmall: 24px !default;
 $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
 $o-mail-ChatHub-bubblesMargin: 10px !default; // same value as BUBBLE_OUTER
-$o-mail-ChatHub-bubblesStart: 15px !default; // same value as BUBBLE_START
+$o-mail-ChatHub-bubblesStart: 15px !default; // same value as BUBBLE_START @deprecated
 $o-mail-ChatBubble-size: 42px !default;
 $o-mail-ChatBubble-sizeBig: 50px !default;
 $o-mail-ChatBubble-zindex: 1001 !default;

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
@@ -95,16 +95,3 @@
 body:has(.o_builder_sidebar_open) .o_notification_manager {
     @include o-position-absolute($top: map-get($spacers, 2), $right: calc(#{$o-we-sidebar-width} + 0.5rem));
 }
-
-body:has(.o_website_preview) {
-    .o-mail-ChatHub-bubbles {
-        transition: transform 400ms ease 0s;
-    }
-}
-
-body:has(.o-website-builder_sidebar.o_builder_sidebar_open) {
-    .o-mail-ChatHub-bubbles {
-        transform: translateX(-$o-we-sidebar-width);
-        transition-delay: 200ms;
-    }
-}

--- a/addons/website/static/src/common/chat_hub_model_patch.js
+++ b/addons/website/static/src/common/chat_hub_model_patch.js
@@ -1,0 +1,14 @@
+import { ChatHub } from "@mail/core/common/chat_hub_model";
+
+import { patch } from "@web/core/utils/patch";
+
+export const CHAT_HUB_WE_SIDEBAR_WIDTH = 288; // Same as $o-we-sidebar-width
+
+patch(ChatHub.prototype, {
+    computeBubbleStart() {
+        if (this.store.env.services["website"]?.context?.edition) {
+            return CHAT_HUB_WE_SIDEBAR_WIDTH;
+        }
+        return super.computeBubbleStart();
+    },
+});

--- a/addons/website/static/src/common/chat_hub_patch.js
+++ b/addons/website/static/src/common/chat_hub_patch.js
@@ -1,0 +1,21 @@
+import { ChatHub } from "@mail/core/common/chat_hub";
+import { useEffect } from "@odoo/owl";
+import { patch } from "@web/core/utils/patch";
+
+patch(ChatHub.prototype, {
+    setup() {
+        super.setup(...arguments);
+        useEffect(
+            () => {
+                this.chatHub.recomputeBubbleStart++;
+                if (!this.position.isDragging) {
+                    this.resetPosition(); // to take into account new bubble offset
+                }
+            },
+            () => [this.isWebsiteEdition]
+        );
+    },
+    get isWebsiteEdition() {
+        return this.env.services.website?.context.edition;
+    },
+});

--- a/addons/website/static/tests/builder/chat_hub.test.js
+++ b/addons/website/static/tests/builder/chat_hub.test.js
@@ -1,0 +1,54 @@
+import {
+    contains,
+    defineMailModels,
+    setupChatHub,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { ChatHub } from "@mail/core/common/chat_hub";
+import { CHAT_HUB_DEFAULT_BUBBLE_START } from "@mail/core/common/chat_hub_model";
+import { animationFrame, describe, expect, queryFirst, test } from "@odoo/hoot";
+import { onRendered } from "@odoo/owl";
+import { getService, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { CHAT_HUB_WE_SIDEBAR_WIDTH } from "@website/common/chat_hub_model_patch";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("chat hub offsets when website in edition mode", async () => {
+    // As to not overlap the website editor panel
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        body: "Orange",
+        res_id: channelId,
+        message_type: "comment",
+        model: "discuss.channel",
+    });
+    setupChatHub({ opened: [channelId] });
+    patchWithCleanup(ChatHub.prototype, {
+        setup() {
+            super.setup();
+            onRendered(() => {
+                const rootEl = this.root.el;
+                if (!rootEl) {
+                    return;
+                }
+                if (this.isWebsiteEdition) {
+                    rootEl.dataset.isWebsiteEdition = this.isWebsiteEdition;
+                } else {
+                    delete rootEl.dataset.isWebsiteEdition;
+                }
+            });
+        },
+    });
+    await start();
+    await contains(".o-mail-ChatWindow");
+    const xOffset_1 = queryFirst(".o-mail-ChatWindow").getBoundingClientRect().x;
+    // simulate website edition mode on
+    getService("website").context.edition = true;
+    await contains(".o-mail-ChatHub[data-is-website-edition]");
+    await animationFrame();
+    const xOffset_2 = queryFirst(".o-mail-ChatWindow").getBoundingClientRect().x;
+    expect(xOffset_2).toBe(xOffset_1 - CHAT_HUB_WE_SIDEBAR_WIDTH + CHAT_HUB_DEFAULT_BUBBLE_START);
+});


### PR DESCRIPTION
Before this commit, chat windows were overlapping website editor panel. This happens because chat windows had a hard-code starting position of 15px starting from the right of the screen, which is applied in all contexts.

This commit turns `BUBBLE_START` into computed field, so that this is patched when in website editor to offset it next to website editor panel, as to not overlap it.

Before / After
<img width="1918" height="604" alt="Screenshot 2026-01-16 at 18 11 50" src="https://github.com/user-attachments/assets/25051548-0c6e-4aea-97a1-459558601636" />
<img width="1920" height="605" alt="Screenshot 2026-01-16 at 18 21 53" src="https://github.com/user-attachments/assets/191c1323-380d-4328-b9c5-cf76deeb1d6a" />
