### PR TITLE
[IMP] hr: restrict HR Responsible to internal users of current company

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -269,6 +269,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="contract_date_start" eval="(DateTime.today() + relativedelta(months=-1, day=1))"/>
             <field name="contract_date_end" eval="(DateTime.today() + relativedelta(months=2))"/>
             <field name="wage" eval="6000"/>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="structure_type_id" ref="hr.structure_type_worker"/>
             <field name="hourly_cost">40</field>
         </record>
@@ -384,6 +385,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="contract_date_start" eval="(DateTime.today() + relativedelta(months=-1, day=1))"/>
             <field name="contract_date_end" eval="(DateTime.today() + relativedelta(months=2))"/>
             <field name="wage" eval="6500"/>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="structure_type_id" ref="hr.structure_type_worker"/>
             <field name="hourly_cost">10</field>
         </record>
@@ -449,6 +451,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="image_1920" type="base64" file="hr/static/img/employee_lur-image.jpg"/>
             <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">male</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="hourly_cost">35</field>
         </record>
 
@@ -472,6 +475,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">female</field>
             <field name="hourly_cost">55</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
         </record>
 
         <record id="work_contact_fme" model="res.partner">
@@ -526,6 +530,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="sex">female</field>
             <field name="distance_home_work">13</field>
             <field name="hourly_cost">25</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
         </record>
 
         <record id="work_contact_jgo" model="res.partner">
@@ -548,6 +553,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="date_version" eval="'2010-01-01'"/>
             <field name="sex">male</field>
             <field name="hourly_cost">45</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
         </record>
 
         <record id="work_contact_jth" model="res.partner">
@@ -776,6 +782,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="sex">female</field>
             <field name="distance_home_work">50</field>
             <field name="hourly_cost">40</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
         </record>
 
         <record id="work_contact_barty_mcbly" model="res.partner">

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -84,6 +84,11 @@ class HrEmployee(models.Model):
         groups="hr.group_hr_user,hr_payroll.group_hr_payroll_user",
     )
 
+    def _get_hr_responsible_domain(self):
+        return "[('share', '=', False), ('company_ids', 'in', company_id), ('all_group_ids', 'in', %s)]" % self.env.ref('hr.group_hr_user').id
+
+    hr_responsible_id = fields.Many2one(related='version_id.hr_responsible_id', readonly=False, inherited=True, domain=_get_hr_responsible_domain, groups="hr.group_hr_user")
+
     @api.model
     def _lang_get(self):
         return self.env['res.lang'].get_installed()

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -38,6 +38,7 @@
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jjo-image.jpg"/>
             <field name="create_date">2020-02-02 00:00:00</field>
             <field name="sex">female</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
         </record>
 
         <record id="work_contact_awa" model="res.partner">
@@ -57,6 +58,7 @@
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_awa-image.jpg"/>
             <field name="create_date">2020-01-01 00:00:00</field>
             <field name="sex">female</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
         </record>
 
         <record id="work_contact_jsm" model="res.partner">
@@ -76,6 +78,7 @@
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jsm-image.jpg"/>
             <field name="create_date">2020-02-02 00:00:00</field>
             <field name="sex">male</field>
+            <field name="hr_responsible_id" ref="base.user_admin"/>
         </record>
 
         <record id="sale_line_services" model="sale.order.line">


### PR DESCRIPTION
Updated the "HR Responsible" field under the Approvers group in the Employee settings to ensure better data integrity.

Changes:
Added a domain filter to the hr_responsible_id field.
Restricted selection to Internal Users only (share=False). This prevents external or portal users from being incorrectly assigned as HR responsibles

Description of the issue/feature this PR addresses:
External users can be assigned to employee as HR responsible

Current behavior before PR:
External users can be assigned to employee as HR responsible

Desired behavior after PR is merged:
Only Internal users can be assigned as HR responsible


task-5602911

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
