### PR TITLE
[FIX] website: wait for the loading screen to disappear in a tour

### DIFF
--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -28,6 +28,10 @@ registerWebsitePreviewTour(
             trigger: ":iframe .o_loading_screen",
         },
         {
+            content: "Wait for the loading screen to disappear",
+            trigger: ":iframe :not(.o_loading_screen)",
+        },
+        {
             content: "Wait for the builder to mount after iframe reload",
             trigger: ":iframe body.editor_enable",
         },


### PR DESCRIPTION
When the iframe reloading starts, the builder can still have the class
`editor_enable`, which breaks the flow of the tour, as the next step is
waiting for that class, so we should wait for the loading screen to disappear
first, and only then check for the `editor_enable` class.

runbot-234504