### PR TITLE
[ADD] pos, pos_product_expiry: handle lot expiration date in POS

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1634,7 +1634,6 @@ class PosOrderLine(models.Model):
                     'id': lot_recordset.id,
                     'name': lot_recordset.name,
                     'product_qty': total_quantity,
-                    'expiration_date': lot_recordset.expiration_date,
                 })
 
         return result

--- a/addons/point_of_sale/static/src/app/components/popups/select_lot_popup/select_lot_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/select_lot_popup/select_lot_popup.js
@@ -42,6 +42,13 @@ export class SelectLotPopup extends Component {
     _nextId() {
         return this._id++;
     }
+    _getOnSelectVals(option) {
+        return {
+            create: true,
+            id: option.id,
+            label: option.name,
+        };
+    }
     getSources() {
         return [
             {
@@ -52,16 +59,13 @@ export class SelectLotPopup extends Component {
                             !this.state.values.some((value) => value.text === option.name)
                     );
                     if (filteredOptions.length) {
-                        return filteredOptions.map((option) => ({
-                            label: option.name,
-                            onSelect: () =>
-                                this.onSelect({
-                                    create: true,
-                                    id: option.id,
-                                    label: option.name,
-                                    expiration_date: option.expiration_date,
-                                }),
-                        }));
+                        return filteredOptions.map((option) => {
+                            const vals = this._getOnSelectVals(option);
+                            return {
+                                label: option.name,
+                                onSelect: () => this.onSelect(vals),
+                            };
+                        });
                     } else if (this.props.customInput && currentInput) {
                         const label = _t("Create Lot/Serial number...");
                         return [
@@ -103,7 +107,7 @@ export class SelectLotPopup extends Component {
         }
         const newItem = lot.currentInput
             ? { text: lot.currentInput, id: lot.id }
-            : { text: lot.label, id: lot.id, expiration_date: lot.expiration_date };
+            : { text: lot.label, id: lot.id };
         this.state.values = this.props.isSingleItem ? [newItem] : [...this.state.values, newItem];
         this.state.value = this.props.isSingleItem ? newItem.text : "";
     }
@@ -127,9 +131,9 @@ export class SelectLotPopup extends Component {
         const result = filteredValues.map((item) => {
             const matchingLot = this.props.array.find((lot) => lot.text === item.text);
             return {
+                item: item,
                 text: item.text,
                 _id: this._nextId(),
-                expiration_date: item.expiration_date,
                 ...(matchingLot ? { id: matchingLot.id } : {}),
             };
         });

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -35,7 +35,7 @@ import { normalize } from "@web/core/l10n/utils";
 import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
-import { formatDate, deserializeDateTime } from "@web/core/l10n/dates";
+import { formatDate } from "@web/core/l10n/dates";
 import { ProductInfoPopup } from "@point_of_sale/app/components/popups/product_info_popup/product_info_popup";
 import { RetryPrintPopup } from "@point_of_sale/app/components/popups/retry_print_popup/retry_print_popup";
 import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
@@ -2325,12 +2325,6 @@ export class PosStore extends WithLazyGetterTrap {
         }
     }
 
-    showNotificationIfLotExpired(lotName, lotExpDate = null) {
-        const lotExpDateTime = deserializeDateTime(lotExpDate);
-        if (lotExpDateTime.isValid && lotExpDateTime.ts <= DateTime.now().ts) {
-            this.notification.add(_t("Lot/Serial %s is expired", lotName));
-        }
-    }
     async editLots(product, packLotLinesToEdit) {
         const isAllowOnlyOneLot = product.isAllowOnlyOneLot();
         let canCreateLots = this.pickingType.use_create_lots || !this.pickingType.use_existing_lots;
@@ -2403,14 +2397,8 @@ export class PosStore extends WithLazyGetterTrap {
 
         const existingLotsName = existingLots.map((l) => l.name);
         if (!packLotLinesToEdit.length && existingLotsName.length === 1) {
-            if (existingLots[0].expiration_date) {
-                this.showNotificationIfLotExpired(
-                    existingLots[0].name,
-                    existingLots[0].expiration_date
-                );
-            }
             // If there's only one existing lot/serial number, automatically assign it to the order line
-            return { newPackLotLines: [{ lot_name: existingLotsName[0] }] };
+            return { newPackLotLines: [{ lot_name: existingLotsName[0], lot: existingLots[0] }] };
         }
         const payload = await makeAwaitable(this.dialog, SelectLotPopup, {
             title: _t("Lot/Serial number(s) required for"),
@@ -2423,12 +2411,6 @@ export class PosStore extends WithLazyGetterTrap {
             isLotNameUsed: isLotNameUsed,
         });
         if (payload) {
-            for (const item of payload) {
-                if (!item.expiration_date) {
-                    continue;
-                }
-                this.showNotificationIfLotExpired(item.text, item.expiration_date);
-            }
             // Segregate the old and new packlot lines
             const modifiedPackLotLines = Object.fromEntries(
                 payload.filter((item) => item.id).map((item) => [item.id, item.text])
@@ -2437,7 +2419,7 @@ export class PosStore extends WithLazyGetterTrap {
                 .filter((item) => !item.id)
                 .map((item) => ({ lot_name: item.text }));
 
-            return { modifiedPackLotLines, newPackLotLines };
+            return { modifiedPackLotLines, newPackLotLines, payload };
         } else {
             return null;
         }

--- a/addons/pos_product_expiry/__init__.py
+++ b/addons/pos_product_expiry/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/pos_product_expiry/__manifest__.py
+++ b/addons/pos_product_expiry/__manifest__.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "POS - Product Expiry",
+    'category': "Technical",
+    'summary': 'Link module between Point of Sale and Product Expiry',
+    'depends': ['point_of_sale', 'product_expiry'],
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_product_expiry/static/src/app/services/*.js',
+        ],
+    },
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/pos_product_expiry/models/__init__.py
+++ b/addons/pos_product_expiry/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_order_line

--- a/addons/pos_product_expiry/models/pos_order_line.py
+++ b/addons/pos_product_expiry/models/pos_order_line.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class PosOrderLine(models.Model):
+    _inherit = "pos.order.line"
+
+    @api.model
+    def get_existing_lots(self, company_id, config_id, product_id):
+        result = super().get_existing_lots(company_id, config_id, product_id)
+        for lot in result:
+            lot_id = lot.get('id')
+            lot_recordset = self.env['stock.lot'].browse(lot_id)
+            lot['expiration_date'] = lot_recordset.expiration_date
+        return result

--- a/addons/pos_product_expiry/static/src/app/services/pos_store.js
+++ b/addons/pos_product_expiry/static/src/app/services/pos_store.js
@@ -1,0 +1,39 @@
+import { _t } from "@web/core/l10n/translation";
+import { deserializeDateTime } from "@web/core/l10n/dates";
+import { patch } from "@web/core/utils/patch";
+import { PosStore } from "@point_of_sale/app/services/pos_store";
+
+const { DateTime } = luxon;
+
+patch(PosStore.prototype, {
+    showNotificationIfLotExpired(lotName, lotExpDate = null) {
+        if (!lotExpDate) {
+            return;
+        }
+        const lotExpDateTime = deserializeDateTime(lotExpDate);
+        if (lotExpDateTime?.isValid && lotExpDateTime.ts <= DateTime.now().ts) {
+            this.notification.add(_t("Lot/Serial %s is expired", lotName));
+        }
+    },
+
+    async editLots(product, packLotLinesToEdit) {
+        const result = await super.editLots(product, packLotLinesToEdit);
+        if (!result) {
+            return result;
+        }
+
+        if (result?.newPackLotLines && result.newPackLotLines[0]?.lot) {
+            const existingLot = result.newPackLotLines[0].lot;
+            this.showNotificationIfLotExpired(existingLot.name, existingLot?.expiration_date);
+        } else if (result?.modifiedPackLotLines && result?.newPackLotLines && result?.payload) {
+            for (const item of result.payload) {
+                if (!item.item.expiration_date) {
+                    continue;
+                }
+                this.showNotificationIfLotExpired(item.text, item.item.expiration_date);
+            }
+        }
+
+        return result;
+    },
+});

--- a/addons/pos_product_expiry/static/src/app/services/select_lot_popup.js
+++ b/addons/pos_product_expiry/static/src/app/services/select_lot_popup.js
@@ -1,0 +1,23 @@
+import { patch } from "@web/core/utils/patch";
+import { SelectLotPopup } from "@point_of_sale/app/components/popups/select_lot_popup/select_lot_popup";
+
+patch(SelectLotPopup.prototype, {
+    _getOnSelectVals(option) {
+        return {
+            ...super._getOnSelectVals(option),
+            expiration_date: option.expiration_date,
+        };
+    },
+
+    onSelect(lot) {
+        super.onSelect(lot);
+        // if the new lot is being created - not need to add expiration_date
+        if (lot?.currentInput) {
+            return;
+        }
+        const updateItem = this.state.values && this.state.values[this.state.values.length - 1];
+        if (updateItem && updateItem.text === lot.label) {
+            updateItem.expiration_date = lot.expiration_date;
+        }
+    },
+});


### PR DESCRIPTION
Installing POS with Lots & Serial Numbers enabled raises an error when selecting a product that uses lots.

**Steps to Reproduce:**
- Install POS (with demo data).
- Activate "Lots & Serial Numbers".
- Open Furniture Shop > Select "Drawer".

**Error:**
`AttributeError - 'stock.lot' object has no attribute 'expiration_date'`

**Cause:**
The POS module directly accesses `expiration_date` on `stock.lot`, but this field is defined in the `product_expiry` module.

**Fix:**
This commit adds a bridge module between `point_of_sale` and `product_expiry`. And update the result, only when the expiry feature is enabled.

Upgrade PR: https://github.com/odoo/upgrade/pull/9321

sentry-7203789966