### PR TITLE
[IMP] hr_holiday: use Luxon method

### DIFF
--- a/addons/hr_holidays/static/src/res_partner_model_patch.js
+++ b/addons/hr_holidays/static/src/res_partner_model_patch.js
@@ -9,7 +9,7 @@ const { DateTime } = luxon;
 export function getOutOfOfficeDateEndText(datetime) {
     const foptions = { ...DateTime.DATE_MED };
     const dt = typeof datetime === "string" ? deserializeDateTime(datetime) : datetime;
-    if (dt.year === DateTime.now().year) {
+    if (DateTime.now().hasSame(dt, "year")) {
         foptions.year = undefined;
     }
     const fdate = dt.toLocaleString(foptions);


### PR DESCRIPTION
This commit uses the Luxon method `hasSame` to compare `DateTime` years.