### PR TITLE
[FIX] im_livechat: prevent local storage loops

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -1,5 +1,7 @@
+import { CHAT_HUB_COMPACT_LS } from "@mail/core/common/chat_hub_model";
 import { ChatWindow } from "@mail/core/common/chat_window";
 import { useHover, useMovable } from "@mail/utils/common/hooks";
+
 import { Component, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
@@ -79,7 +81,8 @@ export class ChatHub extends Component {
     }
 
     expand() {
-        this.chatHub.compact = false;
+        browser.localStorage.removeItem(CHAT_HUB_COMPACT_LS);
+        this.chatHub._recomputeCompact++;
         Object.assign(this.compactPosition, { left: "auto", top: "auto" });
         this.more.isOpen = this.chatHub.folded.length > this.chatHub.maxFolded;
     }

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -4,7 +4,7 @@ import { Record } from "./record";
 import { Deferred, Mutex } from "@web/core/utils/concurrency";
 
 export const CHAT_HUB_KEY = "mail.ChatHub";
-const CHAT_HUB_COMPACT_LS = "mail.user_setting.chathub_compact";
+export const CHAT_HUB_COMPACT_LS = "mail.user_setting.chathub_compact";
 
 export class ChatHub extends Record {
     BUBBLE = 56; // same value as $o-mail-ChatHub-bubblesWidth
@@ -34,7 +34,7 @@ export class ChatHub extends Record {
                 chatHub.load();
             }
             if (ev.key === CHAT_HUB_COMPACT_LS) {
-                chatHub.compact = ev.newValue === "true";
+                chatHub._recomputeCompact++;
             }
         });
         chatHub
@@ -42,18 +42,11 @@ export class ChatHub extends Record {
             .then(() => chatHub.initPromise.resolve());
         return chatHub;
     }
-
+    _recomputeCompact = 0;
     compact = Record.attr(false, {
         compute() {
+            void this._recomputeCompact;
             return browser.localStorage.getItem(CHAT_HUB_COMPACT_LS) === "true";
-        },
-        /** @this {import("models").Chathub} */
-        onUpdate() {
-            if (this.compact) {
-                browser.localStorage.setItem(CHAT_HUB_COMPACT_LS, this.compact.toString());
-            } else {
-                browser.localStorage.removeItem(CHAT_HUB_COMPACT_LS);
-            }
         },
     });
     /** From left to right. Right-most will actually be folded */
@@ -84,7 +77,8 @@ export class ChatHub extends Record {
         for (const cw of this.opened) {
             cw.bypassCompact = false;
         }
-        this.compact = true;
+        browser.localStorage.setItem(CHAT_HUB_COMPACT_LS, true);
+        this._recomputeCompact++;
     }
 
     onRecompute() {

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -5,7 +5,7 @@ import { Record } from "./record";
 import { debounce } from "@web/core/utils/timing";
 import { rpc } from "@web/core/network/rpc";
 
-const MESSAGE_SOUND = "mail.user_setting.message_sound";
+export const MESSAGE_SOUND = "mail.user_setting.message_sound";
 
 export class Settings extends Record {
     id;
@@ -44,17 +44,11 @@ export class Settings extends Record {
             return this.channel_notifications === false ? "mentions" : this.channel_notifications;
         },
     });
+    _recomputeMessageSound = 0;
     messageSound = Record.attr(true, {
         compute() {
+            void this._recomputeMessageSound;
             return browser.localStorage.getItem(MESSAGE_SOUND) !== "false";
-        },
-        /** @this {import("models").Settings} */
-        onUpdate() {
-            if (this.messageSound) {
-                browser.localStorage.removeItem(MESSAGE_SOUND);
-            } else {
-                browser.localStorage.setItem(MESSAGE_SOUND, "false");
-            }
         },
     });
     mute_until_dt = Record.attr(false, { type: "datetime" });
