### PR TITLE
[FIX] mrp_subcontracting_purchase: Prevent singleton error

### DIFF
--- a/addons/mrp_subcontracting_purchase/models/stock_move.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_move.py
@@ -15,7 +15,7 @@ class StockMove(models.Model):
         valuation_data = super()._get_value_from_account_move(quantity, at_date=at_date)
         last_subcontract_done_receipt = self.move_dest_ids.filtered(
             lambda m: m.state == 'done' and m.is_subcontract and m.purchase_line_id
-        )
+        ).sorted('create_date', reverse=True)[:1]
         if not self.production_id or not last_subcontract_done_receipt:
             return valuation_data
 


### PR DESCRIPTION
Related ticket: https://www.odoo.com/odoo/project.task/5416006 (The ticket was made for an unrelated perf issue).
Related PR: https://github.com/odoo/odoo/pull/243742

Reproducing this requires a database with
1. A product with `qty_available`, that is not `lot_valuated`, with a `cost_method` of average. 
2. The product has a stock move with a `production_id` where `is_in` is true.
3. The stock move has move than 1 `move_dest_ids` where `done` and `is_subcontract` is true.
Then:
4. Open an inventory valuation report from any date in the past. One can access inventory valuation reports from Accounting app --> Review menu --> Inventory --> Inventory Valuation. You will get a singleton error.

Note:
Per the related PR, it is no longer possible to give a stock move multiple subcontract move_dest_ids. So, one cannot create new stock moves that will trigger the bug. But also per the PR, this was possible in previous versions, and it is still valid.

Explanation:
In the `_get_value_from_account_move` method of stock.move, `last_subcontract_done_receipt` was changed in the related PR to accommodate the fact that a stock move could have multiple subcontract `move_dest_ids`, preventing a singleton error. However, a singleton error can still occur. It's possible that the `_get_value_from_account_move` method gets invoked on a recordset containing all the subcontract `move_dest_ids`. If there is an "at_date" passed in, it will ask for the date of the record set, causing a singleton error.

Solution:
Limit `last_subcontract_done_receipt` to 1 record.

opw-5416006
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
