### PR TITLE
[FIX] l10n_it_edi: on import fill payment_reference field correctly

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1101,9 +1101,9 @@ class AccountMove(models.Model):
                 ))
                 message_to_log.append(message)
 
-            # Numbering attributed by the transmitter
-            if progressive_id := get_text(tree, '//ProgressivoInvio'):
-                self.payment_reference = progressive_id
+            # Payment code
+            if payment_code := get_text(tree, './/DettaglioPagamento[1]/CodicePagamento'):
+                self.payment_reference = payment_code
 
             # Document Number
             if number := get_text(tree, './/DatiGeneraliDocumento//Numero'):

--- a/addons/l10n_it_edi/tests/test_edi_import.py
+++ b/addons/l10n_it_edi/tests/test_edi_import.py
@@ -331,8 +331,6 @@ class TestItEdiImport(TestItEdi):
             ('res_field', '=', 'l10n_it_edi_attachment_file'),
         ])
         self.assertEqual(len(attachments), 1)
-        invoices = self.env['account.move'].search([('payment_reference', '=', 'TWICE_TEST')])
-        self.assertEqual(len(invoices), 1)
 
     def test_receive_bill_with_global_discount(self):
         applied_xml = """

--- a/doc/cla/individual/blackne0n.md
+++ b/doc/cla/individual/blackne0n.md
@@ -1,0 +1,11 @@
+Italy, 2026-01-21
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alberto Giardino alberto.giardino@al-ce.it https://github.com/blackne0n


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The payment_reference field in invoices was being filled with a wrong field from the imported XML, progressivoinvio is the progressive number of invoices sent by the partner's system, not a partner's requested payment reference.

Current behavior before PR:
On import, payment_reference was being filled with ProgressivoInvio, making automated payments out to partners harder.

Desired behavior after PR is merged:
payment_reference is only being filled if partner specifies a payment reference in the EDI, avoiding confusion.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
