### PR TITLE
[FIX] ruff.toml: min python version

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,7 @@
 # some rules present here are not enabled on runbot (yet) but are still advised to follow when possible : ["B904", "COM812", "E741", "EM101", "I001", "RET", "RUF021", "TRY002", "UP006", "UP007"]
 
 
-target-version = "py310"
+target-version = "py312"
 
 [lint]
 preview = true


### PR DESCRIPTION
The version has been upgraded at runtime check, but not for ruff d357125e09b8f3613269bb8627972588c20900aa

