### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: Add Buyer and Seller Line code for Export invoices

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/data/template/l10n_tr_nilvera_einvoice.account.tax.code-tr.csv
+++ b/addons/l10n_tr_nilvera_einvoice/data/template/l10n_tr_nilvera_einvoice.account.tax.code-tr.csv
@@ -37,3 +37,4 @@
 "l10n_tr_nilvera_einvoice.account_tax_code_626","Other Submissions","Diğer Teslimler","626","0.2","withholding"
 "l10n_tr_nilvera_einvoice.account_tax_code_627","Delivery of Iron and Steel Products","Demir-Çelik Ürünlerinin Teslimi","627","0.5","withholding"
 "l10n_tr_nilvera_einvoice.account_tax_code_701","Export Registered Sales within the scope of Article 11/1-c of the VAT Law No. 3065","3065 s. KDV Kanununun 11/1-c md. Kapsamındaki İhraç Kayıtlı Satış","701","0.0","export_registration"
+"l10n_tr_nilvera_einvoice.account_tax_code_702","Sales under the IPAC and Temporary Acceptance Regime","DİİB ve Geçici Kabul Rejimi Kapsamındaki Satışlar","702","0.0","export_registration"

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_line.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_line.py
@@ -11,6 +11,20 @@ class AccountMoveLine(models.Model):
         store=True,
         readonly=False,
     )
+    l10n_tr_seller_line_code = fields.Char(
+        string="Seller Line Code",
+        compute='_compute_l10n_tr_seller_line_code',
+        store=True,
+        readonly=False,
+    )
+    l10n_tr_customer_line_code = fields.Char(
+        string="Customer Line Code",
+        help="Customer Line Code (11 or fewer characters)",
+        size=11,
+        compute='_compute_l10n_tr_customer_line_code',
+        store=True,
+        readonly=False,
+    )
 
     @api.depends("product_id.l10n_tr_ctsp_number")
     def _compute_l10n_tr_ctsp_number(self):
@@ -22,3 +36,13 @@ class AccountMoveLine(models.Model):
         for record in self:
             if record.l10n_tr_ctsp_number and len(record.l10n_tr_ctsp_number) > 12:
                 raise ValidationError(_("CTSP Number must be 12 digits or fewer."))
+
+    @api.depends("product_id.l10n_tr_seller_line_code")
+    def _compute_l10n_tr_seller_line_code(self):
+        for record in self:
+            record.l10n_tr_seller_line_code = record.product_id.l10n_tr_seller_line_code
+
+    @api.depends("product_id.l10n_tr_customer_line_code")
+    def _compute_l10n_tr_customer_line_code(self):
+        for record in self:
+            record.l10n_tr_customer_line_code = record.product_id.l10n_tr_customer_line_code

--- a/addons/l10n_tr_nilvera_einvoice/models/product_product.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/product_product.py
@@ -7,6 +7,8 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     l10n_tr_ctsp_number = fields.Char(string="CTSP Number", copy=False, index="btree_not_null")
+    l10n_tr_seller_line_code = fields.Char(string="Seller Line Code", copy=False)
+    l10n_tr_customer_line_code = fields.Char(string="Customer Line Code", size=11, copy=False)
 
     @api.constrains("l10n_tr_ctsp_number")
     def _check_l10n_tr_ctsp_number(self):

--- a/addons/l10n_tr_nilvera_einvoice/models/product_template.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/product_template.py
@@ -9,6 +9,16 @@ class ProductTemplate(models.Model):
         compute="_compute_l10n_tr_ctsp_number",
         inverse="_set_l10n_tr_ctsp_number",
     )
+    l10n_tr_customer_line_code = fields.Char(
+        string="Customer Line Code",
+        compute='_compute_l10n_tr_customer_line_code',
+        inverse='_set_l10n_tr_customer_line_code',
+    )
+    l10n_tr_seller_line_code = fields.Char(
+        string="Seller Line Code",
+        compute='_compute_l10n_tr_seller_line_code',
+        inverse='_set_l10n_tr_seller_line_code',
+    )
 
     @api.depends("product_variant_ids.l10n_tr_ctsp_number")
     def _compute_l10n_tr_ctsp_number(self):
@@ -16,3 +26,17 @@ class ProductTemplate(models.Model):
 
     def _set_l10n_tr_ctsp_number(self):
         self._set_product_variant_field("l10n_tr_ctsp_number")
