### PR TITLE
[IMP] orm: stored fields should not depend on context

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -145,7 +145,7 @@ class ProductTemplate(models.Model):
     uom_name = fields.Char(string='Unit Name', related='uom_id.name', readonly=True)
     company_id = fields.Many2one(
         'res.company', 'Company', index=True)
-    seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id', 'Vendors', depends_context=('company',))
+    seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id', 'Vendors')
     variant_seller_ids = fields.One2many('product.supplierinfo', 'product_tmpl_id')
 
     active = fields.Boolean('Active', default=True, help="If unchecked, it will allow you to hide the product without removing it.")

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -556,6 +556,13 @@ class Field[T]:
             if not isinstance(self.readonly, bool):
                 warnings.warn(f'Property {self}.readonly should be a boolean ({self.readonly}).', stacklevel=1)
 
+            if self.store and self._depends_context and not all(
+                (self.translate and c == 'lang')
+                or (self.company_dependent and c == 'company')
+                for c in self._depends_context
+            ):
+                warnings.warn(f'Stored field {self} should not depend on context ({self._depends_context}).', stacklevel=1)
+
             self._setup_done = True
             # column_type might be changed during Field.setup
             reset_cached_properties(self)

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -94,6 +94,11 @@ class _Relational(Field[BaseModel]):
         assert self.comodel_name in model.pool, \
             f"Field {self} with unknown comodel_name {self.comodel_name or '???'!r}"
 
+    def _compute_related(self, records):
+        # Related fields for x2m must be computed in sudo to ensure cache
+        # consistency with the related field which is fetched in sudo.
+        return super()._compute_related(records.sudo())
+
     def setup_inverses(self, registry: Registry, inverses: Collector[Field, Field]):
         """ Populate ``inverses`` with ``self`` and its inverse fields. """
 


### PR DESCRIPTION
Stored values cannot depend on the context because they have a single
stored value. We have a few exceptions:

- "lang" for translated fields
- "company" for company-dependent fields

task-2903826

Fix x2m related fields after the cache pollution fix odoo/odoo#254944: the related x2m fields need to be computed in sudo to fill the cache with all values.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
