### PR TITLE
[IMP] mail: make current user last in mention suggestions

### DIFF
--- a/addons/mail/static/src/core/common/partner_compare.js
+++ b/addons/mail/static/src/core/common/partner_compare.js
@@ -25,6 +25,21 @@ partnerCompareRegistry.add(
 );
 
 partnerCompareRegistry.add(
+    "mail.self-last",
+    (p1, p2, { store }) => {
+        const isSelf1 = p1.eq(store.self);
+        const isSelf2 = p2.eq(store.self);
+        if (isSelf1 && !isSelf2) {
+            return 1;
+        }
+        if (!isSelf1 && isSelf2) {
+            return -1;
+        }
+    },
+    { sequence: 7 }
+);
+
+partnerCompareRegistry.add(
     "mail.internal-users",
     (p1, p2) => {
         const isAInternalUser = p1.main_user_id?.share === false;

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -287,6 +287,7 @@ export class SuggestionService {
             for (const fn of compareFunctions) {
                 const result = fn(p1, p2, {
                     env: this.env,
+                    store: this.store,
                     searchTerm: cleanedSearchTerm,
                     thread,
                     context,

--- a/addons/mail/static/tests/discuss/core/suggestion.test.js
+++ b/addons/mail/static/tests/discuss/core/suggestion.test.js
@@ -306,9 +306,9 @@ test("mention suggestion displays OdooBot before archived partners", async () =>
     await openDiscuss(channelId);
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-Composer-suggestion", { count: 3 });
-    await contains(".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))", {
+    await contains(".o-mail-Composer-suggestion:has(:text('OdooBot'))", {
         before: [
-            ".o-mail-Composer-suggestion:has(:text('OdooBot'))",
+            ".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))",
             {
                 before: [".o-mail-Composer-suggestion:has(:text('Jane'))"],
             },

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -870,7 +870,7 @@ test("Internal user should be displayed first", async () => {
     await contains(".o-mail-Composer-suggestion:eq(3) strong:text('Person A')");
 });
 
-test("[text composer] Current user that is a follower should be considered as such", async () => {
+test("[text composer] Current user is last suggested partner", async () => {
     const pyEnv = await startServer();
     const userId = pyEnv["res.users"].create({});
     pyEnv["res.partner"].create([
@@ -890,8 +890,8 @@ test("[text composer] Current user that is a follower should be considered as su
     await click("button:text('Send message')");
     await insertText(".o-mail-Composer-input", "@");
     await contains(".o-mail-Composer-suggestion", { count: 5 });
-    await contains(".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))", {
-        before: [".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))"],
+    await contains(".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))", {
+        before: [".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))"],
     });
     await contains(".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))", {
         before: [".o-mail-Composer-suggestion:has(:text('Person A (a@test.com)'))"],
@@ -899,7 +899,7 @@ test("[text composer] Current user that is a follower should be considered as su
 });
 
 test.tags("html composer");
-test("Current user that is a follower should be considered as such", async () => {
+test("Current user is last suggested partner", async () => {
     const pyEnv = await startServer();
     const userId = pyEnv["res.users"].create({});
     pyEnv["res.partner"].create([
@@ -927,8 +927,8 @@ test("Current user that is a follower should be considered as such", async () =>
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
     await contains(".o-mail-Composer-suggestion", { count: 5 });
-    await contains(".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))", {
-        before: [".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))"],
+    await contains(".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))", {
+        before: [".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))"],
     });
     await contains(".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))", {
         before: [".o-mail-Composer-suggestion:has(:text('Person A (a@test.com)'))"],


### PR DESCRIPTION
With this commit the current user will be the last suggested partner in the suggestion list, as it's very unlikely to mention yourself so the space is better used to display other more relevant suggestions.

part of task-5867464