### PR TITLE
[FIX] project, crm: hide the color field from stages

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -532,7 +532,8 @@
                                     <field name="partner_id" muted="1" display="full" class="o_text_block"/>
                                     <div class="m-1"/>
                                     <field name="stage_id_color" invisible="1"/>
-                                    <field name="stage_id" widget="badge" options="{'color_field': 'stage_id_color'}"/>
+                                    <field name="color" invisible="1"/>
+                                    <field name="stage_id" widget="badge" options="{'color_field': 'color'}"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -25,7 +25,7 @@
                 <field name="is_won"/>
                 <field name="team_ids" widget="many2many_tags"/>
                 <field name="rotting_threshold_days" optional="hide"/>
-                <field name="color" optional="hide" widget="color_picker"/>
+                <field name="color" optional="hide" widget="color_picker" column_invisible="True"/>
             </list>
         </field>
     </record>
@@ -46,7 +46,7 @@
                     <group>
                         <group>
                             <field name="fold"/>
-                            <field name="color" widget="color_picker"/>
+                            <field name="color" widget="color_picker" invisible="True"/>
                             <field name="team_ids" widget="many2many_tags" placeholder="Shared with all teams"
                                 options='{"no_open": True, "no_create": True}' invisible="team_count &lt;= 1" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                         </group>

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -14,7 +14,7 @@
         />
     </template>
     <template id="portal_my_tasks_badge_widget_template" name="badge Widget Template">
-        <span t-attf-class="badge rounded-pill o_tag o_badge_color_#{task.stage_id_color}"
+        <span t-attf-class="badge rounded-pill o_tag o_badge_color_#{task.color}"
             t-attf-title="#{task.stage_id.name}" t-out="task.stage_id.name"
         />
     </template>

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -9,7 +9,7 @@
                 <field name="name" placeholder="e.g. To Do"/>
                 <field name="mail_template_id" optional="hide" context="{'default_model': 'project.project'}"/>
                 <field name="company_id" optional="hide" groups="base.group_multi_company" options="{'no_create': True}"/>
-                <field name="color" optional="hide" widget="color_picker"/>
+                <field name="color" optional="hide" widget="color_picker" column_invisible="True"/>
                 <field name="fold" optional="show"/>
             </list>
         </field>
@@ -41,7 +41,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="mail_template_id" context="{'default_model': 'project.project'}"/>
-                            <field name="color" widget="color_picker"/>
+                            <field name="color" widget="color_picker" invisible="True"/>
                             <field name="sequence" groups="base.group_no_one"/>
                         </group>
                         <group>
@@ -61,7 +61,7 @@
             <kanban highlight_color="color" class="o_kanban_mobile" sample="1" quick_create_view="project.project_project_stage_view_form_quick_create">
                 <templates>
                     <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
-                        <field name="color" widget="kanban_color_picker"/>
+                        <field name="color" widget="kanban_color_picker" invisible="True"/>
                     </t>
                     <t t-name="card">
                         <field name="name" class="fw-bolder mb-4"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -221,7 +221,9 @@
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                     <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection" invisible="is_template"/>
                     <field name="stage_id_color" column_invisible="1"/>
-                    <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'stage_id_color'}" />
+                    <field name="color" column_invisible="1"/>
+                    <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show"
+                        widget="badge" options="{'no_open': True, 'color_field': 'color'}" />
                     <button string="View Tasks" name="action_view_tasks" type="object"/>
                 </list>
             </field>
@@ -532,12 +534,13 @@
                     scales="month,year"
                     event_open_popup="true"
                     quick_create="0"
-                    color="stage_id_color"
+                    color="color"
                     js_class="project_project_calendar">
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="user_id" widget="many2one_avatar_user" invisible="not user_id"/>
                     <field name="is_favorite" widget="project_is_favorite" nolabel="1" string="Favorite"/>
                     <field name="stage_id_color" invisible="1"/>
+                    <field name="color" invisible="1"/>
                     <field name="stage_id" groups="project.group_project_stages" invisible="not stage_id"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="last_update_status" string="Status" widget="status_with_color" invisible="last_update_status == 'to_define'"/>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -33,7 +33,7 @@
                                 <field name="auto_validation_state" invisible="not rating_template_id"/>
                                 <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color', 'edit_tags': True}" invisible="user_id" required="not user_id"/>
                                 <field name="rotting_threshold_days"/>
-                                <field name="color" widget="color_picker"/>
+                                <field name="color" widget="color_picker" invisible="True"/>
                                 <field name="sequence" groups="base.group_no_one"/>
                             </group>
                             <group>
@@ -83,7 +83,7 @@
                     <field name="rotting_threshold_days" optional="hide"/>
                     <field name="mail_template_id" optional="hide"/>
                     <field name="project_ids" required="1" optional="show" widget="many2many_tags" options="{'color_field': 'color'}"/>
-                    <field name="color" optional="hide" widget="color_picker"/>
+                    <field name="color" optional="hide" widget="color_picker" column_invisible="True"/>
                     <field name="fold" optional="show"/>
                 </list>
             </field>
@@ -108,7 +108,7 @@
                 <kanban highlight_color="color" class="o_kanban_mobile" sample="1" default_group_by="project_ids">
                     <templates>
                         <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
-                            <field name="color" widget="kanban_color_picker"/>
+                            <field name="color" widget="kanban_color_picker" invisible="True"/>
                         </t>
                         <t t-name="card">
                             <field name="name" class="fw-bolder text-truncate"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -825,7 +825,7 @@
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
                 <calendar date_start="date_deadline" string="Tasks" mode="month"
-                          color="stage_id_color" event_limit="5" hide_time="true"
+                          color="color" event_limit="5" hide_time="true"
                           event_open_popup="true" quick_create="0" show_unusual_days="True"
                           js_class="project_task_calendar"
                           scales="day,week,month,year">
@@ -838,6 +838,7 @@
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="priority" widget="priority" readonly="1"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not tag_ids"/>
+                    <field name="color" invisible="1"/>
                     <field name="stage_id_color" invisible="1"/>
                     <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection" filters="1"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>


### PR DESCRIPTION
We used the rotting widget in the stage field, so the stage color field is unused, as explained below in the commit.
https://github.com/odoo/odoo/commit/cd9ed578803605550135cb6fd6d4c267b433abbc

task-5485507