### PR TITLE
[FIX] base: enable payroll tests

### DIFF
--- a/odoo/addons/test_l10n/tests/install_all_l10n.py
+++ b/odoo/addons/test_l10n/tests/install_all_l10n.py
@@ -9,7 +9,9 @@ def test_all_l10n(env):
     """
     # Install the requirements
     l10n_mods = env['ir.module.module'].search([
+        '|',
         ('name', '=like', 'l10n_%'),
+        ('name', '=like', 'test_l10n_%'),
         ('state', '=', 'uninstalled'),
     ])
     l10n_mods.button_immediate_install()


### PR DESCRIPTION
Some payroll test module named test_l10n_xx are not being installed when l10n are tested. This causes the tests to never run, causing mistakes to regularly go through and break things.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
