### PR TITLE
[FIX] stock_account: prevent inflated and negative values in the avco justification report

### DIFF
--- a/addons/stock_account/report/stock_avco_audit_report.py
+++ b/addons/stock_account/report/stock_avco_audit_report.py
@@ -1,4 +1,5 @@
 from odoo import fields, models, tools
+from odoo.tools import float_is_zero
 
 
 class StockAverageCostReport(models.AbstractModel):
@@ -99,20 +100,28 @@ WHERE
             total_quantity = 0.0
             avco = 0.0
             for record in total_records:
+                in_qty = record.quantity
+                in_value = record.value
                 if record.res_model_name == 'stock.move':
-                    if record.quantity > 0:
-                        added_value = record.value
-                    elif record.quantity < 0:
-                        added_value = avco * record.quantity
-                    total_value += added_value
-                    total_quantity += record.quantity
+                    previous_qty = total_quantity
+                    total_quantity += in_qty
+
+                    # Regular case, value from accumulation
+                    if previous_qty > 0:
+                        total_value += in_value
+                        avco = total_value / total_quantity if not float_is_zero(total_quantity, precision_digits=self.env['decimal.precision'].precision_get('Product Unit')) else avco
+                    # From negative quantity case, value from last_in
+                    elif previous_qty <= 0:
+                        avco = in_value / in_qty if in_qty else avco
+                        total_value = avco * total_quantity
+
+                    added_value = avco * in_qty
 
                 elif record.res_model_name == 'product.value':
-                    added_value = (record.value * total_quantity) - total_value
-                    total_value = record.value * total_quantity
+                    avco = in_value
+                    added_value = (avco * total_quantity) - total_value
+                    total_value = avco * total_quantity
 
-                if total_quantity:
-                    avco = total_value / total_quantity
                 if record in current_page_records:
                     record.added_value = added_value
                     record.total_value = total_value


### PR DESCRIPTION
Problem:
In the `stock.avco.report`, there is a chance for floating point inaccuracies to cause avco unit cost to inflate. This occurs specifically when the remaining quantity is calculated to be a positive number extremely close to 0. There are also issues with negative avco value that are tangential to this error.

Solution:
We will mirror the iterative logic from `_run_avco`, being sure to account for whether we have moved from negative quantity to positive or vice versa. Also, before calculating avco value as `total_value / total_quantity`, we will ensure `total_quantity` is not a floating point number very close to 0 to avoid unit cost inflation.

Steps to replicate (Runbot 19):
Have storage locations enabled to make this easier to test
1. Product with tracked inventory, avco perpetual valuation, non-zero cost
2. Set the on hand quantity to -0.3 Units
3. Set the on hand quantity to -0.2 Units
4. Set the on hand quantity to 0 Units (A well-known python quirk, that .1 + .2 = 0.30000000000000004)

Go to the stock report and inspect the unit cost history for the product, note
1. The nonsense Unit Cost on the top row
2. The negative Unit Cost on the 2nd row

Note to reviewer:
I discussed this issue briefly with dafr, who pointed out that there are further adjustments to come with the `_run_avco` method, and several other issues with this report that are not addressed by this PR. However, the problems with this report are affecting a customer so we'd like to push these fixes forward for now.

opw-5430300