### PR TITLE
Saas 18.3 l10n sa edi pos fix downpayments alny

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -286,9 +286,9 @@
                                         <t t-if="line.product_id">
                                             <t t-set="english_name" t-value="line.with_context(lang='en_US').product_id.display_name"/>
                                             <t t-set="arabic_name" t-value="line.with_context(lang=o.env['res.lang']._get_code('ar_001')).product_id.display_name"/>
-
-                                            <span t-out="arabic_name + '\n'" t-if="arabic_name not in line.name" t-options="{'widget': 'text'}" dir="rtl"/>
-                                            <span t-out="english_name + '\n'" t-if="(english_name != arabic_name) and (english_name not in line.name)" t-options="{'widget': 'text'}"/>
+                                            <span t-out="line.product_id.display_name" t-if="not line.name or line.product_id.display_name not in line.name"/>
+                                            <span t-out="arabic_name + '\n'" t-if="arabic_name and arabic_name not in line.product_id.display_name" t-options="{'widget': 'text'}" dir="rtl"/>
+                                            <span t-out="english_name + '\n'" t-if="english_name and (english_name != arabic_name) and (english_name not in line.product_id.display_name)" t-options="{'widget': 'text'}"/>
                                         </t>
                                         <span t-out="line.name" t-options="{'widget': 'text'}" t-att-dir="o.env['res.lang']._get_data(code=o.partner_id.lang).direction"/>
                                     </td>

