### PR TITLE
[FIX] pos: correct change calculation when using quick amount buttons

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -92,11 +92,11 @@ export class PosOrderAccounting extends Base {
         }
 
         const total =
-            Math.abs(this.priceIncl) -
-            Math.abs(this.amountPaid) +
-            (isNegative ? -roundingSanatizer : roundingSanatizer);
+            Math.abs(this.amountPaid) -
+            Math.abs(this.priceIncl) +
+            (isNegative ? roundingSanatizer : -roundingSanatizer);
 
-        const amount = isNegative ? -this.currency.round(total) : this.currency.round(total);
+        const amount = this.currency.round(total);
         return this.config.cash_rounding
             ? this.config.rounding_method.asymmetricRound(amount)
             : amount;

--- a/doc/cla/individual/mitbhavsaar.md
+++ b/doc/cla/individual/mitbhavsaar.md
@@ -1,0 +1,4 @@
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement.
+
+Name: Mit Bhavsar
+Email: mitbhavsaar@gmail.com


### PR DESCRIPTION
Description:
This PR fixes an issue in the POS payment screen where using the quick amount
buttons (+10, +20, +50) could result in an incorrect change amount.

Current behavior before PR:
When a cashier uses the quick amount buttons, the payment line amount is updated,
but the internal total computation could lead to an incorrect (negative or
inconsistent) change value due to the way price and paid amounts were combined
and rounded.

Desired behavior after PR:
Using the quick amount buttons correctly updates the payment amount and computes
the change accurately, ensuring consistent rounding and correct sign handling.

Root cause:
The total amount used for change calculation mixed `priceIncl` and `amountPaid`
in a way that caused incorrect totals, especially when quick increments were
applied.

Fix:
Reorder and simplify the total computation to ensure consistent rounding and
correct change calculation when using quick amount buttons.

Steps to reproduce:
- Start a POS session
- Create an order with a total amount
- Go to the payment screen
- Use the +10 / +20 / +50 buttons
- Observe the change amount

Affected version:
- 19.0

I confirm I have signed the CLA and read the PR guidelines at
https://www.odoo.com/submit-pr
