### PR TITLE
[FIX] mail: fix multiple click on "done" button

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -544,6 +544,7 @@ class MailActivity(models.Model):
         # marking as 'done'
         messages = self.env['mail.message']
         next_activities_values = []
+        ongoing_activities = self.filtered(lambda a: not a.date_done)
 
         # Search for all attachments linked to the activities we are about to archive. This way, we
         # can link them to the message posted and prevent their disparition. The move is done in
@@ -553,7 +554,7 @@ class MailActivity(models.Model):
             ('res_id', 'in', self.ids),
         ], ['res_id']).grouped('res_id')
 
-        for model, activity_data in self.filtered('res_model')._classify_by_model().items():
+        for model, activity_data in ongoing_activities.filtered('res_model')._classify_by_model().items():
             # Allow user without access to the record to "mark as done" activities assigned to them. At the end of the
             # method, the activity is archived which ensure the user has enough right on the activities.
             records_sudo = self.env[model].sudo().browse(activity_data['record_ids'])

--- a/addons/mail/static/src/core/web/activity_markasdone_popover.xml
+++ b/addons/mail/static/src/core/web/activity_markasdone_popover.xml
@@ -9,7 +9,7 @@
                     <button type="button" class="btn btn-sm btn-primary" aria-label="Done and Schedule Next" t-on-click="onClickDoneAndScheduleNext">
                         Done &amp; Schedule Next
                     </button>
-                    <button t-if="isSuggested" type="button" class="btn btn-sm btn-primary mx-2" aria-label="Done" t-on-click="onClickDone">
+                    <button t-if="isSuggested" type="button" class="btn btn-sm btn-primary mx-2" aria-label="Done" t-on-click="onClickDone" t-att-disabled="state.disableDoneButton">
                         Done
                     </button>
                     <button type="button" class="btn btn-sm btn-link" t-on-click="props.close">


### PR DESCRIPTION
Before this commit, the activity done button could be clicked multiple times and generate multiple "done" notifications.
This commit disables the done button once pressed to avoid multiple clicks

task-5504259
