### PR TITLE
[FIX] mail: danger/success effect for actions

### DIFF
--- a/addons/mail/static/src/core/common/action_list.dark.scss
+++ b/addons/mail/static/src/core/common/action_list.dark.scss
@@ -5,7 +5,8 @@
     --mail-ActionList-successBgColor: #{rgba(saturate($success, 20%), .5)};
     --mail-ActionList-buttonInlineIconOpacity: #{85%};
     --mail-ActionList-dangerColor: #{lighten($danger, 5%)};
-    --o-mail-ActionList-dropdownDangerUnfocusedColor: #{lighten($danger, 10%)};
+    --o-mail-ActionList-successNoBgColor: #{lighten($success, 10%)};
+    --o-mail-ActionList-dangerNoBgColor: #{lighten($danger, 10%)};
 
     .o-hasBtnBg.o-tag-SUCCESS {
         @include button-variant(darken($success, 10%), darken($success, 10%));

--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -80,13 +80,22 @@
                 transform: translateY(.5px);
             }
         }
-        &.o-dropdown-item.btn-danger:not(.o-tag-JOIN_LEAVE_CALL) {
-            &.focus {
-                background-color: rgba($danger, 0.75);
-                color: white;
+
+        @each $status, $color in (danger: $danger, success: $success) {
+            &.o-dropdown-item.btn-#{$status}:not(.o-tag-JOIN_LEAVE_CALL) {
+                &.focus {
+                    background-color: rgba($color, 0.75);
+                    color: white;
+                }
+                &:not(.focus) {
+                    color: var(--o-mail-ActionList-#{$status}NoBgColor, #{$color});
+                }
             }
-            &:not(.focus) {
-                color: var(--o-mail-ActionList-dropdownDangerUnfocusedColor, #{$danger});
+            &.o-inline.btn-#{$status}:not(.o-tag-JOIN_LEAVE_CALL):not(.o-hasBtnBg) {
+                color: var(--o-mail-ActionList-#{$status}NoBgColor, #{$color});
+                &:active {
+                    background-color: inherit;
+                }
             }
         }
     }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -136,6 +136,10 @@
     --o-mail-ActionList-Button-opacity--hover: 1;
     --o-mail-ActionList-Button-color--hover: var(--mail-Message-actionIconHoveredColor, black);
 
+    .btn-danger, .btn-success {
+        --o-mail-ActionList-Button-opacity: .5;
+    }
+
     i {
         font-size: 1rem;
     }


### PR DESCRIPTION
PR #224976 fixes the demonstration of an action with a `DANGER` tag in the
dropdown menu in the action list. Such an action may not be located in the
dropdown, but rather in the quick action menu. This change ensures that the
action buttons with `DANGER` or `SUCCESS` tags are demonstrated properly in
either case.

Steps to reproduce:
- Open a document in the portal as a portal user.
- Send a message and hover over the message.
- The `delete` button is not visible in the action list.

