### PR TITLE
[IMP] mail: improve /help text for channels

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1547,7 +1547,7 @@ class DiscussChannel(models.Model):
         self.ensure_one()
         if self.channel_type == 'channel':
             msg = _(
-                "You are in channel %(bold_start)s#%(channel_name)s%(bold_end)s.",
+                "You are in %(bold_start)s#%(channel_name)s%(bold_end)s.",
                 bold_start=Markup("<b>"),
                 bold_end=Markup("</b>"),
                 channel_name=self.name,
@@ -1570,11 +1570,12 @@ class DiscussChannel(models.Model):
     def _execute_command_help_message_extra(self):
         msg = _(
             "%(new_line)s"
-            "%(new_line)sType %(bold_start)s@username%(bold_end)s to mention someone, and grab their attention."
-            "%(new_line)sType %(bold_start)s#channel%(bold_end)s to mention a channel."
-            "%(new_line)sType %(bold_start)s/command%(bold_end)s to execute a command."
-            "%(new_line)sType %(bold_start)s::shortcut%(bold_end)s to insert a canned response in your message."
-            "%(new_line)sType %(bold_start)s:emoji:%(bold_end)s to insert an emoji in your message.",
+            "%(new_line)s%(bold_start)s@username%(bold_end)s to mention someone"
+            "%(new_line)s%(bold_start)s@role%(bold_end)s to notify multiple people"
+            "%(new_line)s%(bold_start)s#channel%(bold_end)s to link a channel"
+            "%(new_line)s%(bold_start)s/command%(bold_end)s to run a command"
+            "%(new_line)s%(bold_start)s::shortcut%(bold_end)s to insert a canned response"
+            "%(new_line)s%(bold_start)s:emoji:%(bold_end)s to insert an emoji",
             bold_start=Markup("<b>"),
             bold_end=Markup("</b>"),
             new_line=Markup("<br>"),

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -601,7 +601,7 @@ export class DiscussChannel extends models.ServerModel {
         const [channel] = this.search_read([["id", "=", id]]);
         const notifBody = /* html */ `
             <span class="o_mail_notification">You are in ${
-                channel.channel_type === "channel" ? "channel" : "a private conversation with"
+                channel.channel_type === "channel" ? "" : "a private conversation with"
             }
             <b>${
                 channel.channel_type === "channel"
@@ -611,9 +611,12 @@ export class DiscussChannel extends models.ServerModel {
                       )
             }</b>.<br><br>
 
-            Type <b>@username</b> to mention someone, and grab their attention.<br>
-            Type <b>#channel</b> to mention a channel.<br>
-            Type <b>/command</b> to execute a command.<br></span>
+            <b>@username</b> to mention someone<br>
+            <b>@role</b> to notify multiple people<br>
+            <b>#channel</b> to link a channel<br>
+            <b>/command</b> to run a command<br>
+            <b>::shortcut</b> to insert a canned response<br>
+            <b>:emoji:</b> to insert an emoji</span>
         `;
         const [partner] = ResPartner.read(this.env.user.partner_id);
         BusBus._sendone(partner, "discuss.channel/transient_message", {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -864,12 +864,13 @@ class TestChannelInternals(MailCommon, HttpCase):
                     "payload": {
                         "body":
                             "<span class='o_mail_notification'>"
-                            "You are in channel <b>#&lt;strong&gt;R&amp;D&lt;/strong&gt;</b>."
-                            "<br><br>Type <b>@username</b> to mention someone, and grab their attention."
-                            "<br>Type <b>#channel</b> to mention a channel."
-                            "<br>Type <b>/command</b> to execute a command."
-                            "<br>Type <b>::shortcut</b> to insert a canned response in your message."
-                            "<br>Type <b>:emoji:</b> to insert an emoji in your message."
+                            "You are in <b>#&lt;strong&gt;R&amp;D&lt;/strong&gt;</b>."
+                            "<br><br><b>@username</b> to mention someone"
+                            "<br><b>@role</b> to notify multiple people"
+                            "<br><b>#channel</b> to link a channel"
+                            "<br><b>/command</b> to run a command"
+                            "<br><b>::shortcut</b> to insert a canned response"
+                            "<br><b>:emoji:</b> to insert an emoji"
                             "</span>",
                         "channel_id": channel.id,
                     },
@@ -903,11 +904,12 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "You are in a private conversation with "
                             f"<a href=# data-oe-model='res.partner' data-oe-id='{test_user.partner_id.id}'>@Mario</a> "
                             f"and <a href=# data-oe-model='res.partner' data-oe-id='{self.partner_employee_nomail.id}'>@&lt;strong&gt;Evita Employee NoEmail&lt;/strong&gt;</a>."
-                            "<br><br>Type <b>@username</b> to mention someone, and grab their attention."
-                            "<br>Type <b>#channel</b> to mention a channel."
-                            "<br>Type <b>/command</b> to execute a command."
-                            "<br>Type <b>::shortcut</b> to insert a canned response in your message."
-                            "<br>Type <b>:emoji:</b> to insert an emoji in your message."
+                            "<br><br><b>@username</b> to mention someone"
+                            "<br><b>@role</b> to notify multiple people"
+                            "<br><b>#channel</b> to link a channel"
+                            "<br><b>/command</b> to run a command"
+                            "<br><b>::shortcut</b> to insert a canned response"
+                            "<br><b>:emoji:</b> to insert an emoji"
                             "</span>",
                         "channel_id": test_group.id,
                     },


### PR DESCRIPTION
Update the help text shown when typing /help in a channel to be more concise and actionable.

task-5873753



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
