### PR TITLE
[IMP] mrp: split MO v2

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1958,7 +1958,7 @@ class MrpProduction(models.Model):
             'orderpoint_id': self.orderpoint_id.id,
         }
 
-    def _split_productions(self, amounts=False, cancel_remaining_qty=False, set_consumed_qty=False, skip_workorder_quantity=False):
+    def _split_productions(self, amounts=False, cancel_remaining_qty=False, set_consumed_qty=False):
         """ Splits productions into productions smaller quantities to produce, i.e. creates
         its backorders.
 
@@ -2171,20 +2171,19 @@ class MrpProduction(models.Model):
             # Adapt duration
             for workorder in bo.workorder_ids:
                 workorder.duration_expected = workorder._get_duration_expected()
-            if not skip_workorder_quantity:
-                # Adapt quantities produced
-                for workorder in production.workorder_ids.sorted('id'):
-                    initial_workorder_remaining_qty.append(max(initial_qty - workorder.qty_reported_from_previous_wo - workorder.qty_produced, 0))
-                    if workorder.production_id.id not in (self.env.context.get('mo_ids_to_backorder') or []):
-                        workorder.qty_produced = min(workorder.qty_produced, workorder.qty_production)
-                workorders_len = len(production.workorder_ids)
-                for index, workorder in enumerate(bo.workorder_ids):
-                    remaining_qty = initial_workorder_remaining_qty[index % workorders_len]
-                    workorder.qty_reported_from_previous_wo = max(workorder.qty_production - remaining_qty, 0)
-                    if remaining_qty:
-                        initial_workorder_remaining_qty[index % workorders_len] = max(remaining_qty - workorder.qty_produced, 0)
-                    else:
-                        workorders_to_cancel += workorder
+            # Adapt quantities produced
+            for workorder in production.workorder_ids.sorted('id'):
+                initial_workorder_remaining_qty.append(max(initial_qty - workorder.qty_reported_from_previous_wo - workorder.qty_produced, 0))
+                if workorder.production_id.id not in (self.env.context.get('mo_ids_to_backorder') or []):
+                    workorder.qty_produced = min(workorder.qty_produced, workorder.qty_production)
+            workorders_len = len(production.workorder_ids)
+            for index, workorder in enumerate(bo.workorder_ids):
+                remaining_qty = initial_workorder_remaining_qty[index % workorders_len]
+                workorder.qty_reported_from_previous_wo = max(workorder.qty_production - remaining_qty, 0)
+                if remaining_qty:
+                    initial_workorder_remaining_qty[index % workorders_len] = max(remaining_qty - workorder.qty_produced, 0)
+                else:
+                    workorders_to_cancel += workorder
         workorders_to_cancel.action_cancel()
         backorders._action_confirm_mo_backorders()
 
@@ -2514,6 +2513,15 @@ class MrpProduction(models.Model):
             action['res_id'] = wizard.id
             return action
         else:
+            if self.state not in ('draft', 'confirmed'):
+                if self.qty_producing <= 0:
+                    raise UserError(_("Please specify a quantity greater than 0."))
+                if self.qty_producing >= self.product_qty:
+                    raise UserError(_("Set a quantity that is smaller than the initial demand to split the manufacturing order."))
+                new_product_qty = self.product_qty - self.qty_producing
+                new_mo = self._split_productions(amounts={self: [self.qty_producing, new_product_qty]})
+                self.message_post(body=self.env._("The backorder %s has been created.", new_mo[-1]._get_html_link()))
+                return
             action = self.env['ir.actions.actions']._for_xml_id('mrp.action_mrp_production_split')
             action['context'] = {
                 'default_production_id': self.id,
@@ -2883,13 +2891,13 @@ class MrpProduction(models.Model):
         if not merge and not split:
             return True
         ope_str = merge and _('merged') or _('split')
-        if any(production.state not in ('draft', 'confirmed') for production in self):
-            raise UserError(_("Only manufacturing orders in either a draft or confirmed state can be %s.", ope_str))
         if any(not production.bom_id for production in self):
             raise UserError(_("Only manufacturing orders with a Bill of Materials can be %s.", ope_str))
         if split:
             return True
 
+        if any(production.state not in ('draft', 'confirmed') for production in self):
+            raise UserError(_("Only manufacturing orders in either a draft or confirmed state can be merged"))
         if len(self) < 2:
             raise UserError(_("You need at least two production orders to merge them."))
         products = set([(production.product_id, production.bom_id) for production in self])

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -505,9 +505,7 @@ class MrpWorkorder(models.Model):
         new_workcenter = False
         if 'qty_produced' in values:
             for wo in self:
-                if wo.state in ['done', 'cancel']:
-                    raise UserError(_('You cannot change the quantity produced of a work order that is in done or cancel state.'))
-                elif wo.uom_id.compare(values['qty_produced'], 0) < 0:
+                if wo.uom_id.compare(values['qty_produced'], 0) < 0:
                     raise UserError(_('The quantity produced must be positive.'))
 
         workorders_with_new_wc = self.env['mrp.workorder']

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5261,8 +5261,8 @@ class TestMrpOrder(TestMrpCommon, MailCase):
         copied_operation = bom.operation_ids[1]
         self.assertFalse(copied_operation.bom_product_template_attribute_value_ids, "'Apply on Variants' should not be copied to the new operation.")
 
-    def test_mo_split(self):
-        """Test to ensure that splitting MO from the `Change Quantity to Produce` is working as intended
+    def test_mo_split_in_progress(self):
+        """Test to ensure that splitting an in progress MO is working as intended
         i.e Only splitting with a quantity less than the original quantity to produce and more than 0.
         """
         mo = self.env['mrp.production'].create({
@@ -5270,36 +5270,14 @@ class TestMrpOrder(TestMrpCommon, MailCase):
             'product_qty': 10,
         })
         mo.action_confirm()
