### PR TITLE
[IMP] iot_drivers: allow testing every driver

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -25,7 +25,7 @@ class Driver(Thread):
         self.device_type = ''
         self.device_manufacturer = ''
         self.data = {'value': '', 'result': ''}  # TODO: deprecate "value"?
-        self._actions = {}
+        self._actions = {"status": self.status}
         self._stopped = Event()
         self._recent_action_ids = LRU(256)
 
@@ -84,3 +84,6 @@ class Driver(Thread):
     def disconnect(self):
         self._stopped.set()
         del iot_devices[self.device_identifier]
+
+    def status(self, _):
+        return self.supported(self.dev)

--- a/addons/iot_drivers/iot_handlers/drivers/ctypes_terminal_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/ctypes_terminal_driver.py
@@ -256,3 +256,18 @@ class CtypesTerminalDriver(Driver, ABC):
         Method implementing the terminal balance request (only for Worldline "Six")
         Not an abstract method as it remains undefined for Worldline
         """
+
+    def status(self, _):
+        self._action_default({
+            "messageType": "Transaction",
+            "transactionType": "Payment",
+            "amount": 1,
+            "cid": 1,
+            "posId": 1,
+            "userId": 1,
+            "currency": "EUR",
+        })
+        self._action_default({
+            "messageType": "Cancel",
+            "cid": 2,
+        })

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -43,7 +43,7 @@ class PrinterDriver(PrinterDriverBase):
         if self.device_subtype == "receipt_printer" and self.receipt_protocol == 'escpos':
             self._init_escpos(device)
 
-        self.print_status()
+        self.status()
 
     def _init_escpos(self, device):
         try:
@@ -134,7 +134,7 @@ class PrinterDriver(PrinterDriverBase):
 
         return {"identifier": identifier, "mac_address": mac_address, "pairing_code": pairing_code, "ssid": ssid, "ips": ips}
 
-    def print_status(self, data=None):
+    def status(self, data=None):
         """Prints the status ticket of the IoT Box on the current printer.
 
         :param data: If not None, it means that it has been called from the action route, meaning

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -141,7 +141,7 @@ class PrinterDriver(PrinterDriverBase):
         _logger.debug("_action_default finished with mimetype %s for printer %s", mimetype, self.device_name)
         return {'print_id': data['print_id']} if 'print_id' in data else {}
 
-    def print_status(self, _data=None):
+    def status(self, _data=None):
         """Prints the status ticket of the IoT Box on the current printer.
 
         :param _data: dict provided by the action route

--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -73,7 +73,6 @@ class PrinterDriverBase(Driver, ABC):
         self._actions.update({
             'cashbox': self.open_cashbox,
             'print_receipt': self.print_receipt,
-            'status': self.print_status,
             '': self._action_default,
         })
 
@@ -279,11 +278,6 @@ class PrinterDriverBase(Driver, ABC):
         :param data: The data to send to the printer
         :param str action_unique_id: The unique identifier of the action
         """
-        pass
-
-    @abstractmethod
-    def print_status(self, data):
-        """Method called to test a printer, printing a status page."""
         pass
 
     @abstractmethod

--- a/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_be_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_be_driver.py
@@ -77,7 +77,6 @@ class BlackBoxDriver(SerialDriver):
             'registerReceiptWeb': self._register_receipt_web,  # 'H' from server (websocket) so requires an answer
             'registerReceipt': self._register_receipt,  # 'H'
             'registerPIN': self._register_pin,  # 'P'
-            'status': self._request_status,  # 'S'
         })
 
     @classmethod
@@ -108,7 +107,7 @@ class BlackBoxDriver(SerialDriver):
             time.sleep(3)
         return False
 
-    def _request_status(self, data):
+    def status(self, data):
         """Request the status of the blackbox, used when clicking "Test" button in the UI."""
         blackbox_response = self._send_to_blackbox("S", data, self._connection)
         return self._parse_blackbox_response(blackbox_response)


### PR DESCRIPTION
We create a standard status method on drivers to allow getting status (clicking "Test" in the database).
Every driver can now override this method to test the device its own way.

see odoo/enterprise#104794
Task: 5491079