### PR TITLE
[FIX] hr_attendance: 3-decimal overtime precision

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -773,7 +773,7 @@ class HrAttendanceOvertimeRule(models.Model):
                     vals.append({
                         'time_start': attendance.check_in,
                         'time_stop': attendance.check_out,
-                        'duration': round(duration, 2),
+                        'duration': round(duration, 3),
                         'employee_id': employee.id,
                         'date': day,
                         'rule_ids': rules.ids,


### PR DESCRIPTION
### Current behavior:
Overtime hours are stored with a two-decimal
point precision. This means a minute is stored as a 
minute and twelve seconds in the worst case, 
which would amplify the overtime given or taken
on a particular attendance. This is problematic 
when aggregating the records for large datasets 
to compute the balance or for reporting

### Expected behavior:
A minute should be stored closer to its real decimal 
value to minimize the error in aggregations 
as a minute and 1.2 seconds

opw-5422827
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
