### PR TITLE
[18.0][FIX] product: Pricelist rule is not applied on variant

### DIFF
--- a/addons/product/tests/test_pricelist.py
+++ b/addons/product/tests/test_pricelist.py
@@ -2,13 +2,13 @@
 
 from odoo.exceptions import UserError
 from odoo.fields import Command
-from odoo.tests import tagged, Form
+from odoo.tests import Form, tagged
 
-from odoo.addons.product.tests.common import ProductCommon
+from odoo.addons.product.tests.common import ProductVariantsCommon
 
 
 @tagged('post_install', '-at_install')
-class TestPricelist(ProductCommon):
+class TestPricelist(ProductVariantsCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -260,3 +260,36 @@ class TestPricelist(ProductCommon):
             company_2_b2b_pl,
             "Assigning pricelists in one company shouldn't impact pricelists in other companies",
         )
+
+    def test_pricelist_applied_on_product_variant(self):
+        # product template with variants
+        sofa_1 = self.product_template_sofa.product_variant_ids[0]
+        # create pricelist with rule on template
+        pricelist = self.env["product.pricelist"].create(
+            {
+                "name": "Pricelist for Acoustic Bloc Screens",
+                "item_ids": [
+                    Command.create(
+                        {
+                            "compute_price": "fixed",
+                            "fixed_price": 123,
+                            "base": "list_price",
+                            "applied_on": "1_product",
+                            "product_tmpl_id": self.product_template_sofa.id,
+                        }
+                    ),
+                ],
+            }
+        )
+        # open rule form and change rule to apply on variant instead of template
+        with Form(pricelist.item_ids) as item_form:
+            item_form.product_id = sofa_1
+        # check that `applied_on` changed to variant
+        self.assertEqual(pricelist.item_ids.applied_on, "0_product_variant")
+        # re-edit rule to apply on template again by clearing `product_id`
+        with Form(pricelist.item_ids) as item_form:
+            item_form.product_id = self.env["product.product"]
+        # check that `applied_on` changed to template
+        self.assertEqual(pricelist.item_ids.applied_on, "1_product")
+        # check that product_id is cleared
+        self.assertFalse(pricelist.item_ids.product_id)

--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -99,6 +99,7 @@
                     <field name="name" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                     <field name="price" invisible="1"/>
+                    <field name="applied_on" invisible="1"/>
                     <group name="pricelist_rule_computation">
                         <group name="pricelist_rule_method">
                             <field name="display_applied_on"


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- A pricelist rule never apply to a product variant, always its template when edited in "expanded" mode
- This is because the `applied_on` field is missing on the `product.pricelist.item` form view.

Current behavior before PR:
- Install `sale_management`
- Enable "Pricelist" setting
- Go to Sales - Products - Pricelists and create a new "Sample" Pricelist.
- Create 3 rules for the same product (template), one with price at 6666, a second one at 6667 and the last one at 3333 <img width="1416" height="649" alt="image" src="https://github.com/user-attachments/assets/1d50499e-cb49-4341-971c-5a2a5111b9ca" />
- Next step, edit 2 first rules for price 6666 and 6667 to set a variant **BUT before starting editing, open the form in expanded mode using two-arrows button** <img width="1416" height="889" alt="image" src="https://github.com/user-attachments/assets/056cb862-3dc6-4868-b6d3-a0917f3e7242" />
- Set the variant to the first price rule (as you can see, the rule name is immediately updated with "Variant: [REF] Product name" <img width="1421" height="428" alt="image" src="https://github.com/user-attachments/assets/168ad5fb-902b-494f-888a-419983324607" />
- Save the price rule (_note that the display name incorrectly resets to default_) <img width="634" height="370" alt="image" src="https://github.com/user-attachments/assets/ec915985-b1a3-4a69-9153-7384abdb190d" />
- Same thing for second rule  <img width="695" height="375" alt="image" src="https://github.com/user-attachments/assets/69b9ae62-493c-4f0e-ae87-438975e1bceb" /> <img width="621" height="369" alt="image" src="https://github.com/user-attachments/assets/e1dc0342-7b87-42df-bf7d-6a3aace61253" />
- Create a new sale quotation with pricelist set to our "Sample"
- Add product [6666] <img width="1207" height="420" alt="image" src="https://github.com/user-attachments/assets/07d4fb94-03b3-45ae-aeb4-feca4fee9c2c" />
- Add product [6667] <img width="1209" height="431" alt="image" src="https://github.com/user-attachments/assets/03e3a76a-2bb1-44e9-a819-ce3ca35703c7" />
- Incorrect prices in sale order <img width="1415" height="828" alt="image" src="https://github.com/user-attachments/assets/3626028d-31d0-4687-b09d-094c0212042a" />


Desired behavior after PR is merged:
- Each variant must have its own price.
- The added test simply edit the pricelist item using its own form.
- The `applied_on` field is added to the pricelist item form to ensure that its value is saved.
- If we edit the rule without expanded mode, it works fine only because the `applied_on` field exists in the list view as an invisible column.

_Note 1_: `applied_on` is updated by `_onchange_rule_content` using `update` instead of `write` (for caching ?).
But if the `applied_on` field is not on the form, then its value is never sent to low level `_write_multi`.

_Note 2_: to clear the field value with the Form test component, we must set `=self.env["product.product"]` instead of `=False` ....

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
