### PR TITLE
[FIX] iot_box_builder: fix geoip2 dependency

### DIFF
--- a/setup/iot_box_builder/configuration/packages.txt
+++ b/setup/iot_box_builder/configuration/packages.txt
@@ -25,6 +25,7 @@ python3-dbus
 python3-decorator
 python3-docutils
 python3-evdev
+python3-geoip2
 python3-jinja2
 python3-libcamera
 python3-lxml-html-clean


### PR DESCRIPTION
This PR adds geoip2 to packages required by the iot box in saas-19.2 Without geoip2 odoo doesn't start on the iot box

Backport of https://github.com/odoo/odoo/pull/243751 to allow to use saas-19.1 images with dbs in master
