### PR TITLE
[FIX] purchase: suggest the right account for downpayments

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -581,6 +581,8 @@ class PurchaseOrderLine(models.Model):
             'purchase_line_id': self.id,
             'is_downpayment': self.is_downpayment,
         }
+        if self.is_downpayment and self.invoice_lines:
+            res['account_id'] = self.invoice_lines.account_id[:1].id
         return res
 
     @api.model


### PR DESCRIPTION
Steps to reproduce:
1/ install purchase and accountant
2/ create and setup an expense account dedicated to your downpayments (typically code 60-, account type "expense"), ACC1.
3/ setup a service type product named "downpayment"
4/ set the default expense account on that product to be ACC1.
5/ create a PO for any product other than the downpayment (PO1). take note of the partner.
6/ create a bill for the same partner as the one set on PO1. Call it BILL1.
7/ On BILL1, add one invoice line with the "downpayment" product. Set a unit price.
8/ Confirm BILL1 and match it with PO1 via the "bill matching" smart button. Add it as a downpayment.
9/ Back on PO1, receive the products. Create a bill (BILL2).

=> The account suggested for the downpayment line in BILL2 will use the default expense account instead of ACC1.

After this commit, the account suggested will be the one used in BILL1 for the downpayment line.

opw-5253877