### PR TITLE
[FIX] html_editor, mass_mailing: ensure simple links inherit font-size

### DIFF
--- a/addons/html_editor/static/src/main/link/link.scss
+++ b/addons/html_editor/static/src/main/link/link.scss
@@ -20,10 +20,14 @@
     // Unset the font size and family applied by `.btn` 
     // if inside `FONT_SIZE_CLASSES`.
     span[class$="-fs"],
-    span.small {
-        .btn:not(:has(span[class$="-fs"], span.small)) {
+    span.small,
+    span[style*="font-size"] {
+        .btn:not(:has(span[class$="-fs"], span.small, span[style*="font-size"])) {
             font-family: unset;
             font-size: unset;
+        }
+        a:not(.btn) {
+            font-size: inherit !important;
         }
     }
     font[class^="text-o-"] a,


### PR DESCRIPTION
Ensure that a simple link can inherit from an ancestor `font-size` defined using
the Editor toolbar, overriding the `mass_mailing` Design Tab `--link-font-size`
special variable.

That variable will be removed in the future, because it is more natural that a
link font-size is aligned with its container.

task-5868086
