### PR TITLE
[FIX] l10n_my_edi_pos: use tax-excluded amounts for discount calculation

### DIFF
--- a/addons/l10n_my_edi_pos/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi_pos/models/account_edi_xml_ubl_my.py
@@ -197,8 +197,13 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
             total_amount = total_amount_currency = 0.0
             for base_line in base_lines:
                 sign = -1 if base_line["is_refund"] else 1
-                total_amount += sign * ((base_line['price_unit'] / base_line['rate']) * base_line['quantity'])
-                total_amount_currency += sign * (base_line['price_unit'] * base_line['quantity'])
+                discount_factor = 1 - (base_line['discount'] / 100.0)
+                if discount_factor:
+                    total_amount += sign * (base_line['tax_details']['raw_total_excluded'] / discount_factor)
+                    total_amount_currency += sign * (base_line['tax_details']['raw_total_excluded_currency'] / discount_factor)
+                else:
+                    total_amount += sign * ((base_line['price_unit'] / base_line['rate']) * base_line['quantity'])
+                    total_amount_currency += sign * (base_line['price_unit'] * base_line['quantity'])
 
             new_base_line = AccountTax._prepare_base_line_for_taxes_computation(
                 {},

--- a/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included.xml
+++ b/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included.xml
@@ -1,0 +1,217 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:ID>/</cbc:ID>
+    <cbc:IssueDate>2025-01-01</cbc:IssueDate>
+    <cbc:IssueTime>00:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>MY Test Company</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:CityName>Kuala Lumpur</cbc:CityName>
+                <cbc:PostalZone>50300</cbc:PostalZone>
+                <cbc:CountrySubentity>Kuala Lumpur</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>14</cbc:CountrySubentityCode>
+                <cac:AddressLine>
+                    <cbc:Line>1 Wisma Dato Dagang</cbc:Line>
+                </cac:AddressLine>
+                <cac:AddressLine>
+                    <cbc:Line>Jln Raja Alang Kampung Bahru Mala</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                    <cbc:Name>Malaysia</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>MY Test Company</cbc:RegistrationName>
+                <cbc:CompanyID>C2584563200</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Kuala Lumpur</cbc:CityName>
+                    <cbc:PostalZone>50300</cbc:PostalZone>
+                    <cbc:CountrySubentity>Kuala Lumpur</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>14</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>1 Wisma Dato Dagang</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:AddressLine>
+                        <cbc:Line>Jln Raja Alang Kampung Bahru Mala</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>MY Test Company</cbc:RegistrationName>
+                <cbc:CompanyID>C2584563200</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Kuala Lumpur</cbc:CityName>
+                    <cbc:PostalZone>50300</cbc:PostalZone>
+                    <cbc:CountrySubentity>Kuala Lumpur</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>14</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>1 Wisma Dato Dagang</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:AddressLine>
+                        <cbc:Line>Jln Raja Alang Kampung Bahru Mala</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:ID>___ignore___</cbc:ID>
+                <cbc:Name>MY Test Company</cbc:Name>
+                <cbc:Telephone>+60123456789</cbc:Telephone>
+                <cbc:ElectronicMail>info@company.myexample.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="TIN">EI00000000010</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="BRN">NA</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>General Public</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:CityName>NA</cbc:CityName>
+                <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+                <cac:AddressLine>
+                    <cbc:Line>NA</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                    <cbc:Name>Malaysia</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>General Public</cbc:RegistrationName>
+                <cbc:CompanyID>EI00000000010</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>NA</cbc:CityName>
+                    <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>NA</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>General Public</cbc:RegistrationName>
+                <cbc:CompanyID>EI00000000010</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>NA</cbc:CityName>
+                    <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>NA</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:ID>___ignore___</cbc:ID>
+                <cbc:Name>General Public</cbc:Name>
+                <cbc:Telephone>NA</cbc:Telephone>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:PrepaidPayment>
+        <cbc:PaidAmount currencyID="MYR">110.00</cbc:PaidAmount>
+    </cac:PrepaidPayment>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="MYR">100.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+            <cbc:Percent>10.0</cbc:Percent>
+            <cac:TaxCategory>
+                <cbc:ID>01</cbc:ID>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="MYR">100.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="MYR">100.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="MYR">110.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="MYR">0.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="MYR">100.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="MYR">100.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxCategory>
+                    <cbc:ID>01</cbc:ID>
+                    <cbc:Percent>10.0</cbc:Percent>
+                    <cac:TaxScheme>
+                        <cbc:ID>VAT</cbc:ID>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>___ignore___</cbc:Description>
+            <cbc:Name>___ignore___</cbc:Name>
+            <cac:CommodityClassification>
+                <cbc:ItemClassificationCode listID="CLASS">004</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>01</cbc:ID>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="MYR">100.0</cbc:PriceAmount>
+        </cac:Price>
+        <cac:ItemPriceExtension>
+            <cbc:Amount currencyID="MYR">100.00</cbc:Amount>
+        </cac:ItemPriceExtension>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included_with_discount.xml
+++ b/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included_with_discount.xml
@@ -1,0 +1,222 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:ID>/</cbc:ID>
+    <cbc:IssueDate>2025-01-01</cbc:IssueDate>
+    <cbc:IssueTime>00:00:00Z</cbc:IssueTime>
+    <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>MY Test Company</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:CityName>Kuala Lumpur</cbc:CityName>
+                <cbc:PostalZone>50300</cbc:PostalZone>
+                <cbc:CountrySubentity>Kuala Lumpur</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>14</cbc:CountrySubentityCode>
+                <cac:AddressLine>
+                    <cbc:Line>1 Wisma Dato Dagang</cbc:Line>
+                </cac:AddressLine>
+                <cac:AddressLine>
+                    <cbc:Line>Jln Raja Alang Kampung Bahru Mala</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                    <cbc:Name>Malaysia</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>MY Test Company</cbc:RegistrationName>
+                <cbc:CompanyID>C2584563200</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Kuala Lumpur</cbc:CityName>
+                    <cbc:PostalZone>50300</cbc:PostalZone>
+                    <cbc:CountrySubentity>Kuala Lumpur</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>14</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>1 Wisma Dato Dagang</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:AddressLine>
+                        <cbc:Line>Jln Raja Alang Kampung Bahru Mala</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>MY Test Company</cbc:RegistrationName>
+                <cbc:CompanyID>C2584563200</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>Kuala Lumpur</cbc:CityName>
+                    <cbc:PostalZone>50300</cbc:PostalZone>
+                    <cbc:CountrySubentity>Kuala Lumpur</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>14</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>1 Wisma Dato Dagang</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:AddressLine>
+                        <cbc:Line>Jln Raja Alang Kampung Bahru Mala</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:ID>___ignore___</cbc:ID>
+                <cbc:Name>MY Test Company</cbc:Name>
+                <cbc:Telephone>+60123456789</cbc:Telephone>
+                <cbc:ElectronicMail>info@company.myexample.com</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="TIN">EI00000000010</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="BRN">NA</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>General Public</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:CityName>NA</cbc:CityName>
+                <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+                <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+                <cac:AddressLine>
+                    <cbc:Line>NA</cbc:Line>
+                </cac:AddressLine>
+                <cac:Country>
+                    <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                    <cbc:Name>Malaysia</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>General Public</cbc:RegistrationName>
+                <cbc:CompanyID>EI00000000010</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>NA</cbc:CityName>
+                    <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>NA</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>General Public</cbc:RegistrationName>
+                <cbc:CompanyID>EI00000000010</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:CityName>NA</cbc:CityName>
+                    <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+                    <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+                    <cac:AddressLine>
+                        <cbc:Line>NA</cbc:Line>
+                    </cac:AddressLine>
+                    <cac:Country>
+                        <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+                        <cbc:Name>Malaysia</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:ID>___ignore___</cbc:ID>
+                <cbc:Name>General Public</cbc:Name>
+                <cbc:Telephone>NA</cbc:Telephone>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:PrepaidPayment>
+        <cbc:PaidAmount currencyID="MYR">88.00</cbc:PaidAmount>
+    </cac:PrepaidPayment>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="MYR">8.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="MYR">80.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="MYR">8.00</cbc:TaxAmount>
+            <cbc:Percent>10.0</cbc:Percent>
+            <cac:TaxCategory>
+                <cbc:ID>01</cbc:ID>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="MYR">80.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="MYR">80.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="MYR">88.00</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="MYR">0.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="MYR">80.00</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+            <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+            <cbc:Amount currencyID="MYR">20.00</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="MYR">8.00</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="MYR">80.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="MYR">8.00</cbc:TaxAmount>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxCategory>
+                    <cbc:ID>01</cbc:ID>
+                    <cbc:Percent>10.0</cbc:Percent>
+                    <cac:TaxScheme>
+                        <cbc:ID>VAT</cbc:ID>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>___ignore___</cbc:Description>
+            <cbc:Name>___ignore___</cbc:Name>
+            <cac:CommodityClassification>
+                <cbc:ItemClassificationCode listID="CLASS">004</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>01</cbc:ID>
+                <cbc:Percent>10.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="MYR">100.0</cbc:PriceAmount>
+        </cac:Price>
+        <cac:ItemPriceExtension>
+            <cbc:Amount currencyID="MYR">80.00</cbc:Amount>
+        </cac:ItemPriceExtension>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -375,6 +375,58 @@ class TestMyInvoisPoS(TestPoSCommon):
             # And the discount should be 100
             self._assert_node_values(xml_tree, "cac:InvoiceLine/cac:AllowanceCharge/cbc:Amount", '100.00')
 
+    @mute_logger('odoo.addons.point_of_sale.models.pos_order')
+    def test_consolidate_invoices_with_tax_included_in_price(self):
+        """ Test that price_include taxes don't incorrectly appear as discounts in XML. """
+        tax_included = self.env['account.tax'].create({
+            'name': "10% Included",
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include_override': 'tax_included',
+            'l10n_my_tax_type': '01',
+        })
+        product = self.create_product("Product", self.categ_basic, 110, tax_ids=tax_included.ids)
+
+        with freeze_time("2025-01-01"):
+            with self.with_pos_session():
+                order = self._create_order({'pos_order_lines_ui_args': [(product, 1.0)]})
+            wizard = self.env['myinvois.consolidate.invoice.wizard'].create({
+                'date_from': '2025-01-01',
+                'date_to': '2025-01-31',
+            })
+            wizard.button_consolidate_orders()
+            order.consolidated_invoice_ids.action_generate_xml_file()
+            root = etree.fromstring(order.consolidated_invoice_ids.myinvois_file_id.raw)
+            with file_open('l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included.xml', 'rb') as f:
+                expected_xml = etree.fromstring(f.read())
+            self.assertXmlTreeEqual(root, expected_xml)
+
+    @mute_logger('odoo.addons.point_of_sale.models.pos_order')
+    def test_consolidate_invoices_with_tax_included_in_price_and_discount(self):
+        """ Test that price_include taxes with actual discounts work correctly. """
+        tax_included = self.env['account.tax'].create({
+            'name': "10% Included",
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include_override': 'tax_included',
+            'l10n_my_tax_type': '01',
+        })
+        product = self.create_product("Product", self.categ_basic, 110, tax_ids=tax_included.ids)
+
+        with freeze_time("2025-01-01"):
+            with self.with_pos_session():
+                order = self._create_order({'pos_order_lines_ui_args': [(product, 1.0, 20)]})
+            wizard = self.env['myinvois.consolidate.invoice.wizard'].create({
+                'date_from': '2025-01-01',
+                'date_to': '2025-01-31',
+            })
+            wizard.button_consolidate_orders()
+            order.consolidated_invoice_ids.action_generate_xml_file()
+            root = etree.fromstring(order.consolidated_invoice_ids.myinvois_file_id.raw)
+            with file_open('l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included_with_discount.xml', 'rb') as f:
+                expected_xml = etree.fromstring(f.read())
+            self.assertXmlTreeEqual(root, expected_xml)
+
     #########
     # Refunds
     #########


### PR DESCRIPTION
The _add_consolidated_invoice_base_lines_vals method computed the gross subtotal using `price_unit * quantity`. When taxes are configured as "Included in Price", `price_unit` contains the tax-included amount, but `total_excluded` (used for the discounted amount) is tax-excluded.

This caused the tax amount to be incorrectly reported as an AllowanceCharge (discount) in the MyInvois XML, because:
  discount_amount = price_unit * qty - total_excluded
                  = tax_included - tax_excluded
                  = TAX AMOUNT (not a discount!)

Example: Product priced at 110 MYR with 10% tax included:
- price_unit = 110 (tax-included)
- total_excluded = 100 (tax-excluded: 110 / 1.10)
- discount_amount = 110 - 100 = 10 ← incorrectly reported as discount

refs:

The cac:AllowanceCharge element in UBL is specifically for discounts and surcharges, NOT for taxes. According to the Peppol Malaysia e-Invoice specification:

https://docs.peppol.eu/poac/my/pint-my-sb/bis/#_allowances_and_charges

https://docs.peppol.eu/poacc/billing/3.0/codelist/UNCL5189/ (For this case we are interested in code 95)

Steps to Reproduce:
1. Configure a tax as "Included in Price" with Malaysia tax type
2. Create a product with that tax.
3. Create POS orders without any discount
4. Generate consolidated invoice and XML
5. XML incorrectly shows <cac:AllowanceCharge> with tax amount as discount

The fix uses `raw_total_excluded / discount_factor` (always tax-excluded) instead of `price_unit * quantity` (may be tax-included), consistent with the parent method:
https://github.com/odoo/odoo/blob/d645361a95037ac580d55e80bcb61d1eeb293efd/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L1846-L1876

Ticket [link](https://www.odoo.com/odoo/project.task/5476526) 
opw-5476526

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
