### PR TITLE
[FIX] l10n_hr_edi: Error handling and UBL tax extension compatibility

### DIFF
--- a/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
+++ b/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
@@ -34,6 +34,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                                     'cbc:ID': {},
                                     'cbc:Name': {},
                                     'cbc:Percent': {},
+                                    'cbc:TaxExemptionReasonCode': {},
                                     'cbc:TaxExemptionReason': {},
                                     'hrextac:HRTaxScheme': {
                                         'cbc:ID': {},
@@ -42,7 +43,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                             }
                         },
                         'hrextac:HRLegalMonetaryTotal': {
-                            'hrextac:HRTaxExclusiveAmount': {},
+                            'cbc:TaxExclusiveAmount': {},
                             'hrextac:OutOfScopeOfVATAmount': {},
                         }
                     }
@@ -140,14 +141,17 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                         '_text': invoice.invoice_date_due
                     }
                 })
-        # HR-BR-6: Each previous invoice reference (BG-3) must have the date of issue of the previous invoice (BT-26).
         # HR-BT-3: Note on previous invoice
-        if invoice.reversed_entry_id:
-            document_node['cac:BillingReference'].update({
+        # HR-BR-6: Each previous invoice reference (BG-3) must have the date of issue of the previous invoice (BT-26).
+        if 'refund' in invoice.move_type and invoice.reversed_entry_id:
+            document_node['cac:BillingReference'] = {
+                'cac:InvoiceDocumentReference': {
+                    'cbc:ID': {'_text': invoice.ref},
+                },
                 'cbc:IssueDate': {
                     '_text': invoice.reversed_entry_id.invoice_date
-                    }
-                })
+                }
+            }
         # Document Type Codes and Process Type Logic
         if invoice.l10n_hr_process_type in ('P4', 'P6'):
             if invoice.move_type == 'out_invoice':
@@ -179,11 +183,16 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                     'cbc:ID': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:ID'],
                     'cbc:Name': hr_tax_name,
                     'cbc:Percent': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:Percent'],
+                    'cbc:TaxExemptionReasonCode': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:TaxExemptionReasonCode'],
                     'cbc:TaxExemptionReason': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:TaxExemptionReason'],
                     'hrextac:HRTaxScheme': tax_subtotals[i]['cac:TaxCategory'][0]['cac:TaxScheme'] if hr_tax_name['_text'] != "HR:POVNAK" else {'_text': "OTH"},
                 }
             }
             hr_tax_subtotals.append(new_item)
+        out_of_scope_node = {
+            'currencyID': document_node['cac:LegalMonetaryTotal']['cbc:TaxExclusiveAmount'].get('currencyID'),
+            '_text': '0.00'     # Currently unsupported, a HR-specific workaround can potentially be made
+        }
         document_node.update({
             'ext:UBLExtensions': {
                 'ext:UBLExtension': {
@@ -195,8 +204,8 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                                 'hrextac:HRTaxSubtotal': hr_tax_subtotals,
                             },
                             'hrextac:HRLegalMonetaryTotal': {
-                                'hrextac:HRTaxExclusiveAmount': document_node['cac:LegalMonetaryTotal']['cbc:TaxExclusiveAmount'],
-                                'hrextac:OutOfScopeOfVATAmount': False,     # Currently unsupported, a HR-specific workaround can potentially be made
+                                'cbc:TaxExclusiveAmount': document_node['cac:LegalMonetaryTotal']['cbc:TaxExclusiveAmount'],
+                                'hrextac:OutOfScopeOfVATAmount': out_of_scope_node,
                             }
                         }
                     },
@@ -273,9 +282,10 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                 'name': hr_category.name,
             })
             if tax.amount == 0:
