### PR TITLE
[FIX] hr_holidays: fix the scrollbar

### DIFF
--- a/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_holidays.KanbanRenderer">
-        <div class="d-flex flex-column h-100 overflow-hidden">
+        <div class="d-flex flex-column h-100">
             <div class="o_timeoff_calendar">
                 <TimeOffDashboard t-if="showDashboard" employeeId="employeeId"/>
             </div>


### PR DESCRIPTION
Before:
the scrollbar of the kanban view in timeoff was not showing coz of which users
were not able to see their timeoffs easily

After:
Fixed the scrollbar of the kanban view so that the user can be able to see their
timeoffs which they were not able to do that easily

Fix:
Added the `overflow-x` as auto so that the scrollbar is visible.

Task:5502863

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
