### PR TITLE
[FIX] web,*: fix favorite icon size in form titles

### DIFF
--- a/addons/product/__manifest__.py
+++ b/addons/product/__manifest__.py
@@ -70,7 +70,6 @@ Print product labels with barcode.
             'product/static/src/product_catalog/**/*.xml',
             'product/static/src/product_catalog/**/*.scss',
             'product/static/src/product_name_and_description/**/*.js',
-            'product/static/src/scss/product_form.scss',
         ],
         'web.report_assets_common': [
             'product/static/src/scss/report_label_sheet.scss',

--- a/addons/product/static/src/scss/product_form.scss
+++ b/addons/product/static/src/scss/product_form.scss
@@ -1,3 +1,0 @@
-.oe_title .o_favorite i.fa {
-    font-size: inherit;
-}

--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -36,12 +36,8 @@
     }
 }
 
-.oe_title .o_favorite i.fa {
-    font-size: inherit;
-}
-
 .o_data_cell .o_favorite i.fa {
-    font-size: 1.35em;
+    --Favorite-font-size: 1.35em;
 }
 
 .o_project_task_kanban_view .o_kanban_quick_create .o_field_widget .o_input  {

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -346,7 +346,7 @@
                 height: max-content;
             }
         }
-        .o_priority > .o_priority_star {
+        .o_priority > .o_priority_star, .o_favorite i.fa {
             font-size: inherit;
         }
         > h1 {


### PR DESCRIPTION
*: product, project

Before this commit, product and project each had a duplicated CSS rule to make the favorite icon inherit the title font-size. This caused inconsistent behavior: modules like hr_recruitment that use the favorite widget in titles would show a smaller icon unless product or project were installed.

This commit moves the rule to the form_controller.scss in web, ensuring  consistent behavior across all modules regardless of which ones are installed.

task-5379834

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
