### PR TITLE
[FIX] html_editor: unsplash images not saving for non-admin user

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -471,7 +471,7 @@ class HTML_Editor(http.Controller):
             else:
                 url_fragments = attachment.url.split('/')
                 url_fragments.insert(-1, str(attachment.id))
-                attachment.url = '/'.join(url_fragments)
+                attachment.with_user(SUPERUSER_ID).url = '/'.join(url_fragments)
 
         if attachment.public:
             return attachment.image_src


### PR DESCRIPTION
Issue: A user with User and web editor access cant use unsplash becuase the write is restricted for create_uid == self.env.uid if not admin. When unsplash uploads an image it creates the attachment.url with the attachment id as part of the unsplash source url. When its saved in the editor it trys to modify it and rewrite the url by removing the id of the attachment. The write operation gets blocked becuase they are not admin.

Fix: Added "with_user(SUPERUSER_ID)" which is the same flow up the flow and then they turn it back to the current user after some fields are already writen. This one just go missed.

opw-5490535

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
