### PR TITLE
[FIX] account: set anglo saxon accounting again

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -528,8 +528,9 @@ class AccountChartTemplate(models.AbstractModel):
         if not company.country_id:
             vals['country_id'] = fiscal_country.id
 
-        # Ensure that we write on 'anglo_saxon_accounting' when changing to a CoA that relies on the default of `False`.
-        vals.setdefault('anglo_saxon_accounting', False)
+        if template_data:
+            # Ensure that we write on 'anglo_saxon_accounting' when changing to a CoA that relies on the default of `False`.
+            vals.setdefault('anglo_saxon_accounting', False)
 
         # This write method is important because it's overridden and has additional triggers
         # e.g it activates the currency


### PR DESCRIPTION
In 19.1 a fix was developed to avoid bridge modules for template data [1].

A couple of `ChartTemplate._pre_load_data` calls without template data were added to discard non-existent fields in the database.

It inadvertently triggers an older fix [2] that was meant to unset `anglo_saxon_accounting` for existing companies if not explicitly set in the template, which meant that in practice `anglo_saxon_accounting` wasn't being set anymore.

[1] https://github.com/odoo/odoo/pull/238115
[2] https://github.com/odoo/odoo/pull/178113

task-5785189