### PR TITLE
[FIX] website(_sale): stop showing eCommerce reporting menu w/o access

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1779,7 +1779,7 @@ class Website(models.Model):
         if (self.env.user.has_group('base.group_system')
                 or self.env.user.has_group('website.group_website_designer')):
             return self.env["ir.actions.actions"]._for_xml_id("website.backend_dashboard")
-        return self.env["ir.actions.actions"]._for_xml_id("website.action_website")
+        raise AccessError(_("You don't have the necessary access rights to access this dashboard."))
 
     def get_client_action_url(self, url, mode_edit=False, mode_debug=0):
         action_params = {

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -403,7 +403,8 @@
             sequence="20"
             parent="menu_reporting"
             action="website.ir_actions_server_website_dashboard"
-            active="0"/>
+            active="0"
+            groups="base.group_system,website.group_website_designer"/>
 
         <menuitem id="menu_website_analytics"
             name="Analytics"

--- a/addons/website_sale/views/website_sale_menus.xml
+++ b/addons/website_sale/views/website_sale_menus.xml
@@ -117,4 +117,7 @@
         parent="website.menu_content"
         sequence="30"/>
 
+    <record id="website.menu_website_dashboard" model="ir.ui.menu">
+        <field name="group_ids" eval="[Command.link(ref('sales_team.group_sale_salesman'))]"/>
+    </record>
 </odoo>


### PR DESCRIPTION
__Steps to reproduce on runbot:__

1. Login with Mitchell Admin
2. Remove Marc Demo from the `sales_team.group_sale_salesman` access
group (User: Own Documents Only)
3. Login with Marc Demo
4. Open the Website app and go to Reporting > eCommerce
=> You are redirected to the website in frontend mode

__Reason:__

Clicking on the eCommerce reporting menu calls
`action_dashboard_redirect`, which redirects to the website if the user
is not in `base.group_system`, `website.group_website_designer`, or
`sales_team.group_sale_salesman`. Since Marc Demo is not in any of these
groups, he is redirected to the website without any message, which is
not very user friendly.

__Fix:__

- Add the groups to the menu to prevent showing it if the user does not
have access to it anyway.
- Raise an access error instead of redirecting to the website to make it
clear to the user that they cannot open the dashboard even if they could
see it.

This also fixes [`TestMenusDemo`] by preventing this menu from being
tested with the demo user in case he doesn't have access to it.

[`TestMenusDemo`]: https://github.com/odoo/odoo/blob/736b71202db840ba6a7ed7e7f014b5b7c493d589/addons/web/tests/test_click_everywhere.py#L41C9-L41C41

runbot-234747