### PR TITLE
[IMP] im_livechat: add color field to expertise

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -214,7 +214,7 @@ class DiscussChannel(models.Model):
         store.add(need_help_after - need_help_before, "_store_channel_fields")
         store.add(need_help_before - need_help_after, ["livechat_status"])
         if "livechat_expertise_ids" in vals:
-            store.add(need_help_after, lambda res: res.many("livechat_expertise_ids", ["name"]))
+            store.add(need_help_after, lambda res: res.many("livechat_expertise_ids", ["name", "color"]))
         store.bus_send()
         return result
 
@@ -418,7 +418,7 @@ class DiscussChannel(models.Model):
         res["internal_users"].attr("livechat_looking_for_help_since_dt", predicate=is_livechat_channel)
         res["internal_users"].many(
             "livechat_expertise_ids",
-            ["name"],
+            ["name", "color"],
             predicate=is_livechat_channel,
         )
 
@@ -441,7 +441,7 @@ class DiscussChannel(models.Model):
             res.attr("livechat_outcome", predicate=is_livechat_channel)
             res.attr("livechat_status", predicate=is_livechat_channel)
             res.attr("livechat_looking_for_help_since_dt", predicate=is_livechat_channel)
-            res.many("livechat_expertise_ids", ["name"], predicate=is_livechat_channel)
+            res.many("livechat_expertise_ids", ["name", "color"], predicate=is_livechat_channel)
 
     def _to_store(self, store: Store, res: Store.FieldList):
         """Extends the channel header by adding the livechat operator and the 'anonymous' profile"""

--- a/addons/im_livechat/models/im_livechat_expertise.py
+++ b/addons/im_livechat/models/im_livechat_expertise.py
@@ -12,6 +12,7 @@ class Im_LivechatExpertise(models.Model):
     _description = "Live Chat Expertise"
     _order = "name"
 
+    color = fields.Integer("Color")
     name = fields.Char("Name", required=True, translate=True)
     user_ids = fields.Many2many(
         "res.users",

--- a/addons/im_livechat/static/src/core/common/livechat_expertise_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_expertise_model.js
@@ -5,6 +5,8 @@ export class LivechatExpertise extends Record {
     static _name = "im_livechat.expertise";
 
     /** @type {number} */
+    color;
+    /** @type {number} */
     id;
     /** @type {string} */
     name;

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
@@ -7,7 +7,7 @@
             t-ref="root"
         >
             <div class="d-flex flex-wrap gap-1">
-                <BadgeTag t-foreach="props.channel.livechat_expertise_ids" t-as="expertise" t-key="expertise.id" text="expertise.name" onDelete="props.disabled ? null : () => this.unlinkExpertise(expertise)"/>
+                <BadgeTag t-foreach="props.channel.livechat_expertise_ids" t-as="expertise" t-key="expertise.id" text="expertise.name" color="expertise.color" onDelete="props.disabled ? null : () => this.unlinkExpertise(expertise)"/>
             </div>
             <div t-if="!props.disabled" class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
                 <Many2XAutocomplete

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -116,7 +116,7 @@ export class DiscussChannel extends mailModels.DiscussChannel {
                 channelInfo["livechat_status"] = channel.livechat_status;
                 channelInfo["livechat_expertise_ids"] = mailDataHelpers.Store.many(
                     this.env["im_livechat.expertise"].browse(channel.livechat_expertise_ids),
-                    makeKwArgs({ fields: ["name"] })
+                    makeKwArgs({ fields: ["name", "color"] })
                 );
                 channelInfo.livechat_channel_id = mailDataHelpers.Store.one(
                     this.env["im_livechat.channel"].browse(channel.livechat_channel_id),

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
@@ -60,7 +60,7 @@ export class ResPartner extends mailModels.ResPartner {
                         "is_in_call",
                         mailDataHelpers.Store.one(
                             "main_user_id",
-                            mailDataHelpers.Store.many("livechat_expertise_ids", "name")
+                            mailDataHelpers.Store.many("livechat_expertise_ids", ["name", "color"])
                         ),
                     ],
                 })

--- a/addons/im_livechat/views/im_livechat_expertise_views.xml
+++ b/addons/im_livechat/views/im_livechat_expertise_views.xml
@@ -8,6 +8,7 @@
                 <list editable="bottom">
                     <field name="name"/>
                     <field name="user_ids" widget="many2many_tags" options="{'no_create': True}" domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]"/>
+                    <field name="color" widget="color_picker"/>
                 </list>
             </field>
         </record>
@@ -21,6 +22,7 @@
                         <group>
                             <field name="name"/>
                             <field name="user_ids" widget="many2many_tags" options="{'no_create': True}" domain="[['all_group_ids', 'in', %(im_livechat.im_livechat_group_user)d]]"/>
+                            <field name="color" widget="color_picker"/>
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
This commit introduces a color field to the livechat expertise model, allowing each expertise tag to have an associated color. The color is displayed alongside the expertise name in the livechat info panel.

task-5873755


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
