### PR TITLE
[REF] point_of_sale: introduce shouldRoundChange for easier override

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -832,9 +832,13 @@ export class PosOrder extends Base {
         );
     }
 
+    shouldRoundChange() {
+        return this.config.cash_rounding;
+    }
+
     getChange() {
         let { order_sign, order_remaining: remaining } = this.taxTotals;
-        if (this.config.cash_rounding) {
+        if (this.shouldRoundChange()) {
             remaining = this.getRoundedRemaining(this.config.rounding_method, remaining);
         }
         return -order_sign * remaining;


### PR DESCRIPTION
In the entreprise associated PR, we override `shouldRoundChange` in `pos_settle_order` module.

opw-5222985