### PR TITLE
[FIX] web: Support reserved words as customer names

### DIFF
--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -447,7 +447,7 @@ export class GraphModel extends Model {
         if (order !== null && mode !== "pie" && domains.length === 1 && groupBy.length > 0) {
             // group data by their x-axis value, and then sort datapoints
             // based on the sum of values by group in ascending/descending order
-            const groupedDataPoints = {};
+            const groupedDataPoints = Object.create(null);
             for (const dataPt of processedDataPoints) {
                 const key = dataPt.labels[0]; // = x-axis value under the current assumptions
                 if (!groupedDataPoints[key]) {

--- a/addons/web/static/tests/views/graph_view_tests.js
+++ b/addons/web/static/tests/views/graph_view_tests.js
@@ -4764,4 +4764,25 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(graph.model.data.datasets.length, 600);
         assert.strictEqual(graph.model.data.labels.length, 600);
     });
+
+    QUnit.test("graph view reserved word", async function (assert) {
+        // Check that the use of reserved words does not interfere with the view.
+        assert.expect(2);
+
+        serverData.models.product.records.push({ id: 38, display_name: "constructor" });
+        serverData.models.foo.records[7].product_id = 38;
+
+        const graph = await makeView({
+            serverData,
+            type: "graph",
+            resModel: "foo",
+            arch: `
+                <graph order="DESC">
+                    <field name="product_id"/>
+                </graph>
+            `,
+        });
+        checkLabels(assert, graph, ["xphone", "xpad", "constructor"]);
+        checkDatasets(assert, graph, ["data", "label"], [{ data: [4, 3, 1], label: "Count" }]);
+    });
 });


### PR DESCRIPTION
Steps:
- Have a customer named "constructor" (or any valid json prototype key value)
- Install `sale_management`
- Create a sale order with "constructor"
- Open Reporting -> Customers
- Traceback `Caused by: TypeError: groupedDataPoints[key].push is not a function`

This problem occurs because we use the client name directly in an object, and “constructor” already exists in all objects but is not initialized correctly, which raises a traceback.
One solution is to use `let object = Object.create(null)` instead of `let object = {}`, which prevents inheritance of `Object.prototype` properties.

https://github.com/odoo/odoo/blob/5e74f04ff35ed3efa25be295567be41f42024692/addons/web/static/src/views/graph/graph_model.js#L451-L457

opw-5474691