### PR TITLE
[FIX] pos_self_order: Fix tracking number collision

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -33,7 +33,10 @@ class PosSelfOrderController(http.Controller):
         elif not order.get('floating_order_name'):
             floating_order_name = f"Self-order {tracking_number}"
 
-        prefix = 'K' if device_type == 'kiosk' else 'S'
+        # The goal of this is to reduce collisions with other pos.order tracking numbers
+        # when several kiosks are used with different pos.configurations.
+        # This is a little hack in stable, in master the prefix will be chosen differently.
+        prefix = f"K{pos_config.id}-" if device_type == "kiosk" else "S"
         order['pos_reference'] = pos_reference
         order['source'] = 'kiosk' if device_type == 'kiosk' else 'mobile'
         order['floating_order_name'] = order.get('floating_order_name') or floating_order_name


### PR DESCRIPTION
Since we cannot add fields in stable we use a little trick to avoid collisions in tracking numbers for POS Self Order module.

We do a modulo operation on the ID of the PoS config to select a random letter from A-Z and prepend it to the tracking number.

