### PR TITLE
[FIX] im_livechat:  correct test_channel_get_livechat_visitor_info tz assertion

### DIFF
--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -25,6 +25,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
 
     def test_channel_get_livechat_visitor_info(self):
         self.maxDiff = None
+        self.partner_root.tz = "Europe/Brussels"
         belgium = self.env.ref('base.be')
         test_user = self.env['res.users'].create({'name': 'Roger', 'login': 'roger', 'password': self.password, 'country_id': belgium.id})
 
@@ -126,7 +127,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "is_company": False,
                     "main_user_id": self.user_root.id,
                     "name": "OdooBot",
-                    "tz": False,
+                    "tz": "Europe/Brussels",
                     "write_date": fields.Datetime.to_string(self.user_root.partner_id.write_date),
                 },
                 {
@@ -241,7 +242,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "is_company": False,
                     "main_user_id": self.user_root.id,
                     "name": "OdooBot",
-                    "tz": False,
+                    "tz": "Europe/Brussels",
                     "write_date": fields.Datetime.to_string(self.user_root.partner_id.write_date),
                 },
                 {


### PR DESCRIPTION
This PR fixes a failing assertion in `test_channel_get_livechat_visitor_info`.
The test fails since [*] because the demo data sets the OdooBot time zone to
'Europe/Brussels', while the test was asserting it to be False.
This PR explicitly sets the time zone of the OdooBot partner record and updates 
assertions accordingly.

[*] https://github.com/odoo/odoo/pull/210094

runbot-237778


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
