### PR TITLE
[FIX] account: strip out dots from VAT numbers

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -839,8 +839,8 @@ class ResPartner(models.Model):
         if not vat:
             return None
 
-        # Sometimes, the vat is specified with some whitespaces.
-        normalized_vat = vat.replace(' ', '')
+        # Sometimes, the vat is specified with some whitespaces or dots.
+        normalized_vat = vat.replace(' ', '').replace('.', '')
         country_prefix = re.match('^[a-zA-Z]{2}|^', vat).group()
 
         partner = self.env['res.partner'].search(extra_domain + [('vat', 'in', (normalized_vat, vat))], limit=2)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Odoo can create two contacts for the same VAT number

Current behavior before PR:
If you have two incoming vendor bills (over a period of time) where the first bill has these details:
- VAT number: `BE0477472701`
- Name: `Odoo`

And the second bill (e.g three months later) has these details:
- VAT number: `BE0477.472.701`
- Name: `Odoo S.A`

Odoo will do something interesting and will create a second new contact.
The reason is because the fallback on `name` from `res.partner` fails (since "Odoo S.A" is not equal to "Odoo".
However, the `vat` number matching also fails! Since the VAT number "BE0477.472.701" is not identical to "BE0477472701".
Throughout Odoo however VAT numbers are parsed and stored without dots in it.
The function `_retrieve_partner_with_vat` however is an exception because the `vat` number here is sanitized for spaces but not for dots.
Because of the combination of no exact match on neither `name` nor `vat` it now creates a second contact although the VAT number is technically the same.

Desired behavior after PR is merged:
Both an incoming vendor bill with `0477.472.701` and `0477472701` match to the same contact even if there are dots in it and if the name of the company is different.


P.S: please find two sample XML's here: 
[sample_odoo_sa_bill.xml](https://github.com/user-attachments/files/24718225/sample_odoo_sa_bill.xml)
[sample_odoo_bill.xml](https://github.com/user-attachments/files/24718226/sample_odoo_bill.xml)

If you upload both back to back on a default V19 you will see two contacts.
After this code change you will only see one contact where both bills are mapped to the same contacts.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
