### PR TITLE
[FIX] product: set uom_ids field to read only in product.product view

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -457,6 +457,7 @@
                                     options="{'no_quick_create': True, 'on_tag_click': 'open_form'}"
                                     groups="uom.group_uom"
                                     force_save="1"
+                                    readonly="1"
                                     context="{'product_id': id}"/>
                                 <field name="product_tag_ids" widget="many2many_tags" readonly="1"/>
                                 <field name="additional_product_tag_ids" widget="many2many_tags" context="{'product_variant_id': id}"/>


### PR DESCRIPTION
## Short functional explanation of the error
When creating a variant, we can click on it and it will show the field "packagings" on the product view, which is editable. However, packagings are managed on the product template view, where the field is also editable. This creates confusion for the users, as it doesn't align with the sentence on the view
"All general settings about this product are managed on the
product template".

## Reproduction Steps
1. Create a product. In the Attributes & Variants tab, create
a variant.
2. The smart button Variants should appear. Click on it.
3. In the list view, click on the variant you just created.
4. Under Sales, modify the Packagings field.
5. Click on 'the product template' blue text. The product
template popup appears.
6. Go to Sales tab and modify the Packagings Field.

### Expected behavior
The packagings should be editable only on the product template
view.

### Unexpected behavior
The packagings is also editable on the product.product view.

## Origin of the issue
Missing a readonly="1" in the xml of product.product view
__
opw-5065419

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
