### PR TITLE
[FIX] web: fix nondeterministic multi build URL

### DIFF
--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -1,4 +1,4 @@
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { PropertiesGroupByItem } from "@web/search/properties_group_by_item/properties_group_by_item";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
@@ -57,13 +57,10 @@ export class SearchBarMenu extends Component {
 
         // Add Share command
         if (this.env.config.actionId && !this.env.inDialog) {
-            const uiService = useService("ui");
-            const togglerRef = useRef("searchview_dropdown_toggler"); // To double check searchBar is in DOM
+            // TODO JESC FIXME BUG CLOSING SOME DIALOG (LIKE INVOICE), WRONG ACTIVE ELEMENT
             useCommand(_t("Share"), () => this.shareViewUrl(), {
                 hotkey: "alt+shift+h",
                 hotkeyOptions: { bypassEditableProtection: true },
-                global: true, // We decide ourself when to add command
-                isAvailable: () => uiService.activeElement.contains(togglerRef.el),
             });
         }
     }

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.js
@@ -5,6 +5,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
 import { sortBy } from "@web/core/utils/arrays";
 import { useBus, useService } from "@web/core/utils/hooks";
+import { browser } from "@web/core/browser/browser";
 import { useCommand } from "@web/core/commands/command_hook";
 import { AccordionItem } from "@web/core/dropdown/accordion_item";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
@@ -194,10 +195,10 @@ export class SearchBarMenu extends Component {
      * clipboard if possible. This url is parsed to reactivate filters if in route.
      */
     async shareViewUrl() {
-        let shareUrl = window.location.href;
+        let shareUrl = browser.location.href;
         const extra = this.env.searchModel.generateQueryString();
         if (extra) {
-            const [base, hash = ""] = window.location.href.split("#");
+            const [base, hash = ""] = browser.location.href.split("#");
             shareUrl = base + (base.includes("?") ? "&" : "?") + extra + (hash ? "#" + hash : "");
         }
 

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -8,7 +8,6 @@
                   t-if="this.env.searchModel.searchMenuTypes.size"
                   bottomSheet="false">
             <button
-                t-ref="searchview_dropdown_toggler"
                 class="o_searchview_dropdown_toggler abcdddd d-print-none btn btn-outline-secondary o-dropdown-caret rounded-start-0"
                 data-hotkey="shift+q"
                 title="Toggle Search Panel"

--- a/addons/web/static/tests/search/search_from_url.test.js
+++ b/addons/web/static/tests/search/search_from_url.test.js
@@ -315,7 +315,7 @@ test("hotkey sharing copies simple domain + groupBy to clipboard", async () => {
     // as when saving favorite filters to encode the search params in the url
     patchWithCleanup(browser.navigator.clipboard, {
         async writeText(url) {
-            expect.step(url.split("&domain=")[1]);
+            expect.step(url.split("?domain=")[1]);
         },
     });
 
@@ -355,7 +355,7 @@ test("hotkey sharing copies complex search to clipboard", async () => {
     // as when saving favorite filters to encode the search params in the url
     patchWithCleanup(browser.navigator.clipboard, {
         async writeText(url) {
-            expect.step(url.split("&domain=")[1]);
+            expect.step(url.split("?domain=")[1]);
         },
     });
 


### PR DESCRIPTION
In the copy to clipboard with filter functionality, we trigger different types of notifications depending on the url length, resulting in underteministic behavior. We fix this by using `browser.location.href` instead of `window.location.href` which is mocked in tests.

ORIGIN:
In `shareViewUrl` we trigger different types of notifications based on the copied url length. In the normal build the base url is short but on multibuilds we include the id of targeted modules in the test url:

`http://127.0.0.1:8069/web/tests?&headless&loglevel=2&preset= desktop&timeout=15000&id=b21ec1ed&id=8d41322c&id=edfe3b06&....`

Where each `&id=...` represents a modules, rasing the total url lenght over the 2000 char limit where we raise a warning.

FIX:
By using `browser.location.href` instead of `window.location.href` the url is patched in the testing environment (see MockLocation)

So instead of having the long url displayed before, the base url becomes `https://hoot-test.com`, thereby dispaying the success notification even in multibuilds where the base url is lenghty.

Breaking PR: odoo/odoo#242079

task#391304


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
