### PR TITLE
[PERF] account_edi_ubl_cii: Batch queries for Peppol cron

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -6,6 +6,7 @@ from odoo.tools.float_utils import float_round
 from odoo.tools.misc import clean_context, formatLang
 from odoo.tools.zeep import Client
 
+from collections import defaultdict
 from markupsafe import Markup
 
 # -------------------------------------------------------------------------
@@ -762,6 +763,90 @@ class AccountEdiCommon(models.AbstractModel):
                 if tax:
                     return tax
         return self.env['account.tax']
+
+    def _import_fill_invoice_line_taxes_batched(self, all_tax_nodes, invoice_lines, all_inv_line_vals, logs):
+
+        update_tax_ids = defaultdict(set)
+        update_discount = defaultdict(set)
+        update_price_unit = defaultdict(set)
+        update_product_uom_id = defaultdict(set)
+
+        taxes_map = defaultdict()
+        for tax_nodes, invoice_line, inv_line_vals in zip(all_tax_nodes, invoice_lines, all_inv_line_vals):
+            # Taxes: all amounts are tax excluded, so first try to fetch price_include=False taxes,
+            # if no results, try to fetch the price_include=True taxes. If results, need to adapt the price_unit.
+            inv_line_vals['taxes'] = []
+            for tax_node in tax_nodes:
+                amount = float(tax_node.text)
+                tax_type = invoice_line.move_id.journal_id.type
+                domain = [
+                    *self.env['account.journal']._check_company_domain(invoice_line.company_id),
+                    ('amount_type', '=', 'percent'),
+                    ('type_tax_use', '=', tax_type),
+                    ('amount', '=', amount),
+                ]
+
+                tax = taxes_map.get((tax_type, amount))
+                if not tax and hasattr(invoice_line, '_predict_specific_tax'):
+                    # company check is already done in the prediction query
+                    predicted_tax_id = invoice_line\
+                        ._predict_specific_tax('percent', amount, tax_type)
+                    tax = self.env['account.tax'].browse(predicted_tax_id)
+                if not tax:
+                    tax = self.env['account.tax'].search(domain + [('price_include', '=', False)], limit=1)
+                if not tax:
+                    tax = self.env['account.tax'].search(domain + [('price_include', '=', True)], limit=1)
+
+                if not tax:
+                    logs.append(_("Could not retrieve the tax: %s %% for line '%s'.", amount, invoice_line.name))
+                else:
+                    if not taxes_map.get((tax_type, amount)):
+                        taxes_map[tax_type, amount] = tax
+                    inv_line_vals['taxes'].append(tax.id)
+                    if tax.price_include:
+                        inv_line_vals['price_unit'] *= (1 + tax.amount / 100)
+
+            # Handle Fixed Taxes
+            for fixed_tax_vals in inv_line_vals['fixed_taxes_list']:
+                tax = self._import_retrieve_fixed_tax(invoice_line, fixed_tax_vals)
+                if not tax:
+                    # Nothing found: fix the price_unit s.t. line subtotal is matching the original invoice
+                    inv_line_vals['price_unit'] += fixed_tax_vals['tax_amount']
+                elif tax.price_include:
+                    inv_line_vals['taxes'].append(tax.id)
+                    inv_line_vals['price_unit'] += tax.amount
+                else:
+                    inv_line_vals['taxes'].append(tax.id)
+
+            # Set the values on the line_form
+            invoice_line.quantity = inv_line_vals['quantity']
+            if not inv_line_vals.get('product_uom_id'):
+                logs.append(
+                    _("Could not retrieve the unit of measure for line with label '%s'.", invoice_line.name))
+            elif not invoice_line.product_id:
+                # no product set on the line, no need to check uom compatibility
+                update_product_uom_id[inv_line_vals['product_uom_id']].add(invoice_line.id)
+            elif inv_line_vals['product_uom_id'].category_id == invoice_line.product_id.product_tmpl_id.uom_id.category_id:
+                # needed to check that the uom is compatible with the category of the product
+                update_product_uom_id[inv_line_vals['product_uom_id']].add(invoice_line.id)
+
+            update_price_unit[inv_line_vals['price_unit']].add(invoice_line.id)
+            update_discount[inv_line_vals['discount']].add(invoice_line.id)
+            update_tax_ids[tuple(inv_line_vals['taxes'])].add(invoice_line.id)
+
+        for product_uom_id, ids in update_product_uom_id.items():
+            self.env['account.move.line'].browse(ids).product_uom_id = product_uom_id or False
+
+        for price_unit, ids in update_price_unit.items():
+            self.env['account.move.line'].browse(ids).price_unit = price_unit
+
+        for discount, ids in update_discount.items():
+            self.env['account.move.line'].browse(ids).discount = discount
+
+        for tax_ids, ids in update_tax_ids.items():
+            self.env['account.move.line'].browse(ids).tax_ids = list(tax_ids) or False
+
+        return logs
 
     def _import_fill_invoice_line_taxes(self, tax_nodes, invoice_line, inv_line_vals, logs):
         # Taxes: all amounts are tax excluded, so first try to fetch price_include=False taxes,

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -940,7 +940,9 @@ class AccountEdiXmlUBL20(models.AbstractModel):
 
         # ==== invoice_line_ids: InvoiceLine/CreditNoteLine ====
 
+        invoice_line_vals = []
         invoice_line_tag = 'InvoiceLine' if invoice.move_type in ('in_invoice', 'out_invoice') or qty_factor == -1 else 'CreditNoteLine'
