### PR TITLE
[IMP] *: cleanup redundant [role=button]  on button elements

### DIFF
--- a/addons/api_doc/static/src/doc_client.xml
+++ b/addons/api_doc/static/src/doc_client.xml
@@ -12,10 +12,10 @@
             />
         </div>
         <div class="d-flex flex-nowrap gap-1">
-            <button class="btn" role="button" t-on-click="() => this.env.modelStore.showApiKeyModal = true">
+            <button class="btn" t-on-click="() => this.env.modelStore.showApiKeyModal = true">
                 <i class="fa fa-key" aria-hidden="true"></i>
             </button>
-            <button class="btn" role="button" t-on-click="() => this.toggleTheme()">
+            <button class="btn" t-on-click="() => this.toggleTheme()">
                 <i class="fa fa-moon-o" aria-hidden="true"></i>
             </button>
         </div>

--- a/addons/auth_passkey/views/res_users_identitycheck_views.xml
+++ b/addons/auth_passkey/views/res_users_identitycheck_views.xml
@@ -11,7 +11,7 @@
                 <div invisible="auth_method != 'webauthn'">
                     <h3><strong>Use your passkey to authenticate</strong></h3>
                     <p class="mb-0 mt-3">Or choose a different method:</p>
-                    <button type="object" name="action_use_password" class="btn btn-link" role="button">Use password</button>
+                    <button type="object" name="action_use_password" class="btn btn-link">Use password</button>
                 </div>
             </xpath>
             <xpath expr="//footer/button[@id='password_confirm']" position="before">

--- a/addons/hr_skills/static/src/fields/one2many_tags_skills/one2many_tags_skills.xml
+++ b/addons/hr_skills/static/src/fields/one2many_tags_skills/one2many_tags_skills.xml
@@ -11,7 +11,6 @@
             </div>
             <button t-on-click="onAdd"
                 class="btn btn-link text-action"
-                role="button"
                 style="padding: 0; line-height: 0; height: min-content;">
                 <i class="fa fa-plus text-info" />
             </button>

--- a/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
+++ b/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
@@ -6,7 +6,7 @@
         </xpath>
         <xpath expr="//table" position="after">
             <t t-if="!showTable">
-                <button t-on-click="props.onAdd" class="btn btn-secondary ms-4 mt-3" role="button" t-if="isEditable">
+                <button t-on-click="props.onAdd" class="btn btn-secondary ms-4 mt-3" t-if="isEditable">
                     Create Resume Lines
                 </button>
             </t>

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
@@ -22,7 +22,7 @@
                         </p>
                         <button t-on-click="skillTypesAction"
                             class="btn btn-secondary align-self-center"
-                            role="button" t-if="isEditable">
+                            t-if="isEditable">
                             Create Skills
                         </button>
                     </div>
@@ -34,7 +34,7 @@
                         </p>
                         <button t-on-click="props.onAdd"
                             class="btn btn-secondary align-self-center"
-                            role="button" t-if="isEditable">
+                            t-if="isEditable">
                             Pick a skill from the list
                         </button>
                     </div>
@@ -51,8 +51,7 @@
                         <span t-esc="skill_group[1].name"/>
                         <button id="add_button" class="btn btn-secondary btn-sm"
                             t-if="isEditable"
-                            t-on-click="() => props.onAdd({ context: { default_skill_type_id: skill_group[1].id }})"
-                            role="button">ADD</button>
+                            t-on-click="() => props.onAdd({ context: { default_skill_type_id: skill_group[1].id }})">ADD</button>
                     </div>
                 </th>
             </tr>

--- a/addons/lunch/static/src/components/lunch_dashboard.xml
+++ b/addons/lunch/static/src/components/lunch_dashboard.xml
@@ -40,7 +40,6 @@
             <div t-if="props.isToOrder" class="d-flex justify-content-between">
                 <div class="o_lunch_order_line_quantity input-group">
                     <button
-                        role="button"
                         type="button"
                         t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-end-0 {{canEdit ? '' : 'opacity-100 disabled'}}"
                         t-on-click="() => this.updateQuantity(-1)"
