### PR TITLE
[FIX] web_editor: fix image being reverted on mail save

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1840,7 +1840,13 @@ export class Wysiwyg extends Component {
                     this.mutex.exec(() => {
                         // TODO In master use a trigger parameter
                         const event = $.Event("image_changed", {_complete: resolve});
-                        $element.trigger(event);
+                        const events = $._data($element[0], "events");
+                        const hasListener = events && events["image_changed"];
+                        if (hasListener && hasListener.length) {
+                            $element.trigger(event);
+                        } else {
+                            resolve();
+                        }
                     });
                 });
             }


### PR DESCRIPTION
**Steps to reproduce:**
- Install Email Marketing app
- Create a new campaign with Subject and Recipients
- Set plain text mail body
- Add one image using /img or /image command
- Save the template
- Remove the image
- Save the template
- Try to re-add an image, on save it will be deleted everytime

**Issue:**
During `commitChanges`, the history of the editor is in a wrong state which triggers a cleanup on
`this.wysiwyg.odooEditor.historyRevertCurrentStep();`.

This is caused by the `await saveCallback(element);` of `_onMediaDialogSave` which never resolve and never call its follow-up:
```js
this.odooEditor.historyUnpauseSteps();
this.odooEditor.historyStep();
```
The resolve is event-dependent and doesn't seem to be triggered in current versions:
`const event = $.Event("image_changed", {_complete: resolve});`

**Fix:**
Check that the current element is listening to the given event.
Might not be the proper fix as I wasn't able to reproduce the expected behavior with `image_changed` event.

related PR: https://github.com/odoo/odoo/pull/205594

opw-5245367
