### PR TITLE
[FIX] purchase_stock: use manual invoice currency rate in valuation

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -167,10 +167,10 @@ class StockMove(models.Model):
             aml_ids.add(aml.id)
             if aml.move_type == 'in_invoice':
                 aml_quantity += aml.product_uom_id._compute_quantity(aml.quantity, self.product_id.uom_id)
-                value += aml.currency_id._convert(aml.price_subtotal, self.company_id.currency_id, date=aml.date)
+                value += aml.company_id.currency_id.round(aml.price_subtotal / aml.currency_rate)
             elif aml.move_type == 'in_refund':
                 aml_quantity -= aml.product_uom_id._compute_quantity(aml.quantity, self.product_id.uom_id)
-                value -= aml.currency_id._convert(aml.price_subtotal, self.company_id.currency_id, date=aml.date)
+                value -= aml.company_id.currency_id.round(aml.price_subtotal / aml.currency_rate)
 
         if aml_quantity <= 0:
             return valuation_data

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -2078,3 +2078,49 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             {'debit': 0.0, 'credit': 100.0, 'reconciled': True},
             {'debit': 100.0, 'credit': 0.0, 'reconciled': True},
         ])
+
+    def test_move_value_invoice_manual_rate(self):
+        """Check that if a rate is manually set on a bill, this rate
+        is used for the valuation of the move.
+        """
+        grp_currencies = self.env.ref('base.group_multi_currency')
+        self.env.user.write({'group_ids': [(4, grp_currencies.id)]})
+        product = self.env['product.product'].create({
+            'name': 'product_a',
+            'standard_price': 100.0,
+        })
+        partner = self.env['res.partner'].create({'name': 'testpartner'})
+        eur_currency = self.env.ref('base.EUR')
+        eur_currency.active = True
+        eur_currency.write({
+            'rate_ids': [Command.create({
+                'rate': 2,
+            })]
+        })
+        product.product_tmpl_id.categ_id.property_cost_method = 'average'
+        product.product_tmpl_id.categ_id.property_valuation = 'real_time'
+
+        po = self.env['purchase.order'].create({
+            'partner_id': partner.id,
+            'currency_id': eur_currency.id,
+            'order_line': [
+                Command.create({
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_qty': 1.0,
+                    'price_unit': 100.0,
+                }),
+            ],
+        })
+        po.button_confirm()
+        receipt_po = po.picking_ids[0]
+        receipt_po.button_validate()
+        self.assertEqual(po.picking_ids.move_ids.value, 50)
+
+        action = po.action_create_invoice()
+        bill = self.env["account.move"].browse(action["res_id"])
+        bill.invoice_date = fields.Date.today()
+        with Form(bill) as move_form:
+            move_form.invoice_currency_rate = 4
+        bill.action_post()
+        self.assertEqual(po.picking_ids.move_ids.value, 25)


### PR DESCRIPTION
**Problem:**
The value of a move does not take the correct currency rate if it 
was changed manually on the invoice.

**Steps to reproduce:**
- make sure dollar is your main currency 
- activate euro and set a rate of 1 USD -> 2 euros
- create an avco perpetual storable product with no tax
- confirm a purchase order for 1 product at 100 euros with no tax
- validate move
- create a bill for this purchase order
- set the currency to euro 
- below 'EUR' change the currency to 4 
(the bug also happens if you open the widget calendar and 
select a date with another rate than the invoice date) 
- in the journal items tab you should see the value going 
from 50 to 25 for the account move lines.
- confirm the invoice
- open stock and search your product 

**Current behavior:**
the unit price is 50 

**Expected behavior:**
it should be 25

**Cause of the issue:**
In _get_value_from_account_move when computing the value, 
we convert the value of the account move line using the _convert 
method on the currency at the date of the 
invoice, but if the rate was changed manually this is no longer correct. 
https://github.com/odoo/odoo/blob/4ad397e94b4661cd64515e137b3e650dc330269c/addons/purchase_stock/models/stock_move.py#L170

**fix**
When manually changing the rate on the widget, the account move lines 
are updated using currency_rate 
https://github.com/odoo/odoo/blob/8d7194128b26a09be75bf5bfe4e63c8bbfaac69f/addons/account/models/account_move_line.py#L1634
Using the same compution for the valuation of the move ensures
alignment.

currency_rate is computed based on invoice_currency_rate which 
is updated in case the rate was set manually.
https://github.com/odoo/odoo/blob/4ad397e94b4661cd64515e137b3e650dc330269c/addons/account/models/account_move_line.py#L726

opw-5416654