### PR TITLE
[REV] delivery: revert the commit 6901863

### DIFF
--- a/addons/delivery/tests/test_delivery_availability.py
+++ b/addons/delivery/tests/test_delivery_availability.py
@@ -194,16 +194,3 @@ class TestDeliveryAvailability(DeliveryCommon, SaleCommon):
         }))
         choose_delivery_carrier = delivery_wizard.save()
         self.assertFalse(self.carrier.id in choose_delivery_carrier.available_carrier_ids.ids, "Carrier excluded tag is set on one product in the order")
-
-    def test_partner_carrier_is_set_in_wizard(self):
-        """Test that the partner's default delivery carrier is correctly preselected in the delivery wizard."""
-        self.sale_order.partner_id.property_delivery_carrier_id = self.carrier
-        delivery_wizard = Form(self.env['choose.delivery.carrier'].with_context({
-            'default_order_id': self.sale_order.id,
-        }))
-        choose_delivery_carrier = delivery_wizard.save()
-        self.assertIn(
-            self.carrier,
-            choose_delivery_carrier.carrier_id,
-            "Delivery carrier set on the partner should be set in the delivery wizard",
-        )


### PR DESCRIPTION
Bug introdcued in: https://github.com/odoo/odoo/commit/6901863d30f524c160971c9f5c97846ffd1fa5f5

The fix was misleading because forcing the context in the unit test caused incorrect assumptions. Passing `default_carrier_id` in the context prevents the computed method from being called, breaking expected behavior.

This revert restores the previous behavior as the fix is incorrect. The issue will be resolved in another PR.