### PR TITLE
[FIX] l10n_gcc_invoicing: reposition GCC format option in settings

### DIFF
--- a/addons/l10n_gcc_invoice/views/res_config_settings_views.xml
+++ b/addons/l10n_gcc_invoice/views/res_config_settings_views.xml
@@ -6,7 +6,7 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="account.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-                <block name="fiscal_localization_setting_container" position="inside">
+                <block id="invoicing_settings" position="inside">
                     <setting string="Gulf Cooperation Council Format" company_dependent="1"
                              invisible="not l10n_gcc_country_is_gcc"
                              help="Add Arabic as a secondary language to your invoices, credit notes, debit notes, vendor bills, and refund bills">


### PR DESCRIPTION
This fix moves the GCC Format checkbox under the 'Customer Invoices' block so it remains accessible in branches where the Fiscal Localization section is hidden.

task-5723793
