### PR TITLE
[REV] hr_holidays: revert color change in time-off overview

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -33,7 +33,6 @@ class HrLeaveReportCalendar(models.Model):
     description = fields.Char("Description", readonly=True, groups='hr_holidays.group_hr_holidays_user')
     work_entry_type_id = fields.Many2one('hr.work.entry.type', readonly=True, string="Time Off Type",
         groups='hr_holidays.group_hr_holidays_user')
-    color = fields.Integer("Color", related='work_entry_type_id.color')
 
     is_hatched = fields.Boolean('Hatched', readonly=True)
     is_striked = fields.Boolean('Striked', readonly=True)


### PR DESCRIPTION
This commit reverts back the change done to gantt color of time-off overview to be based on time off type instead of employee, which made private information (time off type) available to everyone.

Task: 5868354
