### PR TITLE
[FIX] microsoft_calendar: support single-tenant apps

### DIFF
--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 from odoo import api, fields, models, _, Command
 from odoo.exceptions import UserError
 from odoo.loglevels import exception_to_unicode
-from odoo.addons.microsoft_account.models.microsoft_service import DEFAULT_MICROSOFT_TOKEN_ENDPOINT
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import InvalidSyncToken
 from odoo.tools import str2bool
 
@@ -67,11 +66,11 @@ class User(models.Model):
             'client_secret': client_secret,
             'grant_type': 'refresh_token',
         }
-
+        MicrosoftService = self.env['microsoft.service']
         try:
-            dummy, response, dummy = self.env['microsoft.service']._do_request(
-                DEFAULT_MICROSOFT_TOKEN_ENDPOINT, params=data, headers=headers, method='POST', preuri=''
-            )
+            response = MicrosoftService._do_request(
+                MicrosoftService._get_token_endpoint(), params=data, headers=headers, method='POST', preuri=''
+            )[1]
             ttl = response.get('expires_in')
             self.write({
                 'microsoft_calendar_token': response.get('access_token'),

--- a/addons/microsoft_calendar/tests/test_microsoft_service.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_service.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, call, MagicMock
 from odoo import fields
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService
 from odoo.addons.microsoft_calendar.utils.microsoft_event import MicrosoftEvent
-from odoo.addons.microsoft_account.models.microsoft_service import MicrosoftService
+from odoo.addons.microsoft_account.models.microsoft_service import MicrosoftService, DEFAULT_MICROSOFT_TOKEN_ENDPOINT
 from odoo.tests import TransactionCase
 
 
@@ -461,3 +461,40 @@ class TestMicrosoftService(TransactionCase):
             self.call_with_sync_token,
             self.call_without_sync_token
         ])
+
+    @patch.object(MicrosoftService, "_do_request")
+    def test_decline_event_updates_attendee_state(self, mock_do_request):
+        # Ensure we use the correct endpoint (useful for single/multi-tenant deployments).
+        mock_do_request.return_value = self._do_request_result(
+            {
+                "access_token": "dummy_access_token",
+                "token_type": "Bearer",
+                "expires_in": 3599,
+                "scope": "Mail.Read User.Read",
+                "refresh_token": "dummy_refresh_token",
+            }
+        )
+        IrParameter = self.env["ir.config_parameter"].sudo()
+        IrParameter.set_param("microsoft_calendar_client_id", "dummy_client_id")
+        IrParameter.set_param("microsoft_calendar_client_secret", "dummy_client_secret")
+
+        self.env.user._refresh_microsoft_calendar_token()
+
+        custom_token_endpoint = "https://login.microsoftonline.com/dummy_tenant_id/oauth2/v2.0/token"
+        IrParameter.set_param("microsoft_account.token_endpoint", custom_token_endpoint)
+        self.env.user._refresh_microsoft_calendar_token()
+
+        kwargs = {
+            "params": {
+                "refresh_token": False,
+                "client_id": "dummy_client_id",
+                "client_secret": "dummy_client_secret",
+                "grant_type": "refresh_token",
+            },
+            "headers": {"content-type": "application/x-www-form-urlencoded"},
+            "method": "POST",
+            "preuri": "",
+        }
+        first_call = call(DEFAULT_MICROSOFT_TOKEN_ENDPOINT, **kwargs)
+        second_call = call(custom_token_endpoint, **kwargs)
+        mock_do_request.assert_has_calls([first_call, second_call])


### PR DESCRIPTION
Single-tenant Azure applications could synchronize calendar with Outlook, but refresh token renewal fail.

Odoo was always using the default Microsoft token endpoint instead of the tenant-specific endpoint required for single-tenant apps.

Steps to reproduce:
- Create a single-tenant app in the Azure portal
- Configure Odoo Microsoft Calendar with this app
- Set `microsoft_account.auth_endpoint` and `microsoft_account.token_endpoint` system parameters with the specific endpoints using the tenant ID
- Open the Calendar app and sync with Outlook
- Wait for access token expiration
- Refresh token request fails

This commit fixes the issue by using the token endpoint stored in the microsoft_account.token_endpoint system parameter when requesting a refresh token.