### PR TITLE
[FIX] website, html_builder, mass_mailing: register snippet models

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -459,9 +459,12 @@ export const snippetService = {
             if (snippetModelsMap.has(snippetsName)) {
                 return snippetModelsMap.get(snippetsName);
             }
+            const Model = registry
+                .category("html_builder.snippetsModel")
+                .get(snippetsName, SnippetModel);
             snippetModelsMap.set(
                 snippetsName,
-                new SnippetModel(services, {
+                new Model(services, {
                     snippetsName,
                     context,
                 })

--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
@@ -6,8 +6,6 @@ import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/backend/plugin_sets";
 import { registry } from "@web/core/registry";
 import { CustomizeTab } from "@html_builder/sidebar/customize_tab";
 import { OptionsContainerWithSnippetVersionControl } from "./options/options_container";
-import { massMailingSnippetModelPatch } from "./snippet_model_patch";
-import { useService } from "@web/core/utils/hooks";
 
 class CustomizeTabWithSnippetVersionControl extends CustomizeTab {
     static components = {
@@ -31,14 +29,6 @@ export class MassMailingBuilder extends Component {
         toggleCodeView: { type: Function, optional: true },
         toggleFullScreen: { type: Function },
     };
-
-    setup() {
-        this.snippetsService = useService("html_builder.snippets");
-        this.snippetsService.patchSnippetModel(
-            this.props.builderProps.snippetsName,
-            massMailingSnippetModelPatch
-        );
-    }
 
     get builderProps() {
         const builderProps = Object.assign({}, this.props.builderProps);

--- a/addons/mass_mailing/static/src/builder/snippet_model_patch.js
+++ b/addons/mass_mailing/static/src/builder/snippet_model_patch.js
@@ -1,6 +1,8 @@
+import { SnippetModel } from "@html_builder/snippets/snippet_service";
 import { AddSnippetDialogSandboxed } from "./snippet_viewer/add_snippet_dialog";
+import { registry } from "@web/core/registry";
 
-export const massMailingSnippetModelPatch = {
+export class MassMailingSnippetModel extends SnippetModel {
     cleanSnippetForSave(snippetCopyEl, cleanForSaveHandlers) {
         super.cleanSnippetForSave(snippetCopyEl, cleanForSaveHandlers);
         const dynamicPlaceholders = snippetCopyEl.querySelectorAll("t[t-out]");
@@ -11,11 +13,15 @@ export const massMailingSnippetModelPatch = {
             placeholderEl.remove();
         });
         snippetCopyEl.removeAttribute("data-filter-domain");
-    },
+    }
     getTechnicalUsage() {
         return "mass_mailing";
-    },
+    }
     getAddSnippetDialogClass() {
         return AddSnippetDialogSandboxed;
-    },
-};
+    }
+}
+
+registry
+    .category("html_builder.snippetsModel")
+    .add("mass_mailing.email_designer_snippets", MassMailingSnippetModel);

--- a/addons/website/static/src/builder/snippet_model.js
+++ b/addons/website/static/src/builder/snippet_model.js
@@ -1,8 +1,9 @@
 import { applyTextHighlight } from "@website/js/highlight_utils";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
+import { SnippetModel } from "@html_builder/snippets/snippet_service";
 
-export const websiteSnippetModelPatch = {
+export class WebsiteSnippetModel extends SnippetModel {
     /**
      * @override
      */
@@ -12,31 +13,37 @@ export const websiteSnippetModelPatch = {
         for (const textEl of snippetEl?.querySelectorAll(".o_text_highlight") || []) {
             applyTextHighlight(textEl);
         }
-    },
+    }
 
     /**
      * @override
      */
     getSnippetLabel(snippetEl) {
-        const label = super.getSnippetLabel(snippetEl);
+        let label = super.getSnippetLabel(snippetEl);
         // Check if any element in the snippet has the "parallax" class to show
         // the "Parallax" label. This must be done this way because a theme or
         // custom snippet may add or remove parallax elements. Note that if a
         // label is already set, we do not change it.
-        if (!label) {
+        // TODO In master, remove the "|| label === 'Parallax'" part from the
+        // condition, as the label="Parallax" will be removed from the snippet
+        // definition.
+        if (!label || label === "Parallax") {
+            label = "";
             const contentEl = snippetEl.children[0];
             if (contentEl.matches(".parallax") || !!contentEl.querySelector(".parallax")) {
                 return _t("Parallax");
             }
         }
         return label;
-    },
+    }
+
     cleanSnippetForSave(snippetCopyEl, cleanForSaveHandlers) {
         const rootEl = snippetCopyEl.matches(".s_popup")
             ? snippetCopyEl.firstElementChild
             : snippetCopyEl;
         super.cleanSnippetForSave(rootEl, cleanForSaveHandlers);
-    },
+    }
+
     getContext(snippetEl) {
         const context = super.getContext(...arguments);
         const editableParentEl = snippetEl.closest("[data-oe-model][data-oe-field][data-oe-id]");
@@ -45,8 +52,10 @@ export const websiteSnippetModelPatch = {
             field: editableParentEl.dataset.oeField,
             resId: editableParentEl.dataset.oeId,
         });
-    },
-};
+    }
+}
+
+registry.category("html_builder.snippetsModel").add("website.snippets", WebsiteSnippetModel);
 
 registry
     .category("html_builder.snippetsPreprocessor")

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -11,7 +11,6 @@ import { useSetupAction } from "@web/search/action_hook";
 import { ThemeTab } from "./plugins/theme/theme_tab";
 import { Plugin } from "@html_editor/plugin";
 import { revertPreview } from "@html_builder/core/utils";
