### PR TITLE
[18.0][FIX] sale: Avoid error when internal user (no sale permissions) see Orders at /my

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -77,12 +77,12 @@ class CustomerPortal(payment_portal.PaymentPortal):
 
         pager_values = portal_pager(
             url=url,
-            total=SaleOrder.search_count(domain),
+            total=SaleOrder.search_count(domain) if SaleOrder.has_access('read') else 0,
             page=page,
             step=self._items_per_page,
             url_args=url_args,
         )
-        orders = SaleOrder.search(domain, order=sort_order, limit=self._items_per_page, offset=pager_values['offset'])
+        orders = SaleOrder.search(domain, order=sort_order, limit=self._items_per_page, offset=pager_values['offset']) if SaleOrder.has_access('read') else SaleOrder
 
         values.update({
             'date': date_begin,


### PR DESCRIPTION
Avoid error when internal user (no sale permissions) see Orders at /my

Similar to https://github.com/odoo/odoo/commit/5ebab949a06ec338cc28e912317a74bbfb3fe6ac

@Tecnativa TT60025

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
