### PR TITLE
[FIX] html_editor: prevent removal of unremovable non-editable element children

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -659,10 +659,13 @@ export class DeletePlugin extends Plugin {
             for (const child of [...node.childNodes]) {
                 remove(child);
             }
-            if (this.isUnremovable(node, root)) {
+            if (
+                this.isUnremovable(node, root) ||
+                !this.dependencies.selection.isNodeEditable(node)
+            ) {
                 return false;
             }
-            if (node.hasChildNodes()) {
+            if (node.hasChildNodes() && node.isContentEditable) {
                 node.before(...node.childNodes);
                 node.remove();
                 return false;

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -156,6 +156,13 @@ describe("deleteRange method", () => {
                 contentAfter: "<div><p>abc[]def</p></div>",
             });
         });
+        test("should remove contenteditable=false element if fully selected", async () => {
+            await testEditor({
+                contentBefore: `<p>a[bc</p><div contenteditable="false">def</div><p>gh]i</p>`,
+                stepFunction: deleteSelection,
+                contentAfter: `<p>a[]i</p>`,
+            });
+        });
     });
     describe("Block + inline", () => {
         test("should merge paragraph with inline content after it", async () => {
@@ -332,6 +339,13 @@ describe("deleteSelection", () => {
                 contentBefore: `<p>a[bc</p><div class="oe_unremovable">def</div><p>gh]i</p>`,
                 stepFunction: deleteSelection,
                 contentAfter: `<p>a[]</p><div class="oe_unremovable"><br></div><p>i</p>`,
+            });
+        });
+        test("should not remove nor clear content of unremovable contenteditable=false node", async () => {
+            await testEditor({
+                contentBefore: `<p>a[bc</p><div class="oe_unremovable" contenteditable="false">def</div><p>gh]i</p>`,
+                stepFunction: deleteSelection,
+                contentAfter: `<p>a[]</p><div class="oe_unremovable" contenteditable="false">def</div><p>i</p>`,
             });
         });
         test("should move the unremovable up the tree", async () => {


### PR DESCRIPTION
**Steps to reproduce:**
- Drop a dynamic snippet, for example Recent Blogs → “Latest Stories”.
- Click on the section title.
- Press Ctrl + A.
- Press Delete.

**Description of the issue:**
- The content part is removed even though it is inside a contenteditable false container. doing discard after it crash the page.

**Cause:**
- In `removeNode`, there is no check to prevent removal of children of a contenteditable false element.
- As a result, if a contenteditable false element itself is unremovable, the parent node is preserved, but its children are still removed.

**Solution:**
- In `removeNode`, add a check to return false if node is not `isNodeEditable`.

task-5858259
