### PR TITLE
[FIX] pos_self_order: compute price on backend

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -2,6 +2,8 @@ import { registry } from "@web/core/registry";
 import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
 
 registry.category("web_tour.tours").add("self_order_is_close", {
     steps: () => [
@@ -23,6 +25,153 @@ registry.category("web_tour.tours").add("self_order_is_open_consultation", {
 
 registry.category("web_tour.tours").add("self_order_landing_page_carousel", {
     steps: () => [Utils.checkIsNoBtn("My Order"), LandingPage.checkCarouselAutoPlaying()],
+});
+
+registry.category("web_tour.tours").add("self_order_create_price_on_backend", {
+    steps: () => [
+        // Normal flow computes the expected price
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Take Out"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        Utils.clickBtn("Pay"),
+        Utils.checkIsNoBtn("Order Now"),
+        ConfirmationPage.isShown(),
+        ConfirmationPage.checkFinalPrice("$ 2.53"),
+        Utils.clickBtn("Close"),
+
+        // Injected price is rejected
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectLocation("Take Out"),
+        ProductPage.clickProduct("Coca-Cola"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        CartPage.checkProduct("Coca-Cola", "5.06", "2"),
+        {
+            content: "Modify the price with javascript",
+            trigger: "body",
+            run: function () {
+                const pos = window.posmodel;
+                pos.currentOrder.lines[0].price_unit = 0.1;
+                pos.currentOrder.lines[0].product_id.lst_price = 0.1;
+                pos.currentOrder.ammountTotal = 0.1;
+            },
+        },
+        Utils.clickBtn("Pay"),
+        Utils.checkIsNoBtn("Order Now"),
+        ConfirmationPage.isShown(),
+        ConfirmationPage.checkFinalPrice("$ 5.06"),
+        Utils.clickBtn("Close"),
+    ],
+});
+
+registry.category("web_tour.tours").add("self_order_create_price_on_backend_combo_correct", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Office Combo"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Desk Organizer",
+                attributes: [
+                    { name: "Size", value: "M" },
+                    { name: "Fabric", value: "Leather" },
+                ],
+            },
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+            {
+                product: "Combo Product 8",
+                attributes: [],
+            },
+        ]),
+        Utils.clickBtn("Order"),
+        ...CartPage.checkCombo("Office Combo", [
+            {
+                product: "Desk Organizer",
+                attributes: [
+                    { name: "Size", value: "M" },
+                    { name: "Fabric", value: "Leather" },
+                ],
+            },
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+            {
+                product: "Combo Product 8",
+                attributes: [],
+            },
+        ]),
+        Utils.clickBtn("Pay"),
+        ConfirmationPage.isShown(),
+        ConfirmationPage.checkFinalPrice("$ 47.56"),
+        Utils.clickBtn("Ok"),
+        Utils.checkIsNoBtn("Order Now"),
+    ],
+});
+
+registry.category("web_tour.tours").add("self_order_create_price_on_backend_combo_modified", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Office Combo"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Desk Organizer",
+                attributes: [
+                    { name: "Size", value: "M" },
+                    { name: "Fabric", value: "Leather" },
+                ],
+            },
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+            {
+                product: "Combo Product 8",
+                attributes: [],
+            },
+        ]),
+        Utils.clickBtn("Order"),
+        ...CartPage.checkCombo("Office Combo", [
+            {
+                product: "Desk Organizer",
+                attributes: [
+                    { name: "Size", value: "M" },
+                    { name: "Fabric", value: "Leather" },
+                ],
+            },
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+            {
+                product: "Combo Product 8",
+                attributes: [],
+            },
+        ]),
+        {
+            content: "Modify the price with javascript",
+            trigger: "body",
+            run: function () {
+                const pos = window.posmodel;
+                pos.currentOrder.lines[0].price_unit = 0.1;
+                pos.currentOrder.lines[1].price_unit = 0.1;
+                pos.currentOrder.lines[2].price_unit = 0.1;
+                pos.currentOrder.ammountTotal = 0.1;
+            },
+        },
+        Utils.clickBtn("Pay"),
+        ConfirmationPage.isShown(),
+        ConfirmationPage.checkFinalPrice("$ 47.56"),
+        Utils.clickBtn("Ok"),
+        Utils.checkIsNoBtn("Order Now"),
+    ],
 });
 
 registry.category("web_tour.tours").add("self_order_pos_closed", {

--- a/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/confirmation_page_util.js
@@ -5,6 +5,13 @@ export function isShown() {
     };
 }
 
+export function checkFinalPrice(price) {
+    return {
+        content: "Check price computed on the backend",
+        trigger: `.confirmation-page:contains(Pay at the cashier ${price})`,
+    };
+}
+
 export function orderNumberShown() {
     return {
         content: "Check if the order number is shown",

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_self_order_combo
 from . import test_self_order_common
 from . import test_webmanifest
 from . import test_self_order_sequence
+from . import test_pos_backend_price

--- a/addons/pos_self_order/tests/test_pos_backend_price.py
+++ b/addons/pos_self_order/tests/test_pos_backend_price.py
@@ -1,0 +1,48 @@
+from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
+
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
+import odoo
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderSecurity(SelfOrderCommonTest):
+
+    def test_self_order_create_price_on_backend(self):
+        self.pos_config.write({
+            'takeaway': True,
+            'self_ordering_takeaway': True,
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+
+        self.start_tour(self_route, "self_order_create_price_on_backend")
+
+    def test_self_order_create_price_on_backend_combo(self):
+        setup_product_combo_items(self)
+        self.env["product.combo.item"].create(
+            {
+                "product_id": self.desk_organizer.id,
+                "extra_price": 0,
+                "combo_id": self.desk_accessories_combo.id,
+            }
+        )
+        self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
+            'self_ordering_takeaway': False,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+
+        self.start_tour(self_route, "self_order_create_price_on_backend_combo_correct")
+        self.start_tour(self_route, "self_order_create_price_on_backend_combo_modified")


### PR DESCRIPTION
The price computation is done on the backend only for combo products. This means that someone can order stuff on the self order, change the price of the products through JS on the client, and then when they go to pay the backend would generate a payment for the modified price and register everything as normal without any indication to the owner that the price was modified.

This change will force the backend to recompute the price before creating the payment based on the standard prices defined on the backend. This only applies on self orders, so cashiers should still be able to modify prices on the frontend of the normal POS

Task-[5864068](https://www.odoo.com/odoo/project/1737/tasks/5864068)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
