### PR TITLE
[FIX] iot_drivers: pip/apt packages path for upgrade

### DIFF
--- a/addons/iot_drivers/tools/upgrade.py
+++ b/addons/iot_drivers/tools/upgrade.py
@@ -112,7 +112,7 @@ def update_requirements():
     """Update the Python requirements of the IoT Box, installing the ones
     listed in the requirements.txt file.
     """
-    requirements_file = path_file('odoo', 'addons', 'iot_box_image', 'configuration', 'requirements.txt')
+    requirements_file = path_file('odoo', 'setup', 'iot_box_builder', 'configuration', 'requirements.txt')
     if not requirements_file.exists():
         _logger.info("No requirements file found, not updating.")
         return
@@ -127,7 +127,7 @@ def update_packages():
     the packages.txt file.
     Requires ``writable`` context manager.
     """
-    packages_file = path_file('odoo', 'addons', 'iot_box_image', 'configuration', 'packages.txt')
+    packages_file = path_file('odoo', 'setup', 'iot_box_builder', 'configuration', 'packages.txt')
     if not packages_file.exists():
         _logger.info("No packages file found, not updating.")
         return


### PR DESCRIPTION
As we moved configuration folder in `setup/iot_box_builder`, we need to adapt the path to find them.

Related PR: https://github.com/odoo/odoo/pull/229698