-                res.update({
-                    'tax_exemption_reason': hr_category.description,
-                })
+                tax_extension = 'ubl_cii_tax_exemption_reason_code' in tax._fields and tax.ubl_cii_tax_exemption_reason_code
+                # If account_edi_ubl_cii_tax_extension is installed and a value is specified, use that data, if not, override with HR data
+                if not tax_extension:
+                    res.update({'tax_exemption_reason': hr_category.description})
         return res
 
     def _ubl_default_tax_category_grouping_key(self, base_line, tax_data, vals, currency):
@@ -331,6 +341,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
             'cbc:ID': {'_text': tax_category['tax_category_code']},
             'cbc:Name': {'_text': tax_category.get('name')},
             'cbc:Percent': {'_text': tax_category['percent']},
+            'cbc:TaxExemptionReasonCode': {'_text': tax_category.get('tax_exemption_reason_code')},
             'cbc:TaxExemptionReason': {'_text': tax_category.get('tax_exemption_reason')},
             'cac:TaxScheme': {
                 'cbc:ID': {'_text': tax_category['scheme_id']},

--- a/addons/l10n_hr_edi/models/account_move_send.py
+++ b/addons/l10n_hr_edi/models/account_move_send.py
@@ -115,7 +115,7 @@ class AccountMoveSend(models.AbstractModel):
                 addendum.mer_document_status = '50'
                 invoice_data['error'] = e.message
             else:
-                if not isinstance(response, list) and not response.get('ElectronicId'):
+                if not response.get('ElectronicId'):
                     addendum.mer_document_status = '50'
                     errors = []
                     for key in response:

--- a/addons/l10n_hr_edi/models/res_company.py
+++ b/addons/l10n_hr_edi/models/res_company.py
@@ -235,8 +235,7 @@ class ResCompany(models.Model):
                     'fiscalization_channel_type': str(fisc_data.get('channelType')),
                 })
                 if document['fiscalization_status'] != '0':
-                    _logger.warning("Document eID %s is not successfully fiscalized, skipping import.", document['mer_document_eid'])
-                    continue
+                    _logger.warning("Document eID %s is not successfully fiscalized by MojEracun.", document['mer_document_eid'])
                 try:
                     business_data = _mer_api_query_document_process_status_inbox(company, electronic_id=document['mer_document_eid'])[0]
                 except (MojEracunServiceError, UserError):
@@ -299,7 +298,7 @@ class ResCompany(models.Model):
                 try:
                     response_fisc = check_function(company)
                 except (MojEracunServiceError, UserError):
-                    _logger.error("Failed to retreive fiscalizatio data for company %s", company.name)
+                    _logger.error("Failed to retreive fiscalization data for company %s", company.name)
                     if from_cron or company.l10n_hr_mer_connection_mode == 'test':
                         response_fisc = []
                     else:

--- a/addons/l10n_hr_edi/tests/flows/in_invoice.xml
+++ b/addons/l10n_hr_edi/tests/flows/in_invoice.xml
@@ -181,7 +181,8 @@ PhFY/lSNktJsHzsRUaqzfVdRkHRFe/sBHG2YCnEuWSOO9wHWtky7Vc4=</xades:EncapsulatedTime
             </hrextac:HRTaxSubtotal>
           </hrextac:HRTaxTotal>
           <hrextac:HRLegalMonetaryTotal>
-            <hrextac:HRTaxExclusiveAmount currencyID="EUR">47.00</hrextac:HRTaxExclusiveAmount>
+            <cbc:TaxExclusiveAmount currencyID="EUR">47.00</cbc:TaxExclusiveAmount>
+            <hrextac:OutOfScopeOfVATAmount currencyID="EUR">0.00</hrextac:OutOfScopeOfVATAmount>
           </hrextac:HRLegalMonetaryTotal>
         </hrextac:HRFISK20Data>
       </ext:ExtensionContent>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice.xml
@@ -20,7 +20,8 @@
             </hrextac:HRTaxSubtotal>
           </hrextac:HRTaxTotal>
           <hrextac:HRLegalMonetaryTotal>
