### PR TITLE
[FIX] html_editor: restore focus after syntax language change

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.xml
@@ -3,7 +3,7 @@
     <t t-name="html_editor.CodeToolbar">
         <div t-att-class="props.isActive ? 'show' : ''" class="o_code_toolbar">
             <div data-prevent-closing-overlay="true">
-                <Dropdown menuClass="'o_language_selector'">
+                <Dropdown menuClass="'o_language_selector'" focusToggleOnClosed="false">
                     <button class="btn" t-att-title="languages[props.currentLanguage]" name="language">
                         <span class="px-1" t-esc="languages[props.currentLanguage]"/>
                         <i class="fa fa-caret-down"></i>
@@ -18,7 +18,7 @@
                         </t>
                     </t>
                 </Dropdown>
-                <CopyButton content="props.getContent" copyText.translate="Copy" successText.translate="Code copied to the clipboard."/>
+                <CopyButton content="props.getContent" copyText.translate="Copy" successText.translate="Code copied to the clipboard." t-on-pointerdown.prevent="() => {}"/>
                 <button class="text-nowrap btn"
                     t-on-click="this.props.convertToParagraph"
                 >


### PR DESCRIPTION
**Description of the issue:**

- When a user changes the language of a syntax-highlighted code block, the editor loses focus from the code input. As a result, the user must manually click back into the code block to continue typing

**Steps to reproduce:**
- Insert a syntax-highlighted code block.
- Click the language dropdown to change the syntax highlighting language.
- Select a different language from the dropdown.

The language dropdown closes correctly after selection. Focus does not return to the code block input. Instead, focus remains on the dropdown button.

**Cause:**
- Although focus is explicitly set back to the code block input after selecting a language, closing the dropdown restores focus to the element that was active when the dropdown was opened . As a result, the input does not receive focus.

**Solution:**
- For the language selector dropdown, set focusToggleOnClosed = false so that closing the dropdown does not restore focus to the dropdown button.
- For the copy button, prevent focus on pointerdown.

task-5785595
