### PR TITLE
[PERF] html_editor: reduce layout thrashing

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -167,17 +167,17 @@ export class HtmlField extends Component {
         // Update the actual editable if still in the DOM.
         if (this.editor.editable && oldSrcToNewSrcMap) {
             this.editor.editable
-                .querySelectorAll('.o_b64_image_to_save, .o_modified_image_to_save')
-              .forEach((unsavedImage) => {
-                const oldSrc = unsavedImage.getAttribute('src');
-                if (oldSrcToNewSrcMap.has(oldSrc)) {
-                  unsavedImage.setAttribute(
-                    'src',
-                    oldSrcToNewSrcMap.get(oldSrc)
-                  );
-                }
-                unsavedImage.classList.remove("o_b64_image_to_save", "o_modified_image_to_save");
-              });
+                .querySelectorAll(".o_b64_image_to_save, .o_modified_image_to_save")
+                .forEach((unsavedImage) => {
+                    const oldSrc = unsavedImage.getAttribute("src");
+                    if (oldSrcToNewSrcMap.has(oldSrc)) {
+                        unsavedImage.setAttribute("src", oldSrcToNewSrcMap.get(oldSrc));
+                    }
+                    unsavedImage.classList.remove(
+                        "o_b64_image_to_save",
+                        "o_modified_image_to_save"
+                    );
+                });
         }
         return content;
     }
@@ -360,6 +360,12 @@ export const htmlField = {
         }
         if ("baseContainer" in options) {
             editorConfig.baseContainer = options.baseContainer;
+        }
+        if ("debouncePowerbuttons" in options) {
+            editorConfig.debouncePowerbuttons = Boolean(options.debouncePowerbuttons);
+        }
+        if ("debounceHints" in options) {
+            editorConfig.debounceHints = Boolean(options.debounceHints);
         }
         return {
             editorConfig,

--- a/addons/html_editor/static/src/main/align/align_plugin.js
+++ b/addons/html_editor/static/src/main/align/align_plugin.js
@@ -4,6 +4,7 @@ import { isVisibleTextNode } from "@html_editor/utils/dom_info";
 import { _t } from "@web/core/l10n/translation";
 import { AlignSelector } from "./align_selector";
 import { reactive } from "@odoo/owl";
+import { READ, withSequence } from "@html_editor/utils/resource";
 
 const alignmentItems = [
     { mode: "left" },
@@ -51,7 +52,7 @@ export class AlignPlugin extends Plugin {
         ],
 
         /** Handlers */
-        selectionchange_handlers: this.updateAlignmentParams.bind(this),
+        selectionchange_handlers: withSequence(READ, this.updateAlignmentParams.bind(this)),
         post_undo_handlers: this.updateAlignmentParams.bind(this),
         post_redo_handlers: this.updateAlignmentParams.bind(this),
         remove_format_handlers: this.setAlignment.bind(this),

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -21,6 +21,7 @@ import { isColorGradient, isCSSColor, RGBA_REGEX, rgbaToHex } from "@web/core/ut
 import { ColorSelector } from "./color_selector";
 import { isBlock } from "@html_editor/utils/blocks";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
+import { READ, withSequence } from "@html_editor/utils/resource";
 
 const RGBA_OPACITY = 0.6;
 const HEX_OPACITY = "99";
@@ -59,7 +60,7 @@ export class ColorPlugin extends Plugin {
         ],
 
         /** Handlers */
-        selectionchange_handlers: this.updateSelectedColor.bind(this),
+        selectionchange_handlers: withSequence(READ, this.updateSelectedColor.bind(this)),
         remove_format_handlers: this.removeAllColor.bind(this),
 
         /** Predicates */

--- a/addons/html_editor/static/src/main/font/font_family_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_family_plugin.js
@@ -3,7 +3,7 @@ import { _t } from "@web/core/l10n/translation";
 import { FontFamilySelector } from "@html_editor/main/font/font_family_selector";
 import { reactive } from "@odoo/owl";
 import { closestElement } from "../../utils/dom_traversal";
-import { withSequence } from "@html_editor/utils/resource";
+import { READ, withSequence } from "@html_editor/utils/resource";
 
 export const defaultFontFamily = {
     name: "Default system font",
@@ -52,7 +52,7 @@ export class FontFamilyPlugin extends Plugin {
             }),
         ],
         /** Handlers */
-        selectionchange_handlers: this.updateCurrentFontFamily.bind(this),
+        selectionchange_handlers: withSequence(READ, this.updateCurrentFontFamily.bind(this)),
         post_undo_handlers: this.updateCurrentFontFamily.bind(this),
         post_redo_handlers: this.updateCurrentFontFamily.bind(this),
     };

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -27,7 +27,7 @@ import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
 import { FontSelector } from "./font_selector";
 import { getBaseContainerSelector } from "@html_editor/utils/base_container";
