### PR TITLE
[FIX] html_editor: preserve selection when adding multiple files in c…

### DIFF
--- a/addons/html_editor/static/src/utils/sanitize.js
+++ b/addons/html_editor/static/src/utils/sanitize.js
@@ -46,7 +46,7 @@ export function fixInvalidHTML(content) {
     // We do not use selfClosingElementTags because it includes XML-only tags
     // such as <t>, which must not be treated as void in HTML.
     const regex =
-        /<\s*(?!area\b|base\b|br\b|col\b|embed\b|hr\b|img\b|input\b|link\b|meta\b|param\b|source\b|track\b|wbr\b)([a-zA-Z0-9:-]+)\s*((?:(?:\s+[\w:-]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?)*))\s*\/>/g;
+        /<\s*(?!area\b|base\b|br\b|col\b|embed\b|hr\b|img\b|input\b|link\b|meta\b|param\b|v:image\b|v:fill\b|source\b|track\b|wbr\b)([a-zA-Z0-9:-]+)\s*((?:(?:\s+[\w:-]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?)*))\s*\/>/g;
     return htmlReplace(content, regex, (match, tag, attributes) => {
         // markup: content is either already markup or escaped in htmlReplace
         attributes = markup(attributes);

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -163,7 +163,7 @@
                         </group>
                         <field name="user_id" widget="many2one_avatar_user"/>
                     </group>
-                    <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..."/>
+                    <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..." widget="html_mail" />
                     <footer>
                         <field name="id" invisible="1"/>
                         <button id="mail_activity_schedule" string="Schedule" close="1" name="action_close_dialog" type="object" class="btn-primary"


### PR DESCRIPTION
…omposer

Problem:
In the "Activity" tab of the composer, adding a second file does not work. The first file is added correctly, but subsequent uploads are ignored.

Cause:
The selection is lost during file selection because the component is re-rendered, which recreates the DOM nodes.

This re-render only happens in `HtmlMailField` because it processes the value through `convert_inline`. Even when `lastValue` and `value` are logically the same in `useRecordObserver`, they differ in markup:

- `lastValue` contains self-closing `v:image` and `v:fill` tags.
- `value` contains open/closing versions of those tags because they are not excluded from the self-closing to open/closing conversion.

This mismatch triggers a re-render, causing the selection to be lost and preventing the second file from being inserted.

Solution:
Exclude `v:image` and `v:fill` from the self-closing to open/closing tag conversion so that `lastValue` and `value` remain equivalent. This prevents the unnecessary re-render and preserves the selection.

Steps to reproduce:
- Click on "Activity" in the chatter to open the dialog.
- Click in the "Log a note..." field.
- Use the upload button to add a file.
- Press Enter.
- Use the upload button again to add another file.
- Observe that the second file is not added.

task-5490722

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
