### PR TITLE
[IMP] setup: emergency controller for remote debug

### DIFF
--- a/setup/iot_box_builder/overwrite_after_init/etc/nginx/conf.d/iot.conf
+++ b/setup/iot_box_builder/overwrite_after_init/etc/nginx/conf.d/iot.conf
@@ -36,4 +36,9 @@ server {
         alias /var/log/;
         autoindex on;
     }
+
+    location /sos {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+    }
 }

--- a/setup/iot_box_builder/overwrite_after_init/etc/sos-controller.py
+++ b/setup/iot_box_builder/overwrite_after_init/etc/sos-controller.py
@@ -1,0 +1,37 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+import subprocess
+
+
+class Handler(BaseHTTPRequestHandler):
+    def make_response(self, code, message):
+        self.send_response(code)
+        self.end_headers()
+        self.wfile.write(message.encode())
+
+    def do_GET(self):
+        qs = parse_qs(urlparse(self.path).query)
+        token = qs.get("token", [None])[0]
+
+        if not token or not token.startswith("tskey-"):
+            self.make_response(400, "Invalid or missing token")
+            return
+
+        try:
+            subprocess.run(
+                ["sudo", "tailscale", "up", f"--authkey={token}", "--hostname=emergency-access", "--timeout=10s"],
+                check=True,
+            )
+            subprocess.run(
+                ['sudo', 'cp', '-r', '/var/lib/tailscale/', '/root_bypass_ramdisks/var/lib/tailscale/'],
+                check=True,
+            )
+            self.make_response(200, "Remote Debug is enabled, Odoo support team can now access the device.")
+        except subprocess.CalledProcessError:
+            self.make_response(
+                500,
+                "Remote Debug activation failed, please check the token, your internet connection and try again."
+            )
+
+
+HTTPServer(("127.0.0.1", 8080), Handler).serve_forever()

--- a/setup/iot_box_builder/overwrite_after_init/var/www/html/502.html
+++ b/setup/iot_box_builder/overwrite_after_init/var/www/html/502.html
@@ -67,6 +67,26 @@
                 gap: 1rem;
                 margin-top: 12px;
             }
+
+            form {
+                display: flex;
+                gap: 10px;
+            }
+
+            input {
+                width: 100%;
+                padding: 8px;
+                border-radius: 4px;
+                border: 1px solid #212529;
+            }
+
+            button {
+                background-color: #714b67;
+                color: white;
+                border: none;
+                border-radius: 4px;
+                cursor: pointer;
+            }
         </style>
         <title>IoT Box is down</title>
     </head>
@@ -86,6 +106,11 @@
                     <a href="https://www.odoo.com/documentation/latest/applications/general/iot/iot_advanced/updating_iot.html#iot-updating-iot-image-code" target="_blank">documentation</a>
                 </li>
             </ol>
+            <p>Or, enter a Remote Debug token provided by <b>Odoo support ONLY</b>:</p>
+            <form method="GET" action="/sos">
+                <input type="text" name="token" placeholder="tskey-auth-..." required>
+                <button type="submit">Enable</button>
+            </form>
         </div>
         <div class="footer">
             <a target="_blank" href="https://www.odoo.com/help">Help</a>

--- a/setup/iot_box_builder/overwrite_before_init/etc/init_image.sh
+++ b/setup/iot_box_builder/overwrite_before_init/etc/init_image.sh
@@ -229,6 +229,7 @@ systemctl disable userconfig.service
 systemctl enable labwc.service
 systemctl enable odoo.service
 systemctl enable odoo-led-manager.service
+systemctl enable sos.service
 
 # create dirs for ramdisks
 create_ramdisk_dir () {

--- a/setup/iot_box_builder/overwrite_before_init/etc/systemd/system/sos.service
+++ b/setup/iot_box_builder/overwrite_before_init/etc/systemd/system/sos.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Odoo SOS service, meant to enable Tailscale on emergency
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/python3 /etc/sos-controller.py
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
We add a separate service that hosts a simple http server with a controller to start Tailscale.

We make this controller available through a form on the "IoT Box is down" page, so that clients can easily grant access to the support to get help.

Task: 5871829
