### PR TITLE
[FIX] resource: fix gantt progress with flex emp test

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -270,8 +270,14 @@ class ResourceCalendar(models.Model):
             calendar_data_by_resource = tz_resources._get_calendar_data_at(start_dt, tz)
 
             res_intervals = Intervals(res, keep_distinct=True)
-            start_datetime = start_dt.astimezone(tz)
-            end_datetime = end_dt.astimezone(tz)
+
+            """
+                In saas-19.1 and previous versions, timezone tz was passing to this function.
+                Now, only resources_per_tz is passed in master and the timezone of resources_per_tz comes from employee
+                Thus, converting start_dt to start_dt.astimezone(tz) or end_dt to end_dt.astimezone(tz) causes wrong calculations.
+            """
+            start_datetime = start_dt
+            end_datetime = end_dt
 
             for resource in chain(tz_resources, (self.env['resource.resource'],) if self else ()):
                 calendar_data = calendar_data_by_resource.get(resource, {})


### PR DESCRIPTION
Bug reproduction:
    1 - Install and update hr_payroll,hr_contract_salary,l10n_us_hr_payroll,hr_attendance_gantt modules in localhost
    2 - Run test_gantt_progress_with_flexible_employees test and the expected result is 8 but it gives 9.

Bug cause:
    1 - _gantt_progress_bar -> _gantt_progress_bar_employee_ids -> _gantt_compute_max_work_hours_within_interval -> _get_expected_attendances, this function gives calendar intervals wrong
    2 - Calendar intervals are calculated in _work_intervals_batch -> _attendance_intervals_batch
        2.1 - start_datetime = start_dt.astimezone(tz), end_datetime = end_dt.astimezone(tz); start_dt is (2024,1,8,0,0), end_dt is (2024,1,15,0,0), tz is Brussel time zone and due to UTC->UTC+1 conversion, the hours converted to 1 more.
            2.1.1 - In saas-19.1 and previous versions, the function was also taking tz parameter which was UTC, but now there is only resources_per_tz parameter that is coming from employee and it is Brussel, UTC + 1 for this example

        2.2 -
                day_period_start = max(start_datetime, day_start)
                day_period_end = min(end_datetime, day_end)
                allocate_hours = min(max_hours_per_day, remaining_hours, (day_period_end - day_period_start).total_seconds() / 3600)
                2.2.1 - First of all the first week is calculated in the code from (2024,1,8) to (2024,1,14), then it comes to (2024,1,15).
                2.2.2 - day_period_start = (2024,1,15,0,0) and day_period_end = (2024,1,15,1,0) because end_datetime's hour is 1 instead of 0 after conversion.
                Due to that, a new allocation is created with 1 hours. In test, there are 2 allocations which are 8 hours for first week and 1 hours for the second week, in total 9.

Bug solution:
    1 - Deleting conversion and using start_datetime = start_dt, end_datetime = end_dt like that.

task-5865307
Runbot Error: https://runbot.odoo.com/runbot/build/98602946

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
