### PR TITLE
[FIX] hr_work_entry_holidays: Error when writing contract with multiple leaves

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -339,6 +339,10 @@ class HrLeave(models.Model):
 
     @api.depends('employee_id', 'request_date_from', 'request_date_to')
     def _compute_resource_calendar_id(self):
+        # Avoid recomputing the calendar in `_check_contracts`
+        # before the correct calendar is written to the version
+        if self.env.context.get('leave_skip_calendar_recompute', False):
+            return
         leaves_without_emp_or_date = self.filtered(
             lambda leave: not (leave.employee_id and leave.request_date_from and leave.request_date_to)
         )

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -339,6 +339,11 @@ class HrLeave(models.Model):
 
     @api.depends('employee_id', 'request_date_from', 'request_date_to')
     def _compute_resource_calendar_id(self):
+        # skip the calendar compute if there is a new calendar being written to the leave
+        # but not written yet to the version as it might raise errors if there are overlapping
+        # leaves between this version and another one
+        if self.env.context.get('leave_skip_calendar_recompute', False):
+            return
         leaves_without_emp_or_date = self.filtered(
             lambda leave: not (leave.employee_id and leave.request_date_from and leave.request_date_to)
         )
@@ -378,14 +383,14 @@ class HrLeave(models.Model):
         self.ensure_one()
         domain = Domain.AND([
             Domain('employee_id', '=', self.employee_id.id),
-            Domain('contract_date_start', '<=', self.date_to),
+            Domain('date_start', '<=', self.date_to),
             Domain.OR([
-                Domain('contract_date_end', '>=', self.date_from),
-                Domain('contract_date_end', '=', False),
+                Domain('date_end', '>=', self.date_from),
+                Domain('date_end', '=', False),
             ])
         ])
         versions = self.env['hr.version'].sudo().search(domain)
-        return versions.filtered(lambda v: v._is_overlapping_period(self.date_from.date(), self.date_to.date()))
+        return versions
 
     @api.constrains('date_from', 'date_to')
     def _check_contracts(self):

--- a/addons/hr_holidays/models/hr_version.py
+++ b/addons/hr_holidays/models/hr_version.py
@@ -37,21 +37,15 @@ class HrVersion(models.Model):
                     created_versions |= super().create(vals)
                     continue
                 leaves = self._get_leaves_from_vals(vals)
-                is_created = False
                 for leave in leaves:
                     leaves_state = self._refuse_leave(leave, leaves_state)
-                    if not is_created:
-                        created_versions |= super().create([vals])
-                        is_created = True
+                created_versions |= super().create([vals])
+                for leave in leaves:
                     overlapping_contracts = self._check_overlapping_contract(leave)
                     if not overlapping_contracts:
                         continue
                     all_new_leave_origin, all_new_leave_vals = self._populate_all_new_leave_vals_from_split_leave(
                         all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state)
-                # TODO FIXME
-                # to keep creation order, not ideal but ok for now.
-                if not is_created:
-                    created_versions |= super().create([vals])
             if all_new_leave_vals:
                 self._create_all_new_leave(all_new_leave_origin, all_new_leave_vals)
         except ValidationError:
@@ -74,18 +68,18 @@ class HrVersion(models.Model):
                 for contract in self:
                     resource_calendar_id = vals.get('resource_calendar_id', contract.resource_calendar_id.id)
                     extra_domain = [('resource_calendar_id', '!=', resource_calendar_id)] if resource_calendar_id else None
-                    leaves = contract._get_leaves(
+                    leaves = contract.with_context(contract_date_start=vals.get('contract_date_start', False))._get_leaves(
                         extra_domain=extra_domain
                     )
                     for leave in leaves:
-                        super(HrVersion, contract).write(vals)
-                        overlapping_contracts = self._check_overlapping_contract(leave)
+                        overlapping_contracts = contract.with_context(vals=vals)._check_overlapping_contract(leave)
                         if not overlapping_contracts:
                             continue
                         leaves_state = self._refuse_leave(leave, leaves_state)
+                        super(HrVersion, contract).write(vals)
                         specific_contracts += contract
                         all_new_leave_origin, all_new_leave_vals = self._populate_all_new_leave_vals_from_split_leave(
-                            all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state)
+                            all_new_leave_origin, all_new_leave_vals, overlapping_contracts | contract, leave, leaves_state)
                 if all_new_leave_vals:
                     self._create_all_new_leave(all_new_leave_origin, all_new_leave_vals)
             except ValidationError:
