### PR TITLE
[FIX] portal: prevent mutation during testing

### DIFF
--- a/addons/portal/tests/test_addresses.py
+++ b/addons/portal/tests/test_addresses.py
@@ -126,7 +126,7 @@ class TestPortalAddresses(BaseCommon, HttpCase):
 
         internal_partner = self.internal_user.partner_id
         # Fill the incomplete address
-        internal_partner.write(self.default_address_values)
+        internal_partner.write(self.default_address_values.copy())
 
         # Try to update the account name
         res = self._submit_address_values({
@@ -143,7 +143,7 @@ class TestPortalAddresses(BaseCommon, HttpCase):
 
         internal_partner = self.internal_user.partner_id
         # Fill the incomplete address
-        internal_partner.write(self.default_address_values)
+        internal_partner.write(self.default_address_values.copy())
 
         # Try to update the account email
         res = self._submit_address_values({


### PR DESCRIPTION
Before this commit, the values passed in to the `res.partner.write()` method were mutated during the call by an override of `l10n_cl`. This in turn caused tests of the
`portal.tests.test_addresses.TestPortalAddresses` test class to fail as the `self.default_address_values` dictionary which was used to populate fields on partners was mutated during tests and ended in an unexpected state.

After this commit, a copy of `self.default_address_values` is passed instead of the original dictionary.

runbot-164163