### PR TITLE
[FIX] account: exclude exchange difference lines from analytic valida…

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1911,7 +1911,8 @@ class AccountMoveLine(models.Model):
         SKIPPED_ACCOUNT_TYPES = {'asset_receivable', 'liability_payable', 'asset_cash', 'liability_credit_card'}
         lines_to_validate = self.filtered(lambda line: (
             line.display_type == 'product' and
-            line.account_id.account_type not in SKIPPED_ACCOUNT_TYPES
+            line.account_id.account_type not in SKIPPED_ACCOUNT_TYPES and
+            line.journal_id != line.company_id.currency_exchange_journal_id
         ))
         (self - lines_to_validate).has_invalid_analytics = False
         for line in lines_to_validate:
@@ -3043,7 +3044,10 @@ class AccountMoveLine(models.Model):
 
     def _validate_analytic_distribution(self):
         lines_with_missing_analytic_distribution = self.env['account.move.line']
-        for line in self.filtered(lambda line: line.display_type == 'product'):
+        for line in self.filtered(lambda line: (
+            line.display_type == 'product' and
+            line.journal_id != line.company_id.currency_exchange_journal_id
+        )):
             try:
                 line._validate_distribution(
                     company_id=line.company_id.id,


### PR DESCRIPTION
A validation error prevents the confirmation, stating: "One or more lines require a 100% analytic distribution". This appears to be triggered because the system tries to generate the exchange difference entry but fails to validate against the mandatory analytic plan.

The system should create the exchange difference entry successfully without triggering the analytic distribution error (either by exempting exchange difference lines from the mandatory plan or handling the distribution correctly), allowing the Credit Note to be confirmed.

Steps to reproduce:
- Install the `l10n_ar` module and switch to a company with the `Responsable Inscripto` fiscal position (Note: We tested this on the Argentina localization, but it might affect others).
- Create a Sales Journal in USD (foreign currency).
- Create an Analytic Plan with Applicability: Mandatory and create an Analytic Account associated with it.
- Create a Customer Invoice using the USD journal.
- Add an invoice line with any product, set Quantity to 10, and assign the created Analytic Account to the line.
- Confirm the Invoice.
- Click the "Credit Note" button to generate a refund.
- On the draft Credit Note, change the Quantity from 10 to 5.
- Important: Change the currency exchange rate manually on the Credit Note to ensure an exchange difference is generated compared to the original invoice.
- Click to Confirm the Credit Note.

Ticket [link](https://www.odoo.com/odoo/project.task/5869413)
opw-5869413