### PR TITLE
[FIX] l10n_it_edi: prevent crash on zero-amount foreign currency invoices

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -587,7 +587,7 @@ class AccountMove(models.Model):
         # Reference line for finding the conversion rate used in the document
         conversion_rate = float_repr(
             abs(self.amount_total / self.amount_total_signed), precision_digits=5,
-        ) if convert_to_euros and self.invoice_line_ids else None
+        ) if convert_to_euros and self.invoice_line_ids and not self.currency_id.is_zero(self.amount_total_signed) else None
 
         # Reduce downpayment views to a single recordset
         downpayment_moves = self.invoice_line_ids._get_downpayment_lines().move_id

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -244,3 +244,21 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
             self.assertFalse(invoices[1].l10n_it_edi_state)
             self.assertFalse(invoices[1].l10n_it_edi_transaction)
             self.assertTrue(invoices[1].l10n_it_edi_header)
+
+    def test_l10n_it_edi_foreign_currency(self):
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.italian_partner_a.id,
+            'company_id': self.company.id,
+            'currency_id': self.env.ref('base.USD').id,
+            'invoice_line_ids': [(0, 0, {
+                'name': 'Zero total line',
+                'quantity': 1.0,
+                'price_unit': 100.0,
+                'discount': 100.0,
+                'tax_ids': [(6, 0, self.default_tax.ids)],
+            })],
+        })
+        invoice.action_post()
+        self.generate_l10n_it_edi_send_attachments(invoice)
+        self.assertTrue(invoice.l10n_it_edi_attachment_id)


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the `l10n_it_edi` and switch to IT company
2. Go to Accounting → Invoice.
3. Create an invoice add partner and change the currency to USD
4. Add a product and apply tax and discount of 100% and confirm
3. Click on Send

**Issue:**
A ZeroDivisionError is raised during the Italian EDI XML generation. 
`ZeroDivisionError: float division by zero`

**Cause:**
The conversion rate is computed by dividing `amount_total` by `amount_total_signed` without handling the case where `amount_total_signed` is `0.0`.

**Solution:**
Skip the conversion rate computation when the signed total amount is zero, preventing the division by zero

**opw-5481821**
