### PR TITLE
[IMP] web: replace a[href="#"]  by actual button element

### DIFF
--- a/addons/mail/static/src/core/web/activity_button.xml
+++ b/addons/mail/static/src/core/web/activity_button.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ActivityButton">
-        <a class="o-mail-ActivityButton" role="button" t-on-click.prevent.stop="onClick" t-ref="button" t-att-aria-label="title" t-att-title="title">
+        <button class="o-mail-ActivityButton btn btn-link btn-link-inline" t-on-click.stop="onClick" t-ref="button" t-att-aria-label="title" t-att-title="title">
             <i class="fa fa-fw fa-lg" t-att-class="buttonClass" role="img"/>
-        </a>
+        </button>
     </t>
 </templates>

--- a/addons/mail/static/src/views/web/fields/list_activity/list_activity.xml
+++ b/addons/mail/static/src/views/web/fields/list_activity/list_activity.xml
@@ -6,7 +6,7 @@
         </ActivityButton>
     </t>
     <t t-name="mail.ListActivityButton" t-inherit="mail.ActivityButton">
-        <xpath expr="//a[hasclass('o-mail-ActivityButton')]" position="replace">
+        <xpath expr="//button[hasclass('o-mail-ActivityButton')]" position="replace">
             <button class="o-mail-ActivityButton btn btn-link btn-dark p-0 w-100 text-start text-truncate"
                 t-on-click.prevent.stop="onClick" t-ref="button" t-att-aria-label="title" t-att-title="title">
                 <i class="fa fa-fw fa-lg" t-att-class="buttonClass" role="img"/>

--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -26,7 +26,7 @@
                 <t t-if="node.children.length" t-call="web.TreeEditor.connector.children" />
                 <t t-if="!props.readonly">
                     <div class="o_tree_editor_row d-flex align-items-center" t-att-class="{ 'ps-4': addPadding || props.isSubTree }">
-                        <a href="#" role="button" t-on-click="() => this.addNewCondition(node)">New Rule</a>
+                        <button class="btn btn-link btn-link-inline" t-on-click="() => this.addNewCondition(node)">New Rule</button>
                     </div>
                 </t>
             </div>

