### PR TITLE
[IMP] fleet: add contract start and expiration date filters

### DIFF
--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -139,6 +139,8 @@
                 <field name="insurer_id" string="Vendor" filter_domain="[('insurer_id','child_of', self)]"/>
                 <filter string="In Progress" name="open" domain="[('state', '=', 'open')]"/>
                 <filter string="Expired" name="expired" domain="[('state', '=', 'expired')]"/>
+                <filter string="Start Date" name="start_date" date="start_date" default_period="month"/>
+                <filter string="Expiration Date" name="expiration_date" date="expiration_date" default_period="month"/>
                 <field name="activity_user_id" string="Activities of"/>
                 <field name="activity_type_id" string="Activity type"/>
                 <separator/>


### PR DESCRIPTION
This commit introduces start_date and expiration_date filters on contracts making it easier to filter and manage contracts based on their dates.

task-5386856

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
