### PR TITLE
[FIX] product: fix product_variant pricelist rule without product_tmpl_id

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -431,7 +431,9 @@ class ProductPricelistItem(models.Model):
     def _onchange_rule_content(self):
         if not self.env.context.get('default_applied_on', False):
             # If we aren't coming from a specific product template/variant.
-            variants_rules = self.filtered('product_id')
+            variants_rules = self.filtered(
+                lambda r: bool(r.product_id) and bool(r.product_tmpl_id)
+            )
             template_rules = (self-variants_rules).filtered('product_tmpl_id')
             category_rules = self.filtered(
                 lambda cat: bool(cat.categ_id) and cat.categ_id.name != 'All'


### PR DESCRIPTION
Steps:
- Create a price list (or existing one)
- Create (or find) a product with only one variant
- Add price list rule for that variant (Should show as Variant:... in Pricelist listing)
- Go to the pricelist listing, select the pricelist
- Edit price list rule - Remove the product
- Save and check the data (applied_on, product_id, product_tmpl_id) (applied_on still 0_product_variant, product_id, and NO product_tmpl_id)

(Video: https://drive.google.com/file/d/1xmg9A9NgavFQkIFkUZrzuAxVF-PNqdnL/view)

Description of the issue/feature this PR addresses:
Fix corrupted data
<img width="583" height="108" alt="image" src="https://github.com/user-attachments/assets/db5e9f27-d004-4bce-875f-0512fba193d9" />

Current behavior before PR:
product_tmpl_id set to None
product_id / applied_on data stays the same

Desired behavior after PR is merged:
When product_tmpl_id is removed, reset the applied_on type back to 3_global

Reference:
opw-5411034

Affected: 18.0, 19.0, 19.1

Confirmed with Pricelist's PO: BOJE


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
