### PR TITLE
[FIX] html_editor: focus editable after deleting column

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.TableMenu">
         <Dropdown menuClass="'m-0'" position="props.type === 'column' ? 'bottom' : 'right'" state="props.dropdownState">
-            <button t-att-data-type="props.type" class="o-we-table-menu fa" t-attf-class="fa-ellipsis-{{props.type === 'column' ? 'h w-100' : 'v h-100'}}" />
+            <button t-on-pointerdown.prevent="() => {}" t-att-data-type="props.type" class="o-we-table-menu fa" t-attf-class="fa-ellipsis-{{props.type === 'column' ? 'h w-100' : 'v h-100'}}" />
             <t t-set-slot="content">
                 <div t-on-pointerdown.stop="() => {}">
                     <t t-foreach="items" t-as="item" t-key="item_index">

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -275,9 +275,8 @@ export class TablePlugin extends Plugin {
         const index = cells.findIndex((td) => td === cell);
         const siblingCell = cells[index - 1] || cells[index + 1];
         table.querySelectorAll(`tr td:nth-of-type(${index + 1})`).forEach((td) => td.remove());
-        // not sure we should move the cursor?
         siblingCell
-            ? this.dependencies.selection.setCursorStart(siblingCell)
+            ? this.dependencies.selection.setCursorEnd(lastLeaf(siblingCell))
             : this.deleteTable(table);
     }
     /**
@@ -287,9 +286,8 @@ export class TablePlugin extends Plugin {
         const table = closestElement(row, "table");
         const siblingRow = row.previousElementSibling || row.nextElementSibling;
         row.remove();
-        // not sure we should move the cursor?
         siblingRow
-            ? this.dependencies.selection.setCursorStart(siblingRow.querySelector("td"))
+            ? this.dependencies.selection.setCursorEnd(lastLeaf(siblingRow.cells[0]))
             : this.deleteTable(table);
     }
     /**

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1875,7 +1875,7 @@ describe("Selection not collapsed", () => {
             stepFunction: deleteBackward,
             contentAfter: unformat(
                 `<table><tbody>
-                    <tr><td>[]ef</td><td>gh</td></tr>
+                    <tr><td>ef[]</td><td>gh</td></tr>
                 </tbody></table>`
             ),
         });
@@ -1892,7 +1892,7 @@ describe("Selection not collapsed", () => {
             stepFunction: deleteBackward,
             contentAfter: unformat(
                 `<table><tbody>
-                    <tr><td>[]cd</td></tr>
+                    <tr><td>cd[]</td></tr>
                     <tr><td>gh</td></tr>
                 </tbody></table>`
             ),

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -172,13 +172,11 @@ describe("row", () => {
                     </table>
                 `),
                 stepFunction: removeRow(),
-                // @todo @phoenix: consider changing the behavior and placing the cursor
-                // inside the td (normalize deep)
                 contentAfter: unformat(`
                     <table>
                         <tbody>
                             <tr>
-                                <td>[]ef</td> <td>gh</td>
+                                <td>ef[]</td><td>gh</td>
                             </tr>
                         </tbody>
                     </table>
@@ -208,7 +206,7 @@ describe("row", () => {
                     <table>
                         <tbody>
                             <tr>
-                                <td>[]ab</td> <td>cd</td>
+                                <td>ab[]</td><td>cd</td>
                             </tr>
                         </tbody>
                     </table>
@@ -462,7 +460,7 @@ describe("column", () => {
                     <table>
                         <tbody>
                             <tr>
-                                <td>[]cd</td>
+                                <td>cd[]</td>
                             </tr>
                             <tr>
                                 <td>gh</td>
@@ -495,7 +493,7 @@ describe("column", () => {
                     <table>
                         <tbody>
                             <tr>
-                                <td>[]ab</td>
+                                <td>ab[]</td>
                             </tr>
                             <tr>
                                 <td>ef</td>

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -346,7 +346,7 @@ test("basic delete column operation", async () => {
         unformat(`
         <table>
             <tbody>
-                <tr><td class="a">[]1</td></tr>
+                <tr><td class="a">1[]</td></tr>
                 <tr><td class="c">3</td></tr>
             </tbody>
         </table>`)
@@ -391,7 +391,7 @@ test("basic delete row operation", async () => {
         unformat(`
         <table>
             <tbody>
-                <tr><td class="a">[]1</td><td class="b">2</td></tr>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
             </tbody>
         </table>`)
     );
@@ -406,6 +406,41 @@ test("basic delete row operation", async () => {
             </tbody>
         </table>`)
     );
+});
+
+test("editable should be focused after delete operation", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <p><br></p>
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr><td><p>[]<br></p></td><td class="a"><p><br></p></td></tr>
+                <tr><td><p><br></p></td><td><p><br></p></td></tr>
+            </tbody>
+        </table>`)
+    );
+
+    // hover on td to show col ui
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+
+    // click on it to open dropdown
+    await click(".o-we-table-menu");
+    await waitFor("div[name='delete']");
+
+    // delete column
+    await click("div[name='delete']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <p><br></p>
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr><td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td></tr>
+                <tr><td><p><br></p></td></tr>
+            </tbody>
+        </table>`)
+    );
+    expect(document.activeElement).toBe(el);
 });
 
 test("insert column left operation", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

When a user deletes a row or column from table menu, the editor loses focus. As a result, actions like Undo do not behave as expected and require multiple attempts to restore the original table state. This breaks the editing flow, causes confusion when performing table-related actions.

**Desired behavior after PR:**

This PR ensures that editable is focused after deleting row or column from table menu. This commit also makes sure that selection is set properly and hint is visible on empty cell after deleting the column.

task-5725593




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
