### PR TITLE
[FIX] website: allow background color to be edited within s_tabs

### DIFF
--- a/addons/website/static/src/builder/plugins/options/utils.js
+++ b/addons/website/static/src/builder/plugins/options/utils.js
@@ -6,8 +6,7 @@ export const ONLY_BG_COLOR_SELECTOR =
     "section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge";
 export const ONLY_BG_COLOR_EXCLUDE = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, ${CARD_PARENT_HANDLERS}, .s_website_form_cover .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div`;
 
-export const BASE_ONLY_BG_IMAGE_SELECTOR =
-    ".s_tabs .oe_structure > *, footer .oe_structure > *:not(.o_footer_bottom_part)";
+export const BASE_ONLY_BG_IMAGE_SELECTOR = "footer .oe_structure > *:not(.o_footer_bottom_part)";
 export const ONLY_BG_IMAGE_SELECTOR = BASE_ONLY_BG_IMAGE_SELECTOR;
 export const ONLY_BG_IMAGE_EXCLUDE = "";
 


### PR DESCRIPTION
Before this commit, it was not possible to edit the background color of a snippet dropped within the s_tabs snippet. The user could set the background image / video, but not the color. The user could work around the limitation by setting the background color of a snippet, saving it, then dropping it within the s_tabs snippet.

Therefore, it made no sense to disable the background color option.

Moreover, adding the background color option fixes the reverse issue: if the user dropped a snippet with a background color set by default, they cannot remove it since the colorpicker was not available.