### PR TITLE
[FIX] pos_sale: fix qty_delivered with refund

### DIFF
--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1995,6 +1995,9 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(sale_order.order_line[2].qty_invoiced, 1)
 
     def test_refund_ship_later_qty_delivered(self):
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        warehouse.delivery_steps = 'pick_pack_ship'
+
         sale_order = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,
             'order_line': [Command.create({
@@ -2089,7 +2092,8 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         pos_order_refund_id = data['pos.order'][0]['id']
         pos_order_refund_record = self.env['pos.order'].browse(pos_order_refund_id)
         self.assertEqual(sale_order.order_line.qty_delivered, 5)
-        pos_order_refund_record.picking_ids.button_validate()
+        for picking in pos_order_refund_record.picking_ids:
+            picking.button_validate()
         self.assertEqual(sale_order.order_line.qty_delivered, 2)
 
     def test_settle_groupable_lot_total_amount(self):


### PR DESCRIPTION
This commit fixes an issue introduced here : https://github.com/odoo/odoo/pull/240945 If the multi steps delivery was enabled, the flow would give a traceback

The qty_delivered on sale.order.line was not correctly computed when the original order was refunded with a ship later.

Steps to reproduce:
-------------------
* Create a sale order for 5 quantities of any product
* Confirm the sale order
* Settle the order in the PoS
* At this point the qty_delivered on the sale order line is 5
* Now go back to the PoS and refund partially the order for 3 quantities and use the "Ship Later" option
> Observation: The qty_delivered is 0 instead of 2

Why the fix:
------------
This line would crash because picking would contain more than one record
https://github.com/odoo/odoo/blob/2881f049b892b3380bcab62ad5b2b0b71a9ef261/addons/pos_sale/models/sale_order.py#L95

Instead of doing a groupby we just apply the logic separately for the
normal lines and the refund lines.

opw-5059560