### PR TITLE
[FIX] hr: avoid traceback when searching employee in appraisal

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -7,12 +7,7 @@
             <field name="model">hr.employee.public</field>
             <field name="arch" type="xml">
                 <search string="Employees">
-                    <field name="name" string="Employee" 
-                           filter_domain="[
-                           '|',
-                                ('registration_number', 'ilike', self), 
-                                    '|', 
-                                        ('work_email', 'ilike', self), ('name', 'ilike', self)]"/>
+                    <field name="name" string="Employees" filter_domain="['|', ('work_email','ilike',self), ('name','ilike',self)]"/>
                     <searchpanel view_types="kanban,list,graph,pivot,hierarchy">
                         <field name="company_id" groups="base.group_multi_company" icon="fa-building" enable_counters="1"/>
                         <field name="department_id" icon="fa-users" enable_counters="1"/>


### PR DESCRIPTION
Steps to reproduce:
1. Log in with demo user
2. Create a new appraisal
3. Search for an employee

Issue:
A traceback occurs when searching for an employee.

Cause:
The `registration_number` field is not available on the `hr.employee.public` model for public users.

Fix:
Remove `registration_number` from the employee search domain and restrict the search to fields available on the public model.

task-5864546
