### PR TITLE
[FIX] payment_stripe: use stripe special rounding in amount validation

### DIFF
--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -391,7 +391,9 @@ class PaymentTransaction(models.Model):
         else:  # 'online_direct', 'online_token', 'offline'
             payment_data = notification_data['payment_intent']
         amount = payment_utils.to_major_currency_units(
-            payment_data.get('amount', 0), self.currency_id
+            payment_data.get('amount', 0),
+            self.currency_id,
+            arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
         )
         currency_code = payment_data.get('currency', '').upper()
         precision_digits = CURRENCY_MINOR_UNITS.get(


### PR DESCRIPTION
### Issue:
Stripe payment is failing in some special currencies (e.g. ISK, UGX).

### Steps to reproduce:
1- Configure Stripe
2- Enable ISK currency
3- Create a SO with ISK currency and generate a payment.
4- Pay using Stripe.

The payment will fail due to the amount mismatch.

### Cause:
Commit https://github.com/odoo/odoo/commit/9493475273a40320228b92940be15ad8cb0643cb added support for special currency but did not adapt amount validation method in fw.

In stripe payload, we are using `const.CURRENCY_DECIMALS` as `arbitrary_decimal_number` to convert the amount to minor currency unit:
https://github.com/odoo/odoo/blob/6e2a29bbb23a8233132dc039d144d97be4feb3af/addons/payment_stripe/models/payment_transaction.py#L161-L166

However, we are not using the same constant in conversion back to major currency unit in `compare_notification_data`:
https://github.com/odoo/odoo/blob/6e2a29bbb23a8233132dc039d144d97be4feb3af/addons/payment_stripe/models/payment_transaction.py#L393-L395

opw-5871420
