### PR TITLE
[FIX] website_sale: allow group website designer optimize category seo

### DIFF
--- a/addons/website_sale/security/ir.model.access.csv
+++ b/addons/website_sale/security/ir.model.access.csv
@@ -12,6 +12,7 @@ access_product_tag_public_public,product.tag.public,product.model_product_tag,ba
 access_product_tag_public_portal,product.tag.public,product.model_product_tag,base.group_portal,1,0,0,0
 access_product_tag_public_employee,product.tag.public,product.model_product_tag,base.group_user,1,0,0,0
 access_product_category_pos_manager,product.public.category manager,model_product_public_category,sales_team.group_sale_manager,1,1,1,1
+access_product_public_category_designer,product.public.category designer,model_product_public_category,website.group_website_designer,1,1,1,0
 access_product_public_category_public_public,product.category.public,model_product_public_category,base.group_public,1,0,0,0
 access_product_public_category_public_portal,product.category.public,model_product_public_category,base.group_portal,1,0,0,0
 access_product_public_category_public_employee,product.category.public,model_product_public_category,base.group_user,1,0,0,0

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -31,6 +31,7 @@ from . import test_website_sale_product_filters
 from . import test_website_sale_product_page
 from . import test_website_sale_product_template
 from . import test_website_sale_reorder_from_portal
+from . import test_website_sale_seo
 from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_snippets
 from . import test_website_sale_visitor

--- a/addons/website_sale/tests/test_website_sale_seo.py
+++ b/addons/website_sale/tests/test_website_sale_seo.py
@@ -1,0 +1,24 @@
+from odoo.fields import Command
+from odoo.tests import HttpCase
+
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+
+
+class WebsiteSaleSEO(HttpCase, WebsiteSaleCommon):
+    def test_website_sale_user_designer_can_edit_seo(self):
+        public_categ = self.env['product.public.category'].create({'name': 'Website Category'})
+        self.product.write({'public_categ_ids': [Command.link(public_categ.id)]})
+        internal_user = self.env['res.users'].create({
+            'name': 'Web Designer',
+            'login': 'internal_user',
+            'groups_id': [
+                Command.link(self.ref('website.group_website_designer')),
+                Command.link(self.ref('base.group_user')),
+            ],
+        })
+        self.authenticate(internal_user.login, internal_user.login)
+        res = self.make_jsonrpc_request(
+            '/website/get_seo_data',
+            {'res_id': public_categ.id, 'res_model': 'product.public.category'},
+        )
+        self.assertTrue(res['can_edit_seo'])


### PR DESCRIPTION
### Issue:
Due to this issue, website designer cannot optimize seo on category.

#### Steps to reproduce:
1- Create a `eCommerce Category`.
2- In demo user, set Sale access to `All Documents` and Website
   access to `Editor and Designer`.
3- Login with demo user and navigate to website.
4- In shop page, open category.
5- From site tab, click on `Optimize SEO`. You get access error.

Expected: You should be able to optimize seo with `Editor and Designer` access.

### Cause:
The user needs write access on record in order to optimize seo: https://github.com/odoo/odoo/blob/ec5da99ca3f52420e7d973c3cf07167bd4104ffa/addons/website/controllers/main.py#L831-L834


opw-5443854

