### PR TITLE
[IMP] crm_iap_mine: remove redundant fields in mail template

### DIFF
--- a/addons/crm_iap_mine/views/mail_templates.xml
+++ b/addons/crm_iap_mine/views/mail_templates.xml
@@ -4,11 +4,6 @@
     <template id="enrich_company" inherit_id="iap_mail.enrich_company">
         <xpath expr="//div[hasclass('o_partner_autocomplete_enrich_info')]" position="inside">
             <div class="col-sm-12 row m-0 p-0">
-                <div t-if="entity_type" class="d-flex my-1 p-0 col-sm-3">
-                    <i class="fa fa-fw me-2 fa-building text-primary"/>
-                    <b>Company type</b>
-                </div>
-                <div t-if="entity_type" class="my-1 col-sm-9" t-out="entity_type" />
                 <div t-if="vat" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-solid fa-id-card text-primary"/>
                     <b>Tax ID</b>
@@ -33,18 +28,6 @@
                         </div>
                     </div>
                 </div>
-                <div t-if="industry_name" class="d-flex my-1 p-0 col-sm-3">
-                    <i class="fa fa-fw me-2 fa-cube text-primary"/>
-                    <b>Sector</b>
-                </div>
-                <div t-if="industry_name" class="my-1 col-sm-9" t-out="industry_name" />
-                <div t-if="phone" class="d-flex my-1 p-0 col-sm-3">
-                    <i class="fa fa-fw me-2 fa-phone text-primary"/>
-                    <b>Phone</b>
-                </div>
-                <div t-if="phone" class="col-sm-9">
-                    <a t-attf-href="tel:{{phone}}" t-out="phone" style="font-weight:normal; padding: 2px 0px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
-                </div>
                 <div t-if="website" class="d-flex my-1 p-0 col-sm-3">
                     <i class="fa fa-fw me-2 fa-globe text-primary"/>
                     <b>Website</b>
@@ -53,7 +36,7 @@
                     <a target="_blank" t-attf-href="https://{{website}}" t-out="website" style="font-weight:normal; padding: 2px 0px; margin: 1px 0px; border-radius: 13px; display: inline-block;"/>
                 </div>
                 <div t-if="unspsc_codes" class="d-flex my-1 p-0 col-sm-3">
-                    <i class="fa fa-fw me-2 fa-industry text-primary"/>
+                    <i class="fa fa-fw me-2 fa-cube text-primary"/>
                     <b>Industries</b>
                 </div>
                  <div t-if="unspsc_codes" class="col-sm-9">


### PR DESCRIPTION
- Remove newly added fields that can be replaced by existing keys present in `iap_mail.enrich_company` template to ensure we get more data in chatter without upgrade and avoid duplicate entries

IAP PR: https://github.com/odoo/iap-apps/pull/1390