### PR TITLE
[IMP] website: allow no default value for selection field

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option.xml
+++ b/addons/website/static/src/builder/plugins/form/form_option.xml
@@ -195,6 +195,14 @@
             action="'toggleRequired'" actionParam="'s_website_form_required'"
         />
     </BuilderRow>
+    <t t-if="domStateCurrentFieldInput.nodeName === 'SELECT'">
+        <BuilderRow label.translate="Allow Empty">
+            <BuilderCheckbox id="'allow_empty_opt'" action="'toggleAllowEmpty'"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Placeholder" level="1">
+            <BuilderTextInput t-if="isActiveItem('allow_empty_opt')" action="'setEmptyPlaceholder'" placeholder.translate="Please choose any one option"/>
+        </BuilderRow>
+    </t>
     <BuilderRow label.translate="Max # of Files">
         <BuilderNumberInput id="'max_files_number_opt'" t-if="isMaxFilesVisible"
             title.translate="The maximum number of files that can be uploaded."

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -173,6 +173,8 @@ export class FormOptionPlugin extends Plugin {
             SetDefaultErrorMessageAction,
             SetRequirementComparatorAction,
             SetMultipleFilesAction,
+            ToggleAllowEmptyAction,
+            SetEmptyPlaceholderAction,
         },
         content_not_editable_selectors: ".s_website_form form",
         content_editable_selectors: [
@@ -1310,6 +1312,40 @@ export class ToggleDescriptionAction extends BuilderAction {
         return !!description;
     }
 }
