### PR TITLE
[FIX] website: hide notification about delayed translations on edit

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
@@ -34,6 +34,10 @@ export class EditWebsiteSystrayItem extends Component {
         this.props.onEditPage();
     }
 
+    onEditDropdownClick() {
+        this.closeNotification?.();
+    }
+
     get currentWebsiteInfo() {
         return this.websiteService.currentWebsite?.metadata;
     }
@@ -111,7 +115,7 @@ export class EditWebsiteSystrayItem extends Component {
             const parser = new DOMParser();
             const doc = parser.parseFromString(html, "text/html");
             if (doc.querySelector("#wrap .o_delay_translation")) {
-                this.notification.add(
+                this.closeNotification = this.notification.add(
                     _t('Click on "Edit/Translate" to apply changes made on default language.'),
                     { type: "info" }
                 );

--- a/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.xml
+++ b/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.xml
@@ -11,7 +11,7 @@
             <t t-else="">Edit</t>
         </button>
         <Dropdown t-else="">
-            <button class="o-website-btn-custo-primary o-dropdown-toggle-custo btn rounded-0 border-0 px-3" accesskey="a">
+            <button class="o-website-btn-custo-primary o-dropdown-toggle-custo btn rounded-0 border-0 px-3" accesskey="a" t-on-click="this.onEditDropdownClick">
                 <span t-if="websiteContext.edition" role="img" aria-label="Loading" class="fa fa-circle-o-notch fa-spin"/>
                 <t t-else="">Edit</t>
             </button>

--- a/addons/website/static/tests/builder/edit_website_systray_item.test.js
+++ b/addons/website/static/tests/builder/edit_website_systray_item.test.js
@@ -1,0 +1,42 @@
+import { animationFrame, expect, test, waitFor } from "@odoo/hoot";
+import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { registry } from "@web/core/registry";
+import { EditWebsiteSystrayItem } from "@website/client_actions/website_preview/edit_website_systray_item";
+import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+
+defineWebsiteModels();
+
+test("Clicking on 'Edit' hides the notification", async () => {
+    // simulate delay translation
+    onRpc(
+        "/test-path",
+        () => "<html><body><div id='wrap'><div class='o_delay_translation'>Some text</div></html>"
+    );
+    patchWithCleanup(EditWebsiteSystrayItem.prototype, {
+        get translatable() {
+            return true;
+        },
+        getLocation() {
+            return {
+                pathname: "/test-path",
+                search: "",
+                hash: "",
+            };
+        },
+    });
+    await setupWebsiteBuilder(
+        `<div id="test-element" class="o_delay_translation">Test Element</div>`,
+        {
+            openEditor: false,
+            translateMode: true,
+        }
+    );
+    expect(".o_notification_bar").toHaveCount(0);
+    // dispatch content-updated event so we will get the notification
+    registry.category("website_systray").dispatchEvent(new CustomEvent("CONTENT-UPDATED"));
+    await waitFor(".o_notification_bar");
+    // clicking on edit dropdown should hide the notification
+    await contains(".o-website-btn-custo-primary:contains('Edit')").click();
+    await animationFrame();
+    expect(".o_notification_bar").toHaveCount(0);
+});


### PR DESCRIPTION
When we have a delayed translation, we get a notification saying that we should edit, or translate to apply the changes made in the default language. However, when we click on edit, the notification is still present, and it blocks the dropdown, so the user doesn't see it until the notification disappears.

Steps to see the issue:
- In a multilingual websites:
- Add a content in the default language, 'A'
- Translate the content in your other language 'B'
- Come back to 'A', and edit the content, e. g. add some style
- Come back to the language 'B' => A toaster notification appears, and if you click on "Edit" button, you cannot see what's below.

task-5447519
