### PR TITLE
[FIX] {purchase_,}mrp: explode cost_share on nested kits

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -406,7 +406,7 @@ class MrpBom(models.Model):
             for product in products:
                 product_boms.setdefault(product, self.env['mrp.bom'])
 
-        boms_done = [(self, {'qty': quantity, 'product': product, 'original_qty': quantity, 'parent_line': False})]
+        boms_done = [(self, self.env['mrp.bom.line']._prepare_bom_done_values(quantity, product, quantity, []))]
         lines_done = []
 
         bom_lines = []
@@ -436,15 +436,20 @@ class MrpBom(models.Model):
                 for bom_line in bom.bom_line_ids:
                     if bom_line.product_id not in product_boms:
                         product_ids.add(bom_line.product_id.id)
-                boms_done.append((bom, {'qty': converted_line_quantity, 'product': current_product, 'original_qty': quantity, 'parent_line': current_line}))
+                boms_done.append((bom, current_line._prepare_bom_done_values(converted_line_quantity, current_product, quantity, boms_done)))
             else:
                 # We round up here because the user expects that if he has to consume a little more, the whole UOM unit
                 # should be consumed.
                 rounding = current_line.product_uom_id.rounding
                 line_quantity = float_round(line_quantity, precision_rounding=rounding, rounding_method='UP')
-                lines_done.append((current_line, {'qty': line_quantity, 'product': current_product, 'original_qty': quantity, 'parent_line': parent_line}))
+                lines_done.append((current_line, current_line._prepare_line_done_values(line_quantity, current_product, quantity, parent_line, boms_done)))
 
+        lines_done = self._round_last_line_done(lines_done)
         return boms_done, lines_done
+
+    @api.model
+    def _round_last_line_done(self, lines_done):
+        return lines_done
 
     @api.model
     def get_import_templates(self):
@@ -765,6 +770,12 @@ class MrpBomLine(models.Model):
         return {
             'quantity': 0,
         }
+
+    def _prepare_bom_done_values(self, quantity, product, original_quantity, boms_done):
+        return {'qty': quantity, 'product': product, 'original_qty': original_quantity, 'parent_line': self}
+
+    def _prepare_line_done_values(self, quantity, product, original_quantity, parent_line, boms_done):
+        return {'qty': quantity, 'product': product, 'original_qty': original_quantity, 'parent_line': parent_line}
 
 
 class MrpByProduct(models.Model):

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -560,11 +560,7 @@ class StockMove(models.Model):
             else:
                 factor = move.product_uom._compute_quantity(move.product_uom_qty, bom.product_uom_id) / bom.product_qty
             _dummy, lines = bom.sudo().explode(move.product_id, factor, picking_type=bom.picking_type_id, never_attribute_values=move.never_product_template_attribute_value_ids)
-            for bom_line, line_data in lines:
-                if float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding) or self.env.context.get('is_scrap'):
-                    phantom_moves_vals_list += move._generate_move_phantom(bom_line, 0, line_data['qty'])
-                else:
-                    phantom_moves_vals_list += move._generate_move_phantom(bom_line, line_data['qty'], 0)
+            phantom_moves_vals_list += move._generate_all_phantom_moves(lines)
             # delete the move with original product which is not relevant anymore
             moves_ids_to_unlink.add(move.id)
 
@@ -630,6 +626,19 @@ class StockMove(models.Model):
             'picked': self.picked,
             'bom_line_id': bom_line.id,
         }
+
+    def _generate_all_phantom_moves(self, exploded_lines_data):
+        self.ensure_one()
+        phantom_moves_vals_list = []
+        for bom_line, line_data in exploded_lines_data:
+            if float_is_zero(self.product_uom_qty, precision_rounding=self.product_uom.rounding) or self.env.context.get('is_scrap'):
+                vals = self._generate_move_phantom(bom_line, 0, line_data['qty'])
+            else:
+                vals = self._generate_move_phantom(bom_line, line_data['qty'], 0)
+            for val in vals:
+                val['cost_share'] = line_data.get('line_cost_share', 0.0)
+            phantom_moves_vals_list += vals
+        return phantom_moves_vals_list
 
     def _generate_move_phantom(self, bom_line, product_qty, quantity_done):
         vals = []

