### PR TITLE
[FIX] website: remove header padding when visually separated from page

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -251,13 +251,28 @@ body {
                 max-width: 100% !important;
             }
 
-            // Vertical alignment when top-menu has visually "no background"
+            // Remove the left/right padding of the header navbar when the
+            // header has no visible separation from the body:
+            // - The header has no background color (transparent)
+            // - The header background color matches the body
+            // - The header has no shadow defined
             $-menu-color: o-color('menu-custom') or o-color('menu');
-            @if (not $-menu-color or $-menu-color == o-color('body')) {
-                > header {
-                    .navbar, .container {
-                        padding-left: 0;
-                        padding-right: 0;
+            $-header-template: o-website-value('header-template');
+            @if (
+                (not $-menu-color or ($-menu-color == o-color('body') and o-website-value('body-image') == null))
+                and (o-website-value('menu-box-shadow') == none)
+                and (index(("default", "hamburger", "stretch", "vertical", "search"), $-header-template) != null)
+            ) {
+                > header #o_main_nav {
+                    padding-left: 0;
+                    padding-right: 0;
+                    
+                    @if ($-header-template == "search") {
+                        & > div, 
+                        & > .o_header_hide_on_scroll > .container {
+                            padding-left: 0;
+                            padding-right: 0;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Before this PR, the left/right padding of the header would be removed when the header had no background color or when its background color matches the pages color. In these cases, the header boundaries were not visible and so we allowed the header to take more space.

However, the previous condition would not check if the page had a background image, or if the header had a shadow defined. The header would have visible boundaries and the element on the extremities would be stuck to the boundaries.

This commit updates the condition to include any possible option that would make the header boundaries visible.

task-5367502