@@ -102,7 +96,7 @@ class HrVersion(models.Model):
             ('state', '!=', 'refuse'),
             ('employee_id', 'in', self.mapped('employee_id.id')),
             ('date_from', '<=', max(end or date.max for end in self.sudo().mapped('contract_date_end'))),
-            ('date_to', '>=', min(self.sudo().mapped('contract_date_start'))),
+            ('date_to', '>=', fields.Date.from_string(self.env.context.get('contract_date_start', False)) or min(self.sudo().mapped('contract_date_start'))),
         ]
         if extra_domain:
             domain = Domain.AND([domain, extra_domain])
@@ -122,14 +116,18 @@ class HrVersion(models.Model):
     def _check_overlapping_contract(self, leave):
         # Get all overlapping contracts but exclude draft contracts that are not included in this transaction.
         overlapping_contracts = leave._get_overlapping_contracts().sorted(
-            key=lambda c: c.contract_date_start)
-        if len(overlapping_contracts.resource_calendar_id) <= 1:
+            key=lambda c: c.date_start)
+        vals = self.env.context.get('vals', {})
+        context_calendar = self.env['resource.calendar'].browse(vals.get('resource_calendar_id', False))
+        all_calendars = overlapping_contracts.resource_calendar_id if not context_calendar else (overlapping_contracts - self).resource_calendar_id | context_calendar
+        if len(all_calendars) <= 1:
             if overlapping_contracts:
                 first_overlapping_contract = next(iter(overlapping_contracts), overlapping_contracts)
-                if leave.resource_calendar_id != first_overlapping_contract.resource_calendar_id:
-                    leave.resource_calendar_id = first_overlapping_contract.resource_calendar_id
+                new_calendar = context_calendar or first_overlapping_contract.resource_calendar_id
+                if leave.resource_calendar_id != new_calendar:
+                    leave.resource_calendar_id = new_calendar
                     if not leave.request_unit_hours:
-                        leave.with_context(leave_skip_date_check=True, leave_skip_state_check=True)._compute_date_from_to()
+                        leave.with_context(leave_skip_date_check=True, leave_skip_state_check=True, leave_skip_calendar_recompute=True)._compute_date_from_to()
                         if leave.state == 'validate':
                             leave._validate_leave_request()
             return False
@@ -144,8 +142,8 @@ class HrVersion(models.Model):
 
     def _populate_all_new_leave_vals_from_split_leave(self, all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state):
         for overlapping_contract in overlapping_contracts:
