### PR TITLE
[FIX] l10n_sa_edi_pos: skip forced zatca invoice for settlement due on new flow

### DIFF
--- a/addons/l10n_sa_edi_pos/models/__init__.py
+++ b/addons/l10n_sa_edi_pos/models/__init__.py
@@ -2,3 +2,4 @@ from . import pos_config
 from . import account_edi_xml_ubl_21_zatca
 from . import account_move
 from . import pos_order
+from . import account_edi_format

--- a/addons/l10n_sa_edi_pos/models/account_edi_format.py
+++ b/addons/l10n_sa_edi_pos/models/account_edi_format.py
@@ -1,0 +1,22 @@
+from odoo import api, models
+
+
+class AccountEdiFormat(models.Model):
+    _inherit = 'account.edi.format'
+
+    @api.model
+    def is_settlement_order(self, invoice):
+        """
+            Check if the invoice is linked to a POS settlement order
+            Only available when pos_settle_due module is installed
+        """
+        if not self.env['pos.order.line']._fields.get('settled_order_id'):
+            return False
+        return any(line.settled_order_id for line in invoice.pos_order_ids.lines)
+
+    def _get_move_applicability(self, move):
+        # EXTENDS account_edi
+        self.ensure_one()
+        if self.code == 'sa_zatca' and move.country_code == 'SA' and move.move_type in ('out_invoice', 'out_refund') and self.is_settlement_order(move):
+            return {}
+        return super()._get_move_applicability(move)

--- a/addons/l10n_sa_edi_pos/models/account_move.py
+++ b/addons/l10n_sa_edi_pos/models/account_move.py
@@ -6,3 +6,10 @@ class AccountMove(models.Model):
 
     def _l10n_sa_check_refund_reason(self):
         return super()._l10n_sa_check_refund_reason() or (self.pos_order_ids and self.pos_order_ids[0].refunded_orders_count > 0 and self.ref)
+
+    def _compute_qr_code_str(self):
+        for order in self:
+            if any(o.is_settlement_order() for o in order.pos_order_ids):
+                order.l10n_sa_qr_code_str = False
+            else:
+                super(AccountMove, order)._compute_qr_code_str()

--- a/addons/l10n_sa_edi_pos/models/pos_order.py
+++ b/addons/l10n_sa_edi_pos/models/pos_order.py
@@ -6,3 +6,13 @@ class PosOrder(models.Model):
 
     l10n_sa_invoice_qr_code_str = fields.Char(related="account_move.l10n_sa_qr_code_str", string="ZATCA QR Code")
     l10n_sa_invoice_edi_state = fields.Selection(related="account_move.edi_state", string="Electronic invoicing")
+
+    def is_settlement_order(self):
+        self.ensure_one()
+        """
+        Check if the invoice is linked to a POS settlement order
+        Only available when pos_settle_due module is installed
+        """
+        if not self.env["pos.order.line"]._fields.get("settled_order_id"):
+            return False
+        return any(line.settled_order_id for line in self.lines)

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-inherit="point_of_sale.ReceiptHeader" t-name="l10n_sa_edi_pos.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//img[hasclass('pos-receipt-qrcode')]" position="after">
-            <div t-if="order.notLegal and order.isSACompany() and !order.is_settlement()" class="text-center mt-3">
+            <div t-if="order.notLegal and order.isInvoiceMandatoryForSA()" class="text-center mt-3">
                 <p>THIS IS NOT A LEGAL DOCUMENT</p>
                 <p>هذا المستند ليس مستنداً قانونياً</p>
             </div>

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -1,5 +1,5 @@
 import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { AlertDialog, ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { markup } from "@odoo/owl";
@@ -13,7 +13,6 @@ patch(PaymentScreen.prototype, {
         // Skip if invoice is not mandatory(Ex: settlement)
         // note: Skips entirely if journal is not onboarded or electronic invoicing is not selected
         if (
-            order.isSACompany() &&
             order.finalized &&
             !order.l10n_sa_invoice_qr_code_str &&
             order.isInvoiceMandatoryForSA()
@@ -36,5 +35,20 @@ patch(PaymentScreen.prototype, {
                 body: message,
             });
         }
+    },
+
+    async validateOrder(isForceValidate) {
+        const order = this.currentOrder;
+        // the isSettleDueLine() is only available if enterprise:pos_settle_due module is installed
+        const settleLineCount = order.lines.filter((line) => line.isSettleDueLine?.()).length;
+        if (settleLineCount && settleLineCount !== order.lines.length) {
+            return this.dialog.add(AlertDialog, {
+                title: _t("Settlement Error"),
+                body: _t(
+                    "Please remove the new order lines from the order to proceed with the settlement."
+                ),
+            });
+        }
+        await super.validateOrder(...arguments);
     },
 });

