### PR TITLE
[FIX] html_editor: keep editor focus when clicking more options

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -77,6 +77,7 @@ export class PowerButtonsPlugin extends Plugin {
             const btn = this.document.createElement("button");
             btn.className = `power_button btn px-2 py-1 cursor-pointer fa ${icon}`;
             btn.title = title;
+            this.addDomListener(btn, "pointerdown", (ev) => ev.preventDefault());
             this.addDomListener(btn, "click", () => this.applyCommand(run));
             return btn;
         };

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -111,23 +111,10 @@ export class PowerboxPlugin extends Plugin {
         "updatePowerbox",
     ];
     resources = {
-        user_commands: {
-            id: "openPowerbox",
-            run: () =>
-                this.openPowerbox({
-                    commands: this.getAvailablePowerboxCommands(),
-                    categories: this.getResource("powerbox_categories"),
-                }),
-        },
         powerbox_categories: [
             withSequence(10, { id: "structure", name: _t("Structure") }),
             withSequence(60, { id: "widget", name: _t("Widget") }),
         ],
-        power_buttons: withSequence(100, {
-            commandId: "openPowerbox",
-            title: _t("More options"),
-            icon: "fa-ellipsis-v",
-        }),
         hints: {
             text: _t('Type "/" for commands'),
             target,

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -1,9 +1,9 @@
-import { describe, expect, test } from "@odoo/hoot";
-import { click, press, tick, waitFor } from "@odoo/hoot-dom";
+import { describe, expect, queryAllTexts, test } from "@odoo/hoot";
+import { click, pointerDown, press, tick, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
-import { insertText } from "./_helpers/user_actions";
+import { insertText, redo, splitBlock, undo } from "./_helpers/user_actions";
 import { onRpc } from "@web/../tests/web_test_helpers";
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
@@ -177,6 +177,131 @@ describe("buttons", () => {
         click(".o_we_power_buttons .power_button.fa-ellipsis-v");
         await expectElementCount(".o-we-powerbox", 1);
         expect(editor.document.activeElement).toBe(el);
+    });
+
+    test("should filter the powerbox contents based on the search term", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(28);
+        // Type a search term
+        await insertText(editor, "head");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "Heading 1",
+            "Heading 2",
+            "Heading 3",
+        ]);
+        // Remove the search term
+        for (let i = 0; i < 4; i++) {
+            press("backspace");
+        }
+        await animationFrame();
+        // All commands should be available again
+        expect(queryAllTexts(".o-we-command-name").length).toBe(28);
+    });
+
+    test("should close the powerbox on pointerdown outside and not reopen it on subsequent keydown", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        // Click outside the powerbox
+        await pointerDown("p");
+        await expectElementCount(".o-we-powerbox", 0);
+        // Typing should not reopen the powerbox
+        await insertText(editor, "a");
+        await animationFrame();
+        expect(".o-we-powerbox").toHaveCount(0);
+    });
+
+    test("should close the powerbox on undo", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        splitBlock(editor);
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        undo(editor);
+        await expectElementCount(".o-we-powerbox", 0);
+    });
+
+    test("should close the powerbox on redo", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        splitBlock(editor);
+        undo(editor);
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        redo(editor);
+        await expectElementCount(".o-we-powerbox", 0);
+    });
+
+    test("should close the powerbox on backspace", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        splitBlock(editor);
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        press("backspace");
+        await expectElementCount(".o-we-powerbox", 0);
+    });
+
+    test("should filter powerbox commands and keep it open on undo when only the search term changes", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(28);
+        // Type a search term
+        await insertText(editor, "head");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "Heading 1",
+            "Heading 2",
+            "Heading 3",
+        ]);
+        undo(editor);
+        await expectElementCount(".o-we-powerbox", 1);
+    });
+
+    test("should filter powerbox commands and keep it open on redo when only the search term changes", async () => {
+        const { editor } = await setupEditor("<p>[]<br></p>");
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(28);
+        // Type a search term
+        await insertText(editor, "head");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "Heading 1",
+            "Heading 2",
+            "Heading 3",
+        ]);
+        undo(editor);
+        await expectElementCount(".o-we-powerbox", 1);
+    });
+
+    test("should filter and apply a powerbox command when opened via the power buttons", async () => {
+        const { el, editor } = await setupEditor("<p>[]<br></p>");
+        // Open powerbox via the More options button
+        click(".o_we_power_buttons .power_button.fa-ellipsis-v");
+        await expectElementCount(".o-we-powerbox", 1);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(28);
+        // Type a search term
+        await insertText(editor, "head");
+        await animationFrame();
+        expect(queryAllTexts(".o-we-command-name")).toEqual([
+            "Heading 1",
+            "Heading 2",
+            "Heading 3",
+        ]);
+        undo(editor);
+        await expectElementCount(".o-we-powerbox", 1);
+        await press("enter");
+        await expectElementCount(".o-we-powerbox", 0);
+        expect(getContent(el)).toBe('<h1 placeholder="Heading 1" class="o-we-hint">[]<br></h1>');
     });
 });
 

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -172,11 +172,11 @@ describe("buttons", () => {
         await expectElementCount(".o-we-linkpopover", 1);
     });
 
-    test("should open powerbox using power buttons", async () => {
-        await setupEditor("<p>[]<br></p>");
+    test("should open the powerbox using the power buttons without losing editor focus", async () => {
+        const { el, editor } = await setupEditor("<p>[]<br></p>");
         click(".o_we_power_buttons .power_button.fa-ellipsis-v");
-        await animationFrame();
         await expectElementCount(".o-we-powerbox", 1);
+        expect(editor.document.activeElement).toBe(el);
     });
 });
 


### PR DESCRIPTION
**Issue 1:**

Steps to Reproduce

- Click on the More options button in the power buttons.
- The powerbox opens, but the editor loses focus and the button receives focus.

Description of the issue:

- After clicking the power button, the button becomes focused and the editor loses focus.

Solution

- When clicking the power button, after the command is executed in the click event, explicitly restore focus to the editable area so the editor remains focused.

**Issue 2:**

Steps to reproduce

- Click More options in the Power Buttons to open the powerbox.
- Start typing `heading`.

Description of the issue:

- The powerbox does not filter commands and continues to show all commands.

Cause:
- In `search_powerbox_plugin`, commands are filtered only when `shouldUpdate` is true.
- `shouldUpdate` is set only when the powerbox is opened through `search_powerbox_plugin`.
- Power Buttons open the powerbox via `powerbox_plugin`, so `shouldUpdate` remains false and filtering is not triggered.

Solution:
- Introduced `openSearchPowerbox` in `searchPowerboxPlugin`.
- Updated the implementation to use this method instead of `openPowerbox` in `search_powerbox_plugin`.
- Instead of opening the powerbox via `powerbox_plugin`, it is now opened via `search_powerbox_plugin`, ensuring `shouldUpdate` is set correctly and commands are filtered on keypress.

task-5485088

