### PR TITLE
[FIX] im_livechat: do not fetch expertise if not needed

### DIFF
--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -37,6 +37,8 @@ class WebClient(WebclientController):
                 return
             fields_to_store = channel._get_livechat_session_fields_to_store()
             store.add(channel, fields=fields_to_store)
+        if name == "/im_livechat/fetch_self_expertise":
+            store.add(request.env.user, Store.Many("livechat_expertise_ids", ["name"]))
 
     @classmethod
     def _process_request_for_all(self, store: Store, name, params):

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -154,5 +154,3 @@ class ResUsers(models.Model):
                     lambda u: u.has_group("im_livechat.im_livechat_group_manager"),
                 ),
             )
-        if self.env.user.has_access_livechat:
-            store.add(self.env.user, Store.Many("livechat_expertise_ids", ["name"]))

--- a/addons/im_livechat/static/src/core/web/discuss_client_action_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_client_action_patch.js
@@ -6,6 +6,7 @@ patch(DiscussClientAction.prototype, {
     async restoreDiscussThread() {
         if (this.store.has_access_livechat) {
             this.store.livechatChannels.fetch();
+            this.store.livechatSelfExpertises.fetch();
         }
         return super.restoreDiscussThread(...arguments);
     },

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -9,6 +9,7 @@ const storePatch = {
     setup() {
         super.setup(...arguments);
         this.livechatChannels = this.makeCachedFetchData("im_livechat.channel");
+        this.livechatSelfExpertises = this.makeCachedFetchData("/im_livechat/fetch_self_expertise");
         this.has_access_livechat = false;
     },
     /**
@@ -18,6 +19,7 @@ const storePatch = {
         super.onStarted(...arguments);
         if (this.discuss.isActive && this.has_access_livechat) {
             this.livechatChannels.fetch();
+            this.livechatSelfExpertises.fetch();
         }
     },
     /** @returns {boolean} Whether the livechat thread changed. */

--- a/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
+++ b/addons/im_livechat/static/tests/mock_server/livechat_mock_server.js
@@ -3,7 +3,7 @@ import {
     parseRequestParams,
     registerRoute,
 } from "@mail/../tests/mock_server/mail_mock_server";
-import { Command, makeKwArgs } from "@web/../tests/web_test_helpers";
+import { Command, makeKwArgs, serverState } from "@web/../tests/web_test_helpers";
 import { loadBundle } from "@web/core/assets";
 import { patch } from "@web/core/utils/patch";
 
@@ -256,6 +256,10 @@ patch(mailDataHelpers, {
                     DiscussChannel.search([["livechat_status", "=", "need_help"]])
                 )
             );
+        }
+        if (name === "/im_livechat/fetch_self_expertise") {
+            const ResUsers = this.env["res.users"];
+            store.add(ResUsers.browse(serverState.userId), ["livechat_expertise_ids"]);
         }
     },
 });

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -290,7 +290,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "id": operator.id,
                     "is_admin": False,
                     "is_livechat_manager": False,
-                    "livechat_expertise_ids": [],
                     "notification_type": "email",
                     "share": False,
                     "signature": ["markup", str(operator.signature)],

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -426,7 +426,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": self.users[0].id,
                     "is_admin": False,
                     "is_livechat_manager": False,
-                    "livechat_expertise_ids": [],
                     "notification_type": "inbox",
                     "share": False,
                     "signature": ["markup", str(self.users[0].signature)],


### PR DESCRIPTION
Before this commit, the user's live chat expertise were always returned as part of `_init_store_data`. However, this led to a warning in portal tours because the expertises are inserted into the store while the live chat models are not loaded (they are not needed).

We shouldn't return useless data. This commit fixes this issue by fetching the data when they will be needed (i.e. when the discuss app is opened with a live chat user).

runbot-234137

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
