### PR TITLE
[IMP] web: offline searchbar

### DIFF
--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -84,14 +84,15 @@ class OfflineManager extends Reactive {
             this._offlineUI();
             // Create an observer instance linked to the callback function to keep disabling
             // elements that would appear in the DOM while being offline.
-            this._observer = new MutationObserver((mutationList) => {
-                if (this._offline && mutationList.find((m) => m.addedNodes.length > 0)) {
+            this._observer = new MutationObserver(() => {
+                if (this._offline) {
                     this._offlineUI();
                 }
             });
             this._observer.observe(document.body, {
                 childList: true, // listen for direct children being added/removed
                 subtree: true, // also observe descendants (not just direct children)
+                attributeFilter: ["data-available-offline"], // listen for specific attribute change
             });
 
             // Repeatedly check if connection is back.
@@ -187,6 +188,11 @@ class OfflineManager extends Reactive {
      * @private
      */
     _offlineUI() {
+        // Re-enable elements that have been marked as available offline
+        document.querySelectorAll(".o_disabled_offline[data-available-offline]").forEach((el) => {
+            el.removeAttribute("disabled");
+            el.classList.remove("o_disabled_offline");
+        });
         document.querySelectorAll(OfflineManager.SELECTORS_TO_DISABLE.join(", ")).forEach((el) => {
             el.setAttribute("disabled", "");
             el.classList.add("o_disabled_offline");

--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -7,6 +7,7 @@ import { Component, xml, onWillStart, onWillUpdateProps, useState } from "@odoo/
 const defaultActiveField = { attrs: {}, options: {}, domain: "[]", string: "" };
 
 class StandaloneRelationalModel extends RelationalModel {
+    static withCache = false;
     load(params = {}) {
         if (params.values) {
             const data = params.values;

--- a/addons/web/static/src/search/search_bar/offline_search_bar.js
+++ b/addons/web/static/src/search/search_bar/offline_search_bar.js
@@ -1,0 +1,113 @@
+import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { Component, onWillRender, onWillStart, useRef, useState } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { fuzzyLookup } from "@web/core/utils/search";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+
+const INITIAL_SEARCH_LIMIT = 8;
+
+export class OfflineSearchBar extends Component {
+    static template = "web.OfflineSearchBar";
+    static components = {
+        Dropdown,
+        DropdownItem,
+    };
+    static props = {
+        autofocus: { type: Boolean, optional: true },
+        toggler: { type: Object, optional: true },
+    };
+
+    setup() {
+        this.ui = useService("ui");
+        this.rootRef = useRef("root");
+        this.inputRef =
+            this.env.config.disableSearchBarAutofocus || !this.props.autofocus
+                ? useRef("autofocus")
+                : useAutofocus({ mobile: this.ui.isSmall }); // only force the focus on touch devices on small screens
+        this.searchBarDropdownState = useDropdownState();
+        this.visibilityState = useState(this.props.toggler?.state || { showSearchBar: true });
+
+        useHotkey("backspace", () => this.onBackspace(), {
+            area: () => this.inputRef.el,
+            bypassEditableProtection: true,
+            isAvailable: () => this.inputRef.el.value === "",
+        });
+
+        this.allSearches = [];
+        this.state = useState({
+            searches: [],
+            limit: INITIAL_SEARCH_LIMIT,
+        });
+
+        const offlineService = useService("offline");
+        onWillStart(async () => {
+            const { actionId, viewType } = this.env.config;
+            this.allSearches = await offlineService.getAvailableSearches(actionId, viewType);
+            this.emptySearch = this.allSearches.find((search) => !search.facets.length) || null;
+            this.state.searches = this.allSearches;
+        });
+
+        onWillRender(() => {
+            const currentSearch = this.env.searchModel.getCurrentSearch();
+            this.currentSearch =
+                this.allSearches.find((search) => search.key === currentSearch.key) ||
+                currentSearch;
+        });
+    }
+
+    get isSearchMenuDisabled() {
+        return (
+            this.allSearches.length === 0 || (this.allSearches.length === 1 && !!this.emptySearch)
+        );
+    }
+
+    canRemoveSearch() {
+        return (
+            this.currentSearch.facets.length &&
+            (this.emptySearch ||
+                (this.allSearches.length && this.currentSearch.key !== this.allSearches[0].key))
+        );
+    }
+
+    selectSearch(search) {
+        this.state.value = search.key;
+        this.env.searchModel.applySearch(search);
+    }
+
+    onBackspace() {
+        if (this.emptySearch && this.inputRef.el.value === "") {
+            this.selectSearch(this.emptySearch);
+        }
+    }
+
+    onRemoveSearch() {
+        this.selectSearch(this.emptySearch || this.allSearches[0]);
+    }
+
+    onSearchInput(ev) {
+        const query = ev.target.value;
+        if (!query) {
+            this.state.searches = this.allSearches;
+        } else {
+            this.state.searches = fuzzyLookup(query, this.allSearches, ({ facets }) =>
+                facets.map((f) => (f.type === "field" ? f.title : "") + f.values.join("")).join("")
+            );
+        }
+        if (!this.state.searches.length) {
+            this.searchBarDropdownState.close();
+        } else {
+            this.searchBarDropdownState.open();
+        }
+    }
+
+    onSelect(search) {
+        this.inputRef.el.value = "";
+        this.selectSearch(search);
+    }
+
+    onShowMoreSearches() {
+        this.state.limit += INITIAL_SEARCH_LIMIT;
+    }
+}

--- a/addons/web/static/src/search/search_bar/offline_search_bar.xml
+++ b/addons/web/static/src/search/search_bar/offline_search_bar.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.OfflineSearchBar">
+        <div t-if="this.visibilityState.showSearchBar" class="o_offline_search_bar input-group" role="search" t-ref="root">
+            <Dropdown
+                state="this.searchBarDropdownState"
+                disabled="this.isSearchMenuDisabled"
+                noClasses="true"
+                position="'bottom-fit'"
+                menuClass="'o_search_bar_menu_offline'"
+                bottomSheet="false"
+            >
+                <div class="d-flex w-100">
+                    <div class="form-control d-print-contents d-flex align-items-center py-1 border-end-0 rounded-end-0" role="search" aria-autocomplete="list">
+                        <i class="d-print-none oi oi-search me-2" role="img"/>
+                        <div class="d-flex flex-grow-1 flex-wrap gap-1 mw-100">
+                            <t t-call="web.OfflineSearchBar.Facets">
+                                <t t-set="facets" t-value="this.currentSearch.facets"/>
+                            </t>
+                            <div t-if="this.canRemoveSearch()" class="o_searchview_facet d-print-none rounded-2 bg-200 px-1 cursor-pointer" data-tooltip="Clear search" t-on-click.stop="onRemoveSearch">
+                                <i class="oi oi-close small"/>
+                            </div>
+                            <div t-elif="this.currentSearch.facets.length" class="o_searchview_facet d-print-none rounded-2 bg-200 px-1 opacity-50" data-tooltip="Can't remove that search">
+                                <i class="oi oi-close small"/>
+                            </div>
+                            <input type="text"
+                                class="o_input d-print-none flex-grow-1 w-auto border-0"
+                                accesskey="Q"
+                                placeholder="Search..."
+                                role="searchbox"
+                                t-att-disabled="this.isSearchMenuDisabled"
+                                t-ref="autofocus"
+                                t-on-input="onSearchInput"
+                                t-on-compositionend="onCompositionEnd"
+                            />
+                        </div>
+                    </div>
+                    <button
+                        class="o_searchview_dropdown_toggler dropdown-toggle d-print-none btn btn-outline-secondary rounded-start-0"
+                        data-hotkey="shift+q"
+                        title="Toggle Search Panel"
+                        t-att-disabled="this.isSearchMenuDisabled"
+                        data-available-offline=""
+                    />
+                </div>
+                <t t-set-slot="content">
+                    <DropdownItem t-foreach="state.searches.slice(0, state.limit)" t-as="search" t-key="search_index"
+                        t-if="search.facets.length"
+                        onSelected="() => this.onSelect(search)"
+                        class="{
+                            'd-flex': true,
+                            'gap-1': true,
+                            'fw-bolder': search.key === this.currentSearch.key
+                        }">
+                        <t t-call="web.OfflineSearchBar.Facets">
+                            <t t-set="facets" t-value="search.facets"/>
+                        </t>
+                    </DropdownItem>
+                    <DropdownItem t-if="state.searches.length > state.limit"
+                        closingMode="'none'"
+                        onSelected.bind="onShowMoreSearches">
+                        <button class="btn btn-link p-0" data-available-offline="">More...</button>
+                    </DropdownItem>
+                </t>
+            </Dropdown>
+        </div>
+    </t>
+
+    <t t-name="web.OfflineSearchBar.Facets">
+        <t t-foreach="facets" t-as="facet" t-key="facet_index">
+            <div class="o_searchview_facet d-inline-flex align-items-stretch rounded-2 bg-200 text-nowrap mw-100"
+                role="listitem"
+                aria-label="search"
+                tabindex="0"
+                >
+                <div class="rounded-start-2 px-1 rounded-end-0 p-0"
+                    role="img"
+                    t-att-class="{
+                        'text-bg-action': facet.type == 'groupBy',
+                        'text-bg-primary': facet.type == 'field' || facet.type == 'filter',
+                        'text-bg-favourite': facet.type == 'favorite'
+                    }"
+                    >
+                    <i t-if="facet.icon" class="small fa-fw" t-att-class="facet.icon" role="image"/>
+                    <small t-else="" class="px-1" t-esc="facet.title"/>
+                </div>
+                <div class="o_facet_values d-flex flex-wrap align-items-center px-2 rounded-end-2 text-wrap overflow-hidden">
+                    <t t-foreach="facet.values" t-as="facetValue" t-key="facetValue_index">
+                        <em t-if="!facetValue_first" class="o_facet_values_sep small fw-bold mx-1 opacity-50" t-esc="facet.separator"/>
+                        <small class="o_facet_value text-truncate" t-esc="facetValue" t-att-title="facet.tooltip or facetValue"/>
+                    </t>
+                </div>
+            </div>
+        </t>
+    </t>
+
+</templates>

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -50,7 +50,6 @@
                         aria-label="Remove"
                         title="Remove"
                         t-on-click="() => this.onFacetRemove(facet)"
-                        data-available-offline=""
                     />
                 </div>
             </div>

--- a/addons/web/static/src/search/search_bar/search_bar_toggler.js
+++ b/addons/web/static/src/search/search_bar/search_bar_toggler.js
@@ -1,4 +1,4 @@
-import { Component, useEffect, useState } from "@odoo/owl";
+import { Component, onWillStart, useEffect, useState } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
@@ -10,6 +10,18 @@ export class SearchBarToggler extends Component {
         showSearchBar: Boolean,
         toggleSearchBar: Function,
     };
+}
+
+export class OfflineSearchBarToggler extends SearchBarToggler {
+    static template = "web.SearchBar.Toggler.Offline";
+    setup() {
+        const offlineService = useService("offline");
+        onWillStart(async () => {
+            const { actionId, viewType } = this.env.config;
+            const availableSearches = await offlineService.getAvailableSearches(actionId, viewType);
+            this.isDisabled = Object.keys(availableSearches).length <= 1;
+        });
+    }
 }
 
 export function useSearchBarToggler() {
@@ -43,6 +55,7 @@ export function useSearchBarToggler() {
     return {
         state,
         component: SearchBarToggler,
+        offlineComponent: OfflineSearchBarToggler,
         get props() {
             return {
                 isSmall: state.isSmall,

--- a/addons/web/static/src/search/search_bar/search_bar_toggler.xml
+++ b/addons/web/static/src/search/search_bar/search_bar_toggler.xml
@@ -2,7 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="web.SearchBar.Toggler">
-        <button t-if="props.isSmall" t-attf-class="btn btn-secondary {{ props.showSearchBar ? 'active' : '' }}" t-on-click="props.toggleSearchBar" data-available-offline="">
+        <button t-if="props.isSmall" t-attf-class="btn btn-secondary {{ props.showSearchBar ? 'active' : '' }}" t-on-click="props.toggleSearchBar">
+            <i class="fa fa-fw fa-search"/>
+        </button>
+    </t>
+
+    <t t-name="web.SearchBar.Toggler.Offline">
+        <button t-if="props.isSmall" t-att-disabled="isDisabled" t-attf-class="btn btn-secondary {{ props.showSearchBar ? 'active' : '' }}" t-on-click="props.toggleSearchBar" data-available-offline="">
             <i class="fa fa-fw fa-search"/>
         </button>
     </t>

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -11,7 +11,6 @@
                 class="o_searchview_dropdown_toggler abcdddd d-print-none btn btn-outline-secondary o-dropdown-caret rounded-start-0"
                 data-hotkey="shift+q"
                 title="Toggle Search Panel"
-                data-available-offline=""
             >
             </button>
             <t t-set-slot="content">

--- a/addons/web/static/src/search/with_search/with_search.js
+++ b/addons/web/static/src/search/with_search/with_search.js
@@ -58,6 +58,7 @@ export class WithSearch extends Component {
                 field: useService("field"),
                 name: useService("name"),
                 dialog: useService("dialog"),
+                offline: useService("offline"),
                 treeProcessor: useService("tree_processor"),
             },
             this.props.searchModelArgs

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -8,10 +8,12 @@ import { useSetupAction } from "@web/search/action_hook";
 import { ActionMenus, STATIC_ACTIONS_GROUP_NUMBER } from "@web/search/action_menus/action_menus";
 import { Layout } from "@web/search/layout";
 import { usePager } from "@web/search/pager_hook";
+import { OfflineSearchBar } from "@web/search/search_bar/offline_search_bar";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 import { session } from "@web/session";
 import { useModelWithSampleData } from "@web/model/model";
+import { OfflineActionHelper } from "@web/views/offline_action_helper";
 import { standardViewProps } from "@web/views/standard_view_props";
 import { MultiRecordViewButton } from "@web/views/view_button/multi_record_view_button";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
@@ -41,11 +43,13 @@ const QUICK_CREATE_FIELD_TYPES = ["char", "boolean", "many2one", "selection", "m
 export class KanbanController extends Component {
     static template = `web.KanbanView`;
     static components = {
+        OfflineActionHelper,
         ActionMenus,
         DropdownItem,
         Layout,
         KanbanRenderer,
         MultiRecordViewButton,
+        OfflineSearchBar,
         SearchBar,
         CogMenu: KanbanCogMenu,
         SelectionBox,

--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -67,10 +67,14 @@
                     </CogMenu>
                 </t>
                 <t t-set-slot="control-panel-actions">
-                    <SearchBar toggler="searchBarToggler" autofocus="firstLoad"/>
+                    <SearchBar t-if="!offlineService.offline" toggler="searchBarToggler" autofocus="firstLoad"/>
+                    <OfflineSearchBar t-else="" toggler="searchBarToggler" autofocus="firstLoad"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
-                    <t t-if="!hasSelectedRecords" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                    <t t-if="!hasSelectedRecords">
+                        <t t-if="offlineService.offline" t-component="searchBarToggler.offlineComponent" t-props="searchBarToggler.props"/>
+                        <t t-else="" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                    </t>
                 </t>
                 <t t-component="props.Renderer" t-if="model.isReady"
                     list="model.root"
@@ -86,6 +90,9 @@
                     quickCreateState="quickCreateState"
                     progressBarState="progressBarState"
                 />
+                <t t-elif="model.couldNotLoadRootOffline">
+                    <OfflineActionHelper/>
+                </t>
             </Layout>
         </div>
     </t>

--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -270,6 +270,7 @@ export class KanbanRecord extends Component {
         }
         if (
             this.offlineService.offline &&
+            !this.props.record.model.useSampleModel &&
             !this.offlineService.isAvailableOffline(this.env.config.actionId, "form", record.resId)
         ) {
             classes.push("o_disabled_offline");

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -16,11 +16,13 @@ import { MultiRecordViewButton } from "@web/views/view_button/multi_record_view_
 import { ViewButton } from "@web/views/view_button/view_button";
 import { executeButtonCallback, useViewButtons } from "@web/views/view_button/view_button_hook";
 import { ListConfirmationDialog } from "./list_confirmation_dialog";
+import { OfflineSearchBar } from "@web/search/search_bar/offline_search_bar";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 import { session } from "@web/session";
 import { ListCogMenu } from "./list_cog_menu";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { OfflineActionHelper } from "@web/views/offline_action_helper";
 import { SelectionBox } from "@web/views/view_components/selection_box";
 import { useExportRecords, useDeleteRecords } from "@web/views/view_hook";
 
@@ -40,11 +42,13 @@ import {
 export class ListController extends Component {
     static template = `web.ListView`;
     static components = {
+        OfflineActionHelper,
         ActionMenus,
         Layout,
         ViewButton,
         MultiRecordViewButton,
         SearchBar,
+        OfflineSearchBar,
         CogMenu: ListCogMenu,
         DropdownItem,
         SelectionBox,

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -23,10 +23,14 @@
                 </t>
 
                 <t t-set-slot="control-panel-actions">
-                    <SearchBar toggler="searchBarToggler" autofocus="firstLoad"/>
+                    <SearchBar t-if="!offlineService.offline" toggler="searchBarToggler" autofocus="firstLoad"/>
+                    <OfflineSearchBar t-else="" toggler="searchBarToggler" autofocus="firstLoad"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
-                    <t t-if="!hasSelectedRecords" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                    <t t-if="!hasSelectedRecords">
+                        <t t-if="offlineService.offline" t-component="searchBarToggler.offlineComponent" t-props="searchBarToggler.props"/>
+                        <t t-else="" t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                    </t>
                 </t>
 
                 <t t-set-slot="control-panel-additional-actions">
@@ -88,6 +92,9 @@
                     optionalActiveFields="optionalActiveFields"
                     readonly="props.readonly"
                 />
+                <t t-elif="model.couldNotLoadRootOffline">
+                    <OfflineActionHelper/>
+                </t>
             </Layout>
         </div>
     </t>

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -955,7 +955,7 @@ export class ListRenderer extends Component {
         if (this.canResequenceRows) {
             classNames.push("o_row_draggable");
         }
-        if (!this.isRecordAvailable(record)) {
+        if (!this.isRecordAvailable(record) && !this.props.list.model.useSampleModel) {
             classNames.push("o_disabled_offline");
         }
         return classNames.join(" ");

--- a/addons/web/static/src/views/offline_action_helper.js
+++ b/addons/web/static/src/views/offline_action_helper.js
@@ -1,0 +1,21 @@
+import { Component, onWillStart } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class OfflineActionHelper extends Component {
+    static template = "web.OfflineActionHelper";
+    static props = [];
+
+    setup() {
+        const offlineService = useService("offline");
+
+        this.searches = null;
+        onWillStart(async () => {
+            const { actionId, viewType } = this.env.config;
+            this.searches = await offlineService.getAvailableSearches(actionId, viewType);
+        });
+    }
+
+    onResetFilters() {
+        this.env.searchModel.applySearch(this.searches[0]);
+    }
+}

--- a/addons/web/static/src/views/offline_action_helper.xml
+++ b/addons/web/static/src/views/offline_action_helper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.OfflineActionHelper">
+        <div class="o_view_nocontent">
+            <div class="o_nocontent_help">
+                <p><i class="fa fa-4x fa-chain-broken opacity-75"/></p>
+                <p>There is no data to display offline for the given filters</p>
+                <button
+                    t-if="this.searches.length"
+                    class="btn btn-primary"
+                    data-available-offline=""
+                    t-on-click="onResetFilters">
+                    Reset Filters
+                </button>   
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/web/static/src/views/view_components/column_progress.js
+++ b/addons/web/static/src/views/view_components/column_progress.js
@@ -1,5 +1,6 @@
 import { Component } from "@odoo/owl";
 import { AnimatedNumber } from "./animated_number";
+import { useService } from "@web/core/utils/hooks";
 
 export class ColumnProgress extends Component {
     static components = {
@@ -15,6 +16,10 @@ export class ColumnProgress extends Component {
     static defaultProps = {
         onBarClicked: () => {},
     };
+
+    setup() {
+        this.offlineService = useService("offline");
+    }
 
     async onBarClick(bar) {
         await this.props.onBarClicked(bar);

--- a/addons/web/static/src/views/view_components/column_progress.xml
+++ b/addons/web/static/src/views/view_components/column_progress.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ColumnProgress">
-        <div class="o_column_progress progress bg-300 w-75">
+        <div class="o_column_progress progress bg-300 w-75" t-att-class="offlineService.offline ? 'opacity-50 pe-none': ''">
             <t t-set="maxWidth" t-value="100 - Math.max(0, props.progressBar.bars.filter(x => x.count > 0).length - 1) * 5"/>
             <t t-foreach="props.progressBar.bars" t-as="bar" t-key="bar.value">
                 <t t-set="progressWidth" t-value="Math.max(5, bar.count / (props.group.count or 1) * 100)"/>

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1235,7 +1235,10 @@ export function makeActionManager(env, router = _router) {
         if (env.isSmall) {
             view = _findView(views, view.multiRecord, action.mobile_view_mode) || view;
         }
-        if (env.services.offline.offline) {
+        if (
+            env.services.offline.offline &&
+            !env.services.offline.isAvailableOffline(action.id, view.type, action.res_id || false)
+        ) {
             view =
                 views.find((v) => env.services.offline.isAvailableOffline(action.id, v.type)) ||
                 view;

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -19600,6 +19600,7 @@ test(`cache web_read_group (switch view, go back)`, async () => {
 test(`cache web_read_group: do not send opening_info if not necessary`, async () => {
     // This test ensures that the params of the web_read_group aren't polluted by the opening_info
     // kwargs when successively toggling different filters
+    expect.errors(2);
     const setOffline = mockOffline();
     onRpc("web_read_group", async () => {
         expect.step("web_read_group");
@@ -19647,7 +19648,11 @@ test(`cache web_read_group: do not send opening_info if not necessary`, async ()
     expect(`.o_group_header`).toHaveCount(1);
 
     // Do not follow the same steps as earlier, directly remove the filter
-    await removeFacet("First filter");
+    if (getMockEnv().isSmall) {
+        // Toggle searchbar in mobile
+        await contains(`.o_control_panel_navigation .fa-search`).click();
+    }
+    await contains(".o_searchview_facet .oi-close").click();
     expect(`.o_group_header`).toHaveCount(4);
 
     expect.verifyErrors([
@@ -19723,6 +19728,7 @@ test(`[Offline] cache web_search_read: enable filter online/offline`, async () =
             <search>
                 <filter string="My filter" name="my_filter" domain="[['foo', '=', 'blip']]"/>
             </search>`,
+        config: { actionId: 234 },
     });
 
     // put data in cache
@@ -19748,9 +19754,12 @@ test(`[Offline] cache web_search_read: enable filter online/offline`, async () =
     // switch offline => use data from cache
     await setOffline(true);
 
-    await toggleMenuItem("My filter");
+    expect(".o_offline_search_bar").toHaveCount(1);
+    await contains(".o_offline_search_bar .dropdown-toggle").click();
+    expect(".o_search_bar_menu_offline .o-dropdown-item").toHaveCount(1);
+    await contains(".o_search_bar_menu_offline .o-dropdown-item").click();
     expect(queryAllTexts(`.o_list_char`)).toEqual(["blip", "blip"]);
-    await toggleMenuItem("My filter");
+    await contains(".o_searchview_facet .oi-close").click();
     expect(queryAllTexts(`.o_list_char`)).toEqual(["yop", "blip", "gnap", "blip"]);
 
     expect.verifyErrors([

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -2877,3 +2877,29 @@ test("[Offline] execute unavailable action", async () => {
         `Connection to "/web/dataset/call_kw/partner/web_search_read" couldn't be established`,
     ]);
 });
+
+test.tags("desktop");
+test("[Offline] open the asked viewType", async () => {
+    expect.errors(1); // 1x ConnectionLostError
+    const setOffline = mockOffline();
+
+    await mountWithCleanup(WebClient);
+
+    // visit some actions and records to populate the caches
+    await getService("action").doAction(4);
+    expect(".o_kanban_view").toHaveCount(1);
+    await contains(".o_cp_switch_buttons .o_list").click();
+    expect(".o_list_view").toHaveCount(1);
+
+    // switch offline
+    await setOffline(true);
+
+    // execute an action with viewType
+    await getService("action").doAction(4, { viewType: "list" });
+    await animationFrame();
+    expect(".o_list_view").toHaveCount(1);
+
+    expect.waitForErrors([
+        `Connection to "/web/dataset/call_kw/partner/web_search_read" couldn't be established`,
+    ]);
+});


### PR DESCRIPTION
This PR introduces an offline-specific version of the search
bar, in kanban and list views. The offline search bar allows to
select previous searches, for which we know that we have data in
cache. Those searches are sorted by count (# of times they have
been done) and by last visited date. It only displays searches for
which there's a result (groups or records), i.e. no searches that
would lead to an empty screen with the no content helper.

We rely on the offline service (and its `visited-ui-items` idb
table) to store all searches that are available offline. For each
search, we store the description of its facets, to be able to
render them both in the search menu dropdown and in the search bar
when that search is selected, and we store the domain and groupby
of the search, to apply in the search model when that search is
selected.

Note: storing the domain and not a description of the selected
filters allows to ensure that we can restore a search even if the
search view (arch) or favorite items changed meanwhile.

Task~5493339