### PR TITLE
[IMP] hr_attendance: Improve Attendance Record Overtime Approval UI

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -47,11 +47,11 @@ class HrAttendance(models.Model):
     date = fields.Date(string="Date", compute='_compute_date', store=True, index=True, precompute=True, required=True)
     worked_hours = fields.Float(string='Worked Hours', compute='_compute_worked_hours', store=True, readonly=True)
     color = fields.Integer(compute='_compute_color')
-    overtime_hours = fields.Float(string="Over Time", compute='_compute_overtime_hours', store=True)
+    overtime_hours = fields.Float(string="Overtime to Approve", compute='_compute_overtime_hours', store=True)
     overtime_status = fields.Selection(selection=[('to_approve', "To Approve"),
                                                   ('approved', "Approved"),
                                                   ('refused', "Refused")], compute="_compute_overtime_status", store=True, tracking=True, readonly=False)
-    validated_overtime_hours = fields.Float(string="Extra Hours", compute='_compute_validated_overtime_hours', tracking=True, store=True, readonly=True)
+    validated_overtime_hours = fields.Float(string="Approved Overtime", compute='_compute_validated_overtime_hours', tracking=True, store=True, readonly=True)
     in_latitude = fields.Float(string="Latitude", digits=(10, 7), readonly=True, aggregator=None)
     in_longitude = fields.Float(string="Longitude", digits=(10, 7), readonly=True, aggregator=None)
     in_location = fields.Char(help="Based on GPS-Coordinates if available or on IP Address")
@@ -558,6 +558,9 @@ class HrAttendance(models.Model):
 
     def action_refuse_overtime(self):
         self.linked_overtime_ids.action_refuse()
+
+    def action_reset_overtime(self):
+        self.linked_overtime_ids.action_reset()
 
     def _cron_auto_check_out(self):
         def check_in_tz(attendance):

--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -23,9 +23,9 @@ class HrAttendanceOvertimeLine(models.Model):
         compute='_compute_status',
         required=True, store=True, readonly=False, precompute=True,
     )
-    duration = fields.Float(string='Extra Hours', default=0.0, required=True)
+    duration = fields.Float(string='Eligible Overtime', default=0.0, required=True)
     manual_duration = fields.Float(  # TODO -> real_duration for easier upgrade
-        string='Extra Hours (encoded)',
+        string='Overtime (manual)',
         compute='_compute_manual_duration',
         store=True, readonly=False,
     )
@@ -87,6 +87,9 @@ class HrAttendanceOvertimeLine(models.Model):
 
     def action_refuse(self):
         self.write({'status': 'refused'})