--- a/addons/purchase_mrp/models/mrp_bom.py
+++ b/addons/purchase_mrp/models/mrp_bom.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import float_compare
+from odoo.tools import float_compare, float_is_zero, float_round
 
 
 class MrpBom(models.Model):
@@ -21,6 +21,13 @@ class MrpBom(models.Model):
                 raise UserError(_("The total cost share for a BoM's component have to be 100"))
         return res
 
+    @api.model
+    def _round_last_line_done(self, lines_done):
+        result = super()._round_last_line_done(lines_done)
+        if result:
+            result[-1][1]['line_cost_share'] = float_round(100.0 - sum(vals.get('line_cost_share', 0.0) for _, vals in result[:-1]), precision_digits=2)
+        return result
+
 
 class MrpBomLine(models.Model):
     _inherit = 'mrp.bom.line'
@@ -32,8 +39,26 @@ class MrpBomLine(models.Model):
 
     def _get_cost_share(self):
         self.ensure_one()
-        if self.cost_share:
+        if self.cost_share or not all(float_is_zero(bom_line.cost_share, precision_digits=2) for bom_line in self.bom_id.bom_line_ids):
             return self.cost_share / 100
         bom = self.bom_id
         bom_lines_without_cost_share = bom.bom_line_ids.filtered(lambda bl: not bl.cost_share)
         return 1 / len(bom_lines_without_cost_share)
+
+    def _prepare_bom_done_values(self, quantity, product, original_quantity, boms_done):
+        result = super()._prepare_bom_done_values(quantity, product, original_quantity, boms_done)
+        result['bom_cost_share'] = self._get_line_cost_share(boms_done)
+        return result
+
+    def _prepare_line_done_values(self, quantity, product, original_quantity, parent_line, boms_done):
+        result = super()._prepare_line_done_values(quantity, product, original_quantity, parent_line, boms_done)
+        result['line_cost_share'] = float_round(self._get_line_cost_share(boms_done), precision_digits=2)
+        return result
+
+    def _get_line_cost_share(self, boms_done):
+        if not self:
+            return 100.0
+        self.ensure_one()
+        parent_cost_share = next((vals.get('bom_cost_share', 100.0) for bom, vals in reversed(boms_done) if bom == self.bom_id), 100)
+        line_cost_share = parent_cost_share * self._get_cost_share()
+        return line_cost_share

--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -25,7 +25,7 @@ class StockMove(models.Model):
         bom = bom_line.bom_id
         if line.currency_id != self.company_id.currency_id:
             kit_price_unit = line.currency_id._convert(kit_price_unit, self.company_id.currency_id, self.company_id, fields.Date.context_today(self), round=False)
-        cost_share = self.bom_line_id._get_cost_share()
+        cost_share = self.cost_share / 100
         uom_factor = 1.0
         kit_product = bom.product_id or bom.product_tmpl_id
 

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.fields import Date, Datetime
+from odoo.fields import Command, Date, Datetime
 from odoo.tools import mute_logger
 from odoo.tests import Form, tagged
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
-from odoo import Command
 
 
 @tagged('post_install', '-at_install')
@@ -391,3 +390,140 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
                 {'name': f'{account_move.name}', 'debit': 575, 'credit': 0.0},
             ]
         )
