### PR TITLE
[FIX] crm: prevent error when changing the stage of lead

### DIFF
--- a/addons/crm/static/src/views/crm_form/crm_form.js
+++ b/addons/crm/static/src/views/crm_form/crm_form.js
@@ -47,7 +47,7 @@ class CrmFormRecord extends formView.Model.Record {
         }
 
         const res = await super._save(...arguments);
-        if (changeStage) {
+        if (res && changeStage) {
             await checkRainbowmanMessage(this.model.orm, this.model.effect, this.resId);
         }
         return res;


### PR DESCRIPTION
Currently, an error occurs when a user changes the stage of lead.

**Steps to Reproduce:**
 - Install the `crm` module.
 - Go to `crm` and switch to `List view`.
 - Click `New` and then click on any `stage`.

`AssertionError: Invalid falsy real id`

This error occurs because, after the recent commit [1], falsy IDs are no longer allowed.
When the user changes the stage without creating the record, the record ID is passed
as False when it goes to calculate the rainbowman message [2]. Browsing the record with
a falsy ID [3] then raises this error.

This commit ensures that if a record has no ID and the stage ID is changed, the rainbowman
message is not calculated.

[1]: https://github.com/odoo/odoo/commit/4290724a4c8c57fba4f4d3d688d38f65dadcc38f

[2]: https://github.com/odoo/odoo/blob/6bce0128fdd5176c55ac9ed5af1922c1f6f97da5/addons/crm/static/src/views/crm_form/crm_form.js#L51

[3]- https://github.com/odoo/odoo/blob/403f3cf8d291ff2023fc4c5d3631a01465f292c3/odoo/orm/models.py#L5200

sentry-7207509338


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
