### PR TITLE
[FIX] l10n_gcc_invoice: correct xpath in report invoice

### DIFF
--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -169,7 +169,7 @@
             <t t-set="payment_term_details" position="after">
                 <t t-set="payment_term_details_sec" t-value="o_sec.payment_term_details"/>
             </t>
-            <xpath expr="//div[@id='total_payment_term_details_table']//td" position="before">
+            <xpath expr="//div[@id='total_payment_term_details_table']/div" position="before">
                 <td name="td_payment_term_ar" t-if="display_in_ar" t-translation="off">
                     <span t-options='{"widget": "monetary", "display_currency": o_sec.currency_id}'
                           t-out="o_sec.invoice_payment_term_id._get_amount_due_after_discount(o_sec.amount_total, o_sec.amount_tax)" dir="rtl">30.00</span> المبلغ المستحق إذا تم الدفع قبل
@@ -181,7 +181,7 @@
                     <span t-out="o_sec.invoice_payment_term_id._get_last_discount_date_formatted(o_sec.invoice_date)" dir="ltr">2024-01-01</span>
                 </td>
             </xpath>
-            <xpath expr="//div[@id='total_payment_term_details_table']//t[2]" position="before">
+            <xpath expr="//div[@id='total_payment_term_details_table']/div" position="before">
                 <t name="div_payment_term_ar" t-if="len(payment_term_details_sec) > 1 and display_in_ar" t-foreach="payment_term_details_sec" t-as="term" t-translation="off">
                     <div dir="rtl">
                         <span t-out="term_index + 1">1</span> - دفعة من


### PR DESCRIPTION
Currently, an error occurs when editing the invoice report in Studio and adding fields to the report table.

### **Steps to reproduce**
- Install 'l10n_sa' and Studio with demo data
- Open an invoice and switch to Studio mode
- Edit the Invoice report and add the 'Products' field & click save.

### **Error:**
`ValueError: Element xpath //div[@id=total_payment_term_details_table]` `cannot be located in parent view`

### **Root Cause:**
Due to recent updates with [this commit](https://github.com/odoo/odoo/pull/220167/changes/39ba5962923f04eef85174aaf2667481510cfaf4), payment terms are now targeted from `account/report_invoice.xml`. However, the inherited view was still targeting `td` and `indexed t` nodes, which no longer exist in the updated structure. This causes the xpath to fail when the report is altered by Studio.

### **FIX:**
Update the xpath expression to target a stable `div` container.

**opw-5485437,5498946**