### PR TITLE
[FIX] point_of_sale: display correct combo price with multiple quantity

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -484,7 +484,7 @@ export class PosOrder extends Base {
         for (const cLine of pLine.combo_line_ids) {
             if (!(cLine.combo_item_id.combo_id.id in comboRemainingFree)) {
                 comboRemainingFree[cLine.combo_item_id.combo_id.id] =
-                    cLine.combo_item_id.combo_id.qty_free;
+                    cLine.combo_item_id.combo_id.qty_free * pLine.qty;
             }
             const newQty = comboRemainingFree[cLine.combo_item_id.combo_id.id] - cLine.qty;
             const baseData = { combo_item_id: cLine.combo_item_id };
@@ -494,7 +494,7 @@ export class PosOrder extends Base {
             if (cLine.qty) {
                 if (newQty >= 0) {
                     comboRemainingFree[cLine.combo_item_id.combo_id.id] = newQty;
-                    childLineFree.push({ ...baseData, qty: cLine.qty });
+                    childLineFree.push({ ...baseData, qty: cLine.qty, parentQty: pLine.qty });
                 } else {
                     childLineExtra.push({ ...baseData, qty: cLine.qty });
                 }

--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -21,15 +21,22 @@ export const computeComboItems = (
 
     let remainingTotal = parentLstPrice;
     const ProductPrice = currency_id || decimalPrecision.find((dp) => dp.name === "Product Price");
-    if (childLineConf[childLineConf.length - 1]?.qty > 1) {
+    if (
+        childLineConf[childLineConf.length - 1]?.qty > 1 &&
+        (childLineConf[childLineConf.length - 1]?.parentQty ?? 1) === 1
+    ) {
         childLineConf[childLineConf.length - 1].qty -= 1;
         childLineConf.push({ ...childLineConf[childLineConf.length - 1], qty: 1 });
     }
     for (const conf of childLineConf) {
         const comboItem = conf.combo_item_id;
         const combo = comboItem.combo_id;
-        let priceUnit = ProductPrice.round((combo.base_price * parentLstPrice) / originalTotal);
-        remainingTotal -= priceUnit * conf.qty;
+        const parentCoef = conf.parentQty || 1;
+        let priceUnit = ProductPrice.round(
+            (combo.base_price * parentLstPrice * parentCoef) / originalTotal
+        );
+        remainingTotal -= (priceUnit * conf.qty) / parentCoef;
+
         if (conf === childLineConf[childLineConf.length - 1]) {
             priceUnit += remainingTotal;
             remainingTotal = 0;

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -374,3 +374,49 @@ test("priceDoesntChangeWhenChangingPreset", async () => {
     order4.recomputeOrderData();
     expect(order4.amount_total).toBe(total);
 });
+
+test("priceDoesntChangeWhenChangingPresetMultipleQuantity", async () => {
+    const store = await setupPosEnv();
+    store.models["pos.preset"].get(1).pricelist_id = false;
+    const otherPreset = store.models["pos.preset"].get(2);
+    store.models["product.combo"].get(1).qty_free = 2;
+    const comboProduct1 = store.models["product.combo.item"].get(1);
+    const comboProductExtra = store.models["product.combo.item"].get(2);
+    const comboProduct2 = store.models["product.combo.item"].get(3);
+    const template = store.models["product.template"].get(7);
+
+    const recomputeComboData = async (payload, expected_total) => {
+        const order = store.addNewOrder();
+        await store.addLineToOrder(
+            {
+                product_tmpl_id: template,
+                payload: payload,
+                qty: 1,
+            },
+            order
+        );
+        order.lines[0].setQuantity(10);
+        order.recomputeOrderData();
+        expect(order.amount_total).toBe(expected_total);
+        order.setPreset(otherPreset);
+        order.recomputeOrderData();
+        expect(order.amount_total).toBe(expected_total);
+    };
+
+    await recomputeComboData(
+        [[{ combo_item_id: comboProduct1, qty: 2 }], [{ combo_item_id: comboProduct2, qty: 2 }]],
+        23750
+    );
+    await recomputeComboData([[{ combo_item_id: comboProduct1, qty: 2 }]], 18750);
+    await recomputeComboData(
+        [
+            [{ combo_item_id: comboProduct1, qty: 2 }],
+            [{ combo_item_id: comboProductExtra, qty: 2 }],
+        ],
+        22125
+    );
+    await recomputeComboData(
+        [[{ combo_item_id: comboProduct1, qty: 2 }], [{ combo_item_id: comboProduct1, qty: 2 }]],
+        21250
+    );
+});


### PR DESCRIPTION
**Steps to reproduce:**
- Open the PoS
- Select a combo and choose whatever
- Use the numpad or keyboard to set the combo's qty to 10
- Choose another customer or preset
- The price is all wrong

**Why the fix:**
Whenever we change the customer or the preset, the **setPriceList** function is triggered. In this
function we recompute the combo's children lines' price.

Before this commit, we assumed that the combo's parent line's qty would always be one, and the logic was written on this assumption. Meaning that when it's manually changed, the data is wrong. What really happens is that most of the children line's qty end up being treated as an extra price.

This happens because in our exemple, the parent and children lines have a qty of 10, but we only set the free qty based on the assumption that the parent line has a qty of 1 on those lines https://github.com/odoo/odoo/blob/f5d5783b6a0c908127aa620ad0ec5b0008d7adf4/addons/point_of_sale/static/src/app/models/pos_order.js#L482-L485

This means that, as the free qty is rapidly depleted, we fall back on the extra products, and their unit price end up becoming the combo's base_price.

We now set the right amount in the free qty based on the parent line's qty.

When doing this, another problem arises, we have to multiply the children's unit price by the parent's qty, as theunit price's computation was based on the fact that weonly have a qty of one on the parent line.
This is because we were still basing the unit_price the the parent's lstPrice, but this price was not using the parent's qty at all, so we need to multiply it by the parent line's qty to make it work.

The unit price handling has to be done in the **computeComboItems** function, as we also need to adjust the remaining price accordingly. An access to the parent's qty was added onto the child line, to avoid adding a default parameter to the function, which should be avoided in stable if possible.


opw-5266483