### PR TITLE
[FIX] point_of_sale: translate messages in session chatter

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1707,9 +1707,18 @@ class PosSession(models.Model):
             self.name = self.env['ir.sequence'].with_context(company_id=self.config_id.company_id.id).next_by_code('pos.session')
 
     def _post_cash_details_message(self, state, expected, difference, notes):
-        message = (state + " difference: " + self.currency_id.format(difference) + '\n' +
-           state + " expected: " + self.currency_id.format(expected) + '\n' +
-           state + " counted: " + self.currency_id.format(expected + difference) + '\n')
+        expected_formatted = self.currency_id.format(expected)
+        difference_formatted = self.currency_id.format(difference)
+        counted_formatted = self.currency_id.format(expected + difference)
+
+        if state == 'Opening cash':
+            message = _("Opening cash difference: %s \n", difference_formatted)
+            message += _("Opening cash expected: %s \n", expected_formatted)
+            message += _("Opening cash counted: %s \n", counted_formatted)
+        else:
+            message = _("Closing difference: %s \n", difference_formatted)
+            message += _("Closing expected: %s \n", expected_formatted)
+            message += _("Closing counted: %s \n", counted_formatted)
 
         if notes:
             message += _('Opening control message: ')
@@ -1906,9 +1915,9 @@ class PosSession(models.Model):
 
     def log_partner_message(self, partner_id, action, message_type):
         if message_type == 'ACTION_CANCELLED':
-            body = 'Action cancelled ({ACTION})'.format(ACTION=action)
+            body = _('Action cancelled (%(ACTION)s)', ACTION=action)
         elif message_type == 'CASH_DRAWER_ACTION':
-            body = 'Cash drawer opened ({ACTION})'.format(ACTION=action)
+            body = _('Cash drawer opened (%(ACTION)s)', ACTION=action)
 
         self.message_post(body=body, author_id=partner_id)
 


### PR DESCRIPTION
**Problem:**
When opening or closing a POS session, chatter messages display untranslated English text regardless of the user's language setting.

**Steps to reproduce:**
1. Set user language to any non-English language (e.g., Spanish)
2. Open a POS session and register cash in/out operations
3. Close the session
4. Check the chatter messages - labels appear in English

**Current behavior:**
Messages display in English: "Opening cash difference", "Opening cash expected", "Opening cash counted", "Closing difference", etc.

**Expected behavior:**
Messages should be translated according to the user's language setting.

**Cause of the issue:**
The hardcoded strings were not wrapped in the translation function `_()`, preventing them from being translated.

**Fix:**
Wrap the concatenated strings with `_()` to enable proper translation of all cash details messages.

opw-5185310