@@ -55,7 +54,6 @@
                         disabled="true"
                     />
                     <button
-                        role="button"
                         type="button"
                         t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-start-0 {{canAdd ? '' : 'opacity-100 disabled'}}"
                         t-on-click="() => this.updateQuantity(1)"
@@ -146,7 +144,6 @@
                             class="accordion-button collapsed py-2 px-0 bg-view shadow-none"
                             data-bs-toggle="collapse"
                             href="#o_lunch_passed_orders"
-                            role="button"
                             aria-expanded="false"
                             aria-controls="o_lunch_passed_orders"
                         >

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.CallMenu">
         <div class="dropdown" t-attf-class="{{ className }}" t-ref="root">
-            <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow px-0 rounded-2" t-att-title="buttonTitle" role="button" t-on-click="rtc.channel.open">
+            <button t-if="rtc.channel" class="user-select-none dropdown-toggle o-no-caret o-dropdown--narrow px-0 rounded-2" t-att-title="buttonTitle" t-on-click="rtc.channel.open">
                 <div class="o-discuss-CallMenu-buttonContent d-flex align-items-center btn-group rounded-2" t-att-class="{ 'o-is-talking': rtc.selfSession?.isActuallyTalking, 'o-isOdooCommunity': !isEnterprise }">
                     <small class="o-discuss-CallMenu-animationContainer d-flex position-absolute o-xsmaller bg-inherit o-p-0_5 rounded-circle m-n2 z-2">
                         <i class="fa fa-volume-up o-discuss-inCallIconColor bg-inherit rounded-circle o-discuss-CallMenu-animation" t-att-class="{ 'o-isOdooCommunity': !isEnterprise }"/>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -55,7 +55,7 @@
                                         <t t-if="doLoadSampleData.status === 'loading'">Loading...</t>
                                         <t t-else="">Load Sample</t>
                                      </button>
-                                    <button role="button" class="btn btn-lg btn-secondary" t-on-click="()=>pos.editProduct()">Create Manually</button>
+                                    <button class="btn btn-lg btn-secondary" t-on-click="()=>pos.editProduct()">Create Manually</button>
                                 </p>
                             </div>
                         </div>

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -12,7 +12,7 @@
                     <div class="d-flex col-12 col-md-6 col-lg-4 position-relative">
                         <button
                             t-on-click="() => this.selectAttribute(attribute, value)" style="min-height:105px;"
-                            role="button" class="btn btn-light px-3 px-sm-3 py-3 py-sm-3 w-100 d-flex flex-column align-items-start align-items-md-center text-start text-md-center justify-content-center gap-0 border-2 shadow-sm rounded-4"
+                            class="btn btn-light px-3 px-sm-3 py-3 py-sm-3 w-100 d-flex flex-column align-items-start align-items-md-center text-start text-md-center justify-content-center gap-0 border-2 shadow-sm rounded-4"
                             t-attf-class="{{ valueSelected ? 'border-primary': 'border-transparent' }}">
                             <div class="d-flex d-inline-flex justify-content-between w-100 align-items-center gap-1">
                                 <div class="text-center d-flex flex-column gap-2 align-items-center w-100">

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -10,7 +10,7 @@
                         <div class="category_list d-flex mw-100 mx-kiosk-p-auto py-3 px-kiosk-p-4 gap-0 gap-kiosk-p-3 overflow-x-auto overflow-y-hidden position-relative" t-ref="category_list">
                             <t t-foreach="state.topCategories" t-as="category" t-key="category.id">
                                 <t t-set="isSelectedCategory" t-value="category === topSelectedCategory"/>
-                                <button t-on-click="() => this.selectCategory(category)" role="button" class="category_btn btn d-flex flex-column align-items-center p-0 border-0 "  t-att-data-category-pill="category.id">
+                                <button t-on-click="() => this.selectCategory(category)" class="category_btn btn d-flex flex-column align-items-center p-0 border-0 "  t-att-data-category-pill="category.id">
                                     <img class="d-none d-kiosk-p-block mb-2 rounded-4 object-fit-cover transition-base" style="height: 110px; width: 110px;" t-attf-src="/web/image/pos.category/#{category.id}/image_128?unique=#{category.write_date}" draggable="false"/>
                                     <div class="text-nowrap fw-medium rounded-pill px-3 py-1 d-flex align-items-center" t-att-class="{'text-bg-primary btn border-0': isSelectedCategory}" >
                                        <span class="text-nowrap fw-medium" t-esc="category.name" />
