### PR TITLE
[FIX] web: test failure in latest chrome (144)

### DIFF
--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -641,7 +641,7 @@ test("placeholder_field shows as placeholder (datetime)", async () => {
             </form>`,
     });
     await contains("div[name='datetime'] button").click();
-    expect("div[name='datetime'] input").toHaveAttribute("placeholder", "Apr 1, 2025, 9:11 AM", {
+    expect("div[name='datetime'] input").toHaveAttribute("placeholder", /Apr 1, 2025, 9:11\sAM/, {
         message: "placeholder_field should be the placeholder",
     });
 });


### PR DESCRIPTION
Apparently somewhere in the datetime patterns the space between time and A/P mark has been updated from a narrow non-breaking space to a regular space.

Make the code cross-version compatible.
