### PR TITLE
[FIX] resource: attendance intervals batch

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -238,7 +238,7 @@ class ResourceCalendar(models.Model):
                     hour_from, hour_to = hours_per_attendance[att]
                     day_from = datetime.combine(day, float_to_time(hour_from))
                     day_to = datetime.combine(day, float_to_time(hour_to))
-                    base_result.append((day_from, day_to, attendance))
+                    base_result.append((day_from, day_to, att))
                 continue
 
             for attendance in attendances:


### PR DESCRIPTION
Fixes an issue with the attendance interval batch calculation; which would apply the
latest work entry type in the attendances to each and every work entry being generated.

If a work entry type was set on a weekend, that type would be set on every day of the month.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
