### PR TITLE
[FIX] account: a non-expected error should not break the import.

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -6,11 +6,10 @@ import itertools
 import logging
 from lxml import etree
 from markupsafe import Markup
-import psycopg2.errors
 from struct import error as StructError
 
 from odoo import api, models, modules
-from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
+from odoo.exceptions import RedirectWarning
 from odoo.tools import groupby
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.pdf import OdooPdfFileReader, PdfReadError
@@ -350,13 +349,7 @@ class AccountDocumentImportMixin(models.AbstractModel):
                     return
         except RedirectWarning:
             raise
-        except (
-            AccessError,
-            UserError,
-            ValidationError,
-            psycopg2.errors.IntegrityError,
-            psycopg2.errors.SerializationFailure,
-        ) as e:
+        except Exception as e:
             _logger.exception("Error importing attachment %s on record %s", file_data['name'], self)
 
             self.sudo().message_post(body=Markup("%s<br/><br/>%s<br/>%s") % (

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from odoo import Command
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged, RecordCapturer
+from odoo.tools.misc import mute_logger
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.mail.tests.common import MailCommon
@@ -949,3 +950,16 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
                 }
             },
         )
+
+    def test_import_with_traceback(self):
+        # Verify that even an Exception does not cause the import to fail, and that we log the attachment in the chatter
+        attachment = self.env['ir.attachment'].create(self.xml1_vals)
+
+        with (
+            self._patch_import_methods(),
+            patch('odoo.addons.account.models.partner.ResPartner.search', side_effect=ValueError('We want to test an unexpected error')),
+            mute_logger('odoo.addons.account.models.account_document_import_mixin'),
+        ):
+            move_id = self.journal.create_document_from_attachment(attachment.ids).get('res_id')
+
+        self.assertEqual(self.env['account.move'].browse(move_id).attachment_ids, attachment)


### PR DESCRIPTION
When you import a batch of invoice and one of them gets an unexpected Exception, 
the others are created but we stop the method. 
It's a problem with crons that don't expect to be interrupted in the middle. 
It creates duplicates as we fail on the same invoice each time.

Of course, we should avoid all Exceptions when we can, but we should not loop on the same error.

opw-5503069
part of task-5499871




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
