### PR TITLE
[FIX] web: allow 'uuid' in non-secure contexts

### DIFF
--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -264,5 +264,9 @@ export function sprintf(str, ...substitutions) {
  * @returns {string}
  */
 export function uuid() {
-    return crypto.randomUUID().split("-").slice(0, 3).join("");
+    let id = "";
+    for (const b of crypto.getRandomValues(new Uint8Array(8))) {
+        id += b.toString(16).padStart(2, "0");
+    }
+    return id;
 }


### PR DESCRIPTION
### [FIX] web: allow 'uuid' in non-secure contexts

Before this commit, the `uuid` string helper crashed when used in non-
secure contexts. This was due to it using `crypto.randomUUID()`, which
is only available in secure contexts.

Although discouraged, it should be possible to run Odoo in these
contexts, and as such the function has been changed to use
`crypto.getRandomValues()`.

There is no test, as the CI runs in secure contexts anyway, and the
`uuid` function itself is already thoroughly tested.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr