### PR TITLE
[FIX] sale_purchase,stock_dropshipping: set dest_address_id when changing picking_type

### DIFF
--- a/addons/sale_purchase/models/purchase_order.py
+++ b/addons/sale_purchase/models/purchase_order.py
@@ -25,9 +25,12 @@ class PurchaseOrder(models.Model):
     @api.depends('order_line.sale_order_id.partner_shipping_id')
     def _compute_dest_address_id(self):
         super()._compute_dest_address_id()
-        po_with_address = self.filtered(lambda po: po.dest_address_id and len(po._get_sale_orders().partner_shipping_id) == 1)
-        for order in po_with_address:
-            order.dest_address_id = order._get_sale_orders().partner_shipping_id
+        for po in self:
+            if not po._should_set_dest_address():
+                continue
+            sale_orders = po._get_sale_orders()
+            if len(sale_orders.partner_shipping_id) == 1:
+                po.dest_address_id = sale_orders.partner_shipping_id
 
     def action_view_sale_orders(self):
         self.ensure_one()
@@ -77,6 +80,10 @@ class PurchaseOrder(models.Model):
                     'purchase_orders': purchase_order_lines.mapped('order_id'),
                     'purchase_order_lines': purchase_order_lines,
             })
+
+    def _should_set_dest_address(self):
+        self.ensure_one()
+        return bool(self.dest_address_id)
 
 
 class PurchaseOrderLine(models.Model):

--- a/addons/stock_dropshipping/models/purchase.py
+++ b/addons/stock_dropshipping/models/purchase.py
@@ -35,6 +35,9 @@ class PurchaseOrder(models.Model):
         self.ensure_one()
         return self.picking_type_id and self.picking_type_id.code == 'dropship'
 
+    def _should_set_dest_address(self):
+        return super()._should_set_dest_address() or self._is_dropshipped()
+
 
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -575,3 +575,28 @@ class TestDropshipPostInstall(common.TransactionCase):
             default_product_tmpl_id=self.dropship_product.product_tmpl_id.id
         ))
         self.assertNotEqual(replenish_wizard.route_id, self.env.ref('stock_dropshipping.route_drop_shipping'))
+
+    def test_dest_address_when_changing_po_to_dropship(self):
+        """
+        Check that the destination address is set on the purchase order when
+        its picking type is manually changed to the dropshipping picking type.
+        """
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+        mto_route.action_unarchive()
+        buy_route = self.env.ref('purchase_stock.route_warehouse0_buy')
+        self.dropship_product.route_ids += buy_route
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id': self.dropship_product.id,
+                'product_uom_qty': 1.00,
+                'price_unit': 1,
+            })],
+        })
+        so.action_confirm()
+        po = so.order_line.purchase_line_ids.order_id
+        po.picking_type_id = buy_route.rule_ids.picking_type_id[-1]
+        self.assertFalse(po.dest_address_id)
+        po.picking_type_id = self.env['stock.picking.type'].search([('name', '=', 'Dropship'), ('company_id', '=', self.env.company.id)], limit=1)
+        self.assertEqual(po.dest_address_id, self.customer)


### PR DESCRIPTION
## Issue
When setting up a product with both the MTO and the *Dropship* routes, the *Purchase Order* genereated when confirming a *Sales Order* does not contain a *Dropship Address* (`purchase.order.dest_address_id`). It is problematic because that field is both readonly and required to confirm the order.

## Steps to reproduce
1. Install *Stock* (`stock`), *Purchase* (`purchase`) and *Sales* (`sale_management`)
2. In Settings, enable *Dropshipping* and *Replenish on Order (MTO)*
3. Create a Product P
    - Set a vendor in the Purchase tab
    - Enable the *Buy*, *Dropship* and *Replenish on Order (MTO)* routes
4. Create a Sales Order
    - Any Customer
    - Product P
    - Confirm the Sales Order
5. Click on the *Purchase* smart button
6. Set the *Delivery To* (`purchase.order.picking_type_id`) field to *"Dropship"*
7. **The _Dropship Address_ (`purchase.order.dest_address_id`) field appears, but it's empty and readonly. The purchase order cannot be confirmed, as the field is required and cannot be updated.**

## Cause
When confirming a Sales Order, the created Purchase Order has a `dest_addres_id` set by `StockRule._prepare_purchase_order`:

https://github.com/odoo/odoo/blob/19.0/addons/purchase_stock/models/stock_rule.py#L350

At that point, the `picking_type_id` of the PO is set to `"Receipts"`, which `default_location_dest_id` is the user's Stock, and the `usage` of that location is set to `"internal"`. When `_compute_dest_address_id` is triggered, it starts by calling the method in `sale_purchase`:

https://github.com/odoo/odoo/blob/9d96a8a4ae23bd331296ee0fd628c2be3de4bfe3/addons/sale_purchase/models/purchase_order.py#L25-L30

Which calls the one in `purchase_stock`:

https://github.com/odoo/odoo/blob/9d96a8a4ae23bd331296ee0fd628c2be3de4bfe3/addons/purchase_stock/models/purchase_order.py#L80-L82

Which sets the `dest_address_id` to `False`. This impacts the rest of first `_compute_dest_address_id`, as the PO does not have a `dest_address_id` anymore, its value will never be updated by the `_compute_dest_address_id` methods.

## Fix
The `dest_address_id` should only be set when dropshipping. The easiest way to do so is to override the `_compute_dest_address_id` in the `stock_dropshipping` module by following a similar logic as in `sale_purchase`:

https://github.com/odoo/odoo/blob/7a39185f83d0daca207c8007512f4700537c7e88/addons/sale_purchase/models/purchase_order.py#L25-L30

opw-5426322
