### PR TITLE
[IMP] web_tour: allow macro delay only for wanted listed tours

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -35,6 +35,7 @@ export const accountTourSteps = {
 }
 
 registry.category("web_tour.tours").add('account_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo",
     steps: () => [
     ...accountTourSteps.goToAccountMenu(markup(_t('Send invoices to your customers in no time with the <b>Invoicing app</b>.'))),

--- a/addons/auth_passkey/static/tests/passkeys_registration.js
+++ b/addons/auth_passkey/static/tests/passkeys_registration.js
@@ -5,6 +5,7 @@ import * as passkeyLib from "../lib/simplewebauthn";
 let unpatchPasskeyRegistration;
 
 registry.category("web_tour.tours").add('passkeys_tour_registration', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/odoo',
     steps: () => [
         {

--- a/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
+++ b/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
@@ -75,6 +75,7 @@ const assertNoRPC = {
 
 registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivity", {
     url: "/odoo",
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: "body",
@@ -147,6 +148,7 @@ registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivi
 
 registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivity_2fa", {
     url: "/odoo",
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         // Check identity using a passkey, which is 2FA by itself, and check an RPC call works
         assertCheckIdentityForm,

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -72,6 +72,7 @@ function closePreferencesDialog({content, totp_state}) {
 }
 
 registry.category("web_tour.tours").add('totp_tour_setup', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/odoo',
     steps: () => [
 ...openUserPreferencesAtSecurityTab(),
@@ -131,6 +132,7 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
 ]});
 
 registry.category("web_tour.tours").add('totp_login_enabled', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
@@ -203,6 +205,7 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
 }]});
 
 registry.category("web_tour.tours").add('totp_login_device', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
@@ -328,6 +331,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
 ]});
 
 registry.category("web_tour.tours").add('totp_login_disabled', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",

--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -11,6 +11,7 @@ const todayDate = function () {
 };
 
 registry.category("web_tour.tours").add("calendar_appointments_hour_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -129,6 +129,7 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
 });
 
 registry.category("web_tour.tours").add("create_thread_for_attachment_without_body", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             content: "Open general channel",

--- a/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
@@ -7,6 +7,7 @@ import { registry } from "@web/core/registry";
  * @see mail/tests/test_mail_composer.py
  */
 registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_composer_test_tour.js", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             content: "Wait for the chatter to be fully loaded",

--- a/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
@@ -3,6 +3,7 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("mail_template_dynamic_field_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -146,6 +146,7 @@ registry.category("web_tour.tours").add("OrderModificationAfterValidationError",
 });
 
 registry.category("web_tour.tours").add("test_tracking_number_closing_session", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -267,6 +268,7 @@ registry.category("web_tour.tours").add("test_edit_paid_order", {
 });
 
 registry.category("web_tour.tours").add("test_cash_in_out", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -309,6 +311,7 @@ registry.category("web_tour.tours").add("test_zero_decimal_places_currency", {
 });
 
 registry.category("web_tour.tours").add("SessionStatisticsDisplay", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/feedback_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/feedback_screen_tour.js
@@ -14,6 +14,7 @@ import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("FeedbackScreenTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -11,6 +11,7 @@ import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 import { inLeftSide } from "./utils/common";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -156,6 +157,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingDown", {
 });
 
 registry.category("web_tour.tours").add("PaymentScreenTotalDueWithOverPayment", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -206,6 +208,7 @@ registry.category("web_tour.tours").add("PaymentScreenInvoiceOrder", {
 });
 
 registry.category("web_tour.tours").add("test_pos_large_amount_confirmation_dialog", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -224,6 +227,7 @@ registry.category("web_tour.tours").add("test_pos_large_amount_confirmation_dial
 });
 
 registry.category("web_tour.tours").add("test_add_money_button_with_different_decimal_separator", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -159,6 +159,7 @@ registry.category("web_tour.tours").add("ProductComboChangeFP", {
 });
 
 registry.category("web_tour.tours").add("ProductComboMaxFreeQtyTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -256,6 +257,7 @@ registry.category("web_tour.tours").add("ProductComboDiscountTour", {
 });
 
 registry.category("web_tour.tours").add("test_convert_orderlines_to_combo", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pricelist_tour.js
@@ -149,6 +149,7 @@ const test_pricelists_in_pos_steps = [
 ];
 
 registry.category("web_tour.tours").add("test_pricelists_in_pos", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -143,6 +143,7 @@ registry.category("web_tour.tours").add("test_attribute_order", {
 });
 
 registry.category("web_tour.tours").add("test_combo_variant_mix", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -239,6 +239,7 @@ registry.category("web_tour.tours").add("test_tax_control_button_visiblity", {
 });
 
 registry.category("web_tour.tours").add("test_reuse_empty_floating_order", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -1133,6 +1134,7 @@ registry.category("web_tour.tours").add("test_only_existing_lots", {
 });
 
 registry.category("web_tour.tours").add("test_delete_line", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/product_variants_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_variants_tour.js
@@ -19,6 +19,7 @@ function check_variant_price(product, choices, price) {
 }
 
 registry.category("web_tour.tours").add("test_integration_dynamic_variant_price", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -31,6 +32,7 @@ registry.category("web_tour.tours").add("test_integration_dynamic_variant_price"
 });
 
 registry.category("web_tour.tours").add("test_integration_always_variant_price", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -42,6 +44,7 @@ registry.category("web_tour.tours").add("test_integration_always_variant_price",
 });
 
 registry.category("web_tour.tours").add("test_integration_never_variant_price", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -53,6 +56,7 @@ registry.category("web_tour.tours").add("test_integration_never_variant_price", 
 });
 
 registry.category("web_tour.tours").add("test_integration_dynamic_always_variant_price", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -68,6 +72,7 @@ registry.category("web_tour.tours").add("test_integration_dynamic_always_variant
 });
 
 registry.category("web_tour.tours").add("test_integration_dynamic_never_variant_price", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -83,6 +88,7 @@ registry.category("web_tour.tours").add("test_integration_dynamic_never_variant_
 });
 
 registry.category("web_tour.tours").add("test_integration_always_never_variant_price", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -96,6 +102,7 @@ registry.category("web_tour.tours").add("test_integration_always_never_variant_p
 });
 
 registry.category("web_tour.tours").add("test_integration_dynamic_always_never_variant_price", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -329,6 +329,7 @@ registry.category("web_tour.tours").add("test_pay_unpaid_order_from_kiosk", {
 });
 
 registry.category("web_tour.tours").add("refund_multiple_products_amounts_compliance", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -355,6 +356,7 @@ registry.category("web_tour.tours").add("refund_multiple_products_amounts_compli
 });
 
 registry.category("web_tour.tours").add("LotTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/tip_after_payment_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/tip_after_payment_tour.js
@@ -9,6 +9,7 @@ import * as NumberPopup from "@point_of_sale/../tests/generic_helpers/number_pop
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosTipAfterPaymentTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // Open PoS

--- a/addons/portal/static/tests/tours/portal.js
+++ b/addons/portal/static/tests/tours/portal.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("portal_load_homepage", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/my",
     steps: () => [
         {

--- a/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
+++ b/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
@@ -40,6 +40,7 @@ export function assertTaxTotals(baseAmount, taxAmount, totalAmount) {
 }
 
 registry.category("web_tour.tours").add("test_point_of_sale_custom_tax_with_extra_product_field", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_discount/static/tests/tours/test_pos_global_discount_flow.js
+++ b/addons/pos_discount/static/tests/tours/test_pos_global_discount_flow.js
@@ -8,6 +8,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_pos_global_discount_sell_and_refund", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_discount/static/tests/tours/test_taxes_global_discount.js
+++ b/addons/pos_discount/static/tests/tours/test_taxes_global_discount.js
@@ -58,6 +58,7 @@ export function payAndInvoice(totalAmount) {
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_in_pos_global_discount_round_per_line_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -109,6 +110,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_in_pos_global_discount_round_globally_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -193,6 +195,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_in_pos_global_discount_round_globally_price_included", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),

--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -8,6 +8,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("SellingEventInPos", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_event/static/tests/tours/pos_multi_slot_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_multi_slot_event_tour.js
@@ -9,6 +9,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("SellingMultiSlotEventInPos", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -13,6 +13,7 @@ import { registry } from "@web/core/registry";
 import { negate, scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("PosHrTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),
@@ -128,6 +129,7 @@ registry.category("web_tour.tours").add("CashierCanSeeProductInfo", {
 });
 
 registry.category("web_tour.tours").add("CashierCannotClose", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),
@@ -265,6 +267,7 @@ registry.category("web_tour.tours").add("test_cost_and_margin_visibility", {
 });
 
 registry.category("web_tour.tours").add("pos_hr_go_backend_closed_registered", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // Admin --> 403: not the one that opened the session
@@ -372,6 +375,7 @@ registry
     });
 
 registry.category("web_tour.tours").add("test_maximum_closing_difference", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -58,6 +58,7 @@ registry.category("web_tour.tours").add("GiftCardWithRefundtTour", {
 });
 
 registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -73,6 +74,7 @@ registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsGiftcard", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -108,6 +110,7 @@ registry.category("web_tour.tours").add("PosLoyaltyGiftCardTaxes", {
 });
 
 registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -131,6 +134,7 @@ registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
 });
 
 registry.category("web_tour.tours").add("MultiplePhysicalGiftCardProgramSaleTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -219,6 +223,7 @@ registry.category("web_tour.tours").add("EmptyProductScreenTour", {
 });
 
 registry.category("web_tour.tours").add("test_physical_gift_card", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/order_receipt.js
+++ b/addons/pos_loyalty/static/tests/tours/order_receipt.js
@@ -6,6 +6,7 @@ import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_receipt_data_pos_loyalty", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -10,6 +10,7 @@ import { registry } from "@web/core/registry";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -67,6 +68,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // Order1: Immediately set the customer to Test Partner AAA which has 4 points.
@@ -136,6 +138,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyChangeRewardQty", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -8,6 +8,7 @@ import * as ProductConfiguratorPopup from "@point_of_sale/../tests/pos/tours/uti
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -233,6 +234,7 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardPro
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyRewardProductTag", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -317,6 +317,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour9", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour10", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -356,6 +357,7 @@ registry.category("web_tour.tours").add("PosLoyaltyTour11.1", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour11.2", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -571,6 +573,7 @@ registry.category("web_tour.tours").add("PosRewardProductScan", {
 });
 
 registry.category("web_tour.tours").add("PosRewardProductScanGS1", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -594,6 +597,7 @@ registry.category("web_tour.tours").add("PosLoyaltyPromocodePricelist", {
 });
 
 registry.category("web_tour.tours").add("RefundRulesProduct", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -631,6 +635,7 @@ registry.category("web_tour.tours").add("test_settle_dont_give_points_again", {
 });
 
 registry.category("web_tour.tours").add("test_refund_does_not_decrease_points", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -675,6 +680,7 @@ registry.category("web_tour.tours").add("test_scan_loyalty_card_select_customer"
 });
 
 registry.category("web_tour.tours").add("test_min_qty_points_awarded", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_qfpay/static/tests/tours/qfpay_tour.js
+++ b/addons/pos_qfpay/static/tests/tours/qfpay_tour.js
@@ -48,6 +48,7 @@ patch(QFPay.prototype, {
 let paymentUuid = "";
 
 registry.category("web_tour.tours").add("qfpay_order_and_refund", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // Refund have to be made on the same day before 23:00 HKT.

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -13,6 +13,7 @@ import { registry } from "@web/core/registry";
 import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("ControlButtonsTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // Test merging table, transfer is already tested in pos_restaurant_sync_second_login.

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -36,6 +36,7 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
 });
 
 registry.category("web_tour.tours").add("TableMergeUnmergeTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -23,6 +23,7 @@ import { negateStep, assertCurrentOrderDirty } from "@point_of_sale/../tests/gen
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
 registry.category("web_tour.tours").add("pos_restaurant_sync", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -133,6 +134,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
  * This tour should be run after the first tour is done.
  */
 registry.category("web_tour.tours").add("pos_restaurant_sync_second_login", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // There is one draft synced order from the previous tour
@@ -330,7 +332,8 @@ registry.category("web_tour.tours").add("CategLabelCheck", {
             ProductScreen.OrderButtonNotContain("Drinks"),
         ].flat(),
 });
-registry.category("web_tour.tours").add("OrderChange", {
+registry.category("web_tour.tours").add("OrderChangeTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -640,6 +643,7 @@ registry.category("web_tour.tours").add("test_multiple_preparation_printer_diffe
         ].flat(),
 });
 registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -657,6 +661,7 @@ registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
 });
 
 registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.freezeDateTime(1749981600000), // June 15, 2025 - 10:00
@@ -691,6 +696,7 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
 });
 
 registry.category("web_tour.tours").add("test_open_register_with_preset_takeaway", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.freezeDateTime(1749981600000), // June 15, 2025 - 10:00
@@ -766,6 +772,7 @@ registry.category("web_tour.tours").add("test_customer_alone_saved", {
 });
 
 registry.category("web_tour.tours").add("test_no_kitchen_confirmation_for_deposit_money", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -912,6 +919,7 @@ registry
     );
 
 registry.category("web_tour.tours").add("test_transfering_orders", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -15,6 +15,7 @@ import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("SplitBillScreenTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -104,6 +105,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTourPay", {
 });
 
 registry.category("web_tour.tours").add("SplitBillScreenTour2", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -294,6 +296,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour5Actions", {
 });
 
 registry.category("web_tour.tours").add("SplitBillScreenTourTransfer", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -35,6 +35,7 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
 });
 
 registry.category("web_tour.tours").add("test_cancel_order_from_ui", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -13,6 +13,7 @@ import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosResTipScreenTour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // Create order that is synced when draft.
@@ -166,6 +167,7 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
 });
 
 registry.category("web_tour.tours").add("test_edit_payments_with_tip", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -230,6 +232,7 @@ registry.category("web_tour.tours").add("test_edit_payments_with_tip", {
 });
 
 registry.category("web_tour.tours").add("test_tip_after_payment", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -345,7 +345,7 @@ class TestFrontend(TestFrontendCommon):
 
     def test_14_change_synced_order(self):
         self.pos_config.with_user(self.pos_user).open_ui()
-        self.start_pos_tour('OrderChange')
+        self.start_pos_tour('OrderChangeTour')
 
     def test_13_crm_team(self):
         if self.env['ir.module.module']._get('pos_sale').state != 'installed':

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -64,6 +64,7 @@ registry.category("web_tour.tours").add("PosSettleOrder2", {
 });
 
 registry.category("web_tour.tours").add("PosRefundDownpayment", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -253,6 +254,7 @@ registry.category("web_tour.tours").add("test_settle_so_with_non_pos_groupable_u
 });
 
 registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -282,6 +284,7 @@ registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
 });
 
 registry.category("web_tour.tours").add("PoSApplyDownpayment", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -332,6 +335,7 @@ registry.category("web_tour.tours").add("PosOrdersListDifferentCurrency", {
 });
 
 registry.category("web_tour.tours").add("PoSDownPaymentAmount", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -480,6 +484,7 @@ registry.category("web_tour.tours").add("test_settle_order_with_lot", {
 });
 
 registry.category("web_tour.tours").add("test_down_payment_displayed", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
+++ b/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
@@ -69,6 +69,7 @@ export function payAndInvoice(totalAmount) {
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_in_pos_downpayment_round_per_line_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -104,6 +105,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_in_pos_downpayment_round_globally_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -139,6 +141,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_in_pos_downpayment_round_per_line_price_included", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -174,6 +177,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_in_pos_downpayment_round_globally_price_included", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -209,6 +213,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_br_pos_downpayment_round_per_line_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -224,6 +229,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_br_pos_downpayment_round_globally_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -239,6 +245,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_br_pos_downpayment_round_per_line_price_included", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -254,6 +261,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_br_pos_downpayment_round_globally_price_included", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -269,6 +277,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_be_pos_downpayment_round_per_line_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -284,6 +293,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_be_pos_downpayment_round_globally_price_excluded", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -299,6 +309,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_be_pos_downpayment_round_per_line_price_included", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),
@@ -314,6 +325,7 @@ registry
 registry
     .category("web_tour.tours")
     .add("test_taxes_l10n_be_pos_downpayment_round_globally_price_included", {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         steps: () =>
             [
                 Chrome.startPoS(),

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -6,6 +6,7 @@ import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("self_attribute_selector", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Desk Organizer"),
@@ -41,6 +42,7 @@ registry.category("web_tour.tours").add("self_attribute_selector", {
 });
 
 registry.category("web_tour.tours").add("self_multi_attribute_selector", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Multi Check Attribute Product"),

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -5,6 +5,7 @@ import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_
 import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Office Combo"),

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -27,6 +27,7 @@ registry.category("web_tour.tours").add("self_order_landing_page_carousel", {
 });
 
 registry.category("web_tour.tours").add("self_order_pos_closed", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         LandingPage.isClosed(),
         // Normal product
@@ -72,6 +73,7 @@ registry.category("web_tour.tours").add("self_order_pos_closed", {
 });
 
 registry.category("web_tour.tours").add("kiosk_order_pos_closed", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         LandingPage.isClosed(),
         Utils.clickBtn("Order Now"),

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -160,6 +160,7 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
 });
 
 registry.category("web_tour.tours").add("test_self_order_kiosk_combo_sides", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         LandingPage.selectLocation("Test-In"),

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('burndown_chart_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -207,6 +207,7 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
 });
 
 registry.category("web_tour.tours").add("project_task_last_history_steps_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo?debug=1,tests",
     steps: () => [stepUtils.showAppsMenuItem(), {
         content: "Open the project app",

--- a/addons/project/static/tests/tours/project_task_templates_tour.js
+++ b/addons/project/static/tests/tours/project_task_templates_tour.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("project_task_templates_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),

--- a/addons/purchase_stock/static/tests/tours/product_replenishment.js
+++ b/addons/purchase_stock/static/tests/tours/product_replenishment.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_product_replenishment", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         // Show Route column
         {

--- a/addons/sale/static/tests/tours/sale_catalog.js
+++ b/addons/sale/static/tests/tours/sale_catalog.js
@@ -2,6 +2,7 @@ import { addSectionFromProductCatalog, showProductColumn } from "@account/js/tou
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('sale_catalog', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             content: "Create a new SO",

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -293,6 +293,7 @@ registry.category('web_tour.tours').add('test_inventory_adjustment_apply_all', {
 });
 
 registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: ".o_list_view.o_field_x2many .o_data_row button[name='action_show_details']",

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -24,6 +24,7 @@ registry.category("web_tour.tours").add("test_stock_route_diagram_report", {
 });
 
 registry.category("web_tour.tours").add("test_context_from_warehouse_filter", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         // Add "foo" to the warehouse context key
         {

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -93,6 +93,7 @@ registry.category("web_tour.tours").add("test_survey", {
 });
 
 registry.category("web_tour.tours").add("test_survey_multilang", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae",
     steps: () => {
         return [

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -436,6 +436,7 @@ registry.category("web_tour.tours").add("test_form_view_resequence_actions", {
 });
 
 registry.category("web_tour.tours").add("test_form_view_model_id", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: ".o_field_widget[name='model_id'] input",
@@ -506,6 +507,7 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
 });
 
 registry.category("web_tour.tours").add("test_form_view_custom_reference_field", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: ".o_field_widget[name='model_id'] input",
@@ -573,6 +575,7 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
 });
 
 registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: ".o_field_widget[name='model_id'] input",

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -14,6 +14,7 @@ registry.category("web_tour.tours").add("star_message_tour", {
 });
 
 registry.category("web_tour.tours").add("message_actions_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: "#chatterRoot:shadow .o-mail-Thread .o-mail-Message:count(1)",

--- a/addons/test_mail_full/static/tests/tours/portal_composer_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/portal_composer_actions_tour.js
@@ -3,6 +3,7 @@ import { registry } from "@web/core/registry";
 const cannedResponseButtonSelector = "button[title='Insert a Canned response']";
 
 registry.category("web_tour.tours").add("portal_composer_actions_tour_internal_user", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: `#chatterRoot:shadow .o-mail-Composer ${cannedResponseButtonSelector}`,
@@ -26,6 +27,7 @@ registry.category("web_tour.tours").add("portal_composer_actions_tour_internal_u
 });
 
 registry.category("web_tour.tours").add("portal_composer_actions_tour_portal_user", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: `#chatterRoot:shadow .o-mail-Composer:not(:has(${cannedResponseButtonSelector}))`,

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -4,6 +4,7 @@ import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_util
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_sale_with_product_configurator_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -4,6 +4,7 @@ import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_util
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_edition_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -3,6 +3,7 @@ import { stepUtils } from "@web_tour/tour_utils";
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_optional_products_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -81,6 +81,7 @@ const formatErrorMsg =
 registerWebsitePreviewTour(
     "test_image_upload_progress",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/test_image_progress",
         edition: true,
     },

--- a/addons/test_website/static/tests/tours/page_manager.js
+++ b/addons/test_website/static/tests/tours/page_manager.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_website_page_manager", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo/action-test_website.action_test_model_multi_website",
     steps: () => [
         // Part 1: check that the website filter is working

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -14,6 +14,7 @@ const VIDEO_URL = "https://www.youtube.com/watch?v=Dpq87YCHmJc";
 registerWebsitePreviewTour(
     "test_replace_media",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -208,42 +208,55 @@ const ensureWebsiteSwitcherIsVisible = [
     },
 ];
 
-const register = (title, steps) => {
+const register = (title, steps, undeterministicTour_doNotCopy) => {
     registerWebsitePreviewTour(
         title,
         {
             url: "/test_model/1",
+            undeterministicTour_doNotCopy,
         },
         steps
     );
 };
 
-register("test_systray_admin", () => [
-    ...canPublish(),
-    ...canToggleMobilePreview(),
-    ...canSwitchWebsite(),
-    ...canAddNewContent(),
-    ...canEditInBackEnd(),
-    ...canEdit(),
-]);
+register(
+    "test_systray_admin",
+    () => [
+        ...canPublish(),
+        ...canToggleMobilePreview(),
+        ...canSwitchWebsite(),
+        ...canAddNewContent(),
+        ...canEditInBackEnd(),
+        ...canEdit(),
+    ],
+    true
+);
 
-register("test_systray_reditor_tester", () => [
-    ...canPublish(),
-    ...canToggleMobilePreview(),
-    ...canSwitchWebsite(),
-    ...canAddNewContent(),
-    ...canEditInBackEnd(),
-    ...canEdit(),
-]);
+register(
+    "test_systray_reditor_tester",
+    () => [
+        ...canPublish(),
+        ...canToggleMobilePreview(),
+        ...canSwitchWebsite(),
+        ...canAddNewContent(),
+        ...canEditInBackEnd(),
+        ...canEdit(),
+    ],
+    true
+);
 
-register("test_systray_reditor_not_tester", () => [
-    ...cannotPublish(),
-    ...canToggleMobilePreview(),
-    ...canSwitchWebsite(),
-    ...canAddNewContent(),
-    ...canViewInBackEnd(),
-    ...canEditButCannotChange(),
-]);
+register(
+    "test_systray_reditor_not_tester",
+    () => [
+        ...cannotPublish(),
+        ...canToggleMobilePreview(),
+        ...canSwitchWebsite(),
+        ...canAddNewContent(),
+        ...canViewInBackEnd(),
+        ...canEditButCannotChange(),
+    ],
+    true
+);
 
 register("test_systray_not_reditor_tester", () => [
     ...canPublish(),

--- a/addons/test_website/static/tests/tours/translation.js
+++ b/addons/test_website/static/tests/tours/translation.js
@@ -459,6 +459,7 @@ registerWebsitePreviewTour(
     "translation_multi_language_fr_user_fr_en_site",
     {
         url: "/fr",
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureFrUser, ensureFrSite, ...multiLanguage("fr", "en")]
 );
@@ -467,6 +468,7 @@ registerWebsitePreviewTour(
     "translation_multi_language_fr_user_en_fr_site",
     {
         url: "/en",
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureFrUser, ensureEnSite, ...multiLanguage("en", "fr")]
 );
@@ -475,6 +477,7 @@ registerWebsitePreviewTour(
     "translation_multi_language_en_user_fr_en_site",
     {
         url: "/fr",
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureEnUser, ensureFrSite, ...multiLanguage("fr", "en")]
 );
@@ -483,6 +486,7 @@ registerWebsitePreviewTour(
     "translation_multi_language_en_user_en_fr_site",
     {
         url: "/en",
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureEnUser, ensureEnSite, ...multiLanguage("en", "fr")]
 );

--- a/addons/web_tour/static/src/js/tour_automatic/tour_automatic.js
+++ b/addons/web_tour/static/src/js/tour_automatic/tour_automatic.js
@@ -119,6 +119,7 @@ export class TourAutomatic {
         this.macro = new Macro({
             name: this.name,
             steps: macroSteps,
+            allowDelayToRemove: this.config.allowDelayToRemove,
             onError: ({ error }) => {
                 if (error.type === "Timeout") {
                     this.throwError(...this.currentStep.describeWhyIFailed, error.message);

--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -57,6 +57,7 @@ const tourSchema = {
     steps: Function,
     url: { type: String, optional: true },
     wait_for: { type: [Function, Object], optional: true },
+    undeterministicTour_doNotCopy: { type: Boolean, optional: true },
 };
 
 const tourRegistry = registry.category("web_tour.tours");
@@ -302,6 +303,7 @@ export class TourService {
             debug: false,
             redirect: true,
             observeDelay: 3000,
+            allowDelayToRemove: tour.undeterministicTour_doNotCopy,
             ...options,
         };
 

--- a/addons/web_tour/static/tests/tour_automatic.test.js
+++ b/addons/web_tour/static/tests/tour_automatic.test.js
@@ -570,6 +570,9 @@ test("check not possible to click below modal", async () => {
                 run: "click",
             },
             {
+                trigger: ".modal",
+            },
+            {
                 trigger: ".button1",
                 run: "click",
             },
@@ -578,9 +581,10 @@ test("check not possible to click below modal", async () => {
     await odoo.startTour("tour_check_modal", { mode: "auto" });
     await waitForMacro();
     expect.verifySteps([
-        "log: [1/2] Tour tour_check_modal → Step .button0",
-        "log: [2/2] Tour tour_check_modal → Step .button1",
-        `error: FAILED: [2/2] Tour tour_check_modal → Step .button1.
+        "log: [1/3] Tour tour_check_modal → Step .button0",
+        "log: [2/3] Tour tour_check_modal → Step .modal",
+        "log: [3/3] Tour tour_check_modal → Step .button1",
+        `error: FAILED: [3/3] Tour tour_check_modal → Step .button1.
 Element has been found.
 BUT: It is not allowed to do action on an element that's below a modal.
 TIMEOUT step failed to complete within 888 ms.`,

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -599,7 +599,7 @@ export function registerBackendAndFrontendTour(name, options, steps) {
     }
 
     return registry.category("web_tour.tours").add(name, {
-        url: options.url,
+        ...options,
         steps: () => steps(),
     });
 }

--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -173,6 +173,7 @@ const checkSlideNotClickable = () => ({
 registerWebsitePreviewTour(
     "snippet_carousel_clickable_slides",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -218,6 +218,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "conditional_visibility_5",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         edition: true,
         url: "/",
     },

--- a/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
+++ b/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
@@ -7,6 +7,7 @@ import {
 registerWebsitePreviewTour(
     "test_drag_and_drop_on_non_editable",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -34,6 +34,7 @@ const scrollDownToMediaList = function () {
 registerWebsitePreviewTour(
     "dropdowns_and_header_hide_on_scroll",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -7,7 +7,8 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { patch } from "@web/core/utils/patch";
 
-const FIRST_PARAGRAPH = ":iframe #wrap .s_text_image p:not([data-selection-placeholder]):nth-child(2)";
+const FIRST_PARAGRAPH =
+    ":iframe #wrap .s_text_image p:not([data-selection-placeholder]):nth-child(2)";
 
 const clickEditLink = {
     content: "Click on Edit Link in Popover",
@@ -31,6 +32,7 @@ const editLinkAndApply = (url) => [
 registerWebsitePreviewTour(
     "edit_link_popover",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -136,6 +136,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "megamenu_active_nav_link",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },
@@ -374,6 +375,7 @@ const openMenu = () => ({
 registerWebsitePreviewTour(
     "edit_megamenu_visibility",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -74,6 +74,7 @@ registry.category("web_tour.tours").add("parent_child_menu", {
 registerWebsitePreviewTour(
     "edit_menus",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
     },
     () => [

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -15,6 +15,7 @@ const snippet = {
 registerWebsitePreviewTour(
     "website_replace_grid_image",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -4,6 +4,7 @@ import { clickOnSave, goToTheme, registerWebsitePreviewTour } from "@website/js/
 registerWebsitePreviewTour(
     "hide_sidebar_header",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -49,6 +49,7 @@ const saveLinkPopup = () => [
 registerWebsitePreviewTour(
     "test_link_to_document",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -8,6 +8,7 @@ import {
 registerWebsitePreviewTour(
     "website_media_dialog_undraw",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },
@@ -123,6 +124,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_media_dialog_icons",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },
@@ -166,6 +168,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_media_dialog_image_shape",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -3,6 +3,7 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "website_media_iframe_video",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -221,6 +221,7 @@ const duplicateMultiplePage = [
 registerWebsitePreviewTour(
     "website_page_manager",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
     },
     () => [
@@ -272,6 +273,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_page_manager_session_forced",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
     },
     () => [
@@ -298,6 +300,7 @@ registerWebsitePreviewTour(
 
 registry.category("web_tour.tours").add("website_page_manager_direct_access", {
     url: "/odoo/action-website.action_website_pages_list",
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             content: "Check that the homepage is the one of Test Website",
@@ -312,6 +315,7 @@ registry.category("web_tour.tours").add("website_page_manager_direct_access", {
 registerWebsitePreviewTour(
     "website_clone_pages",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -124,6 +124,7 @@ function updateAndCheckCustomGradient({ updateStep, checkGradient }) {
 registerWebsitePreviewTour(
     "snippet_background_edition",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -94,6 +94,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "snippet_image_gallery_reorder",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_image_quality.js
+++ b/addons/website/static/tests/tours/snippet_image_quality.js
@@ -3,6 +3,7 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "website_image_quality",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_image_srcset.js
+++ b/addons/website/static/tests/tours/snippet_image_srcset.js
@@ -7,6 +7,7 @@ import {
 registerWebsitePreviewTour(
     "website_image_srcset",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -56,6 +56,7 @@ const scrollIntoView = (selector) => ({
 registerWebsitePreviewTour(
     "snippet_popup_and_scrollbar",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },
@@ -93,7 +94,8 @@ registerWebsitePreviewTour(
         },
         {
             content: "Remove the s_media_list snippet",
-            trigger: ".o_customize_tab [data-container-title='Media List'] button.oe_snippet_remove",
+            trigger:
+                ".o_customize_tab [data-container-title='Media List'] button.oe_snippet_remove",
             run: "click",
         },
         checkScrollbar(true),
@@ -184,13 +186,15 @@ registerWebsitePreviewTour(
         scrollIntoView("#website_cookies_bar .s_media_list_item:last-child"),
         {
             content: "Remove the first Media List snippet in the Cookies Bar.",
-            trigger: ".o_customize_tab [data-container-title='Media List'] button.oe_snippet_remove",
+            trigger:
+                ".o_customize_tab [data-container-title='Media List'] button.oe_snippet_remove",
             run: "click",
         },
         scrollIntoView("#website_cookies_bar .s_media_list_item:last-child"),
         {
             content: "Remove the second Media List snippet in the Cookies Bar.",
-            trigger: ".o_customize_tab [data-container-title='Media List'] button.oe_snippet_remove",
+            trigger:
+                ".o_customize_tab [data-container-title='Media List'] button.oe_snippet_remove",
             run: "click",
         },
         checkScrollbar(true),

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -13,6 +13,7 @@ const oldWriteText = browser.navigator.clipboard.writeText;
 registerWebsitePreviewTour(
     "snippet_popup_display_on_click",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_popup_open_on_top.js
+++ b/addons/website/static/tests/tours/snippet_popup_open_on_top.js
@@ -9,6 +9,7 @@ import {
 registerWebsitePreviewTour(
     "snippet_popup_open_on_top",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -93,6 +93,7 @@ const addNewSocialNetwork = function (optionIndex, linkIndex, url, replaceIcon =
 registerWebsitePreviewTour(
     "snippet_social_media",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -25,6 +25,7 @@ const checkTOCNavBar = function (tocPosition, activeHeaderPosition) {
 registerWebsitePreviewTour(
     "snippet_table_of_content",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -43,6 +43,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "snippet_translation_changing_lang",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_visibility_option.js
+++ b/addons/website/static/tests/tours/snippet_visibility_option.js
@@ -8,6 +8,7 @@ import {
 registerWebsitePreviewTour(
     "snippet_visibility_option",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -169,6 +169,7 @@ const compareIds = ({ content, firstElSelector, secondElSelector, errorMessage }
 registerWebsitePreviewTour(
     "website_form_editor_tour",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },
@@ -949,6 +950,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_conditional_required_checkboxes",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },
@@ -1216,6 +1218,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_special_characters",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -223,6 +223,7 @@ registry.category("web_tour.tours").add("website_form_editor_tour_results", {
     ],
 });
 registry.category("web_tour.tours").add("website_form_contactus_submit", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/contactus",
     steps: () => [
         // As the demo portal user, only two inputs needs to be filled to send

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -138,6 +138,7 @@ function openBackgroundColorPicker(type, selector) {
 registerWebsitePreviewTour(
     "website_page_breadcrumb",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/contactus",
         edition: false,
     },

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -191,6 +191,7 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_mobile_order_with_drag_and_drop",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/",
         edition: true,
     },

--- a/addons/website_blog/static/tests/tours/blog_context.js
+++ b/addons/website_blog/static/tests/tours/blog_context.js
@@ -7,6 +7,7 @@ import {
 registerWebsitePreviewTour(
     "blog_context_and_social_media",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/blog",
     },
     () => [

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
@@ -20,6 +20,7 @@ const blogPostsSnippet = {
 registerWebsitePreviewTour(
     "blog_posts_dynamic_snippet_options",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/?debug=1",
         edition: true,
     },

--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -12,6 +12,7 @@ import { stepUtils } from "@web_tour/tour_utils";
 registerWebsitePreviewTour(
     "blog_tags",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/blog",
     },
     () => [

--- a/addons/website_blog/static/tests/tours/blog_tags_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_with_date.js
@@ -7,6 +7,7 @@ import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 registerWebsitePreviewTour(
     "blog_tags_with_date",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/blog",
     },
     () => [

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -45,6 +45,7 @@ registerWebsitePreviewTour(
 );
 
 registry.category("web_tour.tours").add('website_crm_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/contactus',
     steps: () => [{
     content: "Complete name",
@@ -81,6 +82,7 @@ registry.category("web_tour.tours").add('website_crm_tour', {
 }]});
 
 registry.category("web_tour.tours").add('website_crm_catch_logged_partner_info_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/contactus',
     steps: () => [
 {

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -4,7 +4,8 @@ import {
 } from '@website/js/tours/tour_utils';
 import { stepUtils } from "@web_tour/tour_utils";
 
-registerBackendAndFrontendTour("question", {
+registerBackendAndFrontendTour("question_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/forum/1',
 }, () => [{
     trigger: ".o_wforum_ask_btn",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('forum_question', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/forum/help-1',
     steps: () => [
     {

--- a/addons/website_forum/tests/test_forum_tours.py
+++ b/addons/website_forum/tests/test_forum_tours.py
@@ -19,7 +19,7 @@ class TestUi(HttpCaseGamification):
         })
 
     def test_01_admin_forum_tour(self):
-        self.start_tour("/", 'question', login="admin")
+        self.start_tour("/", 'question_tour', login="admin")
 
     def test_02_demo_question(self):
         forum = self.env.ref('website_forum.forum_help')

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -26,6 +26,7 @@ const mediumValue = 'Super Specific Medium';
 const sourceValue = 'Super Specific Source';
 
 registry.category("web_tour.tours").add('website_links_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/r',
     steps: () => [
         // 1. Create a tracked URL

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -7,6 +7,7 @@ const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:conta
 let chatbotDelayProcessingDef;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => {
         patchWithCleanup(Chatbot.prototype, {
             // Count the number of times this method is called to check whether the chatbot is regularly

--- a/addons/website_sale/static/tests/tours/add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/add_to_cart_snippet_tour.js
@@ -34,6 +34,7 @@ function checkButtonIsDisabled() {
 registerWebsitePreviewTour(
     'website_sale.add_to_cart_snippet',
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: '/',
         edition: true,
     },

--- a/addons/website_sale/static/tests/tours/cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/cart_recovery.js
@@ -8,6 +8,7 @@ var orderIdKey = 'website_sale.tour_shop_cart_recovery.orderId';
 var recoveryLinkKey = 'website_sale.tour_shop_cart_recovery.recoveryLink';
 
 registry.category("web_tour.tours").add('website_sale.cart_recovery', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: '/shop',
     steps: () => [
         ...tourUtils.addToCart({ productName: "Acoustic Bloc Screens", expectUnloadPage: true }),

--- a/addons/website_sale/static/tests/tours/remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/remove_product_image.js
@@ -47,6 +47,7 @@ const removeImg = [
 registerWebsitePreviewTour(
     "website_sale.add_and_remove_main_product_image_no_variant",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/shop?search=Test Remove Image",
     },
     () => [

--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -22,6 +22,7 @@ registry.category('web_tour.tours').add('website_sale_collect_widget', {
 registry.category('web_tour.tours').add(
     'website_sale_collect_buy_product_default_location_pick_up_in_store',
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: '/shop',
         steps: () => [
             ...tourUtils.searchProduct("Test CAC Product", { select: true }),

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -3,6 +3,7 @@ import { clickOnElement } from '@website/js/tours/tour_utils';
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('website_sale.product_comparison', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/shop",
     steps: () => [
         // test from shop page

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -14,6 +14,7 @@ import {
 registerWebsitePreviewTour(
     "course_publisher_standard",
     {
+        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/slides",
     },
     () =>

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -11,6 +11,7 @@ import { registry } from "@web/core/registry";
  * they rate the course;
  */
 registry.category("web_tour.tours").add("course_member", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/slides",
     steps: () => [
         // eLearning: go on free course and join it

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("course_review_modification", {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/slides",
     steps: () => [
         {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -5,6 +5,7 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('main_flow_tour', {
+    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     url: "/odoo",
     steps: () => [
 ...stepUtils.toggleHomeMenu().map(step => {


### PR DESCRIPTION
We noticed that allowing a delay between each step of the tours
(in the macro engine) leads to indeterministic behavior within the
tours, such as:
- letting animationframes to be calculated
- waiting for the RPC response, which sometimes arrives, sometimes not
within 50ms.

Most of the time, a tour is indeterministic because it
takes a wrong way by pointing to overly general triggers.
Removing this (arbitrary) delay is the final step to ensure the macro
engine always works the same way.

Find trigger => Do Action => Find trigger => Do Action => ...
No more delay between each step of the process.

With this commit, by default, the delay is removed in all tours by
default but it is necessary to tag the tours which are still
indeterministic.