### PR TITLE
[FIX] stock: add filter warehouse to mobile stock report

### DIFF
--- a/addons/stock/static/src/views/search/stock_report_search_panel.js
+++ b/addons/stock/static/src/views/search/stock_report_search_panel.js
@@ -1,10 +1,11 @@
 import { SearchPanel } from "@web/search/search_panel/search_panel";
+import { useState } from "@odoo/owl";
 
 export class StockReportSearchPanel extends SearchPanel {
     static template = "stock.StockReportSearchPanel";
     setup() {
         super.setup(...arguments);
-        this.selectedWarehouse = false;
+        this.selectedWarehouseState = useState({ selectedWarehouse: false });
     }
 
     //---------------------------------------------------------------------
@@ -17,11 +18,11 @@ export class StockReportSearchPanel extends SearchPanel {
 
     clearWarehouseContext() {
         this.env.searchModel.clearWarehouseContext();
-        this.selectedWarehouse = null;
+        this.selectedWarehouseStateState.selectedWarehouse = null;
     }
 
     applyWarehouseContext(warehouse_id) {
         this.env.searchModel.applyWarehouseContext(warehouse_id);
-        this.selectedWarehouse = warehouse_id;
+        this.selectedWarehouseStateState.selectedWarehouse = warehouse_id;
     }
 }

--- a/addons/stock/static/src/views/search/stock_report_search_panel.xml
+++ b/addons/stock/static/src/views/search/stock_report_search_panel.xml
@@ -24,9 +24,43 @@
     </xpath>
 </t>
 
+<t t-name="stock.StockReportSearchPanel.Small" t-inherit="web.SearchPanel.Small" t-inherit-mode="primary">
+    <xpath expr="//Dropdown" position="before">
+        <Dropdown t-if="warehouses.length > 1" menuClass="'my-2 mx-1'">
+            <span class="btn btn-secondary my-2 mx-1 o-dropdown-caret">
+                <i class="fa fa-filter o_search_panel_section_icon text-warning me-2"/>
+                <b class="pe-2">Warehouses</b>
+            </span>
+            <t t-set-slot="content">
+                <div class="o_search_panel_section o_search_panel_warehouse p-2">
+                    <ul class="list-group d-block o_search_panel_field">
+                        <li class="o_search_panel_filter_value list-group-item p-0 mb-1 border-0 o_cursor_pointer">
+                            <span class="d-block p-1" 
+                                    t-on-click="ev => this.clearWarehouseContext(ev)"
+                                    t-att-class="{'fw-bolder': !selectedWarehouse}">
+                                All Warehouses
+                            </span>
+                        </li>
+                        <li class="o_search_panel_filter_value list-group-item p-0 mb-1 border-0 o_cursor_pointer"
+                            t-foreach="warehouses" t-as="warehouse" t-key="warehouse.id">
+                            <div t-out="warehouse.name"
+                                t-on-click="ev => this.applyWarehouseContext(warehouse.id, ev)"
+                                t-att-class="{'fw-bolder': selectedWarehouse === warehouse.id, 
+                                                'bg-info-subtle': selectedWarehouse === warehouse.id}"/>
+                        </li>
+                    </ul>
+                </div>
+            </t>
+        </Dropdown>
+    </xpath>
+</t>
+
 <t t-name="stock.StockReportSearchPanel" t-inherit="web.SearchPanel" t-inherit-mode="primary">
     <xpath expr="//t[@t-call='web.SearchPanel.Regular']" position="attributes">
         <attribute name="t-call">stock.StockReportSearchPanel.Regular</attribute>
+    </xpath>
+    <xpath expr="//t[@t-call='web.SearchPanel.Small']" position="attributes">
+        <attribute name="t-call">stock.StockReportSearchPanel.Small</attribute>
     </xpath>
 </t>
 


### PR DESCRIPTION
On the mobile version the standard filter warehouses is not present.

Steps to reproduce:
-------------------
* Open odoo on a phone
* Inventory>Reporting>Stock
-> The filter Warehouses is not present

Observation:
------------
The basic warehouses filter is loaded in the stock report view :
https://github.com/odoo/odoo/blob/e99e07f2f22b0987468c45d3d7da287cdf703588/addons/stock/views/product_views.xml#L540
and defined in this file :
https://github.com/odoo/odoo/blob/bc46c9783ab00222b86cd951ff7f732b0212bdee/addons/stock/static/src/views/search/stock_report_search_panel.xml#L27-L31
Since the searchPanel is defined for .Regular views and we are in mobile, the searchPanel will not be mounted.

opw-5480119