### PR TITLE
[FIX] mail: tracking UID context dependent

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -539,12 +539,14 @@ class MailThread(models.AbstractModel):
         prepared with ``_tracking_prepare``.
         """
         initial_values = self.env.cr.precommit.data.pop(f'mail.tracking.{self._name}', {})
+        mail_track_with_sudo = self.env.su
         ids = [id_ for id_, vals in initial_values.items() if vals]
         if not ids:
             return
         records = self.browse(ids).sudo()
         fnames = self._track_get_fields()
         context = clean_context(self._context)
+        context.setdefault('mail_track_with_sudo', mail_track_with_sudo)
         tracking = records.with_context(context)._message_track(fnames, initial_values)
         for record in records:
             changes, _tracking_value_ids = tracking.get(record.id, (None, None))

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -198,6 +198,16 @@ class MailTestMultiCompany(models.Model):
     company_id = fields.Many2one('res.company')
 
 
+class MailTestMultiCompanyUIDDependent(models.Model):
+    _name = 'mail.test.multi.company.uid.dependent'
+    _description = "Test Multi Company Mail UID Dependent"
+    _inherit = 'mail.thread.main.attachment'
+
+    name = fields.Char(tracking=True)
+    company_id = fields.Many2one('res.company', tracking=True)
+    company_ids = fields.Many2many('res.company', depends_context=('uid',), tracking=True, string="Companies")
+
+
 class MailTestMultiCompanyRead(models.Model):
     """ Just mail.test.simple, but multi company and supporting posting
     even if the user has no write access. """

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -49,6 +49,8 @@ access_mail_test_lang_portal,mail.test.lang.portal,model_mail_test_lang,base.gro
 access_mail_test_lang_user,mail.test.lang.user,model_mail_test_lang,base.group_user,1,1,1,1
 access_mail_test_multi_company_user,mail.test.multi.company.user,model_mail_test_multi_company,base.group_user,1,1,1,1
 access_mail_test_multi_company_portal,mail.test.multi.company.portal,model_mail_test_multi_company,base.group_portal,1,0,0,0
+access_mail_test_multi_company_uid_dependent_user,mail.test.multi.company.uid.dependent.user,model_mail_test_multi_company_uid_dependent,base.group_user,1,1,1,1
+access_mail_test_multi_company_uid_dependent_portal,mail.test.multi.company.uid.dependent.portal,model_mail_test_multi_company_uid_dependent,base.group_portal,1,0,0,0
 access_mail_test_multi_company_read_user,mail.test.multi.company.read.user,model_mail_test_multi_company_read,base.group_user,1,1,1,1
 access_mail_test_multi_company_read_portal,mail.test.multi.company.read.portal,model_mail_test_multi_company_read,base.group_portal,1,0,0,0
 access_mail_test_multi_company_with_activity_user,mail.test.multi.company.with.activity.user,model_mail_test_multi_company_with_activity,base.group_user,1,1,1,1

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -112,6 +112,13 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <record id="mail_test_multi_company_uid_dependent" model="ir.rule">
+        <field name="name">Mail Test Multi Company</field>
+        <field name="model_id" ref="test_mail.model_mail_test_multi_company_uid_dependent"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+    </record>
+
     <record id="mail_test_multi_company_read_rule" model="ir.rule">
         <field name="name">MC Readonly Rule</field>
         <field name="model_id" ref="test_mail.model_mail_test_multi_company_read"/>


### PR DESCRIPTION
Fields marked with `depends_context('uid')`, such as `company_ids` in the `account.account` model in this [code](https://github.com/odoo/odoo/blob/5607dbdef771527665cf5fe3cb1a15af977c9143/addons/account/models/account_account.py#L107) fragment, can produce false chatter logs when tracking is enabled. 

This happens because the initial values of tracked fields are captured in `precommit.data` under the user environment, but later, when `_track_finalize` calls `_message_track`, the records are read under `sudo()`, see [code](https://github.com/odoo/odoo/blob/79d509a0ab43039cd989b0a70a09231a4e92ba84/addons/mail/models/mail_thread.py#L573). For context-dependent fields, this creates two cached values, one under the user and one under `sudo()`, and `_mail_track` incorrectly detects a difference, generating a tracking log even though the database value has not actually changed.

This fix modifies `_mail_track` so that the current field value is fetched under the same user environment (`sudo()` or not, if possible and if we don't get an access error when trying to do so) that was used to capture the initial value. This ensures that only real changes are tracked in the chatter, while still preventing access errors and preserving multi-company behavior.

Tests have also been added to reproduce this scenario. Without the change in the `_mail_track` method, the new test fails, but it passes successfully when we add the fix.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
