### PR TITLE
[IMP] mail: slight improvement to style of 'Livechat has ended'

### DIFF
--- a/addons/im_livechat/static/src/core/common/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/common/chat_window_patch.xml
@@ -8,7 +8,7 @@
             </t>
         </xpath>
         <xpath expr="//Composer" position="replace">
-            <div t-if="channel.composerHidden" class="bg-200 py-1 text-center d-flex fst-italic fw-bold text-muted" t-ref="composerHiddenContainer">
+            <div t-if="channel.composerHidden" class="bg-200 pt-1 o-pb-0_5 text-center d-flex o-fw-600 text-muted smaller" t-ref="composerHiddenContainer">
                 <span t-if="!showGiveFeedbackBtn" class="flex-grow-1"/>
                 <span>This livechat conversation has ended</span>
                 <span class="flex-grow-1"/>

--- a/addons/im_livechat/static/src/core/public_web/discuss_content_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_content_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussContent" t-inherit-mode="extension">
         <xpath expr="//Composer" position="replace">
-            <span t-if="thread?.composerHidden" class="bg-200 py-1 text-center fst-italic fw-bold text-muted">
+            <span t-if="thread?.composerHidden" class="bg-200 o-py-1_5 text-center o-fw-600 text-muted smaller">
                 This livechat conversation has ended
             </span>
             <t t-else="">$0</t>


### PR DESCRIPTION
The text was hard to read and size was competing with message list content. This commit improves the style which makes it more distinct from message list content while making it more readable.

Before / After
<img width="1169" height="643" alt="Screenshot 2026-01-19 at 18 45 26" src="https://github.com/user-attachments/assets/b7ecdf25-f6c6-4fd5-94d9-d925be0545fd" />
<img width="1167" height="641" alt="Screenshot 2026-01-19 at 18 45 07" src="https://github.com/user-attachments/assets/91db6a20-c7a0-45f7-bb4b-3489d77a8c6a" />
