### PR TITLE
[FIX] mrp: consumption issue warning

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -411,7 +411,7 @@
                                 context="{'default_date': date_start, 'default_date_deadline': date_start, 'default_location_id': location_src_id, 'default_location_dest_id': production_location_id, 'default_warehouse_id': warehouse_id, 'default_state': 'draft', 'default_raw_material_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id, 'form_view_ref': 'mrp.view_mrp_stock_move_operations', 'active_mo_id': id}"
 
                                 readonly="state == 'cancel' or (state == 'done' and is_locked)">
-                                <list default_order="sequence" editable="bottom">
+                                <list editable="bottom">
                                     <control>
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog_raw" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
@@ -483,7 +483,7 @@
                             <field name="move_byproduct_ids"
                                 context="{'default_date': date_finished, 'default_date_deadline': date_deadline, 'default_warehouse_id': warehouse_id, 'default_location_id': production_location_id, 'default_location_dest_id': location_dest_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id, 'form_view_ref': 'mrp.view_mrp_stock_move_operations'}"
                                 readonly="state == 'cancel' or (state == 'done' and is_locked)" options="{'delete': [('state', '=', 'draft')]}">
-                                <list default_order="sequence, id" decoration-muted="state in ['done', 'cancel']" editable="bottom">
+                                <list decoration-muted="state in ['done', 'cancel']" editable="bottom">
                                     <control>
                                         <create string="Add a line"/>
                                         <button name="action_add_from_catalog_byproduct" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>


### PR DESCRIPTION
Usecase to reproduce:
- Create a BoM with a finished product and a component
- Create a MO for 10 units
- Produce all

Expected behavior:
10 units produced

Current behavior:
Consumption warning

It happens because the code use this order:
- Set the moves raw to picked base on their quantity producing
- Set the quantity producing for production without quantity.

So it just don't work and the consumption warning is trigger. The fix just invert the order

task: 5068382

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
