### PR TITLE
[IMP] l10n_sa_edi: zatca onboarding bugprovement

### DIFF
--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -492,3 +492,89 @@ class TestEdiZatca(TestSaEdiCommon):
         invoice = self._create_invoice(**move_data)
         with self.assertRaises(UserError):
             invoice.action_post()
+
+    def test_csr_generation_compliant_company(self):
+        """Test that CSR generation succeeds for a compliant company with valid field lengths."""
+        compliant_company = self.env['res.company'].create({
+            'name': 'Valid Company Name',
+            'vat': '300000000000003',
+            'street': 'Short Street Name',
+            'city': 'Riyadh',
+            'zip': '12345',
+            'country_id': self.saudi_arabia.id,
+            'state_id': self.riyadh.id,
+            'l10n_sa_api_mode': 'sandbox',
+            'currency_id': self.env.ref('base.SAR').id,
+        })
+        compliant_company.partner_id.industry_id = self.env['res.partner.industry'].create({
+            'name': 'Technology',
+        })
+        compliant_company.l10n_sa_private_key = self.env['res.company']._l10n_sa_generate_private_key()
+        compliant_journal = self.env['account.journal'].create({
+            'name': 'Sales',
+            'code': 'SAL',
+            'type': 'sale',
+            'company_id': compliant_company.id,
+        })
+
+        compliant_journal._l10n_sa_edi_set_csr_fields()
+        try:
+            csr_string = compliant_journal._l10n_sa_get_csr_str()
+            self.assertTrue(csr_string, "a Valid CSR should not be empty")
+        except UserError as e:
+            self.fail(f"Compliant company should not raise error: {e}")
+
+    def test_csr_generation_non_compliant_company(self):
+        """Test that CSR generation fails for non-compliant company with all invalid fields listed."""
+        long_name = "A" * 70
+        long_street = "B" * 70
+        long_city = "C" * 70
+        long_state_name = "D" * 70
+        long_industry_name = "E" * 70
+        long_journal_name = "F" * 70
+
+        long_state = self.env['res.country.state'].create({
+            'name': long_state_name,
+            'code': 'LST',
+            'country_id': self.saudi_arabia.id,
+        })
+        long_industry = self.env['res.partner.industry'].create({
+            'name': long_industry_name,
+        })
+
+        non_compliant_company = self.env['res.company'].create({
+            'name': long_name,
+            'vat': '333333333333333',
+            'street': long_street,
+            'city': long_city,
+            'zip': '12345',
+            'country_id': self.saudi_arabia.id,
+            'state_id': long_state.id,
+            'l10n_sa_api_mode': 'sandbox',
+            'currency_id': self.env.ref('base.SAR').id,
+        })
+        non_compliant_company.partner_id.industry_id = long_industry
+        non_compliant_company.l10n_sa_private_key = self.env['res.company']._l10n_sa_generate_private_key()
+        non_compliant_journal = self.env['account.journal'].create({
+            'name': long_journal_name,
+            'code': 'NC',
+            'type': 'sale',
+            'company_id': non_compliant_company.id,
+        })
+        non_compliant_journal._l10n_sa_edi_set_csr_fields()
+
+        with self.assertRaises(UserError) as context:
+            non_compliant_journal._l10n_sa_get_csr_str()
+
+        error_message = str(context.exception)
+        expected_error_fields = [
+            "Company Name",
+            "Common Name",
+            "Street",
+            "Locality Name",
+            "State/Province Name",
+            "Partner Industry Name",
+        ]
+
+        for field_name in expected_error_fields:
+            self.assertIn(field_name, error_message, f"Error message should contain '{field_name}'")

--- a/addons/l10n_sa_edi/views/account_journal_views.xml
+++ b/addons/l10n_sa_edi/views/account_journal_views.xml
@@ -53,7 +53,7 @@
                         <div class="alert alert-danger d-flex flex-column align-items-end" role="alert" groups="base.group_system"
                              invisible="not l10n_sa_csr_errors or l10n_sa_compliance_csid_json or l10n_sa_production_csid_json">
                             <div class="w-100">
-                                <h4 role="alert" class="alert-heading">Journal could not be onboarded. Please make sure the Company VAT/Identification Number are correct.</h4>
+                                <h4 role="alert" class="alert-heading">Journal could not be onboarded.</h4>
                                 <field name="l10n_sa_csr_errors" nolabel="1" readonly="1"/>
                                 <hr/>
                             </div>


### PR DESCRIPTION
Previously, it was assumed that if no 'error' or 'errors' key was present that means we've received a valid response for obtaining CCSID or PCSID.

But sometimes the error is not sent with those keys, and the binarySecurityToken is missing, therefore a traceback is shown to the user because the invalid requests passes through the validation unnoticed. This kind of response is the result of a new change introduced by zatca requiring csr fields to be at most 64 characters long.

This commit improves the error handling mechanism of CSID responses, to show the user an informative message, and handles the length check for csr fields on the client side before sending to zatca.

task-5347269
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
