### PR TITLE
[FIX] account: enable payroll tests

### DIFF
--- a/addons/account/tests/test_account_all_l10n.py
+++ b/addons/account/tests/test_account_all_l10n.py
@@ -50,7 +50,9 @@ def test_all_l10n(env):
     # Install the requirements
     _logger.info('Installing all l10n modules')
     l10n_mods = env['ir.module.module'].search([
+        '|',
         ('name', '=like', 'l10n_%'),
+        ('name', '=like', 'test_l10n_%'),
         ('state', '=', 'uninstalled'),
     ])
     with patch.object(AccountChartTemplate, 'try_loading', try_loading_patch),\


### PR DESCRIPTION
Some payroll test module named test_l10n_xx are not being installed when l10n are tested. This causes the tests to never run, causing mistakes to regularly go through and break things.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
