### PR TITLE
[FIX] point_of_sale: product with unique serial number leads traceback

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -929,16 +929,20 @@ export class PosStore extends WithLazyGetterTrap {
         if (keepGoing === false) {
             return;
         }
-
-        const pack_lot_ids = await this.configureNewOrderLine(
-            productTemplate,
-            vals,
-            values,
-            order,
-            options,
-            configure
-        );
-
+        let pack_lot_ids = {};
+        if (this.requiresOrderLineConfiguration(configure, opts.code, values.product_tmpl_id)) {
+            pack_lot_ids = await this.configureNewOrderLine(
+                productTemplate,
+                vals,
+                values,
+                order,
+                options,
+                configure
+            );
+            if (!pack_lot_ids) {
+                return;
+            }
+        }
         // Handle price unit
         this.handlePriceUnit(values, order, vals.price_unit);
 
@@ -999,7 +1003,9 @@ export class PosStore extends WithLazyGetterTrap {
 
         return order.getSelectedOrderline();
     }
-
+    requiresOrderLineConfiguration(configure, code, product) {
+        return (configure || code) && product.isTracked();
+    }
     async configureNewOrderLine(productTemplate, vals, values, order, opts = {}, configure = true) {
         // In the case of a product with tracking enabled, we need to ask the user for the lot/serial number.
         // It will return an instance of pos.pack.operation.lot

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -356,6 +356,9 @@ registry.category("web_tour.tours").add("LotTour", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Product A"),
+            Dialog.is({ title: "Lot/Serial number(s) required" }),
+            Dialog.discard(),
+            ProductScreen.clickDisplayedProduct("Product A"),
             ProductScreen.enterLotNumber("1"),
             ProductScreen.selectedOrderlineHas("Product A", "1"),
             inLeftSide(


### PR DESCRIPTION
Steps to reproduce:
=
- Configure a product with `Tracking`=`By Unique Serial Number`
- Open POS and click on the configured product.
- The “Lot/Serial number(s) required” dialog opens.
- Click `Discard`.

Issue:
=
- The following error occurs: `TypeError: Cannot read properties of undefined (reading 'modifiedPackLotLines')`

Fix:
=
- Stop further steps to add the product when the lot/serial number dialog is discarded.

Reference:
=
- https://github.com/odoo/odoo/pull/238635/files#diff-9e8905c1e88dc96f9145acda2c6a165fb14a58e0d2cfb5b3b6049411918ba27dL913-L914

task-5505855

related pr: https://github.com/odoo/enterprise/pull/108263