### PR TITLE
Allow image generation using AI from media dialog

### DIFF
--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
@@ -7,10 +7,11 @@ import odoo
 from odoo.tools.misc import file_open
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.cloud_storage_azure.tests.test_cloud_storage_azure import TestCloudStorageAzureCommon
+from odoo.addons.mail.tests.common import MailCommon
 
 
 @odoo.tests.tagged("-at_install", "post_install", "mail_controller")
-class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorageAzureCommon):
+class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorageAzureCommon, MailCommon):
     def test_cloud_storage_azure_attachment_upload(self):
         """Test uploading an attachment with azure cloud storage."""
         thread = self.env["res.partner"].create({"name": "Test"})
@@ -59,7 +60,7 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                         "data": {
                             "attachment_id": attachment.id,
                             "store_data": {
-                                "ir.attachment": [
+                                "ir.attachment": self._filter_attachments_fields(
                                     {
                                         "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                                         "create_date": odoo.fields.Datetime.to_string(
@@ -79,8 +80,16 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                                         "type": "cloud_storage",
                                         "url": "[url]",
                                         "voice_ids": [],
+                                        "access_token": False,
+                                        "description": False,
+                                        "image_src": False,
+                                        "image_height": 0,
+                                        "image_width": 0,
+                                        "original_id": False,
+                                        "public": False,
+                                        "res_id": 0,
                                     }
-                                ],
+                                ),
                             }
                         },
                         "upload_info": {

--- a/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
+++ b/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
@@ -5,10 +5,11 @@ import odoo
 from odoo.tools.misc import file_open
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.cloud_storage_google.tests.test_cloud_storage_google import TestCloudStorageGoogleCommon
+from odoo.addons.mail.tests.common import MailCommon
 
 
 @odoo.tests.tagged("-at_install", "post_install", "mail_controller")
-class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorageGoogleCommon):
+class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorageGoogleCommon, MailCommon):
     def test_cloud_storage_google_attachment_upload(self):
         """Test uploading an attachment with google cloud storage."""
         thread = self.env["res.partner"].create({"name": "Test"})
@@ -44,7 +45,7 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                     "data": {
                         "attachment_id": attachment.id,
                         "store_data": {
-                            "ir.attachment": [
+                            "ir.attachment": self._filter_attachments_fields(
                                 {
                                     "checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                                     "create_date": odoo.fields.Datetime.to_string(
@@ -64,8 +65,16 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                                     "type": "cloud_storage",
                                     "url": "[url]",
                                     "voice_ids": [],
+                                    "access_token": False,
+                                    "description": False,
+                                    "image_src": False,
+                                    "image_height": 0,
+                                    "image_width": 0,
+                                    "original_id": False,
+                                    "public": False,
+                                    "res_id": 0,
                                 }
-                            ],
+                            ),
                         },
                     },
                     "upload_info": {"method": "PUT", "response_status": 200, "url": "[url]"},

