### PR TITLE
[FIX] pos_loyalty: ensure loyalty is loaded in trusted pos

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -51,4 +51,10 @@ patch(TicketScreen.prototype, {
         }
         return false;
     },
+    async _setOrder() {
+        await super._setOrder(...arguments);
+        if (this.pos.isOpenOrderShareable()) {
+            this.pos.updateRewards();
+        }
+    },
 });

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -691,3 +691,28 @@ registry.category("web_tour.tours").add("test_race_conditions_update_program", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_loyalty_in_trusted_pos_make_order", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("AAAA"),
+            ProductScreen.addOrderline("Whiteboard Pen", "1", "100"),
+            PosLoyalty.pointsAwardedAre("100"),
+            ProductScreen.saveOrder(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_loyalty_in_trusted_pos", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectOrder("-0001"),
+            TicketScreen.loadSelectedOrder(),
+            PosLoyalty.pointsAwardedAre("100"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3240,3 +3240,19 @@ class TestUi(TestPointOfSaleHttpCommon):
                 })]
             })
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_race_conditions_update_program', login="pos_user")
+
+    def test_loyalty_in_trusted_pos(self):
+        """This test ensures that when a order is loaded in trusted pos, loyalty is shown"""
+        self.env['loyalty.program'].search([]).write({'active': False})
+        trusted_pos_config = self.main_pos_config.copy()
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        partner = self.env['res.partner'].create({'name': 'AAAA'})
+        self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': partner.id,
+            'points': 0,
+        })
+        self.main_pos_config.trusted_config_ids += trusted_pos_config
+        trusted_pos_config.trusted_config_ids += self.main_pos_config
+        self.start_pos_tour("test_loyalty_in_trusted_pos_make_order", login="pos_user")
+        self.start_pos_tour("test_loyalty_in_trusted_pos", login="pos_user", pos_config=trusted_pos_config)


### PR DESCRIPTION
Step to reproduce:
- Create a loyalty program for a specific product as for 1 $ spent gets 1 point
- Have a trusted pos for our main shop (both pos should have each other as trusted)
- Create an order from the main pos , select a partner (notice we  get LPs)
- save the order
- Open the order in the trusted pos
- we do not see the loyalty points

Cause:
- currently, when loading a order in trusted pos, there is no trigger to update rewards for selected order

Fix:
- the ticket screen in loyalty has been patched to update rewards after loading a order

opw-5412744

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