--- a/addons/web/static/src/scss/bootstrap_review.scss
+++ b/addons/web/static/src/scss/bootstrap_review.scss
@@ -130,4 +130,17 @@ $o-datetime-picker-width: calc(5px * 7 * 8 + (2 * #{map-get($spacers, 2)}));
         // Make sure to have a fallback for :focus-visible state when the element use only the `.btn` class.
         box-shadow: var(--#{$prefix}btn-focus-box-shadow, 0 0 0 #{$btn-focus-width} RGBA(#{$btn-link-focus-shadow-rgb}, .5));
     }
+
+    &.btn-link.btn-link-inline {
+        --#{$prefix}btn-font-family: var(--#{$prefix}body-font-family);
+        --#{$prefix}btn-font-size: var(--#{$prefix}body-font-size);
+        --#{$prefix}btn-font-weight: var(--#{$prefix}body-font-weight);
+        --#{$prefix}btn-line-height: var(--#{$prefix}body-line-height);
+        --#{$prefix}btn-padding-x: 0;
+        --#{$prefix}btn-padding-y: 0;
+        --#{$prefix}btn-border-width: 0;
+        display: inline;
+        vertical-align: baseline;
+        font-weight: var(--#{$prefix}btn-font-weight); /* TODO: remove when the crappy overrides in bootstrap_review_backend are gone */
+    }
 }

--- a/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.xml
+++ b/addons/web/static/src/views/fields/boolean_favorite/boolean_favorite_field.xml
@@ -3,10 +3,10 @@
 
     <t t-name="web.BooleanFavoriteField">
         <div class="o_favorite" t-att-class="{'o_disabled': props.readonly}" t-on-click.prevent.stop="update">
-            <a href="#" t-att-class="{'pe-none' : props.readonly}">
+            <button class="btn btn-link btn-link-inline" t-att-class="{'pe-none' : props.readonly}">
                 <i t-att-class="iconClass" role="img" t-att-title="label" t-att-aria-label="label"/>
                 <t t-if="!props.readonly and !props.noLabel" t-esc="label"/>
-            </a>
+            </button>
         </div>
     </t>
 

--- a/addons/web/static/src/views/fields/priority/priority_field.xml
+++ b/addons/web/static/src/views/fields/priority/priority_field.xml
@@ -17,16 +17,15 @@
                         />
                     </t>
                     <t t-else="">
-                        <a
-                            href="#"
-                            class="o_priority_star fa"
+                        <button
+                            class="o_priority_star btn btn-link btn-link-inline fa"
                             role="radio"
                             t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o opacity-25 opacity-100-hover'"
                             tabindex="0"
                             t-att-data-tooltip="getTooltip(value[1])"
                             t-att-aria-checked="value_index === index ? 'true' : 'false'"
                             t-att-aria-label="value[1]"
-                            t-on-click.prevent.stop="() => this.onStarClicked(value[0])"
+                            t-on-click.stop="() => this.onStarClicked(value[0])"
                             t-on-mouseenter="() => state.index = value_index"
                             t-on-mouseleave="() => state.index = -1"
                         />

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
@@ -4,11 +4,13 @@
         <div id="developer_tool">
             <SettingsBlock title.translate="Developer Tools">
                 <Setting addLabel="false">
-                        <a t-if="!isDebug" class="d-block" t-on-click="() => this.activateDebug(1)" href="#">Activate the developer mode</a>
-                        <a t-if="!isAssets" class="d-block" t-on-click="() => this.activateDebug('assets')" href="#">Activate the developer mode (with assets)</a>
-                        <a t-if="!isTests" class="d-block" t-on-click="() => this.activateDebug('assets,tests')" href="#">Activate the developer mode (with tests assets)</a>
-                        <a t-if="isDebug" class="d-block" t-on-click="() => this.activateDebug(0)" href="#">Deactivate the developer mode</a>
-                        <a t-if="isDebug and !isDemoDataActive" t-on-click.prevent="onClickForceDemo" class="o_web_settings_force_demo" href="#">Load demo data</a>
+                    <ul class="list-unstyled">
+                        <li><button t-if="!isDebug" class="btn btn-link btn-link-inline" t-on-click="() => this.activateDebug(1)">Activate the developer mode</button></li>
+                        <li><button t-if="!isAssets" class="btn btn-link btn-link-inline" t-on-click="() => this.activateDebug('assets')">Activate the developer mode (with assets)</button></li>
+                        <li><button t-if="!isTests" class="btn btn-link btn-link-inline" t-on-click="() => this.activateDebug('assets,tests')">Activate the developer mode (with tests assets)</button></li>
+                        <li><button t-if="isDebug" class="btn btn-link btn-link-inline" t-on-click="() => this.activateDebug(0)">Deactivate the developer mode</button></li>
+                        <li><button t-if="isDebug and !isDemoDataActive" t-on-click="onClickForceDemo" class="o_web_settings_force_demo btn btn-link btn-link-inline">Load demo data</button></li>
+                    </ul>
                 </Setting>
             </SettingsBlock>
         </div>

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.xml
@@ -9,12 +9,11 @@
         </div>
         <t t-if="state.invite.pending_users.length">
             <p class="o_form_label pt-3">Pending Invitations:</p>
-            <span t-foreach="state.invite.pending_users" t-as="pending" t-key="pending[0]">
-                <a href="#" class="badge rounded-pill text-primary border border-primary o_web_settings_user" t-on-click.prevent="(ev) => this.onClickUser(ev, pending)"> <t t-esc="pending[1]"/> </a>
-            </span>
+            <t t-foreach="state.invite.pending_users" t-as="pending" t-key="pending[0]">
+                <button class="o_web_settings_user btn btn-outline-primary btn-sm rounded-pill" t-on-click="(ev) => this.onClickUser(ev, pending)"> <t t-esc="pending[1]"/> </button>
+            </t>
             <t t-if="state.invite.pending_users.length &lt; state.invite.pending_count">
-                <br/>
-                <a href="#" class="o_web_settings_more" t-on-click.prevent="onClickMore"><t t-esc="state.invite.pending_count - state.invite.pending_users.length"/> more </a>
+                <button class="o_web_settings_more btn btn-link btn-link-inline d-block" t-on-click="onClickMore"><t t-esc="state.invite.pending_count - state.invite.pending_users.length"/> more </button>
             </t>
         </t>
     </div>

--- a/addons/web/static/src/webclient/settings_form_view/widgets/settings_widgets.scss
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/settings_widgets.scss
@@ -1,10 +1,3 @@
-.o_setting_container {
-    .o_web_settings_user {
-        font-size: 95%;
-        font-weight: 500;
-    }
-}
-
 .o_doc_link {
     text-decoration: none;
     font-weight: normal;

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -351,7 +351,7 @@ test("check condition by default when creating a new rule", async () => {
     serverState.debug = "";
     Partner._fields.country_id = fields.Char({ string: "Country ID" });
     await makeExpressionEditor({ expression: "expr" });
-    await contains("a[role='button']").click();
+    await contains(".o_tree_editor_row button", { text: "New Rule" }).click();
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         { level: 1, value: "expr" },

--- a/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
@@ -169,7 +169,7 @@ export const SELECTORS = {
     connectorValue: ".o_tree_editor_connector .o_tree_editor_connector_value",
     connectorToggler: ".o_tree_editor_connector .o_tree_editor_connector_value button.o-dropdown",
     condition: ".o_tree_editor_condition",
-    addNewRule: ".o_tree_editor_row > a",
+    addNewRule: ".o_tree_editor_row > button",
     buttonAddNewRule: ".o_tree_editor_node_control_panel > button[data-tooltip='Add rule']",
     buttonAddBranch: ".o_tree_editor_node_control_panel > button[data-tooltip='Add nested rule']",
     buttonDeleteNode: ".o_tree_editor_node_control_panel > button[data-tooltip='Delete rule']",

--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -60,7 +60,7 @@ registry.category("web_tour.tours").add("test_favorite_management", {
             run: "click",
         },
         {
-            trigger: ".o_tree_editor_row:contains(New Rule) > a",
+            trigger: ".o_tree_editor_row:contains(New Rule) > button",
             run: "click",
         },
         {

--- a/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
+++ b/addons/web/static/tests/views/fields/boolean_favorite_field.test.js
@@ -45,19 +45,19 @@ test("FavoriteField in kanban view", async () => {
             </kanban>
         `,
     });
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(1, {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(1, {
         message: "should be favorite",
     });
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a`).toHaveText("Remove from Favorites", {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button`).toHaveText("Remove from Favorites", {
         message: `the label should say "Remove from Favorites"`,
     });
 
     // click on favorite
     await contains(`.o_field_widget .o_favorite`).click();
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(0, {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(0, {
         message: "should not be favorite",
     });
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a`).toHaveText("Add to Favorites", {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button`).toHaveText("Add to Favorites", {
         message: `the label should say "Add to Favorites"`,
     });
 });
@@ -85,10 +85,10 @@ test("FavoriteField saves changes by default", async () => {
 
     // click on favorite
     await contains(`.o_field_widget .o_favorite`).click();
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(0, {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(0, {
         message: "should not be favorite",
     });
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a`).toHaveText("Add to Favorites", {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button`).toHaveText("Add to Favorites", {
         message: `the label should say "Add to Favorites"`,
     });
     expect.verifySteps(["save"]);
@@ -116,10 +116,10 @@ test("FavoriteField does not save if autosave option is set to false", async () 
 
     // click on favorite
     await contains(`.o_field_widget .o_favorite`).click();
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(0, {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(0, {
         message: "should not be favorite",
     });
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a`).toHaveText("Add to Favorites", {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button`).toHaveText("Add to Favorites", {
         message: `the label should say "Add to Favorites"`,
     });
     expect.verifySteps([]);
@@ -136,33 +136,33 @@ test("FavoriteField in form view", async () => {
         type: "form",
         arch: `<form><field name="bar" widget="boolean_favorite"/></form>`,
     });
-    expect(`.o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(1, {
+    expect(`.o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(1, {
         message: "should be favorite",
     });
-    expect(`.o_field_widget .o_favorite > a`).toHaveText("Remove from Favorites", {
+    expect(`.o_field_widget .o_favorite > button`).toHaveText("Remove from Favorites", {
         message: `the label should say "Remove from Favorites"`,
     });
 
     // click on favorite
     await contains(`.o_field_widget .o_favorite`).click();
     expect.verifySteps(["save"]);
-    expect(`.o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(0, {
+    expect(`.o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(0, {
         message: "should not be favorite",
     });
-    expect(`.o_field_widget .o_favorite > a i.fa.fa-star-o`).toHaveCount(1, {
+    expect(`.o_field_widget .o_favorite > button i.fa.fa-star-o`).toHaveCount(1, {
         message: "should not be favorite",
     });
-    expect(`.o_field_widget .o_favorite > a`).toHaveText("Add to Favorites", {
+    expect(`.o_field_widget .o_favorite > button`).toHaveText("Add to Favorites", {
         message: `the label should say "Add to Favorites"`,
     });
 
     // click on favorite
     await contains(`.o_field_widget .o_favorite`).click();
     expect.verifySteps(["save"]);
-    expect(`.o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(1, {
+    expect(`.o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(1, {
         message: "should be favorite",
     });
-    expect(`.o_field_widget .o_favorite > a`).toHaveText("Remove from Favorites", {
+    expect(`.o_field_widget .o_favorite > button`).toHaveText("Remove from Favorites", {
         message: `the label should say "Remove from Favorites"`,
     });
 });
@@ -180,25 +180,25 @@ test("FavoriteField in editable list view without label", async () => {
             </list>
         `,
     });
-    expect(`.o_data_row:first .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(1, {
+    expect(`.o_data_row:first .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(1, {
         message: "should be favorite",
     });
 
     // switch to edit mode
     await contains(`tbody td:not(.o_list_record_selector)`).click();
-    expect(`.o_data_row:first .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(1, {
+    expect(`.o_data_row:first .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(1, {
         message: "should be favorite",
     });
 
     // click on favorite
-    await contains(`.o_data_row .o_field_widget .o_favorite > a`).click();
-    expect(`.o_data_row:first .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(0, {
+    await contains(`.o_data_row .o_field_widget .o_favorite > button`).click();
+    expect(`.o_data_row:first .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(0, {
         message: "should not be favorite",
     });
 
     // save
     await contains(`.o_list_button_save`).click();
-    expect(`.o_data_row:first .o_field_widget .o_favorite > a i.fa.fa-star-o`).toHaveCount(1, {
+    expect(`.o_data_row:first .o_field_widget .o_favorite > button i.fa.fa-star-o`).toHaveCount(1, {
         message: "should not be favorite",
     });
 });
@@ -245,17 +245,17 @@ test("FavoriteField in kanban view with readonly attribute", async () => {
             </kanban>
         `,
     });
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(1, {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(1, {
         message: "should be favorite",
     });
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a`).toHaveClass("pe-none");
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button`).toHaveClass("pe-none");
     expect(`.o_kanban_record .o_field_widget .o_favorite`).toHaveClass("o_disabled");
     expect(`.o_kanban_record .o_field_widget`).toHaveText("");
 
     // click on favorite
     await contains(`.o_field_widget .o_favorite`).click();
     // expect nothing to change since its readonly
-    expect(`.o_kanban_record .o_field_widget .o_favorite > a i.fa.fa-star`).toHaveCount(1, {
+    expect(`.o_kanban_record .o_field_widget .o_favorite > button i.fa.fa-star`).toHaveCount(1, {
         message: "should remain favorite",
     });
     expect.verifySteps([]);

--- a/addons/web/static/tests/views/fields/priority_field.test.js
+++ b/addons/web/static/tests/views/fields/priority_field.test.js
@@ -61,15 +61,15 @@ test("PriorityField when not set", async () => {
     expect(".o_field_widget .o_priority:not(.o_field_empty)").toHaveCount(1, {
         message: "widget should be considered set, even though there is no value for this field",
     });
-    expect(".o_field_widget .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_field_widget .o_priority button.o_priority_star").toHaveCount(2, {
         message:
             "should have two stars for representing each possible value: no star, one star and two stars",
     });
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star").toHaveCount(0, {
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star").toHaveCount(0, {
         message: "should have no full star since there is no value",
     });
 
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star-o").toHaveCount(2, {
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star-o").toHaveCount(2, {
         message: "should have two empty stars since there is no value",
     });
 });
@@ -90,7 +90,7 @@ test("PriorityField tooltip", async () => {
     });
 
     // check data-tooltip attribute (used by the tooltip service)
-    const stars = queryAll(".o_field_widget .o_priority a.o_priority_star");
+    const stars = queryAll(".o_field_widget .o_priority button.o_priority_star");
     expect(stars[0]).toHaveAttribute("data-tooltip", "Selection: Blocked");
     expect(stars[1]).toHaveAttribute("data-tooltip", "Selection: Done");
 });
@@ -116,17 +116,17 @@ test("PriorityField in form view", async () => {
     });
 
     expect(".o_field_widget .o_priority:not(.o_field_empty)").toHaveCount(1);
-    expect(".o_field_widget .o_priority a.o_priority_star").toHaveCount(2);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star").toHaveCount(1);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star-o").toHaveCount(1);
+    expect(".o_field_widget .o_priority button.o_priority_star").toHaveCount(2);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star").toHaveCount(1);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star-o").toHaveCount(1);
 
     // click on the second star in edit mode
-    await click(".o_field_widget .o_priority a.o_priority_star.fa-star-o:last");
+    await click(".o_field_widget .o_priority button.o_priority_star.fa-star-o:last");
     await animationFrame();
 
-    expect(".o_field_widget .o_priority a.o_priority_star").toHaveCount(2);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star").toHaveCount(2);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star-o").toHaveCount(0);
+    expect(".o_field_widget .o_priority button.o_priority_star").toHaveCount(2);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star").toHaveCount(2);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star-o").toHaveCount(0);
 });
 
 test.tags("desktop");
@@ -147,28 +147,28 @@ test("PriorityField hover a star in form view", async () => {
     });
 
     expect(".o_field_widget .o_priority:not(.o_field_empty)").toHaveCount(1);
-    expect(".o_field_widget .o_priority a.o_priority_star").toHaveCount(2);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star").toHaveCount(1);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star-o").toHaveCount(1);
+    expect(".o_field_widget .o_priority button.o_priority_star").toHaveCount(2);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star").toHaveCount(1);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star-o").toHaveCount(1);
 
     // hover last star
-    const star = ".o_field_widget .o_priority a.o_priority_star.fa-star-o:last";
+    const star = ".o_field_widget .o_priority button.o_priority_star.fa-star-o:last";
     await hover(star);
     await animationFrame();
-    expect(".o_field_widget .o_priority a.o_priority_star").toHaveCount(2);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star").toHaveCount(2, {
+    expect(".o_field_widget .o_priority button.o_priority_star").toHaveCount(2);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star").toHaveCount(2, {
         message: "should temporary have two full stars since we are hovering the third value",
     });
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star-o").toHaveCount(0, {
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star-o").toHaveCount(0, {
         message: "should temporary have no empty star since we are hovering the third value",
     });
 
     await leave(star);
     await animationFrame();
 
-    expect(".o_field_widget .o_priority a.o_priority_star").toHaveCount(2);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star").toHaveCount(1);
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star-o").toHaveCount(1);
+    expect(".o_field_widget .o_priority button.o_priority_star").toHaveCount(2);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star").toHaveCount(1);
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star-o").toHaveCount(1);
 });
 
 test("PriorityField can write after adding a record -- kanban", async () => {
@@ -198,7 +198,7 @@ test("PriorityField can write after adding a record -- kanban", async () => {
     });
     expect(".o_kanban_record .fa-star").toHaveCount(0);
 
-    await click(".o_priority a.o_priority_star.fa-star-o");
+    await click(".o_priority button.o_priority_star.fa-star-o");
     // wait for web_save
     await animationFrame();
     expect.verifySteps(['web_save [[1],{"selection":"1"}]']);
@@ -209,7 +209,7 @@ test("PriorityField can write after adding a record -- kanban", async () => {
     await click(".o_kanban_quick_create .o_kanban_add");
     await animationFrame();
     expect.verifySteps(["web_save [[],{}]"]);
-    await click(".o_priority a.o_priority_star.fa-star-o");
+    await click(".o_priority button.o_priority_star.fa-star-o");
     await animationFrame();
     expect.verifySteps([`web_save [[6],{"selection":"1"}]`]);
     expect(".o_kanban_record .fa-star").toHaveCount(2);
@@ -224,14 +224,14 @@ test("PriorityField in editable list view", async () => {
     });
 
     expect(".o_data_row:first-child .o_priority:not(.o_field_empty)").toHaveCount(1);
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2, {
         message:
             "should have two stars for representing each possible value: no star, one star and two stars",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(1, {
         message: "should have one full star since the value is the second value",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(1, {
         message: "should have one empty star since the value is the second value",
     });
 
@@ -239,14 +239,14 @@ test("PriorityField in editable list view", async () => {
     await click("tbody td:not(.o_list_record_selector)");
     await animationFrame();
 
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2, {
         message:
             "should have two stars for representing each possible value: no star, one star and two stars",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(1, {
         message: "should have one full star since the value is the second value",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(1, {
         message: "should have one empty star since the value is the second value",
     });
 
@@ -254,28 +254,28 @@ test("PriorityField in editable list view", async () => {
     await click(".o_control_panel_main_buttons .o_list_button_save");
     await animationFrame();
 
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2, {
         message:
             "should have two stars for representing each possible value: no star, one star and two stars",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(1, {
         message: "should have one full star since the value is the second value",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(1, {
         message: "should have one empty star since the value is the second value",
     });
 
     // click on the first star in readonly mode
-    await click(".o_priority a.o_priority_star.fa-star");
+    await click(".o_priority button.o_priority_star.fa-star");
     await animationFrame();
 
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2, {
         message: "should still have two stars",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(0, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(0, {
         message: "should now have no full star since the value is the first value",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(2, {
         message: "should now have two empty stars since the value is the first value",
     });
 
@@ -283,27 +283,27 @@ test("PriorityField in editable list view", async () => {
     await click("tbody td:not(.o_list_record_selector)");
     await animationFrame();
 
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2, {
         message: "should still have two stars",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(0, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(0, {
         message: "should now have no full star since the value is the first value",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(2, {
         message: "should now have two empty stars since the value is the first value",
     });
 
     // Click on second star in edit mode
-    await click(".o_priority a.o_priority_star.fa-star-o:last");
+    await click(".o_priority button.o_priority_star.fa-star-o:last");
     await animationFrame();
 
-    expect(".o_data_row:last-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:last-child .o_priority button.o_priority_star").toHaveCount(2, {
         message: "should still have two stars",
     });
-    expect(".o_data_row:last-child .o_priority a.o_priority_star.fa-star").toHaveCount(2, {
+    expect(".o_data_row:last-child .o_priority button.o_priority_star.fa-star").toHaveCount(2, {
         message: "should now have two full stars since the value is the third value",
     });
-    expect(".o_data_row:last-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(0, {
+    expect(".o_data_row:last-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(0, {
         message: "should now have no empty star since the value is the third value",
     });
 
@@ -311,13 +311,13 @@ test("PriorityField in editable list view", async () => {
     await click(".o_control_panel_main_buttons .o_list_button_save");
     await animationFrame();
 
-    expect(".o_data_row:last-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:last-child .o_priority button.o_priority_star").toHaveCount(2, {
         message: "should still have two stars",
     });
-    expect(".o_data_row:last-child .o_priority a.o_priority_star.fa-star").toHaveCount(2, {
+    expect(".o_data_row:last-child .o_priority button.o_priority_star.fa-star").toHaveCount(2, {
         message: "should now have two full stars since the value is the third value",
     });
-    expect(".o_data_row:last-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(0, {
+    expect(".o_data_row:last-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(0, {
         message: "should now have no empty star since the value is the third value",
     });
 });
@@ -332,36 +332,36 @@ test("PriorityField hover in editable list view", async () => {
     });
 
     expect(".o_data_row:first-child .o_priority:not(.o_field_empty)").toHaveCount(1);
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2, {
         message:
             "should have two stars for representing each possible value: no star, one star and two stars",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(1, {
         message: "should have one full star since the value is the second value",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(1, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(1, {
         message: "should have one empty star since the value is the second value",
     });
 
     // hover last star
-    const star = ".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o:last";
+    const star = ".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o:last";
     await hover(star);
     await animationFrame();
 
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2);
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(2, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2);
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(2, {
         message: "should temporary have two full stars since we are hovering the third value",
     });
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(0, {
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(0, {
         message: "should temporary have no empty star since we are hovering the third value",
     });
 
     await leave(star);
     await animationFrame();
 
-    expect(".o_data_row:first-child .o_priority a.o_priority_star").toHaveCount(2);
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star").toHaveCount(1);
-    expect(".o_data_row:first-child .o_priority a.o_priority_star.fa-star-o").toHaveCount(1);
+    expect(".o_data_row:first-child .o_priority button.o_priority_star").toHaveCount(2);
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star").toHaveCount(1);
+    expect(".o_data_row:first-child .o_priority button.o_priority_star.fa-star-o").toHaveCount(1);
 });
 
 test("PriorityField with readonly attribute", async () => {
@@ -383,7 +383,7 @@ test("PriorityField with readonly attribute", async () => {
     await hover(".o_priority_star.fa-star-o:last");
     await animationFrame();
     expect.step("hover");
-    expect(".o_field_widget .o_priority a.o_priority_star.fa-star").toHaveCount(0, {
+    expect(".o_field_widget .o_priority button.o_priority_star.fa-star").toHaveCount(0, {
         message: "should have no full stars on hover since the field is readonly",
     });
     await click(".o_priority_star.fa-star-o:last");
@@ -403,7 +403,7 @@ test('PriorityField edited by the smart action "Set priority..."', async () => {
         resId: 1,
     });
 
-    expect("a.fa-star").toHaveCount(1);
+    expect("button.fa-star").toHaveCount(1);
 
     await press(["control", "k"]);
     await animationFrame();
@@ -414,7 +414,7 @@ test('PriorityField edited by the smart action "Set priority..."', async () => {
     expect(queryAllTexts(".o_command")).toEqual(["Normal", "Blocked", "Done"]);
     await click("#o_command_2");
     await animationFrame();
-    expect("a.fa-star").toHaveCount(2);
+    expect("button.fa-star").toHaveCount(2);
 });
 
 test("PriorityField - auto save record when field toggled", async () => {
@@ -432,7 +432,7 @@ test("PriorityField - auto save record when field toggled", async () => {
                 </sheet>
             </form>`,
     });
-    await click(".o_field_widget .o_priority a.o_priority_star.fa-star-o:last");
+    await click(".o_field_widget .o_priority button.o_priority_star.fa-star-o:last");
     await animationFrame();
     expect.verifySteps(["web_save"]);
 });
@@ -453,7 +453,7 @@ test("PriorityField - prevent auto save with autosave option", async () => {
             </form>`,
     });
 
-    await click(".o_field_widget .o_priority a.o_priority_star.fa-star-o:last");
+    await click(".o_field_widget .o_priority button.o_priority_star.fa-star-o:last");
     await animationFrame();
     expect.verifySteps([]);
 });

--- a/addons/web/static/tests/webclient/settings_form_view/res_config_dev_tool.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/res_config_dev_tool.test.js
@@ -38,7 +38,7 @@ test("Simple render", async () => {
     expect(router.current).toEqual({});
     expect(".o_widget_res_config_dev_tool").toHaveCount(1);
     expect(queryAllTexts`#developer_tool h2`).toEqual(["Developer Tools"]);
-    expect(queryAllTexts`#developer_tool .o_setting_right_pane .d-block`).toEqual([
+    expect(queryAllTexts`#developer_tool .o_setting_right_pane button`).toEqual([
         "Activate the developer mode",
         "Activate the developer mode (with assets)",
         "Activate the developer mode (with tests assets)",
@@ -66,7 +66,7 @@ test("Activate the developer mode", async () => {
         resModel: "res.config.settings",
     });
     expect(router.current).toEqual({});
-    await click("a:contains('Activate the developer mode')");
+    await click("button:contains('Activate the developer mode')");
     await tick();
     expect(router.current).toEqual({ debug: 1 });
     expect.verifySteps(["location reload"]);
@@ -93,7 +93,7 @@ test("Activate the developer mode (with assets)", async () => {
         resModel: "res.config.settings",
     });
     expect(router.current).toEqual({});
-    await click("a:contains('Activate the developer mode (with assets)')");
+    await click("button:contains('Activate the developer mode (with assets)')");
     await tick();
     expect(router.current).toEqual({ debug: "assets" });
     expect.verifySteps(["location reload"]);
@@ -121,7 +121,7 @@ test("Activate the developer mode (with tests assets)", async () => {
     });
     expect(router.current).toEqual({});
 
-    await click("a:contains('Activate the developer mode (with tests assets)')");
+    await click("button:contains('Activate the developer mode (with tests assets)')");
     await tick();
     expect(router.current).toEqual({ debug: "assets,tests" });
     expect.verifySteps(["location reload"]);
@@ -150,11 +150,11 @@ test("Activate the developer modeddd (with tests assets)", async () => {
     });
     expect(router.current).toEqual({ debug: "assets,tests" });
 
-    expect(queryAllTexts`#developer_tool .o_setting_right_pane .d-block`).toEqual([
+    expect(queryAllTexts`#developer_tool .o_setting_right_pane button`).toEqual([
         "Deactivate the developer mode",
     ]);
 
-    await click("a:contains('Deactivate the developer mode')");
+    await click("button:contains('Deactivate the developer mode')");
     await tick();
     expect(router.current).toEqual({ debug: 0 });
     expect.verifySteps(["location reload"]);


### PR DESCRIPTION
This commit introduces the `.btn-link-inline` class to reproduce the inline styling of a `<a href="...">` tag as a variant of Bootstrap's `.btn.btn-link`.

This allows to properly uses `<button>` element for interactive DOM elements instead of relying on a "hacky" and non-semantic `<a href="#">` (tl;dr: `<a>` HTML tag are for navigation, `<button>` are for interactivity).

task-4380519