### PR TITLE
[FIX] stock: Add 'view' button to package history list

### DIFF
--- a/addons/stock/models/stock_package_history.py
+++ b/addons/stock/models/stock_package_history.py
@@ -31,3 +31,12 @@ class StockPackageHistory(models.Model):
 
         # Complete name without the first (outermost) package name
         return ' > '.join(self.package_name.split(' > ')[1:])
+
+    def action_show_package(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'view_mode': 'form',
+            'res_model': 'stock.package',
+            'res_id': self.package_id.id,
+        }

--- a/addons/stock/views/stock_package_history_views.xml
+++ b/addons/stock/views/stock_package_history_views.xml
@@ -31,6 +31,7 @@
                 <field name="location_dest_id"/>
                 <field name="parent_dest_id"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
+                <button name="action_show_package" type="object" width="50px" string="View"/>
             </list>
         </field>
     </record>


### PR DESCRIPTION
Steps to reproduce:
- Enable packages
- Do a reception with a product and put it in a pack
- Open the 'Packages' stat button
  - View button is at the end of every line, to open the package
- Go back to the picking and validate it
- Open the 'Packages' stat button again

Issue:
There isn't any 'View' button, so we can't open the package records from here.

It was done somewhat on purpose, as it's a list of `stock.package.history` and not `stock.package`, so we wouldn't open the right record.
But we can simply add a button that opens the linked package instead.

opw-5436847

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
