### PR TITLE
[FIX] point_of_sale: fix customer display url

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -152,7 +152,7 @@ export class Navbar extends Component {
         }/${getDeviceUuid()}`;
 
         this.dialog.add(QrCodeCustomerDisplay, {
-            customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
+            customerDisplayURL: `${this.pos.config._base_url}${customer_display_url}`,
         });
     }
 

--- a/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
@@ -15,5 +15,23 @@ registry.category("web_tour.tours").add("customer_display_shows_qr_popup", {
             Chrome.CustomerDisplayHasQRButton(),
             Chrome.ClickCustomerDisplayQRButton(),
             Chrome.CustomerDisplayQRIsDisplayed(),
+            {
+                isActive: ["mobile"],
+                content: "Check that the Customer display url is valid",
+                trigger: ".o-overlay-item .modal .modal-body .small a",
+                run: function (el) {
+                    const url = el.anchor.href;
+                    if (!url || url.includes("undefined")) {
+                        throw new Error(
+                            `Invalid customer display URL (contains undefined): ${url}`
+                        );
+                    }
+                    try {
+                        new URL(url);
+                    } catch {
+                        throw new Error(`Invalid customer display URL: ${url}`);
+                    }
+                },
+            },
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -280,18 +280,21 @@ export function ClickOnCustomerDisplayButton() {
 }
 export function CustomerDisplayHasThisDeviceButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'This device' button",
         trigger: ".o_dialog .modal-body .container .btn-primary:contains('This device')",
     };
 }
 export function CustomerDisplayHasQRButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'Display QR' button",
         trigger: ".o_dialog .modal-body .container .btn-secondary:contains('Display QR')",
     };
 }
 export function ClickCustomerDisplayThisDeviceButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'This device' button",
         trigger: ".btn-primary:contains('This device')",
         run: "click",
@@ -299,6 +302,7 @@ export function ClickCustomerDisplayThisDeviceButton() {
 }
 export function ClickCustomerDisplayQRButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'Display QR' button",
         trigger: ".btn-secondary:contains('Display QR')",
         run: "click",
@@ -306,6 +310,7 @@ export function ClickCustomerDisplayQRButton() {
 }
 export function CustomerDisplayQRIsDisplayed() {
     return {
+        isActive: ["desktop"],
         content: "Check that the QR code is displayed on screen",
         trigger: ".o-overlay-item .modal .modal-body img.square",
     };

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3567,10 +3567,6 @@ class MobileTestUi(TestUi):
     touch_enabled = True
     allow_inherited_tests_method = True
 
-    # Skip customer display web tests on mobile
-    def test_customer_display_popup(self):
-        return
-
 
 class TestTaxCommonPOS(TestPointOfSaleHttpCommon, TestTaxCommon):
     @classmethod


### PR DESCRIPTION
Step to reproduce:
- start pos
- from top-right menu, click on display icon
- a dialog will appear, click on "this device" button

Observation:
- current session will be closed and open in new tab

Cause:
- Incorrect url formed for redirection which, as a fallback loads currrent pos
- base url is `undefined`, as we try to get it from `pos.session`, which now is attribute of `pos.config`.
https://github.com/odoo/odoo/blob/06ddce00115c906a4d8396387dd3332482145d7f/addons/point_of_sale/models/pos_config.py#L288

opw-5502812

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
