### PR TITLE
[FIX] stock_account: missing moves on avco report

### DIFF
--- a/addons/stock_account/report/stock_avco_audit_report.py
+++ b/addons/stock_account/report/stock_avco_audit_report.py
@@ -65,7 +65,7 @@ WHERE
     -- Ignore moves for standard cost method. Only display the list of cost updates
     AND (
         (pt.categ_id IS NOT NULL AND pc.property_cost_method ->> company.id::text IN ('fifo', 'average'))
-        OR (pt.categ_id IS NULL OR pc.property_cost_method IS NULL AND company.cost_method IN ('fifo', 'average'))
+        OR (pt.categ_id IS NULL OR (pc.property_cost_method IS NULL OR pc.property_cost_method ->> company.id::text IS NULL) AND company.cost_method IN ('fifo', 'average'))
     )
 UNION ALL
 SELECT


### PR DESCRIPTION
When looking at the Unit Cost History we should ignore moves for standard cost method.

Before this fix, we also ignore moves for FIFO or AVCO when the property_cost_method of the product category is not NULL (because is set to a company Y), but it is not set to the current company X.

After this fix, we check if the property_cost_method is set to the specific company so that we don't ignore them.

OPW-5434503

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
