### PR TITLE
[FIX] base_import: prevent errors when importing bank statements

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1208,7 +1208,10 @@ class Import(models.TransientModel):
             # This is probably not a float
             return False
         if len(split_value) == 1:
-            if float_regex.search(split_value[0]) is not None:
+            if (
+                float_regex.search(split_value[0]) is not None and split_value[0] != '.'
+                and split_value[0].count('.') <= 1
+            ):
                 return split_value[0] if not negative else '-' + split_value[0]
             return False
         else:
@@ -1218,7 +1221,10 @@ class Import(models.TransientModel):
                 currency_index = 1
             # Check that currency exists
             currency = self.env['res.currency'].search([('symbol', '=', split_value[currency_index].strip())])
-            if len(currency):
+            if (
+                len(currency) and split_value[(currency_index + 1) % 2] != '.'
+                and split_value[(currency_index + 1) % 2].count('.') <= 1
+            ):
                 return split_value[(currency_index + 1) % 2] if not negative else '-' + split_value[(currency_index + 1) % 2]
             # Otherwise it is not a float with a currency symbol
             return False


### PR DESCRIPTION
Currently, an error occurs when a user imports a file in the Bank Statement.

Steps to Reproduce:

 - Install the `Accounting` module.
 - Go to the `Bank Journal`.
 - Import [this file] and click on `Test`.
 - Error logged in terminal.
 
**Error:**
`ValueError: could not convert string to float: '.'`


This error occurs when the user enters a dot('.') in the balance column. Due to this, it matches float_regex[1] and attempts to convert it into a float value [2], which raises the error [3]. The error only occurs in the case of dot(.).

This commit ensures that if the data contains only a single dot, or multiple dots with numbers, parsing the float from the data raises an import error [4].

[this file]: https://drive.google.com/file/d/1A6p3yV_BtJKipWEjVNTQwN5ChQNPWNKl/view?usp=drive_link

[1]: https://github.com/odoo/odoo/blob/ec5da99ca3f52420e7d973c3cf07167bd4104ffa/addons/base_import/models/base_import.py#L1205

[2]: https://github.com/odoo/enterprise/blob/d57c3ab04a5ef2d056b3c11719ab0ba9db7ccece/account_bank_statement_import_csv/wizard/account_bank_statement_import_csv.py#L96-L98

[3]: https://github.com/odoo/enterprise/blob/ece29e5f962b4ac4e1c8e404b1ca56a9bca3f364/account_bank_statement_import_csv/wizard/account_bank_statement_import_csv.py#L48-L49

[4]: https://github.com/odoo/odoo/blob/ec5da99ca3f52420e7d973c3cf07167bd4104ffa/addons/base_import/models/base_import.py#L1247

sentry-7198329852


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
