### PR TITLE
[FIX] HOOT selection change on keydown helpers + mock model sort

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/events.js
+++ b/addons/web/static/lib/hoot-dom/helpers/events.js
@@ -1400,14 +1400,25 @@ async function _keyDown(target, eventInit) {
                 if (isNil(selectionStart) || isNil(selectionEnd)) {
                     break;
                 }
-                const start = key === "ArrowLeft" || key === "ArrowUp";
                 let selectionTarget;
-                if (ctrlKey) {
-                    // Move to the start/end of the line
-                    selectionTarget = start ? 0 : value.length;
+                if (key === "ArrowUp" || (ctrlKey && key === "ArrowLeft")) {
+                    // Move to the beginning.
+                    // Note that this wrong in multiple situations:
+                    // - ArrowUp in textarea is only correct if on first line.
+                    // - CTRL+ArrowLeft is only correct if no whitespace in all
+                    //   the chars before.
+                    selectionTarget = 0;
+                } else if (key === "ArrowDown" || (ctrlKey && key === "ArrowRight")) {
+                    // Move to the end.
+                    // Note that this wrong in multiple situations:
+                    // - ArrowDown in textarea is only correct if on last line.
+                    // - CTRL+ArrowRight is only correct if no whitespace in all
+                    //   the chars after.
+                    selectionTarget = value.length;
+                } else if (key === "ArrowLeft") {
+                    selectionTarget = selectionStart - 1;
                 } else {
-                    // Move the cursor left or right
-                    selectionTarget = start ? selectionStart - 1 : selectionEnd + 1;
+                    selectionTarget = selectionEnd + 1;
                 }
                 nextSelectionStart = nextSelectionEnd = $max(
                     $min(selectionTarget, value.length),

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -771,7 +771,9 @@ function orderByField(model, orderBy, records) {
             }
         }
         let result;
-        if (v1 === false) {
+        if (v1 === v2) {
+            result = 0;
+        } else if (v1 === false) {
             result = 1;
         } else if (v2 === false) {
             result = -1;
@@ -783,7 +785,7 @@ function orderByField(model, orderBy, records) {
                     }": values must be of the same primitive type (got ${typeof v1} and ${typeof v2})`
                 );
             }
-            result = v1 > v2 ? 1 : v1 < v2 ? -1 : 0;
+            result = v1 > v2 ? 1 : -1;
         }
         return direction === "DESC" ? -result : result;
     });


### PR DESCRIPTION
 [FIX] web: make mock model field sort browser-independent
    
    The sorting done by `orderByField` for mock models was incorrect: when
    two values were empty and compared: the old comparator returned 1 when
    v1 === false, even if v2 === false too. That makes the comparator
    inconsistent (as it basically says "a > b" and "b > a"), so Array.sort
    is free to reorder differently per engine.
    
    This was discovered while making a unit test where it was actually
    working on Chrome and not on Firefox because of that (and switching
    some contact records creation order would make it work on Firefox and
    not on Chrome).

[IMP] web: review press/keydown HOOT helpers regarding selection changes
    
    Commit [1] made it so HOOT keydown helper somewhat handles selection
    changes in input and textarea when pressing arrow keys.
    It assumed that:
    - "up" and "left" have the exact same behavior: going left 1 character
      or to the start if the CTRL key is held.
    - "right" and "down" have the exact same behavior: going right 1
      character or to the end if the CTRL key is held.
    
    The logic is really wrong or at least very incomplete. The minimal
    behavior is:
    - "left" goes 1 character left; if the CTRL key is held, it jumps to the
      previous word.
    - "right" goes 1 character right; if the CTRL key is held, it jumps to
      the next word.
    - "up" goes to the start of the line (independently from the CTRL key).
    - "down" goes to the end of the line (independently from the CTRL key).
    
    This commit implements something in between: the correct behavior,
    without the notion of lines and words, limiting the helper behavior
    change and the line of code added:
    - "left" goes 1 character left; if the CTRL key is held, it jumps to the
      start.
    - "right" goes 1 character right; if the CTRL key is held, it jumps to
      the end.
    - "up" goes to the start (independently from the CTRL key).
    - "down" goes to the end (independently from the CTRL key).
    
    Meaning those limitations:
    - "CTRL+left" is only correct if no whitespace in all the chars before.
    - "CTRL+right" is only correct if no whitespace in all the chars after.
    - "up" in textarea is only correct if on first line.
    - "down" in textarea is only correct if on last line.
    
    [1]: https://github.com/odoo/odoo/commit/ab7d02f49182845e48b31e331d3ccad8d2f36560
    
Related to task-5441808