### PR TITLE
[FIX] pos_sale: make sure amount unpaid is computed correctly

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -46,9 +46,10 @@ class SaleOrder(models.Model):
     @api.depends('transaction_ids.state', 'transaction_ids.amount', 'order_line', 'amount_total', 'order_line.invoice_lines.parent_state', 'order_line.invoice_lines.price_total', 'order_line.pos_order_line_ids')
     def _compute_amount_unpaid(self):
         for sale_order in self:
-            total_invoice_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('invoice_lines').filtered(lambda l: l.parent_state != 'cancel').mapped('price_total'))
+            online_payments_invoices = sale_order.transaction_ids.invoice_ids
+            total_invoice_paid_exc_online = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('invoice_lines').filtered(lambda l: l.parent_state != 'cancel' and l.move_id not in online_payments_invoices).mapped('price_total'))
             total_pos_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('pos_order_line_ids.price_subtotal_incl'))
-            sale_order.amount_unpaid = max(sale_order.amount_total - total_invoice_paid - total_pos_paid - sale_order.amount_paid, 0.0)
+            sale_order.amount_unpaid = max(sale_order.amount_total - total_invoice_paid_exc_online - total_pos_paid - sale_order.amount_paid, 0.0)
 
     @api.depends('order_line.pos_order_line_ids')
     def _compute_amount_to_invoice(self):


### PR DESCRIPTION
**Steps to produce:**
- Install `pos_sale` module.
- Enable `Automatic Invoice` in settings
- Create a new SO with product price 1000.
- In `Other Info`, set `Online Payment` to 30%.
- Preview > make payment.

**Issue:**
 - The computed value of amount_unpaid is 400, whereas it should be 700.

**Root cause:**
- When Automatic Invoice is enabled and an online payment is made, the invoice is automatically created and amount_paid is also updated.
- At [1], the logic subtracts both the total invoice amount and amount_paid from the actual total, which results in an incorrect calculation.

**Solution:**
- When an online payment is made, a transaction is created and linked to an invoice.
- While computing the total invoice amount, if the transaction’s invoice ID is encountered again, it should be skipped to avoid double-counting.

[1]https://github.com/odoo/odoo/blob/75f6be6744006ed1a3c0857881822723f90f5d4a/addons/pos_sale/models/sale_order.py#L46-L51

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
