### PR TITLE
[FIX] base: handle min_precision for monetary field using float widget

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -209,8 +209,10 @@ class FloatConverter(models.AbstractModel):
             _, precision = record._fields[field_name].get_digits(record.env) or (None, None)
             options = dict(options, precision=precision)
         if 'min_precision' not in options:
-            min_precision = record._fields[field_name].get_min_display_digits(record.env)
-            options = dict(options, min_precision=min_precision)
+            field = record._fields[field_name]
+            if hasattr(field, 'get_min_display_digits'):
+                min_precision = field.get_min_display_digits(record.env)
+                options = dict(options, min_precision=min_precision)
         return super(FloatConverter, self).record_to_html(record, field_name, options)
 
 


### PR DESCRIPTION
Before 8c199f7783527735b35c9fbda334cbdcd55a004f, it was possible
to use the float widget with a monetary field in qweb (not used in
standard code).
By using something like:
```
<span
   t-field="o.amount"
   t-options="{
       'widget': 'float',
       'precision': o.currency_id.decimal_places
   }"
/>
```
where `amount` is a monetary field.
It worked as `precision` is defined in the options, which means that
`get_digits` was not called, so no errors were raised (the method only
exists for float fields).

Now that `min_precision` has been added, `get_min_display_digits` is
called if it is not set.
Which causes an error, as the method does not exist for monetary
fields.

As we are in stable, we cannot ask users to add a `min_precision` key
to their options, so the fix is to use `hasattr` to avoid calling a
method that doesn't exists.