### PR TITLE
[FIX] pos_hr: fix removing all employees from basic or minimal list

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -25,10 +25,11 @@ class PosConfig(models.Model):
 
         # write employees in sudo, because we have no access to these corecords
         sudo_vals = {
-            field_name: value
+            field_name: vals.pop(field_name)
             for field_name in ('minimal_employee_ids', 'basic_employee_ids', 'advanced_employee_ids')
             if not self.env.su
-            if (value := vals.pop(field_name, ()))
+            if isinstance(vals.get(field_name), list)
+            if all(isinstance(cmd, (list, tuple)) for cmd in vals[field_name])
         }
 
         res = super().write(vals)

--- a/addons/pos_hr/tests/__init__.py
+++ b/addons/pos_hr/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_frontend
 from . import test_point_of_sale_flow
+from . import test_res_config_settings

--- a/addons/pos_hr/tests/test_res_config_settings.py
+++ b/addons/pos_hr/tests/test_res_config_settings.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo
+
+from odoo.addons.pos_hr.tests.test_frontend import TestPosHrHttpCommon
+from odoo.addons.point_of_sale.tests.test_res_config_settings import TestConfigureShops
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestConfigureShopsPoSHR(TestPosHrHttpCommon, TestConfigureShops):
+    def test_properly_deleting_pos_hr_group_all_members(self):
+        self._remove_on_payment_taxes()
+
+        # Simulate removing all employees from `basic_employee_ids` and
+        # `minimal_employee_ids`. Equivalent to passing an empty command list `[]`.
+        self.main_pos_config.with_context(from_settings_view=True).write({
+            'basic_employee_ids': [],
+            'minimal_employee_ids': []
+        })
+
+        self.assertListEqual(self.main_pos_config.basic_employee_ids.ids, [])
+        self.assertListEqual(self.main_pos_config.minimal_employee_ids.ids, [])


### PR DESCRIPTION
Steps to reproduce
------------------
1. Enable "Log in with Employees"
2. Add employee "A" to the "Basic rights" group.
3. Add employee "B" to the "Minimal rights" group.
4. Make sure to remove all other employees from these 2 groups!!
5. Now save and go back to the main settings page, remove employee "A" from "Basic rights" group, such that this group is now empty.
6. Save the changes.

Observation -> Employee "A" is still in the group "Basic rights"!!

Why the issue
-------------
When deleting records from an `x2many` field in pos, from the main settings page, we do not pass the associated `unlink` commands in the arguments of `web_save` when clicking "Save", we just pass an empty commands list `[]`, because the backend, specifically the method `_preprocess_x2many_vals_from_settings_view` will take care of unlinking all the records before applying the new commands. So passing an empty commands list when updating an `x2many` field will be equivalent to saying "Unlink all records for that field, then apply no commands", i.e. just unlink all records for that field.

However, after https://github.com/odoo/odoo/commit/1f45b035354bb9040be3aba3a79392e603e870b4, we now filter out updates having an empty commands list, and thus now trying to unlink all records of a `x2many` does not work, since an empty command list will be dropped from the updates, before reaching `_preprocess_x2many_vals_from_settings_view`.

The fix
-------
We add stricter filtering logic, to keep valid command lists, even when
they are empty.

opw-5725879