### PR TITLE
[FIX] account_add_gln: Fix label of the GLN in contact view

### DIFF
--- a/addons/account_add_gln/views/res_partner_views.xml
+++ b/addons/account_add_gln/views/res_partner_views.xml
@@ -9,7 +9,7 @@
             <xpath expr=".//page[@name='sales_purchases']//group[@name='misc']" position="inside">
                 <field name="global_location_number" invisible="type != 'delivery'"/>
             </xpath>
-            <xpath expr=".//page[@name='contact_addresses']/field[@name='child_ids']/form//field[@name='phone']" position="after">
+            <xpath expr=".//page[@name='contact_addresses']/field[@name='child_ids']/form//field[@name='company_id']" position="after">
                 <field name="global_location_number" invisible="type != 'delivery'"/>
             </xpath>
         </field>


### PR DESCRIPTION
The field is placed weirdly in the view when opening the contact view of the delivery address.
There is no label, making it almost impossible to discover, and it is in the middle of everything.
Let's put it down before the notes field.

Before:
<img width="971" height="510" alt="image" src="https://github.com/user-attachments/assets/2e0e7d96-1a7f-4fe5-b17d-4c5b25a3e7bf" />


After:
<img width="824" height="554" alt="image" src="https://github.com/user-attachments/assets/3bc47f20-72a9-4247-8dd3-9e939046c6d7" />


task-none