### PR TITLE
[FIX] hr_attendance: allow module upgrade if overtime rule deleted

### DIFF
--- a/addons/hr_attendance/data/hr_attendance_overtime_rule_data.xml
+++ b/addons/hr_attendance/data/hr_attendance_overtime_rule_data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="hr_attendance_overtime_employee_schedule_rule" model="hr.attendance.overtime.rule">
+        <record id="hr_attendance_overtime_employee_schedule_rule" model="hr.attendance.overtime.rule" forcecreate="0">
             <field name="name">Employee Schedule Rule</field>
             <field name="base_off">quantity</field>
             <field name="timing_type">schedule</field>
@@ -10,7 +10,7 @@
             <field name="ruleset_id" ref="hr_attendance_default_ruleset"/>
         </record>
 
-        <record id="hr_attendance_overtime_non_working_days_rule" model="hr.attendance.overtime.rule">
+        <record id="hr_attendance_overtime_non_working_days_rule" model="hr.attendance.overtime.rule" forcecreate="0">
             <field name="name">Non Working Days Rule</field>
             <field name="base_off">timing</field>
             <field name="timing_type">non_work_days</field>


### PR DESCRIPTION
**Steps to reproduce**
- Install `hr_work_entry_attendance`
- Delete one of the overtime rules from the "Default Ruleset", e.g. "Employee Schedule Rule"
- Upgrade the `hr` module
- Traceback: `psycopg2.errors.CheckViolation: new row for relation "hr_attendance_overtime_rule" violates check constraint "hr_attendance_overtime_rule_if_paid_work_entry_type_defined"`

**Cause**
The `_if_paid_work_entry_type_defined` constraint added by the `hr_work_entry_attendance` module on overtime rule records will fail when re-creating an overtime rule record when upgrading another module than `hr_work_entry_attendance`, since the module is not loaded and we don't get a default value for the `work_entry_type_id` field.

**Fix**
Since the ORM cannot manage that, disable forcecreate for these records.
Related: https://github.com/odoo/enterprise/commit/f935e62bae7f204ea3f6db8f08b173bdf011c0d2

opw-5428542
