### PR TITLE
[FIX] pos: prevent payment method auto-selection on backspace

### DIFF
--- a/addons/point_of_sale/static/src/app/services/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/services/number_buffer_service.js
@@ -285,7 +285,8 @@ class NumberBuffer extends EventBus {
             if (isEmpty(buffer)) {
                 this.state.buffer = null;
             } else {
-                const nCharToRemove = buffer[buffer.length - 1] === this.decimalPoint ? 2 : 1;
+                const patterns = ["0" + this.decimalPoint, "-" + "0" + this.decimalPoint];
+                const nCharToRemove = patterns.includes(buffer) ? 2 : 1;
                 this.state.buffer = buffer.substring(0, buffer.length - nCharToRemove);
             }
         } else if (input === "+") {

--- a/doc/cla/individual/mitbhavsaar.md
+++ b/doc/cla/individual/mitbhavsaar.md
@@ -1,0 +1,11 @@
+mitbhavsaar@gmail.comIndia, 2026-01-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement
+version 1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mit Bhavsar <mitbhavsaar@gmail.com> https://github.com/mitbhavsaar


### PR DESCRIPTION
Description:
This PR fixes an issue in the POS payment screen where pressing the numpad
backspace multiple times clears the current payment line and unexpectedly
auto-selects the first payment method.

Current behavior before PR:
When the payment amount is cleared using the backspace key, the number
buffer becomes null, which causes the POS to automatically select the
first payment method again.

Desired behavior after PR:
Clearing the payment amount using backspace should only reset the
current payment line without switching the selected payment method.

Root cause:
The number buffer was set to `null` when empty.

Fix:
Ensure the buffer remains an empty string instead of `null` when cleared
via backspace, preventing the unintended payment method auto-selection.

Steps to reproduce:
- Start a POS session
- Add a product
- Go to the Payment screen
- Select a payment method and enter an amount
- Press backspace multiple times

Affected version:
- 19.0

Fixes #243949
