### PR TITLE
[FIX] crm: prevent error on moving won lead to another won stage in diff year

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1227,15 +1227,18 @@ class CrmLead(models.Model):
         })
         query_result = self.env.cr.dictfetchone()
 
+        def _is_lower_than_expected_revenue(value):
+            return self.expected_revenue and value is not None and value < self.expected_revenue
+
         if query_result['count_user_closed_year'] == 1:
             return _('Go, go, go! Congrats for your first deal.')
-        elif self.expected_revenue and query_result['max_team_31'] < self.expected_revenue:
+        elif _is_lower_than_expected_revenue(query_result['max_team_31']):
             return _('Boom! Team record for the past 30 days.')
-        elif self.expected_revenue and query_result['max_team_7'] < self.expected_revenue:
+        elif _is_lower_than_expected_revenue(query_result['max_team_7']):
             return _('Yeah! Best deal out of the last 7 days for the team.')
-        elif self.expected_revenue and query_result['max_user_31'] < self.expected_revenue:
+        elif _is_lower_than_expected_revenue(query_result['max_user_31']):
             return _('You just beat your personal record for the past 30 days.')
-        elif self.expected_revenue and query_result['max_user_7'] < self.expected_revenue:
+        elif _is_lower_than_expected_revenue(query_result['max_user_7']):
             return _('You just beat your personal record for the past 7 days.')
         elif query_result['count_user_closed_today'] == 5:
             return _('You\'re on fire! Fifth deal won today 🔥')

--- a/addons/crm/tests/test_crm_rainbowman.py
+++ b/addons/crm/tests/test_crm_rainbowman.py
@@ -324,6 +324,22 @@ class TestCrmLeadRainbowmanMessages(TestCrmCommon):
             self.assertEqual(msg_later_record, 'Boom! Team record for the past 30 days.', 'Once a month has passed, \
                 monthly team records may be set even if the amount was lower than the alltime max.')
 
+        # cross-year case
+        current_dt = datetime(2026, 1, 5, 12, 0)
+        past_dt = datetime(2025, 12, 1, 12, 0)
+
+        with self.mock_datetime_and_now(past_dt):
+            lead_cross_year = self.env['crm.lead'].create({
+                'name': 'lead_future_create',
+                'type': 'opportunity',
+                'stage_id': self.stage_team1_won.id,
+                'user_id': self.user_sales_manager.id,
+                'expected_revenue': 500.0,
+            })
+        with self.mock_datetime_and_now(current_dt):
+            msg = self._set_won_get_rainbowman_message(lead_cross_year, self.sales_manager_casey)
+            self.assertFalse(msg)
+
     @users('user_sales_manager')
     def test_leads_rainbowman_timezones(self):
         """


### PR DESCRIPTION
Currently, a traceback occurs when a lead won in a previous year is moved to another won stage in the current year.

### **Steps to Reproduce:**
1) Install CRM without demo data.
2) From the `CRM>Configuration>Stages` make `new` stage as **'won'** stage.
 3) Create a lead with dated in the past (e.g., 30-12-2025 by changing system date)
   and with some expected_revenue.
4) Change the system date to today and move the lead to the Won stage.

Ref Video: https://drive.google.com/file/d/18OCQ4Tl6Co_oh28XNag3qjxMkXJNSMOh/view?usp=sharing

### **Error:**
`TypeError: '<' not supported between instances of 'NoneType' and 'float'`

### **Root Cause:**
When a lead is moved to a won stage, `_get_rainbowman_message` is called and computes the values for `max_{team,user}_{31,7}`. However, when the lead spans different years, the condition of SQL query at [1] fails(because 2025 != 2026) due to which SQL query return null from the MAX() Function. As a result, subsequent comparisons at [2] fail, raising an Error.

### **FIX:**
Introduce small helper method(`_is_lower_than_expected_revenue`) to ensure comparisons
across different years only happen when we have meaningful numeric values.

[1]- https://github.com/odoo/odoo/blob/fb4e08fe46c0e1865e30b0ce1eb5f4436438ea03/addons/crm/models/crm_lead.py#L1218

[2]- https://github.com/odoo/odoo/blob/fb4e08fe46c0e1865e30b0ce1eb5f4436438ea03/addons/crm/models/crm_lead.py#L1232

**opw-5484887**
**sentry-7026119584**