### PR TITLE
[IMP] website_forum: remove search_count from forum pager

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -378,16 +378,33 @@ class WebsiteSearchableMixin(models.AbstractModel):
 
     @api.model
     def _search_fetch(self, search_detail, search, limit, order):
+        offset, per_page = 0, False
+        options = search_detail.get('options', {})
+        if options.get('scope'):
+            scope = options.get('scope')
+            per_page = options.get('per_page', 10)
+            current_page = options.get('current_page', 1)
+
+            extra_limit = max((scope / 2), scope - current_page)
+
+            offset = (current_page - 1) * per_page
+            limit = (extra_limit + 1) * per_page
+
         fields = search_detail['search_fields']
         base_domain = search_detail['base_domain']
         domain = self._search_build_domain(base_domain, search, fields, search_detail.get('search_extra'))
         model = self.sudo() if search_detail.get('requires_sudo') else self
         results = model.search(
             domain,
+            offset=offset,
             limit=limit,
             order=search_detail.get('order', order)
         )
-        count = model.search_count(domain) if limit and limit == len(results) else len(results)
+        if per_page is False:
+            count = model.search_count(domain) if limit and limit == len(results) else len(results)
+        else:
+            count = len(results) + offset
+
         return results, count
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -3013,7 +3013,7 @@ Sitemap: <t t-out="url_root"/>sitemap.xml
         <button type="submit" t-att-class="'btn oe_search_button %s' % (_submit_classes or ('btn-primary' if default_style else 'btn-light'))" aria-label="Search" title="Search">
             <i class="oi oi-search"/>
             <span t-if="search" class="oe_search_found">
-                <small>(<t t-out="search_count or 0"/> found)</small>
+                <small t-if="not hide_search_count">(<t t-out="search_count or 0"/> found)</small>
             </span>
         </button>
     </div>

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -913,6 +913,7 @@ class ForumPost(models.Model):
             'mapping': mapping,
             'icon': 'fa-comment-o',
             'order': order,
+            'options': options,
         }
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):


### PR DESCRIPTION
In production, the search count take more than 100ms while it is only necessary to compute the number of page...

To improve performance, the search count is removed and the pager now displays a scope of 5 pages around the current one.

The existing `scope` parameter is reused to handle this behavior. In stable, a negative value is used to explicitly indicate that the parameter should be reused.