+
+    @api.depends("product_variant_ids.l10n_tr_customer_line_code")
+    def _compute_l10n_tr_customer_line_code(self):
+        self._compute_template_field_from_variant_field("l10n_tr_customer_line_code")
+
+    def _set_l10n_tr_customer_line_code(self):
+        self._set_product_variant_field("l10n_tr_customer_line_code")
+
+    @api.depends("product_variant_ids.l10n_tr_seller_line_code")
+    def _compute_l10n_tr_seller_line_code(self):
+        self._compute_template_field_from_variant_field("l10n_tr_seller_line_code")
+
+    def _set_l10n_tr_seller_line_code(self):
+        self._set_product_variant_field("l10n_tr_seller_line_code")

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_ipac_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_ipac_einvoice.xml
@@ -1,0 +1,182 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+    <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
+    <cbc:ID>EIN2025000000001</cbc:ID>
+    <cbc:CopyIndicator>false</cbc:CopyIndicator>
+    <cbc:UUID>___ignore___</cbc:UUID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+    <cbc:InvoiceTypeCode>IHRACKAYITLI</cbc:InvoiceTypeCode>
+    <cbc:Note>3 products</cbc:Note>
+    <cbc:Note>YALNIZ : YÜZELLISEKIZ TRY KIRK KURUS</cbc:Note>
+    <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+    <cbc:LineCountNumeric>3</cbc:LineCountNumeric>
+    <cac:OrderReference>
+        <cbc:ID>EIN/2025/1</cbc:ID>
+        <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+    </cac:OrderReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>3281. Cadde</cbc:StreetName>
+                <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+                <cbc:CityName>Düzce</cbc:CityName>
+                <cbc:PostalZone>06810</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID>3297552117</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+                <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="VKN">1729171602</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>einvoice_partner</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+                <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+                <cbc:CityName>Ankara</cbc:CityName>
+                <cbc:PostalZone>06934</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+                    <cbc:Name>Türkiye</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:Name>Ulus Malmüdürlüğü</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>einvoice_partner</cbc:RegistrationName>
+                <cbc:CompanyID>1729171602</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+                <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentDueDate>2026-01-20</cbc:PaymentDueDate>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>TR0123456789</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+            <cbc:Percent>20.0</cbc:Percent>
+            <cac:TaxCategory>
+                <cbc:TaxExemptionReasonCode>702</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>DİİB ve Geçici Kabul Rejimi Kapsamındaki Satışlar</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+                    <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="TRY">158.40</cbc:TaxInclusiveAmount>
+        <cbc:AllowanceTotalAmount currencyID="TRY">18.00</cbc:AllowanceTotalAmount>
+        <cbc:PayableAmount currencyID="TRY">132.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+        <cac:Delivery>
+            <cac:Shipment>
+                <cbc:ID></cbc:ID>
+                <cac:GoodsItem>
+                    <cbc:RequiredCustomsID>129392930912</cbc:RequiredCustomsID>
+                </cac:GoodsItem>
+                <cac:TransportHandlingUnit>
+                    <cac:CustomsDeclaration>
+                        <cbc:ID></cbc:ID>
+                        <cac:IssuerParty>
+                            <cac:PartyIdentification>
+                                <cbc:ID schemeID="ALICIDIBSATIRKOD">11223345690</cbc:ID>
+                            </cac:PartyIdentification>
+                            <cac:PartyIdentification>
+                                <cbc:ID schemeID="SATICIDIBSATIRKOD" />
+                            </cac:PartyIdentification>
+                            <cac:PostalAddress>
+                                <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+                                <cbc:CityName>Ankara</cbc:CityName>
+                                <cac:Country>
+                                    <cbc:Name>Türkiye</cbc:Name>
+                                </cac:Country>
+                            </cac:PostalAddress>
+                        </cac:IssuerParty>
+                    </cac:CustomsDeclaration>
+                </cac:TransportHandlingUnit>
+            </cac:Shipment>
+        </cac:Delivery>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+            <cbc:MultiplierFactorNumeric>0.12</cbc:MultiplierFactorNumeric>
+            <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+                <cbc:Percent>20.0</cbc:Percent>
+                <cac:TaxCategory>
+                    <cac:TaxScheme>
+                        <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+                        <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>product_a</cbc:Description>
+            <cbc:Name>product_a</cbc:Name>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -19,6 +19,7 @@ class TestUBLTR(TestUBLTRCommon):
         cls.tax_20_withholding = cls.env['account.chart.template'].ref('tr_s_vat_wh_20_OGH')
         # Registered for Export Reason
         cls.reason_701 = cls.env['account.chart.template'].ref('l10n_tr_nilvera_einvoice.account_tax_code_701')
+        cls.reason_702 = cls.env['account.chart.template'].ref('l10n_tr_nilvera_einvoice.account_tax_code_702')
 
         # Tax Exemption Reason
         cls.reason_212 = cls.env['account.chart.template'].ref('l10n_tr_nilvera_einvoice.account_tax_code_212')
