### PR TITLE
[IMP] base: rewrite IrModule.upstream_dependencies to use an RCTE

### DIFF
--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -43,7 +43,7 @@ class WebsiteBackend(http.Controller):
         show the progress between installed and yet to install features.
         """
         features_not_installed = request.env['website.configurator.feature']\
-            .browse(selected_features).module_id.upstream_dependencies(exclude_states=('',))\
+            .browse(selected_features).module_id.upstream_dependencies(exclude_states=())\
             .filtered(lambda feature: feature.state != 'installed')
 
         # On the 1st run, the total tallies the targeted, not yet installed

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -314,7 +314,7 @@ class IrModuleModule(models.Model):
             :return: recordset of themes ``ir.module.module``
         """
         self.ensure_one()
-        return self.upstream_dependencies(exclude_states=('',)).filtered(lambda x: x.name.startswith('theme_'))
+        return self.upstream_dependencies(exclude_states=()).filtered(lambda x: x.name.startswith('theme_'))
 
     def _theme_get_downstream(self):
         """

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -5,6 +5,7 @@ import logging
 import os
 import platform
 import shutil
+import warnings
 from collections import OrderedDict, defaultdict
 from textwrap import dedent
 
@@ -21,7 +22,7 @@ from odoo.exceptions import AccessDenied, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.modules.module import Manifest, MissingDependency
-from odoo.tools import config
+from odoo.tools import config, SQL
 from odoo.tools.misc import get_flag, topological_sort
 from odoo.tools.parse_version import parse_version
 from odoo.tools.translate import (
@@ -552,23 +553,34 @@ class IrModuleModule(models.Model):
         """
         if not self:
             return self
+        if known_deps is not None:
+            warnings.warn(
+                "The `known_deps` parameter is deprecated since Odoo 20.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
         self.flush_model(['name', 'state'])
         self.env['ir.module.module.dependency'].flush_model(['module_id', 'name'])
-        known_deps = known_deps or self.browse()
-        query = """ SELECT DISTINCT m.id
-                    FROM ir_module_module_dependency d
-                    JOIN ir_module_module m ON (d.module_id=m.id)
-                    WHERE
-                        m.name IN (SELECT name from ir_module_module_dependency where module_id in %s) AND
-                        m.state NOT IN %s AND
-                        m.id NOT IN %s """
-        self.env.cr.execute(query, (tuple(self.ids), tuple(exclude_states), tuple(known_deps.ids or self.ids)))
-        new_deps = self.browse([row[0] for row in self.env.cr.fetchall()])
-        missing_mods = new_deps - known_deps
-        known_deps |= new_deps
-        if missing_mods:
-            known_deps |= missing_mods.upstream_dependencies(known_deps, exclude_states)
-        return known_deps
+        self.env.cr.execute(SQL(
+            """
+            WITH RECURSIVE dependencies AS (
+                SELECT m.id
+                FROM ir_module_module_dependency d
+                JOIN ir_module_module m ON (d.name = m.name)
+                WHERE d.module_id = any(%(ids)s) AND m.state != all(%(states)s)
+            UNION
+                SELECT m.id
+                FROM dependencies
+                JOIN ir_module_module_dependency d ON (d.module_id = dependencies.id)
+                JOIN ir_module_module m ON (d.name = m.name)
+                WHERE m.state != all(%(states)s)
+            )
+            SELECT id FROM dependencies WHERE id != any(%(ids)s)
+            """,
+            ids=self.ids,
+            states=list(exclude_states),
+        ))
+        return self.browse(row[0] for row in self.env.cr.fetchall())
 
     def next(self):
         """


### PR DESCRIPTION
Looping through every module of community + enterprise (1367 modules) and getting their entire set of dependencies, the new version runs in about a third the time on my machine (1.5s to 4.2s), yielding a result that's almost identical: the new version includes `base`, the old one did not (not sure why, or how).

Now supports calling with `exclude_states=()`, which did not work previously and led to wonky workarounds e.g.

    self.upstream_dependencies(exclude_states=('',))

or

    module.upstream_dependencies(exclude_states=('uninstallable'))

(which the keen-eyed will notice does not pass a tuple so excludes the individual non-existent states `u`, `n`, `i`, `s`, `t`, `a`, `l`, `b`, and `e`).

Also drops support for `known_deps`: it's not used anywhere and doesn't really seem useful.
