### PR TITLE
[FIX] pos_restaurant: tb when merging a table with an empty order

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -214,8 +214,10 @@ patch(PosStore.prototype, {
             }
         }
 
-        await this.deleteOrders([sourceOrder], [], true);
-        this.syncAllOrders({ orders: [destOrder] });
+        if (typeof destOrder.id === "number") {
+            await this.syncAllOrders({ orders: [destOrder] });
+        }
+        await this.deleteOrders([sourceOrder], [], typeof sourceOrder.id === "number");
         return destOrder;
     },
     mergeCourses(sourceOrder, destOrder) {

--- a/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_restaurant/static/tests/unit/services/pos_service.test.js
@@ -351,18 +351,29 @@ describe("restaurant pos_store.js", () => {
 
     test("transferOrder", async () => {
         const store = await setupPosEnv();
+        const date = DateTime.now();
         const tableSrc = store.models["restaurant.table"].get(1);
         const tableDst = store.models["restaurant.table"].get(2);
-        const sourceOrder = store.addNewOrder({ table_id: tableSrc });
+        const sourceOrder = store.addNewOrder({
+            table_id: tableSrc,
+            write_date: date,
+            create_date: date,
+        });
         const product1 = store.models["product.template"].get(5);
         await store.addLineToOrder(
             {
                 product_tmpl_id: product1,
                 qty: 2,
+                write_date: date,
+                create_date: date,
             },
             sourceOrder
         );
-        const order = store.addNewOrder({ table_id: tableDst });
+        const order = store.addNewOrder({
+            table_id: tableDst,
+            write_date: date,
+            create_date: date,
+        });
         await store.transferOrder(sourceOrder.uuid, tableDst);
         expect(sourceOrder.lines.length).toBe(0);
         expect(order.lines.length).toBe(1);


### PR DESCRIPTION
Steps to reproduce:
- On an empty table, change the guest count
- Create an order and send it to the kitchen
- Open another table without an order
- Merge the first table with the second one

Issue:
- A server error occurs during table merge

Fix:
- Wait for the merge order to sync before returning the result

Task-5502511

Related: https://github.com/odoo/enterprise/pull/104577

