### PR TITLE
[FIX] point_of_sale: filtering single attribute value products

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -18,6 +18,12 @@ export class ProductInfoPopup extends AbstractAwaitablePopup {
         this.pos = usePos();
         Object.assign(this, this.props.info);
     }
+    searchAttributeValue(variant, attributeValue) {
+        const attributeValueSearch = variant.values.length > 1 ? attributeValue.search : "";
+        this.searchProduct(
+            `${attributeValueSearch};product_tmpl_id:${this.props.product.product_tmpl_id}`
+        );
+    }
     searchProduct(productName) {
         this.pos.setSelectedCategoryId(0);
         this.pos.searchProductWord = productName;

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -104,7 +104,7 @@
                                         </div>
                                         <div class="d-flex flex-wrap gap-1">
                                             <t t-foreach="variant.values" t-as="attribute_value" t-key="attribute_value.name">
-                                                <span class="searchable btn btn-secondary" t-on-click="() => this.searchProduct(attribute_value.search + ';product_tmpl_id:' + props.product.product_tmpl_id)">
+                                                <span class="searchable btn btn-secondary" t-on-click="() => this.searchAttributeValue(variant, attribute_value)">
                                                     <t t-esc="attribute_value.name"/>
                                                 </span>
                                                 <t t-if="attribute_value_index lt variant.values.length - 1"> </t>

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -273,3 +273,20 @@ registry.category("web_tour.tours").add("test_table_stand_number_exported", {
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_products_variants_attribute_value_filtering", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickProductInfo("Small Shelf"),
+            ProductScreen.clickProductInfoAttributeValue("Color", "White"),
+            ProductScreen.checkProductsNumber(2),
+            ProductScreen.productIsDisplayed("Small Shelf (Small)"),
+            ProductScreen.productIsDisplayed("Small Shelf (Medium)"),
+            ProductScreen.clickProductInfo("Small Shelf"),
+            ProductScreen.clickProductInfoAttributeValue("Size", "Medium"),
+            ProductScreen.checkProductsNumber(1),
+            ProductScreen.productIsDisplayed("Small Shelf (Medium)"),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -92,6 +92,14 @@ export function clickOrderline(productName, quantity = "1.0") {
         },
     ];
 }
+export function clickProductInfoAttributeValue(attributeName, attributeValue) {
+    return [
+        {
+            content: `Choose the attribute ${attributeValue} for ${attributeName}`,
+            trigger: `.product-info-popup .section-variants div:contains("${attributeName}") + div .searchable:contains("${attributeValue}")`,
+        },
+    ];
+}
 export function clickSubcategory(name) {
     return [
         {
@@ -515,6 +523,21 @@ export function checkOrderlinesNumber(number) {
                 const orderline_amount = $(".order-container .orderline").length;
                 if (orderline_amount !== number) {
                     throw new Error(`Expected ${number} orderlines, got ${orderline_amount}`);
+                }
+            },
+        },
+    ];
+}
+
+export function checkProductsNumber(number) {
+    return [
+        {
+            content: `check products number should be ${number}`,
+            trigger: `.product-list .product`,
+            run: () => {
+                const productsCount = $(".product-list .product").length;
+                if (productsCount !== number) {
+                    throw new Error(`Expected ${number} products, got ${productsCount}`);
                 }
             },
         },

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1403,6 +1403,36 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_draft_order_deletion_with_printer', login="pos_user")
 
+    def test_products_variants_attribute_value_filtering(self):
+        attribute_color = self.env['product.attribute'].create({'name': 'Color'})
+        attribute_value_white = self.env['product.attribute.value'].create({
+            'name': 'White',
+            'attribute_id': attribute_color.id,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.small_shelf.product_tmpl_id.id,
+            'attribute_id': attribute_color.id,
+            'value_ids': [(6, 0, attribute_value_white.ids)]
+        })
+
+        attribute_size = self.env['product.attribute'].create({'name': 'Size'})
+        attribute_value_small = self.env['product.attribute.value'].create({
+            'name': 'Small',
+            'attribute_id': attribute_size.id,
+        })
+        attribute_value_medium = self.env['product.attribute.value'].create({
+            'name': 'Medium',
+            'attribute_id': attribute_size.id,
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.small_shelf.product_tmpl_id.id,
+            'attribute_id': attribute_size.id,
+            'value_ids': [(6, 0, [attribute_value_small.id, attribute_value_medium.id])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_products_variants_attribute_value_filtering', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Steps to reproduce
------------------
1. Create a product "P", with an attribute e.g. "Size", having only one signe possible attribute value, e.g. "Small".
2. Add it to PoS.
3. In PoS, click the "i" button to show this product's info popup, and click on the "Small" button.

We are supposed to filter out the variants having "Small" attribute value, so we expect to see one product, however, we see NO PRODUCTS.

Reason
------
When clicking the attribute value button, "Small" in this case, we filter for proucts belonging to the product template "Product", which also have "Small" in their names. This assumes that a new product have been created for that "Small" attribute value, however that's not the case, since for single-attribute-value attributes, we don't create a separate product variant. I.e. since we can only have one option for "Size" which is "Small", we don't create a separate prodduct for it.

Fix
----
In the case of single-attribute-value attributes, don't add the attribute name to the search word since no products will be found. Just list all the products from that prodcuct template, they will naturally all match that single attribute value.

opw-5497593