### PR TITLE
[FIX] mass_mailing_themes: update coffeebreak theme

### DIFF
--- a/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
+++ b/addons/mass_mailing_themes/views/mass_mailing_themes_templates.xml
@@ -821,12 +821,12 @@
         <section class="s_header_social o_mail_block_header_social o_mail_snippet_general" style="background-color: rgb(238, 233, 226) !important;" data-vxml="001" data-snippet="s_mail_block_header_social" data-name="Left Logo">
             <div class="container">
                 <div class="row">
-                    <div class="col-md-8 pt16 pb16">
+                    <div class="col-md-6 pt16 pb16">
                         <a style="text-decoration:none;float:none;" href="http://www.example.com">
                              <img src="/mass_mailing_themes/static/src/img/theme_coffeebreak/s_default_image_logo.png" style="height:auto;max-width:400px; width:100px;" alt="Your Logo" class="img-fluid" />
                         </a>
                     </div>
-                    <div class="col-md-4 o_mail_header_social px-0" style="text-align: right">
+                    <div class="col-md-6 o_mail_header_social px-0" style="text-align: right">
                         <t t-call="mass_mailing.s_social_media_template" optionalTextPosition.f="text-end"
                             optionalIconLayout.f="rounded-circle shadow-sm"
                             optionalTextStyle.f="background-color: #D4C5B3; color: #543427"


### PR DESCRIPTION
This commit fixes a display issue with the coffeebreak theme. The new social links weren't correctly displayed, forming 2 lines instead of 1.

Now they are all aligned.

task-5868123

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
