### PR TITLE
[FIX] portal_address_extended: quick fixes

### DIFF
--- a/addons/l10n_br/controllers/portal.py
+++ b/addons/l10n_br/controllers/portal.py
@@ -2,24 +2,13 @@
 
 from odoo.http import request
 
-from odoo.addons.l10n_latam_base.controllers.portal import L10nLatamBasePortalAccount
+from odoo.addons.portal_address_extended.controllers.portal import CustomerPortalExtended
 
 
-class L10nBRPortalAccount(L10nLatamBasePortalAccount):
+class L10nBRPortalAccount(CustomerPortalExtended):
 
     def _is_brazilean_fiscal_country(self):
         return request.env.company.account_fiscal_country_id.code == 'BR'
-
-    def _prepare_address_form_values(self, partner_sudo, *args, **kwargs):
-        rendering_values = super()._prepare_address_form_values(partner_sudo, *args, **kwargs)
-        if self._is_brazilean_fiscal_country():
-            rendering_values.update({
-                'city': partner_sudo.city_id,
-                'state_cities': request.env['res.city'].sudo().search([
-                    ('country_id.code', '=', 'BR'),
-                ]),
-            })
-        return rendering_values
 
     def _get_mandatory_address_fields(self, country_sudo):
         mandatory_fields = super()._get_mandatory_address_fields(country_sudo)

--- a/addons/l10n_br/models/__init__.py
+++ b/addons/l10n_br/models/__init__.py
@@ -8,4 +8,5 @@ from . import l10n_br_zip_range
 from . import res_partner
 from . import res_city
 from . import res_company
+from . import res_country
 from . import res_partner_bank

--- a/addons/l10n_br/models/res_country.py
+++ b/addons/l10n_br/models/res_country.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResCountry(models.Model):
+    _inherit = 'res.country'
+
+    def _get_cities(self, state_id=None):
+        if self.code == 'BR' and not state_id:
+            return self.env['res.city'].sudo().search([('country_id', '=', self.id)])
+        return super()._get_cities(state_id)
+
+    def _get_cities_fields_to_fetch(self):
+        res = super()._get_cities_fields_to_fetch()
+        if self.code == 'BR':
+            res += ['l10n_br_zip_ranges']
+
+        return res

