### PR TITLE
[FIX] web: ensure kanban <main> attributes are preserved during compilation

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_compiler.js
+++ b/addons/web/static/src/views/kanban/kanban_compiler.js
@@ -101,7 +101,10 @@ export class KanbanCompiler extends ViewCompiler {
     compileMain(el, params) {
         const compiled = createElement("div");
 
-        compiled.setAttribute("class", `o_record_main`);
+        for (const { name, value } of el.attributes) {
+            compiled.setAttribute(name, value);
+        }
+        combineAttributes(compiled, "class", ["o_record_main"]);
         for (const child of el.childNodes) {
             append(compiled, this.compileNode(child, params));
         }

--- a/addons/web/static/tests/views/kanban/kanban_compiler.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_compiler.test.js
@@ -36,3 +36,29 @@ test("bootstrap dropdowns with kanban_ignore_dropdown class should be left as is
         </t>`;
     expect(compileTemplate(arch)).toHaveOuterHTML(expected);
 });
+
+test("kanban compiler keeps dynamic attributes on <main> and adds o_record_main", async () => {
+    const arch = `
+        <kanban>
+            <templates>
+                <t t-name="card">
+                    <main t-att-class="{'test': true}">
+                        <span>Content</span>
+                    </main>
+                </t>
+            </templates>
+        </kanban>`;
+    const expected = `
+        <t t-translation="off">
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <div t-att-class="{'test': true}" class="o_record_main">
+                            <span>Content</span>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </t>`;
+    expect(compileTemplate(arch)).toHaveOuterHTML(expected);
+});


### PR DESCRIPTION
Before this commit:
since commit https://github.com/odoo/odoo/commit/3ad0b49b646090e51c4d36bc25480000b3bfd5ad kanban compiler is not preserving its runtime owl directives defined on the `<main>` element, such as t-att-class,t-if,etc.

After this commit:
The compiler now preserves all attributes from the original `<main>` node before converting to the 'o_record_main', restoring correct runtime behavior while keeping the expected kanban structure.

task-5870330

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
