### PR TITLE
[FIX] html_builder: move color picker button to its own component

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -1,5 +1,5 @@
 import { ColorSelector } from "@html_editor/main/font/color_selector";
-import { Component, useComponent, useRef } from "@odoo/owl";
+import { Component, useComponent } from "@odoo/owl";
 import {
     useColorPicker,
     DEFAULT_COLORS,
@@ -107,6 +107,24 @@ export function useColorPickerBuilderComponent() {
     };
 }
 
+export class ColorPickerButton extends Component {
+    static template = "html_builder.ColorPickerButton";
+    static props = {
+        title: { type: String, optional: true },
+        style: { type: String, optional: true },
+        tooltip: { type: String, optional: true },
+        colorPickerConfig: { type: Object, optional: true },
+    };
+
+    setup() {
+        useColorPicker(
+            "colorButton",
+            this.props.colorPickerConfig.props,
+            this.props.colorPickerConfig.options
+        );
+    }
+}
+
 export class BuilderColorPicker extends Component {
     static template = "html_builder.BuilderColorPicker";
     static props = {
@@ -130,16 +148,16 @@ export class BuilderColorPicker extends Component {
     static components = {
         ColorSelector: ColorSelector,
         BuilderComponent,
+        ColorPickerButton,
     };
 
     setup() {
         useBuilderComponent();
         const { state, onApply, onPreview, onPreviewRevert } = useColorPickerBuilderComponent();
-        this.colorButton = useRef("colorButton");
         this.state = state;
-        useColorPicker(
-            "colorButton",
-            {
+
+        this.colorPickerConfig = {
+            props: {
                 state,
                 applyColor: onApply,
                 applyColorPreview: onPreview,
@@ -155,11 +173,11 @@ export class BuilderColorPicker extends Component {
                 className: "o-hb-colorpicker",
                 editColorCombination: this.env.editColorCombination,
             },
-            {
+            options: {
                 onClose: onPreviewRevert,
                 popoverClass: "o-hb-colorpicker-popover",
-            }
-        );
+            },
+        };
     }
 
     getSelectedColorStyle() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.xml
@@ -3,8 +3,23 @@
 
 <t t-name="html_builder.BuilderColorPicker">
     <BuilderComponent>
-        <button t-att-title="props.title" class="o_we_color_preview" t-ref="colorButton" t-att-style="this.getSelectedColorStyle()" t-att-data-tooltip="this.props.tooltip or this.props.title"/>
+        <ColorPickerButton
+            title="props.title"
+            style="this.getSelectedColorStyle()"
+            tooltip="this.props.tooltip or this.props.title"
+            colorPickerConfig="this.colorPickerConfig"
+        />
     </BuilderComponent>
+</t>
+
+<t t-name="html_builder.ColorPickerButton">
+    <button
+        t-att-title="props.title"
+        class="o_we_color_preview"
+        t-ref="colorButton"
+        t-att-style="props.style"
+        t-att-data-tooltip="props.tooltip"
+    />
 </t>
 
 </templates>


### PR DESCRIPTION
When the editing element disappears, BuilderComponent hides the color picker
button via `t-if="state.isVisible"`. When the editing element reappears and
BuilderComponent shows the button again, the button is no longer clickable.

This happens because BuilderComponent's `t-if` conditionally renders the
button, but BuilderColorPicker (which contains the `useColorPicker` hook)
never re-renders. The `useEffect` inside `useColorPicker` only runs cleanup
and re-setup when its parent component patches, which doesn't happen when
only BuilderComponent's state changes.

The component hierarchy was:
```
BuilderColorPicker (contains useEffect)
└─ BuilderComponent (t-if controls visibility)
└── button
```
When BuilderComponent's `state.isVisible` changes, BuilderComponent patches
but BuilderColorPicker does not, so the `useEffect` never re-runs to
re-attach the click event listener.

Solution: Move the button and `useColorPicker` hook into ColorPickerButton
component, so when BuilderComponent's `t-if` unmounts and remounts the
button, a fresh instance with new event listeners is created.

New structure:
```
BuilderColorPicker
└─ BuilderComponent (t-if controls visibility)
└── ColorPickerButton (contains useEffect and button)
```

Steps to reproduce the issue:
- Add a block that contains a ColorPicker option (e.g. s_social_media).
- Disable all social media items and remove any custom ones until the ColorPicker option disappears from the builder.
- Re-enable a social media item or add a new custom one.
- Try to open the ColorPicker option.
- Observe that the ColorPicker Popover does not open.

task-5413351