### PR TITLE
[FIX] iot_drivers: scale result on read_once

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
@@ -97,6 +97,7 @@ class ScaleDriver(SerialDriver):
 
         self._read_weight()
         self.last_sent_value = self.data['result']
+        return self.data['result']
 
     @staticmethod
     def _get_raw_response(connection):


### PR DESCRIPTION
In order to get the first scale weight faster,
we now return the result directly on the action call.

This also fixes the get weight button in PoS as it will now actually provide the weight.