### PR TITLE
[FIX] stock: rely on forecast availability for forecast report icon

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -331,9 +331,9 @@
                                             role="img" title="Assign Serial Numbers"
                                             invisible="not display_assign_serial"/>
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart"
-                                        invisible="quantity == 0 and forecast_availability &lt;= 0 or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
+                                        invisible="forecast_availability &lt;= 0 or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
                                     <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart text-danger"
-                                        invisible="quantity &gt; 0 or forecast_availability &gt; 0 or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
+                                        invisible="forecast_availability &gt; 0 or (parent.picking_type_code == 'outgoing' and state != 'draft')"/>
                                 </tree>
                             </field>
                             <field name="id" invisible="1"/>


### PR DESCRIPTION
**Problem**

The current Forecast Report button visibility relies on the quantity field, which represents user-entered or completed quantities, not actual stock availability.
As a result, when a user enters any quantity or completes a picking, the warning (red) forecast icon never appears, even if the product is out of stock or forecast availability is negative.

This behavior is misleading because stock shortage should be determined by forecast availability, not by the entered quantity.

**Solution**

- This PR updates the button visibility logic to rely solely on forecast_availability:

- Show the normal Forecast Report icon when forecast availability is positive

- Show the warning (red) icon when forecast availability is zero or negative

- Keep the existing condition to hide the button for non-draft outgoing pickings

This aligns the UI behavior with Odoo’s stock forecasting logic and ensures stock shortage warnings remain visible regardless of entered quantities or picking state.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
