### PR TITLE
[FIX] account: Fixed large spacing in invoicing dashboard

### DIFF
--- a/addons/account/static/src/components/bill_guide/bill_guide.scss
+++ b/addons/account/static/src/components/bill_guide/bill_guide.scss
@@ -25,7 +25,7 @@
 }
 
 .mb-9 {
-    margin-bottom: 9rem;
+    margin-bottom: 9rem !important;
 }
 
 .account_drag_drop_btn {

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -1,15 +1,18 @@
 <templates>
 
     <t t-name="account.BillGuide">
-         <div class="d-flex flex-row bill_guide_container mb-9">
+         <div class="d-flex flex-row bill_guide_container mb-3" t-att-class="{ 'mb-9': props.largeIcons }">
             <div class="bill_guide_left d-flex align-items-center justify-content-center py-3">
                 <div>
-                    <img class="bill-guide-img" src="/web/static/img/folder.svg"/>
+                    <div class="text-center">
+                        <img t-att-class="{ 'bill-guide-img': props.largeIcons }" src="/web/static/img/folder.svg"/>
+                    </div>
                     <div class="text-center mt-2">
-                        <span class="btn btn-lg account_drag_drop_btn pe-none">Drag &amp; drop</span>
+                        <span class="btn account_drag_drop_btn pe-none" t-att-class="{ 'btn-lg': props.largeIcons }">Drag &amp; drop</span>
                         <div>
                             <span class="btn pe-none px-1 fw-normal">or</span>
-                            <a class="btn btn-lg btn-link px-0 fw-normal"
+                            <a class="btn btn-link px-0 fw-normal"
+                                t-att-class="{ 'btn-lg': props.largeIcons }"
                                 href="#"
                                 type="object"
                                 name="action_create_vendor_bill"
@@ -34,7 +37,9 @@
             </div>
             <div class="bill_guide_right d-flex align-items-center justify-content-center py-3">
                 <div t-if="alias">
-                    <img class="bill-guide-img" src="/account/static/src/img/bill.svg" alt="Email bills"/>
+                    <div class="text-center">
+                        <img t-att-class="{ 'bill-guide-img': props.largeIcons }" src="/account/static/src/img/bill.svg" alt="Email bills"/>
+                    </div>
                     <div class="text-center mt-2">
                         <div class="">
                             <span class="btn pe-none px-1 fw-normal">Send a bill to</span>
@@ -54,7 +59,9 @@
                     </div>
                 </div>
                 <div t-else="">
-                    <img class="bill-guide-img" src="/web/static/img/bill.svg" alt="Create bill manually"/>
+                    <div class="text-center">
+                        <img t-att-class="{ 'bill-guide-img': props.largeIcons }" src="/web/static/img/bill.svg" alt="Create bill manually"/>
+                    </div>
                     <div class="text-center mt-2">
                         <div class="">
                             <a href="#"

--- a/addons/account/static/src/views/account_move_list/account_move_list_renderer.xml
+++ b/addons/account/static/src/views/account_move_list/account_move_list_renderer.xml
@@ -6,7 +6,7 @@
                 <t t-if="this.env.searchModel._context?.default_move_type == 'in_invoice'">
                     <div class="o_view_nocontent">
                         <div class="o_nocontent_help">
-                            <BillGuide/>
+                            <BillGuide largeIcons="true"/>
                         </div>
                     </div>
                 </t>


### PR DESCRIPTION
As a part of task-5258726 the icons of no-content help in bills list view were enlarged.
The icons used there were also used in the module dashboard, so enlarging them messed the dashboard styling.

This commit fixes this issue by using a prop `largeIcons` on the `BillGuide` componenet to make it with large icons when needed only (in the bills list view no content help).

task-5801970



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
