### PR TITLE
[FIX] website_sale: ensure provider and website company consistency

### DIFF
--- a/addons/website_sale/tests/test_main_controller.py
+++ b/addons/website_sale/tests/test_main_controller.py
@@ -24,7 +24,7 @@ class TestPaymentProviderVisibility(PaymentHttpCommon, SaleCommon):
         website_portal.write({'domain': base_url})
 
         self.provider.write({'website_id': website_portal.id})
-        restricted_provider = self.env['payment.provider'].sudo().search([('name', '=', 'Demo')])
+        restricted_provider = self.env['payment.provider'].sudo().search([('name', '=', 'Demo'), ('company_id', '=', website_shop.company_id.id)])
         restricted_provider.write({'state': 'test', 'website_id': website_shop.id})
 
         url_so = self.sale_order.get_portal_url()


### PR DESCRIPTION
What is fixed
-------------

The test_payment_provider_visibility_with_portal didn't pass due to a multi company issue. In demo data, "Demo" payment provider exists for different companies which led the search method to return every one of them. Trying to assign the shop website id to each of them then raises an error as their company_id are inconsistent.

The fix
-------------

We now ensure only one provider is selected and its company is the same as the website's company.


Runbot error : 237822

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
