### PR TITLE
[FIX] web: unwanted logs in check_undeterminisms

### DIFF
--- a/addons/web_tour/static/tests/check_undeterminisms.test.js
+++ b/addons/web_tour/static/tests/check_undeterminisms.test.js
@@ -7,6 +7,7 @@ import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpe
 import { browser } from "@web/core/browser/browser";
 import { Macro } from "@web/core/macro";
 import { registry } from "@web/core/registry";
+import { enableEventLogs } from "@web/../lib/hoot-dom/helpers/events";
 
 describe.current.tags("desktop");
 
@@ -87,6 +88,7 @@ beforeEach(async () => {
         debug: true,
         observeDelay: 300,
     });
+    enableEventLogs(false);
 });
 
 afterEach(() => {


### PR DESCRIPTION
This commit hides unwanted logs in unit tests check_undeterminisms

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
