### PR TITLE
[FIX] stock_account: fix access error for non-admin users opening stock report

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -336,7 +336,7 @@ class ResCompany(models.Model):
         if not closing:
             return False
         am_state_field = self.env['ir.model.fields'].search([('model', '=', 'account.move'), ('name', '=', 'state')], limit=1)
-        state_tracking = closing.message_ids.tracking_value_ids.filtered(lambda t: t.field_id == am_state_field).sorted('id')
+        state_tracking = closing.message_ids.sudo().tracking_value_ids.filtered(lambda t: t.field_id == am_state_field).sorted('id')
         return state_tracking[-1:].create_date or fields.Datetime.to_datetime(closing.date)
 
     def _save_closing_id(self, move_id):


### PR DESCRIPTION
## Issue before this commit:
When opening the Stock Valuation report as a non-admin user, an access error
occurred. The report attempted to read `tracking_value_ids` from
`mail.message`. Since `mail.tracking.value` is restricted to system
administrator users, this caused the stock report to fail for regular users.

## Steps to Reproduce:
- Install the stock_account module.
- Log in as a non-admin user.
- Open Accounting -> Review -> Inventory Valuation Report.

## Cause of the Issue:
The system reads `mail.tracking.value` to get the last stock valuation closing
date. Without a trusted context, this access fails for non-admin users.

## With This Commit:
Tracking values are now accessed in a trusted context, allowing the stock report
to open for non-admin users without changing the valuation logic.

Steps To Reporduce: [Video Link](https://drive.google.com/file/d/1bFmLgadD7Z3PEntVQVM8flTAWCMDJXxK/view?usp=drive_link)

opw-5483352