@@ -95,6 +96,23 @@ class TestUBLTR(TestUBLTRCommon):
             generated_xml = self._generate_invoice_xml(self.earchive_partner, l10n_tr_is_export_invoice=True, l10n_tr_exemption_code_id=self.reason_301.id, l10n_tr_shipping_type="1", invoice_incoterm_id=self.incoterm.id)
 
         with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_earchive.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))
+
+    def test_xml_invoice_export_ipac_einvoice(self):
+        with freeze_time('2026-01-20'):
+            generated_xml = self._generate_invoice_xml(
+                self.einvoice_partner,
+                l10n_tr_exemption_code_id=self.reason_702.id,
+                l10n_tr_gib_invoice_type="IHRACKAYITLI",
+                invoice_line_data={
+                    'l10n_tr_ctsp_number': '129392930912',
+                    'l10n_tr_customer_line_code': '11223345690',
+                },
+            )
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_export_ipac_einvoice.xml', 'rb') as expected_xml_file:
             expected_xml = expected_xml_file.read()
 
         self.assertXmlTreeEqual(self.get_xml_tree_from_string(generated_xml), self.get_xml_tree_from_string(expected_xml))

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr_common.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr_common.py
@@ -87,6 +87,7 @@ class TestUBLTRCommon(AccountTestInvoicingCommon):
                     'quantity': 3,
                     'discount': 12,
                     'tax_ids': [Command.set(invoice_tax)],
+                    **kwargs.pop('invoice_line_data', {}),
                 }),
             ],
             **kwargs,

--- a/addons/l10n_tr_nilvera_einvoice/tools/ubl_tr_common.py
+++ b/addons/l10n_tr_nilvera_einvoice/tools/ubl_tr_common.py
@@ -228,10 +228,24 @@ ShipmentStage = {
     'cbc:TransportModeCode': {},
 }
 
+TransportHandlingUnit = {
+    'cac:CustomsDeclaration': {
+        'cbc:ID': {},
+        'cac:IssuerParty': {
+            'cac:PartyIdentification': {
+                'cbc:ID': {},
+            },
+            'cac:PartyName': {},
+            'cac:PostalAddress': Address,
+        },
+    },
+}
+
 Shippment = {
     'cbc:ID': {},
     'cac:GoodsItem': GoodsItem,
     'cac:ShipmentStage': ShipmentStage,
+    'cac:TransportHandlingUnit': TransportHandlingUnit,
 }
 
 Delivery = {

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -63,6 +63,8 @@
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']//list//field[@name='tax_ids']" position="after">
                 <field name="l10n_tr_ctsp_number" optional="hide"/>
+                <field name="l10n_tr_seller_line_code" optional="hide"/>
+                <field name="l10n_tr_customer_line_code" optional="hide"/>
             </xpath>
             <xpath expr="//header/field[@name='state']" position="before">
                 <button name="l10n_tr_nilvera_get_pdf"

--- a/addons/l10n_tr_nilvera_einvoice/views/product_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/product_views.xml
@@ -9,10 +9,20 @@
             <field name="arch" type="xml">
                     <xpath expr="//field[@name='barcode']" position="after">
                         <field name="l10n_tr_ctsp_number"
-                               invisible="product_variant_count &gt; 1
+                               invisible="'TR' not in fiscal_country_codes
+                                    or product_variant_count &gt; 1
                                     or (product_variant_count == 0
-                                    and valid_product_template_attribute_line_ids)
-                                    or 'TR' not in fiscal_country_codes"/>
+                                    and valid_product_template_attribute_line_ids)"/>
+                        <field name="l10n_tr_customer_line_code"
+                                 invisible="'TR' not in fiscal_country_codes
+                                        or product_variant_count &gt; 1
+                                        or (product_variant_count == 0
+                                        and valid_product_template_attribute_line_ids)"/>
+                        <field name="l10n_tr_seller_line_code"
+                                 invisible="'TR' not in fiscal_country_codes
+                                        or product_variant_count &gt; 1
+                                        or (product_variant_count == 0
+                                        and valid_product_template_attribute_line_ids)"/>
                     </xpath>
                 </field>
         </record>
@@ -24,6 +34,8 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='barcode']" position="after">
                     <field name="l10n_tr_ctsp_number" invisible="'TR' not in fiscal_country_codes"/>
+                    <field name="l10n_tr_customer_line_code" invisible="'TR' not in fiscal_country_codes"/>
+                    <field name="l10n_tr_seller_line_code" invisible="'TR' not in fiscal_country_codes"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
This commit introduces two new fields on product and invoice lines: `Customer Line Code` and `Seller Line Code`.

It introduces an exemption reason for Registered for Export type invoices with exemption code `702`.
It makes the Customer Line code on each invoice line mandatory for invoices having exemption code `702` while sending e-invoice to Nilvera.

Adds test case for the above scenario.

task-5010752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
