### PR TITLE
[FIX] web: fix embedded action test

### DIFF
--- a/addons/web/static/tests/webclient/actions/embedded_action.test.js
+++ b/addons/web/static/tests/webclient/actions/embedded_action.test.js
@@ -730,9 +730,8 @@ test("an action containing embedded actions should reload if the page is refresh
     await getService("action").doAction(1);
     // First, we create a new (custom) embedded action based on the current one
     await contains(".o_control_panel_navigation > button > i.fa-sliders").click();
-    await contains(".o_embedded_actions .dropdown").click();
+    await waitFor(".o_popover.dropdown-menu");
     await contains(".o_save_current_view ").click();
-    await animationFrame();
     await contains(".o_save_favorite ").click();
     expect(".o_embedded_actions > button").toHaveCount(3, {
         message: "Should have 2 embedded actions in the embedded + the dropdown button",


### PR DESCRIPTION
In this commit, we fix an embedded action test that failed because when clicking on the sliders to show the top bar, the dropdown was directly opened as there is only one visible action
(since this commit: https://github.com/odoo/odoo/pull/208005/commits/a5709e870e033b83d50a2f581c81cceb2a98d91b).

We then adapt the test to wait for the dropdown to open automatically, and then when it's the case, create the new custom embedded action.


runbot error~237752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
