### PR TITLE
[FIX] html_editor: fix blockquote behavior

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -406,15 +406,19 @@ export class DomPlugin extends Plugin {
                     (node) => {
                         // Don't remove the last BR in cases where the
                         // previous sibling is an unsplittable block
-                        // (i.e. a table, a non-editable div, ...)
-                        // to allow placing the cursor after that unsplittable
-                        // element. This can be removed when the cursor
-                        // is properly handled around these elements.
+                        // (i.e. a non-editable div, ...) to allow placing the
+                        // cursor after that unsplittable element.
+                        // Tables are exception because the cursor can be
+                        // places directly at the edge of the table, so the
+                        // trailing BR is not needed.
+                        // This can be removed when the cursor is properly
+                        // handled around these elements.
                         const previousSibling = node.previousSibling;
                         return (
                             previousSibling &&
                             isBlock(previousSibling) &&
-                            this.dependencies.split.isUnsplittable(previousSibling)
+                            this.dependencies.split.isUnsplittable(previousSibling) &&
+                            previousSibling.nodeName !== "TABLE"
                         );
                     },
                 ]);

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -2,7 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { isBlock, closestBlock } from "@html_editor/utils/blocks";
 import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
-import { isRedundantElement, isVisibleTextNode } from "@html_editor/utils/dom_info";
+import { isEmptyBlock, isRedundantElement, isVisibleTextNode } from "@html_editor/utils/dom_info";
 import {
     closestElement,
     createDOMPathGenerator,
@@ -473,7 +473,7 @@ export class FontPlugin extends Plugin {
             return;
         }
         // Check if cursor is inside an empty heading, blockquote or pre.
-        if (!closestHandledElement || closestHandledElement.textContent.length) {
+        if (!closestHandledElement || !isEmptyBlock(closestHandledElement)) {
             return;
         }
         // Check if unremovable.

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -302,7 +302,7 @@ export class ListPlugin extends Plugin {
             return this.baseContainerToList(element, mode);
         }
         // @todo @phoenix: check for callbacks registered as resources instead?
-        if (element.matches("td, th, li.nav-item")) {
+        if (element.matches("td, th, li.nav-item, blockquote")) {
             return this.blockContentsToList(element, mode);
         }
         let list;

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -2073,6 +2073,14 @@ describe("Selection not collapsed", () => {
         });
     });
 
+    test("should not remove blockquote when it contains content on Backspace", async () => {
+        await testEditor({
+            contentBefore: `<blockquote><img>[]</blockquote>`,
+            stepFunction: deleteBackward,
+            contentAfter: `<blockquote>[]<br></blockquote>`,
+        });
+    });
+
     test("should delete if first element and append in paragraph (1)", async () => {
         await testEditor({
             contentBefore: `<h1><br>[]</h1>`,

--- a/addons/html_editor/static/tests/list/toggle_ol.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ol.test.js
@@ -47,6 +47,14 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should create a list inside a blockquote", async () => {
+            await testEditor({
+                contentBefore: "<blockquote>ab[]cd</blockquote>",
+                stepFunction: toggleOrderedList,
+                contentAfter: "<blockquote><ol><li>ab[]cd</li></ol></blockquote>",
+            });
+        });
+
         test("should turn a paragraph in a div into a list", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[]cd</p></div>",

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -55,6 +55,14 @@ describe("Range collapsed", () => {
             });
         });
 
+        test("should create a list inside a blockquote", async () => {
+            await testEditor({
+                contentBefore: "<blockquote>ab[]cd</blockquote>",
+                stepFunction: toggleUnorderedList,
+                contentAfter: "<blockquote><ul><li>ab[]cd</li></ul></blockquote>",
+            });
+        });
+
         test("should turn a paragraph in a div into a list", async () => {
             await testEditor({
                 contentBefore: "<div><p>ab[]cd</p></div>",

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -195,7 +195,6 @@ test("add table inside empty list", async () => {
                         </tr>
                     </tbody>
                 </table>
-                <br>
             </li>
         </ul>`
     );
@@ -248,7 +247,6 @@ test("add table inside non-empty list", async () => {
                         </tr>
                     </tbody>
                 </table>
-                <br>
             </li>
         </ul>`
     );


### PR DESCRIPTION
Description of the issue this PR addresses:

- Pressing Backspace inside a blockquote that has visible content but no text content removes the blockquote instead of the content. The content (image or table) gets moved outside of the blockquote.
- Trailing BR was kept after tables because tables are marked as unsplittable blocks. This left unnecessary BR nodes after tables in blockquote.
- Lists could not be created inside a `blockquote`.

Desired behavior after PR is merged:

- Backspace removes the inner content first when blockquote contains nodes.
- Trailing BR is removed when placed table inside blockquote. Cursor can still be placed at the edge of the table without
  requiring a BR anchor.
- Lists can be created directly inside a blockquote.

task-5864080

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
