### PR TITLE
[FIX] pos_self_order: show missing details widget when required

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -4,9 +4,10 @@
         <t t-foreach="props.productTemplate.attribute_line_ids" t-as="attribute" t-key="attribute.id">
             <t t-set="availableValues" t-value="availableAttributeValue(attribute)"/>
             <t t-if="availableValues.length">
-                <h2 class="text-start py-3 m-0 d-flex align-items-center" t-att-id="attribute.attribute_id.id">
+                <t t-set="attributeRequired" t-value="attribute.attribute_id.display_type !== 'multi'"/>
+                <h2 class="text-start py-3 m-0 d-flex align-items-center" t-att-id="attribute.attribute_id.id" t-att-attr-required="attributeRequired? 'required' : undefined">
                     <t t-out="attribute.attribute_id.name"/>
-                    <span t-if="attribute.attribute_id.display_type !== 'multi'" class="badge smaller rounded-pill bg-danger text-white ms-2">Required</span>
+                    <span t-if="attributeRequired" class="badge smaller rounded-pill bg-danger text-white ms-2">Required</span>
                 </h2>
                 <div class="self_order_attribute_selection row pb-3">
                     <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">

--- a/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.xml
+++ b/addons/pos_self_order/static/src/app/components/missing_required_details/missing_required_details.xml
@@ -5,8 +5,8 @@
             <button class="btn btn-primary mb-2 rounded-circle d-flex align-items-center justify-content-center" t-on-click="scrollUpToRequired" style="width:60px; height: 60px;">
                 <i class="fa fa-fw fa-arrow-up" aria-hidden="true"/>
             </button>
-            <h2 class="mb-3">See what you missed</h2>
-            <p>Make sure you choose all your options for this item. You're alomost there.</p>
+            <h2 class="mb-3" t-on-click="scrollUpToRequired">See what you missed</h2>
+            <p class="text-center">Make sure you choose all your options for this item. You're alomost there.</p>
         </div>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -6,7 +6,7 @@ import { ProductNameWidget } from "@pos_self_order/app/components/product_name_w
 import { ComboStepper } from "@pos_self_order/app/components/combo_stepper/combo_stepper";
 import { computeTotalComboPrice } from "../../services/card_utils";
 import { useScrollShadow } from "../../utils/scroll_shadow_hook";
-import { formatProductName } from "../../utils";
+import { formatProductName, shouldShowMissingDetails } from "../../utils";
 
 export class ComboPage extends Component {
     static template = "pos_self_order.ComboPage";
@@ -93,13 +93,11 @@ export class ComboPage extends Component {
     }
 
     shouldShowMissingDetails() {
-        const el = this.scrollContainerRef?.el;
-        if (!el) {
-            return false;
-        }
-        return (
-            el.scrollHeight > el.clientHeight &&
-            this.currentChoiceState.displayAttributesOfItem.product_id.attribute_line_ids.length > 1
+        const product = this.currentChoiceState.displayAttributesOfItem?.product_id;
+        return shouldShowMissingDetails(
+            product,
+            this.state.selectedValues,
+            this.scrollContainerRef
         );
     }
 

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -8,6 +8,7 @@ import {
     getAttributeValues,
     getAttributeValuesExtraPrice,
 } from "@pos_self_order/app/services/card_utils";
+import { shouldShowMissingDetails } from "../../utils";
 
 export class ProductPage extends Component {
     static template = "pos_self_order.ProductPage";
@@ -68,12 +69,10 @@ export class ProductPage extends Component {
     }
 
     shouldShowMissingDetails() {
-        const el = this.scrollContainerRef?.el;
-        if (!el) {
-            return false;
-        }
-        return (
-            el.scrollHeight > el.clientHeight && this.productTemplate.attribute_line_ids.length > 1
+        return shouldShowMissingDetails(
+            this.productTemplate,
+            this.state.selectedValues,
+            this.scrollContainerRef
         );
     }
 

--- a/addons/pos_self_order/static/src/app/utils.js
+++ b/addons/pos_self_order/static/src/app/utils.js
@@ -16,3 +16,27 @@ export const formatProductName = (product) => {
     const attributes = product.product_template_attribute_value_ids?.map((v) => v.name).join(",");
     return attributes ? `${product.name} (${attributes})` : product.name;
 };
+
+export const shouldShowMissingDetails = (product, selectedValues, scrollContainerRef) => {
+    if (!product || !product.attribute_line_ids.length) {
+        return false;
+    }
+
+    const scrollContainerEl = scrollContainerRef?.el;
+    if (!scrollContainerEl) {
+        return false;
+    }
+
+    const containerRect = scrollContainerEl.getBoundingClientRect();
+    const selection = selectedValues[product.id];
+
+    return product.attribute_line_ids.some((attr) => {
+        const attributeEl = document.getElementById(attr.attribute_id.id);
+
+        return (
+            attributeEl?.hasAttribute("attr-required") &&
+            !selection?.hasValueSelected(attr) &&
+            attributeEl.getBoundingClientRect().top < containerRect.top
+        );
+    });
+};


### PR DESCRIPTION
The "Missing Required Details" widget appeared when there was required attributes to choose in combo item or on the product page AND when the height of the screen was smaller than the content size. So sometimes, it was showing when it was not required and when we clicking on it, nothing was done because we saw everything on the screen. So, what I did, is basically change the condition for displaying the widget. Now it will appear only when a title of a required attributes is hidden by the header and this required attribute is not selected.

part ot task: 5493798


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
