### PR TITLE
[REM] barcodes: remove unnecessary `enableBarcode` dataset check

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -95,7 +95,6 @@ export const barcodeService = {
             // don't trigger native event handlers of elements. So this means that
             // our fake events will not appear in eg. an <input> element.
             if (currentTarget !== barcodeInput && isEditable(currentTarget) &&
-                !currentTarget.dataset.enableBarcode &&
                 currentTarget.getAttribute("barcode_events") !== "true") {
                 return;
             }


### PR DESCRIPTION
This code was introduced in [1] with the new views but part of the code was legacy and was removed in [2].

We can safely remove this leftover line.

[1]: https://github.com/odoo/odoo/commit/920df597d3d7174723736a395e94dc8ff413c70b
[2]: https://github.com/odoo/odoo/commit/49297bc7bba75541ca139e6c84e0d3b311765145

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
