### PR TITLE
[IMP] l10n_us: enable Spanish translations

### DIFF
--- a/.weblate.json
+++ b/.weblate.json
@@ -2886,6 +2886,12 @@
                 "language_regex": "^(sw)$"
             },
             {
+                "name": "l10n_us",
+                "filemask": "addons/l10n_us/i18n/*.po",
+                "new_base": "addons/l10n_us/i18n/l10n_us.pot",
+                "language_regex": "^(es_419)$"
+            },
+            {
                 "name": "l10n_uy",
                 "filemask": "addons/l10n_uy/i18n/*.po",
                 "new_base": "addons/l10n_uy/i18n/l10n_uy.pot",


### PR DESCRIPTION
The official language is English, but Spanish is spoken by ~41 million.

task-5247124
