### PR TITLE
[FIX] l10n_at: correct the Tax Report's total expression

### DIFF
--- a/addons/l10n_at/data/account_tax_report_data.xml
+++ b/addons/l10n_at/data/account_tax_report_data.xml
@@ -795,7 +795,7 @@
                     <record id="tax_report_line_l10n_at_tva_line_7_total" model="account.report.expression">
                         <field name="label">vat</field>
                         <field name="engine">aggregation</field>
-                        <field name="formula">AT_0004.vat - AT_0005.vat + AT_090.vat</field>
+                        <field name="formula">AT_0004.vat + AT_0005.vat + AT_090.vat</field>
                     </record>
                 </field>
                 <field name="hierarchy_level">0</field>


### PR DESCRIPTION
In 19.0, VAT from vendor bills was subtracted from the total in the Austrian Tax Report, instead of being added

The expression `tax_report_line_l10n_at_tva_line_7_total` uses an incorrect formula:
`<field name="formula">AT_0004.vat - AT_0005.vat + AT_090.vat</field>`
It should instead be:
`<field name="formula">AT_0004.vat + AT_0005.vat + AT_090.vat</field>`
This matches the behavior of previous versions

In 18.0, there was no aggregated AT_0005 line
All values were summed together, which effectively resulted in the same total

Steps to reproduce:
- Install `l10n_at_reports`
- Switch to AT Company
- Open the Tax Return and note the last line value for the current month
- Create and confirm a vendor bill with 20% VAT
- Compare the new value in Tax return.
  Before the fix, the total line was decreased instead of increased

Ticket [link](https://www.odoo.com/odoo/project.task/5349445)
opw-5349445
