### PR TITLE
[FIX] iot_drivers: fix scale read_once action

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
@@ -97,6 +97,7 @@ class ScaleDriver(SerialDriver):
 
         self._read_weight()
         self.last_sent_value = self.data['result']
+        return self.data['result']
 
     @staticmethod
     def _get_raw_response(connection):


### PR DESCRIPTION
Since odoo/odoo#237586, events are no longer automatically sent after actions are executed. Since the `read_once` action for scales did not return a value or send an event, this meant it never returned the weight to the frontend.

This commit simply returns the weight value directly from the `read_once` action.

Enterprise: https://github.com/odoo/enterprise/pull/105324

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
