### PR TITLE
[IMP] mail: make activity delete action explicit and safer

### DIFF
--- a/addons/calendar/static/src/core/web/activity_patch.js
+++ b/addons/calendar/static/src/core/web/activity_patch.js
@@ -10,17 +10,4 @@ patch(Activity.prototype, {
     async onClickReschedule() {
         await this.props.activity.rescheduleMeeting();
     },
-    /**
-     * @override
-     */
-    async unlink() {
-        if (this.props.activity.calendar_event_id) {
-            const thread = this.thread;
-            this.props.activity.remove();
-            await this.orm.call("mail.activity", "unlink_w_meeting", [[this.props.activity.id]]);
-            this.props.onActivityChanged(thread);
-        } else {
-            super.unlink();
-        }
-    },
 });

--- a/addons/calendar/static/tests/activity.test.js
+++ b/addons/calendar/static/tests/activity.test.js
@@ -8,7 +8,12 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-dom";
+import { serializeDateTime } from "@web/core/l10n/dates";
+import { clickEvent } from "@web/../tests/views/calendar/calendar_test_helpers";
 import { preloadBundle } from "@web/../tests/web_test_helpers";
+
+const { DateTime } = luxon;
 
 defineCalendarModels();
 preloadBundle("web.fullcalendar_lib");
@@ -44,7 +49,8 @@ test("activity click on Reschedule", async () => {
     await contains(".o_calendar_view");
 });
 
