### PR TITLE
[IMP] mass_mailing: remove Design Tab --link-font-size

### DIFF
--- a/addons/mass_mailing/static/src/builder/plugins/customize_mailing_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/customize_mailing_plugin.js
@@ -2,8 +2,10 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { memoize } from "@web/core/utils/functions";
-import { CUSTOMIZE_MAILING_VARIABLES } from "@mass_mailing/builder/plugins/customize_mailing_variables";
-import { CUSTOMIZE_MAILING_VARIABLES_DEFAULTS } from "./customize_mailing_variables";
+import {
+    CUSTOMIZE_MAILING_VARIABLES,
+    CUSTOMIZE_MAILING_VARIABLES_DEFAULTS,
+} from "@mass_mailing/builder/plugins/customize_mailing_variables";
 import { splitSelectorAroundCommasOutsideParentheses } from "@mail/views/web/fields/html_mail_field/convert_inline";
 
 const RE_SELECTOR_ENDS_WITH_GT_STAR = />\s*\*\s*$/;

--- a/addons/mass_mailing/static/src/builder/plugins/customize_mailing_variables.js
+++ b/addons/mass_mailing/static/src/builder/plugins/customize_mailing_variables.js
@@ -87,7 +87,7 @@ export const CUSTOMIZE_MAILING_VARIABLES = Object.assign(
     generateSimpleMailingVariables(
         "link",
         ["a:not(.btn):not(:has(.fa, img))", "a.btn.btn-link"],
-        textProperties
+        textProperties.filter((prop) => prop !== "font-size")
     ),
     generateSimpleMailingVariables(
         "btn-primary",
@@ -189,9 +189,6 @@ export const CUSTOMIZE_MAILING_VARIABLES_DEFAULTS = {
     },
     "--text-container-margin-bottom": {
         "margin-bottom": "16px",
-    },
-    "--link-font-size": {
-        "font-size": "16px",
     },
     "--link-font-weight": {
         "font-weight": "400",

--- a/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
+++ b/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
@@ -76,10 +76,18 @@
 </t>
 
 <t t-name="mass_mailing.DesignLinkOption">
-    <t t-call="mass_mailing.DesignTextOption">
-        <t t-set="label">Links</t>
-        <t t-set="prefix" t-value="`--link-`"/>
-    </t>
+    <BuilderContext action="'mass_mailing.CustomizeMailingVariable'">
+        <BuilderRow label.translate="Link Style" extraLabelClass="'fw-bolder'">
+            <BuilderColorPicker noTransparency="true" title.translate="Text Color" enabledTabs="['solid', 'custom']"
+                actionParam="{ variable: `--link-color` }"/>
+            <BuilderButton icon="'fa-fw fa-bold'" actionParam="{ variable: `--link-font-weight` }" actionValue="'bolder'"/>
+            <BuilderButton icon="'fa-fw fa-italic'" actionParam="{ variable: `--link-font-style` }" actionValue="'italic'"/>
+            <BuilderButton icon="'fa-fw fa-underline'" actionParam="{ variable: `--link-text-decoration-line`}" actionValue="'underline'"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Font Family" level="1">
+            <FontFamilyPicker action="'mass_mailing.CustomizeMailingVariable'" actionParam="{variable: `--link-font-family`}"/>
+        </BuilderRow>
+    </BuilderContext>
 </t>
 
 <t t-name="mass_mailing.DesignTextOption">


### PR DESCRIPTION
Remove the `mass_mailing` Design Tab `--link-font-size` special variable, as it
is more natural that a link font-size is aligned with its container. It is still
possible to use the editor toolbar `font-size` feature to change the `font-size`
of links individually.

task-5868086
