### PR TITLE
[FIX] mail: show explicit error of fetch message in message list

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -30,6 +30,10 @@
     font-size: smaller;
 }
 
+.o-xsmaller {
+    font-size: 0.65rem;
+}
+
 .o-text-white {
     color: #FFF;
 }

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -113,6 +113,7 @@
         <div class="o-mail-Thread-error">
             An error occurred while fetching messages.
         </div>
+        <span t-if="props.thread.hasLoadingFailedError" class="o-xsmaller text-muted" t-esc="props.thread.hasLoadingFailedError"/>
         <button class="btn btn-link" t-on-click="onClickLoadOlder">
             Click here to retry
         </button>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -306,6 +306,8 @@ export class Thread extends Record {
     /** @type {SuggestedRecipient[]} */
     suggestedRecipients = [];
     hasLoadingFailed = false;
+    /** @type {Error} */
+    hasLoadingFailedError;
     canPostOnReadonly;
     /** @type {String} */
     last_interest_dt;

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -198,9 +198,11 @@ export class ThreadService {
             const messages = this.store.Message.insert(rawMessages.reverse(), { html: true });
             thread.isLoaded = true;
             thread.hasLoadingFailed = false;
+            thread.hasLoadingFailedError = undefined;
             return messages;
         } catch (e) {
             thread.hasLoadingFailed = true;
+            thread.hasLoadingFailedError = e;
             throw e;
         } finally {
             thread.status = "ready";


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/244094

Before this commit, when message list failed to load, it just displays a "Ann error occurred" generic message with a retry button.

This assumes that error happens rarely and when so this is temporarily. However some errors are persistent and it's frustrating to have no clue on why there's error or what may have caused it.

This commit shows the `Error.toString()` from fetch message RPC failure on UI, so that there's a clue on the reason the fetch of messages failed.

Before / After
<img width="305" height="67" alt="Screenshot 2026-01-20 at 15 10 38" src="https://github.com/user-attachments/assets/34c546df-71e6-4055-9f85-8d85a9c89b35" /> <img width="334" height="100" alt="Screenshot 2026-01-20 at 15 09 07" src="https://github.com/user-attachments/assets/5fadd0b7-7ea0-43ca-8c28-0ac1d33650ff" />
