### PR TITLE
[FIX] hr_holidays: fix has mandatory days compute

### DIFF
--- a/addons/hr_holidays/tests/test_mandatory_days.py
+++ b/addons/hr_holidays/tests/test_mandatory_days.py
@@ -325,6 +325,7 @@ class TestHrLeaveMandatoryDays(TransactionCase):
 
     @freeze_time('2021-10-15')
     def test_multiple_employees_mandatory_days(self):
+        self.company.tz = 'Europe/Brussels'
         production_department = self.env['hr.department'].create({
             'name': 'Production Department',
             'company_id': self.company.id,
@@ -344,10 +345,12 @@ class TestHrLeaveMandatoryDays(TransactionCase):
             'company_id': self.company.id,
             'resource_calendar_id': self.default_calendar.id,
             'department_id': deployment_department.id,
+            'tz': 'Asia/Tokyo',
         })
 
         self.employee_emp.write({
-            'department_id': post_production_department.id
+            'department_id': post_production_department.id,
+            'tz': 'Pacific/Honolulu',
         })
 
         self.env['hr.leave.mandatory.day'].create([{


### PR DESCRIPTION
The bug occured following this refactoring PR: https://github.com/odoo/odoo/pull/229706 Since the timezone taken is no longer on the calendar but on the employee, the computation of the `has_mandatory_days` field was wrong. Indeed, the field `date_from` and `date_to` on the leave takes into account the timezone of the employee, which might be on a different calendar day in UTC. To fix this, we can use the fields `request_date_from` and `request_date_to`, which are a simple date and not datetime.

Runbot build error: https://runbot.odoo.com/odoo/runbot.build.error/238015 task-5788459

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
