### PR TITLE
[FIX] stock: update the placeholder for warehouse_ids

### DIFF
--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -218,7 +218,7 @@
                             <div class="o_row">
                                 <field name="warehouse_selectable" class="oe_inline" nolabel="1"/>
                                 <field name="warehouse_domain_ids" invisible="1"/>
-                                <field name="warehouse_ids" widget="many2many_tags" class="o_field_highlighted" placeholder="All Warehouses" nolabel="1" invisible="not warehouse_selectable"/>
+                                <field name="warehouse_ids" widget="many2many_tags" class="o_field_highlighted" placeholder="Choose Warehouses" nolabel="1" invisible="not warehouse_selectable"/>
                             </div>
                         </group>
                     </group>


### PR DESCRIPTION
Update warehouse_ids placeholder ("All Warehouses") to a new placeholder that reflect its behavior.

### Steps to reproduce:

* Enable multi-Step Routes
* Inventory > Routes > Buy > Warehouses
* Select the checkbox but leave the field empty (placeholder says "All Warehouses")

### Steps to verify behavior:

* Leaving the warehouse_ids fields empty ("All Warehouses")
* Create a product tracked by quantity and add a vendor
* Create a Reordering Rule
-> It doesn't put the "Buy" route by default as it should

opw-5264571
