### PR TITLE
[FIX] hr_holidays: traceback when opening employee report

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_report.py
@@ -100,7 +100,16 @@ class HrLeaveEmployeeReport(models.Model):
     def _generate_report_query(self, report_records):
         report_records = [report_record for report_record in report_records if report_record.get('number_of_days', 0) > 0]
         if not report_records:
-            return ""
+            return SQL(
+                """ SELECT
+                        NULL::integer AS id,
+                        NULL::integer AS employee_id,
+                        NULL::integer AS holiday_status_id,
+                        NULL::timestamp AS working_schedule_aligned_date_from,
+                        NULL::float AS number_of_days
+                    WHERE false
+                """
+            )
 
         column_names = list(report_records[0].keys())
         report_records_tuples = []


### PR DESCRIPTION
Steps to Reproduce:
- Install time off module without demo data
- open reporting menu
- open 'by Employee'

Issue:
- Traceback occurs

Reason:
- the method _table_query returns an empty string when there is no data.
- _table_query should return a valid SQL query for report, not an empty string.

Solution:
- Modify _generate_report_query to return a valid SQL query even when there are no records
- Instead of returning an empty string, return a SELECT statement with NULL values for required columns

task-5846974

