### PR TITLE
[FIX] auth_ldap: update last_login on successful LDAP authentication

### DIFF
--- a/addons/auth_ldap/models/res_users.py
+++ b/addons/auth_ldap/models/res_users.py
@@ -24,8 +24,12 @@ class ResUsers(models.Model):
             for conf in Ldap._get_ldap_dicts():
                 entry = Ldap._authenticate(conf, login, credential['password'])
                 if entry:
+                    uid = Ldap._get_or_create_user(conf, login, entry)
+                    # Update last_login as it would be done in base _login method
+                    user = self.env['res.users'].browse(uid)
+                    user.with_user(user)._update_last_login()
                     return {
-                        'uid': Ldap._get_or_create_user(conf, login, entry),
+                        'uid': uid,
                         'auth_method': 'ldap',
                         'mfa': 'default',
                     }

--- a/addons/auth_ldap/tests/test_auth_ldap.py
+++ b/addons/auth_ldap/tests/test_auth_ldap.py
@@ -81,3 +81,9 @@ class TestAuthLDAP(BaseCase):
                 "SELECT id FROM res_users WHERE login = %s and id = %s",
                 ("test_ldap_user", session.uid))
             self.assertTrue(cr.rowcount, "User should be present")
+
+            # Verify that login_date (via res.users.log) was updated
+            cr.execute(
+                "SELECT id FROM res_users_log WHERE create_uid = %s",
+                (session.uid,))
+            self.assertTrue(cr.rowcount, "User login should be logged (login_date should be updated)")


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `login_date` field is not updated when users authenticate via LDAP.

**Fixes:** #244847

## Problem

When a user logs in via LDAP authentication, the `login_date` (Latest Authentication) field remains empty or keeps its old value. This happens because the `_login` method in `auth_ldap` returns early after successful LDAP authentication, bypassing the standard call to `_update_last_login()` that normally happens in the base `res.users` implementation.

## Technical Analysis

In `addons/auth_ldap/models/res_users.py`, the `_login` method:
1. Catches `AccessDenied` from the base implementation
2. Attempts LDAP authentication
3. On success, immediately returns the auth dictionary

This bypasses `user._update_last_login()` which is called in `odoo/addons/base/models/res_users.py` after credential verification.

## Solution

Modified the LDAP login flow to:
1. Extract `uid` from `_get_or_create_user()`
2. Call `_update_last_login()` on the user before returning
3. Return the auth dictionary with the extracted `uid`

```python
uid = Ldap._get_or_create_user(conf, login, entry)
# Update last_login as it would be done in base _login method
user = self.env['res.users'].browse(uid)
user.with_user(user)._update_last_login()
return {
    'uid': uid,
    'auth_method': 'ldap',
    'mfa': 'default',
}
```

## Testing

Added a test assertion to verify that a `res.users.log` entry is created after LDAP login, which populates the `login_date` field.

## Steps to Verify

1. Install `auth_ldap` module
2. Configure a valid LDAP server
3. Log in with an LDAP user
4. Check Settings > Users & Companies > Users
5. ✅ The "Latest Authentication" field should now show the login timestamp

---

[Gittensor contribution - GlobalStar117]