-        wiz = self.env['change.production.qty'].create({
-            'mo_id': mo.id,
-            'product_qty': 8
-        })
-        wiz.action_split_mo()
-        self.assertEqual(mo.product_qty, wiz.product_qty)  # MO product_qty = 8
+        mo.qty_producing = 8
+        mo.action_split()
+        self.assertEqual(mo.qty_producing, mo.product_qty)  # MO product_qty = 8
         with self.assertRaises(UserError):
-            wiz.action_split_mo()
-        wiz.product_qty = 0
+            mo.action_split()
+        mo.qty_producing = 0
         with self.assertRaises(UserError):
-            wiz.action_split_mo()
-        wiz.product_qty = -1
-        with self.assertRaises(UserError):
-            wiz.action_split_mo()
-
-    def test_mo_split_skip_workorder_quantity(self):
-        """Test to ensure that `_split_productions` is correctly skipping workorder quantity. when
-        `skip_workorder_quantity` param is passed as true.
-        """
-        self._handle_workorder_compatibility()
-        mo = self.env['mrp.production'].create({
-            'bom_id': self.bom_4.id,
-            'product_qty': 10,
-        })
-        mo.action_confirm()
-        mo.workorder_ids[0].action_mark_as_done()
-        # User error is thrown when `_split_productions` tries to update workorder quantity in a `done` state.
-        with self.assertRaises(UserError):
-            mo._split_productions(amounts={mo.id: [7, 3]})
-        self.assertTrue(mo._split_productions(amounts={mo.id: [7, 3]}, skip_workorder_quantity=True))
+            mo.action_split()
 
     def test_mark_done_multi_mo_with_different_uom(self):
         """Test marking multiple productions as done with different product UoMs."""

--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -86,7 +86,7 @@ class ChangeProductionQty(models.TransientModel):
                     quantity = 1.0 if not float_is_zero(quantity, precision_digits=precision) else 0.0
                 else:
                     quantity = quantity if (quantity > 0 and not float_is_zero(quantity, precision_digits=precision)) else 0
-                wo._update_qty_producing(quantity)
+                wo._update_qty_producing(quantity if wo.production_id.state != 'to_close' else wo.qty_production)
                 wo.duration_expected = wo._get_duration_expected(ratio=new_production_qty / old_production_qty)
                 if wo.qty_produced < wo.qty_production and wo.state == 'done':
                     wo.state = 'progress'
@@ -102,14 +102,3 @@ class ChangeProductionQty(models.TransientModel):
         self.mo_id.filtered(lambda mo: mo.state in ['confirmed', 'progress']).move_raw_ids._trigger_scheduler()
 
         return {}
-
-    def action_split_mo(self):
-        for wizard in self:
-            if wizard.product_qty <= 0:
-                raise UserError(_("Please specify a quantity bigger than 0."))
-            if wizard.product_qty >= wizard.mo_id.product_qty:
-                raise UserError(_("Set a quantity that is smaller than the intial demand to split the manufacturing order."))
-            new_product_qty = wizard.mo_id.product_qty - wizard.product_qty
-            new_mo = wizard.mo_id._split_productions(amounts={wizard.mo_id: [wizard.product_qty, new_product_qty]}, skip_workorder_quantity=True)
-            wizard.change_prod_qty()
-            wizard.mo_id.message_post(body=wizard.env._("The backorder %s has been created.", new_mo[-1]._get_html_link()))

--- a/addons/mrp/wizard/change_production_qty_views.xml
+++ b/addons/mrp/wizard/change_production_qty_views.xml
@@ -18,14 +18,11 @@
                     </group>
                     <span class="text-muted">
                         Modifying the quantity to produce will also modify the quantities of components to consume for this manufacturing order.
-                        <br/>
-                        Split the MO if you plan to produce the remaining quantity later.
                     </span>
                     <field name="mo_id" invisible="1"/>
                     <footer>
                         <button name="change_prod_qty" string="Set Quantity" data-hotkey="q"
                             colspan="1" type="object" class="btn-primary"/>
-                        <button name="action_split_mo" string="Split" type="object" class="btn-secondary"/>
                         <button class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>


### PR DESCRIPTION
The new split MO was introduced in https://github.com/odoo/odoo/pull/233472
and works to allow users to split an ongoing Mo.
In this commit we add a couple of points,
to furthermore give users more flexibility
when splitting an MO while updating quantity:

- When MO is `to_close` and quantity is bigger than the
new one, quantity will be adjusted to match the demand.
- Adapt error message for standard split method in order
to clarify how to split an MO while in progress.

Furthermore, it was decided to merge it with the
standard split action to avoid having 2 actions for
splitting.

So whenever we try to split an MO in progress, it will
go through the new split logic for in progress MOs and
split based on the `qty_producing`.

Users won't be blocked when splitting an MO with done
workorders, if the workorder's done quantity is more than
the new split quantity, the workorder will just be "cancelled"
as the work is already done to keep it flexible for the user.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
