### PR TITLE
[FIX] *: Fix json decode error imports

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -7,6 +7,7 @@ import logging
 import requests
 from werkzeug.urls import url_quote
 from base64 import b64encode
+from json import JSONDecodeError
 from odoo.addons.account.tools import LegacyHTTPAdapter
 
 from odoo import api, models, _
@@ -56,7 +57,7 @@ class AccountEdiFormat(models.Model):
         if not request_response.ok:
             try:
                 response_data = request_response.json()
-            except requests.exceptions.JSONDecodeError as ex:
+            except JSONDecodeError as ex:
                 return {
                     'error': str(ex),
                     'blocking_level': 'error'

--- a/addons/l10n_ro_edi_stock/models/etransport_api.py
+++ b/addons/l10n_ro_edi_stock/models/etransport_api.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 import requests
 import re
 
@@ -67,7 +68,7 @@ class ETransportAPI:
 
         try:
             response_data = response.json()
-        except requests.exceptions.JSONDecodeError as e:
+        except JSONDecodeError as e:
             return {'error': str(e)}
 
         if response_data['ExecutionStatus'] == 1:

--- a/addons/l10n_rs_edi/models/account_move.py
+++ b/addons/l10n_rs_edi/models/account_move.py
@@ -1,4 +1,5 @@
 import uuid
+from json import JSONDecodeError
 import requests
 
 from odoo import _, api, fields, models
@@ -139,7 +140,7 @@ class AccountMove(models.Model):
         dict_response = {}
         try:
             dict_response = response.json()
-        except requests.exceptions.JSONDecodeError as e:
+        except JSONDecodeError as e:
             error_message = _("Invalid response from eFaktura: %s", str(e))
         self.l10n_rs_edi_state = 'sending_failed' if error_message else 'sent'
         self.l10n_rs_edi_error = error_message


### PR DESCRIPTION
Installing `requests==2.25.1` and using the following line of code:

    from requests.exceptions import JSONDecodeError

It raises the following error:

    ImportError: cannot import name 'JSONDecodeError' from 'requests.exceptions' (python3.10/site-packages/requests/exceptions.py)

It was removed from the following commit in the `requests` package:

    https://github.com/psf/requests/commit/db575eeedcfdb03bf31285afd3033e301df8b685

This change fixes this error importing the original exception from `json` package