+
+    def test_avco_purchase_nested_kit_explode_cost_share(self):
+        """
+        Test the cost share calculation when purchasing a nested kit with several levels of BoMs
+
+        Giga Kit:
+            - C01, cost share 0%
+            - Super Kit, cost share 100%:
+                - C02, cost share 10%
+                - Kit, cost share 60%:
+                    - C02, cost share 25%
+                    - C03, cost share 25%
+                    - Sub Kit, cost share 50%
+                        - C04, cost share 0%
+                        - C05, cost share 0%
+                - Sub Kit, cost share 20%
+                    - C04, cost share 0%
+                    - C05, cost share 0%
+                - Phantom Kit, cost share 0%
+                    - C05, cost share 100%
+                - Triple Kit, cost share 10%
+                    - C01, cost share 0%
+                    - C02, cost share 0%
+                    - C03, cost share 0% (Last line should round to reach 100%)
+        Buy and receive 1 kit Giga Kit @ 1000
+        """
+        components = component01, component02, component03, component04, component05 = self.env['product.product'].create([{
+            'name': 'Component %s' % name,
+            'categ_id': self.avco_category.id,
+        } for name in ('01', '02 ', '03', '04', '05')])
+
+        giga_kit, super_kit, kit, sub_kit, phantom_kit, triple_kit = self.env['product.product'].create([{
+            'name': name,
+        } for name in ('Giga Kit', 'Super Kit', 'Kit', 'Sub Kit', 'Phantom Kit', 'Triple Kit')])
+
+        self.env['mrp.bom'].create([{
+            'product_tmpl_id': giga_kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': component01.id, 'product_qty': 1, 'cost_share': 0}),
+                Command.create({'product_id': super_kit.id, 'product_qty': 1, 'cost_share': 100}),
+            ],
+        }, {
+            'product_tmpl_id': super_kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': component02.id, 'product_qty': 1, 'cost_share': 10}),
+                Command.create({'product_id': kit.id, 'product_qty': 1, 'cost_share': 60}),
+                Command.create({'product_id': sub_kit.id, 'product_qty': 1, 'cost_share': 20}),
+                Command.create({'product_id': phantom_kit.id, 'product_qty': 1, 'cost_share': 0}),
+                Command.create({'product_id': triple_kit.id, 'product_qty': 1, 'cost_share': 10}),
+            ],
+        }, {
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': component02.id, 'product_qty': 1, 'cost_share': 25}),
+                Command.create({'product_id': component03.id, 'product_qty': 1, 'cost_share': 25}),
+                Command.create({'product_id': sub_kit.id, 'product_qty': 1, 'cost_share': 50}),
+            ],
+        }, {
+            'product_tmpl_id': sub_kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': component04.id, 'product_qty': 1, 'cost_share': 0}),
+                Command.create({'product_id': component05.id, 'product_qty': 1, 'cost_share': 0}),
+            ],
+        }, {
+            'product_tmpl_id': phantom_kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': component05.id, 'product_qty': 1, 'cost_share': 100}),
+            ],
+        }, {
+            'product_tmpl_id': triple_kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': component01.id, 'product_qty': 1, 'cost_share': 0}),
+                Command.create({'product_id': component02.id, 'product_qty': 1, 'cost_share': 0}),
+                Command.create({'product_id': component03.id, 'product_qty': 1, 'cost_share': 0}),
+            ],
+        }])
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.vendor01.id,
+            'order_line': [
+                Command.create({'product_id': super_kit.id, 'product_qty': 1, 'price_unit': 1000})
+            ],
+        })
+        purchase_order.button_confirm()
+
+        # Actual cost shares:
+        # Component01:
+        #   0 -> No stock valuation for that line
+        #   1.0 * 0.1 * 0.333... (O%) = 0.0333... -> 3.33%
+        # Component02:
+        #   1.0 * 0.1  = 0.1 -> 10%
+        #   1.0 * 0.6 * 0.25 = 0.15 -> 15%
+        #   1.0 * 0.1 * 0.333... (O%) = 0.0333... -> 3.33%
+        # Component03:
+        #   1.0 * 0.6 * 0.25 = 0.15 -> 15%
+        #   1.0 * 0.1 * 0.333... (O%) = 0.0333... -> 3.34% (last exploded line rounded)
+        # Component04:
+        #   1.0 * 0.6 * 0.5 * 0.5 (0%) = 0.15 -> 15%
+        #   1.0 * 0.2 * 0.5 (0%) = 0.1 -> 10%
+        # Component05:
+        #   1.0 * 0.6 * 0.5 * 0.5 (0%) = 0.15 -> 15%
+        #   1.0 * 0.2 * 0.5 (0%) = 0.1 -> 10%
+        #   1.0 * 0.0 * 1.0 = 0.0 -> 0%
+        self.assertEqual(sum(purchase_order.order_line.move_ids.mapped('cost_share')), 100.0)
+        self.assertRecordValues(purchase_order.order_line.move_ids.sorted(lambda m: m.product_id.id), [
+            {'product_id': component01.id, 'cost_share': 3.33},
+            {'product_id': component02.id, 'cost_share': 10.0},
+            {'product_id': component02.id, 'cost_share': 15.0},
+            {'product_id': component02.id, 'cost_share': 3.33},
+            {'product_id': component03.id, 'cost_share': 15.0},
+            {'product_id': component03.id, 'cost_share': 3.34},
+            {'product_id': component04.id, 'cost_share': 15.0},
+            {'product_id': component04.id, 'cost_share': 10.0},
+            {'product_id': component05.id, 'cost_share': 15.0},
+            {'product_id': component05.id, 'cost_share': 10.0},
+            {'product_id': component05.id, 'cost_share': 0.0},
+        ])
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
+        self.assertRecordValues(components.stock_valuation_layer_ids.sorted(lambda l: l.product_id.id), [
+            {'product_id': component01.id, 'unit_cost':  33.3},
+            {'product_id': component02.id, 'unit_cost': 100.0},
+            {'product_id': component02.id, 'unit_cost': 150.0},
+            {'product_id': component02.id, 'unit_cost':  33.3},
+            {'product_id': component03.id, 'unit_cost': 150.0},
+            {'product_id': component03.id, 'unit_cost':  33.4},
+            {'product_id': component04.id, 'unit_cost': 150.0},
+            {'product_id': component04.id, 'unit_cost': 100.0},
+            {'product_id': component05.id, 'unit_cost': 150.0},
+            {'product_id': component05.id, 'unit_cost': 100.0},
+            {'product_id': component05.id, 'unit_cost': 0.0},
+        ])

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.exceptions import UserError
 from odoo.fields import Command, Date, Datetime
 from odoo.tools import mute_logger
 from odoo.tests import Form, tagged
