### PR TITLE
[FIX] hr_attendance: only keep greatest undertime

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -793,10 +793,11 @@ class HrAttendanceOvertimeRule(models.Model):
         for employee, intervals_by_attendance in undertimes.items():
             tz = timezone(employee._get_tz())
             for attendance, intervals in intervals_by_attendance.items():
+                date = attendance.check_in.astimezone(tz).date()
                 duration_by_day_by_rules = defaultdict(lambda: defaultdict(float))
-                for duration, rules in intervals:
-                    date = attendance.check_in.astimezone(tz).date()
-                    duration_by_day_by_rules[date][rules] += duration
+                min_duration_tuple = max(intervals, key=lambda x: x[0])
+                duration, rules = min_duration_tuple
+                duration_by_day_by_rules[date][rules] += duration
                 _add_overtime_val(attendance, duration_by_day_by_rules)
         return vals
 


### PR DESCRIPTION
### Issue:
When having a ruleset with multiple rules, their undertime amounts are added.

### Steps to reproduce:
- Create an overtime ruleset with two rules:
    - Based on quantity, worked hours on a Day differs from a specific duration of 8h
    - Based on quantity, worked hours on a Day differs from a specific duration of 10h
- Assign this ruleset to an employee
- On a day with no attendance, create one for this employee from 1pm to 6pm
- The computed overtime hours is -8 hours

### Cause:
The undertimes from each rule are added. The first rule computes 3 hours of undertime (8 - 5), the second 5 hours (10 - 5), resulting in 8 hours of undertime.

### Solution:
Instead of adding them, we only keep the greatest undertime.

This ensures that the undertime amount is technically the opposite of the overtime amount.

We only take the undertime value into consideration, whatever the period type of the rule.

opw-5452854