### PR TITLE
[FIX] hr_recruitment: prevent duplicate 'Applicant created' log

### DIFF
--- a/addons/hr_recruitment/data/mail_message_subtype_data.xml
+++ b/addons/hr_recruitment/data/mail_message_subtype_data.xml
@@ -7,7 +7,6 @@
         <field name="res_model">hr.applicant</field>
         <field name="default" eval="False"/>
         <field name="hidden" eval="True"/>
-        <field name="description">Applicant created</field>
     </record>
     <record id="mt_applicant_stage_changed" model="mail.message.subtype">
         <field name="name">Stage Changed</field>
@@ -26,7 +25,6 @@
         <field name="name">New Talent</field>
         <field name="res_model">hr.applicant</field>
         <field name="default" eval="False"/>
-        <field name="description">Talent created</field>
     </record>
 
     <!-- Job-related subtypes for messaging / Chatter -->

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -1115,3 +1115,9 @@ class HrApplicant(models.Model):
             if applicant.refuse_reason_id and applicant.refuse_date:
                 json[applicant.stage_id.id] -= (now - applicant.refuse_date).total_seconds()
         return json
+
+    def _creation_message(self):
+        self.ensure_one()
+        if self.is_pool_applicant:
+            return self.env._("Talent created")
+        return super()._creation_message()


### PR DESCRIPTION
Steps to reproduce:
1. Create a new applicant in recruitment.
2. Open the applicant’s chatter.
3. See multiple “Applicant created” messages for the same creation.

Bug cause:
The applicant creation flow posts the `mt_applicant_new` subtype more than once (create + extra write/track), and the frontend renders the subtype description, so each duplicate post shows “Applicant created” again.

Solution:
- Post the `mt_applicant_new` subtype only once during applicant creation.
- Avoid re-posting it in subsequent writes/tracking so chatter shows a single creation log.

Task Id: 5454691
