### PR TITLE
[FIX] website: fix Full-Screen label on snippet previews

### DIFF
--- a/addons/website/static/src/builder/snippet_model.js
+++ b/addons/website/static/src/builder/snippet_model.js
@@ -19,19 +19,19 @@ export class WebsiteSnippetModel extends SnippetModel {
      * @override
      */
     getSnippetLabel(snippetEl) {
-        let label = super.getSnippetLabel(snippetEl);
-        // Check if any element in the snippet has the "parallax" class to show
-        // the "Parallax" label. This must be done this way because a theme or
-        // custom snippet may add or remove parallax elements. Note that if a
-        // label is already set, we do not change it.
-        // TODO In master, remove the "|| label === 'Parallax'" part from the
-        // condition, as the label="Parallax" will be removed from the snippet
-        // definition.
-        if (!label || label === "Parallax") {
-            label = "";
+        const label = super.getSnippetLabel(snippetEl);
+        // In the following test, we check whether labels should be displayed
+        // depending on whether an option was applied or not. For example, a
+        // snippet will have a “parallax” label if it was saved with the
+        // parallax option enabled. On the other hand, it will not have this
+        // label if the option was disabled before the snippet was saved.
+        if (!label) {
             const contentEl = snippetEl.children[0];
             if (contentEl.matches(".parallax") || !!contentEl.querySelector(".parallax")) {
                 return _t("Parallax");
+            }
+            if (contentEl.matches(".o_full_screen_height")) {
+                return _t("Full-Screen");
             }
         }
         return label;

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -45,7 +45,7 @@
             <t t-snippet="website.s_banner" string="Banner" group="intro">
                 <keywords>hero, jumbotron, headline, header, branding, intro, home, showcase, spotlight, lead, welcome, announcement, splash, top, main</keywords>
             </t>
-            <t t-snippet="website.s_splash_intro" string="Splash Intro" group="intro" label="Full-Screen">
+            <t t-snippet="website.s_splash_intro" string="Splash Intro" group="intro">
                 <keywords>hero, splash, fullscreen, image, background, headline, header, branding, intro, home, showcase, spotlight, main, landing, presentation, top, cover, immersive, visual, impactful</keywords>
             </t>
             <t t-snippet="website.s_cover" string="Cover" group="intro">


### PR DESCRIPTION
Steps to reproduce the issue:

Issue 1
- Enter the "Website" edit mode.
- Drag and drop a "Cover" snippet onto the page.
- Enable the "full-height" option for this snippet.
- Save the snippet as a custom snippet.
- Click on the "Custom" category.
- Bug: the "Full-Screen" label is not displayed on the snippet preview.

Commit [1] added a label on snippet previews to indicate if they are Carousel, Popup, Gallery, Tab, or Parallax. This label is linked directly to the snippet's original template. However, this does not work well for "Full-Screen" because it's an option that can be enabled or disabled. So it doesn't make sense to keep the label when the option is not active.

task-5156137