### PR TITLE
[FIX] account_peppol: Fix embed attachments through peppol

### DIFF
--- a/addons/account_peppol/wizard/account_invoice_send.py
+++ b/addons/account_peppol/wizard/account_invoice_send.py
@@ -244,7 +244,7 @@ class AccountInvoiceSend(models.TransientModel):
             xml_attachment,
             [{
                 'name': attachment.name,
-                'raw_b64': attachment.datas,
+                'raw_b64': attachment.datas.decode(),
                 'mimetype': attachment.mimetype,
             } for attachment in attachments_to_embed],
         )


### PR DESCRIPTION
[FIX] account_peppol: Fix embed attachments through peppol

Embedded attachments sent through peppol are not decoded causing a XSD
validation error

Steps to reproduce the bug:
- Create an invoice
- In the send & print wizard, select "by peppol" and attach a supported
file
- Send
- Run the scheduled action to update document status
- Go in the invoice form and see the error message in the chatter

no-task