### PR TITLE
[FIX] mail: invite user dialog content should take whole width

### DIFF
--- a/addons/mail/static/src/discuss/core/common/action_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/action_panel.scss
@@ -2,7 +2,7 @@
     --form-check-bg: #{$white};
 }
 
-.o-mail-ActionPanel:not(.o-mail-ActionPanel-chatter):not(.o-chatWindow) {
+.o-mail-ActionPanel.o_resizable_panel {
     @media (min-width: 750px) {
         max-width: 30vw;
     }


### PR DESCRIPTION
Before this commit, the channel invitation dialog had its content not taking the whole width of modal.

Steps to reproduce:
- Have window take about half size of a 1080p monitor
- Open "General" in discuss app
- Open the Member list
- Click on "Invite a User" => Invitation dialog takes about half of the width of modal.

This happens because the channel invitation was wrongly assumed to be inside a resizable panel, and thus the size was limited by the max width when in resizable panel.

The rule to determine whether the action is in a resizable panel was poor: any action panel in discuss app was considered as resizable.

This commit fixes the issue by limiting the responsive sizing, intended only for resizable panel, only when the action panel has the `.o_resizable_panel`, which is specific to when action panel is being used inside resizable panel.

Task-5804100

Before / After
<img width="625" height="231" alt="Screenshot 2026-01-20 at 16 12 31" src="https://github.com/user-attachments/assets/10c02939-c4c1-47fa-82f8-4d8d037d3f0c" /> <img width="621" height="231" alt="Screenshot 2026-01-20 at 16 12 18" src="https://github.com/user-attachments/assets/eec1447c-cb42-4751-b17a-ff7b2e70b8e9" />