-test("Can cancel activity linked to an event", async () => {
+test("Can delete activity linked to an event", async () => {
+    registerArchs({ "calendar.event,false,calendar": `<calendar date_start="start"/>` });
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Milan Kundera" });
     const activityTypeId = pyEnv["mail.activity.type"].create({
@@ -57,7 +63,7 @@ test("Can cancel activity linked to an event", async () => {
     const calendaMeetingId = pyEnv["calendar.event"].create({
         res_model: "calendar.event",
         name: "meeting1",
-        start: "2022-07-06 06:30:00",
+        start: serializeDateTime(DateTime.now().plus({ days: 1 })),
         attendee_ids: [attendeeId],
     });
     pyEnv["mail.activity"].create({
@@ -70,6 +76,11 @@ test("Can cancel activity linked to an event", async () => {
     });
     await start();
     await openFormView("res.partner", partnerId);
-    await click(".o-mail-Activity .btn", { text: "Cancel" });
-    await contains(".o-mail-Activity", { count: 0 });
+    await click(".o-mail-Activity .btn", { text: "Reschedule" });
+    await contains(".o_calendar_view");
+    await animationFrame();
+    await clickEvent(calendaMeetingId);
+    await click(".o-overlay-container .o_cw_popover_delete");
+    await click(".o_dialog .modal-footer button.btn.btn-danger");
+    await contains(`.o_event[data-event-id="${calendaMeetingId}"]`, { count: 0 });
 });

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -421,7 +421,7 @@ class FleetVehicle(models.Model):
                 ('res_id', 'in', self.ids),
                 ('note', 'ilike', _('Review driver change')),
                 ('user_id', 'in', self.manager_id.ids or [self.env.user.id])
-            ]).action_cancel()
+            ]).unlink()
 
             cleanup = set()
             for vehicle in self:

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -709,11 +709,6 @@ class MailActivity(models.Model):
     def action_reschedule_nextweek(self):
         self.filtered('active').date_deadline = date.today() + relativedelta(weeks=1, weekday=MO(-1))
 
-    def action_cancel(self):
-        for activity in self:
-            if activity.active:
-                activity.unlink()
-
     @api.readonly
     def activity_format(self):
         return Store().add(self, "_store_activity_fields").get_result()

--- a/addons/mail/static/src/core/web/activity.js
+++ b/addons/mail/static/src/core/web/activity.js
@@ -101,13 +101,6 @@ export class Activity extends Component {
         this.props.onActivityChanged(thread);
     }
 
-    async unlink() {
-        const thread = this.thread;
-        this.props.activity.remove();
-        await this.env.services.orm.unlink("mail.activity", [this.props.activity.id]);
-        this.props.onActivityChanged(thread);
-    }
-
     get thread() {
         return this.env.services["mail.store"]["mail.thread"].insert({
             model: this.props.activity.res_model,

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -62,9 +62,6 @@
                     <button class="o-mail-Activity-edit btn btn-link text-action p-0 me-3" t-on-click="this.edit">
                         <i class="fa fa-pencil"/> Edit
                     </button>
-                    <button class="btn btn-link btn-danger p-0" t-on-click="this.unlink">
-                        <i class="fa fa-times"/> Cancel
-                    </button>
                 </t>
             </div>
         </div>

--- a/addons/mail/static/src/core/web/activity_list_popover_item.js
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.js
@@ -60,11 +60,6 @@ export class ActivityListPopoverItem extends Component {
         }
     }
 
-    get hasCancelButton() {
-        const activity = this.props.activity;
-        return activity.state !== "done" && activity.can_write;
-    }
-
     get hasEditButton() {
         const activity = this.props.activity;
         return activity.state !== "done" && activity.can_write;
@@ -94,12 +89,5 @@ export class ActivityListPopoverItem extends Component {
         });
         await this.props.activity.markAsDone([attachmentId]);
         this.props.onActivityChanged?.();
-    }
-
-    unlink() {
-        this.props.activity.remove();
-        this.env.services.orm
-            .unlink("mail.activity", [this.props.activity.id])
-            .then(() => this.props.onActivityChanged?.());
     }
 }

--- a/addons/mail/static/src/core/web/activity_list_popover_item.xml
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.xml
@@ -24,9 +24,6 @@
                 <button t-if="this.hasEditButton" class="o-mail-ActivityListPopoverItem-editbtn btn btn-sm btn-success btn-link" title="Edit" aria-label="Edit" t-on-click="this.onClickEditActivityButton">
                     <i class="fa fa-pencil"/>
                 </button>
-                <button t-if="this.hasCancelButton" class="o-mail-ActivityListPopoverItem-cancel btn btn-sm btn-danger btn-link" title="Cancel" aria-label="Cancel" t-on-click="this.unlink">
-                    <i class="fa fa-times"/>
-                </button>
             </div>
             <div class="d-flex align-items-center flex-wrap mx-3">
                 <img class="me-2 rounded object-fit-cover" t-if="this.props.activity.user_id?.partner_id" t-att-src="this.props.activity.user_id.partner_id.avatarUrl" style="max-width: 1.5rem; max-height: 1.5rem;"/>

--- a/addons/mail/static/src/views/web/list/archive_disabled_list_controller.js
+++ b/addons/mail/static/src/views/web/list/archive_disabled_list_controller.js
@@ -1,3 +1,4 @@
+import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { ListController } from "@web/views/list/list_controller";
 
@@ -6,6 +7,17 @@ export class ArchiveDisabledListController extends ListController {
         super.setup();
         this.archiveEnabled = false;
         this.store = useService("mail.store");
+    }
+
+    get deleteConfirmationDialogProps() {
+        return {
+            title: _t("Delete Activities"),
+            body: _t(
+                "Are you sure you want to delete these activities? They will be gone forever!\nThink twice before you click that 'Delete' button!"
+            ),
+            confirmLabel: _t("Yes, delete"),
+            cancelLabel: _t("No, go back"),
+        };
     }
 
     async createRecord() {

--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -4,6 +4,7 @@ import {
     click,
     contains,
     defineMailModels,
+    mailModels,
     inputFiles,
     openFormView,
     start,
@@ -16,6 +17,14 @@ import { deserializeDateTime, serializeDate, today } from "@web/core/l10n/dates"
 import { getOrigin } from "@web/core/utils/urls";
 
 describe.current.tags("desktop");
+mailModels.MailActivity._views = {
+    form: `
+        <form>
+            <footer>
+                <button string="Delete" type="object" name="unlink" icon="fa-trash" class="btn-danger ms-auto"/>
+            </footer>
+        </form>`,
+};
 defineMailModels();
 
 test("activity upload document is available", async () => {
@@ -422,7 +431,7 @@ test("activity click on edit should pass correct context", async () => {
     await expect.waitForSteps(["do_action"]);
 });
 
-test("activity click on cancel", async () => {
+test("activity click on edit then delete", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({});
     const activityTypeId = pyEnv["mail.activity.type"].search([["name", "=", "Email"]])[0];
@@ -439,7 +448,8 @@ test("activity click on cancel", async () => {
     });
     await start();
     await openFormView("res.partner", partnerId);
-    await click(".o-mail-Activity .btn:text('Cancel')");
+    await click(".o-mail-Activity .btn:text('Edit')");
+    await click(".modal-dialog .btn:text('Delete')");
     await contains(".o-mail-Activity", { count: 0 });
     await expect.waitForSteps(["unlink"]);
 });

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -161,6 +161,7 @@
                             type="object" class="btn-secondary" data-hotkey="w"
                             context="{'mail_activity_quick_update': True}"/>
                         <button class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <button string="Delete" type="object" name="unlink" icon="fa-trash" class="btn-danger ms-auto" invisible="not id"/>
                     </footer>
                 </sheet>
             </form>
@@ -265,7 +266,6 @@
                     default_order="date_deadline" create="true">
                 <header>
                     <button name="action_done" type="object" string="Done" icon="fa-check"/>
-                    <button name="action_cancel" type="object" string="Cancel" icon="fa-times"/>
                     <button name="action_reschedule_today" type="object" string="Today" icon="fa-arrow-down"/>
                     <button name="action_reschedule_tomorrow" type="object" string="Tomorrow" icon="fa-calendar-plus-o"/>
                     <button name="action_reschedule_nextweek" type="object" string="Next Week" icon="fa-calendar-o"/>
@@ -279,7 +279,6 @@
                 <field name="feedback" optional="hide"/>
                 <widget name="mail_activity_list_reschedule_dropdown"/>
                 <button name="action_done" type="object" string="Done" icon="fa-check" invisible="active == False"/>
-                <button name="unlink" type="object" string="Cancel" icon="fa-times" class="text-danger" invisible="active == False"/>
             </list>
         </field>
     </record>
@@ -346,9 +345,6 @@
                                 <field name="date_deadline" widget="remaining_days" class="ms-2"/>
                                 <button type="object" name="action_done" class="btn btn-link btn-sm ms-auto me-1" invisible="active == False">
                                     <i class="fa fa-check" /> Done
-                                </button>
-                                <button type="object" name="unlink" class="btn btn-link text-danger btn-sm">
-                                    <i class="fa fa-times" /> Cancel
                                 </button>
                             </footer>
                         </main>

--- a/addons/test_mail/static/tests/activity.test.js
+++ b/addons/test_mail/static/tests/activity.test.js
@@ -17,7 +17,7 @@ import { keyDown, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, disableAnimations, mockDate } from "@odoo/hoot-mock";
 import { onMounted, onWillUnmount } from "@odoo/owl";
 import { MailTestActivity } from "@test_mail/../tests/mock_server/models/mail_test_activity";
-import { defineTestMailModels } from "@test_mail/../tests/test_mail_test_helpers";
+import { defineTestMailModels, testMailModels } from "@test_mail/../tests/test_mail_test_helpers";
 import {
     mockService,
     onRpc,
@@ -57,6 +57,14 @@ const archs = {
 };
 
 describe.current.tags("desktop");
+testMailModels.MailActivity._views = {
+    form: `
+        <form>
+            <footer>
+                <button string="Delete" type="object" name="unlink" icon="fa-trash" class="btn-danger ms-auto"/>
+            </footer>
+        </form>`,
+};
 defineTestMailModels();
 beforeEach(async () => {
     // Because tests implicitly use Popover
@@ -536,7 +544,7 @@ test("activity view: activity widget", async () => {
     await expect.waitForSteps(["action_feedback_schedule_next", "serverGeneratedAction"]);
 });
 
-test("activity widget: cancel an activity from the widget", async () => {
+test("activity widget: delete an activity from the widget", async () => {
     const [mailActivityId] = pyEnv["mail.activity"].search([["state", "=", "planned"]]);
     const [mailActivityTypeId] = pyEnv["mail.activity.type"].search([["name", "=", "Email"]]);
     pyEnv["res.users"].write([serverState.userId], {
@@ -566,10 +574,10 @@ test("activity widget: cancel an activity from the widget", async () => {
     // ensure the buttons are in the same order as in the chatter.
     expect(activityListPopoverButtons[0]).toHaveClass("o-mail-ActivityListPopoverItem-markAsDone");
     expect(activityListPopoverButtons[1]).toHaveClass("o-mail-ActivityListPopoverItem-editbtn");
-    expect(activityListPopoverButtons[2]).toHaveClass("o-mail-ActivityListPopoverItem-cancel btn");
 
-    // Cancel the activity
-    await click(".o-mail-ActivityListPopoverItem .o-mail-ActivityListPopoverItem-cancel");
+    // Delete the activity
+    await click(".o-mail-ActivityListPopoverItem .o-mail-ActivityListPopoverItem-editbtn");
+    await click(".modal-dialog .btn:text('Delete')");
     await expect.waitForSteps(["unlink"]);
 
     // Verify no activity is scheduled
@@ -808,7 +816,7 @@ test("Activity view: discard an activity creation dialog", async () => {
         ".o_activity_view  :nth-child(1 of .o_data_row) :nth-child(1 of .o_activity_empty_cell)"
     );
     await contains(".modal.o_technical_modal");
-    await click(".modal.o_technical_modal .o_form_button_cancel");
+    await click(".modal.o_technical_modal .btn-close");
     await contains(".modal.o_technical_modal", { count: 0 });
 });
 


### PR DESCRIPTION
Activities had a 'Cancel' action that permanently delete the records, leading to unintended data loss.

This change:
- Removes quick delete options from chatter, list, kanban, and activity views
- Adds an explicit Delete button in the activity popup form
- Removes custom added 'Cancel' button from list view header, as users
can still perform mass deletion via list view actions.

Task-5468806
