### PR TITLE
[FIX] {l10n_din5008_,}sale: missing Delivery Date on DIN5008 report and preview

### DIFF
--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -28,6 +28,10 @@
                                 <td>Order Date:</td>
                                 <td><div t-field="doc.date_order" t-options="{'widget': 'date'}"/></td>
                             </tr>
+                            <tr t-if="doc.commitment_date">
+                                <td>Delivery Date:</td>
+                                <td><div t-field="doc.commitment_date" t-options="{'widget': 'date'}"/></td>
+                            </tr>
                         </t>
                         <tr t-if="doc.client_order_ref">
                             <td>Customer Reference:</td>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -414,6 +414,10 @@
                                 <th t-else="" class="ps-0 pb-0">Date:</th>
                                 <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.date_order" t-options='{"widget": "date"}'/></td>
                             </tr>
+                            <tr t-if="sale_order.commitment_date and sale_order.state in ['sent', 'sale']">
+                                <th class="ps-0 pb-0">Delivery Date:</th>
+                                <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.commitment_date" t-options='{"widget": "date"}'/></td>
+                            </tr>
                             <tr t-if="sale_order.validity_date and sale_order.state in ['draft', 'sent']">
                                 <th class="ps-0 pb-0">Expiration Date:</th>
                                 <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.validity_date" t-options='{"widget": "date"}'/></td>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install modules `sale_management` and `l10n_din5008_sale`
2. Go to Settings, Configure Document Layout and set layout to DIN 5008
3. Create a new Sale Order
4. Set a customer, add a product, and fill in the Delivery Date (Other Info)
5. Click on Print and Preview

**Issue:**
The Delivery Date (commitment_date) is not displayed on:
- The DIN 5008 sale order report
- The sale order preview (portal view)

Functional experts confirmed that the Delivery Date must be visible when using the DIN 5008 layout.

**Cause:**
The `commitment_date` field was not included in the DIN 5008 sale order report template nor in the preview view.

**Solution:**
This commit adds the Delivery Date information to:
- The DIN 5008 sale order report template
- The sale order portal/preview view

**opw-5490651**

**Before:**
<img width="560" height="145" alt="image" src="https://github.com/user-attachments/assets/fb29cda1-d668-4682-aa04-12c613f248d8" />
<img width="861" height="268" alt="image" src="https://github.com/user-attachments/assets/615f259f-e0ff-4fb5-9852-1fdd75cda4c9" />

**After:**
<img width="589" height="145" alt="image" src="https://github.com/user-attachments/assets/3f1a8d25-783a-4600-b07e-11b547bb326b" />
<img width="824" height="271" alt="image" src="https://github.com/user-attachments/assets/46b37469-5c72-4556-95e2-eaea0824c166" />