@@ -34,12 +34,12 @@
                     <div class="container o_self_container px-kiosk-p-0 d-flex">
                         <div class="category_list d-flex mw-100 mx-kiosk-p-auto py-3 px-kiosk-p-4 gap-0 gap-kiosk-p-3 overflow-x-auto overflow-y-hidden" t-ref="sub_category_list">
                             <t t-set="isAllSelected" t-value="!selectedCategory.parent_id "/>
-                            <button t-on-click="() => this.selectCategory(topSelectedCategory)" role="button" class="child_category_btn child_category_all btn px-3 py-1 rounded-pill border-0" t-att-class="{'btn-light': isAllSelected, 'btn-link text-reset': !isAllSelected}" >
+                            <button t-on-click="() => this.selectCategory(topSelectedCategory)" class="child_category_btn child_category_all btn px-3 py-1 rounded-pill border-0" t-att-class="{'btn-light': isAllSelected, 'btn-link text-reset': !isAllSelected}" >
                                 All
                             </button>
                             <t t-foreach="state.subCategories" t-as="child_category" t-key="child_category.id">
                                 <t t-set="isSelectedChildCategory" t-value="child_category === selectedCategory "/>
-                                <button t-on-click="() => this.selectCategory(child_category)" role="button" class="child_category_btn btn d-flex align-items-center gap-2 px-3 py-1 rounded-pill border-0" t-att-class="{'btn-light': isSelectedChildCategory, 'btn-link text-reset': !isSelectedChildCategory}">
+                                <button t-on-click="() => this.selectCategory(child_category)" class="child_category_btn btn d-flex align-items-center gap-2 px-3 py-1 rounded-pill border-0" t-att-class="{'btn-light': isSelectedChildCategory, 'btn-link text-reset': !isSelectedChildCategory}">
                                     <img class="d-none d-kiosk-p-block object-cover flex-shrink-0 rounded-3 my-1" t-attf-src="/web/image/pos.category/#{child_category.id}/image_128?unique=#{child_category.write_date}" draggable="false"/>
                                     <span class="text-nowrap" t-esc="child_category.name"/>
                                 </button>

--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -39,7 +39,6 @@
                 <button
                     t-if="ancestors.length === 1"
                     class="btn px-2 fs-4"
-                    role="button"
                     data-tooltip="Add nested rule"
                     aria-label="Add nested rule"
                     t-on-click="() => this.addNewConnector(parent, node)"
@@ -51,7 +50,6 @@
                 <button
                     t-else=""
                     class="btn px-2 fs-4"
-                    role="button"
                     data-tooltip="Add rule"
                     aria-label="Add rule"
                     t-on-click="() => this.addNewCondition(parent, node)"
@@ -63,7 +61,6 @@
             </t>
             <button
                 class="btn btn-link px-2 text-danger fs-4"
-                role="button"
                 data-tooltip="Delete rule"
                 aria-label="Delete rule"
                 t-on-click="() => this.delete(ancestors, node)"

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -47,7 +47,6 @@
                         <small class="o_facet_value text-truncate" t-esc="facetValue" t-att-title="facet.tooltip or facetValue"/>
                     </t>
                     <button class="o_facet_remove oi oi-close btn btn-link py-0 px-2 text-danger d-print-none"
-                        role="button"
                         aria-label="Remove"
                         title="Remove"
                         t-on-click="() => this.onFacetRemove(facet)"
@@ -102,7 +101,6 @@
                 <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
                     role="search" aria-autocomplete="list">
                     <button class="d-print-none btn border-0 p-0"
-                        role="button"
                         aria-label="Search..."
                         title="Search..."
                         t-on-click="this.onClickSearchIcon"

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -271,7 +271,7 @@
                                     </div>
                                 </div>
                                 <t t-else="">
