### PR TITLE
[IMP] hr: allow sending bulk emails to employees from the Actions menu

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -1011,6 +1011,18 @@ if employees:
             </field>
         </record>
 
+        <record id="action_partner_mass_mail" model="ir.actions.act_window">
+            <field name="name">Send Email</field>
+            <field name="res_model">mail.compose.message</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="context">{
+                'default_composition_mode': 'mass_mail',
+            }</field>
+            <field name="binding_model_id" ref="hr.model_hr_employee"/>
+            <field name="binding_view_types">list,kanban</field>
+        </record>
+
         <record id="action_hr_employee_reopen" model="ir.actions.server">
             <field name="name">Reopen employees</field>
             <field name="model_id" ref="model_hr_employee"/>

--- a/addons/hr_presence/views/hr_employee_views.xml
+++ b/addons/hr_presence/views/hr_employee_views.xml
@@ -80,7 +80,7 @@
     </record>
 
     <record id="action_hr_employee_presence_sms" model="ir.actions.server">
-        <field name="name">Send a SMS</field>
+        <field name="name">Send SMS</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="binding_model_id" ref="hr.model_hr_employee"/>
         <field name="binding_view_types">form,list,kanban</field>


### PR DESCRIPTION
Before this commit, there was no easy way to send emails to multiple employees at once.

This change adds an option to send bulk emails directly from employee views making communication easier.

Task-5847145

