### PR TITLE
[FIX] website_blog: add test to initialize snippet_blog_post tour

### DIFF
--- a/addons/website_blog/static/tests/tours/snippet_blog_post.js
+++ b/addons/website_blog/static/tests/tours/snippet_blog_post.js
@@ -6,7 +6,7 @@ import {
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
-    "snippet_blog_bost",
+    "snippet_blog_post",
     {
         url: "/",
         edition: true,

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -123,3 +123,6 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
 
     def test_blog_posts_dynamic_snippet_options(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_options', login='admin')
+
+    def test_snippet_blog_post(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_blog_post', login='admin')


### PR DESCRIPTION
This commit fix the typo & add python test to initilize the tour introduced by this PR: https://github.com/odoo/odoo/pull/226427

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
