### PR TITLE
[FIX] mail: fix non-deterministic copy message test

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2166,16 +2166,16 @@ test("Copy Message Link", async () => {
     ]);
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message", { count: 2 });
     await click(".o-mail-Message:eq(0) [title='Expand']");
     await contains(".o-dropdown-item:contains('Copy Link'_", { count: 0 });
     await click(".o-mail-Message:eq(1) [title='Expand']");
     await click(".o-dropdown-item:contains('Copy Link')");
-    await expect.waitForSteps([url(`/mail/message/${messageId_2}`)]);
-    await press(["ctrl", "v"]);
-    await press("Enter");
-    await contains(
-        `.o-mail-Message a[href='${url(`/mail/message/${messageId_2}`)}']:text('channel1')`
-    );
+    const link = url(`/mail/message/${messageId_2}`);
+    await expect.waitForSteps([link]);
+    await insertText(".o-mail-Composer-input", link);
+    await click("button[title='Send']:enabled");
+    await contains(`.o-mail-Message a[href='${link}']:text('channel1')`);
 });
 
 test("deleted message should not have translate feature", async () => {


### PR DESCRIPTION
Before this commit, the "Copy Message Link" test was sometimes failing. It happens for two reasons:
- It presses "ctrl+v" with the intent of copying the message link in the composer but doesn't check if the composer is focused (it should not be as the test clicks away to copy the link).
- It then presses "enter" with the intent of posting the message, without checking if the composer is filled or even ready to send.

This test replaces the "press" steps:
- "ctrl+v" is replaced by `insertText`: we already check that the copy works and "press" is less reliable.
- We click on the send button when enabled.

runbot-237538

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
