### PR TITLE
[IMP] account: update due date color and adjust tests

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -764,10 +764,10 @@ class AccountTestInvoicingCommon(ProductCommon):
         )
 
     @classmethod
-    def _create_account_move_send_wizard_single(cls, move, *, as_user=None, **kwargs):
+    def _create_account_move_send_wizard_single(cls, move, *, as_user=None, no_invoice_reminder=False, **kwargs):
         return cls.env['account.move.send.wizard']\
             .with_user(as_user)\
-            .with_context(active_model='account.move', active_ids=move.ids)\
+            .with_context(active_model='account.move', active_ids=move.ids, no_invoice_reminder=no_invoice_reminder)\
             .create(kwargs)
 
     @classmethod

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -512,7 +512,7 @@ class TestAccountMoveSendCommon(AccountTestInvoicingCommon):
                 {k: v for k, v in expected_values.items() if not check_id_needed and k != 'id'},
             )
 
-    def create_send_and_print(self, invoices, default=False, *, as_user=None, **kwargs):
+    def create_send_and_print(self, invoices, default=False, *, as_user=None, no_invoice_reminder=False, **kwargs):
         invoices.with_user(as_user).action_send_and_print()
         if len(invoices) == 1:
             if not default and not kwargs.get('sending_methods'):
@@ -520,7 +520,7 @@ class TestAccountMoveSendCommon(AccountTestInvoicingCommon):
                 # Therefore by default we deactivate sending methods, unless default parameter is set to True,
                 # or they are explicitly given.
                 kwargs['sending_methods'] = []
-            return self._create_account_move_send_wizard_single(invoices, as_user=as_user, **kwargs)
+            return self._create_account_move_send_wizard_single(invoices, as_user=as_user, no_invoice_reminder=no_invoice_reminder, **kwargs)
         else:
             return self._create_account_move_send_wizard_multi(invoices, as_user=as_user, **kwargs)
 
@@ -584,7 +584,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.assertTrue(self._get_mail_message(invoice))
 
         # Send it again. The PDF must not be created again.
-        wizard = self.create_send_and_print(invoice, sending_methods=['email', 'manual'])
+        wizard = self.create_send_and_print(invoice, no_invoice_reminder=True, sending_methods=['email', 'manual'])
         with patch('odoo.addons.account.models.account_move_send.AccountMoveSend._hook_invoice_document_after_pdf_report_render') as mocked_method:
             results = wizard.action_send_and_print()
             mocked_method.assert_not_called()
@@ -852,7 +852,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         ])
 
         # Resend.
-        wizard = self.create_send_and_print(invoice, sending_methods=['email'])
+        wizard = self.create_send_and_print(invoice, no_invoice_reminder=True, sending_methods=['email'])
         pdf_report_values['id'] = invoice.invoice_pdf_report_id.id
         self._assert_mail_attachments_widget(wizard, [
             pdf_report_values,

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1139,7 +1139,8 @@
                                 <div class="d-flex" invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')" name="due_date">
                                     <field name="invoice_date_due" force_save="1"
                                            placeholder="Date"
-                                           invisible="invoice_payment_term_id"/>
+                                           invisible="invoice_payment_term_id"
+                                           decoration-danger="invoice_date_due and invoice_date_due &lt; context_today().strftime('%Y-%m-%d') and payment_state not in ('paid', 'in_payment', 'reversed')"/>
                                     <span class="o_form_label mx-3 oe_edit_only text-center" style="width: 6ch;"
                                           invisible="state != 'draft' or invoice_payment_term_id">or</span>
                                     <field name="invoice_payment_term_id"
@@ -1466,6 +1467,7 @@
                                                business_domain_compute="parent.move_type in ['out_invoice', 'out_refund', 'out_receipt'] and 'invoice' or parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] and 'bill' or 'general'"/>
                                         <field name="date_maturity"
                                                optional="hide"
+                                               decoration-danger="date_maturity and date_maturity &lt; context_today().strftime('%Y-%m-%d') and parent.payment_state not in ('paid', 'in_payment', 'reversed')"
                                                invisible="display_type in ('line_section', 'line_note')"
                                                column_invisible="context.get('view_no_maturity')"/>
                                         <field name="amount_currency"

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -583,7 +583,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
         self.assertEqual(len(invoice_attachments), 2)
 
         # Send again.
-        wizard = self.create_send_and_print(invoice, sending_methods=['manual'])
+        wizard = self.create_send_and_print(invoice, no_invoice_reminder=True, sending_methods=['manual'])
         self.assertRecordValues(wizard, [{
             'sending_methods': ['manual'],
             'invoice_edi_format': 'ubl_bis3',


### PR DESCRIPTION
With this commit, the invoice due date is displayed in red in the form view
once it has passed.

Tests have been updated accordingly. When the `account_followup` module is
installed and a user performs Send & Print twice on an overdue invoice,
the second email is treated as a reminder. This causes the test to fail due
to the additional attachment of the open items report.

To avoid this, a context is passed while creating the wizard the second time
to skip the invoice reminder.

task-5241209

ent: https://github.com/odoo/enterprise/pull/105264
upg: https://github.com/odoo/upgrade/pull/9587