+
+    def action_reset(self):
+        self.write({'status': 'to_approve'})
 
     def _linked_attendances(self):
         return self.env['hr.attendance'].search([

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -21,8 +21,8 @@
                 <field name="check_in"/>
                 <field name="check_out" options="{}"/>
                 <field name="worked_hours" string="Worked Hours" widget="float_time"/>
-                <field name="overtime_hours" string="Worked Extra Hours" optional="show" widget="float_time"/>
-                <field name="validated_overtime_hours" string="Extra Hours" optional="show" widget="float_time"/>
+                <field name="overtime_hours" string="Overtime to Approve" optional="show" widget="float_time"/>
+                <field name="validated_overtime_hours" string="Approved Overtime" optional="show" widget="float_time"/>
                 <field name="overtime_status" optional="hidden" widget="badge" decoration-warning="overtime_status == 'to_approve'" decoration-success="overtime_status == 'approved'" decoration-danger="overtime_status == 'refused'"/>
                 <field name="in_mode" string="Input Mode (In)" optional="hidden"/>
                 <field name="out_mode" string="Input Mode (Out)" optional="hidden"/>
@@ -71,13 +71,25 @@
                         name="overtime_status"
                         widget="statusbar"
                         readonly="1"
-                        options="{'clickable': '1'}"
-                        invisible="not overtime_status"/>
+                        statusbar_visible="to_approve,approved,refused"
+                        invisible="not overtime_status or overtime_status!='to_approve'"/>
+                    <field
+                        name="overtime_status"
+                        widget="statusbar"
+                        readonly="1"
+                        statusbar_visible="to_approve,approved"
+                        invisible="not overtime_status or overtime_status in ['to_approve', 'refused']"/>
+                    <field
+                        name="overtime_status"
+                        widget="statusbar"
+                        readonly="1"
+                        statusbar_visible="to_approve,refused"
+                        invisible="not overtime_status or overtime_status in ['to_approve', 'approved']"/>
                 </header>
                 <sheet>
                     <group>
-                        <group colspan="2">
-                            <group col="1" name="group_employee">
+                        <group>
+                            <group colspan="2" name="group_employee">
                                 <field
                                     id="employee_no_officer"
                                     name="employee_id"
@@ -101,12 +113,47 @@
                                         ('company_id', 'in', allowed_company_ids),
                                     ]"
                                     groups="hr_attendance.group_hr_attendance_user"/>
-                                <field name="check_in" options="{'rounding': 0}" readonly="not can_edit"/>
-                                <field name="check_out" options="{'rounding': 0}" placeholder="Currently Working" readonly="not can_edit"/>
                             </group>
-                            <group col="2" name="group_worked_hours">
-                                <field name="worked_hours" string="Worked Time" widget="float_time"/>
-                                <field name="overtime_hours" widget="float_time" string="Worked Extra Hours" invisible="overtime_hours == validated_overtime_hours"/>
+                            <group colspan="2">
+                                <div class="o_row">
+                                    <label for="check_in" string="Check In"/>
+                                    <field name="check_in" options="{'rounding': 0}" readonly="not can_edit"/>
+                                    <label for="check_out" string="Check Out"/>
+                                    <field name="check_out" options="{'rounding': 0}" placeholder="Currently Working" readonly="not can_edit"/>
+                                </div>
+                            </group>
+                            <group colspan="2" name="group_worked_hours">
+                                <div class="o_row">
+                                    <label for="worked_hours" string="Worked Time"/>
+                                    <field name="worked_hours" string="Worked Time" widget="float_time"/>
+                                    <label for="expected_hours" string="Expected Time"/>
+                                    <field name="expected_hours" string="Expected Time" widget="float_time"/>
+                                </div>
+                            </group>
+                            <group colspan="2">
+                                <label for="overtime_hours"/>
+                                <div>
+                                    <field
+                                        name="overtime_hours"
+                                        style="width:5ch"
+                                        widget="float_time"/>
+                                    <button
+                                        class="btn btn-outline-success text-success ms-2"
+                                        string="Approve"
+                                        help="Approve all overtimes for the same employee and date"
+                                        invisible="not is_manager or overtime_status in ['approved','refused'] or not overtime_status"
+                                        name="action_approve_overtime"
+                                        type="object"
+                                        groups="hr_attendance.group_hr_attendance_officer"/>
+                                    <button
+                                        class="btn btn-outline-danger text-danger ms-2"
+                                        string="Refuse"
+                                        help="Refuse all overtimes for the same employee and date"
+                                        invisible="not is_manager or overtime_status in ['approved','refused'] or not overtime_status"
+                                        name="action_refuse_overtime"
+                                        type="object"
+                                        groups="hr_attendance.group_hr_attendance_officer"/>
+                                </div>
                                 <label for="validated_overtime_hours"/>
                                 <div>
                                     <field
@@ -116,21 +163,11 @@
                                         readonly="1"/>
                                     <!-- TODO algin icons baseline with text -->
                                     <button
-                                        class="oe_stat_button flex-shrink-0"
-                                        string=" "
-                                        help="Approve all overtimes for the same employee and date"
-                                        invisible="not is_manager or overtime_status not in ['to_approve', 'refused'] or not overtime_status"
-                                        name="action_approve_overtime"
-                                        icon="fa-check"
-                                        type="object"
-                                        groups="hr_attendance.group_hr_attendance_officer"/>
-                                    <button
-                                        class="oe_stat_button flex-shrink-0"
-                                        string=" "
-                                        help="Refuse all overtimes for the same employee and date"
-                                        invisible="not is_manager or overtime_status not in ['to_approve', 'approved'] or not overtime_status"
-                                        name="action_refuse_overtime"
-                                        icon="fa-times"
+                                        class="btn btn-secondary ms-2"
+                                        string="Reset"
+                                        help="Reset all overtimes for the same employee and date"
+                                        invisible="not is_manager or overtime_status in ['to_approve'] or not overtime_status"
+                                        name="action_reset_overtime"
                                         type="object"
                                         groups="hr_attendance.group_hr_attendance_officer"/>
                                 </div>
@@ -402,8 +439,9 @@
                 <field name="check_in" readonly="1"/>
                 <field name="check_out" readonly="1"/>
                 <field name="worked_hours" readonly="1" string="Worked Time" widget="float_time"/>
-                <field name="overtime_hours" string="Worked Extra Hours" widget="float_time"/>
-                <field name="validated_overtime_hours" readonly="overtime_status == 'refused'" string="Extra Hours" widget="float_time"/>
+                <field name="expected_hours" readonly="1" string="Expected Time" widget="float_time"/>
+                <field name="overtime_hours" string="Overtime to Approve" widget="float_time"/>
+                <field name="validated_overtime_hours" readonly="overtime_status == 'refused'" string="Approved Overtime" widget="float_time"/>
                 <button
                     class="oe_stat_button"
                     string="Approve"

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -126,7 +126,7 @@
                 <field name="check_in"/>
                 <field name="check_out"/>
                 <field name="worked_hours" string="Work Hours" widget="float_time"/>
-                <field name="validated_overtime_hours" string="Extra Hours" widget="float_time" column_invisible="not context.get('display_extra_hours')"/>
+                <field name="validated_overtime_hours" string="Approved Overtime" widget="float_time" column_invisible="not context.get('display_extra_hours')"/>
                 <field name="overtime_status" string="Status" widget="badge"
                        decoration-warning="overtime_status == 'to_approve'"
                        decoration-success="overtime_status == 'approved'"


### PR DESCRIPTION
#### Before
- Some field names were confusing, such as **Extra Hours** and **Worked Extra Hours**.
- Approve and Refuse actions were shown only as icons, which were not easy to understand.
- There was no way to reset the overtime status after it was approved or refused.
- In the list view, field names like **Extra Hours** and **Extra Hours (encoded)** were confusing.
- The status bar always showed all three states, even when overtime was already approved or refused.

#### After
- Renamed fields in the form view:
  - **Extra Hours** -> **Approved Overtime**
  - **Worked Extra Hours** -> **Overtime to Approve**
- Replaced icon-only actions with clear buttons:
  - Green **Approve** button
  - Red **Refuse** button
- Added a **Reset** button to move overtime back to *To Approve* state.
- Added a new field **Expected Hours** to show how many hours the employee is expected to work.
- Renamed fields in the list view:
  - **Extra Hours** -> **Eligible Overtime**
  - **Extra Hours (encoded)** -> **Overtime (manual)**
- Improved status bar behavior:
  - Shows **To Approve -> Approved -> Refused** when no decision is made
  - Shows **To Approve -> Approved** when approved
  - Shows **To Approve -> Refused** when refused

#### Impact
- Clear and user-friendly field names.
- Reset button allows changing the overtime decision if needed.
- Approve and Refuse actions are easier to understand.
- Status bar shows only relevant states, making the UI simpler.

---

**Task:** 5440583


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
