### PR TITLE
[IMP] mail: mark message as edited when removing attachments

### DIFF
--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -165,6 +165,8 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         attachment.flush_recordset()
         message = self.env['mail.message'].create({
             'attachment_ids': [(6, 0, attachment.ids)],
+            "model": "res.partner",
+            "res_id": self.partner_a.id,
         })
         res = self.url_open(
             url=f'{self.invoice_base_url}/mail/attachment/delete',
@@ -177,6 +179,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         )
         self.assertEqual(res.status_code, 200)
         self.assertFalse(attachment.exists())
+        self.assertIn("o-mail-Message-edited", message.body)
         message.sudo().unlink()
 
         # Test attachment can't be associated if no attachment token.

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -94,6 +94,9 @@ class AttachmentController(ThreadController):
             raise NotFound()
         message = request.env["mail.message"].sudo().search(
             [("attachment_ids", "in", attachment.ids)], limit=1)
+        if message:
+            thread = request.env[message.model].browse(message.res_id)
+            thread._message_update_content(message, body=message.body)  # marks the message edited
         # sudo: ir.attachment: access is validated with _has_attachments_ownership
         attachment.sudo()._delete_and_notify(message)
 


### PR DESCRIPTION
With this commit, removing an attachment from a message will mark it as edited.

task-5357702