### PR TITLE
[FIX] project_timesheet_holidays: create PH timesheets for right company

### DIFF
--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -121,7 +121,7 @@ class ResourceCalendarLeaves(models.Model):
         resource_calendars = self._get_resource_calendars()
         work_hours_data = self._work_time_per_day(resource_calendars)
         employees_groups = self.env['hr.employee']._read_group(
-            [('resource_calendar_id', 'in', resource_calendars.ids), ('company_id', 'in', self.env.companies.ids)],
+            [('resource_calendar_id', 'in', resource_calendars.ids), ('company_id', 'in', self.company_id.ids if self.company_id else self.env.companies.ids)],
             ['resource_calendar_id'],
             ['id:recordset'])
         mapped_employee = {


### PR DESCRIPTION
**Steps to reproduce**
- Have 2 companies A and B
- Use a single working schedule (needs to have no company on it) for both companies and their employees
- Create a public holiday with company A, while having company B in the selected companies
- There's a timesheet for the public holiday created for employees of company B, even though the public holiday will not apply for them.

**Change**
Only generate the timesheets for employees belonging to the companies of the public holidays.

opw-5498462
