### PR TITLE
[FIX] base: Prevent browsing falsy res_id `ir.model.data`

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -232,7 +232,7 @@ class IrModuleModule(models.Model):
 
             # then, search and group ir.model.data records
             imd_models = defaultdict(list)
-            imd_domain = [('module', '=', module.name), ('model', 'in', tuple(dmodels))]
+            imd_domain = [('module', '=', module.name), ('model', 'in', tuple(dmodels)), ('res_id', '!=', False)]
             for data in IrModelData.sudo().search(imd_domain):
                 imd_models[data.model].append(data.res_id)
 

--- a/odoo/addons/base/tests/test_ir_module.py
+++ b/odoo/addons/base/tests/test_ir_module.py
@@ -21,3 +21,27 @@ class IrModuleCase(TransactionCase):
             {"name": "wrong_icon", "icon": "/not/valid.png"}
         )
         self.assertFalse(module.icon_image)
+
+    @mute_logger("odoo.modules.module")
+    def test_falsy_res_id(self):
+        module = self.env["ir.module.module"].create(
+            {"name": "get_views_test", "state": "installed"},
+        )
+        report = self.env['ir.actions.report'].create({
+            'name': 'good_data_report',
+            'report_name': 'web_studio.test_duplicate_foo',
+            'model': 'res.users',
+        })
+        self.env["ir.model.data"].create({
+            "module": "get_views_test",
+            "name": "bad_data",
+            "model": "ir.actions.report",
+            "res_id": 0,
+        })
+        self.env["ir.model.data"].create({
+            "module": "get_views_test",
+            "name": "good_data",
+            "model": "ir.actions.report",
+            "res_id": report.id,
+        })
+        self.assertEqual(module.reports_by_module, "good_data_report")


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/227477, using falsy ids ids illegal

This commit adds an additional filter to the domain used to browse `ir.model.data` to compute the following fields: `(menus|views|reports)_by_module` in order to avoid selecting any that would contain a falsy `res_id` and thus cause the above-mentioned assertion to fail.

One way to reproduce this in a new trial:
- Create a new trial with several modules: `account`, `crm`, `project`, `sales`
- Install `web_studio`
- Uninstall `base_automation`
- Traceback
```
  File “/home/odoo/src/odoo/saas-19.1/odoo/orm/models.py”, line 5200, in browse
    assert all(ids) or all(isinstance(x, NewId) or x for x in ids), “Invalid falsy real id”
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Invalid falsy real id
```

This is due to an `ir.model.data` containing a falsy res_id in the internal code of `saas_trial` (`installed-17`)

This fix will avoid any additional traceback like this one.

opw-5865316