### PR TITLE
[REM] mail: remove redundant edit() override

### DIFF
--- a/addons/mail/static/src/discuss/core/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/message_model_patch.js
@@ -52,20 +52,6 @@ const messagePatch = {
         );
     },
     /**
-     * @override
-     */
-    async edit(
-        body,
-        attachments = [],
-        { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [] } = {}
-    ) {
-        return await super.edit(body, attachments, {
-            mentionedChannels,
-            mentionedPartners,
-            mentionedRoles,
-        });
-    },
-    /**
      * @param {Thread} thread the thread being viewed
      * @returns {boolean}
      */


### PR DESCRIPTION
The override of the message `edit()` in discuss became a pass through following changes in PR #229546. This change removes this dead code. Considering stable policies, the change is only made in master.
