### PR TITLE
[FIX] pos_self_order: fix ticket font size for preparation printers in kiosk

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -539,6 +539,20 @@ export class SelfOrder extends Reactive {
                     config_name: this.config.name,
                     table_number: this.currentTable?.table_number,
                     floating_order_name: order.floating_order_name,
+                    getLineAttributeNames: (line) => {
+                        const result = (line.attribute_value_ids ?? []).map((a) => a.name);
+                        if (!line.combo_parent_id) {
+                            return result;
+                        }
+                        return [
+                            ...new Set([
+                                ...(line.product_id.product_template_variant_value_ids ?? []).map(
+                                    (a) => a.name
+                                ),
+                                ...result,
+                            ]),
+                        ];
+                    },
                 };
                 const receipt = renderToElement("pos_self_order.OrderChangeReceipt", {
                     changes: printingChanges,

--- a/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
@@ -25,11 +25,18 @@
             <div class="pos-receipt-title">
                 NEW
             </div>
-            <br />
             <t t-foreach="changes.new" t-as="change" t-key="change_index">
-                <div class="product-details d-flex" t-att-class="{'ms-5': change.combo_parent_id}">
-                    <span class="product-quantity me-3 mb-1" t-esc="change.qty"/>
-                    <span class="product-name" t-esc="change.full_product_name"/>
+                <div class="product-details d-flex mx-1" t-att-class="{'ms-5': change.combo_parent_id}" style="font-size: 150%;">
+                    <span class="product-quantity me-3" t-esc="change.qty"/>
+                    <span class="product-name" t-esc="change.product_id.name"/>
+                </div>
+                <div class="mx-1" t-att-class="{'ms-5': change.combo_parent_id}" style="font-size: 150%;">
+                   <t t-set="attribute_names" t-value="changes.getLineAttributeNames(change)" />
+                   <div t-if="attribute_names.length" class="ms-5" style="font-size: 91%;">
+                        <div t-foreach="attribute_names" t-as="attr" t-key="attr_index">
+                            - <t t-esc="attr" />
+                        </div>
+                   </div>
                 </div>
                 <t t-if="change.customer_note">
                     <div>
@@ -42,7 +49,7 @@
             </t>
             <br />
             <br />
-    </div>
+        </div>
     </t>
 
 </templates>


### PR DESCRIPTION
Before this commit, preparation tickets printed from kiosk had a different structure from those printed from the POS.

Two differences were spotted:
1. Font size was smaller than ticket printed from the pos
2. The name of the product displayed was the full product name instead of the basic one with attributes under the product name.

So, to fix that I basically used the same template structure from the point_of_sale module and adapted data to fit with.

task : 5506329

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