+        all_trees = []
         for i, invl_el in enumerate(tree.findall('./{*}' + invoice_line_tag)):
             # Avoid creating a line if its LineExtensionAmount is missing/empty/zero.
             line_total_node = invl_el.find('./{*}LineExtensionAmount')
@@ -953,9 +955,11 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 # If the value is not a valid number, skip creating the line.
                 continue
 
-            invoice_line = invoice.invoice_line_ids.create({'move_id': invoice.id})
-            invl_logs = self._import_fill_invoice_line_form(invl_el, invoice_line, qty_factor)
-            logs += invl_logs
+            all_trees.append(invl_el)
+            invoice_line_vals.append({'move_id': invoice.id})
+
+        invoice_lines = invoice.invoice_line_ids.create(invoice_line_vals)
+        logs += self._import_fill_invoice_line_form_batched(all_trees, invoice_lines, qty_factor)
 
         # ==== Payable Rounding amount ====
 
@@ -963,6 +967,78 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         logs += self._import_rounding_amount(invoice, payable_rounding_node, qty_factor)
 
         return logs
+
+    def _import_fill_invoice_line_form_batched(self, trees, invoice_lines, qty_factor):
+        logs = []
+
+        all_inv_line_vals = []
+        all_tax_nodes = []
+        previously_retrieved_product = defaultdict()
+        for tree, invoice_line in zip(trees, invoice_lines):
+
+            default_code = self._find_value('./cac:Item/cac:SellersItemIdentification/cbc:ID', tree)
+            name = self._find_value('./cac:Item/cbc:Name', tree)
+            barcode = self._find_value("./cac:Item/cac:StandardItemIdentification/cbc:ID[@schemeID='0160']", tree)
+            company = invoice_line.company_id
+
+            # Product.
+            product_id = previously_retrieved_product.get((default_code, name, barcode, company))
+            if not product_id:
+                product_id = self.env['product.product']._retrieve_product(
+                    default_code=default_code,
+                    name=name,
+                    barcode=barcode,
+                    company=company
+                )
+                previously_retrieved_product[default_code, name, barcode, company] = product_id
+
+            invoice_line.product_id = product_id
+
+            # Description
+            description_node = tree.find('./{*}Item/{*}Description')
+            name_node = tree.find('./{*}Item/{*}Name')
+            if description_node is not None:
+                invoice_line.name = description_node.text
+            elif name_node is not None:
+                invoice_line.name = name_node.text  # Fallback on Name if Description is not found.
+
+            # Start and End date (enterprise fields)
+            if invoice_line._fields.get('deferred_start_date'):
+                start_date = tree.find('./{*}InvoicePeriod/{*}StartDate')
+                end_date = tree.find('./{*}InvoicePeriod/{*}EndDate')
+                if start_date is not None and end_date is not None:  # there is a constraint forcing none or the two to be set
+                    invoice_line.write({
+                        'deferred_start_date': start_date.text,
+                        'deferred_end_date': end_date.text,
+                    })
+            xpath_dict = {
+                'basis_qty': [
+                    './{*}Price/{*}BaseQuantity',
+                ],
+                'gross_price_unit': './{*}Price/{*}AllowanceCharge/{*}BaseAmount',
+                'rebate': './{*}Price/{*}AllowanceCharge/{*}Amount',
+                'net_price_unit': './{*}Price/{*}PriceAmount',
+                'billed_qty':  './{*}InvoicedQuantity' if invoice_line.move_id.move_type in ('in_invoice', 'out_invoice') or qty_factor == -1 else './{*}CreditedQuantity',
+                'allowance_charge': './/{*}AllowanceCharge',
+                'allowance_charge_indicator': './{*}ChargeIndicator',
+                'allowance_charge_amount': './{*}Amount',
+                'allowance_charge_reason': './{*}AllowanceChargeReason',
+                'allowance_charge_reason_code': './{*}AllowanceChargeReasonCode',
+                'line_total_amount': './{*}LineExtensionAmount',
+            }
+            # Taxes
+            all_inv_line_vals.append(self._import_fill_invoice_line_values(tree, xpath_dict, invoice_line, qty_factor))
+            # retrieve tax nodes
+            tax_nodes = tree.findall('.//{*}Item/{*}ClassifiedTaxCategory/{*}Percent')
+            if not tax_nodes:
+                for elem in tree.findall('.//{*}TaxTotal'):
+                    percentage_nodes = elem.findall('.//{*}TaxSubtotal/{*}TaxCategory/{*}Percent')
+                    if not percentage_nodes:
+                        percentage_nodes = elem.findall('.//{*}TaxSubtotal/{*}Percent')
+                    tax_nodes += percentage_nodes
+            all_tax_nodes.append(tax_nodes)
+
+        return self._import_fill_invoice_line_taxes_batched(all_tax_nodes, invoice_lines, all_inv_line_vals, logs)
 
     def _import_fill_invoice_line_form(self, tree, invoice_line, qty_factor):
         logs = []


### PR DESCRIPTION
### Description:

Retrieving Peppol documents with high line counts could cause the background cron to timeout and eventually be disabled after multiple failures. This bottleneck occurred because the system processed each invoice line through individual calls.

To resolve this, the code has been refactored to batch the creates and updates. This change significantly reduces I/O overhead and ensures that large invoices no longer block the cron from creating new documents.

### Benchmark:

| N° of lines | Before  | After  |
|-------------|---------|--------|
|        4633 | Timeout |  3 min |

### Reference:
opw-5462267