### PR TITLE
[FIX] account_edi_ubl_cii: remove UNECE code not accepted by Peppol

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -15,7 +15,6 @@ from datetime import datetime
 UOM_TO_UNECE_CODE = {
     'uom.product_uom_unit': 'C62',
     'uom.product_uom_dozen': 'DZN',
-    'uom.product_uom_pack_6': 'HD',
     'uom.product_uom_kgm': 'KGM',
     'uom.product_uom_gram': 'GRM',
     'uom.product_uom_day': 'DAY',


### PR DESCRIPTION
**Steps to reproduce:**
- Use a Belgian company
- Create a Belgian contact with "EU Standard (Peppol Bis 3.0)" as eInvoice format
- Create an invoice for that customer with a product using "Pack of 6" as unit of measure
- Confirm the invoice
- Send it to Peppol

**Issue:**
The validation of the invoice fails with the following error: "[BR-CL-23]-Unit code MUST be coded according to the UN/ECE Recommendation 20 with Rec 21 extension"

**Cause:**
The UNECE code used for "Pack of 6" UoM is "HD".
"HD" is a correct UNECE code for "Half Dozen".
However, it is not part of the subset of codes accepted by Peppol.

opw-5463212




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
