### PR TITLE
[FIX] website_sale: remove variant image tours

### DIFF
--- a/addons/website_sale/static/tests/tours/remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/remove_product_image.js
@@ -30,20 +30,6 @@ const enterEditModeOfTestProduct = () => [
     ...clickOnEditAndWaitEditMode(),
 ];
 
-const removeImg = [
-    {
-        content: "Click on Remove",
-        trigger: ".o_customize_tab [data-container-title='Image'] button[data-action-id='removeMedia']",
-        run: "click",
-    },
-    // If the snippet editor is not visible, the remove process is considered as
-    // finished.
-    {
-        content: "Check that the snippet editor is not visible",
-        trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
-    },
-];
-
 registerWebsitePreviewTour(
     "website_sale.add_and_remove_main_product_image_no_variant",
     {
@@ -65,7 +51,20 @@ registerWebsitePreviewTour(
             content: "Check that the snippet editor of the clicked image has been loaded",
             trigger: ".o_customize_tab [data-container-title='Image']",
         },
-        ...removeImg,
+        {
+            content: "Ensure the green screen image is really loaded in DOM before click on remove",
+            trigger: `:iframe .o_product_detail_img_wrapper img[src*='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA']`,
+        },
+        {
+            content: "Click on Remove",
+            trigger: ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info:contains(1.0 kB)) button[data-action-id='removeMedia']",
+            run: "click",
+        },
+        // If the snippet editor is not visible, the remove process is considered as finished.
+        {
+            content: "Check that the snippet editor is not visible",
+            trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
+        },
     ]
 );
 registerWebsitePreviewTour(
@@ -79,6 +78,19 @@ registerWebsitePreviewTour(
         ...clickOnSave(),
         ...clickOnEditAndWaitEditMode(),
         ...clickOnImgAndWaitForLoad,
-        ...removeImg,
+        {
+            content: "Ensure the image is really loaded in DOM before click on remove",
+            trigger: `:iframe .o_product_detail_img_wrapper img`,
+        },
+        {
+            content: "Click on Remove",
+            trigger: ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info:contains(5.9 kB)) button[data-action-id='removeMedia']",
+            run: "click",
+        },
+        // If the snippet editor is not visible, the remove process is considered as finished.
+        {
+            content: "Check that the snippet editor is not visible",
+            trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
+        },
     ]
 );


### PR DESCRIPTION
With this commit, we fix tours:
- website_sale.remove_main_product_image_with_variant
- website_sale.add_and_remove_main_product_image_no_variant where we want to remove the product image.
This fix add a step to ensure the image is in DOM before clicking on the remove button.

error-runbot-id~237766

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
