### PR TITLE
[FIX] website_sale: correctly encode URL

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1671,7 +1671,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
             rendering_values['signup_url'] = signup_url._replace(
                 query=urlencode(
-                    dict(parse_qs(signup_url.query), redirect='/shop/unarchive_user_addresses')
+                    dict(parse_qs(signup_url.query), redirect='/shop/unarchive_user_addresses'),
+                    doseq=True,
                 )
             ).geturl()
 


### PR DESCRIPTION
Oversight of https://github.com/odoo/odoo/pull/238396
Calling `urlencode` with the result of `parse_qs` is incorrect, and requires `doseq=True` to work as expected.

opw-none

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr