### PR TITLE
[REF] iot_drivers: simplify serial drivers

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_be_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_be_driver.py
@@ -320,8 +320,5 @@ class BlackBoxDriver(SerialDriver):
     def run(self):
         with serial_connection(self.device_identifier, self._protocol) as connection:
             self._connection = connection
-            self.data['status'] = self.STATUS_CONNECTED
             while not self._stopped.is_set():
                 time.sleep(self._protocol.newMeasureDelay)
-
-            self.data['status'] = self.STATUS_DISCONNECTED


### PR DESCRIPTION
We simplify serial drivers by:
- making toledo scale the base scale driver (adam can still inherit),
- removing community specific code to maintain consistency (IoT is now enterprise only),
- simplifying scale serial port read,

see odoo/enterprise#105166