### PR TITLE
[IMP] mrp: change measures in wo and mo pivot views

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -155,8 +155,8 @@ class MrpProduction(models.Model):
         'End', copy=False, default=_get_default_date_finished,
         compute='_compute_date_finished', store=True,
         help="Date you expect to finish production or actual date you finished production.")
-    duration_expected = fields.Float("Expected Duration", help="Total expected duration (in minutes)", compute='_compute_duration_expected')
-    duration = fields.Float("Real Duration", help="Total real duration (in minutes)", compute='_compute_duration')
+    duration_expected = fields.Float("Expected Duration", help="Total expected duration (in minutes)", compute='_compute_duration_expected', store=True)
+    duration = fields.Float("Real Duration", help="Total real duration (in minutes)", compute='_compute_duration', store=True)
 
     bom_id = fields.Many2one(
         'mrp.bom', 'Bill of Material', readonly=False,

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -125,6 +125,9 @@ class MrpWorkorder(models.Model):
     # Technical field to store the cost_mode of a workorder in case it is changed on the operation_id later on.
     # This field should only be changed once at MO confirmation and should reflect the cost_mode of the operation_id.
 
+    cost = fields.Float(
+        string='Cost', compute='_compute_cost', store=True, aggregator="sum",
+        help="Total real cost of the work order based on duration and hourly cost.")
     production_date = fields.Datetime('Production Date', compute='_compute_production_date', store=True)
     json_popover = fields.Char('Popover Data JSON', compute='_compute_json_popover')
     show_json_popover = fields.Boolean('Show Popover?', compute='_compute_json_popover')
@@ -352,6 +355,11 @@ class MrpWorkorder(models.Model):
                 order.duration_percent = max(-2147483648, min(2147483647, 100 * (order.duration_expected - order.duration) / order.duration_expected))
             else:
                 order.duration_percent = 0
+
+    @api.depends('duration', 'costs_hour', 'workcenter_id.costs_hour')
+    def _compute_cost(self):
+        for order in self:
+            order.cost = order._compute_current_operation_cost()
 
     def _set_duration(self):
 

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -608,6 +608,13 @@
             <field name="arch" type="xml">
                 <pivot string="Manufacturing Orders" sample="1">
                     <field name="date_start" type="row"/>
+                    <field name="duration_expected" type="measure" groups="!mrp.group_mrp_routings" invisible="1"/>
+                    <field name="duration_expected" type="measure" string="Expected Duration (minutes)" groups="mrp.group_mrp_routings"/>
+                    <field name="duration" type="measure" groups="!mrp.group_mrp_routings" invisible="1"/>
+                    <field name="duration" type="measure" string="Real Duration (minutes)" groups="mrp.group_mrp_routings"/>
+                    <field name="qty_producing" type="measure" string="Quantity Produced"/>
+                    <field name="backorder_sequence" invisible="1"/>
+                    <field name="product_uom_qty" invisible="1"/>
                 </pivot>
             </field>
         </record>
@@ -618,10 +625,13 @@
             <field name="arch" type="xml">
                 <graph string="Manufacturing Orders" stacked="0" sample="1">
                     <field name="date_finished"/>
-                    <field name="product_uom_qty" type="measure"/>
-                    <field name="backorder_sequence" invisible="1"/>
+                    <field name="duration_expected" type="measure" groups="!mrp.group_mrp_routings" invisible="1"/>
+                    <field name="duration_expected" type="measure" string="Expected Duration (minutes)" groups="mrp.group_mrp_routings"/>
+                    <field name="duration" type="measure" groups="!mrp.group_mrp_routings" invisible="1"/>
+                    <field name="duration" type="measure" string="Real Duration (minutes)" groups="mrp.group_mrp_routings"/>
                     <field name="qty_producing" string="Quantity Produced"/>
-                    <field name="product_uom_qty" string= "Product Quantity"/>
+                    <field name="backorder_sequence" invisible="1"/>
+                    <field name="product_uom_qty" invisible="1"/>
                 </graph>
             </field>
         </record>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -102,11 +102,6 @@
             <field name="res_model">mrp.workorder</field>
             <field name="domain">[('workcenter_id','=', active_id),('state','=','done')]</field>
             <field name="view_mode">graph,pivot,list,form</field>
-            <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Create a new work orders performance
-              </p>
-            </field>
         </record>
 
         <record model="ir.actions.act_window" id="mrp_workorder_report">
@@ -120,11 +115,6 @@
                                    'search_default_progress': True,}</field>
             <field name="view_mode">graph,pivot,list,form</field>
             <field name="search_view_id" ref="view_mrp_production_work_order_search"/>
-            <field name="help" type="html">
-              <p class="o_view_nocontent_smiling_face">
-                Create a new work orders performance
-              </p>
-            </field>
         </record>
 
         <!-- Workcenter Kanban view-->

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -310,7 +310,11 @@
                 <field name="production_id"/>
                 <field name="duration" type="measure" string="Duration (minutes)"/>
                 <field name="duration_unit" type="measure"/>
-                <field name="duration_expected" type="measure"/>
+                <field name="cost" type="measure"/>
+                <field name="duration_expected" type="measure" string="Expected Duration (minutes)" widget="float_time"/>
+                <field name="qty_reported_from_previous_wo" invisible="1"/>
+                <field name="costs_hour" invisible="1"/>
+                <field name="qty_production" invisible="1"/>
             </graph>
         </field>
     </record>
@@ -324,7 +328,11 @@
                 <field name="operation_id"/>
                 <field name="duration" type="measure" string="Duration (minutes)" widget="float_time"/>
                 <field name="duration_unit" type="measure" widget="float_time"/>
-                <field name="duration_expected" type="measure" widget="float_time"/>
+                <field name="cost" type="measure"/>
+                <field name="duration_expected" type="measure" string="Expected Duration (minutes)" widget="float_time"/>
+                <field name="qty_reported_from_previous_wo" invisible="1"/>
+                <field name="costs_hour" invisible="1"/>
+                <field name="qty_production" invisible="1"/>
             </pivot>
         </field>
     </record>

--- a/addons/mrp_account/views/mrp_production_views.xml
+++ b/addons/mrp_account/views/mrp_production_views.xml
@@ -29,4 +29,15 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_production_pivot_inherit_mrp_account" model="ir.ui.view">
+        <field name="name">mrp.production.pivot.inherit.mrp.account</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.view_production_pivot"/>
+        <field name="arch" type="xml">
+            <xpath expr="//pivot" position="inside">
+                <field name="extra_cost" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This commit removes the following measures in WO and MO pivot views:
- Carried Quantity (WO)
- Cost per hour (WO)
- Employee Cost per hour (WO) - removed in related enterprise PR
- Original Production Quantity (WO)
- Backorder Sequence (MO)
- Total Quantity (MO)

The commit also adds the following measures in WO and MO pivot views:
- Cost (MO) - represents the total cost of the work order
- Expected Duration (MO)
- Real Duration (MO)

The commit also removes employee_cost from OEE pivot view measures (Overall Equipment Effectiveness) - removed in related enterprise PR.

Task-5384708