### PR TITLE
[FIX] mail: fix avatar local time failing test

### DIFF
--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -143,7 +143,7 @@ test("Avatar card shows local timezone", async () => {
     await click(".o-discuss-ChannelMember:has(:text('Demo'))");
     await waitStoreFetch(["avatar_card"]);
     await contains(".o-mail-avatar-card-name:text('Demo')");
-    await contains(".o-mail-avatar-card-localtime", { text: "" });
+    await contains(".o-mail-avatar-card-localtime", { count: 0 });
 });
 
 test("should show a button to load more members if they are not all loaded", async () => {


### PR DESCRIPTION
The `Avatar card shows local timezone` ensure partner local time is shown in the avatar card when the user that consults it has a different tz.

This test also ensures that nothing is shown when timezone are the same. However, the assertion expects to find the node containing the text in the DOM while it's not rendered when both tz are the same.

This commit fixes the issue.

runbot-238383

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