-            new_request_date_from = max(leave.request_date_from, overlapping_contract.contract_date_start)
-            new_request_date_to = min(leave.request_date_to, overlapping_contract.contract_date_end or date.max)
+            new_request_date_from = max(leave.request_date_from, overlapping_contract.date_start)
+            new_request_date_to = min(leave.request_date_to, overlapping_contract.date_end or date.max)
             new_leave_vals = leave.copy_data({
                 'request_date_from': new_request_date_from,
                 'request_date_to': new_request_date_to,

--- a/addons/hr_holidays/models/hr_version.py
+++ b/addons/hr_holidays/models/hr_version.py
@@ -37,21 +37,15 @@ class HrVersion(models.Model):
                     created_versions |= super().create(vals)
                     continue
                 leaves = self._get_leaves_from_vals(vals)
-                is_created = False
                 for leave in leaves:
                     leaves_state = self._refuse_leave(leave, leaves_state)
-                    if not is_created:
-                        created_versions |= super().create([vals])
-                        is_created = True
+                created_versions |= super().create([vals])
+                for leave in leaves:
                     overlapping_contracts = self._check_overlapping_contract(leave)
                     if not overlapping_contracts:
                         continue
                     all_new_leave_origin, all_new_leave_vals = self._populate_all_new_leave_vals_from_split_leave(
                         all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state)
-                # TODO FIXME
-                # to keep creation order, not ideal but ok for now.
-                if not is_created:
-                    created_versions |= super().create([vals])
             if all_new_leave_vals:
                 self._create_all_new_leave(all_new_leave_origin, all_new_leave_vals)
         except ValidationError:
@@ -74,15 +68,15 @@ class HrVersion(models.Model):
                 for contract in self:
                     resource_calendar_id = vals.get('resource_calendar_id', contract.resource_calendar_id.id)
                     extra_domain = [('resource_calendar_id', '!=', resource_calendar_id)] if resource_calendar_id else None
-                    leaves = contract._get_leaves(
+                    leaves = contract.with_context(contract_date_start=vals.get('contract_date_start', False))._get_leaves(
                         extra_domain=extra_domain
                     )
                     for leave in leaves:
-                        super(HrVersion, contract).write(vals)
-                        overlapping_contracts = self._check_overlapping_contract(leave)
-                        if not overlapping_contracts:
+                        overlapping_contracts = contract.with_context(vals=vals)._check_overlapping_contract(leave)
+                        if not overlapping_contracts or len(overlapping_contracts) <= 1:
                             continue
                         leaves_state = self._refuse_leave(leave, leaves_state)
+                        super(HrVersion, contract).write(vals)
                         specific_contracts += contract
                         all_new_leave_origin, all_new_leave_vals = self._populate_all_new_leave_vals_from_split_leave(
                             all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state)
@@ -102,7 +96,7 @@ class HrVersion(models.Model):
             ('state', '!=', 'refuse'),
             ('employee_id', 'in', self.mapped('employee_id.id')),
             ('date_from', '<=', max(end or date.max for end in self.sudo().mapped('contract_date_end'))),
-            ('date_to', '>=', min(self.sudo().mapped('contract_date_start'))),
+            ('date_to', '>=', fields.Date.from_string(self.env.context.get('contract_date_start', False)) or min(self.sudo().mapped('contract_date_start'))),
         ]
         if extra_domain:
             domain = Domain.AND([domain, extra_domain])
@@ -122,14 +116,18 @@ class HrVersion(models.Model):
     def _check_overlapping_contract(self, leave):
         # Get all overlapping contracts but exclude draft contracts that are not included in this transaction.
         overlapping_contracts = leave._get_overlapping_contracts().sorted(
-            key=lambda c: c.contract_date_start)
-        if len(overlapping_contracts.resource_calendar_id) <= 1:
+            key=lambda c: c.date_start)
+        vals = self.env.context.get('vals', {})
+        context_calendar = self.env['resource.calendar'].browse(vals.get('resource_calendar_id', False))
+        all_calendars = overlapping_contracts.resource_calendar_id if not context_calendar else (overlapping_contracts - self).resource_calendar_id | context_calendar
+        if len(all_calendars) <= 1:
             if overlapping_contracts:
                 first_overlapping_contract = next(iter(overlapping_contracts), overlapping_contracts)
-                if leave.resource_calendar_id != first_overlapping_contract.resource_calendar_id:
-                    leave.resource_calendar_id = first_overlapping_contract.resource_calendar_id
+                new_calendar = context_calendar or first_overlapping_contract.resource_calendar_id
+                if leave.resource_calendar_id != new_calendar:
+                    leave.resource_calendar_id = new_calendar
                     if not leave.request_unit_hours:
-                        leave.with_context(leave_skip_date_check=True, leave_skip_state_check=True)._compute_date_from_to()
+                        leave.with_context(leave_skip_date_check=True, leave_skip_state_check=True, leave_skip_calendar_recompute=True)._compute_date_from_to()
                         if leave.state == 'validate':
                             leave._validate_leave_request()
             return False
@@ -144,8 +142,8 @@ class HrVersion(models.Model):
 
     def _populate_all_new_leave_vals_from_split_leave(self, all_new_leave_origin, all_new_leave_vals, overlapping_contracts, leave, leaves_state):
         for overlapping_contract in overlapping_contracts:
-            new_request_date_from = max(leave.request_date_from, overlapping_contract.contract_date_start)
-            new_request_date_to = min(leave.request_date_to, overlapping_contract.contract_date_end or date.max)
+            new_request_date_from = max(leave.request_date_from, overlapping_contract.date_start)
+            new_request_date_to = min(leave.request_date_to, overlapping_contract.date_end or date.max)
             new_leave_vals = leave.copy_data({
                 'request_date_from': new_request_date_from,
                 'request_date_to': new_request_date_to,

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -132,6 +132,8 @@ class TestHolidaysMultiContract(TestHolidayContract):
         self.assertEqual(leave.state, 'validate')
 
         self.contract_cdi.contract_date_end = date(2022, 6, 15)
+        no_overlap_leave = self.create_leave(date(2022, 7, 5), date(2022, 7, 10), name="Doctor Appointment", employee_id=self.jules_emp.id)
+        no_overlap_leave.action_approve()
         self.jules_emp.create_version({
             'date_version': date(2022, 6, 16),
             'contract_date_start': date(2022, 6, 16),
@@ -140,9 +142,8 @@ class TestHolidaysMultiContract(TestHolidayContract):
             'resource_calendar_id': self.calendar_40h.id,
             'wage': 5000.0,
         })
-
         leaves = self.env['hr.leave'].search([('employee_id', '=', self.jules_emp.id)])
-        self.assertEqual(len(leaves), 3)
+        self.assertEqual(len(leaves), 4)
         self.assertEqual(leave.state, 'refuse')
 
         first_leave = leaves.filtered(lambda l: l.date_from.day == 1 and l.date_to.day == 15)

--- a/addons/hr_holidays/tests/test_multi_contract.py
+++ b/addons/hr_holidays/tests/test_multi_contract.py
@@ -132,6 +132,8 @@ class TestHolidaysMultiContract(TestHolidayContract):
         self.assertEqual(leave.state, 'validate')
 
         self.contract_cdi.contract_date_end = date(2022, 6, 15)
+        no_overlap_leave = self.create_leave(date(2022, 7, 5), date(2022, 7, 10), name="Doctor Appointment", employee_id=self.jules_emp.id)
+        no_overlap_leave.action_approve()
         self.jules_emp.create_version({
             'date_version': date(2022, 6, 16),
             'contract_date_start': date(2022, 6, 16),
@@ -140,9 +142,8 @@ class TestHolidaysMultiContract(TestHolidayContract):
             'resource_calendar_id': self.calendar_40h.id,
             'wage': 5000.0,
         })
-
         leaves = self.env['hr.leave'].search([('employee_id', '=', self.jules_emp.id)])
-        self.assertEqual(len(leaves), 3)
+        self.assertEqual(len(leaves), 4)
         self.assertEqual(leave.state, 'refuse')
 
         first_leave = leaves.filtered(lambda l: l.date_from.day == 1 and l.date_to.day == 15)
@@ -402,3 +403,50 @@ class TestHolidaysMultiContract(TestHolidayContract):
         # Assert based on partial-time calendar
         self.assertEqual(leave.number_of_days, 1)
         self.assertEqual(leave.number_of_hours, 6)
+
+    def test_contract_creation_with_existing_leave(self):
+        employee = self.env['hr.employee'].create({
+            'name': "Employee",
+            "resource_calendar_id": self.calendar_40h.id,
+        })
+        employee.create_version({
+            "date_version": date(2026, 1, 1),
+            "contract_date_start": date(2026, 1, 1),
+            "contract_date_end": date(2026, 1, 31),
+            "resource_calendar_id": self.calendar_40h.id,
+            "wage": 1000.0,
+        })
+        leave = self.create_leave(date(2026, 1, 23), date(2026, 2, 10), employee_id=employee.id)
+        leave.action_approve()
+        contract_2 = employee.create_version({
+            "date_version": date(2026, 2, 1),
+            "resource_calendar_id": self.calendar_40h.id,
+            "wage": 1000.0,
+        })
+        contract_2.write({
+            'resource_calendar_id': self.calendar_35h.id,
+            'contract_date_start': date(2026, 2, 1),
+        })
+
+    def test_leave_with_contract_amendment(self):
+        employee = self.env['hr.employee'].create({
+            'name': "Employee",
+            "resource_calendar_id": self.calendar_40h.id,
+        })
+        employee.create_version({
+            "date_version": date(2026, 1, 1),
+            "contract_date_start": date(2026, 1, 1),
+            "contract_date_end": date(2026, 2, 28),
+            "resource_calendar_id": self.calendar_40h.id,
+            "wage": 1000.0,
+        })
+        leave = self.create_leave(date(2026, 1, 23), date(2026, 2, 10), employee_id=employee.id)
+        leave.action_approve()
+        version_2 = employee.create_version({
+            "date_version": date(2026, 2, 1),
+            "contract_date_start": date(2026, 1, 1),
+            "contract_date_end": date(2026, 2, 28),
+            "resource_calendar_id": self.calendar_40h.id,
+            "wage": 1000.0,
+        })
+        version_2.resource_calendar_id = self.calendar_35h.id

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -239,20 +239,29 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
                 (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
                 (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
             ],
-            'tz': 'UTC',
+            'tz': 'Europe/Brussels',
         })
-        self.contract_cdi.resource_calendar_id = calendar_20h
-        self.contract_cdi.generate_work_entries(date(2019, 10, 1), date(2019, 10, 30))
+        self.calendar_40h.tz = 'Europe/Brussels'
+        test_emp = self.env['hr.employee'].create({
+            'name': 'Test Emp',
+            'tz': 'Europe/Brussels',
+            'contract_date_start': date(2019, 10, 1),
+            'date_version': date(2019, 10, 1),
+            'contract_date_end': date(2019, 10, 31),
+            'resource_calendar_id': calendar_20h.id,
+            'wage': 1000,
+        })
+        test_emp.version_id.generate_work_entries(date(2019, 10, 1), date(2019, 10, 30))
         leave = self.env['hr.leave'].create({
             'name': 'Holiday!!',
-            'employee_id': self.jules_emp.id,
+            'employee_id': test_emp.id,
             'holiday_status_id': self.leave_type.id,
             'request_date_from': date(2019, 10, 10),
             'request_date_to': date(2019, 10, 10),
         })
         leave.action_approve()
         work_entries = self.env['hr.work.entry'].search([
-            ('employee_id', '=', self.jules_emp.id),
+            ('employee_id', '=', test_emp.id),
             ('date_start', '>=', date(2019, 10, 10)),
             ('date_stop', '<=', date(2019, 10, 10))
         ])
@@ -260,11 +269,11 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         self.assertEqual(work_entries.leave_id, leave)
         self.assertEqual(work_entries.work_entry_type_id, self.leave_type.work_entry_type_id)
         self.assertEqual(work_entries.duration, 4.0)
-        self.assertEqual(work_entries.date_start, datetime(2019, 10, 10, 8, 0))
-        self.assertEqual(work_entries.date_stop, datetime(2019, 10, 10, 12, 0))
-        self.contract_cdi.resource_calendar_id = self.calendar_40h
+        self.assertEqual(work_entries.date_start, datetime(2019, 10, 10, 6, 0))
+        self.assertEqual(work_entries.date_stop, datetime(2019, 10, 10, 10, 0))
+        test_emp.version_id.resource_calendar_id = self.calendar_40h
         work_entries = self.env['hr.work.entry'].search([
-            ('employee_id', '=', self.jules_emp.id),
+            ('employee_id', '=', test_emp.id),
             ('date_start', '>=', date(2019, 10, 10)),
             ('date_stop', '<=', date(2019, 10, 10))
         ])
@@ -272,5 +281,5 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         self.assertEqual(work_entries.leave_id, leave)
         self.assertEqual(work_entries.work_entry_type_id, self.leave_type.work_entry_type_id)
         self.assertEqual(work_entries.mapped('duration'), [4.0, 4.0])
-        self.assertEqual(work_entries.mapped('date_start'), [datetime(2019, 10, 10, 8, 0), datetime(2019, 10, 10, 13, 0)])
-        self.assertEqual(work_entries.mapped('date_stop'), [datetime(2019, 10, 10, 12, 0), datetime(2019, 10, 10, 17, 0)])
+        self.assertEqual(work_entries.mapped('date_start'), [datetime(2019, 10, 10, 6, 0), datetime(2019, 10, 10, 11, 0)])
+        self.assertEqual(work_entries.mapped('date_stop'), [datetime(2019, 10, 10, 10, 0), datetime(2019, 10, 10, 15, 0)])


### PR DESCRIPTION
Issue: when you change in a contract for an employee with multiple leaves and one of them is overlapping multiple contracts, you get a validation error which shouldn't be the case

Steps to reproduce:
Case 1:
- create an employee with a contract ending on a day x
- create a leave for the employee from x-5 to x+5 and approve it
- create another contract with a different calendar for the employee starting on a day x+1 (change both the contract start date and the calendar and save once)
- when you save, you get a validation error but you shouldn't and the operation should be done normally

Case 2:
- create an employee with a contract ending on a day x
- create a leave for the employee from y-5 to y+5 inside the contract and approve it
- create another version with a different calendar for the employee starting on a day y (change both the contract start date and the calendar and save once)
- when you save, you get a validation error but you shouldn't and the operation should be done normally

Fix:
- ensured that the write of vals in contract is only done after refusing leaves that span multiple contracts
- changed the employee in `test_leave_change_working_schedule` and ensured that all timezones are in Europe/Brussels (jules_emp's tz was changing between UTC and Europe/Brussels depending on demo data which caused a runbot error)
- created another leave in `test_leave_multi_contracts_split` to ensure that the split works correctly with more than one leave

task-id: 5499527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
