### PR TITLE
[FIX] point_of_sale: add shouldRoundChange getter for override

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -100,9 +100,12 @@ export class PosOrderAccounting extends Base {
             (isNegative ? -roundingSanatizer : roundingSanatizer);
 
         const amount = isNegative ? -this.currency.round(total) : this.currency.round(total);
-        return this.config.cash_rounding
+        return this.shouldRoundChange
             ? this.config.rounding_method.asymmetricRound(amount)
             : amount;
+    }
+    get shouldRoundChange() {
+        return this.config.cash_rounding;
     }
     get orderIsRounded() {
         const cashPm = this.payment_ids.some((p) => p.payment_method_id.is_cash_count);


### PR DESCRIPTION
We extract the condition into a getter so we can override it elsewhere. For now, it is overriden in `pos_settle_order`. See below for explanation.

`change` is the amount we return to the client, so it's in cash, and therefore, we always round it if `cash_rounding` is true.

However, in pos_settle_order, when a client 'deposits money', the order `change` is what we get paid by that client, and he might choose a payment method different than cash (card for e.g.). We change the `shouldRoundChange` logic to count for such cases.

opw-5222985