### PR TITLE
[FIX] account: correct filter name and logic domain for not sent payments

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -104,7 +104,7 @@
                     <filter string="In Process" name="state_in_process" domain="[('state', '=', 'in_process')]"/>
                     <separator/>
                     <filter string="Sent" name="state_sent" domain="[('is_sent', '=', 'True')]"/>
-                    <filter string="Not Sent" name="state_sent" domain="[('is_sent', '=', 'False')]"/>
+                    <filter string="Not Sent" name="state_no_sent" domain="[('is_sent', '!=', 'True')]"/>
                     <filter string="No Bank Matching" name="unmatched" domain="[('is_matched', '=', False)]"/>
                     <filter string="Reconciled" name="reconciled" domain="[('is_reconciled', '=', True)]"/>
                     <separator/>


### PR DESCRIPTION
The "Not Sent" filter in Payments list view was not returning the expected records. This was due to an incorrect domain condition in the search view.

This commit updates the filter logic to properly identify payments that haven't been processed or sent, ensuring the filter displays the correct records to the user.

Description of the issue/feature this PR addresses:
This PR fixes a bug in the "Not Sent" search filter within the Payment views (Account Payments). Currently, the filter fails to accurately identify and display records that have not been sent, leading to an empty or incorrect list of results regardless of the sending payment's actual status.

Current behavior before PR:
When a user applies the "Not Sent" filter in the Payments list view (including both Customer and Vendor payments), the system returns incorrect records or no records at all. This is caused by an inconsistent domain definition that doesn't align with the internal field tracking the "sent" status of the payment.

Desired behavior after PR is merged:
The "Not Sent" filter will correctly filter the list to show only those payments where the "Sent" status is not True. This will provide users with an accurate view of pending actions for both Customer and Vendor payments, ensuring consistency across the accounting module.

Steps to reproduce:

Navigate to the Accounting (or Invoicing) module.
Go to Vendors > Payments or Customers > Payments (the issue is global).
Ensure there are several payments in the list, some marked as "Sent" and others not yet sent.
Click on the Filters dropdown menu in the search bar.
Select the "Not Sent" filter.
Observe the results: Notice that the list either becomes empty or continues to show records that do not match the "Not Sent" criteria, failing to filter the data correctly.
video
https://drive.google.com/file/d/1NTKQ1tHWyZWfs3CPolfDTOMrqaDD9OcN/view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
