### PR TITLE
[FIX] im_livechat: prevent local storage loop

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app_model_patch.js
@@ -11,7 +11,7 @@ import { patch } from "@web/core/utils/patch";
 // when the user closes the sidebar or switches to another app, wait for 5
 // minutes before unsubscribing.
 export const LFH_UNSUBSCRIBE_DELAY = 5 * 60 * 1000;
-const LIVECHAT_INFO_DEFAULT_OPEN_LS = "im_livechat.isInfoPanelOpenByDefault";
+export const LIVECHAT_INFO_DEFAULT_OPEN_LS = "im_livechat.isInfoPanelOpenByDefault";
 
 const discussAppStaticPatch = {
     new() {
@@ -84,17 +84,11 @@ patch(DiscussApp.prototype, {
         });
         this.lastThread = fields.One("Thread");
         this.livechats = fields.Many("Thread", { inverse: "appAsLivechats" });
+        this._recomputeIsLivechatInfoPanelOpenedByDefault = 0;
         this.isLivechatInfoPanelOpenByDefault = fields.Attr(true, {
             compute() {
+                void this._recomputeIsLivechatInfoPanelOpenedByDefault;
                 return browser.localStorage.getItem(LIVECHAT_INFO_DEFAULT_OPEN_LS) !== "false";
-            },
-            /** @this {import("models").DiscussApp} */
-            onUpdate() {
-                if (this.isLivechatInfoPanelOpenByDefault) {
-                    browser.localStorage.removeItem(LIVECHAT_INFO_DEFAULT_OPEN_LS);
-                } else {
-                    browser.localStorage.setItem(LIVECHAT_INFO_DEFAULT_OPEN_LS, "false");
-                }
             },
         });
     },
@@ -123,7 +117,7 @@ patch(DiscussApp.prototype, {
     onStorage(ev) {
         super.onStorage(ev);
         if (ev.key === LIVECHAT_INFO_DEFAULT_OPEN_LS) {
-            this.isLivechatInfoPanelOpenByDefault = ev.newValue !== "false";
+            this._recomputeIsLivechatInfoPanelOpenedByDefault++;
         }
     },
 });

--- a/addons/im_livechat/static/src/core/web/thread_actions.js
+++ b/addons/im_livechat/static/src/core/web/thread_actions.js
@@ -1,7 +1,9 @@
 import { registerThreadAction } from "@mail/core/common/thread_actions";
 
-import { _t } from "@web/core/l10n/translation";
+import { LIVECHAT_INFO_DEFAULT_OPEN_LS } from "@im_livechat/core/public_web/discuss_app_model_patch";
 import { LivechatChannelInfoList } from "@im_livechat/core/web/livechat_channel_info_list";
+
+import { _t } from "@web/core/l10n/translation";
 
 registerThreadAction("livechat-info", {
     actionPanelComponent: LivechatChannelInfoList,
@@ -14,10 +16,12 @@ registerThreadAction("livechat-info", {
     name: _t("Information"),
     open: ({ store }) => {
         store.discuss.isLivechatInfoPanelOpenByDefault = true;
+        localStorage.removeItem(LIVECHAT_INFO_DEFAULT_OPEN_LS);
     },
     close: ({ action, store }) => {
         if (action.condition) {
             store.discuss.isLivechatInfoPanelOpenByDefault = false;
+            localStorage.setItem(LIVECHAT_INFO_DEFAULT_OPEN_LS, "false");
         }
     },
     sequence: 10,


### PR DESCRIPTION

Since [1], the live chat info panel state is saved to the
local storage. Writing the livechat info panel state to local
storage on every field change (especially coming from the storage
event itself) caused a retroaction loop across tabs, leading to
potential freezes.

For example:
- Tab A writes OPEN to local storage.
- Tab B receives OPEN and updates its field.
- Tab A writes CLOSE, local storage updated.
- Tab B, based on stale state, writes OPEN back to local storage.
- Tab A receives OPEN, updates its field, writes CLOSE again.

This PR fixes the issue: the field is only written on direct user
action and the computeed field is invalidated on storage event,
effectively breaking the loop.

[1]: https://github.com/odoo/odoo/pull/238472