### PR TITLE
[FIX] point_of_sale: prevent rounding issues in cash difference removal

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -212,7 +212,7 @@ class ReportSaleDetails(models.AbstractModel):
                     })
 
                 # If there is a cash difference, we remove the last cash move which is the cash difference
-                if cash_difference != 0:
+                if session.currency_id.round(cash_difference) != 0:
                     cash_moves = cash_moves[:-1]
 
                 for cash_move in cash_moves:


### PR DESCRIPTION
Before this commit, when calculating the cash difference in the report, the code did not account for currency rounding. This could lead to situations where a very small cash difference, due to rounding errors, was not recognized as zero, resulting in the unintended removal of cash moves.

opw-5489958

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
