### PR TITLE
[IMP] cloud_storage: add setting to disable automatic web client uploads

### DIFF
--- a/addons/cloud_storage/models/ir_http.py
+++ b/addons/cloud_storage/models/ir_http.py
@@ -10,7 +10,7 @@ class IrHttp(models.AbstractModel):
     def session_info(self):
         res = super().session_info()
         ICP = self.env['ir.config_parameter'].sudo()
-        if ICP.get_str('cloud_storage_provider'):
+        if ICP.get_str('cloud_storage_provider') and ICP.get_bool('cloud_storage_upload_record_attachments'):
             res['cloud_storage_min_file_size'] = ICP.get_int('cloud_storage_min_file_size', DEFAULT_CLOUD_STORAGE_MIN_FILE_SIZE)
             res['cloud_storage_unsupported_models'] = self.env['ir.attachment']._get_cloud_storage_unsupported_models()
         return res

--- a/addons/cloud_storage/models/res_config_settings.py
+++ b/addons/cloud_storage/models/res_config_settings.py
@@ -36,6 +36,8 @@ class ResConfigSettings(models.TransientModel):
         default=DEFAULT_CLOUD_STORAGE_MIN_FILE_SIZE,
     )
 
+    cloud_storage_upload_record_attachments = fields.Boolean(string='Upload Record Attachments', config_parameter='cloud_storage_upload_record_attachments')
+
     def _setup_cloud_storage_provider(self):
         """
         Setup the cloud storage provider and check the validity of the account
@@ -79,3 +81,5 @@ class ResConfigSettings(models.TransientModel):
             raise UserError(self.env._('Please configure the Cloud Storage before enabling it'))
         if cloud_storage_configuration and cloud_storage_configuration != cloud_storage_configuration_before:
             self._setup_cloud_storage_provider()
+        if self.cloud_storage_upload_record_attachments and not cloud_storage_configuration:
+            ICP.set_bool('cloud_storage_upload_record_attachments', False)

--- a/addons/cloud_storage/views/settings.xml
+++ b/addons/cloud_storage/views/settings.xml
@@ -11,6 +11,9 @@
                     <setting id="cloud_storage_provider" help="Select the cloud storage provider to store new attachments.">
                         <field name="cloud_storage_provider"/>
                     </setting>
+                    <setting id="cloud_storage_upload_record_attachments" help="Upload record attachments to the cloud storage">
+                        <field name="cloud_storage_upload_record_attachments"/>
+                    </setting>
                     <setting string="Minimum File Size"
                              help="Minimum size for attachments to be stored in the cloud storage">
                         <field name="cloud_storage_min_file_size_mb"/><span>MB</span>


### PR DESCRIPTION
Introduce the 'Upload Record Attachments' configuration setting to control whether the web client automatically uploads new attachments to the cloud.

This allows users to keep a valid cloud storage provider configured for customized backend logic or specific workflows, while preventing the default web client behavior from uploading every UI attachment to the cloud.


Upgrade: https://github.com/odoo/upgrade/pull/9288

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
