### PR TITLE
[IMP] account: remove constraint on journal accounts reconciliation

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -164,24 +164,11 @@ class AccountPaymentMethodLine(models.Model):
 
     @api.model
     def _auto_toggle_account_to_reconcile(self, account_id):
-        """ Automatically toggle the account to reconcile if allowed.
+        """This method is deprecated and will be removed.
+        Automatically toggle the account to reconcile if allowed.
 
         :param account_id: The id of an account.account.
         """
         account = self.env['account.account'].browse(account_id)
         if not account.reconcile and account.account_type not in ('asset_cash', 'liability_credit_card', 'off_balance'):
             account.reconcile = True
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        # OVERRIDE
-        for vals in vals_list:
-            if vals.get('payment_account_id'):
-                self._auto_toggle_account_to_reconcile(vals['payment_account_id'])
-        return super().create(vals_list)
-
-    def write(self, vals):
-        # OVERRIDE
-        if vals.get('payment_account_id'):
-            self._auto_toggle_account_to_reconcile(vals['payment_account_id'])
-        return super().write(vals)


### PR DESCRIPTION
Previously, a constraint prevented accounts from being non-reconcilable if they were used as default debit/credit accounts involved in journals. This behavior is too restrictive.

This commit removes the constraint.

task-5254202

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
