### PR TITLE
[FIX] purchase_alternative: fix currency rate in alternative PO test

### DIFF
--- a/addons/purchase_alternative/tests/test_purchase_alternative.py
+++ b/addons/purchase_alternative/tests/test_purchase_alternative.py
@@ -234,11 +234,11 @@ class TestPurchaseAlternative(TestPurchaseAlternativeCommon):
 
         # 1 USD = 0.5 EUR
         self.env['res.currency.rate'].create([{
-            'name': fields.Datetime.today(),
+            'name': fields.Date.today() - timedelta(days=1),
             'currency_id': self.env.ref('base.USD').id,
             'rate': 1,
         }, {
-            'name': fields.Datetime.today(),
+            'name': fields.Date.today() - timedelta(days=1),
             'currency_id': self.env.ref('base.EUR').id,
             'rate': 0.5,
         }])


### PR DESCRIPTION
Issue before this commit:
=========================
The test_12_alternative_po_line_different_currency test was moved to the
purchase_alternative module in this [PR](https://github.com/odoo/odoo/pull/218612).

At the same time, the currency rate logic was updated in another [PR](https://github.com/odoo/odoo/pull/231948). 
During conflict resolution, the test was mistakenly reverted to the old behaviour, causing the test to break.

As a result, the alternative PO price comparison became incorrect.

Steps to Reproduce:
=========================
- Install the purchase_alternative module.
- Run the test: test_12_alternative_po_line_different_currency test case.
- The test fails at: self.assertEqual(best_price_ids[0], po_alt.order_line.id)

Cause of the issue:
=========================
Recent currency rate changes introduced in [PR](https://github.com/odoo/odoo/pull/231948),
That PR ensures that Currency rates are valid only starting the next day.

During conflict resolution, these changes were removed from the test, 
causing invalid currency rates, leading to incorrect price comparisons.

With This Commit:
=========================
Ensure the test runs correctly by aligning it with the updated currency rate logic.

runbot-build-error: [237989](https://runbot.odoo.com/odoo/runbot.build.error/237989)