@@ -349,7 +343,7 @@ export class Settings extends Record {
     }
     onStorage(ev) {
         if (ev.key === MESSAGE_SOUND) {
-            this.messageSound = ev.newValue !== "false";
+            this._recomputeMessageSound++;
         }
     }
     /**

--- a/addons/mail/static/src/core/public_web/discuss.js
+++ b/addons/mail/static/src/core/public_web/discuss.js
@@ -5,6 +5,7 @@ import { ImStatus } from "@mail/core/common/im_status";
 import { Thread } from "@mail/core/common/thread";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
+import { NO_MEMBERS_DEFAULT_OPEN_LS } from "@mail/core/public_web/discuss_app_model";
 import { DiscussSidebar } from "@mail/core/public_web/discuss_sidebar";
 import {
     useMessageEdition,
@@ -24,6 +25,7 @@ import {
 } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 
+import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { FileUploader } from "@web/views/fields/file_handler";
@@ -112,7 +114,8 @@ export class Discuss extends Component {
                     } else if (this.threadActions.activeAction === memberListAction) {
                         return; // no-op (already open)
                     } else {
-                        this.store.discuss.isMemberPanelOpenByDefault = false;
+                        browser.localStorage.setItem(NO_MEMBERS_DEFAULT_OPEN_LS, true);
+                        this.store.discuss._recomputeIsMemberPanelOpenByDefault++;
                     }
                 }
             },

--- a/addons/mail/static/src/core/public_web/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app_model.js
@@ -1,9 +1,8 @@
 import { Record } from "@mail/core/common/record";
 import { browser } from "@web/core/browser/browser";
 
-const NO_MEMBERS_DEFAULT_OPEN_LS = "mail.user_setting.no_members_default_open";
+export const NO_MEMBERS_DEFAULT_OPEN_LS = "mail.user_setting.no_members_default_open";
 export const DISCUSS_SIDEBAR_COMPACT_LS = "mail.user_setting.discuss_sidebar_compact";
-
 export class DiscussApp extends Record {
     /** @returns {import("models").DiscussApp} */
     static get(data) {
@@ -19,33 +18,18 @@ export class DiscussApp extends Record {
     activeTab = "main";
     searchTerm = "";
     isActive = false;
+    _recomputeIsMemberPanelOpenByDefault = 0;
     isMemberPanelOpenByDefault = Record.attr(true, {
         compute() {
+            void this._recomputeIsMemberPanelOpenByDefault;
             return browser.localStorage.getItem(NO_MEMBERS_DEFAULT_OPEN_LS) !== "true";
         },
-        /** @this {import("models").DiscussApp} */
-        onUpdate() {
-            if (this.isMemberPanelOpenByDefault) {
-                browser.localStorage.removeItem(NO_MEMBERS_DEFAULT_OPEN_LS);
-            } else {
-                browser.localStorage.setItem(NO_MEMBERS_DEFAULT_OPEN_LS, "true");
-            }
-        },
     });
+    _recomputeIsSidebarCompact = 0;
     isSidebarCompact = Record.attr(false, {
         compute() {
+            void this._recomputeIsSidebarCompact;
             return browser.localStorage.getItem(DISCUSS_SIDEBAR_COMPACT_LS) === "true";
-        },
-        /** @this {import("models").DiscussApp} */
-        onUpdate() {
-            if (this.isSidebarCompact) {
-                browser.localStorage.setItem(
-                    DISCUSS_SIDEBAR_COMPACT_LS,
-                    this.isSidebarCompact.toString()
-                );
-            } else {
-                browser.localStorage.removeItem(DISCUSS_SIDEBAR_COMPACT_LS);
-            }
         },
     });
     thread = Record.one("Thread");
@@ -65,10 +49,10 @@ export class DiscussApp extends Record {
 
     onStorage(ev) {
         if (ev.key === DISCUSS_SIDEBAR_COMPACT_LS) {
-            this.isSidebarCompact = ev.newValue === "true";
+            this._recomputeIsSidebarCompact++;
         }
         if (ev.key === NO_MEMBERS_DEFAULT_OPEN_LS) {
-            this.isMemberPanelOpenByDefault = ev.newValue !== "true";
+            this._recomputeIsMemberPanelOpenByDefault++;
         }
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.js
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.js
@@ -1,7 +1,10 @@
+import { DISCUSS_SIDEBAR_COMPACT_LS } from "@mail/core/public_web/discuss_app_model";
+
 import { Component } from "@odoo/owl";
+
+import { browser } from "@web/core/browser/browser";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 
@@ -23,5 +26,15 @@ export class DiscussSidebar extends Component {
 
     get discussSidebarItems() {
         return discussSidebarItemsRegistry.getAll();
+    }
+
+    enableSidebarCompact() {
+        browser.localStorage.setItem(DISCUSS_SIDEBAR_COMPACT_LS, true);
+        this.store.discuss._recomputeIsSidebarCompact++;
+    }
+
+    disableSidebarCompact() {
+        browser.localStorage.removeItem(DISCUSS_SIDEBAR_COMPACT_LS);
+        this.store.discuss._recomputeIsSidebarCompact++;
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.xml
@@ -9,7 +9,7 @@
                             <button class="o-mail-DiscussSidebar-optionsBtn btn btn-light p-0 align-items-center justify-content-center smaller border border-dark rounded-circle opacity-25 opacity-100-hover" title="Options" t-att-class="{ 'ms-auto': !store.discuss.isSidebarCompact, 'position-absolute': !store.discuss.isSidebarCompact and !store.inPublicPage, 'o-compact': store.discuss.isSidebarCompact }"><i class="fa fa-ellipsis-h fa-fw fa-lg" style="font-size: 15px;"/></button>
                             <t t-set-slot="content">
                                 <div>
-                                    <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="() => this.store.discuss.isSidebarCompact = !this.store.discuss.isSidebarCompact">
+                                    <DropdownItem class="'px-2 py-1 d-flex align-items-center rounded-0'" onSelected="() => this.store.discuss.isSidebarCompact ? this.disableSidebarCompact() : this.enableSidebarCompact()">
                                          <i class="fa fa-fw" t-att-class="{ 'fa-expand': store.discuss.isSidebarCompact, 'fa-compress': !store.discuss.isSidebarCompact }"/>
                                          <span class="mx-2">
                                              <t t-if="store.discuss.isSidebarCompact">Expand panel</t>

--- a/addons/mail/static/src/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/core/public_web/thread_actions.js
@@ -1,20 +1,63 @@
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
+import { NO_MEMBERS_DEFAULT_OPEN_LS } from "@mail/core/public_web/discuss_app_model";
+import { ChannelMemberList } from "@mail/discuss/core/common/channel_member_list";
+
 import { useComponent } from "@odoo/owl";
+
+import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
-threadActionsRegistry.add("leave", {
-    condition: (component) =>
-        component.ui.isSmall && (component.thread?.canLeave || component.thread?.canUnpin),
-    icon: "fa fa-fw fa-sign-out text-danger",
-    name: (component) => (component.thread.canLeave ? _t("Leave") : _t("Unpin")),
-    nameClass: "text-danger",
-    open: (component) =>
-        component.thread.canLeave ? component.thread.leaveChannel() : component.thread.unpin(),
-    sequence: 10,
-    sequenceGroup: 40,
-    setup() {
-        const component = useComponent();
-        component.ui = useService("ui");
-    },
-});
+threadActionsRegistry
+    .add("leave", {
+        condition: (component) =>
+            component.ui.isSmall && (component.thread?.canLeave || component.thread?.canUnpin),
+        icon: "fa fa-fw fa-sign-out text-danger",
+        name: (component) => (component.thread.canLeave ? _t("Leave") : _t("Unpin")),
+        nameClass: "text-danger",
+        open: (component) =>
+            component.thread.canLeave ? component.thread.leaveChannel() : component.thread.unpin(),
+        sequence: 10,
+        sequenceGroup: 40,
+        setup() {
+            const component = useComponent();
+            component.ui = useService("ui");
+        },
+    })
+    .add("member-list", {
+        component: ChannelMemberList,
+        condition(component) {
+            return (
+                component.thread?.hasMemberList &&
+                (!component.props.chatWindow || component.props.chatWindow.isOpen)
+            );
+        },
+        componentProps(action, component) {
+            return {
+                openChannelInvitePanel({ keepPrevious } = {}) {
+                    component.threadActions.actions
+                        .find(({ id }) => id === "invite-people")
+                        ?.open({ keepPrevious });
+                },
+            };
+        },
+        panelOuterClass: "o-discuss-ChannelMemberList bg-inherit",
+        icon: "fa fa-fw fa-users",
+        iconLarge: "fa fa-fw fa-lg fa-users",
+        name: _t("Members"),
+        close(component) {
+            if (component.env.inDiscussApp) {
+                browser.localStorage.setItem(NO_MEMBERS_DEFAULT_OPEN_LS, true);
+                component.store.discuss._recomputeIsMemberPanelOpenByDefault++;
+            }
+        },
+        open(component) {
+            if (component.env.inDiscussApp) {
+                browser.localStorage.removeItem(NO_MEMBERS_DEFAULT_OPEN_LS);
+                component.store.discuss._recomputeIsMemberPanelOpenByDefault++;
+            }
+        },
+        sequence: 30,
+        sequenceGroup: 10,
+        toggle: true,
+    });

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.js
@@ -1,4 +1,6 @@
+import { MESSAGE_SOUND } from "@mail/core/common/settings_model";
 import { Component, useState } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
 
 export class DiscussNotificationSettings extends Component {
@@ -23,8 +25,23 @@ export class DiscussNotificationSettings extends Component {
         }
     }
 
+    /** @deprecated */
     onChangeMessageSound() {
-        this.store.settings.messageSound = !this.store.settings.messageSound;
+        if (this.store.settings.messageSound) {
+            this.disableMessageSound();
+        } else {
+            this.enableMessageSound();
+        }
+    }
+
+    enableMessageSound() {
+        browser.localStorage.removeItem(MESSAGE_SOUND);
+        this.store.settings._recomputeMessageSound++;
+    }
+
+    disableMessageSound() {
+        browser.localStorage.setItem(MESSAGE_SOUND, false);
+        this.store.settings._recomputeMessageSound++;
     }
 
     onChangeMuteDuration(ev) {

--- a/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/discuss_notification_settings.xml
@@ -43,7 +43,7 @@
                 <h5>Message sound</h5>
                 <div class="flex-grow-1"/>
                 <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.messageSound" t-on-change="onChangeMessageSound"/>
+                    <input class="form-check-input" type="checkbox" role="switch" t-att-checked="store.settings.messageSound" t-on-change="(ev) => ev.target.checked ? this.enableMessageSound() : this.disableMessageSound()"/>
                 </div>
             </label>
         </div>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -1,7 +1,6 @@
 import { threadActionsRegistry } from "@mail/core/common/thread_actions";
 import { AttachmentPanel } from "@mail/discuss/core/common/attachment_panel";
 import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
-import { ChannelMemberList } from "@mail/discuss/core/common/channel_member_list";
 import { NotificationSettings } from "@mail/discuss/core/common/notification_settings";
 
 import { useComponent } from "@odoo/owl";
@@ -106,40 +105,5 @@ threadActionsRegistry
                 });
             }
         },
-        toggle: true,
-    })
-    .add("member-list", {
-        component: ChannelMemberList,
-        condition(component) {
-            return (
-                component.thread?.hasMemberList &&
-                (!component.props.chatWindow || component.props.chatWindow.isOpen)
-            );
-        },
-        componentProps(action, component) {
-            return {
-                openChannelInvitePanel({ keepPrevious } = {}) {
-                    component.threadActions.actions
-                        .find(({ id }) => id === "invite-people")
-                        ?.open({ keepPrevious });
-                },
-            };
-        },
-        panelOuterClass: "o-discuss-ChannelMemberList bg-inherit",
-        icon: "fa fa-fw fa-users",
-        iconLarge: "fa fa-fw fa-lg fa-users",
-        name: _t("Members"),
-        close(component) {
-            if (component.env.inDiscussApp) {
-                component.store.discuss.isMemberPanelOpenByDefault = false;
-            }
-        },
-        open(component) {
-            if (component.env.inDiscussApp) {
-                component.store.discuss.isMemberPanelOpenByDefault = true;
-            }
-        },
-        sequence: 30,
-        sequenceGroup: 10,
         toggle: true,
     });


### PR DESCRIPTION
A bad pattern has been used for some time in discuss for fields stored in localStorage. The field updates via the `onUpdate` function in the current tab and writes to localStorage. Other tabs use the `storage` event to update their field.

This pattern can cause race conditions, leading to loops, high CPU usage, and freezes. When a tab receives a storage event, it may write back an outdated value, triggering further writes and conflicts across tabs.

Storage events should be treated as read-only. Only user actions should update the local storage.

This commit fixes the problematic fields.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
