### PR TITLE
[FIX] html_builder, website, website_sale: avoid timeout dialog actions

### DIFF
--- a/addons/html_builder/static/src/core/operation_plugin.js
+++ b/addons/html_builder/static/src/core/operation_plugin.js
@@ -56,7 +56,7 @@ export class OperationPlugin extends Plugin {
 
         this.services.notification.add(
             _t(
-                "A technical issue occured in the builder, you should save or discard your changes."
+                "A technical issue occurred in the builder, you should save or discard your changes."
             ),
             {
                 type: "danger",

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -407,6 +407,7 @@ export class SwitchThemeAction extends BuilderAction {
     static dependencies = ["savePlugin"];
     setup() {
         this.preview = false;
+        this.canTimeout = false;
     }
     async apply() {
         const save = await new Promise((resolve) => {
@@ -433,6 +434,7 @@ export class AddLanguageAction extends BuilderAction {
     static dependencies = ["savePlugin"];
     setup() {
         this.preview = false;
+        this.canTimeout = false;
     }
     async apply() {
         const def = new Deferred();

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -990,6 +990,9 @@ export class AddActionFieldAction extends BuilderAction {
 export class PromptSaveRedirectAction extends BuilderAction {
     static id = "promptSaveRedirect";
     static dependencies = ["savePlugin"];
+    setup() {
+        this.canTimeout = false;
+    }
     apply({ params: { mainParam } }) {
         const redirectToAction = (action) => {
             redirect(`/odoo/action-${encodeURIComponent(action)}`);

--- a/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_ribbon_options_plugin.js
@@ -393,6 +393,9 @@ class ModifyRibbonAction extends BuilderAction {
 class DeleteRibbonAction extends BuilderAction {
     static id = 'deleteRibbon';
     static dependencies = ['productsRibbonOptionPlugin'];
+    setup() {
+        this.canTimeout = false;
+    }
     async apply({ editingElement }) {
         const save = await new Promise((resolve) => {
             this.services.dialog.add(ConfirmationDialog, {


### PR DESCRIPTION
Commit 6df83abb35c95ab42e55d9a08cf6c411efa64b3e added a timeout on operations, as an heuristic to detect when an operation is stuck. This timeout may be triggered when the action opens a dialog and wait for user choice.

This commit sets `canTimeout = false` on actions that open a dialog and wait for user choice in the `apply` method.

Steps to reproduce:
- Open website builder
- Click on "Theme" tab
- Click "Add a language"
- Wait a bit
- Bug: It show the error message "A technical issue occurred..."

task-5867364