### PR TITLE
[IMP] website: add link obfuscation support

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -618,17 +618,17 @@
     <template id="pager" name="Pager">
         <ul t-if="pager['page_count'] > 1" t-attf-class="#{ classname or '' } pagination m-0 #{_classes}" t-att-style="style or None">
             <li t-attf-class="page-item #{'disabled' if pager['page']['num'] == 1 else ''}">
-                <a t-att-href=" pager['page_previous']['url'] if pager['page']['num'] != 1 else None" t-attf-class="page-link #{extraLinkClass}">
+                <a t-att-href=" pager['page_previous']['url'] if pager['page']['num'] != 1 else None" t-attf-class="page-link #{extraLinkClass}" data-reveal-me="load">
                     <span class="oi oi-chevron-left" role="img" aria-label="Previous" title="Previous"/>
                 </a>
             </li>
             <t t-foreach="pager['pages']" t-as="page">
                 <li t-attf-class="page-item #{'active' if page['num'] == pager['page']['num'] else ''} #{'disabled' if page['num'] == '…' else ''}">
-                    <a t-att-href="page['url']" t-attf-class="page-link #{extraLinkClass} #{'px-0' if page['num'] == '…' else ''}" t-out="page['num']"/>
+                    <a t-att-href="page['url']" t-attf-class="page-link #{extraLinkClass} #{'px-0' if page['num'] == '…' else ''}" t-out="page['num']" data-reveal-me="hover"/>
                 </li>
             </t>
             <li t-attf-class="page-item #{'disabled' if pager['page']['num'] == pager['page_count'] else ''}">
-                <a t-att-href="pager['page_next']['url'] if pager['page']['num'] != pager['page_count'] else None" t-attf-class="page-link #{extraLinkClass}">
+                <a t-att-href="pager['page_next']['url'] if pager['page']['num'] != pager['page_count'] else None" t-attf-class="page-link #{extraLinkClass}" data-reveal-me="load">
                     <span class="oi oi-chevron-right" role="img" aria-label="Next" title="Next"/>
                 </a>
             </li>

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
 import re
 
 from collections import OrderedDict
@@ -113,6 +114,12 @@ class IrQweb(models.AbstractModel):
             return atts
 
         atts = super()._post_processing_att(tagName, atts)
+
+        if atts.get('data-reveal-me') and atts.get('href'):
+            # if this data is set, encode in b64 the url to avoid crawler to parse the url
+            if atts['href'] not in (False, None, ()):
+                atts['hideref'] = base64.b64encode(atts['href'].encode("utf-8")).decode("utf-8")
+                atts['href'] = "#"
 
         website = ir_http.get_request_website()
         if not website and self.env.context.get('website_id'):

--- a/addons/website/static/src/interactions/reveal_link.js
+++ b/addons/website/static/src/interactions/reveal_link.js
@@ -1,0 +1,50 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+class RevealLinkBase extends Interaction {
+    getDecodedHref() {
+        const hrefB64 = this.el.getAttribute("hideref");
+        return hrefB64 ? atob(hrefB64) : null;
+    }
+
+    revealHref() {
+        const href = this.getDecodedHref();
+        if (href) {
+            this.el.setAttribute("href", href);
+        }
+    }
+}
+
+export class RevealLinkClick extends RevealLinkBase {
+    static selector = "a[data-reveal-me='click']";
+
+    dynamicContent = {
+        _root: {
+            "t-on-click": this.revealHref,
+        },
+    };
+}
+
+export class RevealLinkLoad extends RevealLinkBase {
+    static selector = "a[data-reveal-me='load']";
+
+    dynamicContent = {
+        _root: {
+            "t-att-href": () => this.getDecodedHref() || "#",
+        },
+    };
+}
+
+export class RevealLinkHover extends RevealLinkBase {
+    static selector = "a[data-reveal-me='hover']";
+
+    dynamicContent = {
+        _root: {
+            "t-on-mouseenter": this.revealHref,
+        },
+    };
+}
+
+registry.category("public.interactions").add("website.reveal_link_click", RevealLinkClick);
+registry.category("public.interactions").add("website.reveal_link_load", RevealLinkLoad);
+registry.category("public.interactions").add("website.reveal_link_hover", RevealLinkHover);


### PR DESCRIPTION
Purpose is to test whether it is possible to prevent crawlers from accessing certain pages without displaying the link in clear text. The approach is simple: during rendering, the href is encoded in base64, and decoded back on click.
