### PR TITLE
[ADD] l10n_tr_nilvera_einvoice: adding return and withholding return …

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_line.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_line.py
@@ -26,6 +26,19 @@ class AccountMoveLine(models.Model):
         readonly=False,
     )
 
+    l10n_tr_original_line_id = fields.Many2one("account.move.line", readonly=True)
+
+    l10n_tr_original_quantity = fields.Float(
+        string="Original Quantity",
+        digits="Product Unit",
+        help="The quantity originally sold for this product.",
+    )
+
+    l10n_tr_original_tax_without_withholding = fields.Monetary(
+        string="Original Tax After Withholding",
+        help="Taxes collected after deducting withholding taxes for this product on the original invoice.",
+    )
+
     @api.depends("product_id.l10n_tr_ctsp_number")
     def _compute_l10n_tr_ctsp_number(self):
         for record in self:

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_return_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_return_einvoice.xml
@@ -1,0 +1,153 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice 
+  xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+  xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+  xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+  <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
+  <cbc:ID>RNV2025000000001</cbc:ID>
+  <cbc:CopyIndicator>false</cbc:CopyIndicator>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2025-03-05</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>IADE</cbc:InvoiceTypeCode>
+  <cbc:Note>3 products</cbc:Note>
+  <cbc:Note>YALNIZ : SIFIR TRY SIFIR KURUS</cbc:Note>
+  <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+  <cbc:LineCountNumeric>3</cbc:LineCountNumeric>
+  <cac:OrderReference>
+    <cbc:ID>EIN/2025/1</cbc:ID>
+    <cbc:IssueDate>2025-03-05</cbc:IssueDate>
+  </cac:OrderReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>EIN2025000000001</cbc:ID>
+      <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+      <cbc:DocumentTypeCode>İADE</cbc:DocumentTypeCode>
+      <cbc:DocumentDescription>İade Edilen Fatura</cbc:DocumentDescription>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3281. Cadde</cbc:StreetName>
+        <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+        <cbc:CityName>Düzce</cbc:CityName>
+        <cbc:PostalZone>06810</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">1729171602</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>einvoice_partner</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>einvoice_partner</cbc:RegistrationName>
+        <cbc:CompanyID>1729171602</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+        <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:AllowanceCharge>
+    <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+    <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+    <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+  </cac:AllowanceCharge>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="TRY">158.40</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="TRY">18.00</cbc:AllowanceTotalAmount>
+    <cbc:PayableAmount currencyID="TRY">158.40</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
+      <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_return_basic_withholding_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_return_basic_withholding_einvoice.xml
@@ -1,0 +1,153 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+    <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
+    <cbc:ID>RNV2025000000001</cbc:ID>
+    <cbc:CopyIndicator>false</cbc:CopyIndicator>
+    <cbc:UUID>___ignore___</cbc:UUID>
+    <cbc:IssueDate>2025-03-05</cbc:IssueDate>
+    <cbc:InvoiceTypeCode>TEVKIFATIADE</cbc:InvoiceTypeCode>
+    <cbc:Note>3 products</cbc:Note>
+    <cbc:Note>YALNIZ : SIFIR TRY SIFIR KURUS</cbc:Note>
+    <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+    <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
+    <cac:OrderReference>
+        <cbc:ID>EIN/2025/1</cbc:ID>
+        <cbc:IssueDate>2025-03-05</cbc:IssueDate>
+    </cac:OrderReference>
+    <cac:BillingReference>
+        <cac:InvoiceDocumentReference>
+            <cbc:ID>EIN2025000000001</cbc:ID>
+            <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+            <cbc:DocumentTypeCode>İADE</cbc:DocumentTypeCode>
+            <cbc:DocumentDescription>İade Edilen Fatura</cbc:DocumentDescription>
+        </cac:InvoiceDocumentReference>
+    </cac:BillingReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>3281. Cadde</cbc:StreetName>
+                <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+                <cbc:CityName>Düzce</cbc:CityName>
+                <cbc:PostalZone>06810</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID>3297552117</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+                <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">1729171602</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>einvoice_partner</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+                <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+                <cbc:CityName>Ankara</cbc:CityName>
+                <cbc:PostalZone>06934</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>einvoice_partner</cbc:RegistrationName>
+                <cbc:CompanyID>1729171602</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+                <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="TRY">2.64</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="TRY">2.64</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="TRY">2.64</cbc:TaxAmount>
+            <cbc:Percent>100.0</cbc:Percent>
+            <cac:TaxCategory>
+                <cac:TaxScheme>
+                    <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+                    <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="TRY">134.64</cbc:TaxInclusiveAmount>
+        <cbc:AllowanceTotalAmount currencyID="TRY">18.00</cbc:AllowanceTotalAmount>
+        <cbc:PayableAmount currencyID="TRY">134.64</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+            <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
+            <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="TRY">2.64</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="TRY">2.64</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="TRY">2.64</cbc:TaxAmount>
+                <cbc:Percent>100.0</cbc:Percent>
+                <cac:TaxCategory>
+                    <cac:TaxScheme>
+                        <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+                        <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>product_a</cbc:Description>
+            <cbc:Name>product_a</cbc:Name>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -55,6 +55,15 @@ class TestUBLTR(TestUBLTRCommon):
 
         self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))
 
+    def test_xml_invoice_basic_return_einvoice(self):
+        with freeze_time('2025-03-05'):
+            generated_xml = self._generate_return_invoice_xml(self.einvoice_partner)
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_return_einvoice.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))
+
     def test_xml_invoice_basic_tax_exempt_einvoice(self):
         with freeze_time('2025-03-05'):
             generated_xml = self._generate_invoice_xml(self.einvoice_partner, l10n_tr_gib_invoice_type="ISTISNA", l10n_tr_exemption_code_id=self.reason_212.id)
