### PR TITLE
[FIX] mrp: prevent _compute_qty_remaining error when updating BoM on draft MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2477,16 +2477,16 @@ class MrpProduction(models.Model):
         workorders_to_unlink = self.env['mrp.workorder']
         # For draft MO, all the work will be done by compute methods.
         # For cancelled and done MO, we don't want to do anything more than assinging the BoM.
-        if self.state == 'draft':
-            # Don't straight up delete the moves/workorders but keep them for deletion after
-            # the BoM has been assigned (and thus after new moves/WO have been created).
-            moves_to_unlink = self.move_raw_ids
-            workorders_to_unlink = self.workorder_ids
-            if self.bom_id == bom:
-                # Empty the `bom_id` field so that, when the BoM is reassigned to this field, depending
-                # computes are re-triggered (it doesn't happen if the value of the field doesn't change).
-                self.bom_id = False
+        if self.state == 'draft' and self.bom_id == bom:
+            # Empties `bom_id` field so when the BoM is reassigns to this field, depending computes
+            # will be triggered (doesn't happen if the field's value doesn't change).
+            self.bom_id = False
         if self.state in ['cancel', 'done', 'draft']:
+            if self.state == 'draft':
+                # Don't straight delete the moves/workorders to avoid to cancel the MO, those will
+                # be deleted once the BoM is assigned (and thus after new moves/WO were created).
+                moves_to_unlink = self.move_raw_ids
+                workorders_to_unlink = self.workorder_ids
             self.bom_id = bom
             moves_to_unlink.unlink()
             workorders_to_unlink.unlink()

--- a/doc/cla/individual/GautamKantesariya.md
+++ b/doc/cla/individual/GautamKantesariya.md
@@ -1,0 +1,9 @@
+India, 2026-01-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Gautam gautamkantesariya@yahoo.com https://github.com/GautamKantesariya


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Updating quantities in a Bill of Materials (BoM) on a draft Manufacturing Order (MO) and clicking the “Update BoM” button could trigger an error. This happens because the _link_bom function unlinks existing mrp.workorders before writing to product_qty, causing the _compute_qty_remaining compute on now-unlinked workorders to fail.

Closes #243774

Current behavior before PR:
- Editing a BoM quantity on a draft MO and pressing “Update BoM” sometimes raises an error.
- The system fails to properly update mrp.workorder quantities after unlinking existing workorders.

Desired behavior after PR is merged:
- The BoM can be updated safely on draft MOs without raising errors.
- Moves and workorders are unlinked only after the BoM is reassigned.
- `product_qty` and `product_uom_id` are safely reset, and `_compute_qty_remaining` runs correctly.
- Overall, the draft MO workflow behaves as expected, avoiding crashes when updating BoMs.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
