### PR TITLE
[FIX] payment_stripe: fix stripe payment failing due to currency decimal

### DIFF
--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -9,6 +9,7 @@ from odoo import _, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.const import CURRENCY_MINOR_UNITS
 from odoo.addons.payment_stripe import const
 from odoo.addons.payment_stripe import utils as stripe_utils
 from odoo.addons.payment_stripe.controllers.main import StripeController
@@ -393,7 +394,10 @@ class PaymentTransaction(models.Model):
             payment_data.get('amount', 0), self.currency_id
         )
         currency_code = payment_data.get('currency', '').upper()
-        self._validate_amount_and_currency(amount, currency_code)
+        precision_digits = CURRENCY_MINOR_UNITS.get(
+            self.currency_id.name, self.currency_id.decimal_places
+        )
+        self._validate_amount_and_currency(amount, currency_code, precision_digits=precision_digits)
 
     def _process_notification_data(self, notification_data):
         """ Override of `payment` to process the transaction based on Stripe data.

--- a/addons/payment_stripe/tests/common.py
+++ b/addons/payment_stripe/tests/common.py
@@ -93,3 +93,20 @@ class StripeCommon(PaymentCommon):
             }},
             'status': 'succeeded',
         }
+
+    def _mock_payment_intent_request(self, *args, **kwargs):
+        return {
+            'object': 'payment_intent',
+            'id': 'pi_XXXX',
+            'customer': 'cus_XXXX',
+            'description': self.reference,
+            'payment_method': {
+                'id': 'pm_XXXX',
+                'type': 'card',
+                'card': {'brand': 'dummy'},
+            },
+            'amount': self.amount,
+            'amount_received': self.amount,
+            'status': 'succeeded',
+            'currency': self.currency.name.lower(),
+        }


### PR DESCRIPTION
### Issue:
The stripe payments are failing to due setting currency decimals.

#### Steps to reproduce:
1- In USD currency form in developer mode, set the rounding factor
   to `0.001000`, so we have 3 decimal places.
2- From `Decimal Accuracy` set Price Unit to 4 digits.
3- Refresh the page.
4- Create a SO and add a line. Set the price to `200.7647`.
5- Refresh the page again and generate a payment link.
6- Pay through stripe. As you see payments fail.

### Cause:
This is due to rounding the amount before sending to stripe:
https://github.com/odoo/odoo/blob/824e0c42c62de7f570f106860e7dcbf1f7344c14/addons/payment_stripe/models/payment_transaction.py#L160-L165

We are rounding the amount to the minor currency unit.

However, we make a compare between `tx_amount` and the amount paid through stripe:
https://github.com/odoo/odoo/blob/824e0c42c62de7f570f106860e7dcbf1f7344c14/addons/payment/models/payment_transaction.py#L726-L732

Which are not equal. We should use minor current unit as `precision_digits` to fix this issue.

opw-5496825