### PR TITLE
[IMP] setup: auto setup Windows IoT Box firewall rules

### DIFF
--- a/setup/package.py
+++ b/setup/package.py
@@ -428,7 +428,7 @@ class DockerIot(DockerWine):
         self.nt_service_name = "odoo-iot"
 
     def build_image(self):
-        shutil.copy(os.path.join(self.args.build_dir, 'odoo/setup/iot_box_builder/configuration/requirements.txt'), self.docker_dir / 'requirements-iot.txt')
+        shutil.copy(os.path.join(self.args.build_dir, 'setup/iot_box_builder/configuration/requirements.txt'), self.docker_dir / 'requirements-iot.txt')
         self.tag = f'{self.tag}-iot'
         super().build_image()
 


### PR DESCRIPTION
We now automatically add the firewall exception for inbound TCP connections on ports 80,443 and 8069, to avoid manual configuration.

Task: 3748708