### PR TITLE
[FIX] point_of_sale: ensure product is loaded before refunding orderline

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -315,7 +315,10 @@ export class TicketScreen extends Component {
 
         // First pass: add all products to the destination order
         for (const refundDetail of allToRefundDetails) {
-            const product = this.pos.db.get_product_by_id(refundDetail.orderline.productId);
+            const product = await this.pos.getProductById(refundDetail.orderline.productId);
+            if (!product) {
+                continue;
+            }
             const options = this._prepareRefundOrderlineOptions(refundDetail);
             const newOrderline = await destinationOrder.add_product(product, options);
             originalToDestinationLineMap.set(refundDetail.orderline.id, newOrderline);

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1878,6 +1878,14 @@ export class PosStore extends Reactive {
         await this._loadMissingPricelistItems(products);
         this._loadProductProduct(products);
     }
+    async getProductById(productId) {
+        let product = this.db.get_product_by_id(productId);
+        if (!product) {
+            await this._addProducts([productId], false);
+            product = this.db.get_product_by_id(productId);
+        }
+        return product;
+    }
     async _loadProductByIds(productIds) {
         return await this.orm.call("pos.session", "get_pos_ui_product_product_by_params", [
             odoo.pos_session_id,


### PR DESCRIPTION
Before this commit, it was possible the cached toRefundLines included orderlines whose products were not loaded in the POS. This would cause an error when refunding another order for the same partner.

This commit ensures that the product is loaded before refunding an orderline by using a new method in the POS store that loads the product if it is not already present in the database.

opw-5384010

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
