### PR TITLE
[FIX] web: tests - add missing XHR members

### DIFF
--- a/addons/web/static/lib/hoot/hoot_utils.js
+++ b/addons/web/static/lib/hoot/hoot_utils.js
@@ -2076,8 +2076,10 @@ export const INCLUDE_LEVEL = {
 export const MIME_TYPE = {
     formData: "multipart/form-data",
     blob: "application/octet-stream",
+    html: "text/html",
     json: "application/json",
     text: "text/plain",
+    xml: "text/xml",
 };
 
 export const STORAGE = {


### PR DESCRIPTION
### [FIX] web: tests - add missing XHR members

Before this commit, the mocking of XMLHttpRequests was incomplete; this
was due to the fact that `rpc.js` was basically the only user of that
feature, and as such only the properties and methods used in that file
were mocked.

However, it is only a matter of time before modules expose this XHR
object (or declare their own) and manipulate them arbitrarily,
increasing the need for a more complete mocked API.

This commit adds most[1] features of the XHR API into the mocked one.

[1] there may be edge cases that have not been considered to
considerably simplify mocked XHRs. If there is an actual need at some
point, a similar commit may have to be written in the future.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr