### PR TITLE
[FIX] sale_edi_ubl, purchase_edi_ubl_bis3: Fix order import with line-level charges

### DIFF
--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -356,7 +356,6 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
         lines_vals, line_logs = self._import_lines(order, tree, './{*}OrderLine/{*}LineItem', document_type='order', tax_type='purchase')
         # adapt each line to purchase.order.line
         for line in lines_vals:
-            line['product_qty'] = line.pop('quantity')
             # remove invoice line fields
             line.pop('deferred_start_date', False)
             line.pop('deferred_end_date', False)
@@ -369,3 +368,10 @@ class PurchaseEdiXmlUbl_Bis3(models.AbstractModel):
         logs += partner_logs + delivery_logs + line_logs + allowance_charges_logs
 
         return order_vals, logs
+
+    def _retrieve_line_vals(self, tree, document_type=False, qty_factor=1):
+        """Override of `account.edi.common` to adapt dictionary keys from the base method to be
+        compatible with the `purchase.order.line` model."""
+        line_vals = super()._retrieve_line_vals(tree, document_type, qty_factor)
+        line_vals['product_qty'] = line_vals.pop('quantity')
+        return line_vals

--- a/addons/purchase_edi_ubl_bis3/models/purchase_order.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_order.py
@@ -53,5 +53,5 @@ class PurchaseOrder(models.Model):
             'name': name,
             'product_qty': quantity,
             'price_unit': price_unit,
-            'taxes_id': [Command.set(tax_ids)],
+            'tax_ids': [Command.set(tax_ids)],
         } for name, quantity, price_unit, tax_ids in lines_vals]

--- a/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
+++ b/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py
@@ -347,7 +347,6 @@ class SaleEdiXmlUbl_Bis3(models.AbstractModel):
         lines_vals, line_logs = self._import_lines(order, tree, './{*}OrderLine/{*}LineItem', document_type='order', tax_type='sale')
         # adapt each line to sale.order.line
         for line in lines_vals:
-            line['product_uom_qty'] = line.pop('quantity')
             # remove invoice line fields
             line.pop('deferred_start_date', False)
             line.pop('deferred_end_date', False)
@@ -381,3 +380,10 @@ class SaleEdiXmlUbl_Bis3(models.AbstractModel):
             'variant_barcode': './cac:Item/cac:StandardItemIdentification/cbc:ExtendedID',
             'variant_default_code': './cac:Item/cac:SellersItemIdentification/cbc:ExtendedID',
         }
+
+    def _retrieve_line_vals(self, tree, document_type=False, qty_factor=1):
+        """Override of `account.edi.common` to adapt dictionary keys from the base method to be
+        compatible with the `sale.order.line` model."""
+        line_vals = super()._retrieve_line_vals(tree, document_type, qty_factor)
+        line_vals['product_uom_qty'] = line_vals.pop('quantity')
+        return line_vals

--- a/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
+++ b/addons/test_sale_purchase_edi_ubl/tests/test_order_ubl_bis3.py
@@ -307,3 +307,36 @@ class TestOrderEdiUbl(TestAccountEdiUblCii, SaleCommon):
         po = self.env['purchase.order'].with_context(default_partner_id=self.env.user.partner_id.id)._create_records_from_attachments(xml_attachment)
         # Should have same payment term as PO
         self.assertEqual(po.payment_term_id, payment_term)
+
+    def test_so_import_line_allowance_charges(self):
+        po_line_vals = [{
+            'product_id': self.place_prdct.id,
+            'price_unit': 30.0,
+            'product_uom_id': self.uom_units.id,
+            'product_qty': 10.0,
+            'tax_ids': self.purchase_tax.ids,
+            'discount': -10.0,
+        }]
+        xml_attachment = self.get_purchase_xml(po_line_vals)
+
+        so = self.env['sale.order'].with_context(default_partner_id=self.env.user.partner_id.id)._create_records_from_attachments(xml_attachment)
+        self.assertEqual(len(so.order_line), 2)
+        allowance_lines = so.order_line.filtered(lambda l: not l.product_id)
+        self.assertEqual(len(allowance_lines), 1)
+        self.assertEqual(30.0, allowance_lines.price_subtotal)
+
+    def test_po_import_line_allowance_charges(self):
+        so_line_vals = [{
+            'product_id': self.place_prdct.id,
+            'product_uom_id': self.uom_units.id,
+            'product_uom_qty': 10.0,
+            'tax_ids': self.sale_tax.ids,
+            'discount': -10.0,
+        }]
+        xml_attachment = self.get_sale_xml(so_line_vals)
+
+        po = self.env['purchase.order'].with_context(default_partner_id=self.env.user.partner_id.id)._create_records_from_attachments(xml_attachment)
+        self.assertEqual(len(po.order_line), 2)
+        allowance_lines = po.order_line.filtered(lambda l: not l.product_id)
+        self.assertEqual(len(allowance_lines), 1)
+        self.assertEqual(50.0, allowance_lines.price_subtotal)


### PR DESCRIPTION
When importing orders with line-level charges, the import would fail because the `quantity` key was not being renamed to correct quantity keys (`'product_uom_qty'` for sale order and `'product_qty'` for purchase order) for allowance charge lines.

The issue occurred because the key renaming was only applied to the main lines_vals list after calling `_import_lines()`, but not to the `allowance_charges_line_vals` that were created separately.

Also the key for taxes returned in `_get_line_vals_list` method in `purchase.order` model is `'taxes_id'` which is not aligned with the `purchase.order.line` model.

This fix properly handles the quantity key renaming for both regular lines and allowance charge lines and updates `'taxes_id'` key value to `'tax_ids'`, preventing the AttributeError when accessing the quantity key during order line creation.