### PR TITLE
[FIX] orm: method 'is_transient' is not public method.

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5728,6 +5728,7 @@ class BaseModel(metaclass=MetaModel):
         return {key: val[0] if val else ''
                 for key, val in results.items()}
 
+    @api.private
     @classmethod
     def is_transient(cls) -> bool:
         """ Return whether the model is transient.


### PR DESCRIPTION
It was documented within Doc API, but it cannot be called through the Json2 API.

This change removes method from API documentation:  `/doc-bearer/<model>.json` and `/doc/<model>.json`, etc...



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
