### PR TITLE
[IMP] website: improve full-size popup by aligning background behavior

### DIFF
--- a/addons/website/static/src/snippets/s_popup/001.scss
+++ b/addons/website/static/src/snippets/s_popup/001.scss
@@ -26,8 +26,6 @@
         max-width: 100%;
 
         > .modal-content {
-            // Use the backdrop color as background-color
-            background-color: transparent;
             box-shadow: none;
             border-radius: 0;
         }


### PR DESCRIPTION
The full-size popup option can be misleading when using a transparent
background, as the dialog content may visually merge with the page and
become difficult to read.

This change removes the transparent background for the full-size popup
option and aligns its behavior with other popup sizes, ensuring better
readability and visual consistency across all popup layouts.


| Before  | After |
| ------------- | ------------- |
| <img width="1646" height="456" alt="image" src="https://github.com/user-attachments/assets/122b266d-8391-45fe-a6be-08177b97f99c" /> | <img width="1659" height="466" alt="image" src="https://github.com/user-attachments/assets/df4e09de-850e-4735-9169-5115465c1372" /> |
| <img width="1641" height="707" alt="image" src="https://github.com/user-attachments/assets/51d549f8-f7ff-42de-aba1-52ab0b4adaf0" /> | <img width="1655" height="687" alt="image" src="https://github.com/user-attachments/assets/2085b8ec-f318-4f04-a9ed-af8ecb0d6fa8" /> |

task-5435802
