### PR TITLE
[FIX] point_of_sale: close customer display popup

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -168,7 +168,7 @@ export class Navbar extends Component {
         }/${getDeviceUuid()}`;
 
         this.dialog.add(QrCodeCustomerDisplay, {
-            customerDisplayURL: `${this.pos.session._base_url}${customer_display_url}`,
+            customerDisplayURL: `${this.pos.config._base_url}${customer_display_url}`,
         });
     }
 

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
@@ -27,6 +27,7 @@ export class QrCodeCustomerDisplay extends Component {
             "width=800,height=600,left=200,top=200"
         );
         this.notification.add(_t("PoS Customer Display opened in a new window"));
+        this.props.close();
     }
 
     showQr() {


### PR DESCRIPTION
When opening the customer display in POS, the popup would open a new window with the display and show a notification that the window is opened successfully, but the popup would remain active.

This PR is to make the popup close when the customer display is opened.

Task-[5867558](https://www.odoo.com/odoo/project/1737/tasks/5867558)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
