### PR TITLE
[FIX] mail: message reaction menu should close when empty

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -128,11 +128,7 @@ registerMessageAction("reactions", {
     icon: "fa fa-smile-o",
     name: _t("View Reactions"),
     onSelected: ({ message, owner, store }) => {
-        store.env.services.dialog.add(
-            MessageReactionMenu,
-            { message: toRaw(message) },
-            { context: owner }
-        );
+        store.env.services.dialog.add(MessageReactionMenu, { message }, { context: owner });
     },
     sequence: 50,
 });

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -1,7 +1,7 @@
 import { onExternalClick } from "@mail/utils/common/hooks";
 import { loadEmoji } from "@web/core/emoji_picker/emoji_picker";
 
-import { Component, onMounted, useExternalListener } from "@odoo/owl";
+import { Component, onMounted, useEffect, useExternalListener } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useChildRef, useService } from "@web/core/utils/hooks";
@@ -17,6 +17,12 @@ export class MessageReactionMenu extends Component {
         this.tabsRef = useChildRef();
         this.store = useService("mail.store");
         this.ui = useService("ui");
+        useEffect(
+            (closeFn) => {
+                closeFn?.();
+            },
+            () => [this.props.message.reactions.length === 0 ? this.props.close : null]
+        );
         useExternalListener(document, "keydown", this.onKeydown);
         onExternalClick(this.tabsRef, () => this.props.close());
         onMounted(() => {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2048,6 +2048,8 @@ test("Click on view reactions shows the reactions on the message", async () => {
     await click(".o-mail-Message [title='Expand']");
     await click(".o-dropdown-item:text('View Reactions')");
     await contains(".o-mail-MessageReactionMenu:has(:text('😅 1'))");
+    await click(".o-mail-MessageReactionMenu-persona button[title=Remove]");
+    await contains(".o-mail-MessageReactionMenu", { count: 0 });
 });
 
 test("Click on view reactions from right-click on message shows the reactions", async () => {


### PR DESCRIPTION
Since [1], message reaction menu doesn't close when it's empty. This commit fixes the issue.

[1]: https://github.com/odoo/odoo/pull/234161

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