--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -378,8 +378,8 @@ class AccountEdiXmlUbl_21Zatca(models.AbstractModel):
             If an invoice line is linked to a down payment invoice, we need to return the proper values
             to be included in the UBL
         """
-        if not line.move_id._is_downpayment() and line.sale_line_ids and all(sale_line.is_downpayment for sale_line in line.sale_line_ids):
-            prepayment_move_id = line.sale_line_ids.invoice_lines.move_id.filtered(lambda m: m.move_type == 'out_invoice' and m._is_downpayment())
+        if not line.move_id._is_downpayment() and (downpayment_line := line._get_downpayment_lines()):
+            prepayment_move_id = downpayment_line.move_id.filtered(lambda m: m.move_type == 'out_invoice' and m._is_downpayment())
             return {
                 'prepayment_id': prepayment_move_id.name,
                 'issue_date': fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'),

--- a/addons/pos_sale/models/__init__.py
+++ b/addons/pos_sale/models/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move
+from . import account_move_line
 from . import pos_config
 from . import pos_order
 from . import product_template

--- a/addons/pos_sale/models/account_move.py
+++ b/addons/pos_sale/models/account_move.py
@@ -24,3 +24,12 @@ class AccountMove(models.Model):
         res = super().action_post()
         self.reflect_cancelled_sol(False)
         return res
+
+    def _is_downpayment(self):
+        # EXTENDS sale
+        self.ensure_one()
+        if self.invoice_line_ids.sale_line_ids:
+            return super()._is_downpayment()
+
+        base_lines, _ = self._get_rounded_base_and_tax_lines()
+        return base_lines and all('down_payment' in (line['computation_key'] or '').split(',') for line in base_lines)

--- a/addons/pos_sale/models/account_move_line.py
+++ b/addons/pos_sale/models/account_move_line.py
@@ -1,0 +1,43 @@
+from odoo import models
+from odoo.tools import float_compare
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _get_downpayment_lines(self):
+        # EXTENDS sale
+        downpayment_lines = self.env["account.move.line"]
+        for record in self:
+            rounding = record.currency_id.rounding
+            if related_sol := record.sale_line_ids:
+                # if order is not settled through POS
+                # We're assuming that if an order is settled through POS it will have sale_line_ids empty.
+                # We're also assuming that the downpayment line will have the same price_subtotal & tax_ids as the record.
+                pos_downpayment_moves = related_sol.filtered("is_downpayment").pos_order_line_ids.order_id.account_move
+                downpayment_lines |= pos_downpayment_moves.invoice_line_ids.filtered(
+                    lambda r: float_compare(r.price_subtotal, -record.price_subtotal, precision_rounding=rounding) == 0
+                    and r.tax_ids == record.tax_ids,
+                )
+
+            elif related_posl := record.move_id.pos_order_ids.lines:
+                # if order is settled through POS
+                # We get the downpayment lines through:
+                # final invoice -> final POS order -> origin sale order -> downpayment pos order -> downpayment invoice
+                sale_orders = related_posl.sale_order_origin_id
+                candidate_moves = sale_orders.pos_order_line_ids.order_id.account_move.filtered(lambda r: r._is_downpayment())
+                applicable_lines = candidate_moves.invoice_line_ids.filtered(
+                    lambda line: float_compare(line.price_subtotal, -record.price_subtotal, precision_rounding=rounding) == 0
+                    and line.tax_ids == record.tax_ids,
+                )
+
+                if len(applicable_lines) > 1:
+                    # In the case there are multiple downpayment lines with the same tax & total we'll
+                    # pair them up as per their ids and get the downpayment line paired with the record.
+                    move_lines = record.move_id.invoice_line_ids
+                    lines_dict = dict(zip(move_lines.sorted('id'), applicable_lines.sorted('id')))
+                    downpayment_lines |= lines_dict.get(record)
+                else:
+                    downpayment_lines |= applicable_lines
+
+        return downpayment_lines | super()._get_downpayment_lines()

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -179,6 +179,19 @@ registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder2", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            PosSale.settleNthOrder(1),
+            Order.hasLine({}),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("PosOrderDoesNotRemainInList", {
     steps: () =>
         [
@@ -278,6 +291,31 @@ registry.category("web_tour.tours").add("PoSApplyDownpayment", {
             PosSale.downPaymentFirstOrder("+10"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PoSApplyDownpaymentInvoice", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.downPaymentFirstOrder("+10"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickInvoiceButton(),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PoSApplyDownpaymentInvoice2", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            PosSale.downPaymentFirstOrder("+10"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickInvoiceButton(),
             PaymentScreen.clickValidate(),
         ].flat(),
 });

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -988,8 +988,9 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             'name': 'Base Tax',
             'amount': 15,
         })
+        customer = self.env['res.partner'].create({'name': 'Test Partner A'})
         sale_orders = self.env['sale.order'].create([{
-            'partner_id': self.env['res.partner'].create({'name': 'Test Partner A'}).id,
+            'partner_id': customer.id,
             'order_line': [Command.create({
                 'product_id': self.product_a.id,
                 'name': self.product_a.name,

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -981,6 +981,65 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.user.group_ids = selected_groups
         self.assertEqual(downpayment_line.price_unit, 100)
 
+    def test_downpayment_invoice_link(self):
+        # Test to check if the final invoice generated from an SO is correctly linked to the downpayment invoice.
+
+        tax = self.env['account.tax'].create({
+            'name': 'Base Tax',
+            'amount': 15,
+        })
+        sale_orders = self.env['sale.order'].create([{
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner A'}).id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+                'name': self.product_a.name,
+                'product_uom_qty': 1,
+                'price_unit': 100,
+                'tax_ids': [tax.id],
+            })],
+        } for _ in range(2)])
+
+        sale_orders.action_confirm()
+
+        # CASE 1: downpayment generated in POS, invoice settled in backend
+        sale_order = sale_orders[1]
+        self.main_pos_config.open_ui()
+        self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
+        self.start_pos_tour('PoSApplyDownpaymentInvoice')
+
+        downpayment_invoice = sale_order.pos_order_line_ids.order_id.account_move
+        self.assertTrue(downpayment_invoice._is_downpayment())
+
+        self.env['sale.advance.payment.inv'].with_context({
+            'active_model': 'sale.order',
+            'active_ids': [sale_order.id],
+            'active_id': sale_order.id,
+            'default_journal_id': self.company_data['default_journal_sale'].id,
+        }).create({}).create_invoices()
+
+        final_invoice_downpayment_line = sale_order.invoice_ids.invoice_line_ids.filtered(lambda r: r.quantity < 0)
+
+        self.assertEqual(
+            final_invoice_downpayment_line._get_downpayment_lines(),
+            downpayment_invoice.invoice_line_ids,
+        )
+
+        # CASE 2: downpayment generated in POS, invoice settled in POS
+        sale_order = sale_orders[0]
+        self.start_pos_tour('PoSApplyDownpaymentInvoice2')
+
+        downpayment_invoice = sale_order.pos_order_line_ids.order_id.account_move
+        self.assertTrue(downpayment_invoice._is_downpayment())
+
+        self.start_pos_tour('PosSettleAndInvoiceOrder2')
+
+        final_invoice_downpayment_line = sale_order.pos_order_line_ids[-1].order_id.account_move.invoice_line_ids.filtered(lambda r: r.quantity < 0)
+
+        self.assertEqual(
+            final_invoice_downpayment_line._get_downpayment_lines(),
+            downpayment_invoice.invoice_line_ids,
+        )
+
     def test_settle_order_ship_later_effect_on_so(self):
         """This test create an order, settle it in the PoS and ship it later.
             We need to make sure that the quantity delivered on the original sale is updated correctly,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addressed two issues, one related to pos_sale, and the other related to l10n_gcc_invoice that was found during testing.

the first and main issue this PR addresses is that _get_downpayment_lines and _is_downpayment don't work properly on downpayment and final invoices generated in POS since there is no link formed between them through the sale order.

the second issue occurs during when printing downpayment invoices that were made through POS. since there is no line.name for the downpayment line. an error pops up due to the dual language logic in place.

To reproduce the issue:
- install pos_sale & l10n_sa_edi_pos.
- configure downpayment product on pos.config
- generate an SO and confirm it in the backend
- create a downpayment for that SO through POS
- settle the SO on the POS or through the backend.
- you'll find that the final invoice generated doesn't reference the downpayment invoice
- you'll also find that the downpayment invoice doesn't have the correct invoice type code indicating that it's a downpayment. 
- printing the invoice will also give an error when l10n_gcc_invoice is installed (for the downpayment invoice)

Current behavior before PR:
xml documents generated from l10n_sa_edi don't carry the correct reference to the downpayment invoice when it's the final invoice. they also don't have the correct invoice type code when it's a downpayment invoice if generated through POS

Desired behavior after PR is merged:
the methods _get_downpayment_lines and _is_downpayment now correctly identify the downpayment lines & if it's a downpayment respectively.
the dual language product name now shows on the invoice pdf without raising an error if line.name is undefined.

Task-5135918

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
