### PR TITLE
[FIX] website_sale: hide pills variant when single value

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -1294,7 +1294,7 @@ $-product-radius-map: (
     .o_wsale_product_details_content_section_attributes {
         display: none;
 
-        &:where(:has(li.variant_attribute:not(.d-none))), &:where(:has(li.o_variant_pills:not(.d-none))) {
+        &:where(:has(li.variant_attribute:not(.d-none))), &:where(:has(li:not(.variant_attribute) li.o_variant_pills:not(.d-none))) {
             display: block;
         }
 


### PR DESCRIPTION
Before this commit, when a product attribute with display_type 'pills' has only one non-custom value, the parent li.variant_attribute is correctly hidden. However, the CSS :has() selector still matched the inner li.o_variant_pills, causing the attributes section to display with empty borders.

This commit refines the selector to only match pills outside of variant_attribute elements (UOM pills).

task-5852515

| Current (19.0) | After |
|--------|--------|
| <img width="809" height="395" alt="image" src="https://github.com/user-attachments/assets/64519161-e552-492f-b010-d1353b07f80a" /> | <img width="809" height="395" alt="image" src="https://github.com/user-attachments/assets/6022e371-18eb-4d2a-99d0-da3c94b291d0" /> |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