-            <hrextac:HRTaxExclusiveAmount currencyID="EUR">100.00</hrextac:HRTaxExclusiveAmount>
+            <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+            <hrextac:OutOfScopeOfVATAmount currencyID="EUR">0.00</hrextac:OutOfScopeOfVATAmount>
           </hrextac:HRLegalMonetaryTotal>
         </hrextac:HRFISK20Data>
       </ext:ExtensionContent>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_cash_basis.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_cash_basis.xml
@@ -21,7 +21,8 @@
             </hrextac:HRTaxSubtotal>
           </hrextac:HRTaxTotal>
           <hrextac:HRLegalMonetaryTotal>
-            <hrextac:HRTaxExclusiveAmount currencyID="EUR">100.00</hrextac:HRTaxExclusiveAmount>
+            <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+            <hrextac:OutOfScopeOfVATAmount currencyID="EUR">0.00</hrextac:OutOfScopeOfVATAmount>
           </hrextac:HRLegalMonetaryTotal>
         </hrextac:HRFISK20Data>
       </ext:ExtensionContent>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_e.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_e.xml
@@ -5,14 +5,15 @@
       <ext:ExtensionContent>
         <hrextac:HRFISK20Data>
           <hrextac:HRTaxTotal>
-            <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+            <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
             <hrextac:HRTaxSubtotal>
               <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
-              <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+              <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
               <hrextac:HRTaxCategory>
-                <cbc:ID>S</cbc:ID>
-                <cbc:Name>HR:PDV25</cbc:Name>
-                <cbc:Percent>25.0</cbc:Percent>
+                <cbc:ID>E</cbc:ID>
+                <cbc:Name>HR:E</cbc:Name>
+                <cbc:Percent>0.0</cbc:Percent>
+                <cbc:TaxExemptionReason>Exempt from VAT due to a specified reason</cbc:TaxExemptionReason>
                 <hrextac:HRTaxScheme>
                   <cbc:ID>VAT</cbc:ID>
                 </hrextac:HRTaxScheme>
@@ -31,23 +32,19 @@
   <cbc:ProfileID>P1</cbc:ProfileID>
   <cbc:ID>1/1/1</cbc:ID>
   <cbc:CopyIndicator>false</cbc:CopyIndicator>
-  <cbc:IssueDate>___ignore___</cbc:IssueDate>
-  <cbc:IssueTime>___ignore___</cbc:IssueTime>
-  <cbc:DueDate>___ignore___</cbc:DueDate>
+  <cbc:IssueDate>2025-01-02</cbc:IssueDate>
+  <cbc:IssueTime>00:00:00</cbc:IssueTime>
+  <cbc:DueDate>2025-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
   <cac:OrderReference>
     <cbc:ID>INV-2025-0001/1/1</cbc:ID>
   </cac:OrderReference>
-  <cac:AdditionalDocumentReference>
-    <cbc:ID>INV-2025-0001_1_1.pdf</cbc:ID>
-    <cac:Attachment>___ignore___</cac:Attachment>
-  </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
-				<cbc:ID>9934:68139364755</cbc:ID>
+				<cbc:ID>9934:68139364755::HR99:12345</cbc:ID>
 			</cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
@@ -141,13 +138,14 @@
     <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
   </cac:PaymentTerms>
   <cac:TaxTotal>
-    <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+    <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
     <cac:TaxSubtotal>
       <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
-      <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+      <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
       <cac:TaxCategory>
-        <cbc:ID>S</cbc:ID>
-        <cbc:Percent>25.0</cbc:Percent>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt from VAT due to a specified reason</cbc:TaxExemptionReason>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
@@ -157,9 +155,9 @@
   <cac:LegalMonetaryTotal>
     <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
     <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
-    <cbc:TaxInclusiveAmount currencyID="EUR">125.00</cbc:TaxInclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">100.00</cbc:TaxInclusiveAmount>
     <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-    <cbc:PayableAmount currencyID="EUR">125.00</cbc:PayableAmount>
