### PR TITLE
[FIX] stock: prevent serial number update on ready pickings

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -696,8 +696,10 @@ Please change the quantity done or the rounding precision of your unit of measur
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            if (vals.get('quantity') or vals.get('move_line_ids')) and 'lot_ids' in vals:
+            if vals.get('move_line_ids') and vals.get('lot_ids'):
                 vals.pop('lot_ids')
+            if vals.get('quantity') and vals.get('lot_ids'):
+                vals.pop('quantity')
             picking_id = self.env['stock.picking'].browse(vals.get('picking_id'))
             if picking_id.group_id and 'group_id' not in vals:
                 vals['group_id'] = picking_id.group_id.id


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product tracked by serial number (e.g. "P1")
- Set the quantity on hand to 2 with serial numbers SN1 and SN2
- Create a delivery order
- Add any product with available quantity
- Mark the delivery as "To Do" -> The picking is in the `ready` state
- Add a new move line with product "P1" and assign serial number SN2 -> Before saving, the quantity is correctlyupdated to 1
- Save the delivery

Problem
The assigned lot/serial number is unexpectedly replaced with 'SN1'.

Fix:
Do not update or recompute the serial/lot number when creating a move on pickings that are already in the `ready` state.
