### PR TITLE
[FIX] core: fix KeyError when upgrade with manual one2many fields

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -876,7 +876,8 @@ class One2many(_RelationalMulti):
             # link self to its inverse field and vice-versa
             comodel = model.env[self.comodel_name]
             try:
-                comodel._fields[self.inverse_name]
+                field = comodel._fields[self.inverse_name]
+                field.setup(comodel)
             except KeyError:
                 raise ValueError(f"{self.inverse_name!r} declared in {self!r} does not exist on {comodel._name!r}.")
 


### PR DESCRIPTION
When ``setup`` a manual one2many field, if its ``inverse_name`` field hasn't been ``setup`` and is also a manual field which might be ``pop`` when ``setup``, the one2many field can be ``setup`` successfully. But when computing ``setup_inverses`` when ``init_models``, the ``inverse_name`` will cause a ``KeyError``.
``invf = registry[self.comodel_name]._fields[self.inverse_name]``


Reproduce:
see https://github.com/odoo/odoo/pull/240085

This commit simply checks the ``setup`` for the inverse field of the one2many field.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
