### PR TITLE
[IMP] hr_work_entry: reorganize form view & add max caps

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 class HrWorkEntryType(models.Model):
@@ -43,6 +43,27 @@ class HrWorkEntryType(models.Model):
         help="This field decides the behavior of the shortcut in the gantt view of the work entries. Add will always "
              "prompt a duration and will be added to the existing work entries while replace will simply replace all "
              "work entries of that day")
+
+    counter_periodicity = fields.Selection(
+        [('none', 'None'), ('month', 'Every Month'), ('year', 'Every Year')],
+        string="Periodicity",
+        default='none',
+    )
+    counter_use_cap = fields.Boolean(
+        string="Use Maximum Cap",
+        default=False,
+    )
+    counter_maximum_cap = fields.Float(
+        string="Maximum Cap",
+        default=False,
+        help="Define the total of the counter",
+    )
+
+    @api.constrains('counter_periodicity', 'counter_use_cap', 'counter_maximum_cap')
+    def _check_counter_cap_when_periodic(self):
+        for work_entry_type in self:
+            if work_entry_type.counter_periodicity in {'month', 'year'} and work_entry_type.counter_use_cap and work_entry_type.counter_maximum_cap <= 0:
+                raise ValidationError(_("Please set a Maximum Cap greater than zero."))
 
     @api.constrains('country_id')
     def _check_work_entry_type_country(self):