@@ -526,4 +527,200 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
             {'product_id': component05.id, 'unit_cost': 150.0},
             {'product_id': component05.id, 'unit_cost': 100.0},
             {'product_id': component05.id, 'unit_cost': 0.0},
+        ])
+
+    def test_kit_bom_cost_share_constraint_with_variants(self):
+        """
+        Check that the cost share constraint is well behaved with respect to product attribute values:
+        the sum of the cost share's of the bom of any product variant should either be 0% or 100%
+        """
+        attributes = self.env['product.attribute'].create([
+            {'name': name} for name in ('Size', 'Color')
+        ])
+        attributes_values = ((attributes[0], ('S', 'M')), (attributes[1], ('Blue', 'Red')))
+        self.env['product.attribute.value'].create([{
+            'name': name,
+            'attribute_id': attribute.id
+        } for attribute, names in attributes_values for name in names])
+        product_template = self.env['product.template'].create({
+            'name': "lovely product",
+            'is_storable': True,
+        })
+        size_attribute_lines, color_attribute_lines = self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': product_template.id,
+            'attribute_id': attribute.id,
+            'value_ids': [Command.set(attribute.value_ids.ids)]
+        } for attribute in attributes])
+        self.assertEqual(product_template.product_variant_count, 4)
+        c1, c2, c3 = self.env['product.product'].create([
+            {'name': f'Comp {i + 1}', 'categ_id': self.avco_category.id} for i in range(3)
+        ])
+
+        # Total cost share is 100% but in reality it is either 25% or 75% depending on the variant -> Invalid
+        with self.assertRaises(UserError):
+            self.env['mrp.bom'].create({
+                'product_tmpl_id': product_template.id,
+                'product_uom_id': product_template.uom_id.id,
+                'product_qty': 1.0,
+                'type': 'phantom',
+                'bom_line_ids': [
+                    Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 25, 'bom_product_template_attribute_value_ids': [Command.link(size_attribute_lines.product_template_value_ids[0].id)]}),  # S size
+                    Command.create({'product_id': c2.id, 'product_qty': 1, 'cost_share': 75, 'bom_product_template_attribute_value_ids': [Command.link(size_attribute_lines.product_template_value_ids[1].id)]}),  # M size
+                ]
+            })
+
+        # The total cost share for Blue is 100% but for Red is 105% -> Invalid
+        with self.assertRaises(UserError):
+            self.env['mrp.bom'].create({
+                'product_tmpl_id': product_template.id,
+                'product_uom_id': product_template.uom_id.id,
+                'product_qty': 1.0,
+                'type': 'phantom',
+                'bom_line_ids': [
+                    Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 25, 'bom_product_template_attribute_value_ids': [Command.link(color_attribute_lines.product_template_value_ids[0].id)]}),  # Blue
+                    Command.create({'product_id': c2.id, 'product_qty': 1, 'cost_share': 30, 'bom_product_template_attribute_value_ids': [Command.link(color_attribute_lines.product_template_value_ids[1].id)]}),  # Red
+                    Command.create({'product_id': c3.id, 'product_qty': 1, 'cost_share': 75}),  # All attributes
+                ]
+            })
+
+        # Check that optional lines (with a product_qty of 0) are ignored -> Valid
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product_template.id,
+            'product_uom_id': product_template.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 100}),  # All attributes
+                Command.create({'product_id': c2.id, 'product_qty': 0, 'cost_share': 100}),  # All attributes - Qty 0 are Optional so the cost share should not impact the validation
+            ]
+        })
+
+        # Variant with S attribute sum up to 100% others to 0% -> Valid
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product_template.id,
+            'product_uom_id': product_template.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 35, 'bom_product_template_attribute_value_ids': [Command.link(size_attribute_lines.product_template_value_ids[0].id)]}),  # S size
+                Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 65, 'bom_product_template_attribute_value_ids': [Command.link(size_attribute_lines.product_template_value_ids[0].id)]}),  # S size
+                Command.create({'product_id': c2.id, 'product_qty': 1, 'cost_share': 0}),  # All attributes
+            ]
+        })
+
+        # All attribute values of a given attribute are equi-distributed -> Valid
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product_template.id,
+            'product_uom_id': product_template.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 30, 'bom_product_template_attribute_value_ids': [Command.link(size_attribute_lines.product_template_value_ids[0].id)]}),  # S
+                Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 15, 'bom_product_template_attribute_value_ids': [Command.link(size_attribute_lines.product_template_value_ids[1].id)]}),  # M
+                Command.create({'product_id': c2.id, 'product_qty': 1, 'cost_share': 15, 'bom_product_template_attribute_value_ids': [Command.link(size_attribute_lines.product_template_value_ids[1].id)]}),  # M
+                Command.create({'product_id': c2.id, 'product_qty': 1, 'cost_share': 70}),  # All attributes
+            ]
+        })
+
+        # Keep only the S Blue and the M Red variant
+        product_template.product_variant_ids[1:3].action_archive()
+        self.assertEqual(product_template.product_variant_count, 2)
+
+        # Set up is fine for S Blue and M Red but fails for other non existing combination -> Valid
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product_template.id,
+            'product_uom_id': product_template.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 30, 'bom_product_template_attribute_value_ids': [
+                    Command.link(size_attribute_lines.product_template_value_ids[0].id),  # S
+                    Command.link(color_attribute_lines.product_template_value_ids[0].id),  # Blue
+                ]}),  # S or Blue
+                Command.create({'product_id': c2.id, 'product_qty': 1, 'cost_share': 30, 'bom_product_template_attribute_value_ids': [
+                    Command.link(size_attribute_lines.product_template_value_ids[1].id),  # M
+                    Command.link(color_attribute_lines.product_template_value_ids[1].id),  # Red
+                ]}),  # M or Red
+                Command.create({'product_id': c3.id, 'product_qty': 1, 'cost_share': 70}),  # All attributes
+            ]
+        })
+
+    def test_kit_cost_share_variant_and_optional_lines(self):
+        """
+        Ensure the cost share is well computed when purchasing a kit with optional or variant specific lines
+        """
+        size_attribute = self.env['product.attribute'].create({'name': 'Size'})
+        self.env['product.attribute.value'].create([{
+            'name': name,
+            'attribute_id': size_attribute.id
+        } for name in ('S', 'M', 'L')])
+        product_template = self.env['product.template'].create({
+            'name': "Lovely product",
+            'is_storable': True,
+        })
+        attribute_lines = self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': size_attribute.id,
+            'value_ids': [Command.set(size_attribute.value_ids.ids)]
+        })
+        self.assertEqual(product_template.product_variant_count, 3)
+        components = c1, c2, c3, c4, c5, c6 = self.env['product.product'].create([
+            {
+                'name': f'Comp {i + 1}',
+                'categ_id': self.avco_category.id,
+            } for i in range(6)
+        ])
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': product_template.id,
+            'product_uom_id': product_template.uom_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({'product_id': c1.id, 'product_qty': 1, 'cost_share': 25, 'bom_product_template_attribute_value_ids': [Command.link(attribute_lines[0].product_template_value_ids[0].id)]}),  # S size
+                Command.create({'product_id': c2.id, 'product_qty': 1, 'cost_share': 75, 'bom_product_template_attribute_value_ids': [Command.link(attribute_lines[0].product_template_value_ids[0].id)]}),  # S size
+                Command.create({'product_id': c3.id, 'product_qty': 1, 'cost_share': 100, 'bom_product_template_attribute_value_ids': [Command.link(attribute_lines[0].product_template_value_ids[1].id)]}),  # M size
+                Command.create({'product_id': c4.id, 'product_qty': 1, 'cost_share': 0, 'bom_product_template_attribute_value_ids': [Command.link(attribute_lines[0].product_template_value_ids[2].id)]}),  # L sizes
+                Command.create({'product_id': c5.id, 'product_qty': 1, 'cost_share': 0}),  # All sizes
+                Command.create({'product_id': c6.id, 'product_qty': 0, 'cost_share': 100}),  # All sizes
+            ]
+        })
+        # Purchase one variant for each sizes
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.vendor01.id,
+            'order_line': [
+                Command.create({'product_id': variant.id, 'product_qty': 1, 'price_unit': 1000}) for variant in product_template.product_variant_ids
+            ],
+        })
+        purchase_order.button_confirm()
+
+        self.assertEqual(sum(purchase_order.order_line.move_ids.mapped('cost_share')), 300.0, 'There are 3 lines and each line should be associated with a total cost_share of 100%')
+        self.assertRecordValues(purchase_order.order_line.move_ids.sorted(lambda m: m.product_id.id), [
+            {'product_id': c1.id, 'cost_share': 25.0},
+            {'product_id': c2.id, 'cost_share': 75.0},
+            {'product_id': c3.id, 'cost_share': 100.0},
+            {'product_id': c4.id, 'cost_share': 50.0},
+            {'product_id': c5.id, 'cost_share': 0.0},
+            {'product_id': c5.id, 'cost_share': 0.0},
+            {'product_id': c5.id, 'cost_share': 50.0},
+            {'product_id': c6.id, 'cost_share': 0.0},
+            {'product_id': c6.id, 'cost_share': 0.0},
+            {'product_id': c6.id, 'cost_share': 0.0},
+        ])
+
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
+
+        self.assertRecordValues(components.stock_valuation_layer_ids.sorted('id'), [
+            # S attribute
+            {'product_id': c1.id, 'unit_cost':  250.0},
+            {'product_id': c2.id, 'unit_cost':  750.0},
+            {'product_id': c5.id, 'unit_cost':  0.0},
+
+            # M attribute
+            {'product_id': c3.id, 'unit_cost': 1000.0},
+            {'product_id': c5.id, 'unit_cost':  0.0},
+
+            # L attribute - Cost share 0% automatically splitted
+            {'product_id': c4.id, 'unit_cost':  500.0},
+            {'product_id': c5.id, 'unit_cost':  500.0},
         ])

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -243,7 +243,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             self.component_c,
         ]
 
-        self.assertEqual(sum([k.standard_price * k.qty_available for k in components]), 120 * 1260)
+        self.assertAlmostEqual(sum(k.standard_price * k.qty_available for k in components), 120 * 1260, delta=0.5)
 
     def test_kit_component_cost_multi_currency(self):
         # Set kit and component product to automated FIFO


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/218326

This PR adds the feature of computing `cost_share` for nested kits and to loose the cost_share constraints to respect variant dependent lines.

opw-4806023
opw-5085457
opw-5227496

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
