### PR TITLE
[FIX] website: fix carousel preview height in snippet dialog

### DIFF
--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -56,6 +56,11 @@ export class AddSnippetDialog extends Component {
                 });
             }
 
+            // Ensure preview styles are applied before mounting the snippets.
+            // Otherwise layout-dependent measurements (e.g., carousel height in
+            // preview) can be wrong.
+            await this.insertStyle();
+
             const iframeDocument = this.iframeRef.el.contentDocument;
             iframeDocument.body.parentElement.classList.add("o_add_snippets_preview");
             iframeDocument.body.style.setProperty("direction", localization.direction);
@@ -65,7 +70,6 @@ export class AddSnippetDialog extends Component {
             });
             root.mount(iframeDocument.body);
 
-            await this.insertStyle();
             this.state.showIframe = true;
         });
 

--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -28,11 +28,11 @@
             [data-snippet="s_carousel_intro"],
             [data-snippet="s_carousel_cards"],
             [data-snippet="s_quotes_carousel_minimal"],
-            [data-snippet="s_quotes_carousel"] {
-                height: 550px;
-            }
+            [data-snippet="s_quotes_carousel"],
             [data-snippet="s_quotes_carousel_compact"] {
-                height: 350px;
+                .carousel-inner, .carousel-inner > .carousel-item {
+                    height: fit-content;
+                }
             }
             [data-snippet="s_three_columns"] .figure-img[style*="height:50vh"] {
                 /* In Travel theme. */

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -125,8 +125,6 @@ class AddPageTemplatePreview extends Component {
             }
             // Adjust styles.
             const styleEl = document.createElement("style");
-            // Does not work with fit-content in Firefox.
-            const carouselHeight = isFirefox ? '450px' : 'fit-content';
             // Prevent successive resizes.
             const fullHeight = getComputedStyle(document.querySelector(".o_action_manager")).height;
             const halfHeight = `${Math.round(parseInt(fullHeight) / 2)}px`;
@@ -150,7 +148,9 @@ class AddPageTemplatePreview extends Component {
                 section[data-snippet="s_quotes_carousel_minimal"],
                 section[data-snippet="s_quotes_carousel_compact"],
                 section[data-snippet="s_quotes_carousel"] {
-                    height: ${carouselHeight} !important;
+                    .carousel-inner, .carousel-inner > .carousel-item {
+                        height: fit-content !important;
+                    }
                 }
                 section.o_half_screen_height {
                     min-height: ${halfHeight} !important;


### PR DESCRIPTION
Steps to reproduce:

- Open the website editor.
- Open the snippet dialog.
- Look at a carousel snippet preview. => The preview height is too tall.

Before this commit, the dialog loads CSS after JS, so "computeMaxHeight" ran on an unstyled DOM and missed the "fit-content" height for the carousel.

After this commit, the preview forces "fit-content" in JS so the height matches the final CSS layout.

task-5156137

**To see/test the bug, the change made in https://github.com/odoo/odoo/pull/244295 must be present**
