### PR TITLE
[FIX] iot_drivers: fix missing disconnect counter

### DIFF
--- a/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py
@@ -148,7 +148,7 @@ class PrinterInterface(Interface):
                 if device.device_type == 'printer' and ip and ip == device.ip
             ), None)
             if already_registered_identifier:
-                result.append({'identifier': already_registered_identifier})
+                result.append({'identifier': already_registered_identifier, 'disconnect_counter': 0})
                 continue
 
             printers_with_same_ip = sorted(printers_with_same_ip, key=lambda printer: printer['identifier'])


### PR DESCRIPTION
This commit fixes an edge-case between the disconnect counter logic, and the logic added in odoo/odoo#224200 to prevent printers switching between `lpd` and `socket` protocols. In this case, a device is returned that only has the `identifier` key set. Because the driver has already been instantiated, this didn't break anything before, but now it also clears the `disconnect_counter` key, leading to a traceback on the next iteration of the interface when it tries to check the `disconnect_counter`.

The fix is simply to include the `disconnect_counter` as well.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
