### PR TITLE
[FIX] im_livechat: non deterministic canned response test

### DIFF
--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -1014,32 +1014,6 @@ test("Canned response last used changes on posting", async () => {
     expect(cannedResponse.last_used).not.toBeEmpty();
 });
 
-test("Does not auto-select 1st canned response suggestion", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    pyEnv["mail.canned.response"].create({ source: "Hello", substitution: "Hello! How are you?" });
-    await start();
-    await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-NavigableList-active", { text: "Mitchell Admin" });
-    await insertText(".o-mail-Composer-input", "::", { replace: true });
-    await contains(".o-mail-NavigableList-item", { text: "HelloHello! How are you?" });
-    await contains(".o-mail-NavigableList-active", { count: 0 });
-});
-
-test("ENTER closes canned response suggestions", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    pyEnv["mail.canned.response"].create({ source: "Hello", substitution: "Hello! How are you?" });
-    await start();
-    await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "::");
-    await contains(".o-mail-NavigableList-item", { text: "HelloHello! How are you?" });
-    await contains(".o-mail-NavigableList-active", { count: 0 });
-    await triggerHotkey("Enter");
-    await contains(".o-mail-NavigableList-item", { count: 0 });
-});
-
 test("Tab to select of canned response suggestion works in chat window", async () => {
     // This might conflict with focusing next chat window
     const pyEnv = await startServer();


### PR DESCRIPTION
In [1], auto focus was removed for canned responses in the navigable list. The intent was to avoid conflicts with emojis.

In [2], the shortcut for canned response was changed to `::` and the auto focus behavior was restored.

However, tests added in [1] were not removed. Since they were fragile (negative assertion), they are passing most of the time.

This PR removes the tests that are now outdated.

runbot-233358

[1]: https://github.com/odoo/odoo/pull/170900
[2]: https://github.com/odoo/odoo/pull/192953

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
