### PR TITLE
[FIX] mrp: prevent MissingError when updating BoM

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2488,8 +2488,8 @@ class MrpProduction(models.Model):
                 self.bom_id = False
         if self.state in ['cancel', 'done', 'draft']:
             self.bom_id = bom
-            moves_to_unlink.unlink()
-            workorders_to_unlink.unlink()
+            moves_to_unlink.exists().unlink()
+            workorders_to_unlink.exists().unlink()
             if self.state == 'draft':
                 # we reset the product_qty/uom when the bom is changed on a draft MO
                 # change them back to the original value

--- a/doc/cla/individual/GautamKantesariya.md
+++ b/doc/cla/individual/GautamKantesariya.md
@@ -1,0 +1,9 @@
+India, 2026-01-20
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Gautam gautamkantesariya@yahoo.com https://github.com/GautamKantesariya


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fixes a `MissingError` ("Record does not exist or has been deleted") that occurs when updating the Bill of Materials (BoM) on a Manufacturing Order (MO) in the draft state.

Closes #243774

Current behavior before PR:
When a user updates the quantity in a BoM and then proceeds to update the corresponding draft Manufacturing Order, the system attempts to unlink work orders and stock moves that have already been deleted during the BoM re-linking process. This leads to a `MissingError` crash, preventing the MO update.

Desired behavior after PR is merged:
The system should safely handle the re-linking process by verifying that records still exist before attempting to unlink them. Updating the BoM and the Manufacturing Order should proceed smoothly without raising any errors.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
