### PR TITLE
[FIX] sale_loyalty: unlink unused coupon ids

### DIFF
--- a/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
+++ b/addons/sale_loyalty/wizard/sale_loyalty_reward_wizard_views.xml
@@ -28,7 +28,7 @@
                     <!-- Has rewards -->
                     <button type="object" name="action_apply" string="Apply" class="btn btn-primary"
                         invisible="not reward_ids" data-hotkey="q"/>
-                    <button special="cancel" string="Discard" class="btn btn-secondary"
+                    <button type="object" name="action_cancel" string="Discard" class="btn btn-secondary"
                         invisible="not reward_ids" data-hotkey="x"/>
                     <!-- No rewards -->
                     <button special="cancel" string="Discard" class="btn btn-primary"


### PR DESCRIPTION
### Issue:
Due to this issue, `coupon_ids` which are never used are still shown in loyalty coupons history which is confusing for users.

#### Steps to reproduce:
1- Create two promotions:
   - Promo A: 10% discount
   - Promo B: 20% discount

2- Create a SO and add a line. Then confirm the SO.
3- Click on `Reward` button.
4- A dialog should show both promos. Discard the dialog.
5- Navigate to `Discount and Loyalty`.
6- Open Promo A and B and you can see both have lines with
   `coupon_id.order_id` = `created SO` which is confusing. `Issue 1`
7- Navigate back to SO. Click on `Reward` and select Promo A, apply.
8- Navigate to Promo B. As you see the the `coupon_id` related to
   the SO is still there. `Issue 2`

### Cause and Fix:
This is due to unlinking `coupon_ids` only in SO confirm action, causing this issue on already confirmed SOs:
https://github.com/odoo/odoo/blob/604d07ab324caa5f3aa6f3baa9902c2137ea24db/addons/sale_loyalty/models/sale_order.py#L132-L136

We can fix this issue by `unlinking` the `coupons_ids` when a reward is applied or the dialog is discarded.

However there are 2 limitations:
1- The view needs to be updated. Otherwise, `coupon_ids` will not be deleted upon clicking on `discard` button. However the fix is still stable.
2- What if the dialog is closed with the cross button or the tab is closed without selecting a reward? In that case the issue will still persist.

To fix these issues, we can show only used `coupon_ids` in `loyalty_coupon_id` list view. However that cannot be done in stable as it requires `use_count` to be stored.
NB: With some complex filters this also could be fixed on stable but not worth it.

opw-5424753
