### PR TITLE
[FIX] web: restrict group quick create to default groupby backport

### DIFF
--- a/addons/project/static/tests/legacy/views/project_task_kanban/project_task_kanban_view_tests.js
+++ b/addons/project/static/tests/legacy/views/project_task_kanban/project_task_kanban_view_tests.js
@@ -27,7 +27,7 @@ QUnit.module('Project', {
         ]);
         this.views = {
             "project.task,false,kanban":
-                `<kanban js_class="project_task_kanban">
+                `<kanban default_group_by="stage_id" js_class="project_task_kanban">
                     <templates>
                         <t t-name="card">
                             <field name="name"/>

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -357,8 +357,12 @@ export class KanbanRenderer extends Component {
     // ------------------------------------------------------------------------
 
     canCreateGroup() {
-        const { activeActions } = this.props.archInfo;
-        return activeActions.createGroup && this.props.list.groupByField.type === "many2one";
+        const { activeActions, defaultGroupBy } = this.props.archInfo;
+        return (
+            activeActions.createGroup &&
+            this.props.list.groupByField.type === "many2one" &&
+            this.props.list.groupByField.name === defaultGroupBy?.split(",")?.[0]
+        );
     }
 
     canQuickCreate() {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -345,6 +345,17 @@ export class ListRenderer extends Component {
         return this.props.activeActions || {};
     }
 
+    get canCreateGroup() {
+        const { archInfo, list, readonly } = this.props;
+        const { activeActions, defaultGroupBy } = archInfo;
+        return (
+            !readonly &&
+            activeActions.createGroup &&
+            list.groupByField.type === "many2one" &&
+            list.groupByField.name === defaultGroupBy?.split(",")?.[0]
+        );
+    }
+
     get canResequenceRows() {
         if (!this.props.list.canResequence()) {
             return false;

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -1662,7 +1662,9 @@ test("create in grouped on m2o", async () => {
 
     expect(".o_kanban_group.o_group_draggable").toHaveCount(2);
     expect(".o_control_panel_main_buttons button.o-kanban-button-new").toHaveCount(1);
-    expect(".o_column_quick_create").toHaveCount(1);
+    expect(".o_column_quick_create").toHaveCount(0, {
+        message: "no quick create since no default groupby",
+    });
 
     await createKanbanRecord();
 
@@ -4053,14 +4055,13 @@ test("quick create record while adding a new column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -4651,14 +4652,13 @@ test("drag and drop outside of a column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
     expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(2);
     expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(2);
@@ -5293,7 +5293,7 @@ test("environment is updated when (un)folding groups", async () => {
 });
 
 test.tags("desktop");
-test("create a column in grouped on m2o", async () => {
+test("create a column in default grouped on m2o", async () => {
     onRpc("/web/dataset/resequence", async (request) => {
         expect.step("/web/dataset/resequence");
         const { params } = await request.json();
@@ -5307,14 +5307,13 @@ test("create a column in grouped on m2o", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -5398,14 +5397,13 @@ test("create a column in grouped on m2o without sequence field on view model", a
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -5553,14 +5551,13 @@ test("show/hide help message (ESC) in quick create", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await quickCreateKanbanColumn();
@@ -5593,14 +5590,13 @@ test("delete a column in grouped on m2o", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban class="o_kanban_test" on_create="quick_create">
+            <kanban default_group_by="product_id" class="o_kanban_test" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     // check the initial rendering
@@ -5734,14 +5730,13 @@ test("create a column, delete it and create another one", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -5938,14 +5933,13 @@ test("quick create column should be opened if there is no column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         domain: [["foo", "=", "norecord"]],
     });
 
@@ -5961,14 +5955,13 @@ test("quick create column should close on window click if there is no column", a
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         domain: [["foo", "=", "norecord"]],
     });
 
@@ -5989,14 +5982,13 @@ test("quick create several columns in a row", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2, { message: "should have two columns" });
@@ -6040,14 +6032,13 @@ test("quick create column with enter", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await quickCreateKanbanColumn();
@@ -6083,14 +6074,13 @@ test("quick create column and examples", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban examples="test">
+            <kanban default_group_by="product_id" examples="test">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_column_quick_create").toHaveCount(1, {
@@ -6154,14 +6144,13 @@ test("quick create column with x_name as _rec_name", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
     await quickCreateKanbanColumn();
     await editKanbanColumnName("New Column 1");
@@ -6241,14 +6230,13 @@ test("quick create column and examples: with folded columns", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban examples="test">
+            <kanban default_group_by="product_id" examples="test">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     // the quick create should already be unfolded as there are no records
@@ -6296,14 +6284,13 @@ test("quick create column's apply button's display text", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban examples="test">
+            <kanban default_group_by="product_id" examples="test">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     // open the quick create
@@ -6341,14 +6328,13 @@ test("create column and examples background with ghostColumns titles", async () 
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban examples="test">
+            <kanban default_group_by="product_id" examples="test">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_example_background").toHaveCount(1, {
@@ -6375,14 +6361,13 @@ test("create column and examples background without ghostColumns titles", async 
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_example_background").toHaveCount(1, {
@@ -6601,14 +6586,13 @@ test("no nocontent helper for grouped kanban with no records", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6629,14 +6613,13 @@ test("no nocontent helper is shown when no longer creating column", async () => 
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6679,14 +6662,13 @@ test("no nocontent helper is hidden when quick creating a column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6829,14 +6811,13 @@ test("nocontent helper for grouped kanban (on m2o field) with no records with no
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban group_create="false">
+            <kanban default_group_by="product_id" group_create="false">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         noContentHelp: "No content helper",
     });
 
@@ -6857,14 +6838,13 @@ test("nocontent helper for grouped kanban (on date field) with no records with n
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban group_create="false">
+            <kanban default_group_by="date" group_create="false">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["date"],
         noContentHelp: "No content helper",
     });
 
@@ -6880,14 +6860,13 @@ test("empty grouped kanban with sample data and no columns", async () => {
 
     await mountView({
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         resModel: "partner",
         type: "kanban",
         noContentHelp: "No content helper",
@@ -7293,14 +7272,13 @@ test("empty grouped kanban with sample data: add a column", async () => {
 
     await mountView({
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         resModel: "partner",
         type: "kanban",
     });
@@ -7384,14 +7362,13 @@ test("empty grouped kanban with sample data: delete a column", async () => {
         resModel: "partner",
         type: "kanban",
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_content").toHaveClass("o_view_sample_data");
@@ -7426,14 +7403,13 @@ test("empty grouped kanban with sample data: add a column and delete it right aw
         resModel: "partner",
         type: "kanban",
         arch: `
-            <kanban sample="1">
+            <kanban default_group_by="product_id" sample="1">
                 <templates>
                     <div t-name="card">
                         <field name="foo"/>
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_content").toHaveClass("o_view_sample_data");
@@ -7928,14 +7904,13 @@ test("resequence all when creating new record + partial resequencing", async () 
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="id"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await quickCreateKanbanColumn();
@@ -8289,7 +8264,7 @@ test("update buttons after column creation", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>
@@ -8468,14 +8443,13 @@ test("move a record then put it again in the same column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await editKanbanColumnName("column1");
@@ -8519,14 +8493,13 @@ test("resequence a record twice", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="display_name"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     await editKanbanColumnName("column1");
@@ -8676,7 +8649,7 @@ test("filter on progressbar in new groups", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create" quick_create_view="some_view_ref">
+            <kanban default_group_by="product_id" on_create="quick_create" quick_create_view="some_view_ref">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
                     <t t-name="card">
@@ -8684,7 +8657,6 @@ test("filter on progressbar in new groups", async () => {
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_group").toHaveCount(2);
@@ -8861,7 +8833,7 @@ test("column progressbars: creating a new column should create a new progressbar
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <progressbar field="foo" colors='{"yop": "success", "gnap": "warning", "blip": "danger"}'/>
                 <templates>
                     <t t-name="card">
@@ -8869,7 +8841,6 @@ test("column progressbars: creating a new column should create a new progressbar
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_kanban_counter").toHaveCount(2);
@@ -11904,7 +11875,7 @@ test("click on the progressBar of a new column", async () => {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <progressbar field="state" colors='{"abc": "success", "def": "warning", "ghi": "danger"}' />
                 <templates>
                     <div t-name="card">
@@ -11913,7 +11884,6 @@ test("click on the progressBar of a new column", async () => {
                     </div>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
         domain: [["id", ">", 0]],
     });
 
@@ -11942,9 +11912,8 @@ test("keep focus in cp when pressing arrowdown and no kanban card", async () => 
     await mountView({
         type: "kanban",
         resModel: "partner",
-        groupBy: ["product_id"],
         arch: `
-            <kanban on_create="quick_create">
+            <kanban default_group_by="product_id" on_create="quick_create">
                 <templates>
                     <t t-name="card">
                         <field name="display_name"/>
@@ -12191,14 +12160,13 @@ test("column quick create - title and placeholder", async function (assert) {
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="int_field"/>
                     </t>
                 </templates>
             </kanban>`,
-        groupBy: ["product_id"],
     });
 
     expect(".o_column_quick_create .o_quick_create_folded").toHaveText("Product");
@@ -13366,7 +13334,7 @@ test("quick create a column by pressing enter when input is focused", async () =
         type: "kanban",
         resModel: "partner",
         arch: `
-            <kanban>
+            <kanban default_group_by="product_id">
                 <templates>
                     <t t-name="card">
                         <field name="foo"/>

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1955,6 +1955,9 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
         `,
         groupBy: ["m2o", "m2m"],
     });
+    expect(`.o_list_footer td > button`).toHaveCount(0, {
+        message: "no quick create since no default groupby",
+    });
     expect(queryAllTexts(`tbody > tr`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
 
     await contains(`th.o_group_name`).click();
@@ -1979,6 +1982,27 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
     ]);
 });
 
+test(`grouped list rendering with groupby m2o field: group_create = false`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list group_create="false"><field name="foo"/></list>`,
+        groupBy: ["m2o"],
+    });
+    expect(`.o_list_footer td > button`).toHaveCount(0);
+});
+
+test(`grouped list rendering with groupby non m2o field`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `<list group_create="false"><field name="foo"/></list>`,
+        groupBy: ["bar"],
+    });
+    expect(`.o_list_footer td > button`).toHaveCount(0);
+});
+
+test.tags("desktop");
 test(`grouped list with (disabled) pager inside group`, async () => {
     let def;
     onRpc("web_search_read", () => def);


### PR DESCRIPTION
Backport of commit https://github.com/odoo/odoo/commit/95f09fda03b7d2c74ea8cb33d2431d3a4cef95bf.

This commit updates the conditions for enabling group quick create in list and kanban views. In addition to existing checks, the view must now be grouped using its default groupby (if defined) for quick create to be available.

This ensures that group quick create is only shown in contexts where it is properly supported and avoids undesired behavior when grouping by arbitrary fields.

Fixes the RPC_ERROR when trying to add a salesperson while grouped by salesperson in CRM, which incorrectly passed default_type='opportunity' to res.users.name_create in the case of our issue.

Steps to reproduce:
1- Install the CRM module.
2- Go to CRM (kanban view) and groupby salesperson.
3- Add new salesperson from the view.

Ticket [link](https://www.odoo.com/odoo/project.task/5499818)
opw-5499818

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
