### PR TITLE
[FIX] base: prevent cron run without valid access

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -445,6 +445,11 @@ class IrCron(models.Model):
             loop_count = 0
             _logger.info('Job %r (%s) starting', job['cron_name'], job['id'])
 
+            if not env.user.active and env.user != env.ref('base.user_root'):
+                _logger.warning("Forbidden server action %r executed while the user %s is archived.", job['cron_name'], env.user.login)
+                done, remaining = 0, 0
+                status = CompletionStatus.FAILED
+
             # stop after MIN_RUNS_PER_JOB runs and MIN_TIME_PER_JOB seconds, or
             # upon full completion or failure
             while status is None and (

--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -13,7 +13,8 @@ from unittest.mock import patch
 from freezegun import freeze_time
 
 from odoo import fields
-from odoo.tests.common import RecordCapturer, TransactionCase
+from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
+from odoo.tests.common import Like, RecordCapturer, TransactionCase
 from odoo.tools import mute_logger
 
 from odoo.addons.base.models.ir_cron import (
@@ -668,3 +669,28 @@ class TestIrCron(TransactionCase, CronMixinCase):
 
         self.env.invalidate_all()
         self.assertFalse(self.cron.active)
+
+
+class TestIrCronUser(TransactionCaseWithUserDemo, TestIrCron):
+    def test_cron_archived_admin_user(self):
+        cron_data = self._get_cron_data(self.env)
+        cron_data["user_id"] = self.user_demo.id
+
+        user = self.env['res.users'].browse(cron_data['user_id'])
+        user.active = False
+        user.group_ids = user.group_ids + self.env.ref('base.group_system')
+        cron = self.cron.create(cron_data)
+
+        default_progress_values = {'done': 0, 'remaining': 0, 'timed_out_counter': 0}
+
+        cron._trigger()
+        self.env.flush_all()
+        with self.enter_registry_test_mode(), self.registry.cursor() as cr:
+            with self.assertLogs('odoo.addons.base.models.ir_cron', level="WARNING") as log_catcher:
+                self.registry['ir.cron']._process_job(
+                    cr,
+                    {**cron.read(load=None)[0], **default_progress_values},
+                )
+                self.assertEqual([Like(f"...Forbidden server action '{cron.name}' executed while the user {user.login} is archived...")], log_catcher.output)
+
+        self.assertEqual(cron.failure_count, 1, 'The cron should have failed once')


### PR DESCRIPTION
Any user can be used to run a server action, even if archived or without corresponding access right.

Steps:
- Create a scheduled action running with an administrator (code: empty)
- Archive the used administrator
- Do the same steps with random user

Actual result:
- Action continue to run with an archived user
- Action continue to run with a user without corresponding access right

Expected result:
- Action should not run on a archived user (except System)
- Action can run if user has corresponding access right

opw-5475805