### PR TITLE
[FIX] pos_online_payment: automatically close payment QR on order completion

### DIFF
--- a/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_online_payment/static/src/overrides/pos_overrides/components/payment_screen/payment_screen.js
@@ -132,6 +132,7 @@ patch(PaymentScreen.prototype, {
                         {
                             onClose: () => {
                                 onlinePaymentLine.onlinePaymentResolver(false);
+                                this.currentOrder.onlinePaymentData = {};
                             },
                         }
                     );

--- a/addons/pos_online_payment/static/tests/tours/customer_display_tour.js
+++ b/addons/pos_online_payment/static/tests/tours/customer_display_tour.js
@@ -1,4 +1,5 @@
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
+import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 import {
     postMessage,
@@ -7,6 +8,7 @@ import {
     ORDER_IS_FINALIZED,
     NEW_ORDER,
 } from "@point_of_sale/../tests/tours/customer_display_tour";
+import { negateStep } from "@point_of_sale/../tests/tours/utils/common";
 
 const QR_URL =
     "/report/barcode/QR/http%3A%2F%2Flocalhost%3A1740%2Fpos%2Fpay%2F6%3Faccess_token%3D5bb78d6c-bf8e-44ed-8de2-e4ae5b8696ec?width=200&height=200";
@@ -82,6 +84,7 @@ registry.category("web_tour.tours").add("CustomerDisplayTourOnlinePayment", {
                 trigger: `.modal-content img[alt='QR Code to pay'][src='${QR_URL}']`,
             },
             postMessage(PAID, "payment approved"),
+            negateStep(Dialog.is()),
             postMessage(ORDER_IS_FINALIZED, "order is finalized"),
             {
                 content: "Check that we are now on the 'Thank you' screen",


### PR DESCRIPTION
Steps:
---
- Configure online payment on the POS configuration.
- Open a POS session and the customer display.
- Add a product and an online payment line.
- Validate the order and complete the payment via QR code.

Issue:
---
- The order is finalized, but the payment QR code remains visible on the customer display.
- The QR popup must be closed manually every time.

Cause:
---
- The customer display popup lifecycle depends on `onlinePaymentData`.
- This data was not cleared when the order was finalized.

Fix:
---
- Clear `onlinePaymentData` when the order is completed.

task-5502344

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
