### PR TITLE
[FIX] hr_expense: compute same receipt if attachment is linked with expense

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -710,6 +710,7 @@ class HrExpense(models.Model):
 
         expenses_groupby_checksum = dict(self.env['ir.attachment']._read_group(domain=[
             ('res_model', '=', 'hr.expense'),
+            ('res_id', '!=', False),
             ('checksum', 'in', expenses_with_attachments.attachment_ids.mapped('checksum'))],
             groupby=['checksum'],
             aggregates=['res_id:array_agg'],


### PR DESCRIPTION
Currently, an exception occurs when a user tries to open expenses or upload
an attachment on expenses after following the steps described below.

- Create an attachment with an `image/PDF` file and set the resource model as `hr.expense`
- Go to expense > Create a new expense and upload the same `image/PDF` file

This issue occurs because when a user creates an attachment without specifying a `res_id`,
 it defaults to `0`. In the previous version, `0` was allowed in the record set. However, after the
 changes introduced in [1], `falsy` values like `0` are strictly disallowed in the record set.

This commit fixes the issue by reading only the `read_group` attachments that have a
valid `res_id`, effectively ignoring attachments without a `res_id`.

[1]: https://github.com/odoo/odoo/commit/4290724a4c8c57fba4f4d3d688d38f65dadcc38f

sentry-7201563878