--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -98,10 +98,17 @@ export class MediaWebsitePlugin extends Plugin {
         const sel = this.dependencies.selection.getEditableSelection();
         const editableEl =
             closestElement(mediaEl || sel.startContainer, ".o_savable") || this.editable;
-        const params = this.processThrough("replace_media_dialog_params_processors", {
-            node: mediaEl,
-        });
+        const params = this.processThrough(
+            "replace_media_dialog_params_processors",
+            this.getMediaDialogProps({ mediaEl, editableEl })
+        );
         await this.dependencies.media.openMediaDialog(params, editableEl);
+    }
+
+    getMediaDialogProps({ mediaEl, editableEl }) {
+        return {
+            node: mediaEl,
+        };
     }
 
     /**

--- a/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_image_option_plugin.js
@@ -22,7 +22,6 @@ export class BackgroundImageOptionPlugin extends Plugin {
     static shared = [
         "changeEditingEl",
         "setImageBackground",
-        "loadReplaceBackgroundImage",
         "applyReplaceBackgroundImage",
         "removeBackgroundImage",
     ];
@@ -98,23 +97,7 @@ export class BackgroundImageOptionPlugin extends Plugin {
             newEditingEl.classList.toggle("o_modified_image_to_save", isModifiedImage);
         }
     }
-    loadReplaceBackgroundImage({ editingElement }) {
-        return new Promise((resolve) => {
-            const onClose = this.dependencies.media.openMediaDialog({
-                onlyImages: true,
-                node: editingElement,
-                save: async (imageEl) => {
-                    resolve(imageEl);
-                },
-            });
-            onClose.then(resolve);
-        });
-    }
-    applyReplaceBackgroundImage({
-        editingElement,
-        loadResult: imageEl,
-        params: { forceClean = false },
-    }) {
+    applyReplaceBackgroundImage({ editingElement, imageEl, params: { forceClean = false } }) {
         if (!forceClean && !imageEl) {
             // Do nothing: no images has been selected on the media dialog
             return;
@@ -167,7 +150,7 @@ export class BackgroundImageOptionPlugin extends Plugin {
     removeBackgroundImage({ editingElement, params }) {
         this.applyReplaceBackgroundImage({
             editingElement,
-            loadResult: "",
+            imageEl: "",
             params: { ...params, forceClean: true },
         });
         // When background image with position "Repeat pattern" is removed,
@@ -239,13 +222,22 @@ export class SelectFilterColorAction extends StyleAction {
 
 export class ToggleBgImageAction extends BuilderAction {
     static id = "toggleBgImage";
-    static dependencies = ["backgroundImageOption"];
-    load(context) {
-        return this.dependencies.backgroundImageOption.loadReplaceBackgroundImage(context);
+    static dependencies = ["backgroundImageOption", "media"];
+    async apply(context) {
+        await this.dependencies.media.openMediaDialog(this.getMediaDialogProps(context));
     }
-    apply(context) {
-        return this.dependencies.backgroundImageOption.applyReplaceBackgroundImage(context);
+
+    getMediaDialogProps(context) {
+        return {
+            onlyImages: true,
+            node: context.editingElement,
+            save: async (imageEl) => {
+                context.imageEl = imageEl;
+                this.dependencies.backgroundImageOption.applyReplaceBackgroundImage(context);
+            },
+        };
     }
+
     isApplied({ editingElement }) {
         return !!getBgImageURLFromEl(editingElement);
     }
@@ -264,12 +256,20 @@ export class RemoveBgImageAction extends BuilderAction {
 
 export class ReplaceBgImageAction extends BuilderAction {
     static id = "replaceBgImage";
-    static dependencies = ["backgroundImageOption"];
-    load(context) {
-        return this.dependencies.backgroundImageOption.loadReplaceBackgroundImage(context);
+    static dependencies = ["backgroundImageOption", "media"];
+    async apply(context) {
+        await this.dependencies.media.openMediaDialog(this.getMediaDialogProps(context));
     }
-    apply(context) {
-        return this.dependencies.backgroundImageOption.applyReplaceBackgroundImage(context);
+
+    getMediaDialogProps(context) {
+        return {
+            onlyImages: true,
+            node: context.editingElement,
+            save: async (imageEl) => {
+                context.imageEl = imageEl;
+                this.dependencies.backgroundImageOption.applyReplaceBackgroundImage(context);
+            },
+        };
     }
 }
 export class DynamicColorAction extends BuilderAction {

--- a/addons/html_builder/static/src/plugins/image/image_snippet_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_snippet_option_plugin.js
@@ -16,29 +16,40 @@ export class ImageSnippetOptionPlugin extends Plugin {
             return;
         }
 
+        let discardSnippet = false;
         // Open the media dialog and replace the image snippet placeholder by
         // the selected image.
-        let isImageSelected = false;
         await new Promise((resolve) => {
-            const onClose = this.dependencies.media.openMediaDialog({
-                onlyImages: true,
-                save: async (selectedImageEl) => {
-                    isImageSelected = true;
-                    snippetEl.replaceWith(selectedImageEl);
-                    // If the "Image" snippet was dropped as a grid item, make
-                    // it a grid image.
-                    if (dragState.draggedEl.classList.contains("o_grid_item")) {
-                        dragState.draggedEl.classList.add("o_grid_item_image");
-                    }
-                    dragState.replacedSnippetEl = selectedImageEl;
-                },
-            });
-            onClose.then(() => {
+            const onClose = this.dependencies.media.openMediaDialog(
+                this.getMediaDialogProps(snippetEl, dragState)
+            );
+            onClose.then((closeParams) => {
+                discardSnippet = this.onCloseMediaDialog({ closeParams, snippetEl, dragState });
                 resolve();
             });
         });
+        return discardSnippet;
+    }
 
-        return !isImageSelected;
+    getMediaDialogProps(snippetEl, dragState) {
+        return {
+            onlyImages: true,
+            save: async (...args) => {
+                const selectedImageEl = args[0];
+                const elementToReplace = args[3] || snippetEl;
+                elementToReplace.replaceWith(selectedImageEl);
+                // If the "Image" snippet was dropped as a grid item, make
+                // it a grid image.
+                if (dragState.draggedEl.classList.contains("o_grid_item")) {
+                    dragState.draggedEl.classList.add("o_grid_item_image");
+                }
+                dragState.replacedSnippetEl = selectedImageEl;
+            },
+        };
+    }
+
+    onCloseMediaDialog({ closeParams, snippetEl, dragState }) {
+        return closeParams.closeReason !== "save";
     }
 }
 

--- a/addons/html_editor/models/ir_attachment.py
+++ b/addons/html_editor/models/ir_attachment.py
@@ -82,7 +82,15 @@ class IrAttachment(models.Model):
     def _get_media_info(self):
         """Return a dict with the values that we need on the media dialog."""
         self.ensure_one()
-        return self._read_format(['id', 'name', 'description', 'mimetype', 'checksum', 'url', 'type', 'res_id', 'res_model', 'public', 'access_token', 'image_src', 'image_width', 'image_height', 'original_id'])[0]
+        return self._read_format(self._editor_media_fields())[0]
+
+    @api.model
+    def _editor_media_fields(self):
+        return [
+            'original_id', 'id', 'name', 'description', 'mimetype',
+            'checksum', 'url', 'type', 'res_id', 'res_model',
+            'public', 'access_token', 'image_src', 'image_width', 'image_height',
+        ]
 
     def _can_bypass_rights_on_media_dialog(self, **attachment_data):
         """ This method is meant to be overridden, for instance to allow to

--- a/addons/html_editor/static/src/core/dialog_plugin.js
+++ b/addons/html_editor/static/src/core/dialog_plugin.js
@@ -19,14 +19,14 @@ export class DialogPlugin extends Plugin {
      * @param {Component} DialogClass
      * @param {Object} props
      * @param {DialogServiceInterfaceAddOptions} options
-     * @returns {Promise<void>}
+     * @returns {Promise<any>}
      */
     addDialog(DialogClass, props, options = {}) {
         return new Promise((resolve) => {
             this.services.dialog.add(DialogClass, props, {
-                onClose: () => {
+                onClose: (closeParams) => {
                     this.dependencies.selection.focusEditable();
-                    resolve();
+                    resolve(closeParams);
                 },
                 ...options,
             });

--- a/addons/html_editor/static/src/fields/image_field_with_media_dialog/image_field_with_media_dialog.js
+++ b/addons/html_editor/static/src/fields/image_field_with_media_dialog/image_field_with_media_dialog.js
@@ -1,0 +1,50 @@
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { ImageField, imageField } from "@web/views/fields/image/image_field";
+import { saveSingleAttachment } from "@web/core/utils/image_library";
+import { CustomMediaDialog } from "@html_editor/fields/x2many_field/custom_media_dialog";
+
+export class ImageFieldWithMediaDialog extends ImageField {
+    static template = "html_editor.ImageFieldWithMediaDialog";
+
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.dialog = useService("dialog");
+    }
+
+    onFileEdit(ev) {
+        this.dialog.add(CustomMediaDialog, this.mediaDialogProps);
+    }
+
+    get mediaDialogProps() {
+        return {
+            visibleTabs: ["IMAGES"],
+            activeTab: "IMAGES",
+            save: (el) => {}, // Simple rebound to fake its execution
+            imageSave: this.onImageSave.bind(this),
+            imageUrl: this.imageUrl,
+        };
+    }
+
+    get imageUrl() {
+        const fieldName = this.fieldType === "many2one" ? this.props.previewImage : this.props.name;
+        return this.getUrl(fieldName);
+    }
+
+    async onImageSave(attachments) {
+        await saveSingleAttachment(this.env, {
+            attachment: attachments[0],
+            targetRecord: this.props.record,
+            targetFieldName: this.props.name,
+            changeRecordName: false,
+        });
+    }
+}
+
+export const imageFieldWithMediaDialog = {
+    ...imageField,
+    component: ImageFieldWithMediaDialog,
+};
+
+registry.category("fields").add("image_with_media_dialog", imageFieldWithMediaDialog);

--- a/addons/html_editor/static/src/fields/image_field_with_media_dialog/image_field_with_media_dialog.xml
+++ b/addons/html_editor/static/src/fields/image_field_with_media_dialog/image_field_with_media_dialog.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-name="html_editor.ImageFieldWithMediaDialog" t-inherit="web.ImageField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('position-relative')]//div" position="replace">
+            <div t-attf-class="position-absolute d-flex justify-content-between w-100 bottom-0 opacity-0 opacity-100-hover {{isMobile ? 'o_mobile_controls' : ''}}" aria-atomic="true" t-att-style="sizeStyle">
+                <button
+                    t-if="state.isValid"
+                    class="o_select_file_button btn btn-light border-0 rounded-circle m-1 p-1"
+                    data-tooltip="Edit"
+                    aria-label="Edit"
+                    t-on-click.prevent.stop="onFileEdit">
+                    <i class="fa fa-pencil fa-fw"/>
+                </button>
+                <button
+                    t-if="state.isValid"
+                    class="o_clear_file_button btn btn-light border-0 rounded-circle m-1 p-1"
+                    data-tooltip="Clear"
+                    aria-label="Clear"
+                    t-on-click.prevent.stop="onFileRemove">
+                    <i class="fa fa-trash-o fa-fw"/>
+                </button>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/fields/x2many_field/custom_media_dialog.js
+++ b/addons/html_editor/static/src/fields/x2many_field/custom_media_dialog.js
@@ -15,22 +15,26 @@ export class CustomMediaDialog extends MediaDialog {
             return;
         }
         if (this.state.activeTab == "IMAGES") {
-            const attachments = this.selectedMedia[this.state.activeTab];
-            const preloadedAttachments = attachments.filter((attachment) => attachment.res_model);
-            this.selectedMedia[this.state.activeTab] = attachments.filter(
-                (attachment) => !preloadedAttachments.includes(attachment)
-            );
-            if (this.selectedMedia[this.state.activeTab].length > 0) {
-                await super.save();
-                const newAttachments = this.selectedMedia[this.state.activeTab];
-                this.props.imageSave(newAttachments);
-            }
-            if (preloadedAttachments.length) {
-                this.props.imageSave(preloadedAttachments);
-            }
+            await this.imageSave({
+                attachments: this.selectedMedia[this.state.activeTab],
+                superSaveFunction: () => super.save(),
+                propsSaveFunction: (attachments) => this.props.imageSave(attachments),
+            });
         } else {
             this.props.videoSave(this.selectedMedia[this.state.activeTab]);
         }
         this.props.close();
+    }
+
+    async imageSave({ attachments, superSaveFunction, propsSaveFunction }) {
+        const preloadedAttachments = attachments.filter((attachment) => attachment.res_model);
+        const nonPreloadedAttachments = attachments.filter((attachment) => !attachment.res_model);
+        if (nonPreloadedAttachments.length > 0) {
+            await superSaveFunction();
+            await propsSaveFunction(nonPreloadedAttachments);
+        }
+        if (preloadedAttachments.length) {
+            await propsSaveFunction(preloadedAttachments);
+        }
     }
 }

--- a/addons/html_editor/static/src/fields/x2many_field/x2many_image_field.js
+++ b/addons/html_editor/static/src/fields/x2many_field/x2many_image_field.js
@@ -3,6 +3,7 @@ import { useService } from "@web/core/utils/hooks";
 import { ImageField, imageField } from "@web/views/fields/image/image_field";
 import { CustomMediaDialog } from "./custom_media_dialog";
 import { getVideoUrl } from "@html_editor/utils/url";
+import { saveSingleAttachment } from "@web/core/utils/image_library";
 
 export class X2ManyImageField extends ImageField {
     static template = "html_editor.ImageField";
@@ -17,42 +18,31 @@ export class X2ManyImageField extends ImageField {
      * standard behavior of opening file input box in order to update a record.
      */
     onFileEdit(ev) {
+        this.dialog.add(CustomMediaDialog, this.mediaDialogProps);
+    }
+
+    get mediaDialogProps() {
         const isVideo = this.props.record.data.video_url;
         let mediaEl;
         if (isVideo) {
             mediaEl = document.createElement("img");
             mediaEl.dataset.src = this.props.record.data.video_url;
         }
-        this.dialog.add(CustomMediaDialog, {
+        return {
             visibleTabs: ["IMAGES", "VIDEOS"],
             media: mediaEl,
             activeTab: isVideo ? "VIDEOS" : "IMAGES",
             save: (el) => {}, // Simple rebound to fake its execution
             imageSave: this.onImageSave.bind(this),
             videoSave: this.onVideoSave.bind(this),
-        });
+        };
     }
-
-    async onImageSave(attachment) {
-        const attachmentRecord = await this.orm.searchRead(
-            "ir.attachment",
-            [["id", "=", attachment[0].id]],
-            ["id", "raw", "name"],
-            {}
-        );
-        if (!attachmentRecord[0].raw) {
-            // URL type attachments are mostly demo records which don't have any ir.attachment raw
-            // TODO: make it work with URL type attachments
-            return this.notification.add(
-                `Cannot add URL type attachment "${attachmentRecord[0].name}". Please try to reupload this image.`,
-                {
-                    type: "warning",
-                }
-            );
-        }
-        await this.props.record.update({
-            [this.props.name]: attachmentRecord[0].raw,
-            name: attachmentRecord[0].name,
+    async onImageSave(attachments) {
+        await saveSingleAttachment(this.env, {
+            attachment: attachments[0],
+            targetRecord: this.props.record,
+            targetFieldName: this.props.name,
+            changeRecordName: true,
         });
     }
 

--- a/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
+++ b/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
@@ -4,6 +4,7 @@ import { useService } from "@web/core/utils/hooks";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { getVideoUrl } from "@html_editor/utils/url";
 import { CustomMediaDialog } from "./custom_media_dialog";
+import { saveMultipleAttachments } from "@web/core/utils/image_library";
 
 export class X2ManyMediaViewer extends X2ManyField {
     static template = "html_editor.X2ManyMediaViewer";
@@ -24,13 +25,17 @@ export class X2ManyMediaViewer extends X2ManyField {
     }
 
     addMedia() {
-        this.dialogs.add(CustomMediaDialog, {
+        this.dialogs.add(CustomMediaDialog, this.mediaDialogProps);
+    }
+
+    get mediaDialogProps() {
+        return {
             save: (el) => {}, // Simple rebound to fake its execution
             multiImages: true,
             visibleTabs: ["IMAGES", "VIDEOS"],
             imageSave: this.onImageSave.bind(this),
             videoSave: this.onVideoSave.bind(this),
-        });
+        };
     }
 
     onVideoSave(videoInfo) {
@@ -42,115 +47,12 @@ export class X2ManyMediaViewer extends X2ManyField {
     }
 
     async onImageSave(attachments) {
-        const attachmentIds = attachments.map((attachment) => attachment.id);
-        const attachmentRecords = await this.orm.searchRead(
-            "ir.attachment",
-            [["id", "in", attachmentIds]],
-            ["id", "raw", "name", "mimetype"],
-            {}
-        );
-        for (const attachment of attachmentRecords) {
-            const imageList = this.props.record.data[this.props.name];
-            if (!attachment.raw) {
-                // URL type attachments are mostly demo records which don't have any ir.attachment raw
-                // TODO: make it work with URL type attachments
-                return this.notification.add(
-                    `Cannot add URL type attachment "${attachment.name}". Please try to reupload this image.`,
-                    {
-                        type: "warning",
-                    }
-                );
-            }
-            if (
-                this.props.convertToWebp &&
-                !["image/gif", "image/svg+xml"].includes(attachment.mimetype)
-            ) {
-                // This method is widely adapted from onFileUploaded in ImageField.
-                // Upon change, make sure to verify whether the same change needs
-                // to be applied on both sides.
-                // Generate alternate sizes and format for reports.
-                const image = document.createElement("img");
-                image.src = `data:${attachment.mimetype};base64,${attachment.raw}`;
-                await new Promise((resolve) => image.addEventListener("load", resolve));
-
-                const originalSize = Math.max(image.width, image.height);
-                const smallerSizes = [1024, 512, 256, 128].filter((size) => size < originalSize);
-                let referenceId = undefined;
-
-                for (const size of [originalSize, ...smallerSizes]) {
-                    const ratio = size / originalSize;
-                    const canvas = document.createElement("canvas");
-                    canvas.width = image.width * ratio;
-                    canvas.height = image.height * ratio;
-                    const ctx = canvas.getContext("2d");
-                    ctx.drawImage(
-                        image,
-                        0,
-                        0,
-                        image.width,
-                        image.height,
-                        0,
-                        0,
-                        canvas.width,
-                        canvas.height
-                    );
-
-                    // WebP format
-                    const webpData = canvas.toDataURL("image/webp").split(",")[1];
-                    const [resizedId] = await this.orm.call("ir.attachment", "create_unique", [
-                        [
-                            {
-                                name: attachment.name.replace(/\.[^/.]+$/, ".webp"),
-                                description: size === originalSize ? "" : `resize: ${size}`,
-                                raw: webpData,
-                                res_id: referenceId,
-                                res_model: "ir.attachment",
-                                mimetype: "image/webp",
-                            },
-                        ],
-                    ]);
-
-                    referenceId = referenceId || resizedId;
-
-                    // JPEG format for compatibility
-                    const jpegData = canvas.toDataURL("image/jpeg").split(",")[1];
-                    await this.orm.call("ir.attachment", "create_unique", [
-                        [
-                            {
-                                name: attachment.name.replace(/\.[^/.]+$/, ".jpg"),
-                                description: `resize: ${size} - format: jpeg`,
-                                raw: jpegData,
-                                res_id: resizedId,
-                                res_model: "ir.attachment",
-                                mimetype: "image/jpeg",
-                            },
-                        ],
-                    ]);
-                }
-                const canvas = document.createElement("canvas");
-                canvas.width = image.width;
-                canvas.height = image.height;
-                const ctx = canvas.getContext("2d");
-                ctx.drawImage(image, 0, 0, image.width, image.height);
-
-                const webpData = canvas.toDataURL("image/webp").split(",")[1];
-                attachment.raw = webpData;
-                attachment.mimetype = "image/webp";
-                attachment.name = attachment.name.replace(/\.[^/.]+$/, ".webp");
-            }
-
-            imageList.addNewRecord({ position: "bottom" }).then((record) => {
-                const activeFields = imageList.activeFields;
-                const updateData = {};
-                for (const field in activeFields) {
-                    if (attachment.raw && this.supportedFields.includes(field)) {
-                        updateData[field] = attachment.raw;
-                        updateData["name"] = attachment.name;
-                    }
-                }
-                record.update(updateData);
-            });
-        }
+        await saveMultipleAttachments(this.env, {
+            attachments,
+            targetRecord: this.props.record,
+            targetFieldName: this.props.name,
+            convertToWebp: this.props.convertToWebp,
+        });
     }
 
     async onAdd({ context, editable } = {}) {

--- a/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/file_selector.js
@@ -8,7 +8,6 @@ import { KeepLast } from "@web/core/utils/concurrency";
 import { user } from "@web/core/user";
 import { useDebounced } from "@web/core/utils/timing";
 import { SearchMedia } from "./search_media";
-
 import { Component, xml, onWillStart } from "@odoo/owl";
 
 export const IMAGE_MIMETYPES = [
@@ -21,6 +20,24 @@ export const IMAGE_MIMETYPES = [
     "image/webp",
 ];
 export const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".jpe", ".png", ".svg", ".gif", ".webp"];
+
+export const ATTACHMENT_FIELDS = [
+    "id",
+    "name",
+    "mimetype",
+    "description",
+    "checksum",
+    "url",
+    "type",
+    "res_id",
+    "res_model",
+    "public",
+    "access_token",
+    "image_src",
+    "image_width",
+    "image_height",
+    "original_id",
+];
 
 class RemoveButton extends Component {
     static template = xml`<i class="fa fa-trash o_existing_attachment_remove position-absolute top-0 end-0 p-2 bg-white-25 cursor-pointer opacity-0 opacity-100-hover z-1 transition-base" t-att-title="this.removeTitle" role="img" t-att-aria-label="this.removeTitle" t-on-click="this.remove"/>`;
@@ -282,22 +299,7 @@ export class FileSelector extends Component {
         this.state.isFetchingAttachments = true;
         const attachments = await this.orm.call("ir.attachment", "search_read", [], {
             domain: this.attachmentsDomain,
-            fields: [
-                "name",
-                "mimetype",
-                "description",
-                "checksum",
-                "url",
-                "type",
-                "res_id",
-                "res_model",
-                "public",
-                "access_token",
-                "image_src",
-                "image_width",
-                "image_height",
-                "original_id",
-            ],
+            fields: ATTACHMENT_FIELDS,
             order: "id desc",
             // Try to fetch first record of next page just to know whether there is a next page.
             limit,

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -3,26 +3,10 @@ import { _t } from "@web/core/l10n/translation";
 import { useService, useChildRef } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
 import { Notebook } from "@web/core/notebook/notebook";
-import { ImageSelector } from "./image_selector";
-import { IconSelector } from "./icon_selector";
 
 import { Component } from "@odoo/owl";
 import { iconClasses } from "@html_editor/utils/dom_info";
-
-export const TABS = {
-    IMAGES: {
-        id: "IMAGES",
-        title: _t("Images"),
-        Component: ImageSelector,
-        sequence: 10,
-    },
-    ICONS: {
-        id: "ICONS",
-        title: _t("Icons"),
-        Component: IconSelector,
-        sequence: 20,
-    },
-};
+import { TABS, renderAndSaveMedia } from "./media_dialog_utils";
 
 const DEFAULT_SEQUENCE = 50;
 const sequence = (tab) => tab.sequence ?? DEFAULT_SEQUENCE;
@@ -176,107 +160,6 @@ export class MediaDialog extends Component {
         this.props.extraTabs.forEach((tab) => this.addTab(tab));
     }
 
-    /**
-     * Render the selected media for insertion in the editor
-     *
-     * @param {Array<Object>} selectedMedia
-     * @returns {Array<HTMLElement>}
-     */
-    async renderMedia(selectedMedia) {
-        const elements = await this.tabs[this.state.activeTab].Component.createElements(
-            selectedMedia,
-            { orm: this.orm }
-        );
-        elements.forEach((element) => {
-            if (this.props.media) {
-                element.classList.add(...this.props.media.classList);
-                const style = this.props.media.getAttribute("style");
-                if (style) {
-                    element.setAttribute("style", style);
-                }
-                if (this.state.activeTab === TABS.IMAGES.id) {
-                    if (this.props.media.dataset.shape) {
-                        element.dataset.shape = this.props.media.dataset.shape;
-                    }
-                    if (this.props.media.dataset.shapeColors) {
-                        element.dataset.shapeColors = this.props.media.dataset.shapeColors;
-                    }
-                    if (this.props.media.dataset.shapeFlip) {
-                        element.dataset.shapeFlip = this.props.media.dataset.shapeFlip;
-                    }
-                    if (this.props.media.dataset.shapeRotate) {
-                        element.dataset.shapeRotate = this.props.media.dataset.shapeRotate;
-                    }
-                    if (this.props.media.dataset.hoverEffect) {
-                        element.dataset.hoverEffect = this.props.media.dataset.hoverEffect;
-                    }
-                    if (this.props.media.dataset.hoverEffectColor) {
-                        element.dataset.hoverEffectColor =
-                            this.props.media.dataset.hoverEffectColor;
-                    }
-                    if (this.props.media.dataset.hoverEffectStrokeWidth) {
-                        element.dataset.hoverEffectStrokeWidth =
-                            this.props.media.dataset.hoverEffectStrokeWidth;
-                    }
-                    if (this.props.media.dataset.hoverEffectIntensity) {
-                        element.dataset.hoverEffectIntensity =
-                            this.props.media.dataset.hoverEffectIntensity;
-                    }
-                }
-            }
-            for (const otherTab of Object.keys(this.tabs).filter(
-                (key) => key !== this.state.activeTab
-            )) {
-                for (const property of this.tabs[otherTab].Component.mediaSpecificStyles) {
-                    element.style.removeProperty(property);
-                }
-                element.classList.remove(...this.tabs[otherTab].Component.mediaSpecificClasses);
-                const extraClassesToRemove = [];
-                for (const name of this.tabs[otherTab].Component.mediaExtraClasses) {
-                    if (typeof name === "string") {
-                        extraClassesToRemove.push(name);
-                    } else {
-                        // Regex
-                        for (const className of element.classList) {
-                            if (className.match(name)) {
-                                extraClassesToRemove.push(className);
-                            }
-                        }
-                    }
-                }
-                // Remove classes that do not also exist in the target type.
-                element.classList.remove(
-                    ...extraClassesToRemove.filter((candidateName) => {
-                        for (const name of this.tabs[this.state.activeTab].Component
-                            .mediaExtraClasses) {
-                            if (typeof name === "string") {
-                                if (candidateName === name) {
-                                    return false;
-                                }
-                            } else {
-                                // Regex
-                                if (candidateName.match(name)) {
-                                    return false;
-                                }
-                            }
-                        }
-                        return true;
-                    })
-                );
-            }
-
-            element.classList.add(...this.extraClassesToAdd());
-
-            element.classList.remove(...this.initialIconClasses);
-            element.classList.remove("o_modified_image_to_save");
-            element.classList.remove("oe_edited_link");
-            element.classList.add(
-                ...this.tabs[this.state.activeTab].Component.mediaSpecificClasses
-            );
-        });
-        return elements;
-    }
-
     extraClassesToAdd() {
         return [];
     }
@@ -321,26 +204,30 @@ export class MediaDialog extends Component {
                 !this.props.media);
         this.state.isSaving = true;
         if (saveSelectedMedia) {
-            const elements = await this.renderMedia(selectedMedia);
-            if (this.props.multiImages) {
-                await this.props.save(elements, selectedMedia, this.state.activeTab);
-            } else {
-                await this.props.save(elements[0], selectedMedia, this.state.activeTab);
-            }
+            await renderAndSaveMedia({
+                orm: this.orm,
+                activeTab: this.state.activeTab,
+                availableTabs: this.tabs,
+                oldMediaNode: this.props.media,
+                selectedMedia: selectedMedia,
+                extraClassesToAdd: this.extraClassesToAdd(),
+                extraClassesToRemove: this.initialIconClasses,
+                multiImages: this.props.multiImages,
+                saveFunction: this.props.save,
+            });
         }
-        this.props.close();
-        this.state.isSaving = false;
+        this.close({ closeReason: "save" });
     }
 
     onTabChange(tab) {
         this.state.activeTab = tab;
     }
-    async close() {
+    async close(closeParams = {}) {
         if (this.abortUploads) {
             this.abortUploads();
             delete this.abortUploads;
         }
         this.state.isSaving = false;
-        await this.props.close();
+        await this.props.close(closeParams);
     }
 }

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.xml
@@ -7,7 +7,7 @@
         <Notebook pages="notebookPages" onPageUpdate.bind="onTabChange" defaultPage="state.activeTab"/>
         <t t-set-slot="footer">
             <button class="btn btn-primary" t-on-click="() => this.save()" t-custom-ref="add-button" data-hotkey="q">Add</button>
-            <button class="btn btn-secondary" t-on-click="() => this.close()" data-hotkey="x">Discard</button>
+            <button class="btn btn-secondary" t-on-click="() => this.close({ closeReason: 'discard' })" data-hotkey="x">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog_utils.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog_utils.js
@@ -1,0 +1,167 @@
+import { ATTACHMENT_FIELDS } from "./file_selector";
+import { ImageSelector } from "./image_selector";
+import { IconSelector } from "./icon_selector";
+import { _t } from "@web/core/l10n/translation";
+
+export const TABS = {
+    IMAGES: {
+        id: "IMAGES",
+        title: _t("Images"),
+        Component: ImageSelector,
+        sequence: 10,
+    },
+    ICONS: {
+        id: "ICONS",
+        title: _t("Icons"),
+        Component: IconSelector,
+        sequence: 20,
+    },
+};
+
+export async function renderAndSaveMedia({
+    orm,
+    activeTab,
+    availableTabs,
+    oldMediaNode,
+    selectedMedia,
+    extraClassesToAdd,
+    extraClassesToRemove,
+    multiImages,
+    saveFunction,
+    aiChannelId = null,
+}) {
+    const elements = await renderMedia({
+        orm,
+        activeTab,
+        availableTabs,
+        oldMediaNode,
+        selectedMedia,
+        extraClassesToAdd,
+        extraClassesToRemove,
+        aiChannelId,
+    });
+    if (multiImages) {
+        await saveFunction(elements, selectedMedia, activeTab, oldMediaNode);
+    } else {
+        await saveFunction(elements[0], selectedMedia, activeTab, oldMediaNode);
+    }
+}
+
+/**
+ * Render the selected media for insertion in the editor
+ *
+ * @param orm
+ * @param {String} activeTab
+ * @param {Object} availableTabs
+ * @param {HTMLElement} oldMediaNode
+ * @param {Array<Object>} selectedMedia
+ * @param {Array<String>} extraClassesToAdd
+ * @returns {Array<HTMLElement>}
+ */
+export async function renderMedia({
+    orm,
+    activeTab,
+    availableTabs,
+    oldMediaNode,
+    selectedMedia,
+    extraClassesToAdd,
+    extraClassesToRemove,
+    aiChannelId = null,
+}) {
+    const elements = await availableTabs[activeTab].Component.createElements(selectedMedia, {
+        orm: orm,
+    });
+    elements.forEach((element) => {
+        if (oldMediaNode) {
+            element.classList.add(...oldMediaNode.classList);
+            const style = oldMediaNode.getAttribute("style");
+            if (style) {
+                element.setAttribute("style", style);
+            }
+            if (activeTab === TABS.IMAGES.id) {
+                if (oldMediaNode.dataset.shape) {
+                    element.dataset.shape = oldMediaNode.dataset.shape;
+                }
+                if (oldMediaNode.dataset.shapeColors) {
+                    element.dataset.shapeColors = oldMediaNode.dataset.shapeColors;
+                }
+                if (oldMediaNode.dataset.shapeFlip) {
+                    element.dataset.shapeFlip = oldMediaNode.dataset.shapeFlip;
+                }
+                if (oldMediaNode.dataset.shapeRotate) {
+                    element.dataset.shapeRotate = oldMediaNode.dataset.shapeRotate;
+                }
+                if (oldMediaNode.dataset.hoverEffect) {
+                    element.dataset.hoverEffect = oldMediaNode.dataset.hoverEffect;
+                }
+                if (oldMediaNode.dataset.hoverEffectColor) {
+                    element.dataset.hoverEffectColor = oldMediaNode.dataset.hoverEffectColor;
+                }
+                if (oldMediaNode.dataset.hoverEffectStrokeWidth) {
+                    element.dataset.hoverEffectStrokeWidth =
+                        oldMediaNode.dataset.hoverEffectStrokeWidth;
+                }
+                if (oldMediaNode.dataset.hoverEffectIntensity) {
+                    element.dataset.hoverEffectIntensity =
+                        oldMediaNode.dataset.hoverEffectIntensity;
+                }
+            }
+        }
+        if (aiChannelId) {
+            element.dataset.aiChannelId = aiChannelId;
+        }
+        for (const otherTab of Object.keys(availableTabs).filter((key) => key !== activeTab)) {
+            for (const property of availableTabs[otherTab].Component.mediaSpecificStyles) {
+                element.style.removeProperty(property);
+            }
+            element.classList.remove(...availableTabs[otherTab].Component.mediaSpecificClasses);
+            const extraClassesToRemove = [];
+            for (const name of availableTabs[otherTab].Component.mediaExtraClasses) {
+                if (typeof name === "string") {
+                    extraClassesToRemove.push(name);
+                } else {
+                    // Regex
+                    for (const className of element.classList) {
+                        if (className.match(name)) {
+                            extraClassesToRemove.push(className);
+                        }
+                    }
+                }
+            }
+            // Remove classes that do not also exist in the target type.
+            element.classList.remove(
+                ...extraClassesToRemove.filter((candidateName) => {
+                    for (const name of availableTabs[activeTab].Component.mediaExtraClasses) {
+                        if (typeof name === "string") {
+                            if (candidateName === name) {
+                                return false;
+                            }
+                        } else {
+                            // Regex
+                            if (candidateName.match(name)) {
+                                return false;
+                            }
+                        }
+                    }
+                    return true;
+                })
+            );
+        }
+
+        element.classList.add(...extraClassesToAdd);
+
+        element.classList.remove(...extraClassesToRemove);
+        element.classList.remove("o_modified_image_to_save");
+        element.classList.remove("oe_edited_link");
+        element.classList.add(...availableTabs[activeTab].Component.mediaSpecificClasses);
+    });
+    return elements;
+}
+
+export function convertAttachmentRecordToObject(attachment_record) {
+    const imageAttachmentObject = {};
+    for (const attachment_field of ATTACHMENT_FIELDS) {
+        imageAttachmentObject[attachment_field] = attachment_record[attachment_field];
+    }
+    return imageAttachmentObject;
+}

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -10,7 +10,8 @@ import {
     paragraphRelatedElementsSelector,
 } from "@html_editor/utils/dom_info";
 import { _t } from "@web/core/l10n/translation";
-import { MediaDialog, TABS } from "./media_dialog/media_dialog";
+import { MediaDialog } from "./media_dialog/media_dialog";
+import { TABS } from "./media_dialog/media_dialog_utils";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { boundariesOut, rightPos } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
@@ -209,8 +210,7 @@ export class MediaPlugin extends Plugin {
             }
             this.trigger("on_media_replaced_handlers", { newMediaEl: element });
         } else {
-            this.dependencies.dom.insert(element);
-            this.trigger("on_media_added_handlers", { newMediaEl: element });
+            await this.addMedia(element);
         }
         // Collapse selection after the inserted/replaced element.
         const [anchorNode, anchorOffset] = rightPos(element);
@@ -219,9 +219,13 @@ export class MediaPlugin extends Plugin {
         this.dependencies.history.addStep();
     }
 
+    async addMedia(element) {
+        this.dependencies.dom.insert(element);
+        this.trigger("on_media_added_handlers", { newMediaEl: element });
+    }
+
     openMediaDialog(params = {}, editableEl = null) {
-        const oldSave =
-            params.save || ((element) => this.onSaveMediaDialog(element, { node: params.node }));
+        const oldSave = params.save || this.getSaveFunction(params);
         params.save = async (...args) => {
             const selection = args[0];
             const elements = selection
@@ -231,7 +235,7 @@ export class MediaPlugin extends Plugin {
                 : [];
             await Promise.all(
                 this.trigger("on_will_save_media_dialog_handlers", elements, {
-                    node: params.node,
+                    node: args[3] || params.node,
                 })
             );
             return oldSave(...args);
@@ -240,6 +244,7 @@ export class MediaPlugin extends Plugin {
         const mediaDialogClosedPromise = this.dependencies.dialog.addDialog(MediaDialog, {
             resModel,
             resId,
+            field,
             useMediaLibrary: !!(
                 field &&
                 ((resModel === "ir.ui.view" && field === "arch") || type === "html")
@@ -252,6 +257,14 @@ export class MediaPlugin extends Plugin {
             ...params,
         });
         return mediaDialogClosedPromise;
+    }
+
+    getSaveFunction(params) {
+        return (...args) => {
+            const element = args[0];
+            const node = args[3] || params.node;
+            this.onSaveMediaDialog(element, { node });
+        };
     }
 
     /**

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -2131,6 +2131,22 @@ class MailCommon(MailCase):
                 data.pop("rating_count", None)
         return list(threads_data)
 
+    def _filter_attachments_fields(self, /, *attachments_data):
+        """ Remove store attachment data dependant on other modules if they are not not installed.
+        Not written in a modular way to avoid complex override for a simple test tool.
+        """
+        for data in attachments_data:
+            if 'ai.agent' not in self.env:
+                data.pop("access_token", None)
+                data.pop("description", None)
+                data.pop("image_src", None)
+                data.pop("image_height", None)
+                data.pop("image_width", None)
+                data.pop("original_id", None)
+                data.pop("public", None)
+                data.pop("res_id", None)
+        return list(attachments_data)
+
     @classmethod
     def _setup_push_devices_for_partners(cls, partners, endpoint=None):
         """ Generate keys and devices """

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -13,7 +13,7 @@ from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 
 
 @odoo.tests.tagged("mail_controller")
-class TestMessageController(HttpCaseWithUserDemo):
+class TestMessageController(HttpCaseWithUserDemo, MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -97,7 +97,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         data1 = res2.json()["result"]
         self.assertEqual(
             data1["store_data"]["ir.attachment"],
-            [
+            self._filter_attachments_fields(
                 {
                     "checksum": False,
                     "create_date": fields.Datetime.to_string(self.attachments[0].create_date),
@@ -115,8 +115,16 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "voice_ids": [],
                     'type': 'binary',
                     'url': False,
+                    "access_token": False,
+                    "description": False,
+                    "image_src": False,
+                    "image_height": 0,
+                    "image_width": 0,
+                    "original_id": False,
+                    "public": False,
+                    "res_id": self.attachments[0].res_id,
                 },
-            ],
+            ),
             "guest should be allowed to add attachment with token when posting message",
         )
         # test message update: token error
@@ -163,7 +171,7 @@ class TestMessageController(HttpCaseWithUserDemo):
         data2 = res4.json()["result"]
         self.assertEqual(
             data2["ir.attachment"],
-            [
+            self._filter_attachments_fields(
                 {
                     "checksum": False,
                     "create_date": fields.Datetime.to_string(self.attachments[0].create_date),
@@ -181,6 +189,14 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "voice_ids": [],
                     'type': 'binary',
                     'url': False,
+                    "access_token": False,
+                    "description": False,
+                    "image_src": False,
+                    "image_height": 0,
+                    "image_width": 0,
+                    "original_id": False,
+                    "public": False,
+                    "res_id": self.attachments[0].res_id,
                 },
                 {
                     "checksum": False,
@@ -199,8 +215,16 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "voice_ids": [],
                     'type': 'binary',
                     'url': False,
+                    "access_token": False,
+                    "description": False,
+                    "image_src": False,
+                    "image_height": 0,
+                    "image_width": 0,
+                    "original_id": False,
+                    "public": False,
+                    "res_id": self.attachments[1].res_id,
                 },
-            ],
+            ),
             "guest should be allowed to add attachment with token when updating message",
         )
 

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -52,7 +52,7 @@
                     <group class="o_form_header_group flex-md-row-reverse">
                         <field
                             name="image_1920"
-                            widget="image"
+                            widget="image_with_media_dialog"
                             options="{'convert_to_webp': True, 'preview_image': 'image_128'}"
                         />
                         <group class="o_form_header_details flex-grow-1">

--- a/addons/project/tests/test_project_sharing.py
+++ b/addons/project/tests/test_project_sharing.py
@@ -634,7 +634,7 @@ class TestProjectSharing(TestProjectSharingCommon):
         # Reading the milestone should no longer trigger an access error.
         project_milestone.with_user(self.user_portal).read(['name'])
         with self.assertRaises(AccessError, msg="Should not accept the portal user to update a milestone."):
-            project_milestone.with_user(self.user_portal).write(['name'])
+            project_milestone.with_user(self.user_portal).write({'name': 'test_milestone'})
         with self.assertRaises(AccessError, msg="Should not accept the portal user to delete a milestone."):
             project_milestone.with_user(self.user_portal).unlink()
         with self.assertRaises(AccessError, msg="Should not accept the portal user to create a milestone."):

--- a/addons/web/static/src/core/utils/image_library.js
+++ b/addons/web/static/src/core/utils/image_library.js
@@ -1,0 +1,133 @@
+export async function saveSingleAttachment(
+    env,
+    { attachment, targetRecord, targetFieldName, changeRecordName }
+) {
+    const attachmentRecord = (
+        await retrieveAttachmentRecords(env, { attachmentIds: [attachment.id] })
+    )[0];
+    if (!attachmentRecord.raw) {
+        return notifyURLAttachmentUploadFailed(env, { attachmentName: attachmentRecord.name });
+    }
+    const update_data = {
+        [targetFieldName]: attachmentRecord.raw,
+    };
+    if (changeRecordName) {
+        update_data["name"] = attachmentRecord.name;
+    }
+    await targetRecord.update(update_data);
+}
+
+export async function saveMultipleAttachments(
+    env,
+    { attachments, targetRecord, targetFieldName, convertToWebp }
+) {
+    const imageList = targetRecord.data[targetFieldName];
+    const supportedFields = ["image_1920", "image_1024", "image_512", "image_256", "image_128"];
+    const attachmentRecords = await retrieveAttachmentRecords(env, {
+        attachmentIds: attachments.map((attachment) => attachment.id),
+    });
+    for (const attachmentRecord of attachmentRecords) {
+        if (!attachmentRecord.raw) {
+            return notifyURLAttachmentUploadFailed(env, { attachmentName: attachmentRecord.name });
+        }
+        if (convertToWebp && !["image/gif", "image/svg+xml"].includes(attachmentRecord.mimetype)) {
+            await convertToWebpFormat(env, { attachmentRecord });
+        }
+        const activeFields = imageList.activeFields;
+        imageList.addNewRecord({ position: "bottom" }).then((record) => {
+            const updateData = {};
+            for (const field in activeFields) {
+                if (attachmentRecord.raw && supportedFields.includes(field)) {
+                    updateData[field] = attachmentRecord.raw;
+                    updateData["name"] = attachmentRecord.name;
+                }
+            }
+            record.update(updateData);
+        });
+    }
+}
+
+async function retrieveAttachmentRecords(env, { attachmentIds }) {
+    return await env.services.orm.searchRead(
+        "ir.attachment",
+        [["id", "in", attachmentIds]],
+        ["id", "raw", "name", "mimetype"],
+        {}
+    );
+}
+
+function notifyURLAttachmentUploadFailed(env, { attachmentName }) {
+    // URL type attachments are mostly demo records which don't have any ir.attachment raw
+    // TODO: make it work with URL type attachments
+    return env.services.notification.add(
+        `Cannot add URL type attachment "${attachmentName}". Please try to reupload this image.`,
+        {
+            type: "warning",
+        }
+    );
+}
+
+async function convertToWebpFormat(env, { attachmentRecord }) {
+    // This method is widely adapted from onFileUploaded in ImageField.
+    // Upon change, make sure to verify whether the same change needs
+    // to be applied on both sides.
+    // Generate alternate sizes and format for reports.
+    const image = document.createElement("img");
+    image.src = `data:${attachmentRecord.mimetype};base64,${attachmentRecord.raw}`;
+    await new Promise((resolve) => image.addEventListener("load", resolve));
+
+    const originalSize = Math.max(image.width, image.height);
+    const smallerSizes = [1024, 512, 256, 128].filter((size) => size < originalSize);
+    let referenceId = undefined;
+
+    for (const size of [originalSize, ...smallerSizes]) {
+        const ratio = size / originalSize;
+        const canvas = document.createElement("canvas");
+        canvas.width = image.width * ratio;
+        canvas.height = image.height * ratio;
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(image, 0, 0, image.width, image.height, 0, 0, canvas.width, canvas.height);
+
+        // WebP format
+        const webpData = canvas.toDataURL("image/webp", 0.75).split(",")[1];
+        const [resizedId] = await env.services.orm.call("ir.attachment", "create_unique", [
+            [
+                {
+                    name: attachmentRecord.name.replace(/\.[^/.]+$/, ".webp"),
+                    description: size === originalSize ? "" : `resize: ${size}`,
+                    raw: webpData,
+                    res_id: referenceId,
+                    res_model: "ir.attachment",
+                    mimetype: "image/webp",
+                },
+            ],
+        ]);
+
+        referenceId = referenceId || resizedId;
+
+        // JPEG format for compatibility
+        const jpegData = canvas.toDataURL("image/jpeg", 0.75).split(",")[1];
+        await env.services.orm.call("ir.attachment", "create_unique", [
+            [
+                {
+                    name: attachmentRecord.name.replace(/\.[^/.]+$/, ".jpg"),
+                    description: `resize: ${size} - format: jpeg`,
+                    raw: jpegData,
+                    res_id: resizedId,
+                    res_model: "ir.attachment",
+                    mimetype: "image/jpeg",
+                },
+            ],
+        ]);
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(image, 0, 0, image.width, image.height);
+
+    const webpData = canvas.toDataURL("image/webp", 0.75).split(",")[1];
+    attachmentRecord.raw = webpData;
+    attachmentRecord.mimetype = "image/webp";
+    attachmentRecord.name = attachmentRecord.name.replace(/\.[^/.]+$/, ".webp");
+}

--- a/addons/web_unsplash/static/src/media_dialog/media_dialog_patch.js
+++ b/addons/web_unsplash/static/src/media_dialog/media_dialog_patch.js
@@ -1,4 +1,5 @@
-import { MediaDialog, TABS } from "@html_editor/main/media/media_dialog/media_dialog";
+import { MediaDialog } from "@html_editor/main/media/media_dialog/media_dialog";
+import { TABS } from "@html_editor/main/media/media_dialog/media_dialog_utils"
 import { patch } from "@web/core/utils/patch";
 import { useService } from "@web/core/utils/hooks";
 

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -18,7 +18,6 @@ import { renderToElement } from "@web/core/utils/render";
 import { CompositeAction } from "@html_builder/core/composite_action_plugin";
 import { ImagePositionOverlay } from "@html_builder/plugins/image/image_position_overlay";
 import { loadImage } from "@html_editor/utils/image_processing";
-
 /**
  * @typedef { Object } CustomizeWebsiteShared
  * @property { CustomizeWebsitePlugin['customizeWebsiteColors'] } customizeWebsiteColors
@@ -485,7 +484,7 @@ export class AddLanguageAction extends BuilderAction {
 
 export class ToggleBodyBgImageAction extends BuilderAction {
     static id = "toggleBodyBgImage";
-    static dependencies = ["builderActions", "history", "customizeWebsite"];
+    static dependencies = ["builderActions", "history", "customizeWebsite", "media"];
     isApplied() {
         return !!this.dependencies.customizeWebsite.getWebsiteVariableValue("body-image");
     }
@@ -528,16 +527,21 @@ export class ToggleBodyBgImageAction extends BuilderAction {
         });
     }
     async apply({ editingElement: el } = {}) {
-        const getAction = this.dependencies.builderActions.getAction;
-        const { type: currentType, image: currentImage } = this.getCurrentConfig();
-        const oldConfig = { type: currentType, image: currentImage };
-
-        const imageEl = await getAction("replaceBgImage").load({ el });
-        if (!imageEl) {
-            return;
-        }
-        const newConfig = { type: currentType, image: imageEl.src };
-        await this.applyConfig(oldConfig, newConfig);
+        await this.dependencies.media.openMediaDialog(
+            this.getMediaDialogProps({ editingElement: el })
+        );
+    }
+    getMediaDialogProps({ editingElement }) {
+        return {
+            onlyImages: true,
+            node: editingElement,
+            save: async (imageEl) => {
+                const { type: currentType, image: currentImage } = this.getCurrentConfig();
+                const oldConfig = { type: currentType, image: currentImage };
+                const newConfig = { type: currentType, image: imageEl.src };
+                await this.applyConfig(oldConfig, newConfig);
+            },
+        };
     }
     async clean() {
         const { type: currentType, image: currentImage } = this.getCurrentConfig();

--- a/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
@@ -98,21 +98,19 @@ export class AddGridElementAction extends BuilderAction {
 
     async apply({ editingElement: rowEl, params: { mainParam: elementType } }) {
         if (elementType === "image") {
-            // Choose an image with the media dialog.
-            let imageEl;
             await this.dependencies.media.openMediaDialog({
                 onlyImages: true,
                 noDocuments: true,
-                save: (selectedImageEl) => (imageEl = selectedImageEl),
+                save: async (imageEl) => {
+                    if (!imageEl) {
+                        return;
+                    }
+                    await onceAllImagesLoaded(imageEl);
+                    this.dependencies.addElementOption.addGridElement(rowEl, imageEl, 6, 6, [
+                        "o_grid_item_image",
+                    ]);
+                },
             });
-            if (!imageEl) {
-                return;
-            }
-            // Wait for the image to be loaded.
-            await onceAllImagesLoaded(imageEl);
-            this.dependencies.addElementOption.addGridElement(rowEl, imageEl, 6, 6, [
-                "o_grid_item_image",
-            ]);
         } else if (elementType === "text") {
             // Create default text content.
             const pEl = document.createElement("p");

--- a/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/cover_properties_option_plugin.js
@@ -124,51 +124,56 @@ export class SetCoverBackgroundAction extends BaseCoverPropertiesAction {
         this.classAction = this.dependencies.builderActions.getAction("classAction");
         this.styleAction = this.dependencies.builderActions.getAction("styleAction");
     }
-    load({ params: { mainParam: setBackground } }) {
-        if (!setBackground) {
-            return;
-        }
-        let resultPromise;
-        return this.dependencies.media
-            .openMediaDialog({
-                onlyImages: true,
-                save: (imageEl) => {
-                    resultPromise = (async () => {
-                        const b64ToSave = imageEl.getAttribute("src").startsWith("data:");
-                        return { imageSrc: imageEl.getAttribute("src"), b64ToSave };
-                    })();
-                },
-            })
-            .then(() => resultPromise || { cancel: true });
-    }
 
     isApplied({ editingElement, params: { mainParam: setBackground } }) {
         const bg = editingElement.querySelector(".o_record_cover_image").style.backgroundImage;
         return !setBackground === (!bg || bg === "none");
     }
-    apply({ editingElement, loadResult: { imageSrc, b64ToSave, cancel } = {} }) {
-        if (cancel) {
+
+    async apply({ editingElement, params: { mainParam: setBackground } }) {
+        if (!setBackground) {
+            this.styleAction.apply({
+                editingElement: editingElement.querySelector(".o_record_cover_image"),
+                params: { mainParam: "background-image" },
+                value: "",
+            });
+            editingElement.closest(
+                ".o_record_cover_container"
+            ).dataset.coverPropertiesToBeSaved = true;
             return;
         }
-        (imageSrc ? this.classAction.apply : this.classAction.clean)({
-            editingElement,
-            params: { mainParam: "o_record_has_cover" },
-        });
+        await this.dependencies.media.openMediaDialog(this.getMediaDialogProps({ editingElement }));
+    }
 
-        const bgEl = editingElement.querySelector(".o_record_cover_image");
+    getMediaDialogProps({ editingElement }) {
+        return {
+            onlyImages: true,
+            save: (imageEl) => {
+                const imageSrc = imageEl.getAttribute("src");
+                const b64ToSave = imageEl.getAttribute("src").startsWith("data:");
 
-        (b64ToSave ? this.classAction.apply : this.classAction.clean)({
-            editingElement: bgEl,
-            params: { mainParam: "o_b64_cover_image_to_save" },
-        });
+                (imageSrc ? this.classAction.apply : this.classAction.clean)({
+                    editingElement,
+                    params: { mainParam: "o_record_has_cover" },
+                });
 
-        this.styleAction.apply({
-            editingElement: bgEl,
-            params: { mainParam: "background-image" },
-            value: imageSrc ? `url('${imageSrc}')` : "",
-        });
+                const bgEl = editingElement.querySelector(".o_record_cover_image");
 
-        editingElement.closest(".o_record_cover_container").dataset.coverPropertiesToBeSaved = true;
+                (b64ToSave ? this.classAction.apply : this.classAction.clean)({
+                    editingElement: bgEl,
+                    params: { mainParam: "o_b64_cover_image_to_save" },
+                });
+
+                this.styleAction.apply({
+                    editingElement: bgEl,
+                    params: { mainParam: "background-image" },
+                    value: imageSrc ? `url('${imageSrc}')` : "",
+                });
+                editingElement.closest(
+                    ".o_record_cover_container"
+                ).dataset.coverPropertiesToBeSaved = true;
+            },
+        };
     }
 }
 export class MarkCoverPropertiesToBeSavedAction extends BaseCoverPropertiesAction {

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -456,29 +456,26 @@ export class ImageGalleryOptionPlugin extends Plugin {
 export class AddImageAction extends BuilderAction {
     static id = "addImage";
     static dependencies = ["media", "imageGalleryOption"];
-    async load({ editingElement }) {
-        let selectedImages;
-        await new Promise((resolve) => {
-            const onClose = this.dependencies.media.openMediaDialog({
-                onlyImages: true,
-                multiImages: true,
-                save: (images) => {
-                    selectedImages = images;
-                    resolve();
-                },
-            });
-            onClose.then(resolve);
+    async apply({ editingElement }) {
+        await this.dependencies.media.openMediaDialog({
+            onlyImages: true,
+            multiImages: true,
+            save: async (images) => {
+                const { images: processedImages } =
+                    await this.dependencies.imageGalleryOption.processImages(
+                        editingElement,
+                        images
+                    );
+                if (processedImages && processedImages.length) {
+                    const mode = this.dependencies.imageGalleryOption.getMode(editingElement);
+                    this.dependencies.imageGalleryOption.setImages(
+                        editingElement,
+                        mode,
+                        processedImages
+                    );
+                }
+            },
         });
-        if (!selectedImages) {
-            return [];
-        }
-        return this.dependencies.imageGalleryOption.processImages(editingElement, selectedImages);
-    }
-    apply({ editingElement, loadResult: { images } }) {
-        if (images && images.length) {
-            const mode = this.dependencies.imageGalleryOption.getMode(editingElement);
-            this.dependencies.imageGalleryOption.setImages(editingElement, mode, images);
-        }
     }
 }
 export class RemoveAllImagesAction extends BuilderAction {

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -18,7 +18,7 @@ import wUtils from "@website/js/utils";
 const WORD_SEPARATORS_REGEX =
     "([\\u2000-\\u206F\\u2E00-\\u2E7F'!\"#\\$%&\\(\\)\\*\\+,\\-\\.\\/:;<=>\\?¿¡@\\[\\]\\^_`\\{\\|\\}~\\s]+|^|$)";
 
-const seoContext = reactive({
+export const seoContext = reactive({
     description: "",
     keywords: [],
     title: "",

--- a/addons/website/static/src/components/media_dialog/media_dialog.js
+++ b/addons/website/static/src/components/media_dialog/media_dialog.js
@@ -1,10 +1,11 @@
 import { patch } from "@web/core/utils/patch";
-import { MediaDialog, TABS } from "@html_editor/main/media/media_dialog/media_dialog";
+import { MediaDialog } from "@html_editor/main/media/media_dialog/media_dialog";
+import { TABS } from "@html_editor/main/media/media_dialog/media_dialog_utils";
 
 patch(MediaDialog.prototype, {
     extraClassesToAdd() {
         const classes = super.extraClassesToAdd();
-        const closestDivEl = this.props.node?.parentElement.closest("div");
+        const closestDivEl = this.props.node?.parentElement?.closest("div");
         if (
             this.state.activeTab == TABS.IMAGES.id &&
             closestDivEl?.matches(".s_social_media, .s_share")

--- a/addons/website/static/tests/builder/website_builder/customize_website.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website.test.js
@@ -14,7 +14,7 @@ import {
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
 import { redo, undo } from "@html_editor/../tests/_helpers/user_actions";
-import { ReplaceBgImageAction } from "@html_builder/plugins/background_option/background_image_option_plugin";
+import { ToggleBodyBgImageAction } from "@website/builder/plugins/customize_website_plugin";
 import { renderToString } from "@web/core/utils/render";
 
 defineWebsiteModels();
@@ -440,12 +440,12 @@ test("theme background image is properly set", async () => {
         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYIIA" +
         "A".repeat(1000);
 
-    // To avoid mocking the media dialog
-    patchWithCleanup(ReplaceBgImageAction.prototype, {
-        async load() {
-            const img = document.createElement("img");
-            img.src = base64Image;
-            return img;
+    patchWithCleanup(ToggleBodyBgImageAction.prototype, {
+        async apply(params) {
+            const { type: currentType, image: currentImage } = this.getCurrentConfig();
+            const oldConfig = { type: currentType, image: currentImage };
+            const newConfig = { type: "image", image: base64Image };
+            await this.applyConfig(oldConfig, newConfig);
         },
     });
 

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -3,7 +3,7 @@ import { registry } from "@web/core/registry";
 import { PRODUCT_PAGE_OPTION_SELECTOR } from "./product_page_option";
 import { rpc } from "@web/core/network/rpc";
 import { isImageCorsProtected } from "@html_editor/utils/image";
-import { TABS } from "@html_editor/main/media/media_dialog/media_dialog";
+import { TABS } from "@html_editor/main/media/media_dialog/media_dialog_utils";
 import { WebsiteConfigAction, PreviewableWebsiteConfigAction } from "@website/builder/plugins/customize_website_plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import wSaleUtils from "@website_sale/js/website_sale_utils";
@@ -317,15 +317,19 @@ export class ProductReplaceMainImageAction extends BaseProductPageAction {
         this.reload = false;
         this.canTimeout = false;
     }
-    apply({ editingElement: productDetailMainEl }) {
+    async apply({ editingElement }) {
+        await this.dependencies.media.openMediaDialog(this.getMediaDialogProps({ editingElement }));
+    }
+
+    getMediaDialogProps({ editingElement: productDetailMainEl }){
         // Emulate click on the main image of the carousel.
         const image = productDetailMainEl.querySelector(
             `[data-oe-model="${this.model}"][data-oe-field=image_1920] img`
         );
-        this.dependencies.media.openMediaDialog({
+        return {
             multiImages: false,
             visibleTabs: ["IMAGES"],
-            node: productDetailMainEl,
+            node: image,
             save: (imgEl, selectedMedia) => {
                 const attachment = selectedMedia[0];
                 if (["image/gif", "image/svg+xml"].includes(attachment.mimetype)) {
@@ -348,7 +352,7 @@ export class ProductReplaceMainImageAction extends BaseProductPageAction {
                     image_1920: image.src.split(",")[1],
                 });
             },
-        });
+        }
     }
 }
 
@@ -367,21 +371,28 @@ export class ProductAddExtraImageAction extends BaseProductPageAction {
             );
         }
         return new Promise((resolve) => {
-            const onClose = this.dependencies.media.openMediaDialog({
-                addFieldImage: true,
-                multiImages: true,
-                visibleTabs: ["IMAGES", "VIDEOS"],
-                node: el,
-                // Kinda hack-ish but the regular save does not get the information we need
-                save: async (imgEls, selectedMedia, activeTab) => {
-                    if (selectedMedia.length) {
-                        const type = activeTab === TABS["IMAGES"].id ? "image" : "video";
-                        resolve({ imgEls, selectedMedia, type });
-                    }
-                },
-            });
-            onClose.then(resolve);
+            const onClose = this.dependencies.media.openMediaDialog(this.getMediaDialogProps({ editingElement: el, loadPromiseResolveFunction: resolve }));
+            // Make sure to resolve with a Falsy value when the mediaDialog is closed without selecting an image so that
+            // loadResult is Falsy and apply() cancels the reload of the page.
+            onClose.then(() => resolve());
         });
+    }
+
+    getMediaDialogProps({ editingElement, loadPromiseResolveFunction }) {
+        return {
+            addFieldImage: true,
+            multiImages: true,
+            visibleTabs: ["IMAGES", "VIDEOS"],
+            node: editingElement,
+            // Kinda hack-ish but the regular save does not get the information we need
+            save: async (imgEls, selectedMedia, activeTab) => {
+                if (selectedMedia.length) {
+                    const type =
+                        activeTab === TABS["IMAGES"].id ? "image" : "video";
+                    loadPromiseResolveFunction({ imgEls, selectedMedia, type });
+                }
+            },
+        };
     }
     async apply({ editingElement: el, loadResult }) {
         if (!loadResult) {


### PR DESCRIPTION
[IMP] *: allow AI image generation on media dialog

*: html_editor, html_builder, mail, product, web_splash, website,
website_sale

- Extract the MediaDialog save logic into media_dialog_utils so that it can be reused from 'ai_chat' channels to save generated images.

- Extract the X2ManyImageField and X2ManyMediaViewer save logic into image_library to be reused from 'ai_chat' channels to save generated images.

- Create a new ImageFieldWithMediaDialog to be used with Many2One fields and use it with product.template model. When editing the image of a product, the media manager will appear instead of the file browser. This will give users the ability to select from images already stored in the media manager, upload images, use URLs to retrieve images or generate images using AI.

- Some plugin actions open the media dialog in the load function and sets the save function of the media dialog to a dummy save function that only assigns the selected images from the media dialog to a variable and the actual save logic is done in the apply method (which takes the assigned variable of the load function as an input). Given that the save logic is passed from the media dialog to the 'ai_chat' channel (which is a dummy function in this case), it is not possible to save AI generated images. So, these actions are refactored such that the load method is removed and the media dialog is opened in the apply method with the full save logic.

SEE https://github.com/odoo/enterprise/pull/104712
task-5153846