### PR TITLE
[FIX] stock: prevent error when setting inventory quantity to 0

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -997,22 +997,31 @@ class StockQuant(models.Model):
         # Consider the inventory_quantity as set => recompute the inventory_diff_quantity if needed
         self.inventory_quantity_set = True
         move_vals = []
+        default_loss_locations = {}
+        quants_with_missing_loss_locations = self.filtered(lambda quant: not quant.product_id.with_company(quant.company_id).property_stock_inventory)
+        if quants_with_missing_loss_locations:
+            for company in quants_with_missing_loss_locations.mapped('company_id'):
+                loss_location_id = self.env['ir.default'].with_company(company)._get_model_defaults(
+                    'product.template').get('property_stock_inventory')
+                default_loss_locations[company.id] = self.env['stock.location'].browse(loss_location_id)
         for quant in self:
             # if inventory applied from product's inverse_qty and the inventory_diff_quantity is 0,
             # we skip creating a move with 0 quantity.
             if quant.env.context.get('from_inverse_qty') and quant.product_uom_id.compare(quant.inventory_diff_quantity, 0) == 0:
                 continue
+            inventory_location = quant.product_id.with_company(quant.company_id).property_stock_inventory or\
+                default_loss_locations.get(quant.company_id.id)
             # Create and validate a move so that the quant matches its `inventory_quantity`.
             if quant.product_uom_id.compare(quant.inventory_diff_quantity, 0) > 0:
                 move_vals.append(
                     quant._get_inventory_move_values(quant.inventory_diff_quantity,
-                                                     quant.product_id.with_company(quant.company_id).property_stock_inventory,
+                                                     inventory_location,
                                                      quant.location_id, package_dest_id=quant.package_id))
             else:
                 move_vals.append(
                     quant._get_inventory_move_values(-quant.inventory_diff_quantity,
                                                      quant.location_id,
-                                                     quant.product_id.with_company(quant.company_id).property_stock_inventory,
+                                                     inventory_location,
                                                      package_id=quant.package_id))
         moves = self.env['stock.move'].with_context(inventory_mode=False).create(move_vals)
         moves.with_context(ignore_dest_packages=True)._action_done()

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -1401,6 +1401,28 @@ class TestStockQuant(TestStockCommon):
             'lot_id': False,
         }])
 
+    def test_set_inventory_no_property_stock_inventory(self):
+        """
+        Test that quant inventory can be applied on products with no property_stock_inventory set.
+        """
+        quant = self.env['stock.quant'].create([{
+            'location_id': self.stock_location.id,
+            'product_id': self.productA.id,
+            'inventory_quantity': 10,
+        }])
+
+        self.productA.property_stock_inventory = False
+
+        quant.with_context(inventory_report_mode=True).action_set_inventory_quantity_zero()
+        move_line = self.env['stock.move.line'].search([('product_id', '=', self.productA.id)])
+        loss_location_id = self.env['ir.default']._get_model_defaults('product.template').get('property_stock_inventory')
+
+        self.assertEqual(
+            move_line.location_dest_id.id, loss_location_id,
+            "The destination location should be the default loss location"
+        )
+        self.assertEqual(quant.inventory_quantity, 0)
+
 
 class TestStockQuantRemovalStrategy(TestStockCommon):
 


### PR DESCRIPTION
When a user sets the inventory quantity to 0 on a quant while
the product’s Inventory Location is unset, a traceback is raised.

Steps to reproduce the error:
- Install ``stock`` module with demo data
- Open ``Cabinet with Doors`` product
- In Inventory tab, unset Inventory Location > Open forecast report > click the On Hand quantity
- Select the quant > Actions > Set to 0

Traceback:
```py
ValueError: NotNullViolation('null value in column "location_dest_id"
of relation "stock_move" violates not-null constraint
```

https://github.com/odoo/odoo/blob/bc790e13ddf3ceacead40cc6ff8d27f1a5f5364d/addons/stock/models/stock_quant.py#L1005-L1016
When property_stock_inventory is unset,
the ``_get_inventory_move_values`` method assigns a NULL value to ``location_dest_id`` in ``move_vals``.
As a result, creating the stock move with a NULL ``location_dest_id`` leads to the above traceback.

sentry-7117991902

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
