### PR TITLE
[IMP] fleet: improve vehicle and model form layouts

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -240,7 +240,7 @@ class FleetVehicle(models.Model):
     @api.depends('model_id.brand_id.name', 'model_id.name', 'license_plate')
     def _compute_vehicle_name(self):
         for record in self:
-            record.name = (record.model_id.brand_id.name or '') + '/' + (record.model_id.name or '') + '/' + (record.license_plate or _('No Plate'))
+            record.name = (record.license_plate or self.env._('No Plate')) + ': ' + (record.model_id.brand_id.name or '') + '/' + (record.model_id.name or '')
 
     @api.depends('range_unit')
     def _compute_co2_emission_unit(self):

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -35,7 +35,7 @@ class FleetVehicleModel(models.Model):
     vendors = fields.Many2many('res.partner', 'fleet_vehicle_model_vendors', 'model_id', 'partner_id', string='Vendors')
     image_128 = fields.Image(related='brand_id.image_128', readonly=True)
     active = fields.Boolean(default=True)
-    vehicle_type = fields.Selection([('car', 'Car'), ('bike', 'Bike')], default='car', required=True, tracking=True)
+    vehicle_type = fields.Selection([('car', 'Car'), ('bike', 'Bike'), ('other', 'Other')], default='car', required=True, tracking=True)
     transmission = fields.Selection(
         selection=[('manual', 'Manual'), ('semi_automatic', 'Semi-Automatic'), ('automatic', 'Automatic')],
         string='Transmission', tracking=True)

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -26,10 +26,9 @@
                         <h1>
                             <field name="name" placeholder="e.g. Model S"/>
                         </h1>
-                        <label for="brand_id"/>
-                        <h2>
+                        <group>
                             <field name="brand_id" placeholder="e.g. Tesla"/>
-                        </h2>
+                        </group>
                     </div>
                     <group>
                         <group>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -74,16 +74,14 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="image_128" widget='image' class="oe_avatar"/>
                     <div class="oe_title">
-                        <label for="model_id"/>
-                        <h1>
-                            <field name="model_id" placeholder="e.g. Model S" class="w-100"/>
-                        </h1>
                         <label for="license_plate"/>
-                        <h2>
-                            <field name="license_plate" class="oe_inline" placeholder="e.g. PAE 326"/>
-                        </h2>
-                        <label for="tag_ids" class="me-3"/>
-                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"/>
+                        <h1>
+                            <field name="license_plate" class="oe_inline" placeholder="Unregistered"/>
+                        </h1>
+                        <group>
+                            <field name="model_id" placeholder="e.g. Model S" class="w-100"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"/>
+                        </group>
                     </div>
                     <group col="2">
                         <group string="Driver">
@@ -295,10 +293,7 @@
                         </aside>
                         <main>
                             <div>
-                                <t t-if="record.license_plate.raw_value">
-                                    <field class="fw-bolder fs-5" name="license_plate"/>:
-                                </t>
-                                <field class="fw-bolder fs-5" name="model_id"/>
+                                <field name="name" class="fw-bolder fs-5"/>
                             </div>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"/>
                             <div class="d-flex gap-1" t-if="record.driver_id.raw_value">


### PR DESCRIPTION
This commit improves the usability and consistency of Fleet forms.

Vehicle form:
- Use license_plate as the main header (H1)
- make model_id field from header to a regular field
- Update license_plate placeholder to "Unregistered"

Model form:
- Display brand_id as a regular field
- Add a new "Other" option to vehicle_type selection field

task-5013634