### PR TITLE
[FIX] event: prevent concurrent update error during event registration

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -206,7 +206,7 @@ class EventMailScheduler(models.Model):
         self.ensure_one()
         context_registrations = self.env.context.get('event_mail_registration_ids')
 
-        auto_commit = not getattr(threading.current_thread(), 'testing', False)
+        auto_commit = not getattr(threading.current_thread(), 'testing', False) and not context_registrations
         batch_size = int(
             self.env['ir.config_parameter'].sudo().get_param('mail.batch_size')
         ) or 50  # be sure to not have 0, as otherwise no iteration is done


### PR DESCRIPTION
Registering for an event while the mail scheduler cron was running could lead to a PostgreSQL serialization failure, leading to a 500 error and the failure of the registration.

### Reproduction Steps

1. Configure an Event with a "Mail Scheduler" set to trigger "After each registration" with an interval of "Immediately".
2. Ensure the "Event: Mail Scheduler" cron job is active and running.
3. As a public user or portal user, attempting to register for this event will intermittently fail with an HTTP 500 error.
4. The server logs will show `psycopg2.errors.SerializationFailure: could not serialize access due to concurrent update`, followed by `psycopg2.errors.InFailedSqlTransaction`.
5. The registration is not created.

### Cause

When a user registers for an event, the system immediately attempts to process any "on-registration" emails. The method used (`_execute_attendee_based`) forces a database `commit()`.

When this `commit()` is executed, the Postgres database attempts to finalize the user's transaction. However, if the concurrent background cron job has modified the same event/mail records while the user's request was processing, Postgres detects a serialization conflict.

Consequently, the commit itself fails and raises `SerializationFailure`. Because the commit failed, the user's transaction is rolled back, and the registration record is never persisted to the database (explaining the missing attendees).

Critically, the exception handling logic in `_update_mail_schedulers` catches this `SerializationFailure` (preventing odoo from retrying the transaction) but then attempts to perform further database operations (to log the error). Since the transaction is already in an aborted state due to the failed commit, this triggers a secondary `InFailedSqlTransaction` error. This secondary error is not recognized as a concurrency error by Odoo's automatic retry mechanism (`odoo.service.model.retrying`), resulting in a hard crash instead of a retry.

### Fix

The logic now checks the execution context using `event_mail_registration_ids`. If triggered by a user registration (indicated by the presence of specific registration IDs in the context), the explicit `commit()` is skipped.

opw-5355116