### PR TITLE
[FIX] web: display invalid operation instead of oh snap for user errors

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -184,7 +184,7 @@ export class RedirectWarningDialog extends Component {
         this.additionalContext = additionalContext;
     }
     async onClick() {
-        const options = {};
+        const options = { forceLeave: true };
         if (this.additionalContext) {
             options.additionalContext = this.additionalContext;
         }

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -289,7 +289,7 @@ export class FormController extends Component {
         useSetupAction({
             rootRef: this.rootRef,
             beforeVisibilityChange: () => this.beforeVisibilityChange(),
-            beforeLeave: () => this.beforeLeave(),
+            beforeLeave: (options) => this.beforeLeave(options),
             beforeUnload: (ev) => this.beforeUnload(ev),
             getLocalState: () => {
                 return {
@@ -482,8 +482,8 @@ export class FormController extends Component {
         }
     }
 
-    async beforeLeave() {
-        if (this.model.root.dirty && !this.allowLeavingWithoutSaving) {
+    async beforeLeave({ forceLeave } = {}) {
+        if (this.model.root.dirty && !forceLeave && !this.allowLeavingWithoutSaving) {
             return this.save({
                 reload: false,
                 onError: this.onSaveError.bind(this),
@@ -666,9 +666,6 @@ export class FormController extends Component {
     }
 
     saveButtonClicked(params = {}) {
-        if (!("onError" in params)) {
-            params.onError = this.onSaveError.bind(this);
-        }
         return executeButtonCallback(this.ui.activeElement, () => this.save(params));
     }
 

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9180,6 +9180,7 @@ test(`multiple clicks on save should reload only once`, async () => {
 });
 
 test(`form view is not broken if save operation fails`, async () => {
+    expect.errors(1);
     onRpc("web_save", ({ args }) => {
         if (args[1].foo === "incorrect value") {
             throw makeServerError();
@@ -9198,6 +9199,7 @@ test(`form view is not broken if save operation fails`, async () => {
     await contains(`.o_form_button_save`).click();
     await animationFrame();
     expect(`.o_dialog`).toHaveCount(1);
+    expect.verifyErrors(["RPC_ERROR: Odoo Server Error"]);
     expect.verifySteps(["web_save"]); // write on save (it fails, does not trigger a read)
 
     await contains(`.o_dialog .modal-footer .btn-primary`).click();
@@ -9256,6 +9258,7 @@ test(`form view is not broken if save operation fails with redirect warning`, as
 
 test.tags("desktop");
 test("Redirect Warning full feature: additional context, action_id, leaving while dirty", async function () {
+    expect.errors(1);
     defineActions([
         {
             id: 1,
@@ -9315,10 +9318,11 @@ test("Redirect Warning full feature: additional context, action_id, leaving whil
     expect.verifySteps(["web_save"]);
 
     await waitFor(".o_error_dialog");
+    expect.verifyErrors(["RPC_ERROR: Odoo Server Error"]);
     expect(".o_error_dialog .btn-primary").toHaveCount(1);
-    expect(".o_error_dialog .btn-secondary").toHaveCount(2);
+    expect(".o_error_dialog .btn-secondary").toHaveCount(1);
 
-    await contains(".o_error_dialog .btn-secondary").click();
+    await contains(".o_error_dialog .btn-primary").click();
     await waitFor(".o_list_view");
     expect.verifySteps(["web_search_read"]);
     expect(".o_breadcrumb").toHaveText("first record\nPartner List");


### PR DESCRIPTION
This commit https://github.com/odoo/odoo/commit/e566570e82e9 introduced a regression where the saveButtonClicked method automatically bound onSaveError as the error handler. This displays FormErrorDialog with "Oh snap!" for all save errors, causing UserErrors and ValidationErrors to show the generic "Oh snap!" message instead of the proper "Invalid Operation" dialog.

If you compare the original commit to the one here for the forward port 18.3+: https://github.com/odoo/odoo/pull/224620, you can see that the author reverted the problematic onError binding in saveButtonClicked and added forceLeave support to handle RedirectWarning redirects when the form is dirty. This PR backports those same changes to 18.0.

Steps To Reproduce:
1. Go to Time Off > Allocations > Create new allocation.
2. Set an End Date before the Start Date.
3. Click Save.
4. Error displays as "Oh snap!" instead of "Invalid Operation".
5. Switching tabs then shows the expected "Invalid Operation" dialog.

Ticket [link](https://www.odoo.com/odoo/project.task/5488127)
opw-5488127

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
