### PR TITLE
[FIX] mail: channel member actions are hard to find

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member.js
@@ -1,12 +1,16 @@
 import { ImStatus } from "@mail/core/common/im_status";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
+import { useChannelMemberActions } from "@mail/discuss/core/common/channel_member_actions";
 
 import { Component, useState } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 
 import { useService } from "@web/core/utils/hooks";
+import { ActionList } from "@mail/core/common/action_list";
 
 export class ChannelMember extends Component {
-    static components = { ImStatus, ActionPanel };
+    static components = { ActionList, ActionPanel, Dropdown, ImStatus };
     static props = ["member"];
     static template = "discuss.ChannelMember";
 
@@ -14,6 +18,8 @@ export class ChannelMember extends Component {
         super.setup();
         this.state = useState({});
         this.store = useService("mail.store");
+        this.actions = useChannelMemberActions({ member: () => this.props.member });
+        this.showingActions = useDropdownState();
     }
 
     /** @return {import("models").ChannelMember} */

--- a/addons/mail/static/src/discuss/core/common/channel_member.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member.scss
@@ -12,10 +12,9 @@
         &:not(:has(.o-discuss-ChannelMember-actions:hover)) {
             background-color: var(--discuss-ChannelMember-hoverBg, mix($gray-100, $gray-200));
         }
-
-        .o-discuss-ChannelMember-actions {
-            display: flex !important;
-        }
+    }
+    &:hover .o-discuss-ChannelMember-actions {
+        display: flex !important;
     }
 }
 

--- a/addons/mail/static/src/discuss/core/common/channel_member.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member.scss
@@ -9,7 +9,23 @@
     }
 
     &.cursor-pointer:hover, &.o-active {
-        background-color: var(--discuss-ChannelMember-hoverBg, mix($gray-100, $gray-200));
+        &:not(:has(.o-discuss-ChannelMember-actions:hover)) {
+            background-color: var(--discuss-ChannelMember-hoverBg, mix($gray-100, $gray-200));
+        }
+
+        .o-discuss-ChannelMember-actions {
+            display: flex !important;
+        }
+    }
+}
+
+.o-discuss-ChannelMember-actions button {
+    aspect-ratio: 1;
+
+
+    &:hover, &:active, &:focus-visible, &.o-showingActions {
+        --border-opacity: 1;
+        --border-color: #{rgba($o-action, var(--o-mail-DiscussSidebar-borderOpacity, 1))};
     }
 }
 

--- a/addons/mail/static/src/discuss/core/common/channel_member.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member.xml
@@ -17,6 +17,19 @@
                 <span t-elif="member.rtcSession?.is_deaf" class="p-1 fa fa-deaf opacity-75"/>
                 <span t-if="member.rtcSession?.raisingHand" class="p-1 fa fa-hand-paper-o"/>
             </span>
