### PR TITLE
[IMP] mail: check author name when searching messages

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -967,6 +967,10 @@ class MailMessage(models.Model):
             message_domain = Domain.OR([
                 # sudo: access to attachment is allowed if you have access to the parent model
                 [("attachment_ids", "in", self.env["ir.attachment"].sudo()._search([("name", "ilike", search_term)]))],
+                # sudo: res.partner - allow searching by author name
+                [("author_id", "in", self.env["res.partner"].sudo()._search([("name", "ilike", search_term)]))],
+                # sudo: mail.guest - allow searching by guest name
+                [("author_guest_id", "in", self.env["mail.guest"].sudo()._search([("name", "ilike", search_term)]))],
                 [("body", "ilike", search_term)],
                 [("subject", "ilike", search_term)],
                 [("subtype_id.description", "ilike", search_term)],

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -39,7 +39,7 @@
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': isEditing }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.isNote, 'pe-2': props.asCard and isMobileOS }" name="header">
                             <span t-if="message.authorName and shouldDisplayAuthorName" class="o-mail-Message-author smaller" t-att-class="getAuthorAttClass()">
-                                <strong class="me-1 o-fw-600" t-esc="message.authorName"/>
+                                <strong class="me-1 o-fw-600" t-out="props.messageSearch?.highlight(message.authorName) ?? message.authorName"/>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
                             <t t-if="isAlignedRight and !message.bubbleColor and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -118,18 +118,24 @@ test("Search highlight", async () => {
 test("Display highlighted search in chatter", async () => {
     patchUiSize({ size: SIZES.XXL });
     const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
+    const partnerId = pyEnv["res.partner"].create({ name: "Groot" });
     pyEnv["mail.message"].create({
-        body: "not empty",
+        author_id: partnerId,
+        body: "I am Groot",
         model: "res.partner",
         res_id: partnerId,
     });
     await start();
     await openFormView("res.partner", partnerId);
     await click("[title='Search Messages']");
-    await insertText(".o_searchview_input", "empty");
+    await insertText(".o_searchview_input", "Groot");
     triggerHotkey("Enter");
-    await contains(`.o-mail-SearchMessageResult .o-mail-Message span.${HIGHLIGHT_CLASS}`);
+    await contains(
+        `.o-mail-SearchMessageResult .o-mail-Message-author .${HIGHLIGHT_CLASS}:text('Groot')`
+    );
+    await contains(
+        `.o-mail-SearchMessageResult .o-mail-Message-body .${HIGHLIGHT_CLASS}:text('Groot')`
+    );
 });
 
 test("Display multiple highlighted search in chatter", async () => {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -539,9 +539,13 @@ export class MailMessage extends models.ServerModel {
             search_term = search_term.replace(" ", "%");
             const subtypeIds = MailMessageSubtype.search([["description", "ilike", search_term]]);
             const irAttachmentIds = IrAttachment.search([["name", "ilike", search_term]]);
+            const authorIds = this.env["res.partner"].search([["name", "ilike", search_term]]);
+            const guestIds = this.env["mail.guest"].search([["name", "ilike", search_term]]);
             let message_domain = Domain.or([
                 [["body", "ilike", search_term]],
                 [["attachment_ids", "in", irAttachmentIds]],
+                [["author_id", "in", authorIds]],
+                [["author_guest_id", "in", guestIds]],
                 [["subject", "ilike", search_term]],
                 [["subtype_ids", "in", subtypeIds]],
             ]);


### PR DESCRIPTION
**Current behavior before PR:**

Previously, message search only matched message content and subject, making it difficult to find messages from a specific author.

**Desired behavior after PR is merged:**

This commit expands the search scope to include the author's name, making it easier to find messages from a specific sender in a thread, with matching author names highlighted in the search results.

task-5473532

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
