### PR TITLE
[FIX] stock_account: fix avco product value update

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -289,7 +289,7 @@ class ProductProduct(models.Model):
             order='date, id'
         )
         # TODO convert to company UoM
-        product_value_domain = Domain([('product_id', '=', self.id)])
+        product_value_domain = Domain([('product_id', '=', self.id), ('move_id', '=', False)])
         if lot:
             product_value_domain &= Domain(['|', ('lot_id', '=', lot.id), ('lot_id', '=', False)])
         else:

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3005,3 +3005,25 @@ class TestStockValuation(TestStockValuationCommon):
         self._make_dropship_move(self.product_avco, 15, unit_cost=15)
         self.assertEqual(self.product_avco.qty_available, -10)
         self.assertEqual(self.product_avco.standard_price, 10)
+
+    def test_avco_adjusted_valuation_updates_unit_cost_correctly(self):
+        """Ensure that for AVCO products, adjusting the total valuation recomputes
+        the unit cost correctly.
+
+        Scenario:
+        - Receive 100 units with an initial total value of 1000$ (unit cost = 10$)
+        - Adjust the move valuation to 2000$
+        - Expected unit cost = 2000 / 100 = 20$
+        """
+        move = self._make_in_move(self.product_avco, 100, 10)
+        self.assertEqual(move.quantity, 100.0)
+        self.assertEqual(self.product_avco.total_value, 1000)
+        self.assertEqual(self.product_avco.standard_price, 10)
+
+        self.env['product.value'].create({
+            'product_id': self.product_avco.id,
+            'move_id': move.id,
+            'value': 2000,
+        })
+        self.assertEqual(self.product_avco.total_value, 2000)
+        self.assertEqual(self.product_avco.standard_price, 20)


### PR DESCRIPTION
**Steps to reproduce:**
- Create a storable product "P1"
  - Product category: AVCO

- Create a purchase order with 100 units of P1 at $10
- Confirm the PO and validate the receipt
- Go to Inventory -> Reporting -> Stock

- P1 unit cost is $10 and total value is $1000

- Click on $1000
  - Select the first stock move
  - Action -> Adjust valuation
    - New value: $2000 -> Save

- Go back to Inventory -> Reporting -> Stock

**Problem:**
- The unit cost becomes $2,000 and the total value $200,000

When a valuation adjustment is made on an AVCO product, a `product.value`
record is created with the new total valuation value.

However, `product.value.value` can represent two different things:
- for a standard price update, `value` contains the new unit cost
- for a stock move valuation, `value` contains the total value of the move

When `run_avco` processes a `product.value` coming from a move valuation,
it incorrectly treats the value as a unit price and multiplies it by
the quantity

opw-5460829