### PR TITLE
[FIX] web: prevent list header border disappear in Firefox

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -78,11 +78,11 @@
         }
 
         thead {
-            background-color: var(--ListRenderer-thead-bg-color);
+            background-color: transparent;
 
             th {
                 padding-top: var(--ListRenderer-thead-padding-y);
-                background-color: transparent;
+                background-color: var(--ListRenderer-thead-bg-color);
                 color: $headings-color;
 
                 @include media-only(print) {


### PR DESCRIPTION
In Firefox, the separator below the list header could disappear 
at certain zoom levels when using sticky headers.

After this commit, the list header border will not disappear.

Task-5249221

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
