### PR TITLE
[FIX] l10n_at: Fix VAT prepayment calculation in tax report

### DIFF
--- a/addons/l10n_at/data/account_tax_report_data.xml
+++ b/addons/l10n_at/data/account_tax_report_data.xml
@@ -795,7 +795,7 @@
                     <record id="tax_report_line_l10n_at_tva_line_7_total" model="account.report.expression">
                         <field name="label">vat</field>
                         <field name="engine">aggregation</field>
-                        <field name="formula">AT_0004.vat - AT_0005.vat + AT_090.vat</field>
+                        <field name="formula">AT_0004.vat + AT_0005.vat + AT_090.vat</field>
                     </record>
                 </field>
                 <field name="hierarchy_level">0</field>


### PR DESCRIPTION
The Austrian tax report computes line 7 by subtracting the deductible input tax instead of adding it, leading to an overstated VAT payable or understated credit.

### **Steps to reproduce:**
- Install `Accounting` app with `l10n_at` localization and switch to AT Company.
- Create a customer invoice for some product with price 1000 and 20% Tax.
- Create a vendor bill for some product with price 100 and 20% Tax.
- Open the Austrian tax report for the corresponding period.

### **Observed behavior:**
section-7 shows `-220` instead of the correct amount `-180`. because value of,
section-4 = -200
section-5 = 20
section-6 = 0

Current calculation for **section-7 = section-4 - section-5 + section-6** which is equal to `-220`

### **Expected behavior:**
1) Section-4(VAT Computation (U1/U30))- negative value is correct as this is the amount of
sales tax which needs to pay to the tax office.

2) Section-5(Deductible input tax computation) and section-6(Other corrections) - are positive
values and are added to section-4 as this is the input tax which is get back from the tax office.

hence the correct calculation for **section-7 will be section(4+5+6).**
### **Root cause**
Since [commit](https://github.com/odoo/odoo/pull/224604/commits/06666fc55a7a3f569a0d15f0827ed8e2199cf51c), introduced a formula that subtracts the deductible input tax(section-5) in section-7, causing the
miscalculation.

### **Fix**
Update the section-7 aggregation formula to add deductible input tax instead of subtracting it.

**opw-5476604**
