### PR TITLE
[FIX] purchase: allow cross-company payment matching

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -143,7 +143,8 @@ class AccountMove(models.Model):
             'res_model': 'purchase.bill.line.match',
             'domain': [
                 ('partner_id', 'in', (self.partner_id | self.partner_id.commercial_partner_id).ids),
-                ('company_id', 'in', self.env.company.ids),
+                ('company_id', 'in', self.env.companies.ids),
+                ('company_id', 'child_of', self.company_id.ids),
                 ('account_move_id', 'in', [self.id, False]),
             ],
             'views': [(self.env.ref('purchase.purchase_bill_line_match_tree').id, 'list')],


### PR DESCRIPTION
On bills, the `purchase_vendor_bill_id` field already allows matching with cross-company purchase orders. This commit extends this behavior to payment matching.

Steps to reproduce:
- Create a child company from a parent company.
- Create a purchase order in the child company.
- Create a bill in the parent company.
- In the bill’s payment matching, the child company’s purchase order should be available.

opw-5416947