### PR TITLE
[FIX] mail: fix inbox mark as read test

### DIFF
--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -728,8 +728,16 @@ test("[text composer] Opening thread with needaction messages should mark all me
             ["res_id", "=", channelId],
         ]);
     });
+    pyEnv["mail.message"].create({
+        body: "Hello there!",
+        model: "discuss.channel",
+        res_id: channelId,
+        author_id: partnerId,
+    });
     await start();
     await openDiscuss(channelId);
+    await contains(".o-mail-Message:contains('Hello there!)");
+    await contains("button", { text: "Inbox", contains: [".badge", { count: 0 }] });
     await contains(".o-mail-Composer-input");
     await triggerEvents(".o-mail-Composer-input", ["blur", "focusout"]);
     await click("button", { text: "Inbox" });


### PR DESCRIPTION
The `Opening thread with needaction messages should mark all messages of thread as read` text composer test ensures that opening a channel marks the related inbox messages as read.

However, this test can fail in a non-deterministic fashion. There are two flows that can mark inbox messages as read: fetching the messages or a manual request after opening the channel.

The test expects the rpc to be issued, but if the messages are fetched before, it won't happen thus making the test fail.

This commit awaits the initial fetch to prevent this issue. As a bonus, the second flow is also tested.

runbot-238360

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
