### PR TITLE
[FIX] mrp_subcontracting{,_purchase}: fix inconsistency between stock move and move line quantities

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -104,7 +104,7 @@ class StockMove(models.Model):
                 production.qty_producing = 1
                 if not production.lot_producing_id:
                     production.action_generate_serial()
-                production.with_context(cancel_backorder=False).subcontracting_record_component()
+                production.with_context(cancel_backorder=False, skip_consumption=True).subcontracting_record_component()
         else:
             production.qty_producing = qty
             if float_compare(production.qty_producing, production.product_qty, precision_rounding=production.product_uom_id.rounding) > 0:
@@ -115,7 +115,7 @@ class StockMove(models.Model):
             if production.product_tracking == 'lot' and not production.lot_producing_id:
                 production.action_generate_serial()
             production._set_qty_producing()
-            production.with_context(cancel_backorder=False).subcontracting_record_component()
+            production.with_context(cancel_backorder=False, skip_consumption=True).subcontracting_record_component()
 
     def copy(self, default=None):
         self.ensure_one()

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -485,6 +485,58 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         self.assertEqual(account_move_credit_line.account_id.id, stock_in_acc_id)
         self.assertEqual(account_move_credit_line.credit, 5)
 
+    def test_receipt_consumption_issues_due_to_subcontract_bom_modifications(self):
+        """
+        Buy 10 subcontracted serial and non-serial products. Modify the BOM quantities.
+        Then set move quantities to 2 for both product type and validate the receipt.
+        """
+        self.finished3 = self.env['product.product'].create({
+            'name': 'SuperProduct',
+            'type': 'product',
+            'tracking': 'serial',
+        })
+        self.bom_finished3 = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.finished3.product_tmpl_id.id,
+            'type': 'subcontract',
+            'subcontractor_ids': [Command.set(self.subcontractor_partner1.ids)],
+            'bom_line_ids': [Command.create({
+                'product_id': self.comp3.id,
+                'product_qty': 1,
+            })],
+        })
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [
+                Command.create({
+                    'name': self.finished2.name,
+                    'product_id': self.finished2.id,
+                    'product_qty': 10,
+                    'product_uom': self.finished2.uom_id.id,
+                    'price_unit': 1,
+                }),
+                Command.create({
+                    'name': self.finished3.name,
+                    'product_id': self.finished3.id,
+                    'product_qty': 10,
+                    'product_uom': self.finished3.uom_id.id,
+                    'price_unit': 1,
+                }),
+            ],
+        })
+        po.button_confirm()
+
+        for p in [self.bom_finished2, self.bom_finished3]:
+            line = p.bom_line_ids[0]
+            line.product_qty = line.product_qty + 1
+
+        receipt = po.picking_ids
+        receipt.move_ids.quantity = 2
+        self.assertRecordValues(receipt.move_ids, [{'quantity': sum(ml.quantity for ml in move.move_line_ids)} for move in receipt.move_ids])
+
+        receipt.button_validate()
+        self.assertRecordValues(receipt.move_ids, [{'quantity': sum(ml.quantity for ml in move.move_line_ids)} for move in receipt.move_ids])
+        self.assertRecordValues(receipt.move_ids, [{'quantity': 2} for _ in receipt.move_ids])
+
     def test_return_and_decrease_pol_qty(self):
         """
         Buy and receive 10 subcontracted products. Return one. Then adapt the


### PR DESCRIPTION
**Issue**
In subcontracting, if a BOM is modified after the creation of a PO, then modifying the move quantity of the associated receipt can lead to inconsistency between move and move line quantities.

**Steps to reproduce**
- Create a subcontracting BOM of a final product using 1 component product
- Create a PO of the final product for a quantity of 10 and confirm it
- Modify the BOM to use 2 component products instead
- Go to the receipt of the PO and modify the quantity to 2 and validate it
- Click on the move line of the receipt -> The displayed quantity is 10 instead of 2

**Cause**
Setting the quantity triggers this line:
https://github.com/odoo/odoo/blob/c496235b9520b2a33040174974de7d37e74b0580/addons/mrp_subcontracting/models/stock_move.py#L78-L78 
which calls:
https://github.com/odoo/odoo/blob/c496235b9520b2a33040174974de7d37e74b0580/addons/mrp_subcontracting/models/stock_move.py#L107

Since the BOM has been modified, a `consumption_issues` is detected and `_update_finished_move()` won't be called:
https://github.com/odoo/odoo/blob/c496235b9520b2a33040174974de7d37e74b0580/addons/mrp_subcontracting/models/mrp_production.py#L86-L89

And since the returned action is not used when calling `subcontracting_record_component`, `_update_finished_move()` won't be called later neither, which is the method responsible for updating the move line quantities:
https://github.com/odoo/odoo/blob/c496235b9520b2a33040174974de7d37e74b0580/addons/mrp_subcontracting/models/mrp_production.py#L142-L146

**Solution**
Since the consumption issue actions are ignored in this case, just skipped it and avoid inconsistencies.

opw-5493577
