### PR TITLE
[IMP] l10n_be_hr_payroll: add Night and Shift work entry types

### DIFF
--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -1009,6 +1009,33 @@
         <field name="category" eval="'absence'"/>
     </record>
 
+    <record id="work_entry_type_night_work" model="hr.work.entry.type">
+        <field name="name">Night Work</field>
+        <field name="code">WORK_NIGHT</field>
+        <field name="display_code">NW</field>
+        <field name="color">1</field>
+        <field name="category" eval="'working_time'"/>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
+    <record id="work_entry_type_shift_work" model="hr.work.entry.type">
+        <field name="name">Shift Work</field>
+        <field name="code">WORK_SHIFT</field>
+        <field name="display_code">SW</field>
+        <field name="color">2</field>
+        <field name="category" eval="'working_time'"/>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
+    <record id="work_entry_type_night_shift_work" model="hr.work.entry.type">
+        <field name="name">Night Shift Work</field>
+        <field name="code">WORK_NIGHT_SHIFT</field>
+        <field name="display_code">NSW</field>
+        <field name="color">3</field>
+        <field name="category" eval="'working_time'"/>
+        <field name="country_id" ref="base.be"/>
+    </record>
+
 <!-- CH : Switzerland -->
     <record id="l10n_ch_work_entry_type_bank_holiday" model="hr.work.entry.type">
         <field name="name">Public Holiday</field>


### PR DESCRIPTION
This commit introduces specific work entry types required to distinguish standard attendance from night and shift work in Belgian payroll.

These new types are necessary to correctly calculate the Night Shift & Team Work withholding tax exemption (Nature 274.06), as the eligibility depends on the specific ratio of night hours worked.

Added Work Entry Types (Category: Working Time):
- Night Work (WORK_NIGHT)
- Shift Work (WORK_SHIFT)
- Night Shift Work (WORK_NIGHT_SHIFT)

task-5431636

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