-import { withSequence } from "@html_editor/utils/resource";
+import { READ, withSequence } from "@html_editor/utils/resource";
 import { reactive } from "@odoo/owl";
 import { FontSizeSelector } from "./font_size_selector";
 
@@ -260,8 +260,8 @@ export class FontPlugin extends Plugin {
         /** Handlers */
         input_handlers: this.onInput.bind(this),
         selectionchange_handlers: [
-            this.updateFontSelectorParams.bind(this),
-            this.updateFontSizeSelectorParams.bind(this),
+            withSequence(READ, this.updateFontSelectorParams.bind(this)),
+            withSequence(READ, this.updateFontSizeSelectorParams.bind(this)),
         ],
         post_undo_handlers: [
             this.updateFontSelectorParams.bind(this),

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -5,7 +5,7 @@ import { ImageDescription } from "./image_description";
 import { ImageToolbarDropdown } from "./image_toolbar_dropdown";
 import { createFileViewer } from "@web/core/file_viewer/file_viewer_hook";
 import { boundariesOut } from "@html_editor/utils/position";
-import { withSequence } from "@html_editor/utils/resource";
+import { READ, withSequence } from "@html_editor/utils/resource";
 import { ImageTransformButton } from "./image_transform_button";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { closestBlock } from "@html_editor/utils/blocks";
@@ -183,7 +183,7 @@ export class ImagePlugin extends Plugin {
         ],
 
         /** Handlers */
-        selectionchange_handlers: this.updateImageParams.bind(this),
+        selectionchange_handlers: withSequence(READ, this.updateImageParams.bind(this)),
         post_undo_handlers: this.updateImageParams.bind(this),
         post_redo_handlers: this.updateImageParams.bind(this),
 

--- a/addons/html_editor/static/src/utils/resource.js
+++ b/addons/html_editor/static/src/utils/resource.js
@@ -1,5 +1,14 @@
 export const resourceSequenceSymbol = Symbol("resourceSequence");
 
+/**
+ * Sequence marker used with `withSequence` to ensure the wrapped handler
+ * runs before other handlers of the same resource.
+ *
+ * Intended for DOM read logic so it executes before potential DOM mutations,
+ * avoiding layout thrashing.
+ */
+export const READ = 0;
+
 export function withSequence(sequenceNumber, object) {
     return {
         [resourceSequenceSymbol]: sequenceNumber,

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -13,6 +13,11 @@ export const Direction = {
     FORWARD: "FORWARD",
 };
 
+const defaultTestConfig = {
+    debouncePowerbuttons: false,
+    debounceHints: false,
+};
+
 class TestEditor extends Component {
     static template = xml`
         <t t-if="props.styleContent">
@@ -78,7 +83,10 @@ class TestEditor extends Component {
  */
 export async function setupEditor(content, options = {}) {
     const wysiwygProps = Object.assign({}, options.props);
-    wysiwygProps.config = options.config || {};
+    wysiwygProps.config = {
+        ...defaultTestConfig,
+        ...(options.config || {}),
+    };
     const attachedEditor = new Promise((resolve) => {
         wysiwygProps.onLoad = (editor) => {
             const oldAttachTo = editor.attachTo;

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -8,7 +8,7 @@ import {
     setContent,
     setSelection,
 } from "./_helpers/selection";
-import { insertText } from "./_helpers/user_actions";
+import { insertText, simulateArrowKeyPress } from "./_helpers/user_actions";
 
 test("hints are removed when editor is destroyed", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>", {});
@@ -204,4 +204,26 @@ test("hint for blockquote should have the same padding as its text content", asy
     expect(hintStyle.content).toBe("none");
     const paddingText = getComputedStyle(blockquote).padding;
     expect(paddingHint).toBe(paddingText);
+});
+
+test("should debounce hint on selection change", async () => {
+    const { el, editor } = await setupEditor(
+        "<p>[]<br></p><p><br></p><p><br></p><p><br></p><p><br></p>",
+        {
+            config: { debounceHints: true },
+        }
+    );
+    expect(getContent(el)).toBe(`<p>[]<br></p><p><br></p><p><br></p><p><br></p><p><br></p>`);
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    expect(getContent(el)).toBe(`<p><br></p><p>[]<br></p><p><br></p><p><br></p><p><br></p>`);
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    expect(getContent(el)).toBe(`<p><br></p><p><br></p><p>[]<br></p><p><br></p><p><br></p>`);
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    expect(getContent(el)).toBe(`<p><br></p><p><br></p><p><br></p><p>[]<br></p><p><br></p>`);
+    await simulateArrowKeyPress(editor, "ArrowDown");
+    await animationFrame();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(getContent(el)).toBe(
+        `<p><br></p><p><br></p><p><br></p><p><br></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
+    );
 });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -876,7 +876,7 @@ test("Embed video by pasting video URL", async () => {
         resModel: "partner",
         arch: `
             <form>
-                <field name="txt" widget="html"/>
+                <field name="txt" widget="html" options="{'debounceHints': false}"/>
             </form>`,
     });
 
@@ -1007,7 +1007,7 @@ test("html field with a placeholder", async () => {
         resModel: "partner",
         arch: `
             <form>
-                <field name="txt" widget="html" placeholder="test"/>
+                <field name="txt" widget="html" placeholder="test" options="{'debounceHints': false}"/>
             </form>`,
     });
 

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -9,7 +9,7 @@ import { PowerboxPlugin } from "../src/main/powerbox/powerbox_plugin";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
-import { insertText } from "./_helpers/user_actions";
+import { insertText, simulateArrowKeyPress } from "./_helpers/user_actions";
 
 describe.tags("desktop");
 describe("visibility", () => {
@@ -110,6 +110,27 @@ describe("visibility", () => {
         expect(Math.floor(powerButtons.getBoundingClientRect().left)).toEqual(
             Math.floor(placeholderWidth + 30)
         );
+    });
+    test("should debounce powerButtons on selection change", async () => {
+        const { el, editor } = await setupEditor(
+            "<p>[]<br></p><p><br></p><p><br></p><p><br></p><p><br></p>",
+            {
+                config: { debouncePowerbuttons: true },
+            }
+        );
+        expect(getContent(el)).toBe(
+            `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p><p><br></p><p><br></p><p><br></p><p><br></p>`
+        );
+        await simulateArrowKeyPress(editor, "ArrowDown");
+        expect(".o_we_power_buttons").not.toBeVisible();
+        await simulateArrowKeyPress(editor, "ArrowDown");
+        expect(".o_we_power_buttons").not.toBeVisible();
+        await simulateArrowKeyPress(editor, "ArrowDown");
+        expect(".o_we_power_buttons").not.toBeVisible();
+        await simulateArrowKeyPress(editor, "ArrowDown");
+        await animationFrame();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        expect(".o_we_power_buttons").toBeVisible();
     });
 });
 

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -106,10 +106,10 @@ describe("visibility", () => {
         el.appendChild(tempP);
         const placeholderWidth = tempP.getBoundingClientRect().width;
         el.removeChild(tempP);
-        const powerButtons = document.querySelector(
-            'div[data-oe-local-overlay-id="oe-power-buttons-overlay"]'
+        const powerButtons = document.querySelector(".o_we_power_buttons");
+        expect(Math.floor(powerButtons.getBoundingClientRect().left)).toEqual(
+            Math.floor(placeholderWidth + 30)
         );
-        expect(powerButtons.getBoundingClientRect().left).toEqual(placeholderWidth + 20);
     });
 });
 


### PR DESCRIPTION
Description of the issue this PR addresses:

I. The power buttons positioning logic was interleaving DOM writes and layout reads during selectionchange, causing repeated style/layout recalculations. This PR reorders the logic so geometry is read first and DOM mutations are
applied afterwards, reducing the number of forced reflows and significantly improving performance.

II. Debounce `updateHints` and `updatePowerButtons` to avoid excessive UI updates on frequent selection changes. Introduce `debounceHints` and `debouncePowerButtons` editor config options so debouncing can be disabled in tests for deterministic behavior.

III. Introduce READ helper for withSequence to explicitly order resource handlers so DOM reads run before DOM mutations.

Before:
<img width="1705" height="399" alt="image" src="https://github.com/user-attachments/assets/2fca797a-0311-4c4a-9063-2051934baa7c" />

After:
<img width="1490" height="343" alt="image" src="https://github.com/user-attachments/assets/0f295969-b962-4190-a7f9-fe5366d7fafd" />


task-5499625

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
