### PR TITLE
[FIX] stock_account: make valuation by lot warehouse sensitive

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -230,10 +230,10 @@ class ProductProduct(models.Model):
         return last_in
 
     def _get_value_from_lots(self):
-        lots = self.env['stock.lot'].search([
-            ('product_id', 'in', self.ids),
-            ('product_qty', '!=', 0),
-        ])
+        domain = Domain([('product_id', 'in', self.ids)])
+        if not self.env.context.get('warehouse_id'):
+            domain &= Domain([('product_qty', '!=', 0)])
+        lots = self.env['stock.lot'].search(domain)
         return sum(lots.mapped('total_value'))
 
     def _with_valuation_context(self):
@@ -301,13 +301,11 @@ class ProductProduct(models.Model):
 
         # If the last value was defined by the user just return it
         if product_values and not moves_in:
-            quantity = self._with_valuation_context().with_context(to_date=at_date).qty_available
+            quantity = self._with_valuation_context().with_context(to_date=at_date, lot_id=lot.id if lot else None, warehouse_id=False).qty_available
             last_value = product_values[-1]
             return last_value.value, last_value.value * quantity
         if product_values and moves_in and product_values[-1].date > moves_in[-1].date:
-            quantity = self._with_valuation_context().with_context(to_date=at_date).qty_available
-            if lot:
-                quantity = lot.product_qty
+            quantity = self._with_valuation_context().with_context(to_date=at_date, lot_id=lot.id if lot else None, warehouse_id=False).qty_available
             avco_value = product_values[-1].value
             return avco_value, avco_value * quantity
 

--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -19,7 +19,7 @@ class StockLot(models.Model):
     )
 
     @api.depends('product_id.lot_valuated', 'product_id.product_tmpl_id.lot_valuated')
-    @api.depends_context('to_date', 'company')
+    @api.depends_context('to_date', 'company', 'warehouse_id')
     def _compute_value(self):
         """Compute totals of multiple svl related values"""
         company_id = self.env.company
@@ -31,13 +31,17 @@ class StockLot(models.Model):
                 lot.total_value = 0.0
                 continue
 
-            qty_available = lot.product_qty
-            if lot.product_id.cost_method == 'standard':
-                lot.total_value = lot.standard_price * qty_available
-            elif lot.product_id.cost_method == 'average':
-                lot.total_value = lot.product_id._run_avco(at_date=at_date, lot=lot)[1]
+            valuated_product = lot.product_id.with_context(at_date=at_date, lot_id=lot.id)
+            qty_valued = valuated_product.qty_available
+            qty_available = valuated_product.with_context(warehouse_id=False).qty_available
+            if valuated_product.uom_id.is_zero(qty_valued):
+                lot.total_value = 0
+            elif valuated_product.cost_method == 'standard' or valuated_product.uom_id.is_zero(qty_available):
+                lot.total_value = lot.standard_price * qty_valued
+            elif valuated_product.cost_method == 'average':
+                lot.total_value = valuated_product._run_avco(at_date=at_date, lot=lot)[1] * qty_valued / qty_available
             else:
-                lot.total_value = lot.product_id._run_fifo(qty_available, at_date=at_date, lot=lot)
+                lot.total_value = valuated_product._run_fifo(qty_available, at_date=at_date, lot=lot) * qty_valued / qty_available
 
     # TODO: remove avg cost column in master and merge the two compute methods
     @api.depends('product_id.lot_valuated')

