### PR TITLE
[FIX] mass_mailing: don't enforce deep font-family

### DIFF
--- a/addons/mass_mailing/static/src/scss/mass_mailing_mail.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing_mail.scss
@@ -2,7 +2,7 @@
 .o_layout * {
     box-sizing: border-box !important;
 }
-.o_layout :not(.fa) {
+.o_layout {
     font-family: Arial,Helvetica Neue,Helvetica,sans-serif;
 }
 /* Remove space around the email design. */


### PR DESCRIPTION
There is an issue where some editor descendants have a rule overriding their
`font-family` which has more precedence than the inherited `font-family` from
the Design Tab.

How to reproduce:
- create a new mass_mailing
- add a text snippet
- select all text and change e.g. the `font-size`
- open the Design Tab and change the `font-family` of paragraphs

Issue:
- the text `font-family` does not change

Resolution:
Fix a css rule applying on every element that is not a `fa` element so that it
only applies on the `o_layout` element to let the Design Tab override the
`font-family` for specific elements (e.g. `<p>`, `<a>`, ...).

task-5869568