### PR TITLE
[IMP] web: detect correct closest elements

### DIFF
--- a/addons/web/static/tests/core/utils/closest.test.js
+++ b/addons/web/static/tests/core/utils/closest.test.js
@@ -1,0 +1,38 @@
+import { expect, test } from "@odoo/hoot";
+import { closest } from "@web/core/utils/ui";
+
+test("Closest function works correctly with nested elements", () => {
+    const inner = {
+        getBoundingClientRect: () => ({ x: 50, y: 50, width: 50, height: 50 }),
+    };
+    const outer = {
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 200, height: 200 }),
+    };
+    const pos = { x: 60, y: 60 };
+    const result = closest([inner, outer], pos);
+    expect(result).toBe(inner);
+});
+
+test("Closest function finds the correct element", () => {
+    const inner = {
+        getBoundingClientRect: () => ({ x: 50, y: 50, width: 50, height: 50 }),
+    };
+    const outer = {
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 200, height: 200 }),
+    };
+    const pos = { x: 10, y: 10, width: 40, height: 40 };
+    const result = closest([inner, outer], pos);
+    expect(result).toBe(outer);
+});
+
+test("Closest function returns the right element when position is right next to it", () => {
+    const el1 = {
+        getBoundingClientRect: () => ({ x: 50, y: 50, width: 100, height: 100 }),
+    };
+    const el2 = {
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 300, height: 200 }),
+    };
+    const pos = { x: 49, y: 49, width: 20, height: 20 };
+    const result = closest([el1, el2], pos);
+    expect(result).toBe(el1);
+});


### PR DESCRIPTION
This commit improves the drag and drop functionality by detecting
the closest elements when dragging. The previous implementation
only calculated distance when the cursor was outside the
rectangle, returning 0 for any position inside. This caused
issues with nested dropdowns: when a small dropdown is inside a
larger one, the quadrance of the larger one would be 0, but since
for the smaller one it is actually harder to place it perfectly inside,
the distance would be non-zero, so the larger one would be preferred.

The new implementation:
- Handles rectangle-to-rectangle overlap detection using center
  distances
- For non overlapping rectangles, returns correct quadrance
- Returns negative normalized overlap ratio for overlapping
  elements, preferring smaller elements with similar overlap
  percentages
- Supports both point queries (x, y) and rectangle queries
  (x, y, width, height)

Steps to see the issue:
- Open Website and start editing
- Drop the `s_banner` snippet
- Try to drop a button (or any other inner element) next to the
existing button in the snippet
=> The experience is not the most user-friendly

Old implementation:

https://github.com/user-attachments/assets/507c0402-b855-46a7-938d-8f05d905dd3e

New implementation:

https://github.com/user-attachments/assets/34b352b4-e08a-4a7f-a2b5-2702ee8e63ef

It might not look like an improvement in the video, but it feels actually easier now when trying to drag and drop to a relatively small dropzone.

task-5794898