### PR TITLE
[FIX] web_tour: avoid interacting with triggers behind modals

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -35,8 +35,6 @@ export const accountTourSteps = {
 }
 
 registry.category("web_tour.tours").add('account_tour', {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo",
     steps: () => [
     ...accountTourSteps.goToAccountMenu(markup(_t('Send invoices to your customers in no time with the <b>Invoicing app</b>.'))),
     ...accountTourSteps.onboarding(),

--- a/addons/auth_passkey/static/tests/passkeys_registration.js
+++ b/addons/auth_passkey/static/tests/passkeys_registration.js
@@ -5,8 +5,6 @@ import * as passkeyLib from "../lib/simplewebauthn";
 let unpatchPasskeyRegistration;
 
 registry.category("web_tour.tours").add('passkeys_tour_registration', {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/odoo',
     steps: () => [
         {
             content: 'Open user account menu',

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -58,8 +58,6 @@ function closePreferencesDialog({content, totp_state}) {
 }
 
 registry.category("web_tour.tours").add('totp_tour_setup', {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/odoo',
     steps: () => [
 ...openUserPreferencesAtSecurityTab(),
 {
@@ -323,8 +321,6 @@ registry.category("web_tour.tours").add('totp_login_device', {
 ]});
 
 registry.category("web_tour.tours").add('totp_login_disabled', {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
     isActive: ["body:not(:has(input#login))"],

--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -119,7 +119,7 @@ class TestTOTP(TestTOTPMixin, HttpCase):
         self.assertEqual(r['login'], 'test_user')
 
     def test_totp_administration(self):
-        self.start_tour('/web', 'totp_tour_setup', login='test_user')
+        self.start_tour('/odoo', 'totp_tour_setup', login='test_user')
         # If not enabled (like in demo data), landing on res.config will try
         # to disable module_sale_quotation_builder and raise an issue
         group_order_template = self.env.ref('sale_management.group_sale_order_template', raise_if_not_found=False)

--- a/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
+++ b/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
@@ -47,6 +47,11 @@ registry.category("web_tour.tours").add("version_timeline_auto_save_tour", {
             run: "click",
         },
         {
+            content: "Wait the form is dirty and click on save button",
+            trigger: "body:has(.o_form_dirty) .o_form_button_save",
+            run: "click",
+        },
+        {
             content: "Wait until the form is saved",
             trigger: "body .o_form_saved",
         },

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -4,11 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("hr_holidays_tour", {
-    // Remove this key to get warning
-    // Record does not exist or has been deleted.
-    // (Record: hr.leave(3,), User: 2)
-    undeterministicTour_doNotCopy: true,
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/l10n_sa_edi_pos/static/tests/tours/generic_tour.js
+++ b/addons/l10n_sa_edi_pos/static/tests/tours/generic_tour.js
@@ -1,0 +1,30 @@
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+import "@point_of_sale/../tests/pos/tours/generic_tour";
+
+patch(registry.category("web_tour.tours").get("generic_localization_tour"), {
+    steps() {
+        const originalSteps = super.steps();
+        const stStep = originalSteps.findIndex(
+            (step) => step.content === "feedback screen has finished the validation"
+        );
+
+        return [
+            ...originalSteps.slice(0, stStep),
+            {
+                content: "Close the modal that appears with l10n_sa_edi_pos",
+                trigger: `body`,
+                async run({ waitFor, click }) {
+                    const selector = `.modal:has(.modal-title:contains(zatca validation error))`;
+                    const modal = await waitFor(selector, {
+                        timeout: 9000,
+                    }).catch(() => false);
+                    if (modal) {
+                        await click(`${selector} .btn:contains(ok)`);
+                    }
+                },
+            },
+            ...originalSteps.slice(stStep + 1),
+        ];
+    },
+});

--- a/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
@@ -69,6 +69,10 @@ function getMeetingViewTourSteps({ inWelcomePage = false } = {}) {
     if (inWelcomePage) {
         steps.unshift(
             { trigger: "input[name='guest_name']", run: "edit Guest" },
+            {
+                trigger: ".modal .btn-close",
+                run: "click",
+            },
             { trigger: "[title='Join Channel']", run: "click" }
         );
     }

--- a/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
@@ -7,7 +7,6 @@ import { registry } from "@web/core/registry";
  * @see mail/tests/test_mail_composer.py
  */
 registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_composer_test_tour.js", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             content: "Wait for the chatter to be fully loaded",

--- a/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
@@ -20,10 +20,12 @@ export function cancel({ title } = {}) {
         run: "click",
     };
 }
-export function discard() {
+export function discard({ title } = {}) {
     return {
         content: "discard dialog",
-        trigger: `.modal .modal-footer button:contains("Discard")`,
+        trigger: `.modal${
+            title ? `:has(.modal-title:contains(${title}))` : ``
+        } .modal-footer button:contains("Discard")`,
         run: "click",
     };
 }

--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -126,7 +126,7 @@ export function searchCustomerValue(val, pressEnter = false) {
         },
         {
             content: `Search customer with "${val}"`,
-            trigger: `.modal-dialog .input-group input`,
+            trigger: `.modal-header:has(.modal-title:contains(choose customer)) .input-group input`,
             run: `edit ${val}`,
         },
     ];
@@ -134,7 +134,7 @@ export function searchCustomerValue(val, pressEnter = false) {
     if (pressEnter) {
         steps.push({
             content: `Manually trigger keyup event`,
-            trigger: ".modal-header .input-group input",
+            trigger: ".modal-header:has(.modal-title:contains(choose customer)) .input-group input",
             run: function () {
                 document
                     .querySelector(".modal-header .input-group input")
@@ -143,7 +143,7 @@ export function searchCustomerValue(val, pressEnter = false) {
         });
         steps.push({
             content: `Press Enter to trigger "search more"`,
-            trigger: `.modal-dialog .input-group input`,
+            trigger: `.modal-header:has(.modal-title:contains(choose customer)) .input-group input`,
             run: function () {
                 document
                     .querySelector(".modal-dialog .input-group input")

--- a/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
+++ b/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
@@ -40,7 +40,6 @@ export function assertTaxTotals(baseAmount, taxAmount, totalAmount) {
 }
 
 registry.category("web_tour.tours").add("test_point_of_sale_custom_tax_with_extra_product_field", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -13,7 +13,6 @@ import { registry } from "@web/core/registry";
 import { negate, scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("PosHrTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),
@@ -129,7 +128,6 @@ registry.category("web_tour.tours").add("CashierCanSeeProductInfo", {
 });
 
 registry.category("web_tour.tours").add("CashierCannotClose", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.clickBtn("Open Register"),

--- a/addons/pos_loyalty/static/tests/tours/multiple_gift_wallet_programs_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/multiple_gift_wallet_programs_tour.js
@@ -7,9 +7,6 @@ import { registry } from "@web/core/registry";
 
 const getEWalletText = (suffix) => "eWallet" + (suffix !== "" ? ` ${suffix}` : "");
 registry.category("web_tour.tours").add("MultipleGiftWalletProgramsTour", {
-    // Already repertoried in runbot error.
-    // Remove this key to increase the frequency of failings.
-    undeterministicTour_doNotCopy: true,
     steps: () =>
         [
             // One card for gift_card_1.

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_loyalty_program_tour.js
@@ -10,7 +10,6 @@ import { registry } from "@web/core/registry";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -642,7 +642,6 @@ registry.category("web_tour.tours").add("test_multiple_preparation_printer_diffe
         ].flat(),
 });
 registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -663,7 +662,6 @@ registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
 });
 
 registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.freezeDateTime(1749981600000), // June 15, 2025 - 10:00
@@ -698,7 +696,6 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
 });
 
 registry.category("web_tour.tours").add("test_open_register_with_preset_takeaway", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.freezeDateTime(1749981600000), // June 15, 2025 - 10:00
@@ -1271,6 +1268,7 @@ registry.category("web_tour.tours").add("test_guest_count_bank_payment", {
             Order.hasLine({ productName: "Coca-Cola" }),
             ProductScreen.clickPayButton(false),
             ProductScreen.confirmOrderWarningDialog(),
+            Chrome.closePrintingWarning(),
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickBackToProductScreen(),
             ProductScreen.isShown(),

--- a/addons/pos_restaurant/static/tests/tours/utils/chrome.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/chrome.js
@@ -1,5 +1,3 @@
-import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
-
 export function isTabActive(tabText) {
     return [
         {
@@ -12,8 +10,10 @@ export function isTabActive(tabText) {
 export function closePrintingWarning() {
     return [
         {
-            ...Dialog.confirm(),
             content: "acknowledge printing error ( because we don't have printer in the test. )",
+            trigger: `.modal:has(.modal-header:contains(printing failed)) .modal-footer .btn-primary:contains(continue)`,
+            run: "click",
+            timeout: 15000,
         },
     ];
 }

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -138,7 +138,7 @@ export function discardOrderWarningDialog() {
         {
             trigger: `.modal-dialog:contains("It seems that the order has not been sent. Would you like to send it to preparation?")`,
         },
-        Dialog.discard(),
+        Dialog.discard({ title: `Warning !` }),
     ];
 }
 

--- a/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
+++ b/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
@@ -33,8 +33,7 @@ const checkRows = (values) => ({
     },
 });
 
-registry.category("web_tour.tours").add("mail_activity_view", {
-    undeterministicTour_doNotCopy: true,
+registry.category("web_tour.tours").add("mail_activity_view_tour", {
     steps: () => [
         {
             content: "Open the debug menu",

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -962,8 +962,4 @@ class TestTours(HttpCase):
                 </activity>
             """,
         })
-        self.start_tour(
-            "/odoo?debug=1",
-            "mail_activity_view",
-            login="admin",
-        )
+        self.start_tour("/odoo?debug=1", "mail_activity_view_tour", login="admin")

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -206,6 +206,9 @@ registerWebsitePreviewTour(
         {
             content: "check upload progress bar is correctly shown",
             trigger: `.o_we_progressbar:contains('icon.ico'):contains('${formatErrorMsg}')`,
+        },
+        {
+            trigger: "body",
             run() {
                 patchWithError = false;
             },

--- a/addons/test_website/static/tests/tours/page_manager.js
+++ b/addons/test_website/static/tests/tours/page_manager.js
@@ -1,8 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_website_page_manager", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo/action-test_website.action_test_model_multi_website",
     steps: () => [
         // Part 1: check that the website filter is working
         {

--- a/addons/website/static/tests/tours/custom_popup_snippet.js
+++ b/addons/website/static/tests/tours/custom_popup_snippet.js
@@ -13,10 +13,6 @@ const snippets = [
 registerWebsitePreviewTour(
     "custom_popup_snippet",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -375,8 +375,6 @@ const openMenu = () => ({
 registerWebsitePreviewTour(
     "edit_megamenu_visibility",
     {
-        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -15,8 +15,6 @@ const snippet = {
 registerWebsitePreviewTour(
     "website_replace_grid_image",
     {
-        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -124,8 +124,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_media_dialog_icons",
     {
-        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_popup_add_remove.js
+++ b/addons/website/static/tests/tours/snippet_popup_add_remove.js
@@ -8,10 +8,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_popup_add_remove",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website_sale/static/tests/tours/remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/remove_product_image.js
@@ -34,7 +34,6 @@ const enterEditModeOfTestProduct = () => [
 registerWebsitePreviewTour(
     "website_sale.add_and_remove_main_product_image_no_variant",
     {
-        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         url: "/shop?search=Test Remove Image",
     },
     () => [

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -11,134 +11,128 @@ import {
  * they create some lessons in it;
  * they publish it;
  */
-registerWebsitePreviewTour(
-    "course_publisher_standard",
-    {
-        undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/slides",
-    },
-    () =>
+registerWebsitePreviewTour("course_publisher_standard", {}, () =>
+    [
+        {
+            content: "eLearning: click on New (top-menu)",
+            trigger: "div.o_new_content_container button",
+            run: "click",
+        },
+        {
+            content: "eLearning: click on New Course",
+            trigger: "button.o_new_content_element:contains('Course')",
+            run: "click",
+        },
+        {
+            content: "eLearning: set name",
+            trigger: 'div[name="name"] input',
+            run: "edit How to Déboulonnate",
+        },
+        {
+            content: "eLearning: click on tags",
+            trigger: ".o_field_many2many_tags input",
+            run: "edit Gard",
+        },
+        {
+            content: "eLearning: select Gardening tag",
+            trigger: '.ui-autocomplete span:contains("Gardening")',
+            run: "click",
+        },
+        {
+            content: "eLearning: set description",
+            trigger: '.o_field_html[name="description"] .odoo-editor-editable div.o-paragraph',
+            run: "editor Déboulonnate is very common at Fleurus",
+        },
+        {
+            content: "eLearning: we want reviews",
+            trigger: '.o_field_boolean[name="allow_comment"] input',
+            run: "click",
+        },
+        {
+            content: "eLearning: seems cool, create it",
+            trigger: ".modal-footer button.o_form_button_save",
+            run: "click",
+        },
+        {
+            trigger: "body:not(:has(.modal))",
+        },
+        {
+            content: "wait the slide course main is in body before edition",
+            trigger: ":iframe main .o_wslides_course_main",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "eLearning: double click image to edit it",
+            trigger: ":iframe img.o_wslides_course_pict",
+            run: "dblclick",
+        },
+        {
+            content: 'eLearning: click "Add URL" to trigger URL box',
+            trigger: ".o_upload_media_url_button",
+            run: "click",
+        },
+        {
+            content: "eLearning: add a bioutifoul URL",
+            trigger: "input.o_we_url_input",
+            run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
+        },
+        {
+            trigger: ".o_we_url_success",
+        },
+        {
+            content: 'eLearning: click "Add URL" really adding image',
+            trigger: ".o_upload_media_url_button",
+            run: "click",
+        },
+        {
+            content: "eLearning: is the Corgi set ?",
+            trigger:
+                ':iframe img.o_wslides_course_pict.o_modified_image_to_save[data-original-src$="GoldWinnerPembrookeWelshCorgi.jpg"][src^="data:image"]',
+            run: "click",
+        },
+        {
+            content: "eLearning: save course edition",
+            trigger: 'button[data-action="save"]',
+            run: "click",
+        },
+        {
+            trigger: ":iframe body:not(.editor_enable)", // wait for editor to close
+        },
+        {
+            content: "eLearning: course create with current member",
+            trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
+        },
+    ].concat(
+        slidesTourTools.addExistingCourseTag(true),
+        slidesTourTools.addNewCourseTag("The Most Awesome Course", true),
+        slidesTourTools.addSection("Introduction", true),
+        slidesTourTools.addArticleToSection("Introduction", "MyArticle", true),
         [
             {
-                content: "eLearning: click on New (top-menu)",
-                trigger: "div.o_new_content_container button",
+                content: "eLearning: check editor is loaded for article",
+                trigger: ":iframe body.editor_enable",
+                timeout: 30000,
+            },
+            {
+                content: "eLearning: save article",
+                trigger: '.o-snippets-top-actions button[data-action="save"]',
                 run: "click",
             },
             {
-                content: "eLearning: click on New Course",
-                trigger: "button.o_new_content_element:contains('Course')",
-                run: "click",
+                trigger: ":iframe body[is-ready=true]:not(.editor_enable)",
             },
             {
-                content: "eLearning: set name",
-                trigger: 'div[name="name"] input',
-                run: "edit How to Déboulonnate",
-            },
-            {
-                content: "eLearning: click on tags",
-                trigger: ".o_field_many2many_tags input",
-                run: "edit Gard",
-            },
-            {
-                content: "eLearning: select Gardening tag",
-                trigger: '.ui-autocomplete span:contains("Gardening")',
-                run: "click",
-            },
-            {
-                content: "eLearning: set description",
-                trigger: '.o_field_html[name="description"] .odoo-editor-editable div.o-paragraph',
-                run: "editor Déboulonnate is very common at Fleurus",
-            },
-            {
-                content: "eLearning: we want reviews",
-                trigger: '.o_field_boolean[name="allow_comment"] input',
-                run: "click",
-            },
-            {
-                content: "eLearning: seems cool, create it",
-                trigger: ".modal-footer button.o_form_button_save",
-                run: "click",
-            },
-            {
-                trigger: "body:not(:has(.modal))",
-            },
-            {
-                content: "wait the slide course main is in body before edition",
-                trigger: ":iframe main .o_wslides_course_main",
-            },
-            ...clickOnEditAndWaitEditMode(),
-            {
-                content: "eLearning: double click image to edit it",
-                trigger: ":iframe img.o_wslides_course_pict",
-                run: "dblclick",
-            },
-            {
-                content: 'eLearning: click "Add URL" to trigger URL box',
-                trigger: ".o_upload_media_url_button",
-                run: "click",
-            },
-            {
-                content: "eLearning: add a bioutifoul URL",
-                trigger: "input.o_we_url_input",
-                run: "edit https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg/800px-ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg",
-            },
-            {
-                trigger: ".o_we_url_success",
-            },
-            {
-                content: 'eLearning: click "Add URL" really adding image',
-                trigger: ".o_upload_media_url_button",
-                run: "click",
-            },
-            {
-                content: "eLearning: is the Corgi set ?",
                 trigger:
-                    ':iframe img.o_wslides_course_pict.o_modified_image_to_save[data-original-src$="GoldWinnerPembrookeWelshCorgi.jpg"][src^="data:image"]',
+                    ":iframe main:has(.o_wslides_course_nav a:contains(Déboulonnate)):has(.o_wslides_lesson_header_container:contains(completed)):has(.o_wslides_lesson_content:contains(screen to edit))",
+            },
+            {
+                content: "eLearning: use breadcrumb to go back to channel",
+                trigger:
+                    ':iframe .o_wslides_course_nav a:contains("Déboulonnate")[href^="/slides/how-to-deboulonnate"]',
                 run: "click",
             },
-            {
-                content: "eLearning: save course edition",
-                trigger: 'button[data-action="save"]',
-                run: "click",
-            },
-            {
-                trigger: ":iframe body:not(.editor_enable)", // wait for editor to close
-            },
-            {
-                content: "eLearning: course create with current member",
-                trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
-            },
-        ].concat(
-            slidesTourTools.addExistingCourseTag(true),
-            slidesTourTools.addNewCourseTag("The Most Awesome Course", true),
-            slidesTourTools.addSection("Introduction", true),
-            slidesTourTools.addArticleToSection("Introduction", "MyArticle", true),
-            [
-                {
-                    content: "eLearning: check editor is loaded for article",
-                    trigger: ":iframe body.editor_enable",
-                    timeout: 30000,
-                },
-                {
-                    content: "eLearning: save article",
-                    trigger: '.o-snippets-top-actions button[data-action="save"]',
-                    run: "click",
-                },
-                {
-                    trigger: ":iframe body[is-ready=true]:not(.editor_enable)",
-                },
-                {
-                    trigger:
-                        ":iframe main:has(.o_wslides_course_nav a:contains(Déboulonnate)):has(.o_wslides_lesson_header_container:contains(completed)):has(.o_wslides_lesson_content:contains(screen to edit))",
-                },
-                {
-                    content: "eLearning: use breadcrumb to go back to channel",
-                    trigger:
-                        ':iframe .o_wslides_course_nav a:contains("Déboulonnate")[href^="/slides/how-to-deboulonnate"]',
-                    run: "click",
-                },
-            ],
-            slidesTourTools.addImageToSection("Introduction", "Overview", true),
-            slidesTourTools.addPdfToSection("Introduction", "Exercise", true)
-        )
+        ],
+        slidesTourTools.addImageToSection("Introduction", "Overview", true),
+        slidesTourTools.addPdfToSection("Introduction", "Exercise", true)
+    )
 );


### PR DESCRIPTION
Before this commit, the automatic tour engine checked whether the DOM
contained a `.modal` and whether the trigger element was inside it, in
order to avoid interacting with elements behind a modal. However, when
the DOM also contained a popover or a notification, this check was
skipped.

With this commit, this logic has been improved to also take other
overlay items into account.

This improvement involves some fixes and adaptations in a few tours.
