### PR TITLE
[FIX] hr_recruitment: fix Unable to Send Emails to Refused Applicants

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_send_mail.py
+++ b/addons/hr_recruitment/wizard/applicant_send_mail.py
@@ -8,7 +8,7 @@ class ApplicantSendMail(models.TransientModel):
     _inherit = 'mail.composer.mixin'
     _description = 'Send mails to applicants'
 
-    applicant_ids = fields.Many2many('hr.applicant', string='Applications', required=True)
+    applicant_ids = fields.Many2many('hr.applicant', string='Applications', required=True, context={'active_test': False})
     author_id = fields.Many2one('res.partner', 'Author', required=True, default=lambda self: self.env.user.partner_id.id)
 
     @api.depends('subject')


### PR DESCRIPTION
Version:
- 17.0

Steps to reproduce:
- Create an applicant.
- Archive the applicant.
- Select the archived applicant.
- Click the Send Email action.

Issue:
- Unable to Send Emails to Refused Applicants

Cause:
- The applicant_ids many2many field does not include archived applicants. Because of this, when an applicant is archived, the field becomes empty.

Solution:
- Add active_test to the field context.

Task - 5786195

