### PR TITLE
[FIX] account_peppol: Fix register branch in peppol using parent

### DIFF
--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -263,13 +263,13 @@ class TestPeppolParticipant(PeppolConnectorCommon):
             self._mock_create_user(),
             self._mock_lookup_participant(),
             self._mock_register_sender(),
-            self._mock_participant_status('sender'),
+            self._mock_participant_status('receiver'),
         ]):
             wizard.button_register_peppol_participant()
 
         settings = self.env['res.config.settings'].with_context(allowed_company_ids=self.env.company.ids).create({})
         self.assertRecordValues(settings, [{
-            'account_peppol_proxy_state': 'sender',
+            'account_peppol_proxy_state': 'receiver',
             'peppol_use_parent_company': False,
         }])
 

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -68,7 +68,7 @@ class PeppolRegistration(models.TransientModel):
         string='EDI user',
         compute='_compute_edi_user_id',
     )
-    account_peppol_proxy_state = fields.Selection(related='selected_company_id.account_peppol_proxy_state')
+    account_peppol_proxy_state = fields.Selection(related='company_id.account_peppol_proxy_state')
     peppol_warnings = fields.Json(
         string="Peppol warnings",
         compute="_compute_peppol_warnings",


### PR DESCRIPTION
1. Activate Peppol in the main company for both sending and receiving;
2. Create a branch company;
3. Activate Peppol in the branch and select "Send from parent company"; => Error message: "Cannot register a user with a receiver application".

opw-5725278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