+            <div class="o-discuss-ChannelMember-actions" t-att-class="{
+                'd-none': !showingActions.isOpen and !store.useMobileView,
+                'd-flex': showingActions.isOpen or store.useMobileView,
+            }">
+                <Dropdown state="showingActions" position="'bottom-end'" menuClass="'my-1 ' + store.discussDropdownMenuClass(this)">
+                    <button class="btn btn-light rounded-circle d-flex o-p-0_5 align-items-center justify-content-center o-mail-discussSidebarBgColor border" t-att-class="{ 'o-showingActions': showingActions.isOpen }" title="Member Actions">
+                        <i role="img" class="oi oi-fw oi-lg oi-ellipsis-h"/>
+                    </button>
+                    <t t-set-slot="content">
+                        <ActionList actions="actions.actions" dropdown="true"/>
+                    </t>
+                </Dropdown>
+            </div>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/common/channel_member_actions.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_actions.js
@@ -1,0 +1,101 @@
+import { registry } from "@web/core/registry";
+import { Action, ACTION_TAGS, useAction, UseActions } from "@mail/core/common/action";
+import { _t } from "@web/core/l10n/translation";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { rpc } from "@web/core/network/rpc";
+
+export const channelMemberActionsRegistry = registry.category("discuss.channel.member/actions");
+
+/** @typedef {import("@odoo/owl").Component} Component */
+/** @typedef {import("@mail/core/common/action").ActionDefinition} ActionDefinition */
+/** @typedef {import("models").ChannelMember} ChannelMember */
+
+/**
+ * @typedef {ActionDefinition} ChannelActionDefinition
+ */
+
+/**
+ * @param {string} id
+ * @param {ChannelActionDefinition} definition
+ */
+export function registerChannelMemberAction(id, definition) {
+    channelMemberActionsRegistry.add(id, definition);
+}
+
+registerChannelMemberAction("set-admin", {
+    condition: ({ member }) => member.canSetAdmin,
+    icon: "fa fa-star text-primary",
+    name: _t("Set Admin"),
+    onSelected: ({ member }) => member.setChannelRole("admin"),
+    sequence: 10,
+});
+
+registerChannelMemberAction("remove-admin", {
+    condition: ({ member }) => member.canRemoveAdmin || member.canRemoveOwner,
+    icon: ({ member }) =>
+        member.canRemoveOwner ? "fa fa-star-o text-primary" : "fa fa-star-o text-warning",
+    name: ({ member }) => (member.canRemoveOwner ? _t("Remove Owner") : _t("Remove Admin")),
+    onSelected: ({ member }) => member.setChannelRole(false),
+    sequence: 20,
+});
+
+registerChannelMemberAction("set-owner", {
+    condition: ({ member }) => member.canSetOwner,
+    icon: "fa fa-star text-warning",
+    name: _t("Set Owner"),
+    onSelected: ({ member }) => member.setChannelRole("owner"),
+    sequence: 30,
+});
+
+registerChannelMemberAction("remove-member", {
+    condition: ({ member }) => member.canRemoveMember,
+    icon: "fa fa-sign-out",
+    name: _t("Remove Member"),
+    onSelected: ({ member, store }) => {
+        store.env.services.dialog.add(ConfirmationDialog, {
+            body: _t('Do you want to remove "%(member_name)s" from this channel?', {
+                member_name: member.name,
+            }),
+            cancel: () => {},
+            confirm: () => {
+                rpc("/discuss/channel/remove_member", {
+                    member_id: member.id,
+                });
+            },
+        });
+    },
+    sequence: 40,
+    tags: [ACTION_TAGS.DANGER],
+});
+
+export class ChannelMemberAction extends Action {
+    /** @type {() => ChannelMember} */
+    memberFn;
+
+    /**
+     * @param {Object} param0
+     * @param {Thread|() => ChannelMember} member
+     */
+    constructor({ member }) {
+        super(...arguments);
+        this.memberFn = typeof member === "function" ? member : () => member;
+    }
+
+    get params() {
+        return Object.assign(super.params, { member: this.memberFn() });
+    }
+}
+
+class UseChannelMemberActions extends UseActions {
+    ActionClass = ChannelMemberAction;
+}
+
+/**
+ * @param {Object} [params0={}]
+ * @param {ChannelMember|() => ChannelMember} member
+ */
+export function useChannelMemberActions({ member } = {}) {
+    return useAction(channelMemberActionsRegistry, UseChannelMemberActions, ChannelMemberAction, {
+        member,
+    });
+}

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -5,6 +5,8 @@ import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { user } from "@web/core/user";
 import { rpc } from "@web/core/network/rpc";
+import { _t } from "@web/core/l10n/translation";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 const { DateTime } = luxon;
 
