### PR TITLE
[FIX] sale: pass force_discount_recomputation context to discount compute

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1473,7 +1473,7 @@ class SaleOrder(models.Model):
         # i.e. to make sure the discount is correctly reset
         # if pricelist rule is different than when the price was first computed.
         lines_to_recompute.discount = 0.0
-        lines_to_recompute._compute_discount()
+        lines_to_recompute.with_context(force_discount_recomputation=True)._compute_discount()
         self.show_update_pricelist = False
 
     def _default_order_line_values(self, child_field=False):


### PR DESCRIPTION
When `_recompute_prices` is triggered (e.g., by changing a Pricelist), the system resets line discounts to 0.0 and recomputes them.

This commit adds `force_discount_recomputation=True` to the context of the `_compute_discount` call in this method.

This is necessary for modules extending `sale.order.line` (such as `sale_subscription`) that implement optimization logic to skip recomputation when line values (product, qty) are unchanged. By checking this context key, those modules can distinguish between an unnecessary trigger and a mandatory price update requested by the user.

task: 5788384
ref: https://github.com/odoo/enterprise/pull/105077

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