@@ -69,6 +78,15 @@ class TestUBLTR(TestUBLTRCommon):
             generated_xml = self._generate_invoice_xml(self.einvoice_partner, self.tax_20_withholding, l10n_tr_gib_invoice_type="TEVKIFAT")
 
         with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_basic_withholding_einvoice.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))
+
+    def test_xml_invoice_basic_withholding_return_einvoice(self):
+        with freeze_time('2025-03-05'):
+            generated_xml = self._generate_return_invoice_xml(self.einvoice_partner, self.tax_20_withholding, l10n_tr_gib_invoice_type="TEVKIFAT")
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_return_basic_withholding_einvoice.xml', 'rb') as expected_xml_file:
             expected_xml = expected_xml_file.read()
 
         self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))

--- a/addons/l10n_tr_nilvera_einvoice/tools/ubl_tr_common.py
+++ b/addons/l10n_tr_nilvera_einvoice/tools/ubl_tr_common.py
@@ -37,7 +37,7 @@ Contact = {
     'cbc:Telefax': {},
 }
 
-DocumentReference = {
+MeasurementDimension = {
     'cbc:AttributeID': {},
     'cbc:Measure': {},
     'cbc:Description': {},
@@ -85,10 +85,6 @@ Address = {
     'cac:Country': Country,
 }
 
-BillingReference = {
-    'cac:InvoiceDocumentReference': DocumentReference,
-}
-
 IssuerParty = {
     'cbc:EndpointID': {},
     'cac:PartyIdentification': {
@@ -108,6 +104,10 @@ DocumentReference = {
     'cbc:DocumentDescription': {},
     'cac:Attachment': Attachment,
     'cac:IssuerParty': IssuerParty,
+}
+
+BillingReference = {
+    'cac:InvoiceDocumentReference': DocumentReference,
 }
 
 Signature = {

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -17,10 +17,10 @@
                 <attribute name="invisible" separator=" or " add="l10n_tr_nilvera_send_status == 'error' and l10n_tr_nilvera_uuid"/>
             </xpath>
             <xpath expr="//div[@name='journal_div']" position="after">
-                <label for="l10n_tr_nilvera_send_status" invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'in_invoice']"/>
+                <label for="l10n_tr_nilvera_send_status" invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'out_refund', 'in_invoice']"/>
                 <div name="nilvera_div"
                      class="d-flex"
-                     invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'in_invoice']">
+                     invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'out_refund', 'in_invoice']">
                     <field name="l10n_tr_nilvera_send_status" class="oe_inline"/>
                 </div>
                 <field name="l10n_tr_is_export_invoice"
@@ -29,7 +29,7 @@
                 <div class="o_td_label"
                      invisible="l10n_tr_is_export_invoice
                                 or country_code != 'TR'
-                                or move_type != 'out_invoice'
+                                or move_type not in ['out_invoice', 'out_refund']
                                 or l10n_tr_nilvera_customer_status not in ['einvoice', 'earchive']">
                     <label for="l10n_tr_gib_invoice_scenario" invisible="l10n_tr_nilvera_customer_status != 'einvoice'" />
                     <label string="Invoice Type"
@@ -39,7 +39,7 @@
                 <div class="d-flex"
                      invisible="l10n_tr_is_export_invoice
                                 or country_code != 'TR'
-                                or move_type != 'out_invoice'
+                                or move_type not in ['out_invoice', 'out_refund']
                                 or l10n_tr_nilvera_customer_status not in ['einvoice', 'earchive']">
                     <field name="l10n_tr_gib_invoice_scenario"
                            invisible="l10n_tr_nilvera_customer_status != 'einvoice'"
@@ -65,12 +65,24 @@
                 <field name="l10n_tr_ctsp_number" optional="hide"/>
                 <field name="l10n_tr_seller_line_code" optional="hide"/>
                 <field name="l10n_tr_customer_line_code" optional="hide"/>
+                <field name="l10n_tr_original_quantity"
+                       required="parent.l10n_tr_gib_invoice_type == 'TEVKIFATIADE'"
+                       column_invisible="parent.l10n_tr_gib_invoice_type != 'TEVKIFATIADE'"/>
+                <field name="l10n_tr_original_tax_without_withholding"
+                       required="parent.l10n_tr_gib_invoice_type == 'TEVKIFATIADE'"
+                       column_invisible="parent.l10n_tr_gib_invoice_type != 'TEVKIFATIADE'"/>
             </xpath>
             <xpath expr="//header/field[@name='state']" position="before">
                 <button name="l10n_tr_nilvera_get_pdf"
                         string="Fetch Nilvera PDF"
                         type="object"
-                        invisible="move_type != 'out_invoice' or l10n_tr_nilvera_send_status != 'succeed'"/>
+                        invisible="move_type not in ['out_invoice', 'out_refund'] or l10n_tr_nilvera_send_status != 'succeed'"/>
+            </xpath>
+            <xpath expr="//group[@name='sale_info_group']/field[@name='ref']" position="attributes">
+                <attribute name="required">country_code == 'TR' and not reversed_entry_id and move_type == 'out_refund'</attribute>
+            </xpath>
+            <xpath expr="//group[@name='sale_info_group']/field[@name='ref']" position="after">
+                <field name="l10n_tr_original_invoice_date" string="Original Invoice Date" invisible="country_code != 'TR' or move_type != 'out_refund' or reversed_entry_id" required="country_code == 'TR' and not reversed_entry_id and move_type == 'out_refund'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
…invoice scenarios

This commit introduces two new invoicing scenarios to our Nilvera implementaiton. The first scenario is the "Return", which is a credit note for a basic sales invoice. The second scenario is the "Withholding Return", which is a credit note for withholding invoices.

task-id: 4774826

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
