### PR TITLE
[FIX] point_of_sale: raise error when can not make order paid

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 from random import randrange
 from pprint import pformat
 
-import psycopg2
 import pytz
 
 from odoo import api, fields, models, tools, _
@@ -139,15 +138,7 @@ class PosOrder(models.Model):
     def _process_saved_order(self, draft):
         self.ensure_one()
         if not draft and self.state != 'cancel':
-            try:
-                self.action_pos_order_paid()
-            except psycopg2.DatabaseError:
-                # do not hide transactional errors, the order(s) won't be saved!
-                raise
-            except UserError as e:
-                _logger.warning('Could not fully process the POS Order: %s', tools.exception_to_unicode(e))
-            except Exception as e:
-                _logger.error('Could not fully process the POS Order: %s', tools.exception_to_unicode(e), exc_info=True)
+            self.action_pos_order_paid()
             self._create_order_picking()
             self._compute_total_cost_in_real_time()
 


### PR DESCRIPTION
After commit https://github.com/odoo/odoo/commit/dde26e5372b8328bbc9e050f0fdedadd1de649fd, when trying to validate a POS order that was not fully paid, the order state would remain in 'draft' state but the picking and other related operations would be done. This could lead to double entries and inconsistencies.

opw-5447749

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
