### PR TITLE
[FIX] test_website_modules: shop performance tests

### DIFF
--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -338,10 +338,11 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             queries['account_tax_repartition_line'] = 2
 
         if self._has_demo_data():
-            query_count += 5
+            query_count += 6
             queries['product_template'] += 1
             queries['product_product'] += 2
             queries['ir_attachment'] += 1
+            queries['product_ribbon'] += 1
             queries['res_company'] += 1
         else:
             query_count += 3


### PR DESCRIPTION
Error:
AssertionError: Expected 63 queries but 64 where ran: Diff of select queries: {'product_ribbon': 1}

Cause:
Commit fc8d7bdc365a0d202b978d9a42d1471be6175725 removed the expected query count of `product.ribbon` model for
demo data installation.

Fix:
Increase the expected query count by 1 for the `product.ribbon` model when demo data is installed.

runbot-{237964, 237966}