### PR TITLE
[FIX] website: Align menu items based on chosen alignment menu

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -441,6 +441,22 @@ $-navbar-mobile-bg-color: o-color('menu-custom') or o-color('menu');
             }
         }
     }
+
+    .top_menu {
+        &.text-end > .accordion .accordion-button {
+            flex-direction: row-reverse;
+
+            &::after {
+                margin-left: 0;
+                margin-right: auto;
+            }
+        }
+
+        &.text-center > .accordion .accordion-button > span {
+            text-align: center;
+            flex-grow: 1;
+        }
+    }
 }
 
 // Apply background color to the offcanvas menu


### PR DESCRIPTION
Steps to reproduce:
===================
1- Enter the website editor
2- Enable mobile view
3- Edit the alignment of the mobile menu to be center or right aligned

The group labels (e.g. "Shop", "Forum") stay left-aligned regardless
of the chosen alignment.

This can also be seen on desktop by switching to the sidebar header
template.

Cause:
======
The class .accordion-button uses `display:flex` and `text-align:left`
and that class is used for the menu groups labels.
this prevents the alignment from working.

Solution:
=========
When right-aligned (`text-end`), reverse the flex direction so the arrow
moves to the left and the text stays on the right.

When centered (`text-center`), let the text span fill the remaining
space and center its content via `text-align: center`,
keeping the arrow on its position.

The default left-aligned case is unchanged.

opw-5494765
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
