### PR TITLE
[FIX] html_editor: check if the `activeSelection` offsets are valid

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -488,9 +488,17 @@ export class SelectionPlugin extends Plugin {
                           : null,
                   })
                 : null;
+        // On Chrome, a specific sequence of actions could leave activeSelection
+        // having a connected anchorNode but with offset too high, pointing to
+        // an element that no longer exists. This is why the following condition
+        // is necessary (see commit message).
+        const isSelectionConnected =
+            this.activeSelection.anchorNode.isConnected &&
+            nodeSize(this.activeSelection.anchorNode) >= this.activeSelection.anchorOffset &&
+            nodeSize(this.activeSelection.focusNode) >= this.activeSelection.focusOffset;
         if (documentSelectionIsInEditable) {
             this.activeSelection = this.makeActiveSelection(selection);
-        } else if (!this.activeSelection.anchorNode.isConnected) {
+        } else if (!isSelectionConnected) {
             this.activeSelection = this.makeActiveSelection();
         }
         let { anchorNode, anchorOffset, focusNode, focusOffset, isCollapsed, direction } =


### PR DESCRIPTION
**Description of the problem**
In the website editor, the user can manipulate the page in such a way to generate a
problematic `SelectionPlugin.activeSelection`, which still points to an existing
`anchorElement`, but has an invalid `offset`.

**How to reproduce**
This seems to be reproducible only on Chrome.
1. Enter in the website edit mode
2. Drop the `s_newsletter` snippet
3. Drop the `s_popup` snippet
4. Click on the popup, and delete it
5. Click on the blank space inside the `s_newsletter` snippet
6. Delete the `s_newsletter` snippet
7. The error occurs

Notes:
1. Snippet different than `s_newsletter` can be used to reproduce the problem, as
long as they contain a blank space.
2. It is important to make sure that the movement of the mouse pointer does not
trigger any preview when going from step 5 to step 6.

**Why the problem happens**
On Chrome, clicking on a blank area can cause `document.getSelection()` to return a
selection with a null `anchorNode.` When this happens, `SelectionPlugin.getSelectionData()`
will use the already existing `activeSelection` if `activeSelection.anchorNode` is still
connected. Before this commit, this method only checked that `anchorNode` was connected,
without validating offsets. This leads to the following edge case:
1. The user removes the `s_popup`
2. At this point, `document.getSelection()` would point to the `s_newsletter` snippet, so if the
user just deletes the snippet nothing bad would happen. But instead, if:
3. The user clicks on a blank area in `s_newsletter`, `document.getSelection()` will now return
a null `anchorNode`
4. The user delete the `s_newsletter` snippet, and `SelectionPlugin.getSelectionData()` is called
by an handler after the deletion
5. At this point: `document.getSelection()` has a null `anchorNode`, so the method will check if
`activeSelection.anchorNode` is still connected, WITHOUT validating the offsets.
6. Since `anchorNode` is still connected, this selection will be used, and an error will be
triggered shortly after, because the offset is too high (pointing to `s_popup` which does not
exist anymore).

**Fix**
After this commit, when `SelectionPlugin.getSelectionData()` checks that `activeSelection.anchorNode`
is still connected it also checks that the offsets are valid (meaning that they are smaller than the
number of nodes).

task-5430500