### PR TITLE
[IMP] core: run at-install like post-install when no module update from config

### DIFF
--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -28,6 +28,7 @@ from .registry import Registry
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Iterable
+    from typing import Literal
     from odoo.api import Environment
     from odoo.sql_db import BaseCursor
     from odoo.tests.result import OdooTestResult
@@ -271,23 +272,9 @@ def load_module_graph(
 
         update_from_config = tools.config['update'] or tools.config['init'] or tools.config['reinit']
         if tools.config['test_enable'] and (update_operation or not update_from_config):
-            from odoo.tests import loader  # noqa: PLC0415
-            suite = loader.make_suite([module_name], 'at_install')
-            if suite.countTestCases():
-                if not update_operation:
-                    registry._setup_models__(env.cr, [])  # incremental setup
-                registry.check_null_constraints(env.cr)
-                # Python tests
-                tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-                test_results = loader.run_suite(suite, global_report=report)
-                assert report is not None, "Missing report during tests"
-                report.update(test_results)
-                test_time = time.time() - tests_t0
-                test_queries = odoo.sql_db.sql_counter - tests_q0
-
-                # tests may have reset the environment
-                module = env['ir.module.module'].browse(module_id)
-
+            test_time, _, test_queries, test_results = test_modules(registry, env.cr, [module_name], 'at_install', report)
+            # tests may have reset the environment
+            module = env['ir.module.module'].browse(module_id)
 
         extra_queries = odoo.sql_db.sql_counter - module_extra_query_count - test_queries
         extras = []
@@ -600,6 +587,38 @@ def load_modules(
                 ON CONFLICT DO NOTHING
                 """
             )
+
+
+def test_modules(
+    registry: Registry,
+    module_names: list[str],
+    position: Literal['at_install', 'post_install'],
+    report: OdooTestResult | None = None
+) -> tuple[float, int, int, OdooTestResult | None]:
+    from odoo.tests import loader  # noqa: PLC0415
+    suite = loader.make_suite(module_names, position)
+    test_time, test_queries, test_results = 0.0, 0, None
+    if suite.countTestCases():
+        assert report is not None, "Missing report during tests"
+        tests_before = report.testsRun
+        with registry.cursor() as cr:
+            if position == 'at_install' and not registry.ready:
+                registry._setup_models__(cr, [])  # incremental setup
+                registry.check_null_constraints(cr)
+            else:  # post_install
+                if suite.has_http_case():
+                    env = api.Environment(cr, api.SUPERUSER_ID, {})
+                    env['ir.qweb']._pregenerate_assets_bundles()
+
+        # Python tests
+        tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
+        test_results = loader.run_suite(suite, global_report=report)
+        report.update(test_results)
+        test_time = time.time() - tests_t0
+        test_queries = odoo.sql_db.sql_counter - tests_q0
+        test_count = report.testsRun - tests_before
+
+    return test_time, test_count, test_queries, test_results
 
 
 def reset_modules_state(db_name: str) -> None:

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -611,7 +611,17 @@ def test_modules(
 
         # Python tests
         tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-        test_results = loader.run_suite(suite, global_report=report)
+        loaded_before = registry.loaded
+        ready_before = registry.ready
+        try:
+            if ready_before and position == 'at_install':
+                # best effort to restore the test environment
+                registry.ready = registry.loaded = False
+            test_results = loader.run_suite(suite, global_report=report)
+        finally:
+            registry.loaded = loaded_before
+            registry.ready = ready_before
+
         report.update(test_results)
         test_time = time.time() - tests_t0
         test_queries = odoo.sql_db.sql_counter - tests_q0

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -270,9 +270,8 @@ def load_module_graph(
         test_queries = 0
         test_results = None
 
-        update_from_config = tools.config['update'] or tools.config['init'] or tools.config['reinit']
-        if tools.config['test_enable'] and (update_operation or not update_from_config):
-            test_time, _, test_queries, test_results = test_modules(registry, env.cr, [module_name], 'at_install', report)
+        if tools.config['test_enable'] and update_operation:
+            test_time, _, test_queries, test_results = test_modules(registry, [module_name], 'at_install', report)
             # tests may have reset the environment
             module = env['ir.module.module'].browse(module_id)
 
@@ -597,7 +596,7 @@ def test_modules(
 ) -> tuple[float, int, int, OdooTestResult | None]:
     from odoo.tests import loader  # noqa: PLC0415
     suite = loader.make_suite(module_names, position)
-    test_time, test_queries, test_results = 0.0, 0, None
+    test_time, test_count, test_queries, test_results = 0.0, 0, 0, None
     if suite.countTestCases():
         assert report is not None, "Missing report during tests"
         tests_before = report.testsRun

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1598,8 +1598,19 @@ def preload_registries(dbnames):
 
                 registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'], reinit_modules=config['reinit'])
 
-                # run post-install tests
                 if config['test_enable']:
+                    # run at-install tests if not update_module from config
+                    if not update_module:
+                        _logger.info("Starting at-install tests after registry loaded")
+                        module_names = sorted(registry._init_modules)
+                        test_time, test_count, test_queries, _ = test_modules(registry, module_names, 'at_install', registry._assertion_report)
+                        if test_count:
+                            _logger.info("%d at-install tests after registry loaded in %.2fs, %s queries",
+                                        test_count,
+                                        test_time,
+                                        test_queries)
+
+                    # run post-install tests
                     module_names = sorted(registry.updated_modules if update_module else
                                     registry._init_modules)
                     _logger.info("Starting post tests")


### PR DESCRIPTION


When repeatedly testing at-install tests with required fields added by
auto-install modules, the current behavior causes issues.

(for example: `TestPerformance.test_read_base`)

The problem occurs when creating records in tests: the INSERT query
violates the NOT NULL constraint of fields from unloaded modules.
Previously, the only workarounds were to either:
- Change the test to post-install, or
- Update the module with `-u` or `--reinit` to drop the NOT NULL constraint

Since the behavior of at-install tests for non-newly-installed modules
is not strictly defined, this change makes them behave the same as
post-install tests in such cases, providing a more practical testing workflow.
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