--- a/addons/l10n_br/static/src/interactions/address.js
+++ b/addons/l10n_br/static/src/interactions/address.js
@@ -11,12 +11,12 @@ patch(CustomerAddress.prototype, {
 
     async onChangeZip() {
         await super.onChangeZip();
-        if (this.countryCode !== 'BR' || this._getSelectedCountryCode() !== 'BR') return;
+        if (this._getSelectedCountryCode() !== 'BR') return;
 
         const newZip = this.addressForm.zip.value.padEnd(5, '0');
 
-        for (const option of this.addressForm.querySelectorAll('select[name="city_id"] option')) {
-            const ranges = option.getAttribute('zip-ranges');
+        for (const option of this.elementCities.options) {
+            const ranges = option.dataset.l10n_br_zip_ranges;
             if (ranges) {
                 // Parse the l10n_br_zip_ranges field (e.g. "[01000-001 05999-999] [08000-000 08499-999]").
                 // Loop over each range that is enclosed in [] (e.g. "[01000-001 05999-999]" followed by "[08000-000 08499-999]").
@@ -32,7 +32,7 @@ patch(CustomerAddress.prototype, {
                             new CustomEvent('select', { detail: { value: option.value } })
                         );
                         option.selected = 'selected';
-                        this._selectState(option.getAttribute('state-id'));
+                        this._selectState(option.dataset.state_id);
                         return;
                     }
                 }
@@ -42,13 +42,11 @@ patch(CustomerAddress.prototype, {
 
     async onChangeCity() {
         await super.onChangeCity();
-        if (this.countryCode !== 'BR' || this._getSelectedCountryCode() !== 'BR') return;
+        if (this._getSelectedCountryCode() !== 'BR') return;
 
         if (this.elementCities.value) {
             this._selectState(
-                this.elementCities
-                    .querySelector(`option[value='${this.elementCities.value}']`)
-                    .getAttribute('state-id')
+                this.elementCities.selectedOptions[0].dataset.state_id
             );
         }
     },
@@ -73,7 +71,7 @@ patch(CustomerAddress.prototype, {
 
     async onChangeState() {
         // For BR: don't want the standard behavior of reloading cities based on state
-        if (this.countryCode == 'BR' && this._getSelectedCountryCode() == 'BR') {
+        if (this._getSelectedCountryCode() == 'BR') {
             this.elementCities.value = '';
             return;
         }
@@ -82,7 +80,6 @@ patch(CustomerAddress.prototype, {
 
     async _onChangeCountry(init=false) {
         await this.waitFor(super._onChangeCountry(...arguments));
-        if (this.countryCode !== 'BR') return;
 
         if (this._getSelectedCountryCode() === 'BR') {
             this._setVisibility('.o_standard_address', false); // hide

--- a/addons/l10n_br/views/portal_address_templates.xml
+++ b/addons/l10n_br/views/portal_address_templates.xml
@@ -3,7 +3,7 @@
 
     <template id="address_form_fields" inherit_id="portal.address_form_fields">
         <xpath expr="//select[@name='city_id']/option[not(@value='')]" position="attributes">
-            <attribute name="t-att-zip-ranges" add="c.l10n_br_zip_ranges"/>
+            <attribute name="t-att-data-l10n_br_zip_ranges" add="c.l10n_br_zip_ranges"/>
         </xpath>
         <!-- put base_address_extended fields separately to be more user-friendly -->
         <div id="div_street" position="attributes">

--- a/addons/l10n_pe/controllers/portal.py
+++ b/addons/l10n_pe/controllers/portal.py
@@ -40,7 +40,8 @@ class L10nPEPortalAccount(L10nLatamBasePortalAccount):
         website=True,
     )
     def city_infos(self, city, **kw):
-        districts = request.env['l10n_pe.res.city.district'].sudo().search(
-            [('city_id', '=', city.id)],
-        )
-        return {'districts': [(d.id, d.name, d.code) for d in districts]}
+        return {
+            'districts': request.env['l10n_pe.res.city.district'].sudo().search_read(
+                [('city_id', '=', city.id)], ['id', 'name', 'code']
+            )
+        }

--- a/addons/portal/static/src/interactions/address.js
+++ b/addons/portal/static/src/interactions/address.js
@@ -98,6 +98,8 @@ export class CustomerAddress extends Interaction {
         data.required_fields.forEach((fieldName) => {
             this._markRequired(fieldName, true);
         })
+
+        return data;
     }
 
     _getInputDiv(name) {

--- a/addons/portal_address_extended/controllers/portal.py
+++ b/addons/portal_address_extended/controllers/portal.py
@@ -1,27 +1,23 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.http import request, route
+
 from odoo.addons.portal.controllers.portal import CustomerPortal
 
 
 class CustomerPortalExtended(CustomerPortal):
-
-    def _is_enforce_cities(self):
-        return request.env.company.country_id.enforce_cities
-
     def _prepare_address_form_values(self, partner_sudo, *args, **kwargs):
         rendering_values = super()._prepare_address_form_values(partner_sudo, *args, **kwargs)
-        if self._is_enforce_cities():
-            state_cities = request.env['res.city'].sudo().search([
-                ('country_id', '=', partner_sudo.country_id.id),
-            ])
-            rendering_values.setdefault('city', partner_sudo.city_id)
-            rendering_values.setdefault('state_cities', state_cities)
+        country = rendering_values['country']
+        rendering_values.update({
+            'city': partner_sudo.city_id,
+            'state_cities': country._get_cities(state_id=rendering_values['state_id']),
+        })
         return rendering_values
 
     def _get_mandatory_address_fields(self, country_sudo):
         mandatory_fields = super()._get_mandatory_address_fields(country_sudo)
-        if self._is_enforce_cities() and country_sudo.enforce_cities:
+        if country_sudo._enforce_city_choice():
             mandatory_fields.add('city_id')
             mandatory_fields.remove('city')
         return mandatory_fields
@@ -30,7 +26,7 @@ class CustomerPortalExtended(CustomerPortal):
         address_values, extra_form_data = super()._parse_form_data(form_data)
         country_id = address_values.get('country_id')
         country_sudo = request.env['res.country'].browse(country_id)
-        if country_sudo.enforce_cities and self._is_enforce_cities() and form_data.get('city_id'):
+        if country_sudo.enforce_cities and form_data.get('city_id'):
             if city := request.env['res.city'].sudo().browse(int(form_data['city_id'])):
                 address_values['city'] = city.name
         return address_values, extra_form_data
@@ -44,5 +40,28 @@ class CustomerPortalExtended(CustomerPortal):
         readonly=True,
     )
     def portal_address_state_info(self, state, **kw):
-        cities = request.env['res.city'].sudo().search([('state_id', '=', state.id)])
-        return {'cities': [(city.id, city.name) for city in cities]}
+        country = state.country_id
+
+        if country._enforce_city_choice():
+            return {
+                'cities': request.env['res.city'].sudo().search_read(
+                    [('state_id', '=', state.id)],
+                    country._get_cities_fields_to_fetch(),
+                    load='',  # we only want the ids of relational fields
+                )
+            }
+
+        return {
+            'cities': [],
+        }
+
+    @route()
+    def portal_address_country_info(self, country, address_type, **kw):
+        res = super().portal_address_country_info(country, address_type, **kw)
+
+        if country._enforce_city_choice():
+            res['cities'] = country._get_cities().read(
+                country._get_cities_fields_to_fetch(), load='',
+            )
+
+        return res

--- a/addons/portal_address_extended/models/__init__.py
+++ b/addons/portal_address_extended/models/__init__.py
@@ -1,1 +1,3 @@
-from . import res_partner
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import res_country, res_partner

--- a/addons/portal_address_extended/models/res_country.py
+++ b/addons/portal_address_extended/models/res_country.py
@@ -1,0 +1,34 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResCountry(models.Model):
+    _inherit = 'res.country'
+
+    def _enforce_city_choice(self):
+        if not self:
+            return False
+
+        # Only enabled on frontend for those countries for now
+        # Feature has to be adapted to be more generic and less blocking
+        # before being enabled for other countries
+        if self.code not in ['BR', 'CL', 'PE', 'CO', 'TW']:
+            return False
+
+        self.ensure_one()
+        return self.enforce_cities and bool(
+            self.env['res.city'].sudo().search_count([('country_id', '=', self.id)], limit=1)
+        )
+
+    def _get_cities(self, state_id=None):
+        if not self:
+            return self.env['res.city'].sudo()
+
+        return self.env['res.city'].sudo().search([
+            ('country_id', '=', self.id),
+            ('state_id', 'in', [state_id, False]),
+        ])
+
+    def _get_cities_fields_to_fetch(self):
+        return ['id', 'name', 'state_id']

--- a/addons/portal_address_extended/static/src/interactions/address.js
+++ b/addons/portal_address_extended/static/src/interactions/address.js
@@ -13,7 +13,6 @@ patch(CustomerAddress.prototype, {
         });
         this.elementState = this.addressForm.state_id;
         this.elementCities = this.addressForm.city_id;
-        this.countryEnforceCities = this.addressForm['enforce_cities'].value === "True";
     },
 
     /**
@@ -25,7 +24,7 @@ patch(CustomerAddress.prototype, {
 
     async onChangeState() {
         await this.waitFor(super.onChangeState());
-        if (!this.countryEnforceCities || !this._getSelectedCountryEnforceCities()) return;
+        if (!this._getSelectedCountryEnforceCities()) return;
 
         const stateId = this.elementState.value;
         let choices = [];
@@ -37,26 +36,32 @@ patch(CustomerAddress.prototype, {
     },
 
     async _onChangeCountry(init=false) {
-        await this.waitFor(super._onChangeCountry(...arguments));
-        if(!this.countryEnforceCities) return;
+        const data = await this.waitFor(super._onChangeCountry(...arguments));
 
+        let choices = [];
         if (this._getSelectedCountryEnforceCities()) {
             const cityInput = this.addressForm.city;
             cityInput.value = '';
             this._hideInput('city');
             this._showInput('city_id');
+            choices = data.cities || [];
         } else {
             this._hideInput('city_id');
             this._showInput('city');
-            this.elementCities.value = '';
         }
+        this._changeOption(this.elementCities, choices);
     },
 
     _changeOption(selectElement, choices) {
         selectElement.options.length = 1;
         if (choices.length) {
-            choices.forEach((item) => {
-                const option = new Option(item[1], item[0]);
+            choices.forEach((choice) => {
+                const option = new Option(choice.name, choice.id);
+                Object.keys(choice).forEach((key) => {
+                    if (!['name', 'id'].includes(key) && choice[key]) {
+                        option.dataset[key] = choice[key];
+                    }
+                });
                 selectElement.appendChild(option);
             });
         }

--- a/addons/portal_address_extended/views/portal_address_templates.xml
+++ b/addons/portal_address_extended/views/portal_address_templates.xml
@@ -2,27 +2,25 @@
 <odoo>
     <template id="address_extended_form_fields" inherit_id="portal.address_form_fields">
         <div id="div_state" position="after">
-            <input type="hidden" name="enforce_cities"
-                t-att-value="res_company.country_id.enforce_cities"/>
-            <div t-if="res_company.country_id.enforce_cities"
-                 id="div_city_id"
-                 class="col-lg-6 mb-2"
-                 t-att-style="not country and 'display:none;'" >
+            <div
+                id="div_city_id"
+                class="col-lg-6 mb-2"
+                t-att-style="not country._enforce_city_choice() and 'display:none;'"
+            >
                 <label class="col-form-label label-optional" for="city_id">City</label>
                 <select id="o_city_id" name="city_id" class="form-select">
                     <option value="">City...</option>
                     <option t-foreach="state_cities"
                             t-as="c"
                             t-att-value="c.id"
-                            t-att-selected="c.id == (city.id if city else partner_sudo.city_id.id)"
-                            t-att-state-id="c.state_id.id"
+                            t-att-selected="c.id == city.id"
+                            t-att-data-state_id="c.state_id.id"
                             t-out="c.name"/>
                 </select>
             </div>
         </div>
         <xpath expr="//select[@name='country_id']/option[not(@value='')]" position="attributes">
-            <attribute name="t-att-enforce-cities"
-                add="c.enforce_cities" />
+            <attribute name="t-att-enforce-cities" add="c._enforce_city_choice()" />
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
* Do not consider current company country, only customer country
* Do not enforce cities if no cities are defined for the country
* Do not force city choice for all countries, feature will be improved in the coming months but it's too restrictive to impose on all the countries set to `enforce_cities` in the data (e.g. us payroll enables it for US, leading to issues when doing a demo with mitchell admin on runbot).

Current enforcement makes it impossible to buy on the ecommerce if data is incomplete (e.g. if you select Micronesia in the US states, there is no available city, so there is no way to save your address before this commit).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
