### PR TITLE
[FIX] account_edi_ubl_cii,account_peppol: better filter embed attachment

### DIFF
--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -51,7 +51,6 @@ class IrActionsReport(models.Model):
         :param is_main_pdf: Is the extra attachments list containing ONLY the Invoice PDF
         :param check_for_additionnal_document_elements: flag to not embed extra attachments if any document is already embedded into the xml
         """
-        # [{'name': '', 'raw_b64': '', 'mimetype': ''}, {'name': '', 'raw_b64': '', 'mimetype': ''}]
         old_xml = base64.b64decode(xml_attachment.with_context(bin_size=False).datas, validate=True)
         tree = etree.fromstring(old_xml)
         anchor_elements = tree.xpath("//*[local-name()='AccountingSupplierParty']")

--- a/addons/account_peppol/wizard/account_invoice_send.py
+++ b/addons/account_peppol/wizard/account_invoice_send.py
@@ -232,11 +232,12 @@ class AccountInvoiceSend(models.TransientModel):
             self._cr.commit()
 
     def _embed_extra_attachments(self, invoice, xml_attachment, extra_attachments):
-        pdf_name = f'{invoice.name.replace("/", "_")}.pdf'
+        pdf_names = (f'{invoice._get_report_mail_attachment_filename()}.pdf', invoice._get_report_attachment_filename())
         attachments_to_embed, _not_supported_attachments = self._get_peppol_available_attachments(
             invoice,
             extra_attachments.filtered(
-                lambda attachment: attachment.name not in (xml_attachment.name, pdf_name, f'Invoice_{pdf_name}')
+                # We make sure not to embed the xml or the pdf that was already embed in the xml
+                lambda attachment: attachment.name not in (xml_attachment.name, *pdf_names)
             ),
         )
         self.env['ir.actions.report']._add_attachments_into_invoice_xml(


### PR DESCRIPTION
[FIX] account_edi_ubl_cii,account_peppol: better filter embed attachment

When you send an invoice by peppol with extra attachments, we want to make sure to only embed the extra attachments (not the xml nor the original PDF). To do this, a filter is applied on the attachments, this commit improves the filter to handle translations

no-task