--- a/addons/stock_account/tests/common.py
+++ b/addons/stock_account/tests/common.py
@@ -121,7 +121,7 @@ class TestStockValuationCommon(BaseCommon):
             in_move.move_line_ids.unlink()
             in_move.move_line_ids = [Command.create({
                 'location_id': self.supplier_location.id,
-                'location_dest_id': in_move.location_dest_id,
+                'location_dest_id': in_move.location_dest_id.id,
                 'quantity': quantity / len(lot_ids),
                 'product_id': product.id,
                 'lot_id': lot.id,

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2308,6 +2308,90 @@ class TestStockValuation(TestStockValuationCommon):
         self.assertRecordValues(product.with_context(warehouse_id=warehouse_2.id), [{'avg_cost': 30.0, 'total_value': 150, 'qty_available': 5}])
         self.assertRecordValues(product.with_context(warehouse_id=warehouse_3.id), [{'avg_cost': 30.0, 'total_value': -600, 'qty_available': -20}])
 
+    def test_stock_report_avco_lot_valuation_warehouse_dependency(self):
+        """
+        Create two warehouses and check that the total value and the on hand quantity
+        displayed in the stock report accurately depends on the contextual warehouse.
+        """
+        product = self.product_avco_auto
+        product.write({
+            'tracking': 'lot',
+            'lot_valuated': True,
+        })
+        warehouse_1, warehouse_2 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=2)
+        lots = self.env['stock.lot'].create([{
+            'name': f'lot{i}',
+            'product_id': product.id,
+        } for i in range(1, 4)])
+        self._make_in_move(product=product, quantity=15.0, unit_cost=10, location_dest_id=warehouse_1.lot_stock_id.id, lot_ids=lots[0])
+        self._make_in_move(product=product, quantity=5.0, unit_cost=50, location_dest_id=warehouse_2.lot_stock_id.id, lot_ids=lots[0])
+        self._make_in_move(product=product, quantity=10.0, unit_cost=50, location_dest_id=warehouse_2.lot_stock_id.id, lot_ids=lots[1])
+        self.assertRecordValues(product, [{'avg_cost': 30.0, 'total_value': 900, 'qty_available': 30}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_1.id), [{'avg_cost': 20.0, 'total_value': 300, 'qty_available': 15}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_2.id), [{'avg_cost': 40.0, 'total_value': 600, 'qty_available': 15}])
+        warehouse_3 = self.env['stock.warehouse'].create([
+            {'name': 'warehouse negative', 'code': 'WH-neg'},
+        ])
+        self._make_out_move(product=product, quantity=30.0, location_id=warehouse_3.lot_stock_id.id, lot_ids=lots[2])
+        self.assertRecordValues(product, [{'avg_cost': 0.0, 'total_value': 600.0, 'qty_available': 0}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_1.id), [{'avg_cost': 20.0, 'total_value': 300, 'qty_available': 15.0}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_2.id), [{'avg_cost': 40.0, 'total_value': 600, 'qty_available': 15}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_3.id), [{'avg_cost': 10.0, 'total_value': -300, 'qty_available': -30}])
+        self.assertRecordValues(lots, [{'total_value': 400.0}, {'total_value': 500.0}, {'total_value': -300.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_1.id), [{'total_value': 300.0}, {'total_value': 0.0}, {'total_value': 0.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_2.id), [{'total_value': 100.0}, {'total_value': 500.0}, {'total_value': 0.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_3.id), [{'total_value': 0.0}, {'total_value': 0.0}, {'total_value': -300.0}])
+
+        # Add 30 x LOT3 so that product_qty is null but the lot should still be valued in each warehouse with stock
+        self._make_in_move(product=product, quantity=30.0, location_dest_id=warehouse_2.lot_stock_id.id, lot_ids=lots[2])
+        with freeze_time(Datetime.now() + timedelta(seconds=1)):
+            product.standard_price = 10.0
+        self.assertRecordValues(product, [{'avg_cost': 10.0, 'total_value': 300.0, 'qty_available': 30}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_1.id), [{'avg_cost': 10.0, 'total_value': 150, 'qty_available': 15.0}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_2.id), [{'avg_cost': 10.0, 'total_value': 450, 'qty_available': 45}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_3.id), [{'avg_cost': 10.0, 'total_value': -300, 'qty_available': -30}])
+        self.assertRecordValues(lots, [{'total_value': 200.0}, {'total_value': 100.0}, {'total_value': 0.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_1.id), [{'total_value': 150.0}, {'total_value': 0.0}, {'total_value': 0.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_2.id), [{'total_value': 50.0}, {'total_value': 100.0}, {'total_value': 300.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_3.id), [{'total_value': 0.0}, {'total_value': 0.0}, {'total_value': -300.0}])
+
+    def test_stock_report_fifo_lot_valuation_warehouse_dependency(self):
+        """
+        Create two warehouses and check that the total value and the on hand quantity
+        displayed in the stock report accurately depends on the contextual warehouse.
+        """
+        product = self.product_fifo_auto
+        product.write({
+            'tracking': 'lot',
+            'lot_valuated': True,
+        })
+        warehouse_1, warehouse_2 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=2)
+        lots = self.env['stock.lot'].create([{
+            'name': f'lot{i}',
+            'product_id': product.id,
+        } for i in range(1, 3)])
+        self._make_in_move(product=product, quantity=15.0, unit_cost=10, location_dest_id=warehouse_1.lot_stock_id.id, lot_ids=lots[0])
+        self._make_in_move(product=product, quantity=5.0, unit_cost=50, location_dest_id=warehouse_2.lot_stock_id.id, lot_ids=lots[0])
+        self._make_in_move(product=product, quantity=10.0, unit_cost=35, location_dest_id=warehouse_2.lot_stock_id.id, lot_ids=lots[1])
+        self.assertRecordValues(product, [{'avg_cost': 25.0, 'total_value': 750, 'qty_available': 30}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_1.id), [{'avg_cost': 20.0, 'total_value': 300, 'qty_available': 15}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_2.id), [{'avg_cost': 30.0, 'total_value': 450, 'qty_available': 15}])
+        warehouse_3 = self.env['stock.warehouse'].create([
+            {'name': 'warehouse negative', 'code': 'WH-neg'},
+        ])
+        # Remove 10 x lot1 to test the fifo
+        self._make_out_move(product=product, quantity=8.0, location_id=warehouse_3.lot_stock_id.id, lot_ids=lots[0])
+        self._make_out_move(product=product, quantity=2.0, location_id=warehouse_2.lot_stock_id.id, lot_ids=lots[1])
+        lots.invalidate_recordset(['total_value'])
+        self.assertRecordValues(product, [{'avg_cost': 30.0, 'total_value': 600.0, 'qty_available': 20.0}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_1.id), [{'avg_cost': 26.67, 'total_value': 400, 'qty_available': 15.0}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_2.id), [{'avg_cost': 31.79, 'total_value': 413.33, 'qty_available': 13}])
+        self.assertRecordValues(product.with_context(warehouse_id=warehouse_3.id), [{'avg_cost': 26.67, 'total_value': -213.33, 'qty_available': -8}])
+        self.assertRecordValues(lots, [{'total_value': 320.0}, {'total_value': 280.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_1.id), [{'total_value': 400.0}, {'total_value': 0.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_2.id), [{'total_value': 133.33}, {'total_value': 280.0}])
+        self.assertRecordValues(lots.with_context(warehouse_id=warehouse_3.id), [{'total_value': -213.33}, {'total_value': 0.0}])
+
     def test_fifo_and_sml_owned_by_company(self):
         """
         When receiving a FIFO product, if the picking is owned by the company,


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable Lots and Serial Numbers and Multi-steps routes
- Create a storable product P Tracked by lots with an avco perpetual valuation cateory 
   and enable the valuation by Lot/Serial in its inventory tab
- Inventory > Configuration > Warehouse Management > Warehouses
- Create a new warehouse: WH2
- Create and confirm a PO for 10 units LOT001 for $20 in WH1
- Create and confirm a PO for 5 units LOT002 for $50 in WH2
- Inventory > Reporting > Stock
> The product total value is correctly set to 450 with a unit cost of $30
- Click on Warehouse 2 for the related report
#### > The total Value did not change and the product unit cost is set to $90

### Expected behavior:

The unit cost should be $50 and the total value should be 250$ for this warehouse.

#### Cause of the issue:

The total value of the product is computed in the `_compute_value`, which is supposed to rely on the contextual warehouse to determine the unit cost and total value of the product:
https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/product.py#L139-L141 https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/product.py#L152-L168 While `qty_valued` relies on this context key because of the `qty_available` which is it self context dependent: https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock/models/product.py#L147-L151 and is used in standard, AVCO, and FIFO valuation, it is not used for `lot_valuated` products:
https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/product.py#L154-L155 https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/product.py#L232-L237 https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/stock_lot.py#L21-L40

### Solution:

There are several issues to be addressed here. To begin with, in order for the valuation to be warehouse-dependent, it is necessary for the `total_value` of the `stock.lot` model to be `warehouse_id` context-dependent and to rely on the qty_available of the lot in each warehouse, rather than the global internal lot.product_qty, which is not: https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock/models/stock_lot.py#L210-L215

Additionally, since it is possible for a lot to have a null `lot.product_qty` but have 10 units in WH1 and -10 units in WH2, it is necessary not to exclude lots with a null `product_qty` from the lot valuation (at least when the warehouse_id is in the context): https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/product.py#L232-L237

Furthermore, the quantity used in _run_avco here is not correct (both cases are now covered by our tests):
https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/product.py#L302-L312 To begin with, both conditions are incorrectly dependent on the contextual `warehouse_id` because of `qty_available`. They should not be, because `_run_avco` is supposed to provide a non-warehouse context-dependent value that is then proportionally re-evaluated via `qty_valued` in the `_compute_value`:
https://github.com/odoo/odoo/blob/944d7c8d5d6bf97cba71644b615e081e4fff6595/addons/stock_account/models/product.py#L165-L166 In addition, the first condition does not rely on the lot at all (and it should for lot-valuated products). And the scond one rely on the lot via the `lot.product_qty` which is incorrect as this qty is not dependent on the date (as it is just the sum of qty on quants. For uniformity, we therefore change both conditions to rely on `qty_available` with the contextual lot. Note that it would be equivalent to rely on the `lot.product_qty` if the lot if to_date is not provided.

Finally, for the `total_value` computation of each lot itself, we change the logic to follow the same behavior as for non-lot valuated products (but where we consider each specific lot similarly to a separate product). That is:
- If the qty_valued is null, its valuation should also be null.
- In AVCO and FIFO computations, we rely on the global value (full available quantity) and then weight it by the percentage present in stock.
- If the total available quantity is null, we return the `standard_price * qty_valued` and avoid unnecessary computations.

opw-5469786

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
