### PR TITLE
[FIX] base: prevent error when unarchiving company

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -299,8 +299,6 @@ class Company(models.Model):
     def write(self, values):
         invalidation_fields = self.cache_invalidation_fields()
         asset_invalidation_fields = {'font', 'primary_color', 'secondary_color', 'external_report_layout_id'}
-        if not invalidation_fields.isdisjoint(values):
-            self.env.registry.clear_cache()
 
         if not asset_invalidation_fields.isdisjoint(values):
             # this is used in the content of an asset (see asset_styles_company_report)
@@ -316,6 +314,10 @@ class Company(models.Model):
                 currency.write({'active': True})
 
         res = super(Company, self).write(values)
+
+        # Must be done after call to super
+        if not invalidation_fields.isdisjoint(values):
+            self.env.registry.clear_cache()
 
         # Archiving a company should also archive all of its branches
         if values.get('active') is False:


### PR DESCRIPTION
**Steps to reproduce**
- Have at least two active companies
- Archive one company
- Unarchive the company
- Select the just unarchived company in the company selector
- `Access Error: Access to unauthorized or invalid companies.`

**Cause**
There was a timing issue between the cache invalidation and the call to super. After the cache invalidation, if `_get_company_ids` of `res.users` was called before the call to `super` in the `write`, it would not return the just unarchived company.

opw-5449925