### PR TITLE
[IMP] purchase_requisition: Allow manual reordering of requisition lines

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -165,7 +165,9 @@ class PurchaseRequisitionLine(models.Model):
     _inherit = ['analytic.mixin']
     _description = "Purchase Requisition Line"
     _rec_name = 'product_id'
+    _order = 'sequence, id'
 
+    sequence = fields.Integer(string='Sequence', default=10)
     product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)], required=True)
     uom_id = fields.Many2one(
         'uom.uom', 'Unit',

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -81,6 +81,7 @@
                     <page string="Products" name="products">
                         <field name="line_ids" readonly="state == 'done'">
                             <list string="Products" editable="bottom">
+                                <field name="sequence" widget="handle"/>
                                 <field name="product_id"
                                        domain="[('purchase_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
                                 <field name="product_description_variants" invisible="product_description_variants == ''"/>


### PR DESCRIPTION
In purchase agreements, users cannot change the order of requisition lines,
making it difficult to organize products logically (e.g., by priority or
category).

This improvement allows users to reorder purchase requisition lines via
drag-and-drop, improving usability.

Task ID - 5426637