### PR TITLE
[FIX] im_livechat: quick action non-deterministic test

### DIFF
--- a/addons/im_livechat/static/tests/embed/message_actions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_actions.test.js
@@ -29,7 +29,7 @@ test("Only two quick actions are shown", async () => {
     await insertText(".o-mail-Composer-input", "Hello World!");
     triggerHotkey("Enter");
     // message data from post contains no reaction, wait now to avoid overriding newer value later
-    await expect.waitForSteps(["discuss.channel/new_message"]);
+    await expect.waitForSteps(["discuss.channel/new_message"], { timeout: 3000 });
     await click("[title='Add a Reaction']");
     await click(".o-mail-QuickReactionMenu button", { text: "😅" });
     await contains(".o-mail-MessageReaction", { text: "😅" });


### PR DESCRIPTION
The `Only two quick actions are shown` live chat test awaits the first posted message because to avoid conflict with the reaction being added afterwards.

To do so, the test uses the `waitForSteps` helper. However, during high load, 200ms might be too short to receive the notification, leading to the test failing.

This commit increases the timeout.

runbot-237587

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
