### PR TITLE
[FIX] html_builder, website: correctly move to `initialTab` on open

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -62,7 +62,9 @@ export class Builder extends Component {
         this.state = useState({
             canUndo: false,
             canRedo: false,
-            activeTab: this.props.config.initialTab || "blocks",
+            activeTab: this.displayOnlyCustomizeTab
+                ? "customize"
+                : this.props.config.initialTab || "blocks",
             currentOptionsContainers: undefined,
         });
         this.invisibleElementsPanelState = useState({

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -211,7 +211,7 @@ export class WebsiteBuilderClientAction extends Component {
             isMobile: this.websiteContext.isMobile,
             config: {
                 initialTarget: this.target,
-                initialTab: this.initialTab || this.translation ? "customize" : "blocks",
+                initialTab: this.initialTab,
                 builderSidebar: {
                     withHiddenSidebar: async (cb) => {
                         try {


### PR DESCRIPTION
In commit 281ce591d4271a15dc867b439365cb41e9dee0b4, the condition for the `initiaTab` introduced a mistake: the actual value is ignored, and a truthy value is interpreted as `blocks`.

This commit fixes the operation order and move the logic to a single place.

Steps to reproduce:
- Open website builder
- Go to "Theme" tab
- Change an option that reloads (like "Show header" in last section)
- Bug: it goes to "Edit" (aka customize) tab

task-5722163