### PR TITLE
[FIX] hr_recruitment: synchronize employees count in job's smart button

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -205,6 +205,7 @@ class HrJob(models.Model):
             for job, count in self.env['hr.employee'].sudo()._read_group(
                 domain=[
                     ('job_id', 'in', self.ids),
+                    ('company_id', 'in', self.env.companies.ids),
                 ],
                 groupby=['job_id'],
                 aggregates=['__count'],
@@ -409,6 +410,7 @@ class HrJob(models.Model):
             'res_model': res_model,
             'view_mode': 'list,kanban,form',
             'views': [(False, 'list'), (False, 'kanban'), (False, 'form')],
+            'domain': [('company_id', 'in', self.env.companies.ids)],
             'context': {
                 'default_job_id': self.id,
                 'search_default_group_job': 1,


### PR DESCRIPTION
### Steps to reproduce:
- Create a job for multiple companies.
- Go to its configuration and click the Employees smart button.
- Click the smart button and compare the employee count.

### Before/Root cause:
- Currently selected companies were not considered. Instead, all companies were taken into account during the computation.

### After:
- When you click on employee smart button only currently selected companies will be considered.

### Fix:
- Added a domain filter to consider only the currently selected companies.

task-5785245

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
