### PR TITLE
[FIX] l10n_tw_edi_ecpay_website_sale: add post-init hook to manifest

### DIFF
--- a/addons/l10n_tw_edi_ecpay_website_sale/__manifest__.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/__manifest__.py
@@ -28,4 +28,5 @@
         ],
     },
     "auto_install": True,
+    'post_init_hook': '_post_init_hook',
 }


### PR DESCRIPTION
The extra invoicing info step for EDI was unpublished and hidden on ecommerce. This commit fixes that.

Task-5493138

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
