### PR TITLE
[FIX] pos_event: Event Ticket in PoS and pricelist

### DIFF
--- a/addons/pos_event/static/src/app/models/pos_order.js
+++ b/addons/pos_event/static/src/app/models/pos_order.js
@@ -10,4 +10,21 @@ patch(PosOrder.prototype, {
         // Override to ensure orderline price of event tickets are not recomputed
         return super.getLinesToCompute().filter((line) => !line.event_ticket_id);
     },
+    setPricelist(pricelist) {
+        super.setPricelist(...arguments);
+
+        const eventTicketLines = this.lines.filter((line) => line.event_ticket_id);
+
+        for (const line of eventTicketLines) {
+            const newPrice = line.product_id.product_tmpl_id.getPrice(
+                pricelist,
+                line.getQuantity(),
+                line.getPriceExtra(),
+                false,
+                line.product_id,
+                line
+            );
+            line.setUnitPrice(newPrice);
+        }
+    },
 });

--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -182,7 +182,6 @@ patch(ProductScreen.prototype, {
             const line = await this.pos.addLineToCurrentOrder({
                 product_id: ticket.product_id,
                 product_tmpl_id: ticket.product_id.product_tmpl_id,
-                price_unit: ticket.price,
                 price_type: "original",
                 qty: data.length,
                 event_ticket_id: ticket,


### PR DESCRIPTION
Before this fix, pricelist didn't take effect on event products.

How to reproduce :
1. Create a pricelist with fixed price and make it available for a pos.
2. Open a pos with event products.
3. Make an orderline with an event product
4. Apply a pricelist on it.

The solution is to override setPricelist() in pos_event. Which is called when we apply a pricelist to an order.

task: 5092613

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
