### PR TITLE
[FIX] stock: hide Lots/Serial numbers creation from contacts

### DIFF
--- a/addons/stock/views/res_partner_views.xml
+++ b/addons/stock/views/res_partner_views.xml
@@ -36,6 +36,7 @@
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button type="object"
                     name="action_view_stock_serial"
+                    context="{'create': False}"
                     class="oe_stat_button" icon="fa-bars" groups="stock.group_production_lot">
                     <div class="o_stat_info">
                         <span class="o_stat_text">Lots/Serial Numbers</span>


### PR DESCRIPTION
Currently, users can `create` new `Lots/Serial Numbers` directly from the 
Contacts app via the `Lots/Serial Numbers` smart button.

**Steps to reproduce:**
- Install the `stock` and `contacts` modules.
- Enable `Lots & Serial Numbers` from the inventory settings.
- Open the `Contacts` app and open any contact record.
- Click the `Lots/Serial Numbers` smart button.

**Observation:**
The user can `create` a new lot/serial number from the Contacts, even 
though this flow is not supported and results in inconsistent data.

**Root cause:**
After PR [1], `lot/serial number` creation was accidentally enabled from the 
Contact. The intended behavior is that Contacts should only be able to view 
related lots/serial numbers, not create them. (Confirm with PO `crl`)

**Fix:**
This commit disables the creation of Lot/Serial Numbers from the contact by 
`hiding` the New button. This prevents users from creating inconsistent records 
until a complete and correct flow is implemented in a future improvement 
as mentioned at [2].

[1]:
https://github.com/odoo/odoo/pull/184242

[2]:
https://www.odoo.com/mail/message/978482657

opw-5504073