### PR TITLE
[IMP] calendar: time detection in calendar event title

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -3,9 +3,10 @@
 import itertools
 import logging
 import math
+import re
 import uuid
+from babel.dates import parse_time
 from datetime import datetime, timedelta, UTC
-from itertools import repeat
 from zoneinfo import ZoneInfo
 
 from markupsafe import Markup
@@ -27,7 +28,7 @@ from odoo.addons.calendar.models.calendar_recurrence import (
 from odoo.addons.calendar.models.utils import interval_from_events
 from odoo.tools.intervals import intervals_overlap
 from odoo.tools.translate import _
-from odoo.tools.misc import get_lang
+from odoo.tools.misc import get_lang, babel_locale_parse
 from odoo.tools import html2plaintext, html_sanitize, is_html_empty, single_email_re
 from odoo.exceptions import UserError, ValidationError
 
@@ -51,6 +52,29 @@ RRULE_TYPE_SELECTION_UI = [
     ('yearly', 'Yearly'),
     ('custom', 'Custom')
 ]
+
+# regex to match common ways to represent time
+# (9h, 9H, 9:00, 09:00, 9 am, 9am, 9a.m. 21h, 21:30, 9-10, 9-11h...)
+HOUR = r'(?:[01]?\d|2[0-3])'  # 0-23
+MINUTES = r'(?:[0-5]\d)'  # :00-:59
+SUFFIX = r'(?:h|hr|am|pm|a\.m\.?|p\.m\.?)'
+RANGE_DELIM = r'(?:-|–|to)'
+HOUR_WITH_MINUTES = rf'{HOUR}:{MINUTES}\s*{SUFFIX}?'
+HOUR_WITH_SUFFIX = rf'{HOUR}\s*{SUFFIX}'
+LOOSE_TIME = rf'(?:{HOUR_WITH_MINUTES}|{HOUR_WITH_SUFFIX}|{HOUR})'
+# Hour range uses lookahead, to make sure that a delimiter and a time follow.
+# Needed to disallow single hours 'meeting 5', but match ranges like '5-7pm'
+HOUR_RANGE = rf'{HOUR}(?=\s*{RANGE_DELIM}\s*{LOOSE_TIME})'
+TIME_REGEX = re.compile(
+    rf'''
+    (?:^|\s) # start of string or space
+    ({HOUR_WITH_MINUTES}|{HOUR_WITH_SUFFIX}|{HOUR_RANGE})  # Valid start times, with an optional range lookahead
+    (?:\s*{RANGE_DELIM}\s*({LOOSE_TIME}))? # Optional end time
+    (?:$|\s) # end of string or space
+    ''',
+    re.IGNORECASE | re.VERBOSE,
+)
+
 
 def get_weekday_occurence(date):
     """
@@ -590,6 +614,58 @@ class CalendarEvent(models.Model):
     def get_discuss_videocall_location(self):
         access_token = uuid.uuid4().hex
         return f"{self.get_base_url()}/{self.DISCUSS_ROUTE}/{access_token}"
+
+    @api.onchange('name')
+    def _onchange_name_extract_time(self):
+        for event in self:
+            if not event.env.context.get("is_quick_create_form") or not event.name or not event.allday:
+                continue
+
+            parsed_time = event._parse_time_from_title()
+            if not parsed_time:
+                continue
+
+            event.update({
+                'allday': False,
+                'start': parsed_time[0],
+                'stop': parsed_time[1],
+            })
+
+    def _parse_time_from_title(self):
+        """Extract datetime information from an event title.
+        Returns a tuple of (start_datetime_utc, end_datetime_utc) or None if no time is found."""
+        match = TIME_REGEX.search(self.name)
+        if not match:
+            return None
+
+        start_raw, end_raw = match.groups()
+
+        locale = babel_locale_parse(get_lang(self.env).code)
+        start_time = parse_time(start_raw, locale=locale)
+        end_time = parse_time(end_raw, locale=locale) if end_raw else None
+
+        # The user enters the meeting time in their own timezone, but we store it as UTC
+        tz_name = self.env.context.get('tz') or self.env.user.tz or 'UTC'
+        tz = ZoneInfo(tz_name)
+
+        # Combine event date and parsed time, using the user's timezone
+        start_local_dt = datetime.combine(self.start.date(), start_time, tzinfo=tz)
+        if end_time:
+            end_local_dt = datetime.combine(self.start.date(), end_time, tzinfo=tz)
+        else:
+            end_local_dt = start_local_dt + timedelta(hours=1)
+
+        # 9 to 5 should assume 9am to 5pm
+        if start_local_dt > end_local_dt and start_local_dt.hour <= 12:
+            end_local_dt += timedelta(hours=12)
+
+        # Handle overnight events edge case (e.g. 23:00 - 01:00)
+        if end_local_dt <= start_local_dt:
+            end_local_dt += timedelta(days=1)
+
+        start_utc = start_local_dt.astimezone(UTC).replace(tzinfo=None)
+        end_utc = end_local_dt.astimezone(UTC).replace(tzinfo=None)
+        return start_utc, end_utc
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/calendar/tests/__init__.py
+++ b/addons/calendar/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_attendees
 from . import test_calendar
 from . import test_calendar_activity
 from . import test_calendar_controller
+from . import test_calendar_event_time_extraction
 from . import test_calendar_recurrent_event_case2
 from . import test_calendar_tour
 from . import test_event_recurrence

--- a/addons/calendar/tests/test_calendar_event_time_extraction.py
+++ b/addons/calendar/tests/test_calendar_event_time_extraction.py
@@ -1,0 +1,171 @@
+from datetime import datetime
+from odoo.tests import TransactionCase, tagged, new_test_user, users
+
+
+@tagged('post_install', '-at_install')
+class TestCalendarEventTimeExtraction(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_utc_tz = new_test_user(
+            cls.env,
+            login='user_utc_tz',
+            name='Humphrey Appleby',
+            groups='base.group_user',
+            tz='UTC',
+        )
+        cls.user_brussels_tz = new_test_user(
+            cls.env,
+            login='user_brussels_tz',
+            name='Hercule Poirot',
+            groups='base.group_user',
+            tz='Europe/Brussels',
+        )
+        cls.user_japan_tz = new_test_user(
+            cls.env,
+            login='user_japan_tz',
+            name='Gojo Satoru',
+            groups='base.group_user',
+            tz='Asia/Tokyo',
+        )
+
+    @users('user_utc_tz')
+    def test_parse_time_from_title(self):
+        test_cases = [
+            # Single times
+            ('9am meeting', 9, 0, 10, 0),
+            ('9h coffee break', 9, 0, 10, 0),
+            ('9H standup', 9, 0, 10, 0),
+            ('9:00 presentation', 9, 0, 10, 0),
+            ('09:00 call', 9, 0, 10, 0),
+            ('9 pm sync', 21, 0, 22, 0),
+            ('21h dinner', 21, 0, 22, 0),
+            ('21:30 evening call', 21, 30, 22, 30),
+            ('2pm review', 14, 0, 15, 0),
+            ('14:30 meeting', 14, 30, 15, 30),
+            ('9:30pm sync', 21, 30, 22, 30),
+            ('sync 9:30', 9, 30, 10, 30),
+
+            # Basic ranges
+            ('9-10 workshop', 9, 0, 10, 0),
+            ('9 to 10 workshop', 9, 0, 10, 0),
+            ('9–11h training', 9, 0, 11, 0),  # en-dash
+            ('2pm-4pm meeting', 14, 0, 16, 0),
+            ('14:30-16:00 review', 14, 30, 16, 0),
+            ('9:00-10:30 session', 9, 0, 10, 30),
+            ('10h-12h break', 10, 0, 12, 0),
+            ('11 pm to 1 am lan party', 23, 0, 1, 0),
+            ('9 to 5 worktime', 9, 0, 17, 0),
+
+            # Mixed suffix inheritance
+            ('9am-11 workshop', 9, 0, 11, 0),
+            ('9-11am workshop', 9, 0, 11, 0),
+            ('9am–11h training', 9, 0, 11, 0),
+            ('9–11 pm shift', 9, 0, 23, 0),
+
+            # Minutes on one side only
+            ('9:30-11 meeting', 9, 30, 11, 0),
+            ('9-11:30 meeting', 9, 0, 11, 30),
+
+            # Time range boundaries
+            ('Meeting 9-10', 9, 0, 10, 0),
+        ]
+
+        for title, start_h, start_m, end_h, end_m in test_cases:
+            event = self.env['calendar.event'].new({'name': title})
+            result = event._parse_time_from_title()
+
+            self.assertIsNotNone(result, f"Failed to parse time from: {title}")
+            self.assertEqual(result[0].hour, start_h, f"Wrong start hour for: {title}")
+            self.assertEqual(result[0].minute, start_m, f"Wrong start minute for: {title}")
+            self.assertEqual(result[1].hour, end_h, f"Wrong end hour for: {title}")
+            self.assertEqual(result[1].minute, end_m, f"Wrong end minute for: {title}")
+
+    @users('user_utc_tz')
+    def test_parse_time_from_title_no_time(self):
+        """Test titles without time information"""
+        test_cases = [
+            # No time
+            'Project meeting',
+            'Standup',
+            'Quick sync',
+            'Review session',
+
+            # Numbers that are not times
+            'Version 2.10 release',
+            'RFC 3339 discussion',
+            'Budget 2024 review',
+            'Top 10 priorities',
+
+            # Invalid times
+            '25h maintenance',
+            '9:99 meeting',
+            '32:00 review',
+
+            # Partial or ambiguous
+            'meeting at nine',
+            'room 9 booking',
+            'phase 2 planning',
+
+            # Broken ranges
+            'test 19-3-2026',
+            '9-11-12 meeting',
+            '9- meeting',
+            '-11 training',
+            '9--11 workshop',
+            'foo10am',
+            'meeting10-11',
+        ]
+
+        for title in test_cases:
+            event = self.env['calendar.event'].new({'name': title})
+            result = event._parse_time_from_title()
+            self.assertIsNone(result, f"Should not find time in: {title}")
+
+    @users('user_utc_tz', 'user_brussels_tz', 'user_japan_tz')
+    def test_onchange_name_with_different_timezones(self):
+        event = self.env['calendar.event'].with_context(is_quick_create_form=True).create([{
+            'name': '8-10am meeting',
+            'allday': True,
+            'start': datetime(2024, 1, 15),
+        }])
+
+        timezone_to_utc = {
+            'UTC': (8, 10),                # UTC
+            'Europe/Brussels': (7, 9),     # UTC+1
+            'Asia/Tokyo': (23, 1)          # UTC+9, different date!
+        }
+
+        event._onchange_name_extract_time()
+        start_hour_utc, end_hour_utc = timezone_to_utc.get(self.env.user.tz)
+
+        self.assertFalse(event.allday)
+        self.assertEqual(event.start.hour, start_hour_utc, "Start hour should be updated to 9 (UTC)")
+        self.assertEqual(event.stop.hour, end_hour_utc, "End hour should be updated to 10 (UTC)")
+
+        if self.env.user.tz == 'Asia/Tokyo':
+            self.assertEqual(event.start.date(), datetime(2024, 1, 14).date(), "Japan's event should start one day earlier")
+            self.assertEqual(event.stop.date(), datetime(2024, 1, 15).date(), "End time for japan should be the same day")
+        else:
+            self.assertEqual(event.start.date(), datetime(2024, 1, 15).date(), "Date should remain unchanged")
+
+    @users('user_utc_tz')
+    def test_onchange_name_without_parsing(self):
+        original_start = datetime(2024, 1, 15, 10, 0, 0)
+
+        event_no_quickcreate = self.env['calendar.event'].new({
+            'name': '9am meeting',
+            'allday': True,
+            'start': original_start,
+        })
+        event_no_time = self.env['calendar.event'].with_context(is_quick_create_form=True).new({
+            'name': 'Project meeting',
+            'allday': True,
+            'start': original_start,
+        })
+        for event in (event_no_quickcreate, event_no_time):
+            with self.subTest(event=event):
+                event._onchange_name_extract_time()
+                self.assertTrue(event.allday, "Event should remain allday without quickcreate context")
+                self.assertEqual(event.start, original_start, "Start should not change without quick create context")

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -283,6 +283,7 @@ export class CalendarController extends Component {
     getQuickCreateFormViewProps(record) {
         const rawRecord = this.model.buildRawRecord(record);
         const context = this.model.makeContextDefaults(rawRecord);
+        context.is_quick_create_form = true;
         return {
             resModel: this.model.resModel,
             viewId: this.model.quickCreateFormViewId,


### PR DESCRIPTION
We to create a meeting by typing the time into the meeting title: e.g. '9am meeting'

This should:
-> uncheck all day
-> autofill start time
-> autofill end time if provided, otherwise set it to one hour after start

This behavior should only apply in the all day quick create form, and should cover a wide range of possible time formats, e.g.: 9h, 9H, 9:00, 09:00, 9 am, 9am, 21h, 21:30, 9-10, 9–11h

A regex was used to match times, time ranges, and time format suffixes. See the regex comments and tests for covered cases.

task-5380671