### PR TITLE
[FIX] hr_holidays, *: no access error on fetching portal partner data

### DIFF
--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -37,7 +37,8 @@ class ResPartner(models.Model):
     def _to_store_defaults(self, target):
         defaults = super()._to_store_defaults(target)
         if target.is_internal(self.env):
+            # sudo: res.users - to access other company's portal user leave date
             defaults.append(
-                Store.One("main_user_id", Store.Many("employee_ids", "leave_date_to"))
+                Store.One("main_user_id", Store.Many("employee_ids", "leave_date_to", sudo=True)),
             )
         return defaults

--- a/addons/test_discuss_full/tests/__init__.py
+++ b/addons/test_discuss_full/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_im_livechat_portal
 from . import test_performance
 from . import test_performance_inbox
 from . import test_livechat_session_open
+from . import test_res_partner

--- a/addons/test_discuss_full/tests/test_res_partner.py
+++ b/addons/test_discuss_full/tests/test_res_partner.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tools.discuss import Store
+
+
+class TestResPartner(MailCommon):
+
+    def test_portal_user_store_data_access(self):
+        portal_user = mail_new_test_user(self.env, login="portal-user", groups="base.group_portal")
+        Store().add(portal_user.partner_id.with_user(self.user_employee_c2))


### PR DESCRIPTION
* = test_discuss_full

Before this commit, mentioning a portal user from another company would result in an access error.

Steps to reproduce:
1. Install `hr_holidays` module. 2 Have a portal user in company A.
3. Switch the active company to company B.
4. In any chatter, try to mention said portal user.

This happens because portal user read access depends on the current active company (see `res_users_rule`).
The access error happens since [1], which added user information to the partner's default Store fields.

[1] https://github.com/odoo/odoo/pull/212173

task-5499827