### PR TITLE
[FIX] portal: fix address form with hidden relational input values

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -680,16 +680,22 @@ class CustomerPortal(Controller):
             # commercial partner values, and would be reset if modified on the commercial partner.
             if not (is_commercial_address := partner_sudo == partner_sudo.commercial_partner_id):
                 for commercial_field_name in partner_sudo._commercial_fields():
+                    if commercial_field_name not in address_values:
+                        continue
+                    partner_sudo_field = partner_sudo._fields[commercial_field_name]
+                    partner_sudo_value = partner_sudo_field.convert_to_cache(
+                        partner_sudo[commercial_field_name],
+                        partner_sudo,
+                    )
                     if (
-                        commercial_field_name in address_values
-                        and partner_sudo[commercial_field_name] != address_values[commercial_field_name]
+                        partner_sudo_value != address_values[commercial_field_name]
                         and (
-                            bool(partner_sudo[commercial_field_name])
+                            bool(partner_sudo_value)
                             or bool(address_values[commercial_field_name])
                         )
                     ):
                         invalid_fields.add(commercial_field_name)
-                        field_description = partner_sudo._fields[commercial_field_name]._description_string(request.env)
+                        field_description = partner_sudo_field._description_string(request.env)
                         if partner_sudo.commercial_partner_id.is_company:
                             error_messages.append(_(
                                 "The %(field_name)s is managed on your company account.",


### PR DESCRIPTION
**Steps to reproduce:**
- Create a DB with l10n_ar and l10n_ar ecommerce
- Go to Settings > Invoicing > Fiscal Localization
- Select the 'Argentina - Argentine Generic Chart of Accounts for Registered Accountants' package
- Create a website, and a portal user
- Add a main and a secondary address to the user using the website form in 'My Account'
- Go to the secondary address and change any field
- Click on Save Address
- Multiple errors will appear on the form (reproducible with other similar config)
(and in logs: `UserWarning: unsupported operand type(s) for "==": 'l10n_latam.identification.type()' == '1'`)

**Issue:**
In `address_form_fields` some hidden input field are used to add specific non-editable values to the forms.

This breaks the address validation of `CustomerPortal` in `def _validate_address_values` due to the following comparison: `partner_sudo[commercial_field_name] != address_values[commercial_field_name]`
which try to compare recordsets with the given ids.

**Fix:**
Cast relational field to their id values to ensure they can be properly compared to the website form values.

related fix which introduces the input issue: https://github.com/odoo/odoo/commit/0ee91631214c34b650342a0210ee8db27764f252

opw-5247171
