### PR TITLE
[FIX] l10n_vn_edi_viettel: taxAmount decimal

### DIFF
--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -706,7 +706,7 @@ class AccountMove(models.Model):
                 # Values are either: -2 (no tax), -1 (not declaring/paying taxes), 0,5,8,10 (the tax %)
                 # Most use cases will be -2 or a tax percentage, so we limit the support to these.
                 'taxPercentage': line.tax_ids and line.tax_ids[0].amount or -2,
-                'taxAmount': (line.price_total - line.price_subtotal),
+                'taxAmount': line.currency_id.round(line.price_total - line.price_subtotal),
                 'discount': line.discount,
                 'itemTotalAmountAfterDiscount': line.price_subtotal,
                 'itemTotalAmountWithTax': line.price_total,

--- a/addons/l10n_vn_edi_viettel/tests/test_edi.py
+++ b/addons/l10n_vn_edi_viettel/tests/test_edi.py
@@ -453,3 +453,17 @@ class TestVNEDI(AccountTestInvoicingCommon):
              patch('odoo.addons.l10n_vn_edi_viettel.models.account_move.AccountMove._l10n_vn_edi_fetch_invoice_xml_file_data', return_value=xml_response), \
              patch('odoo.addons.l10n_vn_edi_viettel.models.account_move._l10n_vn_edi_send_request', return_value=(request_response, None)):
             self.env['account.move.send.wizard'].with_context(active_model=invoice._name, active_ids=invoice.ids).create({}).action_send_and_print()
+
+    @freeze_time('2024-01-01')
+    def test_decimal_rounding(self):
+        """ Test that taxAmount are correctly rounded in the JSON data. """
+        invoice = self.init_invoice(
+            move_type='out_invoice',
+            amounts=[1000.25],
+            taxes=self.tax_sale_a,
+            currency=self.other_currency,
+            post=True,
+        )
+        json_values = invoice._l10n_vn_edi_generate_invoice_json()
+        itemInfo = json_values['itemInfo'][0]
+        self.assertEqual(itemInfo['taxAmount'], 100.03, "Tax amount should be correctly rounded to 2 decimals.")


### PR DESCRIPTION
When sending an invoice to SInvoice (Viettel), the API raises an `INVALID_DECIMAL_POINT_TAX_MONEY` error if the tax amount contains excessive decimal places (e.g., 100.02999999999997).

This occurs because the tax amount is currently calculated using simple subtraction (`total - subtotal`). Due to standard floating-point precision issues, this can result in unrounded values that the API rejects.

The tax amount calculation is now updated to explicitly use the currency's rounding method, ensuring the value is accepted by SInvoice.

task-[5484845](https://www.odoo.com/odoo/project/967/tasks/5484845)