+export class ToggleAllowEmptyAction extends BuilderAction {
+    static id = "toggleAllowEmpty";
+    static dependencies = ["websiteFormOption"];
+    setup() {
+        this.preview = false;
+    }
+    load(context) {
+        return this.dependencies.websiteFormOption.prepareFields(context);
+    }
+    apply({ editingElement: fieldEl, loadResult: fields }) {
+        const field = getActiveField(fieldEl, { fields });
+        field.allowEmpty = !field.allowEmpty;
+        field.records.forEach((rec) => (rec.selected = false));
+        this.dependencies.websiteFormOption.replaceField(fieldEl, field, fields);
+    }
+    isApplied({ editingElement: fieldEl }) {
+        return !!fieldEl.querySelector(".s_website_form_empty_option");
+    }
+}
+export class SetEmptyPlaceholderAction extends BuilderAction {
+    static id = "setEmptyPlaceholder";
+    static dependencies = ["websiteFormOption"];
+    load(context) {
+        return this.dependencies.websiteFormOption.prepareFields(context);
+    }
+    apply({ editingElement: fieldEl, loadResult: fields, value }) {
+        const field = getActiveField(fieldEl, { fields });
+        field.placeholder = value;
+        this.dependencies.websiteFormOption.replaceField(fieldEl, field, fields);
+    }
+    getValue({ editingElement: fieldEl }) {
+        return fieldEl.querySelector(".s_website_form_empty_option")?.textContent;
+    }
+}
 export class SelectTextareaValueAction extends BuilderAction {
     static id = "selectTextareaValue";
     apply({ editingElement: fieldEl, value }) {
@@ -1440,18 +1476,13 @@ export class SetFormCustomFieldValueListAction extends BuilderAction {
         const valueList = JSON.parse(value);
         const field = getActiveField(fieldEl, { fields });
         field.records = valueList;
+        // add an empty option, if no option is selected
+        field.allowEmpty = !field.records.some((value) => value.selected);
         this.dependencies.websiteFormOption.replaceField(fieldEl, field, fields);
     }
     getValue({ editingElement: fieldEl }) {
         const fields = [];
         const field = getActiveField(fieldEl, { fields });
-        if (
-            field.records.length &&
-            field.records[0].display_name === "" &&
-            field.records[0].selected === true
-        ) {
-            field.records.shift();
-        }
         return JSON.stringify(field.records);
     }
 }

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -95,18 +95,6 @@ export function renderField(field, resetId = false) {
     if (!field.id) {
         field.id = generateHTMLId();
     }
-    if (field.records && (field.type === "many2one" || field.type === "selection")) {
-        const hasDefault =
-            field.records[0]?.["display_name"] === "" ||
-            field.records.some((value) => value.selected);
-        if (!hasDefault) {
-            field.records.unshift({
-                id: "",
-                display_name: "",
-                selected: true,
-            });
-        }
-    }
     const params = { field: { ...field }, defaultName: field.string || _t("Field") };
     if (["url", "email", "tel"].includes(field.type)) {
         params.field.inputType = field.type;
@@ -250,6 +238,7 @@ export function setActiveProperties(fieldEl, field) {
         'input[type="text"], input[type="email"], input[type="number"], input[type="tel"], input[type="url"], textarea'
     );
     const fileInputEl = fieldEl.querySelector("input[type=file]");
+    const selectInputEl = fieldEl.querySelector("select");
     const description = fieldEl.querySelector(".s_website_form_field_description");
     field.placeholder = input?.placeholder || "";
     if (input) {
@@ -260,6 +249,10 @@ export function setActiveProperties(fieldEl, field) {
     } else if (fileInputEl) {
         field.maxFilesNumber = fileInputEl.dataset.maxFilesNumber;
         field.maxFileSize = fileInputEl.dataset.maxFileSize;
+    } else if (selectInputEl) {
+        const emptyOptionEl = selectInputEl.querySelector(".s_website_form_empty_option");
+        field.allowEmpty = !!emptyOptionEl;
+        field.placeholder = emptyOptionEl?.textContent || _t("Please choose any one option");
     }
     // property value is needed for date/datetime (formated date).
     field.propertyValue = input && input.value;
@@ -524,7 +517,11 @@ export function getListItems(fieldEl) {
     const multipleInputsEl = getMultipleInputs(fieldEl);
     let options = [];
     if (selectEl) {
-        options = [...selectEl.querySelectorAll("option:not([value='_other'])")];
+        options = [
+            ...selectEl.querySelectorAll(
+                "option:not([value='_other'], .s_website_form_empty_option)"
+            ),
+        ];
     } else if (multipleInputsEl) {
         options = [
             ...multipleInputsEl.querySelectorAll(

--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -779,7 +779,7 @@ export class Form extends Interaction {
      *      is between or !between
      * @returns {boolean}
      */
-    compareTo(comparator, value = "", comparable, between) {
+    compareTo(comparator, value = "", comparable = "", between) {
         // Value can be null when the compared field is supposed to be
         // visible, but is not yet retrievable from the FormData() because
         // the field was conditionally hidden. It can be considered empty.

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -292,6 +292,7 @@
                 <select t-else="" class="form-select s_website_form_input" t-att-name="field.name"
                     t-att-required="field.required || field.modelRequired || None" t-att-id="field.id"
                     t-attf-data-link-state-to-country="{{ field.name == 'state_id' and field.linkStateToCountry ? 'true' : 'false' }}">
+                    <option t-if="field.allowEmpty" t-out="field.placeholder" class="s_website_form_empty_option" value="" selected="selected"/>
                     <t t-foreach="field.records" t-as="record" t-key="record_index">
                         <option t-out="record.display_name" t-att-id="field.id + record_index" t-att-value="record.id"
                             t-att="{

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -183,10 +183,15 @@ test("empty placeholder selection input for selection field", async () => {
     );
     getEditor();
     expect(":iframe select option").toHaveCount(3);
-    await contains(":iframe .s_website_form_field[data-type='many2one'").click();
-    await contains(".o_we_table_wrapper input[type='checkbox']").click();
+
+    await contains(":iframe .s_website_form_field[data-type='many2one']").click();
+    await contains("div[data-action-id='toggleAllowEmpty'] .form-switch").click();
     expect(":iframe select option").toHaveCount(4);
-    expect(":iframe select option:eq(0)").toHaveText("");
+    expect(".o_we_table_wrapper tr").toHaveCount(3);
+    expect(":iframe select option:eq(0)").toHaveText("Please choose any one option");
+
+    await contains("div[data-action-id='setEmptyPlaceholder'] input").edit("test");
+    expect(":iframe select option:eq(0)").toHaveText("test");
 });
 
 test("Set 'Message' as form success action and show/hide the message preview", async () => {
@@ -676,7 +681,7 @@ describe("Many2one Field", () => {
         expect(":iframe select option").toHaveCount(2, {
             message: "Disabling Belgium as selected item should add an empty item selected",
         });
-        expect(":iframe select option[selected]").toHaveText("");
+        expect(":iframe select option[selected]").toHaveText("Please choose any one option");
 
         // Select it back
         await contains(".o_we_table_wrapper table tr input[type=checkbox]").click();


### PR DESCRIPTION
Previously, selection fields in website forms always included an empty option with a no label that could not be customized.

This change introduces options to control the presence of the empty option and customize its label.

Features added:
- Toggle to enable or disable the placeholder option
- Input field to define a dynamic placeholder text

task-3861126