@@ -124,6 +126,42 @@ export class ChannelMember extends Record {
     typingTimeoutId;
     unpin_dt = fields.Datetime();
 
+    get canRemoveAdmin() {
+        return (
+            this.channel_role === "admin" &&
+            (this.store.self_user?.is_admin || this.selfChannelRole === "owner")
+        );
+    }
+
+    get canRemoveMember() {
+        return (
+            this.store.self_user?.is_admin ||
+            (this.selfChannelRole && this.channel_role !== "owner")
+        );
+    }
+
+    get canRemoveOwner() {
+        return (
+            this.channel_role === "owner" && (this.store.self_user?.is_admin || this.threadAsSelf)
+        );
+    }
+
+    get canSetAdmin() {
+        return (
+            this.channel_role !== "admin" &&
+            (this.store.self_user?.is_admin ||
+                (this.channel_role === "owner" && this.channel_role !== "owner") ||
+                (this.channel_role === "owner" && this.threadAsSelf))
+        );
+    }
+
+    get canSetOwner() {
+        return (
+            this.channel_role !== "owner" &&
+            (this.store.self_user?.is_admin || this.selfChannelRole === "owner")
+        );
+    }
+
     get name() {
         if (this.guest_id) {
             return this.guest_id.name;
@@ -168,7 +206,32 @@ export class ChannelMember extends Record {
             : undefined;
     }
 
-    async setChannelRole(channel_role) {
+    get selfChannelRole() {
+        return this.channel_id?.self_member_id?.channel_role;
+    }
+
+    /** @param {string} role */
+    setChannelRole(role) {
+        if (!this.store.self_user?.is_admin && (this.threadAsSelf || role === "owner")) {
+            this.store.env.services.dialog.add(ConfirmationDialog, {
+                body: this.threadAsSelf
+                    ? _t(
+                          "Do you want to remove owner from yourself? You will no longer have full control over the channel and its settings."
+                      )
+                    : _t(
+                          'Do you want to set "%(member_name)s" as the owner? This means that the member will have full control over the channel and its settings.\n\nThis action cannot be reverted.',
+                          { member_name: this.name }
+                      ),
+                cancel: () => {},
+                confirm: () => this.setChannelRoleRpc(role),
+            });
+        } else {
+            this.setChannelRoleRpc(role);
+        }
+    }
+
+    /** @param {string} role */
+    async setChannelRoleRpc(channel_role) {
         await rpc("/discuss/channel/member/set_role", {
             member_id: this.id,
             channel_role,

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -148,6 +148,7 @@ export class ChannelMember extends Record {
 
     get canSetAdmin() {
         return (
+            this.partner_id &&
             this.channel_role !== "admin" &&
             (this.store.self_user?.is_admin ||
                 (this.channel_role === "owner" && this.channel_role !== "owner") ||
@@ -157,6 +158,7 @@ export class ChannelMember extends Record {
 
     get canSetOwner() {
         return (
+            this.partner_id &&
             this.channel_role !== "owner" &&
             (this.store.self_user?.is_admin || this.selfChannelRole === "owner")
         );

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -22,19 +22,7 @@
                                     <i class="oi oi-ellipsis-v"/>
                                 </button>
                                 <t t-set-slot="content">
-                                    <DropdownItem t-if="canSetAdmin" onSelected="() => this.setChannelRole('admin')">
-                                        Set Channel Admin
-                                    </DropdownItem>
-                                    <DropdownItem t-if="canRemoveAdmin or canRemoveOwner" onSelected="() => this.setChannelRole(false)">
-                                        <t t-if="canRemoveOwner">Remove Channel Owner</t>
-                                        <t t-if="canRemoveAdmin">Remove Channel Admin</t>
-                                    </DropdownItem>
-                                    <DropdownItem t-if="canSetOwner" onSelected="() => this.setChannelRole('owner')">
-                                        Set Channel Owner
-                                    </DropdownItem>
-                                    <DropdownItem t-if="canRemoveMember" onSelected.bind="onClickRemove">
-                                        <span class="text-danger">Remove from Channel</span>
-                                    </DropdownItem>
+                                    <ActionList actions="chanelMemberActions.actions" dropdown="true"/>
                                 </t>
                             </Dropdown>
                         </div>

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -299,3 +299,49 @@ test("Members are partitioned by online/offline", async () => {
         after: ["h6:text('Offline - 1')"],
     });
 });
+
+test("Shows owner / admin in members panel + member actions", async () => {
+    const pyEnv = await startServer();
+    const [demoPid, johnPid] = pyEnv["res.partner"].create([{ name: "Demo" }, { name: "John" }]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, channel_role: "owner" }),
+            Command.create({ partner_id: demoPid, channel_role: "admin" }),
+            Command.create({ partner_id: johnPid }),
+        ],
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMember", { count: 3 });
+    await contains(
+        ".o-discuss-ChannelMember:text('" +
+            serverState.partnerName +
+            "') .fa-star.text-warning[title='Channel Owner']"
+    );
+    await contains(
+        ".o-discuss-ChannelMember:text('Demo') .fa-star.text-primary[title='Channel Admin']"
+    );
+    await click(
+        ".o-discuss-ChannelMember:text('" + serverState.partnerName + "') [title='Member Actions']"
+    );
+    await contains(".o-dropdown-item", { count: 3 });
+    await contains(".o-dropdown-item:eq(0):has(:text(Set Admin))");
+    await contains(".o-dropdown-item:eq(1):has(:text(Remove Owner))");
+    await contains(".o-dropdown-item:eq(2):has(:text(Remove Member))");
+    await click(".o-mail-Thread");
+    await contains(".o-dropdown-item", { count: 0 });
+    await click(".o-discuss-ChannelMember:text('Demo') [title='Member Actions']");
+    await contains(".o-dropdown-item", { count: 3 });
+    await contains(".o-dropdown-item:eq(0):has(:text(Remove Admin))");
+    await contains(".o-dropdown-item:eq(1):has(:text(Set Owner))");
+    await contains(".o-dropdown-item:eq(2):has(:text(Remove Member))");
+    await click(".o-mail-Thread");
+    await contains(".o-dropdown-item", { count: 0 });
+    await click(".o-discuss-ChannelMember:text('John') [title='Member Actions']");
+    await contains(".o-dropdown-item", { count: 3 });
+    await contains(".o-dropdown-item:eq(0):has(:text(Set Admin))");
+    await contains(".o-dropdown-item:eq(1):has(:text(Set Owner))");
+    await contains(".o-dropdown-item:eq(2):has(:text(Remove Member))");
+});

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -303,18 +303,24 @@ test("Members are partitioned by online/offline", async () => {
 test("Shows owner / admin in members panel + member actions", async () => {
     const pyEnv = await startServer();
     const [demoPid, johnPid] = pyEnv["res.partner"].create([{ name: "Demo" }, { name: "John" }]);
+    const marioGid = pyEnv["mail.guest"].create({ name: "Mario" });
     const channelId = pyEnv["discuss.channel"].create({
         name: "TestChannel",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, channel_role: "owner" }),
             Command.create({ partner_id: demoPid, channel_role: "admin" }),
             Command.create({ partner_id: johnPid }),
+            Command.create({ guest_id: marioGid }),
         ],
         channel_type: "channel",
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-discuss-ChannelMember", { count: 3 });
+    await contains(".o-discuss-ChannelMember", { count: 4 });
+    await contains(`.o-discuss-ChannelMember:has(:text(${serverState.partnerName}))`);
+    await contains(".o-discuss-ChannelMember:has(:text(Demo))");
+    await contains(".o-discuss-ChannelMember:has(:text(John))");
+    await contains(".o-discuss-ChannelMember:has(:text(Mario))");
     await contains(
         ".o-discuss-ChannelMember:text('" +
             serverState.partnerName +
@@ -344,4 +350,7 @@ test("Shows owner / admin in members panel + member actions", async () => {
     await contains(".o-dropdown-item:eq(0):has(:text(Set Admin))");
     await contains(".o-dropdown-item:eq(1):has(:text(Set Owner))");
     await contains(".o-dropdown-item:eq(2):has(:text(Remove Member))");
+    await click(".o-discuss-ChannelMember:text('Mario') [title='Member Actions']");
+    await contains(".o-dropdown-item", { count: 1 });
+    await contains(".o-dropdown-item:has(:text(Remove Member))");
 });

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -209,6 +209,7 @@ export class DiscussChannelMember extends models.ServerModel {
     get _to_store_defaults() {
         return [
             "channel_id",
+            "channel_role",
             "create_date",
             "fetched_message_id",
             "seen_message_id",


### PR DESCRIPTION
Before this commit, the channel member actions were hard to find:
- Click on Members panel.
- Click on Member to open popover card.
- Click on "..." in top-right corner of card.

This is hard because only this avatar card from this menu has the "..." button, and the actions are hidden in this menu. This is easy to miss since avatar cards in message list or other places don't have this "...", and since the actions are hidden there many people could easily miss these actions.

This commit improves the visibility of action by their showing as a "..." on the member item on hover in the "Members" panel. This works like the "..." button in the discuss left sidebar, where the button is shown on mouse-hover. Mobile view (small or mobile device) shows the button all the time next to member, making the discoverability of the action very clear.

Task-5871730

Before / After
<img width="589" height="385" alt="Screenshot 2026-01-23 at 14 45 17" src="https://github.com/user-attachments/assets/bca66975-13cd-423a-a43d-9eb2be03741a" />
<img width="249" height="270" alt="Screenshot 2026-01-26 at 11 56 09" src="https://github.com/user-attachments/assets/edfe34c9-6b4c-4394-b532-7f79f9653b4a" />


----

This PR also makes channel member actions available in guest items, so we can now "Remove Member" on guests too.

<img width="252" height="296" alt="Screenshot 2026-01-27 at 18 25 54" src="https://github.com/user-attachments/assets/ee4b1271-0529-4e96-bda1-e621d7592555" />
