### PR TITLE
[FIX] l10n_it: handle VP14b carryover origin during VAT report migration

### DIFF
--- a/addons/l10n_it/migrations/0.7/post-map_carryover_to_new_report.py
+++ b/addons/l10n_it/migrations/0.7/post-map_carryover_to_new_report.py
@@ -50,7 +50,7 @@ def migrate(cr, version):
     carryover_origin_info = cr.fetchall()
     old2new_origin = {old_origin: new_origin for old_origin, new_origin in carryover_origin_info}
     data_to_insert = [
-        (code2expression_id[report_line_code], old2new_origin[carryover_origin_report_line_id], *other_external_vals)
+        (code2expression_id[report_line_code], old2new_origin.get(carryover_origin_report_line_id, carryover_origin_report_line_id), *other_external_vals)
         for report_id, _, report_line_code, carryover_origin_report_line_id, *other_external_vals in report_info
         if report_id == vat_report_id
     ]


### PR DESCRIPTION
Handle `carryover_origin_report_line_id` for report line having `code = 'VP14b`, since the line does not exist in the new monthly VAT report after this commit: odoo/odoo@51a72ab42d118d6fb0eb3e3545a09e10019b9140

As the line is not present in the monthy vat report while mapping it will raise keyerror:

```py
File "/home/odoo/src/odoo/19.0/addons/l10n_it/migrations/0.7/post-map_carryover_to_new_report.py", line 52, in migrate
    data_to_insert = [
  File "/home/odoo/src/odoo/19.0/addons/l10n_it/migrations/0.7/post-map_carryover_to_new_report.py", line 53, in <listcomp>
    (code2expression_id[report_line_code], old2new_origin[carryover_origin_report_line_id], *other_external_vals)
KeyError: 80
```

```sql
apan_3806634=> select id,carryover_origin_report_line_id,target_report_expression_id from account_report_external_value;
 id | carryover_origin_report_line_id | target_report_expression_id
----+---------------------------------+-----------------------------
  3 |                              80 |                         102
  4 |                              80 |                         105
  7 |                              80 |                         102
  8 |                              80 |                         102
  9 |                              80 |                         102
 10 |                              80 |                         102
 11 |                              80 |                         102
(7 rows)

apan_3806634=> select id,name->>'en_US',code from account_report_line where id=80;
 id |           ?column?           | code
----+------------------------------+-------
 80 | VP14b - VAT payable (credit) | VP14b
(1 row)
```

Note this error will only appears in the dbs without this commit: odoo/odoo@a220a28595dbfacce2d8322222d1961547bb4b07

opw-5494959
upg-3806634
tbg-2272


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
