### PR TITLE
[FIX] project_purchase: fix profitability costs calculation

### DIFF
--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -170,9 +170,8 @@ class ProjectProject(models.Model):
                         )
                     )
                     if invoice_lines:
-                        invoiced_qty = sum(invoice_lines.filtered(lambda l: not l.is_refund).mapped('quantity'))
-                        if invoiced_qty < purchase_line.product_qty:
-                            amount_to_invoice -= purchase_line_amount_to_invoice * ((purchase_line.product_qty - invoiced_qty) / purchase_line.product_qty)
+                        # Calculate total invoiced amount (posted + draft, excluding refunds for unbilled calculation)
+                        total_invoiced_amount = 0.0
                         for line in invoice_lines:
                             price_subtotal = line.currency_id._convert(line.price_subtotal, self.currency_id, self.company_id)
                             if not line.analytic_distribution:
@@ -183,10 +182,15 @@ class ProjectProject(models.Model):
                                 if str(self.account_id.id) in ids.split(',')
                             ) / 100.
                             cost = price_subtotal * analytic_contribution * (-1 if line.is_refund else 1)
+                            # Only count non-refund invoices for unbilled calculation
+                            if not line.is_refund:
+                                total_invoiced_amount += cost
                             if line.parent_state == 'posted':
                                 amount_invoiced -= cost
                             else:
                                 amount_to_invoice -= cost
+                        # Calculate the unbilled portion: PO amount - total invoiced amount (non-refunds only)
+                        amount_to_invoice -= purchase_line_amount_to_invoice - total_invoiced_amount
                     else:
                         amount_to_invoice -= purchase_line_amount_to_invoice
 

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -1031,3 +1031,45 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
                 },
             },
         )
+
+    def test_partial_billing_profitability(self):
+        """Test profitability calculation when a purchase order is partially billed with a downpayment."""
+        purchase_order = self.env['purchase.order'].create({
+            'name': "PO with Downpayment",
+            'partner_id': self.partner_a.id,
+            'project_id': self.project.id,
+            'order_line': [Command.create({
+                'analytic_distribution': {self.analytic_account.id: 100},
+                'product_id': self.product_order.id,
+                'price_unit': 100.0,
+            })],
+        })
+        purchase_order.button_confirm()
+        # Create a partial vendor bill (downpayment) of 30
+        vendor_bill = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': datetime.today(),
+            'invoice_line_ids': [Command.create({
+                'analytic_distribution': {self.analytic_account.id: 100},
+                'product_id': self.product_order.id,
+                'price_unit': 30.0,
+            })],
+        })
+        vendor_bill.action_post()
+        # Add the bill as downpayment to the purchase order
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+        action = match_lines.action_add_to_po()
+        wizard = self.env['bill.to.po.wizard'].with_context({
+            **action['context'],
+            'active_ids': match_lines.ids
+        }).create({
+            'purchase_order_id': purchase_order.id
+        })
+        wizard.action_add_downpayment()
+        items = self.project._get_profitability_items(with_action=False)['costs']
+
+        self.assertDictEqual(items['total'], {
+            'billed': -30.0,
+            'to_bill': -70.0,
+        })


### PR DESCRIPTION
Steps to reproduce:
-----------------------------------------
1. Install `sale_purchase_project` and Accounting modules
2. From settings, enable Budget Management
3. Create a new product with type Service and enable Create a project on order.
4. Create and confirm the sale order with that product (note the name of created project)
5. Create and confirm purchase order as follows:
> In other information page, select the created project in the Project field
> Add the same product in POL, Set price unit price to 100 and remove any tax
6. Create and post a Vendor Bill for the same vendor as the PO as follows:
> Add Bill line with label downpayment
> Set the Analytic Distribution to the created project
> Set amount to 30
7. Go to the created purchase order > Click on bill matching
8. Select the downpayment bill > Add to PO > Select created PO > Add Down Payment
9. Go to the created project and open dashboard

Observation:
-----------------------------------------
In the Costs section:
Expected Cost: 130
To Bill: 100
Billed: 30

Expected values:
-----------------------------------------
Expected Cost: 100
To Bill: 70
Billed: 30

Issue:
----------------------------------------
In the following code:
https://github.com/odoo/odoo/blob/7e81c528ae350aab4432207f5655dcfadf6ec627/addons/project_purchase/models/project_project.py#L186-L190

When an invoice line was posted (billed), the code correctly subtracted the cost from `amount_invoiced` (making it negative, representing actual cost). But the billed amount was NOT removed from `amount_to_invoice`. This caused double counting the same cost appeared in both 'To Bill' and 'Billed'

Solution:
-----------------------------------------
Replaced the quantity-based calculation with a proper amount-based approach:
- Introduced `total_invoiced_amount` to track the sum of all non-refund invoice line amounts (both posted and draft).
- Modified the unbilled calculation to: `PO_amount - total_invoiced_amount`, ensuring that the unbilled portion accurately reflects what remains to be invoiced from the purchase order.
- Excluded refunds from `total_invoiced_amount` calculation because credit notes represent reversals of previous invoices, not consumption of the purchase order.  Refunds still correctly affect the "billed" and "to_bill" buckets through the normal invoice line processing.

This ensures the accounting principle is maintained: Total Expected Cost = Billed + To Bill = Purchase Order Amount

opw-5167734