### PR TITLE
[FIX] web: increase test_unit_desktop timeout

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -196,7 +196,7 @@ class WebSuite(HootCommon, odoo.tests.CrossModule):
         filters = self._get_hoot_filters(addons_from_asset_bundle, modules)
         if not filters:
             return
-        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=desktop&timeout=15000{filters}', "", "", login='admin', timeout=3000, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
+        self.browser_js(f'/web/tests?&headless&loglevel=2&preset=desktop&timeout=15000{filters}', "", "", login='admin', timeout=3600, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
 
 
 @odoo.tests.tagged('hoot', 'post_install', '-at_install')


### PR DESCRIPTION
This commit increases the timeout of the main (desktop) hoot test suite.

Since [1], the suite is split by sub-builds, such that each sub-build only runs the tests defined in the addons that are tested by that sub-build. So the suite never timeouts anymore on regular builds.

However, in nightly, we still run the whole suite "old school", i.e. all tests in the same run. In that case, the suite sometimes (in 19.1) or often (in master) exceeds the previous timeout (50m). With 1 hour, we hope that it will be enough.

Note that the number of tests keeps increasing, hence the need to increase the timeout.

[1] https://github.com/odoo/odoo/pull/234132

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
