### PR TITLE
[IMP] sale: add % delivered quantity

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -288,6 +288,9 @@ class SaleOrderLine(models.Model):
         readonly=False,
         copy=False,
     )
+    qty_delivered_percent = fields.Float(
+        string="% Delivered", compute="_compute_qty_delivered_percent", readonly=False
+    )
 
     # Analytic & Invoicing fields
     qty_invoiced = fields.Float(
@@ -1015,6 +1018,19 @@ class SaleOrderLine(models.Model):
         for so_line in self:
             if not so_line.qty_delivered or so_line in delivered_qties:
                 so_line.qty_delivered = delivered_qties[so_line]
+
+    @api.depends("qty_delivered", "product_uom_qty")
+    def _compute_qty_delivered_percent(self):
+        for line in self:
+            if line.product_uom_qty:
+                line.qty_delivered_percent = 100 * (line.qty_delivered / line.product_uom_qty)
+            else:
+                line.qty_delivered_percent = 100
+
+    @api.onchange("qty_delivered_percent")
+    def _onchange_qty_delivered_percent(self):
+        for line in self:
+            line.qty_delivered = (line.qty_delivered_percent * line.product_uom_qty) / 100
 
     @api.depends("qty_delivered")
     @api.depends_context("accrual_entry_date")
@@ -1819,7 +1835,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
 
         billable_lines = self.order_id.order_line.filtered(
-            lambda line: line.product_type != 'combo' and self._is_line_in_section(line)
+            lambda line: line.product_type != "combo" and self._is_line_in_section(line)
         )
 
         if display_taxes:

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -780,6 +780,14 @@
                                     readonly="is_downpayment"/>
                                 <widget name="simple_qty_at_date_widget" width="20px"/>
                                 <field
+                                    name="qty_delivered_percent"
+                                    decoration-info="(not display_type and invoice_status == 'to invoice')"
+                                    decoration-bf="(not display_type and invoice_status == 'to invoice')"
+                                    readonly="qty_delivered_method != 'manual' or is_downpayment or product_uom_qty == 0"
+                                    column_invisible="parent.state != 'sale'"
+                                    optional="hide"
+                                />
+                                <field
                                     name="qty_delivered"
                                     string="Delivered"
                                     decoration-info="(not display_type and invoice_status == 'to invoice')"

--- a/addons/sale_project/models/product_template.py
+++ b/addons/sale_project/models/product_template.py
@@ -12,7 +12,7 @@ class ProductTemplate(models.Model):
         service_policies = [
             # (service_policy, string)
             ('ordered_prepaid', _('Prepaid/Fixed Price')),
-            ('delivered_manual', _('Based on Delivered Quantity (Manual)')),
+            ('delivered_manual', _('Based on Delivery (Manual)')),
         ]
 
         if self.env['res.groups']._is_feature_enabled('project.group_project_milestone'):


### PR DESCRIPTION
In many cases, where you manually set delivered quantities on your SO, it would be easier to do it with a % of completion instead. In this commit, we add an optional field to set it. 

task-5387190