+    <cbc:PayableAmount currencyID="EUR">100.00</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>
@@ -172,9 +170,10 @@
         <cbc:ItemClassificationCode listID="CG">01.11.11</cbc:ItemClassificationCode>
       </cac:CommodityClassification>
       <cac:ClassifiedTaxCategory>
-        <cbc:ID>S</cbc:ID>
-        <cbc:Name>HR:PDV25</cbc:Name>
-        <cbc:Percent>25.0</cbc:Percent>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Name>HR:E</cbc:Name>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt from VAT due to a specified reason</cbc:TaxExemptionReason>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_k.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_k.xml
@@ -21,7 +21,8 @@
             </hrextac:HRTaxSubtotal>
           </hrextac:HRTaxTotal>
           <hrextac:HRLegalMonetaryTotal>
-            <hrextac:HRTaxExclusiveAmount currencyID="EUR">100.00</hrextac:HRTaxExclusiveAmount>
+            <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+            <hrextac:OutOfScopeOfVATAmount currencyID="EUR">0.00</hrextac:OutOfScopeOfVATAmount>
           </hrextac:HRLegalMonetaryTotal>
         </hrextac:HRFISK20Data>
       </ext:ExtensionContent>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_refund.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_refund.xml
@@ -20,7 +20,8 @@
             </hrextac:HRTaxSubtotal>
           </hrextac:HRTaxTotal>
           <hrextac:HRLegalMonetaryTotal>
-            <hrextac:HRTaxExclusiveAmount currencyID="EUR">100.00</hrextac:HRTaxExclusiveAmount>
+            <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+            <hrextac:OutOfScopeOfVATAmount currencyID="EUR">0.00</hrextac:OutOfScopeOfVATAmount>
           </hrextac:HRLegalMonetaryTotal>
         </hrextac:HRFISK20Data>
       </ext:ExtensionContent>

--- a/addons/l10n_hr_edi/tests/test_ubl_hr.py
+++ b/addons/l10n_hr_edi/tests/test_ubl_hr.py
@@ -87,9 +87,9 @@ class TestL10nHrEdiXml(TestL10nHrEdiCommon, AccountTestInvoicingCommon):
             self.get_xml_tree_from_string(expected_content),
         )
 
-    def test_export_invoice_with_exemption(self):
+    def test_export_invoice_with_exemption_k(self):
         """
-        Test the content of a generated invoice with VAT exemption in Croation UBL format.
+        Test the content of a generated invoice with HR:K exemption in Croation UBL format.
         """
         self.setup_partner_as_hr(self.env.company.partner_id)
         self.setup_partner_as_hr_alt(self.partner_a)
@@ -114,7 +114,41 @@ class TestL10nHrEdiXml(TestL10nHrEdiCommon, AccountTestInvoicingCommon):
             'fiscalization_number': self.env['account.move']._get_l10n_hr_fiscalization_number(invoice.name),
         })
         actual_content, _dummy = self.env['account.edi.xml.ubl_hr'].with_context(lang='en_US')._export_invoice(invoice)
