### PR TITLE
[IMP] sale: SO signature integrity

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -376,6 +376,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             request
             .env["ir.actions.report"]
             .sudo()
+            .with_context(sale_include_signature=True)
             ._render_qweb_pdf("sale.action_report_saleorder", [order_sudo.id])[0]
         )
 

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -336,7 +336,10 @@
             </div>
             <div class="oe_structure"></div>
 
-            <div t-if="not doc.signature" class="oe_structure"></div>
+            <div
+                t-if="not doc.signature or not doc.env.context.get('sale_include_signature')"
+                class="oe_structure"
+            />
             <div t-else="" class="mt-4 ml64 mr4" name="signature">
                 <div class="offset-8">
                     <strong>Signature</strong>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -979,13 +979,6 @@
                             </group>
                         </group>
                     </page>
-                    <page groups="base.group_no_one" string="Customer Signature" name="customer_signature" invisible="not require_signature and not signed_by and not signature and not signed_on">
-                        <group>
-                            <field name="signed_by" readonly="signature"/>
-                            <field name="signed_on" readonly="signature"/>
-                            <field name="signature" widget="image"/>
-                        </group>
-                    </page>
                 </notebook>
             </sheet>
             <chatter/>

--- a/addons/sale_pdf_quote_builder/report/ir_actions_report.xml
+++ b/addons/sale_pdf_quote_builder/report/ir_actions_report.xml
@@ -13,7 +13,7 @@
     </record>
 
     <record id="sale.action_report_saleorder" model="ir.actions.report">
-        <field name="name">PDF Quote</field>
+        <field name="binding_model_id" eval="False"/>
     </record>
 
 </odoo>


### PR DESCRIPTION
A signed order can be modified afterward while retaining the signature on the newly generated PDF. After this commit, we will only print the signature on the document generated by the signature itself and not on any generated PDF afterwards. 

We also take this opportunity to:
- Eliminate the "PDF Quote" option, leaving "Quotation/Order" as the option to print the raw quote, and "Print"(button) to print the quote with the additional hearder/footer.
- Stop storing the signature related fields and remove the Customer Signature tab

Enterprise PR: https://github.com/odoo/enterprise/pull/107529
 
task-5421716