### PR TITLE
[FIX] website: preserve urls when removing or reordering gallery images

### DIFF
--- a/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
@@ -43,6 +43,7 @@ export class SetGalleryElementPositionAction extends BuilderAction {
             : "GalleryImageList";
 
         // Get the items to reorder.
+        activeItemEl = activeItemEl.closest("a") || activeItemEl;
         const itemEls = [];
         for (const getGalleryItems of this.getResource("get_gallery_items_handlers")) {
             itemEls.push(...getGalleryItems(activeItemEl, optionName));

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -116,7 +116,7 @@ class ImageGalleryOption extends Plugin {
         if (optionName === "GalleryImageList") {
             const galleryEl = activeItemEl.closest(".s_image_gallery");
             const containerEl = this.getContainer(galleryEl);
-            itemEls = this.getImages(containerEl);
+            itemEls = this.getImageHolder(containerEl);
         }
         return itemEls;
     }
@@ -133,7 +133,10 @@ class ImageGalleryOption extends Plugin {
             const galleryEl = activeItemEl.closest(".s_image_gallery");
 
             // Update the content with the new order.
-            itemEls.forEach((img, i) => (img.dataset.index = i));
+            itemEls.forEach((itemEl, i) => {
+                const imgEl = this.getImageElement(itemEl);
+                imgEl.dataset.index = i;
+            });
             const mode = this.getMode(galleryEl);
             this.setImages(galleryEl, mode, itemEls);
 
@@ -250,30 +253,39 @@ class ImageGalleryOption extends Plugin {
         }
     }
 
-    nomode(imageGalleryElement, images) {
+    nomode(imageGalleryElement, itemEls) {
         const row = this.document.createElement("div");
         row.classList.add("row", "s_nb_column_fixed");
         const container = this.getContainer(imageGalleryElement);
         container.replaceChildren(row);
-        for (const img of images) {
+        for (const itemEl of itemEls) {
+            const imgEl = this.getImageElement(itemEl);
             let wrapClass = "col-lg-3";
-            if (img.width >= img.height * 2 || img.width > 600) {
+            if (imgEl.width >= imgEl.height * 2 || imgEl.width > 600) {
                 wrapClass = "col-lg-6";
             }
 
             const wrap = this.document.createElement("div");
             wrap.classList.add(wrapClass);
-            wrap.appendChild(img);
+            wrap.appendChild(itemEl);
             row.appendChild(wrap);
         }
     }
 
-    slideshow(imageGalleryElement, images) {
+    slideshow(imageGalleryElement, itemEls) {
         const container = this.getContainer(imageGalleryElement);
         const currentInterval = imageGalleryElement.querySelector(".carousel")?.dataset.bsInterval;
         const carouselEl = imageGalleryElement.querySelector(".carousel");
         const colorContrast =
             carouselEl && carouselEl.classList.contains("carousel-dark") ? "carousel-dark" : " ";
+
+        const imagesData = itemEls.map(itemEl => {
+            const imgEl = this.getImageElement(itemEl);
+            const linkEl = itemEl.tagName === 'A' ? itemEl : null;
+            return { imgEl, linkEl };
+        });
+
+        const images = imagesData.map(data => data.imgEl);
         const slideshowEl = renderToElement("website.s_image_gallery_slideshow", {
             images: images,
             index: 0,
@@ -289,6 +301,11 @@ class ImageGalleryOption extends Plugin {
         container.replaceChildren(slideshowEl);
         slideshowEl.querySelectorAll("img").forEach((img, index) => {
             img.setAttribute("data-index", index);
+            if (imagesData[index]?.linkEl) {
+                const linkEl = imagesData[index].linkEl.cloneNode(false);
+                img.before(linkEl);
+                linkEl.append(img);
+            }
         });
         if (images.length) {
             slideshowEl
@@ -436,7 +453,7 @@ class ImageGalleryOption extends Plugin {
         // gallery.
         if (this.imageRemovedGalleryElement) {
             const mode = this.getMode(this.imageRemovedGalleryElement);
-            const images = this.getImages(this.imageRemovedGalleryElement);
+            const images = this.getImageHolder(this.imageRemovedGalleryElement);
             this.setImages(this.imageRemovedGalleryElement, mode, images);
             this.imageRemovedGalleryElement = undefined;
         }
@@ -446,6 +463,10 @@ class ImageGalleryOption extends Plugin {
         if (mediaEl.matches(".s_image_gallery img")) {
             forwardToThumbnail(mediaEl);
         }
+    }
+
+    getImageElement(el) {
+        return el.tagName === 'IMG' ? el : el.querySelector('img');
     }
 }
 


### PR DESCRIPTION
Before this change, using the website editor with image galleries, removing or reordering an image caused all image links to be lost. This happened because the gallery was rebuilt using image nodes only, dropping anchor wrappers during the process.

### How to reproduce:
* Open the website editor.
* Add an Image Gallery block.
* Add links to some of the images.
* Remove or reorder an image.
* All image links are lost.

### Solution:
Pass image holders instead of raw images to setImages and handle the different gallery modes.
opw-5422081

