### PR TITLE
[FIX] im_livechat: align info panel section title fonts

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -58,7 +58,7 @@
 
     <t t-name="im_livechat.LivechatChannelInfoList.info_links">
         <div t-if="templateParams.info_records.length" class="d-flex flex-column bg-inherit gap-1">
-            <h3 class="pt-3" t-out="templateParams.title"/>
+            <h6 class="pt-3" t-out="templateParams.title"/>
             <t t-foreach="templateParams.info_records" t-as="record" t-key="record.localId">
                 <a
                     class="btn btn-sm btn-secondary d-flex align-items-center justify-content-start gap-1 px-3 py-1 rounded-3"


### PR DESCRIPTION
**Description of the issue this PR addresses:**
------------------------------------------------

In the live chat info side panel, the "Open Tickets" and "Open Leads" section titles were displayed with a different font size compared to the other section titles. This created an inconsistent visual appearance in the info side panel.

**Current behavior before PR:**
---------------------------------

- "Open Tickets" and "Open Leads" titles use a different font size  

**Desired behavior after PR is merged:**
-----------------------------------------

- "Open Tickets" and "Open Leads" titles use the same font size as other sections  
- Info side panel displays a consistent and uniform style  

**Task:** [5385392](https://www.odoo.com/odoo/project/1519/tasks/5385392)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
