### PR TITLE
[FIX] base: avoid single tuple error in query

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -359,25 +359,25 @@ class IrModel(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_related_attachments(self):
         """ Delete attachment associated with the models being deleted. """
-        models = tuple(self.mapped('model'))
+        models = list(self.mapped('model'))
 
         # Get files attached solely to the models being deleted (and none other)
         fname_rows = self.env.execute_query(SQL(
             """
             SELECT DISTINCT store_fname
             FROM ir_attachment
-            WHERE res_model IN %s AND store_fname IS NOT NULL
+            WHERE res_model = ANY(%s) AND store_fname IS NOT NULL
             EXCEPT
             SELECT store_fname
             FROM ir_attachment
-            WHERE res_model NOT IN %s
+            WHERE res_model != ALL(%s)
             """,
-            models, models,
+            (models, models),
         ))
 
         self.env.execute_query(SQL(
-            "DELETE FROM ir_attachment WHERE res_model IN %s",
-            models,
+            "DELETE FROM ir_attachment WHERE res_model = ANY(%s)",
+            (models,),
         ))
 
         for (fname,) in fname_rows:


### PR DESCRIPTION
Reviewing recent commit https://github.com/odoo/odoo/commit/4cced9f4e87aecc2894c44313d20d5fea5c4dd7b, I realized that the code is error prone, by not considering what happens when there is only one model (single tuple case). Queries cannot have `WHERE x IN (y,)`. We use this by using `ANY()`, which accepts 0,1, or N elements.

Maybe we should check others parts of the Odoo code too (I won't do it).




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr