### PR TITLE
[IMP] account,l10n*: add `is_refund` method

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1185,7 +1185,7 @@ class AccountMoveLine(models.Model):
     def _compute_is_refund(self):
         for line in self:
             is_refund = False
-            if line.move_id.move_type in ('out_refund', 'in_refund'):
+            if line.move_id.is_refund():
                 is_refund = True
             elif line.move_id.move_type == 'entry':
                 if line.tax_repartition_line_id:

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -2410,7 +2410,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
                 })
             reversal = move_reversal.refund_moves()
             reverse_move = self.env['account.move'].browse(reversal['res_id'])
-            if reverse_move.move_type in ('out_refund', 'in_refund'):
+            if reverse_move.is_refund():
                 reverse_move.write({
                     'invoice_line_ids': [
                         Command.update(reverse_move.invoice_line_ids.id, {'price_unit': amount}),

--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -52,7 +52,7 @@ class AccountDebitNote(models.TransientModel):
             record.journal_type = record.move_type in ['in_refund', 'in_invoice'] and 'purchase' or 'sale'
 
     def _prepare_default_values(self, move):
-        if move.move_type in ('in_refund', 'out_refund'):
+        if move.is_refund():
             type = 'in_invoice' if move.move_type == 'in_refund' else 'out_invoice'
         else:
             type = move.move_type
@@ -65,7 +65,7 @@ class AccountDebitNote(models.TransientModel):
                 'debit_origin_id': move.id,
                 'move_type': type,
             }
-        if not self.copy_lines or move.move_type in [('in_refund', 'out_refund')]:
+        if not self.copy_lines or move.is_refund():
             default_values['line_ids'] = [(5, 0, 0)]
         return default_values
 

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -66,7 +66,7 @@ class AccountMove(models.Model):
         docs_used_for_inv_and_ref = self.filtered(
             lambda x: x.country_code == 'AR' and
             x.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() and
-            x.move_type in ['out_refund', 'in_refund'])
+            x.is_refund())
 
         super(AccountMove, self - docs_used_for_inv_and_ref)._check_invoice_type_document_type()
 
@@ -127,7 +127,7 @@ class AccountMove(models.Model):
             domain = Domain(domain)
             domain &= Domain('l10n_ar_letter', '=', False) | Domain('l10n_ar_letter', 'in', letters)
             domain &= Domain(self.journal_id._get_journal_codes_domain())
-            if self.move_type in ['out_refund', 'in_refund']:
+            if self.is_refund():
                 domain = Domain('code', 'in', self._get_l10n_ar_codes_used_for_inv_and_ref()) | domain
         return domain
 
@@ -290,7 +290,7 @@ class AccountMove(models.Model):
         sign = -1 if self.is_inbound() else 1
 
         # if we are on a document that works invoice and refund and it's a refund, we need to export it as negative
-        sign = -sign if self.move_type in ('out_refund', 'in_refund') and\
+        sign = -sign if self.is_refund() and\
             self.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() else sign
 
         tax_lines = self.line_ids.filtered('tax_line_id')
@@ -337,7 +337,7 @@ class AccountMove(models.Model):
     def _get_vat(self):
         """ Applies on wsfe web service and in the VAT digital books """
         # if we are on a document that works invoice and refund and it's a refund, we need to export it as negative
-        sign = -1 if self.move_type in ('out_refund', 'in_refund') and\
+        sign = -1 if self.is_refund() and\
             self.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref() else 1
 
         res = []

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -442,7 +442,7 @@ class AccountMove(models.Model):
             'invoice_record': self,
             'invoice_currency': inv_curr,
             'InvoiceDocumentType': 'FA' if self.l10n_es_is_simplified else 'FC',
-            'InvoiceClass': 'OR' if self.move_type in ['out_refund', 'in_refund'] else 'OO',
+            'InvoiceClass': 'OR' if self.is_refund() else 'OO',
             'Corrective': self._l10n_es_edi_facturae_get_corrective_data(),
             'InvoiceIssueData': {
                 'OperationDate': operation_date,
@@ -509,7 +509,7 @@ class AccountMove(models.Model):
             - invoice_values['TotalGeneralDiscounts']
             + invoice_values['TotalGeneralSurcharges']
         )
-        refund_multiplier = -1 if self.move_type in ('out_refund', 'in_refund') else 1
+        refund_multiplier = -1 if self.is_refund() else 1
 
         template_values = {
             'self_party': company.partner_id,

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -51,7 +51,7 @@ class AccountEdiFormat(models.Model):
             filter_invl_to_apply=full_filter_invl_to_apply,
             filter_to_apply=filter_to_apply,
         )
-        sign = -1 if invoice.move_type in ('out_refund', 'in_refund') else 1
+        sign = -1 if invoice.is_refund() else 1
 
         tax_details_info = defaultdict(dict)
 
@@ -294,7 +294,7 @@ class AccountEdiFormat(models.Model):
 
             # === Taxes ===
 
-            sign = -1 if invoice.move_type in ('out_refund', 'in_refund') else 1
+            sign = -1 if invoice.is_refund() else 1
 
             if invoice.is_sale_document():
                 # Customer invoices

--- a/addons/l10n_gr_edi/models/account_move.py
+++ b/addons/l10n_gr_edi/models/account_move.py
@@ -194,7 +194,7 @@ class AccountMove(models.Model):
                     # If we have previously calculated the inv_type, reuse it here.
                     # For entry moves, we want the inv_type to be False. (we don't send anything to myDATA on entry moves)
                     move.l10n_gr_edi_inv_type = move.l10n_gr_edi_inv_type
-                elif move.move_type in ('out_refund', 'in_refund'):
+                elif move.is_refund():
                     # inv_type specific for credit notes
                     if move.l10n_gr_edi_correlation_id:
                         # when possible, we must add the associate invoice/bill mark (id)

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -1043,7 +1043,7 @@ class AccountMove(models.Model):
             'cash_rounding_base_amount_currency', 'cash_rounding_base_amount',
         )
 
