### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: Change field type from Binary to Json

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -99,7 +99,7 @@ class AccountMove(models.Model):
         string="Exemption Reason",
         help="The exception reason of the invoice.",
     )
-    l10n_tr_exemption_code_domain_list = fields.Binary(compute='_compute_l10n_tr_exemption_code_domain_list')
+    l10n_tr_exemption_code_domain_list = fields.Json(compute='_compute_l10n_tr_exemption_code_domain_list')
     l10n_tr_nilvera_customer_status = fields.Selection(
         string="Partner Nilvera Status",
         related='partner_id.l10n_tr_nilvera_customer_status',


### PR DESCRIPTION
After a recent PR, #235832 the `fields.Binary` can not store data other than bytes, due to this a traceback occurs while trying to change the Invoice Type, since a compute method is triggered that computes domain for a field that is of type Binary.

Error: `TypeError: 'str' object cannot be interpreted as an integer`

This commit fixes that issue by changing field type from Binary to Json.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
