### PR TITLE
[FIX] web: fix aggregation crash on float monetary fields

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -736,7 +736,7 @@ export class ListRenderer extends Component {
                     } else {
                         currencyId = values[0][currencyField] && values[0][currencyField].id;
                     }
-                    if (func) {
+                    if (func && type === "monetary") {
                         const currencies = this.getFieldCurrencies(fieldName);
                         // in case of multiple currencies, convert values into default currency using conversion rates
                         if (currencies.size > 1) {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4898,6 +4898,22 @@ test(`aggregates are formatted according to field widget`, async () => {
     });
 });
 
+test(`aggregates of monetary widget with no currency data in grouped list`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        groupBy: ["bar"],
+        arch: `
+            <list>
+                <field name="qux" widget="monetary" options="{'currency_field': 'currency_id'}" sum="Sum"/>
+                <field name="currency_id" column_invisible="True"/>
+            </list>`,
+    });
+    expect(`tfoot`).toHaveText("19.40", {
+        message: "aggregates monetary should still be displayed without currency",
+    });
+});
+
 test(`aggregates of monetary field with no currency field`, async () => {
     await mountView({
         resModel: "foo",


### PR DESCRIPTION
This commit resolves a traceback during list view aggregation when the view is grouped.

The crash occurred specifically when aggregating a `float` field that uses the `monetary` widget. Unlike true `monetary` fields, the server does not automatically send a `currency_id` aggregate for `float` fields. The aggregation logic previously failed when this data was missing; it now handles the case by ignoring it since it's not supported.

opw-5725692
