### PR TITLE
[FIX] account_edi_ubl_cii : fix selfbilling attributeError

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -202,6 +202,9 @@ class AccountEdiCommon(models.AbstractModel):
             if val:
                 return val
 
+    def _can_export_selfbilling(self):
+        return False
+
     # -------------------------------------------------------------------------
     # TAXES
     # -------------------------------------------------------------------------


### PR DESCRIPTION
While computing the self-billing export eligibility, the system called ```_can_export_selfbilling()``` on the  EDI builder. However, this method is only implemented for the ```account.edi.xml.ubl_bis3``` builder and is not available on other EDI formats such as ```oioubl_21```,
```oioubl_201```.

When a partner is configured to use the ```oioubl_21``` eInvoice format,
this resulted in an ```AttributeError``` during record reads, causing menu crawl and
UI access failures (e.g., Accounting → Vendors → Bills/Refunds).

```sql
 Traceback (most recent call last):
   File "/tmp/tmpznsful5y/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpznsful5y/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmpznsful5y/migrations/base/tests/test_mock_crawl.py", line 506, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpznsful5y/migrations/base/tests/test_mock_crawl.py", line 539, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 3858, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4089, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 7078, in __getitem__
    return self._fields[key].__get__(self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1311, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1493, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 442, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5297, in _compute_field_value
    fields.determine(field.compute, self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 110, in determine
    return needle(*args)
   File "/home/odoo/src/odoo/18.0/addons/account_peppol_selfbilling/models/account_move.py", line 13, in _compute_can_send_as_self_invoice
    if move._is_exportable_as_self_invoice():
   File "/home/odoo/src/odoo/18.0/addons/account_peppol_selfbilling/models/account_move.py", line 31, in _is_exportable_as_self_invoice
    and edi_builder._can_export_selfbilling()
 AttributeError: 'account.edi.xml.oioubl_21' object has no attribute '_can_export_selfbilling'
```
**Steps to reproduce**
1) Install l10n_dk_nemhandel module
2) Set the eInvoice format to oioubl_21 for the partner
3) Create Bill for that partner
3) Confirm the bill

OPW - 5863081
UPG - 3846482




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
