### PR TITLE
[FIX] pos_self_order: fix empty order lines check before printing changes

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -319,7 +319,7 @@ export class SelfOrder extends Reactive {
             const orderlines = this._getKioskPrintingCategoriesChanges(
                 Object.values(printer.config.product_categories_ids)
             );
-            if (orderlines) {
+            if (orderlines.length > 0) {
                 const printingChanges = {
                     new: orderlines,
                     tracker: this.currentOrder.table_stand_number,


### PR DESCRIPTION
Before this commit:
To reproduce (version 17 and >):
 1. Install Restaurant
 2. In PoS restaurant config allow "Self ordering" in Kiosk mode and enable "Preparation printers"
 3. Create a preparation printer with NO categories and set it as a restaurant preparation printer
 4. Open the Kiosk
 5. Make an order with any product and checkout

-> Printer will print a ticket with no product
<img width="512" height="415" alt="image" src="https://github.com/user-attachments/assets/31bd08f9-2470-4f72-9e3d-822564b43f70" />


After this commit:
No kitchen printer is printed (expected as no category set on the kitchen printer)
