### PR TITLE
[FIX] website_sale: persist multiple attribute filters during pagination

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -291,6 +291,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         attribute_value_ids = set(itertools.chain.from_iterable(attribute_value_dict.values()))
         if attribute_values:
             request.session['attribute_values'] = attribute_values
+            post['attribute_values'] = attribute_values
         else:
             request.session.pop('attribute_values', None)
 

--- a/addons/website_sale/static/tests/tours/website_sale_shop_filters.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_filters.js
@@ -1,0 +1,33 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("shop_attribute_filters_remain_when_changing_page", {
+    url: "/shop",
+    steps: () => [
+        {
+            content: "Select first attribute value",
+            trigger: ".products_attributes_filters form.js_attributes input:eq(0)",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Select last attribute value",
+            trigger: ".products_attributes_filters form.js_attributes input:eq(3)",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Select page 2",
+            trigger: 'li a.page-link:contains("2")',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "First attribute value should be checked",
+            trigger: ".products_attributes_filters form.js_attributes input:eq(0):checked",
+        },
+        {
+            content: "Last attribute value should be checked",
+            trigger: ".products_attributes_filters form.js_attributes input:eq(3):checked",
+        },
+    ],
+});

--- a/addons/website_sale/tests/test_website_sale_product_filters.py
+++ b/addons/website_sale/tests/test_website_sale_product_filters.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests import tagged
+from odoo.tests import tagged, HttpCase
 
 from odoo.addons.product.tests.test_product_attribute_value_config import (
     TestProductAttributeValueCommon,
@@ -10,7 +10,7 @@ from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged('post_install', '-at_install')
-class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestProductAttributeValueCommon):
+class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestProductAttributeValueCommon, HttpCase):
 
     @classmethod
     def setUpClass(cls):
@@ -322,3 +322,12 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestProductAttributeValue
                 16,
                 "When displaying newest product templates, 16 unique templates should be shown",
             )
+
+    def test_shop_attribute_filters_remain_when_changing_page(self):
+        self.env['product.attribute'].search([]).write({'visibility': 'hidden'})
+        self.color_attribute.visibility = 'visible'
+        self.size_attribute.visibility = 'visible'
+        self.env['website'].get_current_website().shop_ppg = 1
+        computer_case_copy = self.computer_case.copy()
+        computer_case_copy.website_published = True
+        self.start_tour('/shop', 'shop_attribute_filters_remain_when_changing_page')


### PR DESCRIPTION
Current behavior:
When a user selects multiple filters (attributes) that result in multiple pages of products, navigating to the second page causes some filters to be lost. Specifically, only the last selected attribute value is kept in the URL of the pager.

This happens because the `/shop` controller processes query parameters using a standard Python dictionary (**post). Since a dictionary cannot hold duplicate keys, an URL like `?attrib=1&attrib=2` is reduced to `{'attrib': '2'}`, losing all previous values.

Steps to reproduce:
1. Install `website_sale`.
2. Reduce "Products per Page" (e.g., to 4) to easily trigger pagination.
3. Go to the /shop page.
4. Select a first attribute (e.g., Color: White).
5. Select a second attribute (e.g., Size: M).
6. Ensure the result spans at least two pages.
7. Click on page "2".
8. Observation: The second attribute filter is lost, and the product list changes incorrectly.

Fix:
Ensure that `attribute_values` are stored as a list within the `url_args` passed to the pager. Since Odoo's `website.pager` uses `url_encode` internally, passing a list of values for a single key correctly generates repeated parameters in the resulting URL (e.g., `attrib=1&attrib=2`).

opw-4152637