### PR TITLE
[FIX] l10n_vn: add missing VAT 8% tag to report formula

### DIFF
--- a/addons/l10n_vn/data/account_tax_report_data.xml
+++ b/addons/l10n_vn/data/account_tax_report_data.xml
@@ -234,7 +234,7 @@
                             <record id="account_tax_report_line_01_02_vn_tag_base" model="account.report.expression">
                                 <field name="label">amount_untaxed</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">VAT_SALES_0.amount_untaxed + VAT_SALES_5.amount_untaxed + VAT_SALES_10.amount_untaxed + VAT_SALES_EXEMPTION.amount_untaxed</field>
+                                <field name="formula">VAT_SALES_0.amount_untaxed + VAT_SALES_5.amount_untaxed + VAT_SALES_8.amount_untaxed + VAT_SALES_10.amount_untaxed + VAT_SALES_EXEMPTION.amount_untaxed</field>
                             </record>
                         </field>
                         <field name="children_ids">


### PR DESCRIPTION
`VAT_SALES` report line aggregates total untaxed amount from its children lines.

Previously, the formula for this line was missing `VAT_SALES_8.amount_untaxed`.
As a result, the base amount for 8% VAT transactions was excluded from the total
sales base calculation.

This commit adds the missing tag to the `VAT_SALES` formula to ensure the total
taxable base is calculated correctly.

task-5836154