### PR TITLE
[FIX] point_of_sale: correct discount amount on session report

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1761,7 +1761,7 @@ class PosOrderLine(models.Model):
 
     def _get_discount_amount(self):
         self.ensure_one()
-        original_price = self.tax_ids.compute_all(self.price_unit, self.currency_id, self.qty, product=self.product_id, partner=self.order_id.partner_id)['total_included']
+        original_price = self.tax_ids_after_fiscal_position.compute_all(self.price_unit, self.currency_id, self.qty, product=self.product_id, partner=self.order_id.partner_id)['total_included']
         return original_price - self.price_subtotal_incl
 
 


### PR DESCRIPTION
Steps:
----
- Create a fiscal position with 2 different taxes
- Add a line in POS
- Apply fiscal position and add line discount
- Finish the order cycle
- Download the session report

Issue:
----
- The discount amount was calculated incorrectly in the session report

Cause:
----
- The discount amount calculation used taxes before applying the fiscal position

Fix:
----
- Used `tax_ids_after_fiscal_position` for tax calculation while computing the discount amount

task-5421215


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