--- a/addons/hr_work_entry/static/src/dashboard/work_entry_dashboard.js
+++ b/addons/hr_work_entry/static/src/dashboard/work_entry_dashboard.js
@@ -1,0 +1,108 @@
+import { Component, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
+import { serializeDate } from "@web/core/l10n/dates";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { formatFloatTime } from "@web/views/fields/formatters";
+
+const { DateTime } = luxon;
+
+export class WorkEntryDashboard extends Component {
+    static template = "hr_work_entry.WorkEntryDashboard";
+    static props = {
+        employeeId: { type: Number, optional: true },
+        rangeStart: { type: Object, optional: true },
+        rangeEnd: { type: Object, optional: true },
+        reloadKey: { type: Number, optional: true },
+    };
+
+    setup() {
+        this.orm = useService("orm");
+        this.state = useState({ counters: [] });
+
+        onWillStart(() => this.loadCounters());
+
+        onWillUpdateProps(async (nextProps) => {
+            const changed = this.props.employeeId !== nextProps.employeeId ||
+                this.props.rangeStart?.toISODate?.() !== nextProps.rangeStart?.toISODate?.() ||
+                this.props.rangeEnd?.toISODate?.() !== nextProps.rangeEnd?.toISODate?.() ||
+                this.props.reloadKey !== nextProps.reloadKey;
+
+            if (changed) {
+                await this.loadCounters(nextProps);
+            }
+        });
+    }
+
+    get hasCounters() {
+        return Boolean(this.state.counters.length);
+    }
+
+    async loadCounters(props = this.props) {
+        const { employeeId, rangeStart } = props;
+        if (!employeeId || !rangeStart) {
+            this.state.counters = [];
+            return;
+        }
+
+        const dt = DateTime.fromJSDate(rangeStart.toJSDate());
+
+        const fetchSum = (start, end) => this.orm.formattedReadGroup(
+            "hr.work.entry",
+            [
+                ["employee_id", "=", employeeId],
+                ["date", ">=", serializeDate(start)],
+                ["date", "<=", serializeDate(end)],
+            ],
+            ["work_entry_type_id"],
+            ["duration:sum"]
+        );
+
+        const [monthGroups, yearGroups] = await Promise.all([
+            fetchSum(dt.startOf("month"), dt.endOf("month")),
+            fetchSum(dt.startOf("year"), dt.endOf("year")),
+        ]);
+
+        const typeIds = [...new Set([...monthGroups, ...yearGroups].map(g => g.work_entry_type_id?.[0]).filter(Boolean))];
+        if (!typeIds.length) {
+            this.state.counters = [];
+            return;
+        }
+
+        const types = await this.orm.read(
+            "hr.work.entry.type",
+            typeIds,
+            ["display_name", "counter_periodicity", "counter_use_cap", "counter_maximum_cap"]
+        );
+
+        const mUsed = Object.fromEntries(monthGroups.map(g => [g.work_entry_type_id[0], g["duration:sum"] || 0]));
+        const yUsed = Object.fromEntries(yearGroups.map(g => [g.work_entry_type_id[0], g["duration:sum"] || 0]));
+
+        this.state.counters = types.flatMap(type => {
+            if (type.counter_periodicity === "none") {
+                return [];
+            }
+            const isYearly = type.counter_periodicity === "year";
+            const used = (isYearly ? yUsed : mUsed)[type.id] || 0;
+            const cap = type.counter_maximum_cap || 0;
+            const hasCap = Boolean(type.counter_use_cap && cap);
+
+            if (used <= 0) return [];
+
+            return {
+                id: type.id,
+                name: type.display_name,
+                periodicity: type.counter_periodicity,
+                periodLabel: isYearly ? _t("This Year") : _t("This Month"),
+                used,
+                cap,
+                hasCap,
+                usedStr: this._formatDuration(used),
+                capStr: this._formatDuration(cap),
+            };
+        });
+    }
+
+    _formatDuration(duration) {
+        return formatFloatTime(duration, { noLeadingZeroHour: true });
+    }
+}

--- a/addons/hr_work_entry/static/src/dashboard/work_entry_dashboard.scss
+++ b/addons/hr_work_entry/static/src/dashboard/work_entry_dashboard.scss
@@ -1,0 +1,64 @@
+.o_work_entry_dashboard {
+    display: flex;
+    flex-direction: row;
+
+    width: 100%;
+    height: auto;
+
+    box-shadow: inset 0 -1px 0 $border-color;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background-color: $o-webclient-background-color;
+}
+
+.o_work_entry_dashboard_cards {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+
+    &>* {
+        flex: 1;
+    }
+}
+
+.o_work_entry_card {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    flex: 1;
+    text-align: center;
+    border-right: 1px solid $border-color;
+
+    &>* {
+        width: fit-content;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    span {
+        line-height: 1;
+    }
+
+    .o_work_entry_name {
+        color: $body-color;
+        font-size: 15px;
+        margin-bottom: 3px;
+    }
+
+    .o_work_entry_duration {
+        font-size: 30px;
+        font-weight: bold;
+        width: auto;
+        padding: 0 5px;
+    }
+
+    .o_work_entry_details {
+        width: fit-content;
+        margin: 0 auto;
+    }
+
+    &:last-child {
+        border-right: none;
+    }
+}

--- a/addons/hr_work_entry/static/src/dashboard/work_entry_dashboard.xml
+++ b/addons/hr_work_entry/static/src/dashboard/work_entry_dashboard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="hr_work_entry.WorkEntryDashboard">
+        <div class="o_work_entry_dashboard" t-if="hasCounters">
+            <div class="o_work_entry_dashboard_cards">
+                <t t-foreach="state.counters" t-as="counter" t-key="counter.id">
+                    <div class="o_work_entry_card py-3">
+                        <strong class="o_work_entry_name"><t t-esc="counter.name"/></strong>
+                        <span class="o_work_entry_duration">
+                            <span t-att-class="counter.hasCap and counter.used > counter.cap ? 'text-danger' : ''">
+                                <t t-esc="counter.usedStr"/>
+                            </span>
+                            <t t-if="counter.hasCap">
+                                <span class="text-muted"> / <t t-esc="counter.capStr"/></span>
+                            </t>
+                        </span>
+                        <span class="text-uppercase o_work_entry_details p-1">
+                            <t t-esc="counter.periodLabel"/>
+                        </span>
+                    </div>
+                </t>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -32,6 +32,7 @@ export class WorkEntryCalendarModel extends CalendarModel {
             super.updateData(...arguments),
             this._fetchUserFavoritesWorkEntries(),
         ]);
+        data.dashboardReloadKey = (data.dashboardReloadKey || 0) + 1;
     }
 
     async _fetchUserFavoritesWorkEntries() {

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_renderer.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_renderer.js
@@ -1,9 +1,34 @@
-import { CalendarRenderer } from "@web/views/calendar/calendar_renderer";
+import { WorkEntryDashboard } from "@hr_work_entry/dashboard/work_entry_dashboard";
 import { WorkEntryCalendarCommonRenderer } from "@hr_work_entry/views/work_entry_calendar/calendar_common/work_entry_calendar_common_renderer";
+import { CalendarRenderer } from "@web/views/calendar/calendar_renderer";
 
 export class WorkEntryCalendarRenderer extends CalendarRenderer {
+    static template = "hr_work_entry.CalendarRenderer";
     static components = {
         ...CalendarRenderer.components,
         month: WorkEntryCalendarCommonRenderer,
+        WorkEntryDashboard,
     };
+
+    get employeeId() {
+        return this.props.model.meta?.context?.default_employee_id;
+    }
+
+    get rangeStart() {
+        // Use the calendar's focused date, not the grid range start.
+        // In month view, range.start often includes leading days from the previous month.
+        return this.props.model.date;
+    }
+
+    get rangeEnd() {
+        return this.props.model.data?.range?.end;
+    }
+
+    get dashboardReloadKey() {
+        return this.props.model.data?.dashboardReloadKey;
+    }
+
+    get showDashboard() {
+        return !this.env.isSmall && Boolean(this.employeeId) && Boolean(this.rangeStart);
+    }
 }

--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_renderer.xml
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_renderer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_work_entry.CalendarRenderer">
+        <div class="o_work_entry_calendar d-flex flex-column h-100 flex-grow-1">
+            <WorkEntryDashboard t-if="showDashboard" employeeId="employeeId" rangeStart="rangeStart" rangeEnd="rangeEnd" reloadKey="dashboardReloadKey"/>
+            <t t-call="web.CalendarRenderer"/>
+        </div>
+    </t>
+</templates>

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -258,30 +258,59 @@
                         </group>
                     </group>
 
-                    <group>
-                        <group name='computation' string="Computation">
-                            <label for="amount_rate"/>
-                            <div name="amount_rate">
-                                <field style='width: 4em;' name="amount_rate" widget="percentage"/>
-                            </div>
-                            <field name="is_extra_hours"/>
-                            <field name="shortcut_behavior" widget="radio" options="{'horizontal': True}"/>
-                            <field string="Considered as" name="category" widget="radio" options="{'horizontal': True}" />
-                        </group>
-                        <group string="Display">
-                            <field name="display_code" placeholder="e.g. ATT, PTO, STO, OT, RW, ..."/>
-                            <field name="color" widget="color_picker"/>
-                        </group>
-                    </group>
+                    <notebook>
+                        <page name="computation" string="Computation">
+                            <group>
+                                <group name="computation" col="2">
+                                    <label for="amount_rate"/>
+                                    <div name="amount_rate">
+                                        <field style='width: 4em;' name="amount_rate" widget="percentage"/>
+                                    </div>
+                                    <field name="is_extra_hours"/>
+                                    <field string="Considered as" name="category" widget="radio" options="{'horizontal': True}"/>
+                                </group>
+                            </group>
+                        </page>
 
-                    <group>
-                        <group name="exports_code" string="Exports Code">
-                            <field name="external_code" string="External" placeholder="Code used in manual exports"/>
-                        </group>
-                    </group>
+                        <page name="description" string="Description">
+                            <field rows="5" nolabel="1" name="description" placeholder="Provide a description of the Work Entry Type, in which case should it be used"/>
+                        </page>
 
-                    <separator string="Description" />
-                    <field rows="5" nolabel="1" name="description" placeholder="Provide a description of the Work Entry Type, in which case should it be used"/>
+                        <page name="display" string="Display">
+                            <group>
+                                <group col="2" class="o_form_fw_labels">
+                                    <field name="code" placeholder="e.g. ATT, PTO, STO, OT, RW, ..."/>
+                                    <field name="color" widget="color_picker"/>
+                                </group>
+                            </group>
+                        </page>
+
+                        <page name="export_codes" string="Export Codes">
+                            <group>
+                                <group name="exports_code">
+                                    <field name="external_code" string="External" placeholder="Code used in manual exports"/>
+                                </group>
+                            </group>
+                        </page>
+
+                        <page name="counters" string="Counters">
+                            <group>
+                                <group class="o_form_fw_labels">
+                                    <label for="counter_periodicity"/>
+                                    <div class="o_row" name="counter_periodicity">
+                                        <field name="counter_periodicity" widget="radio" options="{'horizontal': True}"/>
+                                    </div>
+                                    <label for="counter_maximum_cap" invisible="counter_periodicity == 'none'"/>
+                                    <div class="o_row" invisible="counter_periodicity == 'none'">
+                                        <field name="counter_use_cap"/>
+                                        <field name="counter_maximum_cap" class="o_hr_narrow_field" invisible="not counter_use_cap" required="counter_periodicity != 'none' and counter_use_cap"/>
+                                        <span invisible="counter_periodicity != 'month' or not counter_use_cap">Hours per Month</span>
+                                        <span invisible="counter_periodicity != 'year' or not counter_use_cap">Hours per Year</span>
+                                    </div>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
[IMP] hr_work_entry: reorganize form view & add max caps

### Motivation

The current configuration for Work Entry Types was becoming cluttered as more fields were added. Additionally, there was a need to monitor and limit specific work entry types (e.g., specific overtime or leave types) over monthly or yearly periods to ensure compliance and visibility for managers.

### Implementation

- Form Layout: Reorganized the `hr.work.entry.type` form view using a `notebook` structure with dedicated pages for Computation, Description, Display, and Counters.
- Cap Logic: Added `counter_periodicity` and `counter_maximum_cap` fields to track usage limits.
- Dashboard & UI: Introduced a `WorkEntryDashboard` component for the Calendar view and updated the Gantt renderer to display "danger" status and warning icons when periodic caps are exceeded.

task-5430951
