### PR TITLE
[FIX] account_edi_ubl_cii: set imported partner as company

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -381,7 +381,8 @@ class AccountEdiCommon(models.AbstractModel):
             .with_company(invoice.company_id) \
             ._retrieve_partner(name=name, phone=phone, mail=mail, vat=vat, domain=domain)
         if not invoice.partner_id and name and vat:
-            partner_vals = {'name': name, 'email': mail, 'phone': phone, 'street': street, 'street2': street2, 'zip': zip_code, 'city': city}
+            partner_vals = {'name': name, 'email': mail, 'phone': phone, 'street': street, 'street2': street2,
+                            'zip': zip_code, 'city': city, 'is_company': True}
             if peppol_eas and peppol_endpoint:
                 partner_vals.update({'peppol_eas': peppol_eas, 'peppol_endpoint': peppol_endpoint})
             country = self.env.ref(f'base.{country_code.lower()}', raise_if_not_found=False) if country_code else False


### PR DESCRIPTION
Importing an xml with an unknown partner sets the partner as individual when it should be set as a company

Steps to reproduce:
1. Install Invoicing
2. Open Invoicing and click on "Upload"
3. Select any invoice xml (e.g. https://docs.oasis-open.org/ubl/os-UBL-2.2/xml/UBL-Invoice-2.1-Example.xml)
4. On the draft invoice created, click on the internal link next to the customer
5. The new partner created is an individual, it should be a company

Solution:
Set new imported partners as company
backport of https://github.com/odoo/odoo/commit/aa9fd54ab321eb591666244fbd14c1127151de70

opw-5490363