### PR TITLE
[FIX] account: error when printing statement

### DIFF
--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.js
@@ -27,7 +27,10 @@ export class AccountMoveListController extends FileUploadListController {
     }
 
     async loadExtraPrintItems() {
-        return this.orm.call("account.move", "get_extra_print_items", [this.actionMenuProps.getActiveIds()]);
+        if (this.actionMenuProps.resModel === "account.move") {
+            return this.orm.call("account.move", "get_extra_print_items", [this.actionMenuProps.getActiveIds()]);
+        }
+        return []
     }
 
     async onDeleteSelectedRecords() {


### PR DESCRIPTION
When trying to print a statement via the list view, we get a traceback.

This is because the module `account_bank_statement_import` inherits the
`view_bank_statement_tree` and use `accountMoveUploadListView` which use
`AccountMoveListController`. Therefore, when calling
`get_extra_print_items` from the controller, we call it with model
`account.move` but with a statement id, which leads to either wrong
behavior or access error.

Steps:

- Make sure account_bank_statement_import is installed
- Have 2 companies
- Create a bank statement for company B, make sure it has the same id as
  any account move from company A
- From the bank statement list view, select the statement
- Click on the print button
-> Traceback

opw-5427019
