### PR TITLE
[IMP] html_editor, *: substitute emojis on the fly

### DIFF
--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -1,6 +1,7 @@
 import { ChatGPTTranslatePlugin } from "@html_editor/main/chatgpt/chatgpt_translate_plugin";
 import { ColorPlugin } from "@html_editor/main/font/color_plugin";
 import { CORE_PLUGINS } from "@html_editor/plugin_sets";
+import { EmojiPlugin } from "@html_editor/main/emoji_plugin";
 import { FeffPlugin } from "@html_editor/main/feff_plugin";
 import { HintPlugin } from "@html_editor/main/hint_plugin";
 import { InlineCodePlugin } from "@html_editor/main/inline_code";
@@ -18,6 +19,7 @@ export const MAIL_CORE_PLUGINS = [
     ...CORE_PLUGINS,
     ChatGPTTranslatePlugin,
     ColorPlugin,
+    EmojiPlugin,
     FeffPlugin,
     HintPlugin,
     InlineCodePlugin,

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -160,7 +160,7 @@ test("add an emoji", async () => {
     await contains(".o-mail-Composer-html.odoo-editor-editable:text('😤')");
 });
 
-test("emojis are auto-substituted from text", async () => {
+test("[text composer] emojis are auto-substituted from text", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "swamp-safari" });
     await start();
@@ -172,6 +172,33 @@ test("emojis are auto-substituted from text", async () => {
     await press("Enter");
     await contains(".o-mail-Message-body:text('😂')");
     await insertText(".o-mail-Composer-input", ">:)");
+    await press("Enter");
+    await contains(".o-mail-Message-body:text('😈')");
+});
+
+test.tags("html composer");
+test("emojis are auto-substituted from text", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    await start();
+    await openDiscuss(channelId);
+    const composerService = getService("mail.composer");
+    composerService.setHtmlComposer();
+    await focus(".o-mail-Composer-html.odoo-editor-editable");
+    const editor = {
+        document,
+        editable: document.querySelector(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, ":)");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('😊')");
+    await press("Enter");
+    await contains(".o-mail-Message-body:text('😊')");
+    await htmlInsertText(editor, "x'D");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('😂')");
+    await press("Enter");
+    await contains(".o-mail-Message-body:text('😂')");
+    await htmlInsertText(editor, ">:)");
+    await contains(".o-mail-Composer-html.odoo-editor-editable:text('😈')");
     await press("Enter");
     await contains(".o-mail-Message-body:text('😈')");
 });

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -43,7 +43,7 @@ export function useEmojiPicker(...args) {
 
 export const loader = reactive({
     loadEmoji: () => loadBundle("web.assets_emoji"),
-    /** @type {{ emojiValueToShortcodes: Object<string, string[]>, emojiRegex: RegExp} }} */
+    /** @type {{ emojiValueToShortcodes: Object<string, string[]>, emojiRegex: RegExp, emojiSourceToEmoji: Map<string, Emoji>} }} */
     loaded: undefined,
 });
 
@@ -64,11 +64,16 @@ export async function loadEmoji() {
     } finally {
         if (!loader.loaded) {
             const emojiValueToShortcodes = {};
+            const emojiSourceToEmoji = new Map();
             for (const emoji of res.emojis) {
                 emojiValueToShortcodes[emoji.codepoints] = emoji.shortcodes;
+                for (const source of [...emoji.shortcodes, ...emoji.emoticons]) {
+                    emojiSourceToEmoji.set(source, emoji);
+                }
             }
             loader.loaded = {
                 emojiValueToShortcodes,
+                emojiSourceToEmoji,
                 emojiRegex: new RegExp(
                     Object.keys(emojiValueToShortcodes).length
                         ? Object.keys(emojiValueToShortcodes)


### PR DESCRIPTION
1. emojis should be substituted on the fly as the user types.
2. if the user presses the backspace key or undo next to an emoji, it should revert back to text

task-5478835


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
