### PR TITLE
[FIX] hr_homeworking: send current day location field in get_views

### DIFF
--- a/addons/hr_homeworking/models/hr_employee.py
+++ b/addons/hr_homeworking/models/hr_employee.py
@@ -40,8 +40,9 @@ class HrEmployeeBase(models.AbstractModel):
         dayfield = self._get_current_day_location_field()
         if 'search' in res['views']:
             res['views']['search']['arch'] = res['views']['search']['arch'].replace('today_location_name', dayfield)
-        if 'list' in res['views']:
-            res['views']['list']['arch'] = res['views']['list']['arch'].replace('name_work_location_display', dayfield)
+        if 'tree' in res['views']:
+            res['views']['tree']['arch'] = res['views']['tree']['arch'].replace('name_work_location_display', dayfield)
+        res["models"][self._name].update(self.fields_get([dayfield]))
         return res
 
     @api.depends('exceptional_location_id', *DAYS)

--- a/addons/hr_homeworking/tests/test_hr_employee_location.py
+++ b/addons/hr_homeworking/tests/test_hr_employee_location.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from freezegun import freeze_time
 
 from odoo.addons.hr_homeworking.tests.common import TestHrHomeworkingCommon
 
@@ -107,3 +108,16 @@ class TestHrHomeworkingHrEmployeeLocation(TestHrHomeworkingCommon):
 
         # exception should be deleted
         self.assertEqual(len(created_worklocations), 0, 'should have deleted the worklocation record')
+
+    def test_get_views_replace_hw_location_by_date(self):
+        view = self.env["ir.ui.view"].create({
+            "arch": """<tree><field name="name_work_location_display" /></tree>""",
+            "model": "hr.employee",
+            "type": "tree",
+        })
+        # Wednesday January 28 2026
+        with freeze_time("2026-01-28"):
+            got_view = self.env["hr.employee"].get_views([(view.id, "tree")])
+        self.assertTrue("name_work_location_display" in got_view["models"]["hr.employee"])
+        self.assertTrue("wednesday_location_id" in got_view["models"]["hr.employee"])
+        self.assertEqual(got_view["views"]["tree"]["arch"], """<tree><field name="wednesday_location_id"/></tree>""")


### PR DESCRIPTION
Before this commit, the feature at commit odoo/odoo@b3be3af61cc08d0dea84969425d24957f215b26f worked by chance, because in most cases ALL fields where returned in the get views, since most of the time the search view is asked for as well, hence yielding all fields in the model

There were issues when triggering get_views from another place, namely studio when creating a many2many.

After this commit, we make sure the current day location field's description is sent

opw-5484321

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
