### PR TITLE
[FIX] point_of_sale: use config base_url for customer display URL

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -152,7 +152,7 @@ export class Navbar extends Component {
         }/${getDeviceUuid()}`;
 
         this.dialog.add(QrCodeCustomerDisplay, {
-            customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
+            customerDisplayURL: `${this.pos.config._base_url}${customer_display_url}`,
         });
     }
 

--- a/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
@@ -15,5 +15,6 @@ registry.category("web_tour.tours").add("customer_display_shows_qr_popup", {
             Chrome.CustomerDisplayHasQRButton(),
             Chrome.ClickCustomerDisplayQRButton(),
             Chrome.CustomerDisplayQRIsDisplayed(),
+            Chrome.checkCustomerDisplayQRPopupMobile(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -280,18 +280,21 @@ export function ClickOnCustomerDisplayButton() {
 }
 export function CustomerDisplayHasThisDeviceButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'This device' button",
         trigger: ".o_dialog .modal-body .container .btn-primary:contains('This device')",
     };
 }
 export function CustomerDisplayHasQRButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'Display QR' button",
         trigger: ".o_dialog .modal-body .container .btn-secondary:contains('Display QR')",
     };
 }
 export function ClickCustomerDisplayThisDeviceButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'This device' button",
         trigger: ".btn-primary:contains('This device')",
         run: "click",
@@ -299,6 +302,7 @@ export function ClickCustomerDisplayThisDeviceButton() {
 }
 export function ClickCustomerDisplayQRButton() {
     return {
+        isActive: ["desktop"],
         content: "Check that the customer display popup has a 'Display QR' button",
         trigger: ".btn-secondary:contains('Display QR')",
         run: "click",
@@ -306,8 +310,17 @@ export function ClickCustomerDisplayQRButton() {
 }
 export function CustomerDisplayQRIsDisplayed() {
     return {
+        isActive: ["desktop"],
         content: "Check that the QR code is displayed on screen",
         trigger: ".o-overlay-item .modal .modal-body img.square",
+    };
+}
+export function checkCustomerDisplayQRPopupMobile() {
+    const customerDisplayURL = window.location.origin + "/pos_customer_display/";
+    return {
+        isActive: ["mobile"],
+        content: "Check that the QR code has valid url link",
+        trigger: `.o-overlay-item .modal .modal-body a[href^='${customerDisplayURL}']`,
     };
 }
 export function freezeDateTime(millis) {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3567,10 +3567,6 @@ class MobileTestUi(TestUi):
     touch_enabled = True
     allow_inherited_tests_method = True
 
-    # Skip customer display web tests on mobile
-    def test_customer_display_popup(self):
-        return
-
 
 class TestTaxCommonPOS(TestPointOfSaleHttpCommon, TestTaxCommon):
     @classmethod


### PR DESCRIPTION
Steps:

- Install point_of_sale.
- Open a POS session on a mobile device.
- Click on the customer display menu.

Issue:

- The QR code for the customer display contains an invalid URL: undefined/pos_customer_display/${config_id}.

Issue:

- The base URL was being accessed from the POS session, where it is not available.

Fix:

- Retrieve the base URL from the POS configuration instead of the session.

task-5792308
