### PR TITLE
[FIX] point_of_sale: fix report price for refunds

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -66,10 +66,10 @@ class ReportPosOrder(models.Model):
                 l.id AS id,
                 1 AS nbr_lines, -- number of lines in order line is always 1
                 s.date_order AS date,
-                ROUND((l.price_subtotal) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places) AS price_subtotal_excl,
+                ROUND((l.price_subtotal * CASE WHEN s.is_refund THEN -1 ELSE 1 END) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places) AS price_subtotal_excl,
                 l.qty AS product_qty,
                 l.qty * l.price_unit / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS price_sub_total,
-                ROUND((l.price_subtotal_incl) / COALESCE(NULLIF(s.currency_rate, 0), 1.0), cu.decimal_places) AS price_total,
+                ROUND((l.price_subtotal_incl * CASE WHEN s.is_refund THEN -1 ELSE 1 END) / COALESCE(NULLIF(s.currency_rate, 0), 1.0), cu.decimal_places) AS price_total,
                 (l.qty * l.price_unit) * (l.discount / 100) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS total_discount,
                 CASE
                     WHEN l.qty * u.factor = 0 THEN NULL

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1698,9 +1698,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         current_session.post_closing_cash_details(total_cash_payment)
         current_session.close_session_from_ui()
         self.assertEqual(current_session.state, 'closed')
+
+        # Testing report values
         report_refund_order, report_order = self.env['report.pos.order'].sudo().search([('order_id', 'in', current_session.order_ids.ids)])
         self.assertEqual(report_order.margin, 20.0)
         self.assertEqual(report_refund_order.margin, -20.0)
+        self.assertEqual(report_refund_order.price_sub_total, -20.0)
+        self.assertEqual(report_refund_order.price_subtotal_excl, -20.0)
+        self.assertEqual(report_refund_order.price_total, -20.0)
 
     def test_product_combo_price(self):
         """ Check that the combo has the expected price """


### PR DESCRIPTION
When doing a refund the price is positive in the reporting.

Steps to reproduce:
-------------------
* Open pos session
* Make an order
* Refund the order
* Go backend and look at the order reporting
> Observation: if the product sold was 100$, the report shows
200$ in positive

Why the fix:
------------
orderSign exist only in the js side resulting in values to be positive. We know multiply the prices in the report by 1 or -1 if the order is a refund or not. This fix works because starting from 19.0 pos refund orders cannot have anything else than refund product.

opw-5483471