### PR TITLE
[IMP] point_of_sale: improve LNA status

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -21,6 +21,7 @@ import { _t } from "@web/core/l10n/translation";
 import { uuidv4 } from "@point_of_sale/utils";
 import { QrCodeCustomerDisplay } from "@point_of_sale/app/customer_display/customer_display_qr_code_popup";
 import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 export class Navbar extends Component {
     static template = "point_of_sale.Navbar";
@@ -53,6 +54,13 @@ export class Navbar extends Component {
         });
         useExternalListener(document, "keydown", this.handleKeydown.bind(this));
         this.openPresetTiming = useAsyncLockedMethod(this.openPresetTiming);
+    }
+
+    openLnaPopup() {
+        this.dialog.add(AlertDialog, {
+            title: _t("LNA Permission status"),
+            body: this.pos.lnaState.message,
+        });
     }
 
     handleKeydown(event) {

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -87,6 +87,11 @@
                                     Close Register
                                 </DropdownItem>
                             </div>
+                            <div class="border-top p-2">
+                                <span t-on-click="openLnaPopup" t-attf-class="btn btn-{{this.pos.lnaState.type}} btn-sm rounded" title="Local Network Access">
+                                    <i class="fa fa-wifi" aria-hidden="true" /> Local Network Access
+                                </span>
+                            </div>
                         </t>
                     </Dropdown>
                 </div>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -178,7 +178,13 @@ export class PosStore extends WithLazyGetterTrap {
             this.syncAllOrdersDebounced();
         });
 
-        initLNA(this.notification);
+        this.lnaState = {
+            type: "pending",
+            message: _t("Checking Local Network Access permission..."),
+        };
+        initLNA(this.notification, (type, message) => {
+            this.lnaState = { type, message };
+        });
     }
 
     navigate(routeName, routeParams = {}) {

--- a/addons/point_of_sale/static/src/app/utils/init_lna.js
+++ b/addons/point_of_sale/static/src/app/utils/init_lna.js
@@ -1,32 +1,61 @@
 import { _t } from "@web/core/l10n/translation";
 
-export const initLNA = async (notificationService) => {
+/**
+ * Initialize Local Network Access permission handling.
+ *
+ * @returns {Promise<{
+ *  type: "warning" | "danger" | "success" | "info"
+ *  message: string
+ * }>}
+ */
+export const initLNA = async (notificationService, callback = () => {}) => {
     if (!odoo.use_lna) {
+        callback("info", _t("Local Network Access is not configured for this POS."));
         return;
     }
-    try {
-        const result = await navigator.permissions.query({ name: "local-network-access" });
-        if (["granted", "prompt"].includes(result?.state)) {
-            return;
+
+    const processLNAState = (result) => {
+        let type = "";
+        let message = "";
+
+        if (result.state === "granted") {
+            type = "success";
+            message = _t("Local Network Access permission granted.");
+        } else if (result.state === "prompt") {
+            type = "warning";
+            message = _t(
+                "Local Network Access permission is not yet granted. Some hardware devices might not work properly. Please allow Local Network Access in your browser settings."
+            );
+        } else {
+            type = "danger";
+            message = _t(
+                "Local Network Access permission is denied. Some hardware devices might not work properly. Please allow Local Network Access in your browser settings."
+            );
+            notificationService.add(message, { type: "warning" });
         }
 
-        const message = _t(
-            "Local Network Access permission is denied. Some hardware devices might not work properly. Please allow Local Network Access in your browser settings."
-        );
-        notificationService.add(message, { type: "warning" });
+        callback(type, message);
+    };
+
+    try {
+        const result = await navigator.permissions.query({ name: "local-network-access" });
+        processLNAState(result);
+        result.onchange = () => processLNAState(result);
     } catch {
         odoo.use_lna = false;
         const isChromiumBased = navigator.userAgent.includes("Chromium") || !!window.chrome;
         let message;
         if (!isChromiumBased) {
             message = _t(
-                "Local Network Access configuration is enabled, but your browser is not Chromium-based. Please use a Chromium-based browser to benefit from this feature."
+                "Local Network Access configuration is enabled, but your browser is not Chromium-based. Please use a Chromium-based browser to benefit from this feature. Please note that IOS devices do not support Local Network Access yet."
             );
         } else {
             message = _t(
                 "Local Network Access is enabled for this POS, but your browser version does not support it. Please update your browser to the latest version."
             );
         }
+
         notificationService.add(message, { type: "warning" });
+        callback("danger", message);
     }
 };


### PR DESCRIPTION
Before this commit it was not possible to know if LNA permission was granted, denied or not yet granted from the POS interface. This commit adds a button in the navbar to show the current LNA status and open a popup with more information.

taskId: 5874947

