### PR TITLE
[IMP] mail: mark all related notifications as read when unfollowing from inbox

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -879,10 +879,10 @@ export class Message extends Record {
     }
 
     async unfollow() {
-        if (this.needaction) {
-            await this.setDone();
-        }
         const thread = this.thread;
+        if (this.needaction) {
+            await thread.markAllMessagesAsRead();
+        }
         await thread.selfFollower.remove();
         this.store.env.services.notification.add(
             _t('You are no longer following "%(thread_name)s".', {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -961,17 +961,11 @@ test("Unfollow message", async function () {
     await contains(".o-dropdown-item:contains('Unfollow')", { count: 0 });
     await click(".o-mail-Message:eq(0) [title='Expand']");
     await click(".o-dropdown-item:contains('Unfollow')");
-    await contains(".o-mail-Message", { count: 2 }); // Unfollowing message 0 marks it as read -> Message removed
-    await contains(".o-mail-Message:eq(0)", {
-        contains: [[".o-mail-Message-header small:text('on Thread followed')"]],
-    });
-    await click(".o-mail-Message:eq(0) [title='Expand']");
-    await contains(".o-dropdown-item:contains('Reply')");
-    await contains(".o-dropdown-item:contains('Unfollow')", { count: 0 });
-    await contains(".o-mail-Message:eq(1)", {
+    // Unfollowing message 0 marks all messages of the thread as read -> All messages on 'Thread followed' removed
+    await contains(".o-mail-Message", {
         contains: [[".o-mail-Message-header small:text('on Thread not followed')"]],
     });
-    await click(".o-mail-Message:eq(1) [title='Expand']");
+    await click(".o-mail-Message [title='Expand']");
     await contains(".o-dropdown-item:contains('Reply')");
     await contains(".o-dropdown-item:contains('Unfollow')", { count: 0 });
 });


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Previously, unfollowing a record from the inbox only marked the notification 
on which the action was performed as read.
As a result, other unread notifications related to the same record remained 
in the inbox, even though unfollowing is a global action, indicating that the 
user is no longer interested in the entire conversation.

**Desired behavior after PR is merged:**
- Marks all notifications related to the same record as read when unfollowing 
from the inbox.
- Ensures the inbox state accurately reflects the user’s intent to stop 
following the conversation.

task-[5119331](https://www.odoo.com/odoo/project/1519/tasks/5119331)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
