### PR TITLE
[IMP] point_of_sale: toggle preset control when only two presets are configured

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2249,18 +2249,25 @@ export class PosStore extends WithLazyGetterTrap {
     }
     async selectPreset(preset = false, order = this.getOrder()) {
         if (!preset) {
-            const selectionList = this.models["pos.preset"].map((preset) => ({
+            const selectionList = this.config.available_preset_ids.map((preset) => ({
                 id: preset.id,
                 label: preset.name,
                 isSelected: order.preset_id && preset.id === order.preset_id.id,
                 item: preset,
             }));
 
-            preset = await makeAwaitable(this.dialog, SelectionPopup, {
-                title: _t("Select preset"),
-                list: selectionList,
-                size: "md",
-            });
+            if (selectionList.length <= 1) {
+                return;
+            }
+
+            preset =
+                selectionList.length === 2
+                    ? selectionList.find((preset) => !preset.isSelected).item
+                    : await makeAwaitable(this.dialog, SelectionPopup, {
+                          title: _t("Select preset"),
+                          list: selectionList,
+                          size: "md",
+                      });
         }
 
         if (preset) {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1053,7 +1053,7 @@ registry.category("web_tour.tours").add("test_preset_timing_retail", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            ProductScreen.selectPreset("Dine in", "Delivery"),
+            ProductScreen.selectPreset("Dine in", "Delivery", false),
             PartnerList.clickPartner("A simple PoS man!"),
             Chrome.presetTimingSlotHourNotExists("09:00"),
             Chrome.selectPresetTimingSlotHour("15:00"),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -218,20 +218,23 @@ export function clickCustomer(name, pressEnter = false) {
         { ...back(), isActive: ["mobile"] },
     ];
 }
-export function selectPreset(selectedPreset, presetToSelect) {
-    return [
+export function selectPreset(selectedPreset, presetToSelect, presetPopup = true) {
+    const steps = [
         clickReview(),
         {
             content: "click preset button",
             trigger: `.product-screen button:contains("${selectedPreset}")`,
             run: "click",
         },
-        {
-            content: `click preset '${presetToSelect}' from preset modal`,
-            trigger: `.modal-body button:contains(${presetToSelect})`,
-            run: "click",
-        },
     ];
+    if (presetPopup) {
+        steps.push({
+            content: `click preset '${presetToSelect}' from preset modal`,
+            trigger: `.modal-body button:contains("${presetToSelect}")`,
+            run: "click",
+        });
+    }
+    return steps;
 }
 export function customerIsSelected(name) {
     return [

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -479,7 +479,7 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
             Chrome.clickPlanButton(),
             FloorScreen.clickTable("4"),
             ProductScreen.clickDisplayedProduct("Water"),
-            ProductScreen.selectPreset("Eat in", "Takeaway"),
+            ProductScreen.selectPreset("Eat in", "Takeaway", false),
             Chrome.presetTimingSlotHourNotExists("09:00"),
             Chrome.selectPresetTimingSlotHour("12:00"),
             Chrome.presetTimingSlotIs("12:00"),


### PR DESCRIPTION
In this commit:
===============
When only two presets are configured on a POS config, skip the preset selection popup and make the preset button work as a toggle between the two presets.

Task-5491093



