### PR TITLE
[FIX] account: block deletion of used tax groups

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -340,10 +340,9 @@ class AccountTax(models.Model):
                     WHERE EXISTS(
                         SELECT 1
                         FROM account_move_line_account_tax_rel AS line
-                        WHERE account_tax_id IN %s
-                        AND account_tax.id = line.account_tax_id
-                    ) """,
-                tuple(self.ids),
+                        WHERE account_tax.id = line.account_tax_id
+                    ) AND id IN %s
+                    """, tuple(self.ids),
             )))
             taxes_to_compute = set(self.ids) - used_taxes
 
@@ -356,10 +355,9 @@ class AccountTax(models.Model):
                         WHERE EXISTS(
                             SELECT 1
                             FROM account_reconcile_model_line_account_tax_rel AS reco
-                            WHERE account_tax_id IN %s
-                            AND account_tax.id = reco.account_tax_id
-                        ) """,
-                    tuple(taxes_to_compute)
+                            WHERE account_tax.id = reco.account_tax_id
+                        ) AND id IN %s
+                        """, tuple(taxes_to_compute)
                 )))
                 taxes_to_compute -= used_taxes
 

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -5125,6 +5125,11 @@ class AccountTax(models.Model):
             return ''
         return html2plaintext(self.description)
 
+    @api.ondelete(at_uninstall=False)
+    def unlink_except_tax_used(self):
+        if any(self.mapped('is_used')):
+            raise ValidationError(self.env._("You cannot delete taxes that are currently in use. Consider archiving them instead."))
+
 
 class AccountTaxRepartitionLine(models.Model):
     _name = 'account.tax.repartition.line'

--- a/addons/account/tests/test_account_tax.py
+++ b/addons/account/tests/test_account_tax.py
@@ -309,6 +309,45 @@ class TestAccountTax(AccountTestInvoicingCommon):
             {'display_type': 'payment_term',    'tax_ids': [],          'balance': 100.0,   'account_id': self.company_data['default_account_receivable'].id},
         ])
 
+    def test_cannot_delete_group_tax_in_use(self):
+        """ Test that a group of taxes (parent tax) cannot be deleted when it's used. """
+
+        sales_10_perc = self.env['account.tax'].create({
+            'name': '10% Sales tax',
+            'amount': 10.0,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+        sales_5_perc = self.env['account.tax'].create({
+            'name': '5% Sales tax',
+            'amount': 5.0,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+        # Group of taxes
+        sales_15_perc = self.env['account.tax'].create({
+            'name': '15% Sales tax',
+            'amount': 15.0,
+            'amount_type': 'group',
+            'type_tax_use': 'sale',
+            'children_tax_ids': [Command.set([sales_10_perc.id, sales_5_perc.id])],
+        })
+        self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2025-01-01',
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'invoice_line',
+                    'quantity': 1.0,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(sales_15_perc.ids)],
+                }),
+            ],
+        })
+        self.assertTrue(sales_15_perc.is_used)
+        with self.assertRaisesRegex(ValidationError, "delete taxes that are currently in use"):
+            sales_15_perc.unlink()
+
     def test_negative_factor_percent(self):
         account_1 = self.company_data['default_account_tax_sale'].copy()
         with self.assertRaisesRegex(ValidationError, r"Invoice and credit note distribution should have a total factor \(\+\) equals to 100\."):

--- a/addons/hr_expense/models/account_tax.py
+++ b/addons/hr_expense/models/account_tax.py
@@ -20,9 +20,8 @@ class AccountTax(models.Model):
                 WHERE EXISTS(
                     SELECT 1
                     FROM expense_tax AS exp
-                    WHERE tax_id IN %s
-                    AND account_tax.id = exp.tax_id
-                )
+                    WHERE account_tax.id = exp.tax_id
+                ) AND id IN %s
             """, [tuple(taxes_to_compute)])
 
             used_taxes.update([tax[0] for tax in self.env.cr.fetchall()])

--- a/addons/point_of_sale/models/account_tax.py
+++ b/addons/point_of_sale/models/account_tax.py
@@ -42,9 +42,8 @@ class AccountTax(models.Model):
                 WHERE EXISTS(
                     SELECT 1
                     FROM account_tax_pos_order_line_rel AS pos
-                    WHERE account_tax_id IN %s
-                    AND account_tax.id = pos.account_tax_id
-                )
+                    WHERE account_tax.id = pos.account_tax_id
+                ) AND id IN %s
             """, [tuple(taxes_to_compute)])
 
             used_taxes.update([tax[0] for tax in self.env.cr.fetchall()])

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1150,7 +1150,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.PosOrder.sync_from_ui([product5_order])
 
         # delete tax
-        dummy_50_perc_tax.unlink()
+        dummy_50_perc_tax.active = False
 
         total_cash_payment = sum(pos_session.mapped('order_ids.payment_ids').filtered(lambda payment: payment.payment_method_id.type == 'cash').mapped('amount'))
         pos_session.post_closing_cash_details(total_cash_payment)

--- a/addons/purchase/models/account_tax.py
+++ b/addons/purchase/models/account_tax.py
@@ -20,9 +20,8 @@ class AccountTax(models.Model):
                 WHERE EXISTS(
                     SELECT 1
                     FROM account_tax_purchase_order_line_rel AS pur
-                    WHERE account_tax_id IN %s
-                    AND account_tax.id = pur.account_tax_id
-                )
+                    WHERE account_tax.id = pur.account_tax_id
+                ) AND id IN %s
             """, [tuple(taxes_to_compute)])
 
             used_taxes.update([tax[0] for tax in self.env.cr.fetchall()])


### PR DESCRIPTION
Before this PR:
- Group of taxes can be deleted by a user, even if they are used.

After this PR:
- If a user tries to delete a group of taxes in use, a validation
  error is raised.

- Fixed a test case in POS and deactivated the tax instead of
  deleting the tax.

Related PR: https://github.com/odoo/enterprise/pull/105174

task-5472834