### PR TITLE
[FIX] html_editor: Force selection update on group qweb branching

### DIFF
--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -236,6 +236,11 @@ export class QWebPlugin extends Plugin {
         this.selectedNode = node;
         this.picker.close();
         this.selectNode(node);
+        // Force Chrome to clear the selection.
+        // Without this, Chrome's optimization may skip the 'selectionchange' event
+        // if the new node is structurally identical to the previous one
+        const selection = this.document.getSelection();
+        selection.removeAllRanges();
     }
 
     clearDataAttributes(root) {


### PR DESCRIPTION
This happens only on Chrome, when switching between two identical t-if/else
structures.

In Odoo's t-if/t-else structures, Chromium may fail to properly update
the selection when switching between two structurally identical elements
via the group switcher.

This happens because Chrome's implementation of the [Selection API](https://www.w3.org/TR/selection-api/#selectionchange-event)
contains an optimization that suppresses the 'selectionchange' event if the
new Range has the same logical coordinates (Node type and Offset) as the
previous one, even if the underlying DOM node reference has changed.

This can break editor commands such as `/table` or `/field` like in the
following steps:

Steps:
- Install `sale_management` and `web_studio`
- Open report editor on PDF Quote
- Add a new column to the left in the table
- Click on the table body
- Select `t-else` in the group switcher
- Click again at the same place
- (Here the selection is not correctly set by chromium)
- Try to use `/field` to add a field
- It will not work as field selector doesn't have the right selection
You can use this [video](https://drive.google.com/file/d/1ua7nlla7km1_l-wqgL8zeHaM-tFLA9jJ/view) to reproduce it easily 
or you reproduce it [here](https://stackblitz.com/edit/javascript-v65edaq5?file=index.html,index.js)
If you click after the “1” and then after the “2,” you will see that
Chromium does not fire the selectionchange event, whereas Firefox does.

This commit fixes this by adding a "removeAllRanges()" to force Chrome to
"forget" the old range. This ensures that the next selection is correctly
treated.

opw-5219989