### PR TITLE
[FIX] website_sale: remove variant image tours

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/website_sale_remove_product_image.js
@@ -30,47 +30,59 @@ const enterEditModeOfTestProduct = () => [
     ...clickOnEditAndWaitEditMode(),
 ];
 
-const removeImg = [
+registerWebsitePreviewTour(
+    "add_and_remove_main_product_image_no_variant",
     {
-        content: "Click on Remove",
-        trigger: ".o_customize_tab [data-container-title='Image'] button[data-action-id='removeMedia']",
-        run: "click",
+        url: "/shop?search=Test Remove Image",
     },
-    // If the snippet editor is not visible, the remove process is considered as
-    // finished.
+    () => [
+        ...enterEditModeOfTestProduct(),
+        {
+            content: "Double click on the product image",
+            trigger: ":iframe #o-carousel-product img[alt='Test Remove Image']",
+            run: "dblclick",
+        },
+        {
+            content: "Click on the new image",
+            trigger: ".o_select_media_dialog img[title='green.jpg']",
+            run: "click",
+        },
+        {
+            content: "Check that the snippet editor of the clicked image has been loaded",
+            trigger: ".o_customize_tab [data-container-title='Image']",
+        },
+        {
+            content: "Click on Remove",
+            trigger: ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info:contains(1.0 kB)) button[data-action-id='removeMedia']",
+            run: "click",
+        },
+        // If the snippet editor is not visible, the remove process is considered as finished.
+        {
+            content: "Check that the snippet editor is not visible",
+            trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
+        },
+    ]
+);
+registerWebsitePreviewTour(
+    "remove_main_product_image_with_variant",
     {
-        content: "Check that the snippet editor is not visible",
-        trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
+        url: "/shop?search=Test Remove Image",
     },
-];
-
-registerWebsitePreviewTour("add_and_remove_main_product_image_no_variant", {
-    url: "/shop?search=Test Remove Image",
-}, () => [
-    ...enterEditModeOfTestProduct(),
-    {
-        content: "Double click on the product image",
-        trigger: ":iframe #o-carousel-product img[alt='Test Remove Image']",
-        run: "dblclick",
-    },
-    {
-        content: "Click on the new image",
-        trigger: ".o_select_media_dialog img[title='green.jpg']",
-        run: "click",
-    },
-    {
-        content: "Check that the snippet editor of the clicked image has been loaded",
-        trigger: ".o_customize_tab [data-container-title='Image']",
-    },
-    ...removeImg,
-]);
-registerWebsitePreviewTour("remove_main_product_image_with_variant", {
-    url: "/shop?search=Test Remove Image",
-}, () => [
-    ...enterEditModeOfTestProduct(),
-    ...clickOnImgAndWaitForLoad,
-    ...clickOnSave(),
-    ...clickOnEditAndWaitEditMode(),
-    ...clickOnImgAndWaitForLoad,
-    ...removeImg,
-]);
+    () => [
+        ...enterEditModeOfTestProduct(),
+        ...clickOnImgAndWaitForLoad,
+        ...clickOnSave(),
+        ...clickOnEditAndWaitEditMode(),
+        ...clickOnImgAndWaitForLoad,
+        {
+            content: "Click on Remove",
+            trigger: ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info:contains(5.9 kB)) button[data-action-id='removeMedia']",
+            run: "click",
+        },
+        // If the snippet editor is not visible, the remove process is considered as finished.
+        {
+            content: "Check that the snippet editor is not visible",
+            trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
+        },
+    ]
+);


### PR DESCRIPTION
With this commit, we fix tours:
- website_sale.remove_main_product_image_with_variant
- website_sale.add_and_remove_main_product_image_no_variant where we want to remove the product image.
This fix add a step to ensure the image is in DOM before clicking on the remove button.

error-runbot-id~237766
