### PR TITLE
[FIX] website_sale: Auto crop of product images in product tiles

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -113,7 +113,7 @@
         }
         .oe_product_image_img, .oe_product_image_img_secondary {
             position: absolute;
-            object-fit: var(--o-wsale-card-thumb-fill-mode, contain);
+            object-fit: var(--o-wsale-card-thumb-fill-mode, contain) !important;
             object-position: var(--o-wsale-card-thumb-position, center);
             background-size: var(--o-wsale-card-thumb-fill-mode, contain);
             background-position: var(--o-wsale-card-thumb-position, center);

--- a/addons/website_sale/views/product_tile_templates.xml
+++ b/addons/website_sale/views/product_tile_templates.xml
@@ -90,7 +90,7 @@
                 <!-- Primary image -->
                 <span
                     t-field="primary_image_holder.image_1920"
-                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img h-100 w-100 object-fit-contain'}"
+                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img h-100 w-100'}"
                     class="oe_product_image_img_wrapper oe_product_image_img_wrapper_primary d-flex h-100 justify-content-center align-items-center"
                 />
 


### PR DESCRIPTION
Steps to reproduce:
===================
1- Go to website > shop & open edit mode
2- Select any product and click on "paint-brush" icon 3- Click on "Image ratio" option and enable "Auto crop"

-> nothing happens to the images.

Cause:
======
After this commit [1] `object-fit-contain` was used even for auto crop which will override the `o_wsale_products_opt_thumb_cover` class object-fit value.

Solution:
=========
Apply basic fit contain only when autocrop is disabled.

[1]: https://github.com/odoo/odoo/pull/238108/commits/002a8a1ff65fd48fd69e41c9a881fddceee34bf5

opw-5868057

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
