### PR TITLE
[FIX] account: different batches should not be grouped

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -2057,3 +2057,46 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon, PaymentCommon):
             {'amount_currency': 300, 'date_maturity': fields.Date.from_string('2017-01-06')},
             {'amount_currency': 600, 'date_maturity': fields.Date.from_string('2017-01-11')},
         ])
+
+    def test_payment_register_misc_different_batches(self):
+        """ Tests that payments that should be in different batches stay in different ones """
+        move1 = self.env['account.move'].create({
+            'move_type': 'entry',
+            'journal_id': self.company_data['default_journal_misc'].id,
+            'date': '2025-01-01',
+            'line_ids': [
+                Command.create({
+                    'account_id': self.company_data['default_account_receivable'].id,
+                    'partner_id': self.partner_a.id,
+                    'balance': 100.0,
+                }),
+                Command.create({
+                    'account_id': self.company_data['default_account_receivable'].id,
+                    'partner_id': self.partner_b.id,
+                    'balance': 100.0,
+                }),
+                Command.create({
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'balance': -200.0,
+                }),
+            ],
+        })
+        move2 = self.env['account.move'].create({
+            'move_type': 'entry',
+            'journal_id': self.company_data['default_journal_misc'].id,
+            'date': '2025-01-01',
+            'line_ids': [
+                Command.create({
+                    'account_id': self.company_data['default_account_receivable'].id,
+                    'partner_id': self.partner_a.id,
+                    'balance': 100.0,
+                }),
+                Command.create({
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'balance': -100.0,
+                }),
+            ],
+        })
+
+        payments = self._register_payment(move1 + move2, group_payment=False)
+        self.assertEqual(len(payments), 3, "We should get 2 payments from the first move and 1 for the second one")

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -1242,15 +1242,16 @@ class AccountPaymentRegister(models.TransientModel):
             if not self.group_payment:
                 # Don't group payments: Create one batch per move.
                 lines_to_pay = self._get_total_amounts_to_pay(batches)['lines'] if self.installments_mode in ('next', 'overdue', 'before_date') else self.line_ids
-                new_batches = {}
+                new_batches = []
                 for batch_result in batches:
+                    sub_batches = {}
                     for line in batch_result['lines']:
                         if line not in lines_to_pay:
                             continue
-                        if line.move_id.id in new_batches:
-                            new_batches[line.move_id.id]['lines'] += line
+                        if line.move_id.id in sub_batches:
+                            sub_batches[line.move_id.id]['lines'] += line
                         else:
-                            new_batches[line.move_id.id] = {
+                            sub_batches[line.move_id.id] = {
                                 **batch_result,
                                 'payment_values': {
                                     **batch_result['payment_values'],
@@ -1258,7 +1259,8 @@ class AccountPaymentRegister(models.TransientModel):
                                 },
                                 'lines': line,
                             }
-                batches = list(new_batches.values())
+                    new_batches.extend(sub_batches.values())
+                batches = new_batches
 
             for batch_result in batches:
                 to_process.append({


### PR DESCRIPTION
- Create a misc with 2 receivable lines with different partners
- Pay it
- You only get a single payment, for the first partner only

=> We grouped the lines per move, but we should only do that inside a same batch

Also fixes some caba tests that were incomplete




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
