### PR TITLE
[IMP] survey: add minimum width on columns to improve ux

### DIFF
--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -98,9 +98,9 @@
                                     <field name="page_id" optional="hidden"/>
                                     <field name="question_id"/>
                                     <field name="answer_type" optional="hidden"/>
-                                    <field name="skipped" hide="1"/>
+                                    <field name="skipped" width="[70]" hide="1"/>
                                     <field name="display_name" string="Answer"/>
-                                    <field name="answer_is_correct"/>
+                                    <field name="answer_is_correct" width="[70]"/>
                                     <field name="answer_score" sum="Score"/>
                                 </list>
                             </field>


### PR DESCRIPTION
The columns 'Skipped' and 'Correct' would by default show as 'S...' and 'C...'. By adding a minimum column width of 70 we ensure that the column names will be shown.

Task-5242008