### PR TITLE
[FIX] iot_drivers: treat pin as a string, not dict

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_be_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_be_driver.py
@@ -220,7 +220,8 @@ class BlackBoxDriver(SerialDriver):
         return self._parse_blackbox_response(blackbox_response)
 
     def _register_pin(self, data):
-        data = data.get('high_level_message', data)
+        if isinstance(data, dict):
+            data = data.get('high_level_message', data)  # from batch action, data is only a string (the pincode)
 
         blackbox_response = self._send_to_blackbox("P", data, self._connection)
         return self._parse_blackbox_response(blackbox_response)


### PR DESCRIPTION
Batch action provides only the pin as a string. We had a traceback when trying to get `high_level_message` as if the data provided was a dict.