### PR TITLE
[FIX] cli: restore obfuscate command

### DIFF
--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -158,7 +158,13 @@ class Obfuscate(Command):
             if opt.allfields and not opt.unobfuscate:
                 _logger.error("--allfields can only be used in unobfuscate mode")
                 sys.exit("ERROR: --allfields can only be used in unobfuscate mode")
-            self.dbname = config['db_name']
+            if not opt.db_name:
+                _logger.error('Obfuscate command needs a database name. Use "-d" argument')
+                sys.exit('ERROR: Obfuscate command needs a database name. Use "-d" argument')
+            if len(opt.db_name) > 1:
+                _logger.error("-d/--database has multiple databases, please provide a single one")
+                sys.exit("ERROR: -d/--database has multiple databases, please provide a single one")
+            self.dbname = config['db_name'][0]
             self.registry = Registry(self.dbname)
             with self.registry.cursor() as cr:
                 self.cr = cr


### PR DESCRIPTION
It is not possible to use the obfuscate command

Steps to reproduce:
1. Initialize a database `test`
2. In a terminal, try to obfuscate the database with the command `python odoo/odoo-bin obfuscate --pwd=1234 -d test`
3. An error occurs

Issue:
`config['db_name']` returns a list

Solution:
Make sure we use obfuscate with a single database and get the first (and only) database in the list

opw-5480280