### PR TITLE
[IMP] iot_base: use ip instead of domain when LNA enabled

### DIFF
--- a/addons/iot_base/static/src/network_utils/http.js
+++ b/addons/iot_base/static/src/network_utils/http.js
@@ -25,7 +25,8 @@ export function uuid() {
  */
 export function formatEndpoint(ip, route, forceHttp = false) {
     const protocol = forceHttp ? "http:" : window.location.protocol;
-    const url = new URL(`${protocol}//${ip}`);
+    const rawIp = forceHttp ? ip.replace(/^(\d+)-(\d+)-(\d+)-(\d+).*/, "$1.$2.$3.$4") : ip;
+    const url = new URL(`${protocol}//${rawIp}`);
     url.pathname = route;
     return url.toString();
 }


### PR DESCRIPTION
In order to avoid DNS resolution issues, we now parse the domain to get the IP of the IoT Box if LNA is enabled.