### PR TITLE
[FIX] im_livechat: fix non-deterministic session tour

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
@@ -1,15 +1,12 @@
-import { whenReady } from "@odoo/owl";
-
-import { registry } from "@web/core/registry";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
+import { registry } from "@web/core/registry";
 
 let firstChannelId;
 registry.category("web_tour.tours").add("im_livechat_session_history_open", {
     steps: () => [
         {
-            trigger: "body",
+            trigger: ".o_switch_view[data-tooltip='List']",
             async run() {
-                await whenReady();
                 const busService = odoo.__WOWL_DEBUG__.root.env.services.bus_service;
                 patchWithCleanup(busService, {
                     addChannel(channel) {
@@ -21,11 +18,8 @@ registry.category("web_tour.tours").add("im_livechat_session_history_open", {
                         return super.deleteChannel(...arguments);
                     },
                 });
+                this.anchor.click();
             },
-        },
-        {
-            trigger: ".o_switch_view[data-tooltip='List']",
-            run: "click",
         },
         {
             trigger: ".o_data_cell:contains('test 2')",


### PR DESCRIPTION
The `test_form_view_embed_thread` ensures that the live chat list view redirects to the discuss app and that the bus subscription for the selected channel is properly made. This ensure that a live chat agent looking at a channel will receive the latest updates for the conversation.

To ensure the bus subscription is made, the bus service is patched in order to detect calls to add or remove methods. However, we only wait for `whenReady` which is not enough to guarantee the bus is already exposed via `odoo.__WOWL_DEBUG__`.

This PR ensure we wait for the list view to be displayed, which ensures the webclient is mounted and the debug info is already set.

runbot-234928

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
