### PR TITLE
[FIX] l10n_nl: correct labels for COGS and SALE

### DIFF
--- a/addons/l10n_nl/__manifest__.py
+++ b/addons/l10n_nl/__manifest__.py
@@ -3,7 +3,7 @@
     'name': 'Netherlands - Accounting',
     'icon': '/account/static/description/l10n.png',
     'countries': ['nl'],
-    'version': '3.4',
+    'version': '3.5',
     'category': 'Accounting/Localizations/Account Charts',
     'author': 'Onestein (http://www.onestein.eu)',
     'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/netherlands.html',

--- a/addons/l10n_nl/data/account_account_tag.xml
+++ b/addons/l10n_nl/data/account_account_tag.xml
@@ -36,7 +36,7 @@
             <field name="country_id" ref="base.nl"/>
         </record>
         <record id="account_tag_7" model="account.account.tag">
-            <field name="name">Cost of sales</field>
+            <field name="name">Cost of goods sold</field>
             <field name="applicability">accounts</field>
             <field name="country_id" ref="base.nl"/>
         </record>
@@ -52,7 +52,7 @@
             <field name="active" eval="False"/>
         </record>
         <record id="account_tag_10" model="account.account.tag">
-            <field name="name">Cost of Goods Sold</field>
+            <field name="name">Cost of sales</field>
             <field name="applicability">accounts</field>
             <field name="country_id" ref="base.nl"/>
         </record>

--- a/addons/l10n_nl/migrations/3.5/pre-migrate.py
+++ b/addons/l10n_nl/migrations/3.5/pre-migrate.py
@@ -1,0 +1,14 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    tag_cos = env.ref("l10n_nl.account_tag_7")
+    tag_cogs = env.ref("l10n_nl.account_tag_10")
+
+    if not (tag_cogs and tag_cos):
+        return
+
+    tag_cos.write({"name": "tmp_swap_cost_tag"})
+    tag_cogs.write({"name": "Cost of sales"})
+    tag_cos.write({"name": "Cost of goods sold"})


### PR DESCRIPTION
**Steps to reproduce:**
1. Install l10n_nl_report.
2. Go to Accounting → Configuration  →  Accounting Reports.
3. Open Profit and loss report (tags).
4. Click on Cost of Goods Sold or Cost of Sales and check the related codes.

**Issue:**
In the Dutch Profit and Loss report, the "Cost of Goods Sold" and "Cost of Sales" names are swapped.
According to Dutch accounting standards:
- Cost of goods sold should represent direct costs ([mapping to NL_COGS / 7xxx](https://github.com/odoo/odoo/blob/master/addons/l10n_nl/data/template/account.account-nl.csv#L288-L317)).
- Cost of sales should represent indirect selling costs ([mapping to NL_SALE/45xx](https://github.com/odoo/odoo/blob/master/addons/l10n_nl/data/template/account.account-nl.csv#L249-L260))

**Cause:**
In [PR : #157362 ](https://github.com/odoo/odoo/pull/157362/files#diff-1ba769f7e47f7a941e45b6c662ec2a0558272e9fe8bdbfed368f261c8e43aa5dR55), The names were swapped. While the technical codes and expressions correctly targeted the intended account ranges

**Solution:**
Updated account_tag_7 and account_tag_10 to match corrected naming convention.

Related Enterprise PR : https://github.com/odoo/enterprise/pull/103150

**opw-5407885**