### PR TITLE
[IMP] point_of_sale: Format numbers of cash control popups

### DIFF
--- a/addons/point_of_sale/static/src/app/components/inputs/input/cash_input/cash_input.js
+++ b/addons/point_of_sale/static/src/app/components/inputs/input/cash_input/cash_input.js
@@ -1,0 +1,20 @@
+import { Input } from "../input";
+
+export class CashInput extends Input {
+    static template = "point_of_sale.CashInput";
+    static props = {
+        ...super.props,
+        class: { type: String, optional: true },
+        currencySymbol: { type: String, optional: true },
+        currencyPosition: { type: String, optional: true },
+    };
+    static defaultProps = {
+        ...super.defaultProps,
+        class: "",
+        currencySymbol: "",
+        currencyPosition: "after",
+    };
+    setup() {
+        super.setup(...arguments);
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/inputs/input/cash_input/cash_input.xml
+++ b/addons/point_of_sale/static/src/app/components/inputs/input/cash_input/cash_input.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.CashInput" t-inherit="point_of_sale.input" t-inherit-mode="primary">
+        <xpath expr="//input[@class='o_input border-0 mx-2 text-body']" position="before">
+            <span t-if="props.currencyPosition === 'before'" class="mx-2" t-esc="props.currencySymbol"/>
+        </xpath>
+        <xpath expr="//input[@class='o_input border-0 mx-2 text-body']" position="after">
+            <span t-if="props.currencyPosition === 'after'" class="mx-2" t-esc="props.currencySymbol"/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/src/app/components/inputs/input/input.js
+++ b/addons/point_of_sale/static/src/app/components/inputs/input/input.js
@@ -30,6 +30,8 @@ export class Input extends TModelInput {
         callback: { type: Function, optional: true },
         isOpenCallback: { type: Function, optional: true },
         readonly: { type: Boolean, optional: true },
+        onBlur: { type: Function, optional: true },
+        onClick: { type: Function, optional: true },
     };
     static defaultProps = {
         class: "",

--- a/addons/point_of_sale/static/src/app/components/inputs/input/input.xml
+++ b/addons/point_of_sale/static/src/app/components/inputs/input/input.xml
@@ -22,7 +22,9 @@
                         t-ref="input"
                         t-att-value="getValue()"
                         t-on-input="(event) => this.setValue(event.target.value)"
-                        t-att-readonly="props.readonly" />
+                        t-att-readonly="props.readonly"
+                        t-on-blur="(ev) => props.onBlur?.(ev)"
+                        t-on-click="(ev) => props.onClick?.(ev)" />
                     <t t-if="!props.iconOnLeftSide" t-call="point_of_sale.inputIcon" />
                     <i t-att-class="{ 'invisible': !getValue() }" class="fa fa-times mx-2" t-on-click="() => this.setValue('')"/>
                 </div>

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -2,20 +2,20 @@ import { useState } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { parseFloat } from "@web/views/fields/parsers";
-import { Component } from "@odoo/owl";
+import { Component, useRef } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { CashMoveListPopup } from "@point_of_sale/app/components/popups/cash_move_popup/cash_move_list_popup/cash_move_list_popup";
 import { Dialog } from "@web/core/dialog/dialog";
 import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
-import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
+import { CashInput } from "@point_of_sale/app/components/inputs/input/cash_input/cash_input";
 
 const { DateTime } = luxon;
 
 export class CashMovePopup extends Component {
     static template = "point_of_sale.CashMovePopup";
-    static components = { Input, Dialog };
+    static components = { Dialog, CashInput };
     static props = ["confirmKey?", "close", "getPayload?"];
     setup() {
         super.setup();
@@ -30,6 +30,7 @@ export class CashMovePopup extends Component {
         });
         this.confirm = useAsyncLockedMethod(this.confirm);
         this.ui = useService("ui");
+        this.inputRef = useRef("inputRef");
     }
 
     get partnerId() {
@@ -124,5 +125,8 @@ export class CashMovePopup extends Component {
         if (result) {
             this.state.amount = result;
         }
+    }
+    handleAmountBlur() {
+        this.state.amount = this.env.utils.parseAndFormatCurrency(this.state.amount);
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
@@ -12,16 +12,18 @@
                         Cash Out
                     </button>
                 </div>
-                <div t-attf-class="{{this.ui.isSmall ? 'mw-50 h-50' : 'w-25'}}">
-                    <Input tModel="[state, 'amount']"
-                        icon="{type: 'string', value: pos.currency.symbol}"
-                        iconOnLeftSide="pos.currency.position === 'before'"
-                        isValid.bind="env.utils.isValidFloat"
-                        autofocus="true"
-                        getRef="(ref) => this.inputRef = ref"
-                        t-on-click="openNumpadDialog"
-                        readonly="ui.isSmall ? true : false" />
-                </div>
+                <CashInput
+                    class="this.ui.isSmall ? 'mw-50 h-50' : 'w-25'"
+                    tModel="[state, 'amount']"
+                    currencySymbol="pos.currency.symbol"
+                    currencyPosition="pos.currency.position"
+                    isValid="(val) => env.utils.isValidFloat(val)"
+                    autofocus="true"
+                    readonly="ui.isSmall"
+                    onBlur="() => this.handleAmountBlur()"
+                    onClick="() => this.openNumpadDialog()"
+                    getRef="(ref) => this.inputRef = ref"
+                />
             </div>
             <div class="form-floating">
                 <textarea class="form-control cash-reason" placeholder="Leave a reason here" name="reason" id="reason" t-model="state.reason" style="height:100px;" />

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -9,16 +9,16 @@ import { ConnectionLostError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { parseFloat } from "@web/views/fields/parsers";
-import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
 import { ask } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { PaymentMethodBreakdown } from "@point_of_sale/app/components/payment_method_breakdown/payment_method_breakdown";
+import { CashInput } from "@point_of_sale/app/components/inputs/input/cash_input/cash_input";
 
 const { DateTime } = luxon;
 
 export class ClosePosPopup extends Component {
-    static components = { SaleDetailsButton, Input, Dialog, PaymentMethodBreakdown };
+    static components = { SaleDetailsButton, Dialog, PaymentMethodBreakdown, CashInput };
     static template = "point_of_sale.ClosePosPopup";
     static props = [
         "orders_details",
@@ -142,6 +142,17 @@ export class ClosePosPopup extends Component {
             this.state.notes = "";
             this.moneyDetails = null;
         }
+    }
+    handleCashCountBlur() {
+        const counted = this.state.payments[this.props.default_cash_details.id].counted;
+        this.setManualCashInput(counted);
+        this.state.payments[this.props.default_cash_details.id].counted =
+            this.env.utils.parseAndFormatCurrency(counted);
+    }
+    handlePaymentCountBlur(paymentId) {
+        this.state.payments[paymentId].counted = this.env.utils.parseAndFormatCurrency(
+            this.state.payments[paymentId].counted
+        );
     }
     getDifference(paymentId) {
         const counted = this.state.payments[paymentId].counted;

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
@@ -62,11 +62,11 @@
                     <div class="col-12" t-if="pos.config.cash_control" t-att-class="{'col-md-6': !this.isOnePmUsed()}">
                         <label class="form-label">Cash Count</label>
                         <div class="d-flex w-100 gap-2 mt-1">
-                            <Input
-                                tModel="[state.payments[props.default_cash_details.id], 'counted']"
-                                callback.bind="(value) => this.setManualCashInput(value)"
-                                isValid.bind="env.utils.isValidFloat"
+                            <CashInput
                                 class="'cash-input w-100'"
+                                tModel="[state.payments[props.default_cash_details.id], 'counted']"
+                                isValid="(val) => env.utils.isValidFloat(val)"
+                                onBlur="() => this.handleCashCountBlur()"
                             />
                             <button
                                 class="icon fa fa-money btn btn-secondary"
@@ -80,10 +80,11 @@
                                 <t t-esc="pm.name" /> Count
                             </label>
                             <div class="d-flex w-100 gap-2 mt-1">
-                                <Input
-                                    tModel="[state.payments[pm.id], 'counted']"
-                                    isValid.bind="env.utils.isValidFloat"
+                                <CashInput
                                     class="'w-100'"
+                                    tModel="[state.payments[pm.id], 'counted']"
+                                    isValid="(val) => env.utils.isValidFloat(val)"
+                                    onBlur="() => this.handlePaymentCountBlur(pm.id)"
                                 />
                                 <t t-if="pm.type == 'cash'">
                                     <button

--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.js
@@ -4,10 +4,10 @@ import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { MoneyDetailsPopup } from "@point_of_sale/app/components/popups/money_details_popup/money_details_popup";
 import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
-import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import { parseFloat } from "@web/views/fields/parsers";
 import { Dialog } from "@web/core/dialog/dialog";
 import { RPCError } from "@web/core/network/rpc";
+import { CashInput } from "@point_of_sale/app/components/inputs/input/cash_input/cash_input";
 
 class CustomDialog extends Dialog {
     onEscape() {}
@@ -15,7 +15,7 @@ class CustomDialog extends Dialog {
 
 export class OpeningControlPopup extends Component {
     static template = "point_of_sale.OpeningControlPopup";
-    static components = { Input, Dialog: CustomDialog };
+    static components = { Dialog: CustomDialog, CashInput };
     static props = {
         close: Function,
     };
@@ -83,6 +83,9 @@ export class OpeningControlPopup extends Component {
             return;
         }
         this.state.notes = "";
+    }
+    handleInputBlur() {
+        this.state.openingCash = this.env.utils.parseAndFormatCurrency(this.state.openingCash);
     }
     get cashMethodCount() {
         return this.pos.config.payment_method_ids.filter((pm) => pm.is_cash_count).length;

--- a/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/opening_control_popup/opening_control_popup.xml
@@ -16,11 +16,15 @@
             <div class="opening-cash-section mb-3" t-if="this.cashMethodCount">
                 <label class="form-label">Opening cash</label>
                 <div t-att-class="{ 'w-50': !ui.isSmall }" class="cash-input-sub-section d-flex gap-1">
-                    <Input tModel="[state, 'openingCash']"
-                        isValid.bind="env.utils.isValidFloat"
-                        callback.bind="handleInputChange"
+                    <CashInput
+                        class="'flex-grow-1'"
+                        tModel="[state, 'openingCash']"
+                        isValid="(val) => env.utils.isValidFloat(val)"
                         autofocus="true"
-                        placeholder.translate="Opening Balance Eg: 123"/>
+                        placeholder="'Opening Balance Eg: 123'"
+                        onBlur="() => this.handleInputBlur()"
+                        getRef="(ref) => this.openingCashInput = ref"
+                    />
                     <div class="button icon btn btn-secondary btn-lg lh-lg" t-on-click="openDetailsPopup">
                         <i class="fa fa-money" role="img" title="Open the money details popup"/>
                     </div>

--- a/addons/point_of_sale/static/src/app/services/contextual_utils_service.js
+++ b/addons/point_of_sale/static/src/app/services/contextual_utils_service.js
@@ -45,12 +45,20 @@ export const contextualUtilsService = {
         const parseValidFloat = (inputValue) =>
             isValidFloat(inputValue) ? parseFloat(inputValue) : 0;
 
+        const parseAndFormatCurrency = (inputValue, hasSymbol = false) => {
+            if (!isValidFloat(inputValue)) {
+                return inputValue;
+            }
+            return formatCurrency(parseFloat(inputValue), hasSymbol);
+        };
+
         env.utils = {
             formatCurrency,
             roundCurrency,
             formatProductQty,
             isValidFloat,
             parseValidFloat,
+            parseAndFormatCurrency,
         };
     },
 };


### PR DESCRIPTION
The aim of this pr was to format the numbers displayed in the cash control popups in the same way as in the backend depending of the currency used.

**Note :** I had to replace Input template with basic input field or I was not able to use t-on-blur. 

task: 5490983

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
