### PR TITLE
[FIX] pos: add product_expiry dependency for product expiration handling

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Sales/Point of Sale',
     'sequence': 40,
     'summary': 'Handle checkouts and payments for shops and restaurants.',
-    'depends': ['resource', 'stock_account', 'barcodes', 'html_editor', 'digest', 'phone_validation', 'google_address_autocomplete'],
+    'depends': ['resource', 'stock_account', 'barcodes', 'html_editor', 'digest', 'phone_validation', 'google_address_autocomplete', 'product_expiry'],
     'uninstall_hook': 'uninstall_hook',
     'data': [
         'security/point_of_sale_security.xml',


### PR DESCRIPTION
Installing POS with Lots & Serial Numbers enabled raises an error when
selecting a product that uses lots.

**Steps to Reproduce:**
- Install POS (with demo data).
- Activate "Lots & Serial Numbers".
- Open Furniture Shop > Select "Drawer".

**Error:**
`AttributeError - 'stock.lot' object has no attribute 'expiration_date'`

The commit (ref 1) adds functionality from the product_expiry module to POS. However, the module is not included in the dependencies, leading to an error.

Ref 1: https://github.com/odoo/odoo/pull/236456/changes

sentry-7203789966