### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: migrate last fetched dates to fields

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/res_company.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/res_company.py
@@ -1,9 +1,20 @@
+from dateutil.relativedelta import relativedelta
+
 from odoo import fields, models
 
 
 class ResCompany(models.Model):
     _inherit = "res.company"
 
+    l10n_tr_earchive_sale_last_fetched_date = fields.Datetime(
+        default=lambda s: fields.Datetime.now() - relativedelta(months=1)
+    )
+    l10n_tr_einvoice_sale_last_fetched_date = fields.Datetime(
+        default=lambda s: fields.Datetime.now() - relativedelta(months=1)
+    )
+    l10n_tr_einvoice_purchase_last_fetched_date = fields.Datetime(
+        default=lambda s: fields.Datetime.now() - relativedelta(months=1)
+    )
     l10n_tr_tax_office_id = fields.Many2one(related="partner_id.l10n_tr_tax_office_id", readonly=False)
     l10n_tr_nilvera_export_alias = fields.Char(
         string="Nilvera Export Alias",


### PR DESCRIPTION
To store the last fetched date in stable to allow for synchronization, config parameters were used. In master, these are now replaced with dedicated fields on the company model for better performance and easier maintenance.

This commit adds dedicated fields on res.company for einvoice and earchive dates.

task-5865683

Upgrade PR: https://github.com/odoo/upgrade/pull/9315