-import { websiteSnippetModelPatch } from "./snippet_model";
 import { rpc } from "@web/core/network/rpc";
 import { redirect } from "@web/core/utils/urls";
 
@@ -36,11 +35,6 @@ export class WebsiteBuilder extends Component {
     setup() {
         this.websiteService = useService("website");
         this.dialog = useService("dialog");
-        this.snippetsService = useService("html_builder.snippets");
-        this.snippetsService.patchSnippetModel(
-            this.props.builderProps.snippetsName,
-            websiteSnippetModelPatch
-        );
         useSetupAction({
             beforeUnload: (ev) => this.onBeforeUnload(ev),
             beforeLeave: () => this.onBeforeLeave(),

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -45,7 +45,7 @@
             <t t-snippet="website.s_banner" string="Banner" group="intro">
                 <keywords>hero, jumbotron, headline, header, branding, intro, home, showcase, spotlight, lead, welcome, announcement, splash, top, main</keywords>
             </t>
-            <t t-snippet="website.s_cover" string="Cover" group="intro" label="Parallax">
+            <t t-snippet="website.s_cover" string="Cover" group="intro">
                 <keywords>hero, jumbotron, headline, header, branding, intro, home, showcase, spotlight, main, landing, presentation, top, splash, parallax</keywords>
             </t>
             <t t-snippet="website.s_text_cover" string="Text Cover" group="intro">
@@ -66,10 +66,10 @@
             <t t-snippet="website.s_motto" string="Motto" group="intro">
                 <keywords>cite, slogan, tagline, mantra, catchphrase, statements, sayings, comments, mission, citations, maxim, quotes, principle, ethos, values</keywords>
             </t>
-            <t t-snippet="website.s_banner_connected" string="Banner connected" group="intro" label="Parallax">
+            <t t-snippet="website.s_banner_connected" string="Banner connected" group="intro">
                 <keywords>content, picture, photo, connection, cover, shape, background, image, headings, hero, light, experience, parallax</keywords>
             </t>
-            <t t-snippet="website.s_kickoff" string="Kickoff" group="intro" label="Parallax">
+            <t t-snippet="website.s_kickoff" string="Kickoff" group="intro">
                 <keywords>picture, photo, illustration, media, visual, start, launch, commencement, initiation, opening, kick-off, kickoff, beginning, events, parallax</keywords>
             </t>
             <t t-snippet="website.s_closer_look" string="Closer Look" group="intro">
@@ -287,7 +287,7 @@
             <t t-snippet="website.s_image_punchy" string="Punchy Image" group="images">
                 <keywords>headline, header, content, picture, photo, illustration, media, visual, article, combination, trendy, pattern, design, bold, impactful, vibrant, standout</keywords>
             </t>
-            <t t-snippet="website.s_parallax" string="Parallax" group="images" label="Parallax">
+            <t t-snippet="website.s_parallax" string="Parallax" group="images">
                 <keywords>scrolling, depth, effect, background, layer, visual, movement, parallax</keywords>
             </t>
             <t t-snippet="website.s_unveil" string="Unveil" group="images">
@@ -375,7 +375,7 @@
             <t t-snippet="website.s_pricelist_cafe" string="Pricelist Cafe" group="text">
                 <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, rates, prices, expenses, columns</keywords>
             </t>
-            <t t-snippet="website.s_pricelist_boxed" string="Pricelist Boxed" group="text" label="Parallax">
+            <t t-snippet="website.s_pricelist_boxed" string="Pricelist Boxed" group="text">
                 <keywords>menu, pricing, shop, table, cart, product, cost, charges, fees, rates, prices, expenses</keywords>
             </t>
 
@@ -383,7 +383,7 @@
             <t t-snippet="website.s_title_form" string="Title - Form" t-forbid-sanitize="form" group="contact_and_forms" label="Form">
                 <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request</keywords>
             </t>
-            <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms" label="Parallax"/>
+            <t t-snippet="website.s_opening_hours" string="Opening Hours" group="contact_and_forms"/>
             <t t-snippet="website.s_contact_info" string="Contact Info" group="contact_and_forms"/>
             <t t-snippet="website.s_website_form_overlay" string="Form Overlay" t-forbid-sanitize="form" group="contact_and_forms" label="Form">
                 <keywords>contact, collect, submission, input, fields, questionnaire, survey, registration, request</keywords>
@@ -399,7 +399,7 @@
             </t>
 
             <!-- Catalog group -->
-            <t t-snippet="website.s_floating_blocks" string="Floating Cards" group="catalog" label="Parallax">
+            <t t-snippet="website.s_floating_blocks" string="Floating Cards" group="catalog">
                 <keywords>hero, animation, animated, cards, float, stacked, promo, categories, ecommerce, shop</keywords>
             </t>
             <t t-snippet="website.s_attributes_horizontal" string="Horizontal Attributes" group="catalog">
@@ -411,7 +411,7 @@
             <t t-snippet="website.s_bento_banner" string="Bento Banner" group="catalog">
                 <keywords>hero, jumbotron, headline, header, introduction, banner, call to action, cta, button, highlight, showcase, spotlight, sober, trendy, design, picture, photo, illustration, visual, description, containers, layouts, product, buy</keywords>
             </t>
-            <t t-snippet="website.s_banner_product" string="Collection Banner" group="catalog" label="Parallax">
+            <t t-snippet="website.s_banner_product" string="Collection Banner" group="catalog">
                 <keywords>hero, jumbotron, headline, header, shop, cart, product, ecommerce, picture, photo, illustration, media, visual, intro, home, content, description, call to action, cta, minimalist, marketing</keywords>
             </t>
             <t t-snippet="website.s_bento_block" string="Bento Block" group="catalog">


### PR DESCRIPTION
Steps to reproduce:
- Go to a website page.
- Enter Edit mode.
- Save a "s_cover" snippet as a custom block.
- Reopen the snippet preview modal. => The "Parallax" label is missing for the custom "s_cover" snippet.

Before this commit, website and mass mailing snippet overrides were patched only when the builder mounted, while snippets were already preloaded before entering edit mode (since this commit [1]).

After this commit, snippet models are registered per snippets set and are used when the model is created, so preload and editor share the same overrides and parallax labels are computed correctly.

[1]: https://github.com/odoo/odoo/commit/06ad29904cc8c2d93b61fcf7f6a111e10de23a2e

task-5156137