-                                    <button class="position-absolute top-0 start-0 h-100 w-100 opacity-0" role="button" type="open" t-if="record.url.value"/>
+                                    <button class="position-absolute top-0 start-0 h-100 w-100 opacity-0" type="open" t-if="record.url.value"/>
                                 </t>
                             </div>
                             <div class="o_theme_preview_bottom mt-2 mb-3 px-2">

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -158,7 +158,7 @@
 <template id="event_time" inherit_id="website_event.index_topbar" name="Filter by Date">
     <xpath expr="//div[hasclass('o_wevent_search')]" position="before">
         <div class="dropdown d-none d-lg-block">
-            <button role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown" title="Filter by Date" aria-label="Filter by date" aria-expanded="false">
+            <button class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown" title="Filter by Date" aria-label="Filter by date" aria-expanded="false">
                 <t t-if="current_date" t-out="current_date"/>
                 <t t-else="">Scheduled Events</t>
             </button>

--- a/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
+++ b/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
@@ -67,7 +67,7 @@
     <t t-name="quiz.validation">
         <div id="validation" class="d-md-flex">
             <div class="flex-grow-1">
-                <button t-if="!widget.track.completed" role="button" title="Check answers" aria-label="Check answers"
+                <button t-if="!widget.track.completed" title="Check answers" aria-label="Check answers"
                     class="btn btn-primary text-uppercase fw-bold o_quiz_js_quiz_submit">
                     Check your answers
                 </button>

--- a/addons/website_slides/static/src/xml/slide_quiz.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz.xml
@@ -100,7 +100,7 @@
             </div>
             <div t-else="" class="d-md-flex align-items-center justify-content-between">
                 <div t-att-class="'d-flex align-items-center' + (slide.completed ? ' alert alert-success my-0 py-1 px-3' : '')">
-                    <button t-if="!slide.completed" role="button" title="Check answers"
+                    <button t-if="!slide.completed" title="Check answers"
                         class="btn btn-primary text-uppercase fw-bold o_wslides_js_lesson_quiz_submit">Check your answers</button>
                     <b t-else="" class="my-0 h5">Done!</b>
                     <span class="my-0 h5" style="line-height: 1">

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -269,7 +269,7 @@
             </table>
 
             <div class="mt-3 d-grid o_not_editable">
-                <button role="button" class="o_wslides_share btn btn-link" title="Share Channel"
+                <button class="o_wslides_share btn btn-link" title="Share Channel"
                         aria-label="Share Channel" t-att-data-id="channel.id" t-att-data-name="channel.name"
                         t-att-data-url="channel.website_absolute_url" data-is-channel="True"
                         t-att-data-email-sharing="bool(channel.share_channel_template_id)">

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3482,11 +3482,11 @@ class TestViews(ViewCase):
 
     def test_valid_focusable_button(self):
         self.assertValid('<form><a class="btn" role="button"/></form>')
-        self.assertValid('<form><button class="btn" role="button"/></form>')
+        self.assertValid('<form><button class="btn"/></form>')
         self.assertValid('<form><select class="btn" role="button"/></form>')
-        self.assertValid('<form><input type="button" class="btn" role="button"/></form>')
-        self.assertValid('<form><input type="submit" class="btn" role="button"/></form>')
-        self.assertValid('<form><input type="reset" class="btn" role="button"/></form>')
+        self.assertValid('<form><input type="button" class="btn"/></form>')
+        self.assertValid('<form><input type="submit" class="btn"/></form>')
+        self.assertValid('<form><input type="reset" class="btn"/></form>')
         self.assertValid('<form><div type="reset" class="btn btn-group" role="button"/></form>')
         self.assertValid('<form><div type="reset" class="btn btn-toolbar" role="button"/></form>')
         self.assertValid('<form><div type="reset" class="btn btn-addr" role="button"/></form>')


### PR DESCRIPTION
The `<button>`  HTML element has by default the "role", well, "button". No need to specify it again.

Reference:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/button_role

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
