### PR TITLE
[FIX] mail: fix invite by email tour

### DIFF
--- a/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
+++ b/addons/mail/static/tests/tours/discuss_invite_by_email_tour.js
@@ -2,6 +2,9 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("discuss.invite_by_email", {
     steps: () => [
+        // Wait for the auto-open of the memberlist. Otherwise, it will
+        // conflict with the opening of the invite panel.
+        { trigger: ".o-discuss-ChannelMemberList" },
         {
             trigger: "button[title='Invite People']",
             run: "click",


### PR DESCRIPTION
The `test_01_invite_by_email_flow` test ensures we can invite partners to a channel using their email.

The tour opens the invitation panel, then sends an email. However, it conflicts with the auto-open of the member list. Sometimes, the member list opens after clicking on the invite panel button.

This only occurs because the tour runs very fast. It's very unlikely that this occurs to a real user. This commit fixes the tour in order to wait for the member list to open initially.

runbot-237994

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
