### PR TITLE
[IMP] product_combo : change free into include

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
@@ -8,7 +8,7 @@
                     <t t-if="combo.qty_free > 0">
                         <h5 class="text-muted ms-2 mb-0">
                             <t t-esc="this.getSelectedComboItemsText(combo)"/>
-                            <span class="fst-italic"> free</span>
+                            <span class="fst-italic"> included</span>
                         </h5>
                     </t>
                 </div>

--- a/addons/point_of_sale/views/product_combo_views.xml
+++ b/addons/point_of_sale/views/product_combo_views.xml
@@ -19,7 +19,7 @@
                     <span class="o_form_label oe_inline fw-bolder">Includes</span>
                     <div>
                         <field name="qty_free" class="text-center" style="width:50px;"/>
-                        <label for="qty_free" string="free" class="fw-bolder ps-3" />
+                        <label for="qty_free" string="items" class="fw-bolder ps-3" />
                     </div>
                 </group>
                 <group>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

combo choice products are not free products. They are included in the combo product price. Therefore it creates misunderstanding for our users

Current behavior before PR:

Desired behavior after PR is merged:

Change the "free" string into "item" in the backend
and into "included" in pos frontend to align with the display in self



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