-        with misc.file_open(f'addons/{self.test_module}/tests/test_files/test_invoice_exemption.xml', 'rb') as file:
+        with misc.file_open(f'addons/{self.test_module}/tests/test_files/test_invoice_exemption_k.xml', 'rb') as file:
+            expected_content = file.read()
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(actual_content),
+            self.get_xml_tree_from_string(expected_content),
+        )
+
+    def test_export_invoice_with_exemption_e(self):
+        """
+        Test the content of a generated invoice with HR:E exemption in Croation UBL format.
+        """
+        self.setup_partner_as_hr(self.env.company.partner_id)
+        self.setup_partner_as_hr_alt(self.partner_a)
+        tax = self.env['account.chart.template'].ref('VAT_S_other_exempt_O')
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2025-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(tax.ids)],
+                }),
+            ],
+        })
+        invoice.action_post()
+        invoice.l10n_hr_edi_addendum_id = self.env['l10n_hr_edi.addendum'].create({
+            'move_id': invoice.id,
+            'invoice_sending_time': '2025-01-02',
+            'fiscalization_number': self.env['account.move']._get_l10n_hr_fiscalization_number(invoice.name),
+        })
+        actual_content, _dummy = self.env['account.edi.xml.ubl_hr'].with_context(lang='en_US')._export_invoice(invoice)
+        with misc.file_open(f'addons/{self.test_module}/tests/test_files/test_invoice_exemption_e.xml', 'rb') as file:
             expected_content = file.read()
         self.assertXmlTreeEqual(
             self.get_xml_tree_from_string(actual_content),

--- a/addons/l10n_hr_edi/tools.py
+++ b/addons/l10n_hr_edi/tools.py
@@ -80,7 +80,8 @@ def _make_request(company, endpoint_type, params=False):
     # Structure-specific error handling
     if response.status_code != 200:
         try:
-            error_message = response.json().get('errors')
+            error_message = response.json()
+            error_message = error_message.get('errors') or error_message.get('message')
         except (JSONDecodeError, TypeError):
             error_message = False
         raise UserError(company.env._("Error handling request: %s", error_message) if error_message else company.env._("HTTP %s: Connection error.", response.status_code))

--- a/addons/l10n_hr_edi/views/account_move_views.xml
+++ b/addons/l10n_hr_edi/views/account_move_views.xml
@@ -28,10 +28,16 @@
                         class="oe_highlight"
                         type="object"
                         groups="account.group_account_invoice"
-                        invisible="not l10n_hr_mer_document_eid or (amount_total - amount_residual) == l10n_hr_payment_reported_amount"
+                        invisible="not l10n_hr_mer_document_eid or (amount_total - amount_residual) == l10n_hr_payment_reported_amount or move_type not in ('out_invoice', 'out_refund')"
                     />
                 </xpath>
                 <xpath expr="//header" position="after">
+                    <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="move_type not in ('in_invoice', 'in_refund') or not l10n_hr_mer_document_eid or l10n_hr_fiscalization_status == '0' or invoice_date &gt;= '2026-01-01 00:00:00'"  role="alert">
+                        <span>This document is dated before 01.01.2026 and is not fiscalized by MojEracun</span>
+                    </div>
+                    <div class="alert alert-danger w-100 d-flex align-items-center gap-1" invisible="move_type not in ('in_invoice', 'in_refund') or not l10n_hr_mer_document_eid or l10n_hr_fiscalization_status == '0' or invoice_date &lt; '2026-01-01 00:00:00'"  role="alert">
+                        <span>This document is not successfully fiscalized by MojEracun</span>
+                    </div>
                     <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="not l10n_hr_mer_document_eid or l10n_hr_fiscalization_channel_type != '1'"  role="alert">
                         <span>Warning: this document was not successfully delivered to the recepient via EDI and needs to be sent manually (ex. via e-mail)</span>
                     </div>
@@ -100,7 +106,7 @@
                         </group>
                         <group string="Payment reporting"
                                 name="l10n_hr_payment_info_group"
-                                invisible="not l10n_hr_edi_addendum_id">
+                                invisible="not l10n_hr_edi_addendum_id or move_type not in ('out_invoice', 'out_refund')">
                             <field name="l10n_hr_payment_reported_amount"
                                 readonly="True"
                             />


### PR DESCRIPTION
- Improving error handling for various requests
- Adjusting XML generation to not conflict with `account_edi_ubl_cii_tax_extension` if it is installed
- Adding a separate test for HR:E category taxes
- Replacing skipping import of not successfully fiscalized document with warnings displayed on the moves after import
task-none

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
