### PR TITLE
[IMP] hr_expense_stripe: refused error message improvments

### DIFF
--- a/addons/hr_expense/data/mail_templates.xml
+++ b/addons/hr_expense/data/mail_templates.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <template id="hr_expense_template_refuse_reason">
-            <p>Your Expense <t t-out="name"/> has been refused</p>
+            <p>Expense refused</p>
             <ul class="o_timeline_tracking_value_list">
                 <li>Reason: <t t-out="reason"/></li>
             </ul>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
A company in belgium creates a card, it's "allowed countries" is set to Belgium by default. If said card is used to pay online on a website ending with .be, it is understandable that the user believes the vendor to be located in Belgium
If it is not the case (the vendor is actually in Luxembourg), the payment is refused but the message on the refused expense is unclear "Country not allowed"
The change adds the data received to make the
decision in the error message




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
