### PR TITLE
[FIX] website_blog : Pass updated blog context from active iframe

### DIFF
--- a/addons/website_blog/static/src/js/systray_items/new_content.js
+++ b/addons/website_blog/static/src/js/systray_items/new_content.js
@@ -23,7 +23,7 @@ patch(NewContentSystrayItem.prototype, {
 
     getCurrentBlogContext() {
         // Using iframe to access mainObject to check if we are on blog page
-        const iframeEl = document.querySelector("iframe").contentDocument;
+        const iframeEl = document.querySelector(".o_iframe_container > iframe:not(.o_ignore_in_tour)").contentDocument;
         const isBlogPage = iframeEl.documentElement.dataset.mainObject?.startsWith("blog");
 
         if (isBlogPage) {


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The blog context detection uses a generic `document.querySelector("iframe")`, which may select the iframe fallback instead of the active iframe when multiple iframes are present. This query selector will still worked on the first load because the fallback iframe still carried the same mainObject dataset, but failed when navigating to another blog and creating a new post with wrong blog id, as the fallback iframe was no longer updated. Also, if there is a new iframe added in front in future development or other customization, there will be a javascript error. 

```
Odoo Client Error
UncaughtClientError > TypeError
Uncaught Javascript Error > Cannot read properties of null (reading 'documentElement')
TypeError: Cannot read properties of null (reading 'documentElement')
    at NewContentSystrayItem.getCurrentBlogContext (/web/assets/6/8d2af65/web.assets_web.min.js:22099:863)
    at odoo.define.patch.setup.newBlogElement.createNewContent 
```
Fix by explicitly selecting the active iframe inside the website iframe container and excluding fallback iframes, ensuring the latest mainObject is used. Referencing on the following iframe query selector already existed in Odoo.
https://github.com/odoo/odoo/blob/e43ed4f7081a97916ce9fe4909fe155471c46371/addons/website/static/src/components/dialog/seo.js#L1007

**Current behavior before PR:**
A generic iframe selector is selecting the first fallback iframe in document instead of the active one. The blog post id selector will only work at the first loaded.

**Desired behavior after PR is merged:**
The active iframe is correctly selected, allowing blog page detection to work as expected when multiple similar iframes are present and reduce risk of having selecting error.

Please feel free to let me know if it is in purpose to select the fallback iframe and I am happy to know more on it :)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