--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_order.js
@@ -19,7 +19,7 @@ patch(PosOrder.prototype, {
     isInvoiceMandatoryForSA() {
         // Zatca enforces invoice, but for settlement due, invoices are not needed
         // Only applicable if enterprise:pos_settle_due module is installed
-        return this.isSACompany() && !this.is_settling_account;
+        return this.isSACompany() && !this.is_settlement() && !this.is_deposit_order();
     },
 
     isToInvoice() {
@@ -44,7 +44,7 @@ patch(PosOrder.prototype, {
         is_settling_account is only applicable if enterprise:pos_settle_due module is installed
         */
         super.setPartner(partner);
-        if (this.is_settling_account) {
+        if (this.isSACompany() && !this.isInvoiceMandatoryForSA()) {
             this.setToInvoice(false);
         }
     },

--- a/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
+++ b/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
@@ -5,7 +5,7 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_settlement", {
+registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_deposit", {
     steps: () =>
         [
             Chrome.startPoS(),
@@ -24,7 +24,7 @@ registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_settleme
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("ZATCA_invoice_mandatory_if_not_settlement", {
+registry.category("web_tour.tours").add("ZATCA_invoice_mandatory_if_regular_order", {
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
+++ b/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
@@ -1,11 +1,11 @@
 from unittest.mock import patch
 
+from odoo.tests import tagged
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.l10n_sa_edi.tests.common import AccountEdiTestCommon
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
-
-from odoo.tests import tagged
 
 
 @tagged('post_install', '-at_install', 'post_install_l10n')
@@ -44,27 +44,29 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     @patch('odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices',
            new=lambda self: True)
-    def test_ZATCA_invoice_not_mandatory_if_settlement(self):
+    def test_ZATCA_invoice_not_mandatory_if_deposit(self):
         """
-        Tests that the invoice is  not mandatory in POS payment for ZATCA if it's a settlement.
+        Tests that the invoice is  not mandatory in POS payment for ZATCA if it's a deposit.
         """
+
         self.test_partner = self.env["res.partner"].create({"name": "AAA Partner"})
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
-            'ZATCA_invoice_not_mandatory_if_settlement',
-            login="pos_admin",
+            'ZATCA_invoice_not_mandatory_if_deposit',
+            login="pos_admin"
         )
 
     @patch('odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices',
            new=lambda self: True)
-    def test_ZATCA_invoice_mandatory_if_not_settlement(self):
+    def test_ZATCA_invoice_mandatory_if_regular_order(self):
         """
         Tests that the invoice is mandatory in POS payment for ZATCA.
         Also is by default checked.
         """
+
         self.test_partner = self.env["res.partner"].create({"name": "AAA Partner"})
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
-            'ZATCA_invoice_mandatory_if_not_settlement',
+            'ZATCA_invoice_mandatory_if_regular_order',
             login="pos_admin",
         )

--- a/addons/l10n_sa_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_sa_pos/static/src/overrides/models/pos_order.js
@@ -24,21 +24,24 @@ patch(PosOrder.prototype, {
         return false;
     },
     /**
-     * If the order is empty (there are no products)
-     * and all "pay_later" payments are negative,
-     * we are settling a customer's account.
      * If the module pos_settle_due is not installed,
-     * the function always returns false (since "pay_later" doesn't exist)
+     * the function always returns false (since "isSettleDueLine" doesn't exist)
      * @returns {boolean} true if the current order is a settlement, else false
      */
     is_settlement() {
-        return (
-            this.isEmpty() &&
-            !!this.payment_ids.filter(
-                (paymentline) =>
-                    paymentline.payment_method_id.type === "pay_later" && paymentline.amount < 0
-            ).length
-        );
+        return this.lines.some((line) => line.isSettleDueLine?.());
+    },
+
+    /**
+     * Before validating the order, is_settling_account is set to True.
+     * Once the order is validated and before sending the request to api,
+     * is_settling_account property is not there anymore, thus checking lines
+     * If the module pos_settle_due is not installed,
+     * the function always returns false (since "isDepositLine or is_settling_account" doesn't exist)
+     * @returns {boolean} true if the current order is a deposit, else false
+     */
+    is_deposit_order() {
+        return this.is_settling_account || this.lines.some((line) => line.isDepositLine?.());
     },
 
     compute_sa_qr_code(name, vat, date_isostring, amount_total, amount_tax) {


### PR DESCRIPTION
# Description of the issue/feature this PR addresses

In Point of Sale with ZATCA enabled (l10n_sa_edi_pos), invoicing is enforced on all orders.
In 18.0, settlement and deposit flows were both correctly excluded from mandatory ZATCA invoicing using the is_settling_account flag.

From saas-18.2, the Settle Due flow was refactored to include a dedicated settlement product line. 
As a result, is_settling_account now only covers account deposit flows, and is no longer sufficient to identify Settle Due orders.

# Current behavior before PR

With ZATCA enabled on saas-18.2:

- Account deposit flows are still correctly excluded from mandatory invoicing using is_settling_account.
- Settle Due orders are no longer detected by this flag and are treated as standard sales because they now contain order lines.
- This causes ZATCA invoice enforcement to be applied to Settle Due orders, even though the original invoice was already reported.
- Additionally, mixed orders combining settlement lines and new sale items would require partial ZATCA reporting, which is not supported.

# Desired behavior after PR is merged

After this fix:

- ZATCA invoice enforcement is skipped for account deposit flows using the existing is_settling_account flag.
- Even if invoice is checked, the invoice is not sent to ZATCA
- Settle Due orders are correctly identified using the isSettleDueLine() check on order lines and excluded from mandatory ZATCA invoicing.
- Mixed settlement and sale orders are explicitly blocked for ZATCA to avoid inconsistent or partial reporting.

This restores the intended settlement behavior from 18.0 while adapting it to the refactored Settle Due flow in saas-18.2.

task-5144679
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
