### PR TITLE
[FIX] point_of_sale: prevent multiple prints of general note message

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1747,7 +1747,7 @@ export class PosStore extends Reactive {
                 }
             }
             // Print Order Note if changed
-            if (orderChange.generalNote && anyChangesToPrint) {
+            if (orderChange.generalNote && !anyChangesToPrint) {
                 const printed = await this.printReceipts(order, printer, "Message", []);
                 if (!printed) {
                     unsuccedPrints.push("General Message");


### PR DESCRIPTION
Before this commit:
===================
The general note message was printed multiple times for a single order, resulting in duplicate prints on the printer.

After this commit:
====================
Ensure the general note message is printed only once, preventing duplicate prints.

Task-5502902

