### PR TITLE
[FIX] html_editor: extract correct URL in `loadImageInfo`

### DIFF
--- a/addons/html_editor/static/src/utils/image_processing.js
+++ b/addons/html_editor/static/src/utils/image_processing.js
@@ -207,7 +207,7 @@ export async function loadImageInfo(el, attachmentSrc = "") {
     // URLs too). Capture the filename part until a slash, query or hash so we
     // can replace only that segment and preserve the rest of the URL (host,
     // querystring, hash...).
-    const m = realSrc.match(/\/(?:web_editor|html_editor)\/image_shape\/([^/?#]+)/);
+    const m = realSrc.match(/\/(?:web_editor|html_editor)\/image_shape\/([^/?#]+)[^?#]*/);
     if (el.dataset.shape && m) {
         let filename = m[1];
         if (filename.endsWith("_perspective")) {

--- a/addons/website/static/tests/tours/snippet_shape_image.js
+++ b/addons/website/static/tests/tours/snippet_shape_image.js
@@ -1,0 +1,26 @@
+import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour(
+    "snippet_shape_image",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({ id: "s_shape_image", name: "Shape image", groupName: "Content" }),
+        {
+            content: "Click on the image",
+            trigger: ":iframe .s_shape_image img",
+            run: "click",
+        },
+        {
+            content: "Click on the remove shape button",
+            trigger: "div[data-label='Shape'] i.oi-close",
+            run: "click",
+        },
+        {
+            content: "Very if shape is removed",
+            trigger: ":iframe .s_shape_image img:not([data-shape])",
+        },
+    ]
+);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -159,3 +159,6 @@ class TestSnippets(HttpCase):
         website.google_analytics_key = 'G-XXXXXXXXXXX'
         website.cookies_bar = True
         self.start_tour(website.get_client_action_url('/'), 'cookie_bar_updates_gtag_consent')
+
+    def test_shape_image_snippet(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_shape_image', login='admin')


### PR DESCRIPTION
When removing a shape from an image within the `s_shape_image` snippet, a traceback occurred because the `originalSrc` dataset property was missing.

The issue was introduced in [1], where the regex in `loadImageInfo` failed to correctly parse URLs with the format:
`html_editor/image_shape/<id>/<shape_path>`. Instead of generating the base image path (`web/image/<id>`), the regex incorrectly included the shape path, resulting in an invalid URL being set to the controller. This commit updates the logic to ensure that the correct URl is sent.

Steps to reproduce:
1. Drop an 'Image Shape' (`s_shape_image`) snippet onto a page.
2. Select the image and click the option to remove the shape.
3. Observe the traceback.

[1]: https://github.com/odoo/odoo/commit/43464576bb772c70910b960bb370148fe73687b9

Task: [5499122](https://www.odoo.com/odoo/project/974/tasks/5499122)