### PR TITLE
[FIX] account: hide Auto-Complete field when Vendor is not selected

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1061,9 +1061,9 @@
                                 <field name="ref" default_focus="1" invisible="move_type != 'entry'"/>
                                 <field name="tax_cash_basis_origin_move_id" invisible="not tax_cash_basis_origin_move_id"/>
                                 <label name="invoice_vendor_bill_id_label" for="invoice_vendor_bill_id" string="Auto-Complete" class="oe_edit_only"
-                                       invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')"/>
+                                       invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund') or not partner_id"/>
                                 <field name="invoice_vendor_bill_id" nolabel="1" class="oe_edit_only"
-                                       invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund')"
+                                       invisible="state != 'draft' or move_type not in ('in_invoice', 'in_refund') or not partner_id"
                                        domain="[('company_id', '=', company_id), ('partner_id', 'child_of', [partner_id]), ('move_type', '=', move_type)]"
                                        placeholder="Select an old purchase document"
                                        options="{'no_create': True}" context="{'show_total_amount': True}"/>


### PR DESCRIPTION
Currently, an exception is generated when the user tries to select
`Auto-Complete` without selecting `Vendor`.

Steps to produce an error
- Go to Invoicing > Vendors > Bills > Click New
- Try selecting `Auto-Complete` >>> Error occurs

Error `AssertionError: Invalid falsy real id`

This error occurs because, after the recent refactoring in commit [1], falsy
ids are no longer allowed in domains. In the `Account Entry` view
`[partner_id]` (see [2]) is passed as part of the domain. When the user has
not selected a vendor (partner_id) it evaluates to False, which results in
[False] being passed and triggers the error introduced by commit [1].

This commit will fix the above issue by hiding the `Auto-Complete`
field when `Vendor` is not selected.

[1]: https://github.com/odoo/odoo/commit/4290724a4c8c57fba4f4d3d688d38f65dadcc38f
[2]: https://github.com/odoo/odoo/blob/7b288aa436f669d8c8e2ddac5277bb98321a390e/addons/account/views/account_move_views.xml#L1067

Sentry-7201563878