### PR TITLE
[FIX] website_sale: make test demo-data-independent again

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_mail.js
@@ -29,17 +29,17 @@ registry.category("web_tour.tours").add('shop_mail', {
     {
         content: "Open recipients dropdown",
         trigger: '.o_field_many2many_tags_email[name=partner_ids] input',
-        run: 'click',
+        run: 'text Azure Interior (Test)',
     },
     {
         content: "Select azure interior",
-        trigger: '.ui-menu-item a:contains(olson28)',
+        trigger: '.ui-menu-item a:contains(Interior24)',
         in_modal: false,
     },
     {
         content: "click Send email",
         trigger: '.btn[name="action_send_mail"]',
-        extra_trigger: '.o_badge_text:contains("Acme")',
+        extra_trigger: '.o_badge_text:contains("Azure")',
     },
     {
         content: "wait mail to be sent, and go see it",

--- a/addons/website_sale/tests/test_website_sale_mail.py
+++ b/addons/website_sale/tests/test_website_sale_mail.py
@@ -21,7 +21,7 @@ class TestWebsiteSaleMail(HttpCase):
             'website_published': True,
         })
         self.env['res.partner'].create({
-            'name': 'Azure Interior',
+            'name': 'Azure Interior (Test)',
             'email': 'azure.Interior24@example.com',
         })
 


### PR DESCRIPTION
As part of the forward part for [1] the shop mail tour was updated because the new demo partner was earlier alphabetically than the partner generated for the test, and tests run with demo data for CI in this version.

The test should create a partner that will appear first in the m2o selection regardless of whether demo data is installed.

[1]: 549708965924b17403ef7c8e6a6d5bc43af460c3

runbot-238406