### PR TITLE
[IMP] account_edi_ubl_cii: (un)group lines by tax

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -27,6 +27,7 @@ Pro rules and show the errors.
         'data/cii_22_templates.xml',
         'data/ubl_20_templates.xml',
         'data/ubl_21_templates.xml',
+        'views/account_move_views.xml',
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
         'wizard/account_move_send_views.xml',

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from odoo import api, fields, models
+import re
+
+from odoo import _, api, fields, models, Command
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -16,6 +19,121 @@ class AccountMove(models.Model):
         string="UBL/CII File",
         copy=False,
     )
+
+    # -------------------------------------------------------------------------
+    # ACTIONS
+    # -------------------------------------------------------------------------
+    def action_group_ungroup_lines_by_tax(self):
+        """
+        This action allows the user to reload an imported move, grouping or not lines by tax
+        """
+        self.ensure_one()
+        self._check_move_for_group_ungroup_lines_by_tax()
+
+        # Check if lines look like they're grouped
+        lines_grouped = any(
+            re.match(re.escape(self.partner_id.name or _("Unknown partner")) + r' - \d+ - .*', line.name)
+            for line in self.line_ids.filtered(lambda x: x.display_type == 'product')
+        )
+
+        if lines_grouped:
+            self._ungroup_lines()
+        else:
+            self._group_lines_by_tax()
+
+    def _ungroup_lines(self):
+        """
+        Ungroup lines using the original file, used to import the move
+        """
+        error_message = _("Cannot find the origin file, try by importing it again")
+        attachments = self.env['ir.attachment'].search([
+            ('res_model', '=', 'account.move'),
+            ('res_id', '=', self.id),
+        ], order='create_date')
+        if not attachments:
+            raise UserError(error_message)
+
+        success = False
+        for file_data in attachments._unwrap_edi_attachments():
+            if file_data.get('xml_tree') is None:
+                continue
+            ubl_cii_xml_builder = self._get_ubl_cii_builder_from_xml_tree(file_data['xml_tree'])
+            if ubl_cii_xml_builder is None:
+                continue
+            self.invoice_line_ids = [Command.clear()]
+            res = ubl_cii_xml_builder._import_invoice_ubl_cii(self, file_data)
+            if res:
+                success = True
+                self._message_log(body=_("Ungrouped lines from %s", file_data['attachment'].name))
+                break
+        if not success:
+            raise UserError(error_message)
+
+    def _group_lines_by_tax(self):
+        """
+        Group lines by tax, based on the invoice lines
+        """
+        line_vals = self._get_line_vals_group_by_tax(self.partner_id, fields.Date.to_string(self.date))
+        self.invoice_line_ids = [Command.clear()]
+        self.invoice_line_ids = line_vals
+        self._message_log(body=_("Grouped lines by tax"))
+
+    def _get_line_vals_group_by_tax(self, partner, date):
+        """
+        Create a collection of dicts containing the values to create invoice lines, grouped by
+        tax and deferred date if present.
+        :param partner: partner linked to the move
+        :param date: date of the move (string format)
+        """
+        base_lines = [
+            line._convert_to_tax_base_line_dict()
+            for line in self.line_ids.filtered(lambda x: x.display_type == 'product')
+        ]
+
+        to_process = []
+        for base_line in base_lines:
+            to_update_vals, tax_values_list = self.env['account.tax']._compute_taxes_for_single_line(base_line)
+            to_process.append((base_line, to_update_vals, tax_values_list))
+
+        deferred = 'deferred_start_date' in self.env['account.move.line']._fields  # enterprise field
+
+        def grouping_key_generator(base_line, tax_values):
+            dates = (False, False)
+            record = base_line['record']
+            if deferred:
+                dates = (record.deferred_start_date, record.deferred_end_date)
+            return {'tax': (record.tax_ids, record.account_id, dates)}
+
+        aggregated_lines = self.env['account.tax'].with_company(self.company_id)._aggregate_taxes(to_process, grouping_key_generator=grouping_key_generator)
+
+        to_create = []
+        for tax_detail in aggregated_lines['tax_details'].values():
+            taxes, account, (deferred_start_date, deferred_end_date) = tax_detail['tax']
+            vals = {
+                'name': " - ".join([partner.name or _("Unknown partner"), account.code, " / ".join([tax.name for tax in taxes]) or _("Untaxed")]),
+                'quantity': 1,
+                'price_unit': tax_detail['base_amount_currency'],
+                'tax_ids': [Command.link(tax.id) for tax in taxes],
+                'account_id': account.id,
+            }
+            if deferred:
+                vals.update({'deferred_start_date': deferred_start_date, 'deferred_end_date': deferred_end_date})
+            to_create.append(Command.create(vals))
+
+        return to_create
+
+    def _check_move_for_group_ungroup_lines_by_tax(self):
+        """
+        Perform checks to evaluate if a move is eligible to grouping/ungrouping
+        """
+        if not self.is_purchase_document(include_receipts=True):
+            raise UserError(_("You can only (un)group lines of a incoming invoice (vendor bill)"))
+        if self.state != 'draft':
+            raise UserError(_("You can only (un)group lines of a draft invoice"))
+        # TO REMOVE IN 18.0+ as purchase_edi_ubl_bis module is created
+        if 'purchase_order_id' in self.env['account.move.line']._fields:  # purchase field
+            if any(line.purchase_order_id for line in self.line_ids):
+                raise UserError(_("You can only (un)group lines of an invoice not linked to a purchase order"))
 
     # -------------------------------------------------------------------------
     # EDI

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_group_by_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_group_by_tax.xml
@@ -1,0 +1,184 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>FAC/2023/00052</cbc:ID>
+  <cbc:IssueDate>2023-08-04</cbc:IssueDate>
+  <cbc:DueDate>2023-09-04</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>FAC/2023/00052</cbc:ID>
+    <cbc:SalesOrderID>S00012</cbc:SalesOrderID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>FAC_2023_00052.pdf</cbc:ID>
+    <cac:Attachment>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9938">LU25587702</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>ALD Automotive LU</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>270 rte d'Arlon</cbc:StreetName>
+        <cbc:CityName>Strassen</cbc:CityName>
+        <cbc:PostalZone>8010</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>LU12977109</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>ALD Automotive LU</cbc:RegistrationName>
+        <cbc:CompanyID>LU12977109</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>ALD Automotive LU</cbc:Name>
+        <cbc:ElectronicMail>adl@test.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9938">LU25587702</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>Odoo Lu</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rue de l'industrie 13</cbc:StreetName>
+        <cbc:CityName>Windhof</cbc:CityName>
+        <cac:Country>
+          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>LU25587702</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>Odoo Lu</cbc:RegistrationName>
+        <cbc:CompanyID>LU25587702</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>Odoo Lu</cbc:Name>
+        <cbc:ElectronicMail>odoo@test.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Rue de l'industrie 13</cbc:StreetName>
+        <cbc:CityName>Windhof</cbc:CityName>
+        <cac:Country>
+          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>FAC/2023/00052</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>LU071241358706500000</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">369.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">600.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">96.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>16.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">1300.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">273.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">1900.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">1900.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2269.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">2269.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">600.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>Locations et leasing opérationnel - Véhicule HG6542</cbc:Description>
+      <cbc:Name>Locations et leasing opérationnel</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>16.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">600.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">300.0</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>A product 21% tax</cbc:Description>
+      <cbc:Name>Product 21%</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">300.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="EA">2.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">1000.0</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>An other product 21% tax</cbc:Description>
+      <cbc:Name>Other product 21%</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">500.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/views/account_move_views.xml
+++ b/addons/account_edi_ubl_cii/views/account_move_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record model="ir.actions.server" id="action_group_ungroup_lines_by_tax">
+            <field name="name">(Un)Group lines by tax</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
+            <field name="binding_model_id" ref="account.model_account_move"/>
+            <field name="state">code</field>
+            <field name="binding_view_types">form</field>
+            <field name="code">
+                if records:
+                    records.action_group_ungroup_lines_by_tax()
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
[IMP] account_edi_ubl_cii: (un)group lines by tax
    
Once an invoice is imported, a server action allows the user to group
lines by tax, and then if the same action is triggered again it will
ungroup all lines from the origin file
    
This feature is useful because accountants don't always need the
detail of the vendor bills, and also all the lines clutter up the
journal items
    
task-5047859