### PR TITLE
[IMP] spreadsheet: add helper functions for column letters and cell references

### DIFF
--- a/addons/spreadsheet/tests/test_utils.py
+++ b/addons/spreadsheet/tests/test_utils.py
@@ -7,6 +7,10 @@ from odoo.addons.spreadsheet.utils.formatting import (
     datetime_to_spreadsheet_date_number,
 )
 from odoo.addons.spreadsheet.utils.json import extend_serialized_json
+from odoo.addons.spreadsheet.utils.helpers import (
+    index_to_column_letter,
+    to_cell_reference
+)
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
@@ -65,3 +69,21 @@ class TestSpreadsheetUtils(TransactionCase):
 
         dt = datetime.datetime(2023, 10, 1, 12, 0, 0)
         self.assertEqual(datetime_to_spreadsheet_date_number(dt, 'Etc/GMT-8'), 45200.5 + test_tz_offset)
+
+    def test_index_to_column_letter(self):
+        self.assertEqual(index_to_column_letter(0), "A")
+        self.assertEqual(index_to_column_letter(25), "Z")
+        self.assertEqual(index_to_column_letter(26), "AA")
+        self.assertEqual(index_to_column_letter(27), "AB")
+        self.assertEqual(index_to_column_letter(701), "ZZ")
+        self.assertEqual(index_to_column_letter(702), "AAA")
+
+    def test_index_to_column_letter_negative(self):
+        with self.assertRaises(ValueError):
+            index_to_column_letter(-1)
+
+    def test_to_cell_reference(self):
+        self.assertEqual(to_cell_reference(0, 0), "A1")
+        self.assertEqual(to_cell_reference(0, 1), "A2")
+        self.assertEqual(to_cell_reference(1, 1), "B2")
+        self.assertEqual(to_cell_reference(26, 9), "AA10")

--- a/addons/spreadsheet/utils/helpers.py
+++ b/addons/spreadsheet/utils/helpers.py
@@ -1,0 +1,25 @@
+
+DEFAULT_COLUMN_WIDTH = 150   # pixels, default width of a column
+MIN_COLUMNS = 26             # minimum number of columns (A-Z)
+MIN_ROWS = 100               # minimum number of rows
+
+
+def index_to_column_letter(n):
+    """Convert 0-based index to spreadsheet column letter (A, B, ..., Z, AA, AB…)."""
+    if n < 0:
+        raise ValueError(f"number must be positive. Got {n}")
+    if n < 26:
+        return chr(65 + n)
+    else:
+        return index_to_column_letter(n // 26 - 1) + index_to_column_letter(n % 26)
+
+
+def to_cell_reference(col, row):
+    """
+    Convert 0-based column and row indices into spreadsheet cell reference.
+    Example:
+        to_cell_reference(0, 0) -> "A1"
+        to_cell_reference(1, 2) -> "B3"
+    """
+    col_letter = index_to_column_letter(col)
+    return f"{col_letter}{row + 1}"


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
Currently, spreadsheet code in Odoo contains repeated “magic numbers” (column widths, min rows/columns) and manually builds cell references using column letters and row indices. This makes table generation less readable and harder to maintain.

### Current behavior before PR:

Column letters and cell references are computed inline in model methods.

Magic numbers (e.g., 26, 100, 150) are hardcoded in multiple places.

No centralized helper functions for spreadsheet indexing.

### Desired behavior after PR is merged:

DEFAULT_COLUMN_WIDTH, MIN_COLUMNS, and MIN_ROWS constants provide clear defaults for spreadsheet tables.

index_to_column_letter converts 0-based indices to spreadsheet letters (A, B, …, AA, AB) in a reusable way.

to_cell_reference converts (col, row) indices into standard spreadsheet cell references (A1, B2, …).

Models can now generate spreadsheet tables using these helpers, improving readability, maintainability, and reducing magic numbers.

Task: 5424006

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
