### PR TITLE
[FIX] hr_holidays: ensure leave is requested at consistent time during test

### DIFF
--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -5,6 +5,7 @@ import unittest
 
 from datetime import date
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import tests
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
@@ -359,6 +360,7 @@ class TestAcessRightsStates(TestHrHolidaysAccessRightsCommon):
             leave._force_cancel("Cancel the leave")
             leave.with_user(self.user_hrmanager.id).action_reset_confirm()
 
+    @freeze_time('2026-01-23 10:00:00')
     def test_holiday_responsible_refuse_leave(self):
         """
             The holiday responsible should be able to accept and refuse correct type leaves of users they are responsible for


### PR DESCRIPTION
The test 'test_holiday_responsible_refuse_leave' is creating build errors in the runbot, it requests a leave for the current day, which can fall on a legal day off, and will then result in an error.

This commit ensures the leave is consistently requested for a correct date.

https://runbot.odoo.com/odoo/runbot.build.error/237917