### PR TITLE
[FIX] account,account_edi_ubl_cii: Fix partner and invoice line tax recognition during import.

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -897,9 +897,10 @@ class AccountEdiCommon(models.AbstractModel):
                     line=line_values['name']),
                 )
             else:
-                taxes.append(tax.id)
-                if tax.price_include:
-                    line_values['price_unit'] *= (1 + tax.amount / 100)
+                for t in tax:
+                    taxes.append(t.id)
+                    if t.price_include:
+                        line_values['price_unit'] *= (1 + t.amount / 100)
         return taxes, logs
 
     def _retrieve_line_charges(self, record, line_values, taxes):


### PR DESCRIPTION
Context :
When importing an XML invoice or vendor bill, if an invoice line is predicted to have multiple taxes, the import fails, as we assume that an invoice line should have one and only one tax.

This assumption is not always correct, especially in contexts such as international commerce where Peppol is not used.

Moreover, partner recognition was not correct or rigorous, as it was based only on the VAT number.

After this fix :
- We correctly handle the case of having multiples taxes in an invoice line.
- We correctly identify the partner based on both VAT number and name.

task-5499871

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
