### PR TITLE
[FIX] spreadsheet: printing a dashboard crashes

### DIFF
--- a/addons/spreadsheet/static/src/hooks.js
+++ b/addons/spreadsheet/static/src/hooks.js
@@ -89,21 +89,25 @@ export function useSpreadsheetPrint(model) {
             offset: model().getters.getActiveSheetScrollInfo(),
             mode: model().config.mode,
         };
+        const startPrinting = () => {
+            // reset the viewport to A1 visibility
+            model().dispatch("SET_VIEWPORT_OFFSET", { offsetX: 0, offsetY: 0 });
+            model().dispatch("RESIZE_SHEETVIEW", { ...getPrintRect() });
+            printState.active = true;
+        };
+        if (model().getters.isDashboard()) {
+            startPrinting();
+            return;
+        }
         // FIXME: updateMode is not meant fore production use,
         // we should render a specific component with limited interface instead
         model().updateMode("dashboard");
-        // reset the viewport to A1 visibility
-        model().dispatch("SET_VIEWPORT_OFFSET", { offsetX: 0, offsetY: 0 });
-        model().dispatch("RESIZE_SHEETVIEW", {
-            ...getPrintRect(),
-        });
-
         // loaded here as the store provider might be empty (no Model store) when the hook is used
         const gridRendererStore = env.getStore(GridRenderer);
         const intervalId = setInterval(() => {
             if (!gridRendererStore.animations.size) {
                 clearInterval(intervalId);
-                printState.active = true;
+                startPrinting();
             }
         }, 50);
     }


### PR DESCRIPTION
1) Printing a sahboard crashes, because `env.getStore` isn't defined since we're not in a spreadsheet context.

The `env.getStore` was needed to wait for cell animations that triggered when changing the mode to `dashboard` to print, but since here we already are in dashboard mode, no aimations are triggered and we don't need this check.

2) Only the first page is now printned in spreadsheet mode

This was because while waiting for the cells animations to end, the resize observer changed the sheetview size back to the correct size, instead of the print sheet size. We now change the size to the print size after waiting for the animations to end.

Task: [5502436](https://www.odoo.com/web#id=5502436&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
