### PR TITLE
[FIX] pos_loyalty: load product without gift card

### DIFF
--- a/addons/pos_loyalty/models/product_template.py
+++ b/addons/pos_loyalty/models/product_template.py
@@ -29,7 +29,7 @@ class ProductTemplate(models.Model):
             'loyalty.gift_card_product_50',
             'loyalty.ewallet_product_50',
         ])
-        special_display_products = self.env['product.product'].browse(loyality_products)
+        special_display_products = self.env['product.product'].search([('id', 'in', loyality_products)])
         # Include trigger products from loyalty programs of type 'gift_card' or 'ewallet'
         special_display_products += self.env['loyalty.program'].search([
             ('program_type', 'in', ['gift_card', 'ewallet']),

--- a/addons/pos_loyalty/tests/test_product_loading.py
+++ b/addons/pos_loyalty/tests/test_product_loading.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details
 
+from odoo import Command
 from odoo.tests import tagged
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
@@ -70,3 +71,33 @@ class TestPOSLoyaltyProductLoading(TestPointOfSaleHttpCommon):
 
         self.assertIn(new_product.id, data['pos.session'][0]['_pos_special_products_ids'],
                         "Loyalty product should be in _pos_special_products_ids since it is loaded but not available in the PoS.")
+
+    def test_product_loading_without_gift_card(self):
+        """
+        Test that products are loaded correctly in the PoS session of company
+        if special loyalty products are not visible to them
+        """
+        gift_card = self.env.ref('loyalty.gift_card_product_50').sudo()
+        gift_card.company_id = self.env.company
+
+        company_b_data = self.setup_other_company(name='Company B')
+        company_b = company_b_data['company']
+        payment_method = self.env['pos.payment.method'].create({
+            'name': 'Cash',
+            'receivable_account_id': company_b_data['default_account_receivable'].id,
+            'journal_id': company_b_data['default_journal_cash'].id,
+            'company_id': company_b.id,
+        })
+        pos_config = self.env['pos.config'].create({
+            'name': 'new pos',
+            'company_id': company_b.id,
+            'journal_id': company_b_data['default_journal_sale'].id,
+            'invoice_journal_id': company_b_data['default_journal_sale'].id,
+            'payment_method_ids': [Command.set([payment_method.id])],
+        })
+        pos_config.open_ui()
+        current_session = pos_config.current_session_id
+        data = current_session.with_company(company_b).load_data(['pos.config', 'product.template'])
+        self.assertTrue(len(data['product.template']) > 0)
+        self.assertNotIn(gift_card.product_tmpl_id.id, [product['id'] for product in data['product.template']],
+                        "Product should be loaded in the PoS session, even if Gift card is not available in the PoS.")


### PR DESCRIPTION
Step to reproduce
- install `pos_loyalty` and have two companies
- for this record: `loyalty.gift_card_product_50` set company_id = company1
- switch to company b and start pos

Observation:
- no products are loaded

Cause:
- `browse()` was used to load records `gift_card_product_50` and `ewallet_product_50`
- when any of them is restricted on one company it fails to load whole model

Fix:
- Instead of directly loading them, we use `search()` to avoid `AccessError` so that rest of the products can be loaded.
- Gift card is still not shown as expected

opw-5449466

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
