### PR TITLE
[FIX] hr: employee version timeline auto save

### DIFF
--- a/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
+++ b/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
@@ -21,26 +21,6 @@ registry.category("web_tour.tours").add("version_timeline_auto_save_tour", {
             run: "click",
         },
         {
-            content: "Open contract start date",
-            trigger: ".o_field_widget[name='contract_date_start'] .o_input",
-            run: "click",
-        },
-        {
-            content: "Go to the next month",
-            trigger: ".o_next",
-            run: "click",
-        },
-        {
-            content: "Choose any date X",
-            trigger: ".o_date_item_cell:nth-child(10)",
-            run: "click",
-        },
-        {
-            content: "saving the form",
-            trigger: ".o_form_button_save",
-            run: "click",
-        },
-        {
             content: "Open contract end date",
             trigger: ".o_field_widget[name='contract_date_end'] .o_input",
             run: "click",

--- a/addons/hr/tests/test_ui.py
+++ b/addons/hr/tests/test_ui.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import HttpCase, tagged, new_test_user
+from odoo.tests import HttpCase, freeze_time, tagged, new_test_user
 
 
 @tagged('-at_install', 'post_install', 'is_tour')
@@ -19,6 +19,7 @@ class TestEmployeeUi(HttpCase):
 
         self.start_tour("/odoo", 'hr_employee_tour', login="davidelora")
 
+    @freeze_time('2024-01-01')
     def test_version_timeline_auto_save_tour(self):
         # as payroll tap access will be overridden by hr_payroll
         is_payroll_installed = self.env['ir.module.module'].search_count([
@@ -36,6 +37,11 @@ class TestEmployeeUi(HttpCase):
             'name': 'Bob M.',
             "user_id": bob_user.id,
         }])
+
+        bob_employee.write({
+            'contract_date_start': '2024-01-01',
+            'contract_date_end': False,
+        })
 
         self.start_tour("/odoo", 'version_timeline_auto_save_tour', login="alice")
         self.assertFalse(bob_employee.version_ids[-1].contract_date_start)


### PR DESCRIPTION
As runbot faketimes test fail because the usage of dynamic dates

now the test uses freeze_time

Task#5717031

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