-        if self.move_type in ('out_refund', 'in_refund'):
+        if self.is_refund():
             invert_dict(tax_totals, fields_to_reverse)
             for subtotal in tax_totals['subtotals']:
                 invert_dict(subtotal, fields_to_reverse)

--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -732,7 +732,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             if self.env['myinvois.document']._myinvois_is_debit_notes_used() and ref_invoice.debit_origin_id:
                 document_type_code = '03' if ref_invoice.move_type == 'out_invoice' else '13'
                 original_documents = invoices.debit_origin_id._get_active_myinvois_document()
-            elif ref_invoice.move_type in ('out_refund', 'in_refund'):
+            elif ref_invoice.is_refund():
                 is_refund, refunded_document = self._l10n_my_edi_get_refund_details(invoices)
                 if is_refund:
                     document_type_code = '04' if ref_invoice.move_type == 'out_refund' else '14'

--- a/addons/l10n_my_edi/models/myinvois_document.py
+++ b/addons/l10n_my_edi/models/myinvois_document.py
@@ -622,7 +622,7 @@ class MyInvoisDocument(models.Model):
         :return: True if this document is linked to a single refund invoice.
         """
         has_single_document = self.invoice_ids and len(self.invoice_ids) == 1
-        return has_single_document and self.invoice_ids[0].move_type in ('out_refund', 'in_refund')
+        return has_single_document and self.invoice_ids[0].is_refund()
 
     def _get_rounded_base_lines(self):
         """


### PR DESCRIPTION
Before this commit-
We had methods on `account.move` i.e.
`is_sale_document`, `is_invoice` but
at many instance in the code base,
we did do `self.move_type in ('out_refund', 'in_refund')`

After this commit-
We add new methods on `account.move` to
get and check if the move is refund

task-5850565


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
