### PR TITLE
[FIX] hr: fix employee action view

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -176,7 +176,7 @@
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="hr_employee_public_view_search"/>
             <field name="help" type="html">
-                <div class="o_view_nocontent">
+                <div>
                     <div class="o_nocontent_help">
                         <div>
                             <p class="text-center fs-1">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -556,7 +556,7 @@
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_employee_filter"/>
             <field name="help" type="html">
-                <div class="o_view_nocontent">
+                <div>
                     <div class="o_nocontent_help">
                         <div>
                             <p class="text-center fs-1">


### PR DESCRIPTION
While performing a task I observed an improper view in employees action.

Steps to Reproduce :
1. Activate debug mode and go to Employees/Employees/Employees menu
2. Go to its action
3. You will see improper view(content overlapping) in help section.

These changes were added [here](https://github.com/odoo/odoo/pull/214810/changes#diff-99eff1b023601f0f844a2fa7efc6c4e62e13a8592d5b799113f848ac4c7565f8L549-R658
).
I have made the changes accordingly so that the Help content looks fine in both Employees menu and action.

before : 
<img width="1695" height="752" alt="image" src="https://github.com/user-attachments/assets/6a847373-5ac2-4877-a07f-ad58338429c5" />


after : 
<img width="1272" height="823" alt="image" src="https://github.com/user-attachments/assets/16b50843-e736-490a-8a00-44848c6011fa" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr