### PR TITLE
[FIX] mail: display Invitation to follow notification correctly in inbox

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4690,6 +4690,8 @@ class MailThread(models.AbstractModel):
             msg_values.update({
                 'partner_ids': list(partner_ids or [])
             })
+        if "subject" in kwargs:
+            msg_values["subject"] = kwargs["subject"]
         if msg_values:
             message.write(msg_values)
 
@@ -4715,6 +4717,8 @@ class MailThread(models.AbstractModel):
             "recipients": Store.many(message.partner_ids, fields=["avatar_128", "name"]),
             "write_date": message.write_date,
         }
+        if "subject" in kwargs:
+            res["subject"] = message.subject
         if body is not None:
             # sudo: mail.message.translation - discarding translations of message after editing it
             self.env["mail.message.translation"].sudo().search([("message_id", "=", message.id)]).unlink()
@@ -4805,7 +4809,7 @@ class MailThread(models.AbstractModel):
 
     @api.model
     def _get_allowed_message_update_params(self):
-        return {"attachment_ids", "body", "partner_ids"}
+        return {"attachment_ids", "body", "partner_ids", "subject"}
 
     @api.model
     def _get_thread_with_access(self, thread_id, mode="read", **kwargs):

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -352,7 +352,7 @@ export class Message extends Record {
     }
 
     get hasTextContent() {
-        return !this.isBodyEmpty;
+        return !this.isBodyEmpty || this.subject;
     }
 
     isEmpty = Record.attr(false, {
@@ -387,7 +387,8 @@ export class Message extends Record {
             this.isBodyEmpty &&
             this.attachment_ids.length === 0 &&
             this.trackingValues.length === 0 &&
-            !this.subtype_description
+            !this.subtype_description &&
+            !this.subject
         );
     }
 
@@ -543,6 +544,7 @@ export class Message extends Record {
             attachment_ids: [],
             attachment_tokens: [],
             body: "",
+            subject: "",
             message_id: this.id,
             ...this.thread.rpcParams,
         };

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -352,7 +352,7 @@ export class Message extends Record {
     }
 
     get hasTextContent() {
-        return !this.isBodyEmpty;
+        return !this.isBodyEmpty || this.subject;
     }
 
     isEmpty = Record.attr(false, {
@@ -387,7 +387,8 @@ export class Message extends Record {
             this.isBodyEmpty &&
             this.attachment_ids.length === 0 &&
             this.trackingValues.length === 0 &&
-            !this.subtype_description
+            !this.subtype_description &&
+            !this.subject
         );
     }
 

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -159,21 +159,39 @@ test('"reply to" composer should send message if message replied to is not a not
 
 test("show subject of message in Inbox", async () => {
     const pyEnv = await startServer();
-    const messageId = pyEnv["mail.message"].create({
-        body: "not empty",
-        model: "discuss.channel",
-        needaction: true,
-        subject: "Salutations, voyageur",
-    });
-    pyEnv["mail.notification"].create({
-        mail_message_id: messageId,
-        notification_status: "sent",
-        notification_type: "inbox",
-        res_partner_id: serverState.partnerId,
-    });
+    const [messageId1, messageId2] = pyEnv["mail.message"].create([
+        {
+            body: "not empty",
+            model: "discuss.channel",
+            needaction: true,
+            subject: "Salutations, voyageur",
+        },
+        {
+            body: "",
+            model: "discuss.channel",
+            needaction: true,
+            subject: "Hello, wanderer",
+        },
+    ]);
+    pyEnv["mail.notification"].create([
+        {
+            mail_message_id: messageId1,
+            notification_status: "sent",
+            notification_type: "inbox",
+            res_partner_id: serverState.partnerId,
+        },
+        {
+            mail_message_id: messageId2,
+            notification_status: "sent",
+            notification_type: "inbox",
+            res_partner_id: serverState.partnerId,
+        },
+    ]);
     await start();
     await openDiscuss();
     await contains(".o-mail-Message", { text: "Subject: Salutations, voyageurnot empty" });
+    // Empty body: display subject only
+    await contains(".o-mail-Message:has(:text('Subject: Hello, wanderer'))");
 });
 
 test("show subject of message in history", async () => {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1081,7 +1081,7 @@ test('Quick edit (edit from Composer with ArrowUp) ignores empty ("deleted") mes
     await contains(".o-mail-Message .o-mail-Composer-input", { value: "not empty" });
 });
 
-test("Editing a message to clear its composer opens message delete dialog.", async () => {
+test("Can delete a message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         name: "general",
@@ -1091,16 +1091,20 @@ test("Editing a message to clear its composer opens message delete dialog.", asy
         author_id: serverState.partnerId,
         body: "not empty",
         model: "discuss.channel",
+        subject: "Hello, wanderer",
         res_id: channelId,
         message_type: "comment",
     });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message");
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
     await insertText(".o-mail-Message.o-editing .o-mail-Composer-input", "", { replace: true });
     triggerHotkey("Enter");
     await contains(".modal-body p", { text: "Are you sure you want to delete this message?" });
+    await click("button:text('Confirm')");
+    await contains(".o-mail-Message", { count: 0 });
 });
 
 test("Clear message body should not open message delete dialog if it has attachments", async () => {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -698,7 +698,7 @@ async function mail_message_update_content(request) {
     /** @type {import("mock_models").MailMessage} */
     const MailMessage = this.env["mail.message"];
 
-    const { attachment_ids, body, message_id } = await parseRequestParams(request);
+    const { attachment_ids, body, message_id, ...kwargs } = await parseRequestParams(request);
     const [message] = MailMessage.browse(message_id);
     const msg_values = {};
     if (body !== null) {
@@ -722,23 +722,30 @@ async function mail_message_update_content(request) {
         );
         msg_values.attachment_ids = attachment_ids;
     }
+    if ("subject" in kwargs) {
+        msg_values.subject = kwargs.subject;
+    }
     MailMessage.write([message_id], msg_values);
     if (body === "" && attachment_ids.length === 0) {
         MailMessage.write([message_id], { pinned_at: false });
         MailMessage._cleanup_side_records([message_id]);
     }
+    const res = {
+        attachment_ids: mailDataHelpers.Store.many(IrAttachment.browse(message.attachment_ids)),
+        body: message.body,
+        pinned_at: message.pinned_at,
+        recipients: mailDataHelpers.Store.many(
+            this.env["res.partner"].browse(message.partner_ids),
+            makeKwArgs({ fields: ["avatar_128", "name"] })
+        ),
+    };
+    if ("subject" in kwargs) {
+        res.subject = message.subject;
+    }
     BusBus._sendone(
         MailMessage._bus_notification_target(message.id),
         "mail.record/insert",
-        new mailDataHelpers.Store(MailMessage.browse(message.id), {
-            attachment_ids: mailDataHelpers.Store.many(IrAttachment.browse(message.attachment_ids)),
-            body: message.body,
-            pinned_at: message.pinned_at,
-            recipients: mailDataHelpers.Store.many(
-                this.env["res.partner"].browse(message.partner_ids),
-                makeKwArgs({ fields: ["avatar_128", "name"] })
-            ),
-        }).get_result()
+        new mailDataHelpers.Store(MailMessage.browse(message.id), res).get_result()
     );
     return new mailDataHelpers.Store(
         MailMessage.browse(message_id),


### PR DESCRIPTION
Steps to reproduce:

- Configure user A to receive inbox notifications.
- As user B, invite user A to follow a record with Notify recipients enabled.
- Open the inbox of user A.

The Invitation to follow notification is not displayed in the inbox when no additional comment is provided. This happens because the notification body is empty unless extra comments are added.

This commit fixes the issue by displaying only the subject when the body is empty.

Task-[5485727](https://www.odoo.com/odoo/project/1519/tasks/5485727)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
