### PR TITLE
[IMP] web, *: revamp calendar side panel layout and persistence

### DIFF
--- a/addons/google_calendar/static/src/scss/google_calendar.scss
+++ b/addons/google_calendar/static/src/scss/google_calendar.scss
@@ -1,4 +1,4 @@
-.o_calendar_sidebar .o_google_sync_button_configured {
+.o_calendar_sidepanel .o_google_sync_button_configured {
 
     &:hover #google_check {
         display: none;

--- a/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_holidays.TimeOffCalendarSidePanel" t-inherit="web.CalendarSidePanel" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_calendar_sidebar')]" position="inside">
+        <xpath expr="//div[hasclass('o_calendar_sidepanel_content')]" position="inside">
             <div class="o_calendar_filter mt-4">
                 <h5>Legend</h5>
                 <div class="d-flex flex-column">

--- a/addons/microsoft_calendar/static/src/scss/microsoft_calendar.scss
+++ b/addons/microsoft_calendar/static/src/scss/microsoft_calendar.scss
@@ -1,4 +1,4 @@
-.o_calendar_sidebar .o_microsoft_sync_button_configured {
+.o_calendar_sidepanel .o_microsoft_sync_button_configured {
 
     &:hover #microsoft_check {
         display: none;

--- a/addons/project/static/tests/project_task_calendar.test.js
+++ b/addons/project/static/tests/project_task_calendar.test.js
@@ -200,7 +200,7 @@ test("tasks to plan should be visible in the sidebar when `default_project_id` i
     expect(".o_calendar_view").toHaveCount(1);
     expect(".o_event_to_schedule_draggable").toHaveCount(2);
     expect(queryAllTexts(".o_event_to_schedule_draggable")).toEqual(["Task-10", "Task-11"]);
-    expect(".o_calendar_view .o_calendar_sidebar h5").toHaveText("To Schedule");
+    expect(".o_calendar_view .o_calendar_sidepanel h5").toHaveText("2 to schedule");
     expect.verifySteps(["search_read", "fetch tasks to schedule"]);
 });
 
@@ -220,7 +220,7 @@ test("search domain should be taken into account in Tasks to Schedule", async ()
     expect(".o_calendar_view").toHaveCount(1);
     expect(".o_event_to_schedule_draggable").toHaveCount(1);
     expect(".o_event_to_schedule_draggable").toHaveText("Task-10");
-    expect(".o_calendar_view .o_calendar_sidebar h5").toHaveText("To Schedule");
+    expect(".o_calendar_view .o_calendar_sidepanel h5").toHaveText("1 to schedule");
     expect.verifySteps(["search_read", "fetch tasks to schedule"]);
 });
 
@@ -243,7 +243,7 @@ test("planned dates used in search domain should not be taken into account in Ta
     expect(".o_calendar_view").toHaveCount(1);
     expect(".o_event_to_schedule_draggable").toHaveCount(1);
     expect(".o_event_to_schedule_draggable").toHaveText("Task-10");
-    expect(".o_calendar_view .o_calendar_sidebar h5").toHaveText("To Schedule");
+    expect(".o_calendar_view .o_calendar_sidepanel h5").toHaveText("1 to schedule");
     expect.verifySteps(["search_read", "fetch tasks to schedule"]);
 });
 

--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -10,6 +10,10 @@
 
     width: $o-datetime-picker-width;
 
+    &.o_datetime_picker_reduced {
+        width: $o-datetime-picker-reduced-width;
+    }
+
     // Day
     .o_selected {
         color: $o-component-active-color;

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -99,6 +99,7 @@
 
     <t t-name="web.DateTimePicker">
         <div
+            t-att-class="{'o_datetime_picker_reduced': !props.showWeekNumbers}"
             class="o_datetime_picker d-flex flex-column gap-2 user-select-none p-2"
             t-attf-style="--DateTimePicker__Day-template-columns: {{ props.showWeekNumbers ? 8 : 7 }}"
         >

--- a/addons/web/static/src/scss/bootstrap_review.scss
+++ b/addons/web/static/src/scss/bootstrap_review.scss
@@ -121,6 +121,7 @@ $o-calendar-today-color: color-contrast($o-calendar-today-background-color);
 // by 5. This ratio has been chosen to have enough space for different language (e.g. Vietnamese)
 // Finally, we have to take into account the gaps.
 $o-datetime-picker-width: calc(5px * 7 * 8 + (2 * #{map-get($spacers, 2)}));
+$o-datetime-picker-reduced-width: calc(5px * 7 * 7 + (2 * #{map-get($spacers, 2)}));
 
 
 // Buttons

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -16,8 +16,8 @@
         <t t-set="categories" t-value="getCategorySelection()" />
         <t t-set="filters" t-value="getFilterSelection()" />
         <div class="d-flex">
-            <button class="btn btn-light btn-sm m-1 mb-2 p-2">
-                <i class="oi oi-fw oi-panel-right fa-flip-horizontal"/>
+            <button class="btn btn-light btn-sm m-2 p-1 py-2">
+                <i class="oi oi-panel-right fa-flip-horizontal"/>
             </button>
             <div class="o_search_panel_current_selection text-truncate mx-auto">
                 <t t-if="!categories.length and !filters.length">
@@ -54,7 +54,7 @@
          t-attf-class="#{env.isSmall ? 'px-3' : 'pe-1 ps-3'}"
          t-ref="root">
         <button t-if="!env.isSmall" class="btn btn-light btn-sm end-0 m-2 position-absolute px-2 py-1 top-0 z-1" t-on-click="toggleSidebar">
-            <i class="oi oi-fw oi-panel-right fa-flip-horizontal"/>
+            <i class="oi oi-panel-right fa-flip-horizontal"/>
         </button>
         <div t-if="!sections or sections.length === 0" class="o_search_panel_empty_state me-3">
             <button class="btn mt-2 w-100 overflow-visible">

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -75,16 +75,16 @@ export class CalendarController extends Component {
         useSetupAction({
             getLocalState: () => this.model.exportedState,
         });
-
-        const sessionShowSidebar = browser.sessionStorage.getItem("calendar.showSideBar");
+        this.keyExpandSidebar = `calendar_sidepanel_expanded,${this.env.config.viewId},${this.env.config.actionId}`;
+        const localSidePanelExpanded = browser.localStorage.getItem(this.keyExpandSidebar);
         this.state = useState({
             isWeekendVisible:
                 browser.localStorage.getItem("calendar.isWeekendVisible") != null
                     ? JSON.parse(browser.localStorage.getItem("calendar.isWeekendVisible"))
                     : true,
-            showSideBar:
+            sidePanelExpanded:
                 !this.env.isSmall &&
-                Boolean(sessionShowSidebar != null ? JSON.parse(sessionShowSidebar) : true),
+                Boolean(localSidePanelExpanded != null ? JSON.parse(localSidePanelExpanded) : true),
         });
 
         this.searchBarToggler = useSearchBarToggler();
@@ -183,9 +183,9 @@ export class CalendarController extends Component {
     get mobileFilterPanelProps() {
         return {
             model: this.model,
-            sideBarShown: this.state.showSideBar,
-            toggleSideBar: () => {
-                this.state.showSideBar = !this.state.showSideBar;
+            sidePanelShown: this.state.sidePanelExpanded,
+            toggleSidePanel: () => {
+                this.state.sidePanelExpanded = !this.state.sidePanelExpanded;
             },
         };
     }
@@ -194,24 +194,26 @@ export class CalendarController extends Component {
         return {
             model: this.model,
             editRecord: this.editRecord.bind(this),
+            sidePanelExpanded: this.state.sidePanelExpanded,
+            toggleSidePanel: this.toggleSidePanel.bind(this),
         };
     }
 
-    toggleSideBar() {
-        this.state.showSideBar = !this.state.showSideBar;
-        browser.sessionStorage.setItem("calendar.showSideBar", this.state.showSideBar);
+    toggleSidePanel() {
+        this.state.sidePanelExpanded = !this.state.sidePanelExpanded;
+        browser.localStorage.setItem(this.keyExpandSidebar, this.state.sidePanelExpanded);
     }
 
     get showCalendar() {
-        return !this.env.isSmall || !this.state.showSideBar;
+        return !this.env.isSmall || !this.state.sidePanelExpanded;
     }
 
-    get hasSideBar() {
+    get hasSidePanel() {
         return this.model.showDatePicker || this.model.filterSections.length > 0;
     }
 
-    get showSideBar() {
-        return this.state.showSideBar;
+    get sidePanelExpanded() {
+        return this.state.sidePanelExpanded;
     }
 
     get className() {

--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -19,10 +19,6 @@ $o-cw-filter-avatar-size: 20px;
         grid-area: 1 / 1 / 2 / 3;
     }
 
-    .o_sidebar_toggler {
-        grid-area: 1 / 3;
-    }
-
     .o_calendar_wrapper {
         grid-area: 3 / 1 / 3 / 4;
 
@@ -49,13 +45,14 @@ $o-cw-filter-avatar-size: 20px;
     }
 }
 
-.o_calendar_sidebar_container {
+.o_calendar_sidepanel_container {
     --Avatar-size: #{$o-cw-filter-avatar-size};
 
     flex: 0 0 auto;
+    border-right: $border-width solid $border-color;
 
     .o_calendar_unschedule_zone {
-        width: $o-datetime-picker-width;
+        width: $o-datetime-picker-reduced-width;
         height: stretch;
         min-height: 200px; // Fallback for firefox < 146
         border: 1px solid rgba($o-enterprise-action-color, 0.4);
@@ -63,20 +60,47 @@ $o-cw-filter-avatar-size: 20px;
         background-color: mix($o-enterprise-action-color, $o-view-background-color, 10%);
     }
 
-    .o_calendar_sidebar {
-        @include o-webclient-padding($top: $o-horizontal-padding/2);
-        width: calc(#{$o-datetime-picker-width} + 2 * #{map-get($spacers, 3)});
+    .o_calendar_sidepanel {
+        width: $o-datetime-picker-reduced-width;
 
         .o_datetime_picker {
             padding-right: 0 !important;
             padding-left: 0 !important;
         }
 
+        .o_time_picker input {
+            field-sizing: content;
+        }
+
         // sync buttons are only displayed on calendar.event views
         .o_calendar_sync {
             padding-bottom: 0.5em;
         }
+
+        .o_event_to_schedule_draggable {
+            // This is necessary because it lets fullcalendar override the display
+            // style when needed (unlike with bootstrap's d-flex)
+            display: flex;
+            max-width: fit-content;
+            .o_event_to_schedule_handle {
+                cursor: grab;
+                color: #adb5bd;
+                &:hover {
+                    color: #666666;
+                }
+            }
+            &.o_dragged .o_event_to_schedule_handle {
+                color: #666666;
+            }
+        }
     }
+}
+
+.o_calendar_sidebar {
+    width: 46px;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    border-right: $border-width solid $border-color;
 }
 
 //  Print

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -56,13 +56,10 @@
                         </h5>
                         <MultiSelectionButtons reactive="this.multiSelectionButtonsReactive" />
                     </div>
-                    <div t-if="hasSideBar and !env.isSmall" class="o_sidebar_toggler d-flex d-print-none align-items-center border-bottom pe-3">
-                        <button class="btn btn-light oi oi-panel-right collapsed ms-2 lh-base" t-on-click="toggleSideBar"/>
-                    </div>
-                    <MobileFilterPanel t-if="env.isSmall and hasSideBar" t-props="mobileFilterPanelProps" />
+                    <MobileFilterPanel t-if="env.isSmall and hasSidePanel" t-props="mobileFilterPanelProps" />
                     <div class="o_calendar_wrapper d-flex overflow-hidden">
+                        <CalendarSidePanel t-if="hasSidePanel" t-props="sidePanelProps"/>
                         <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps"/>
-                        <CalendarSidePanel t-if="hasSideBar and showSideBar" t-props="sidePanelProps"/>
                     </div>
                 </div>
             </Layout>

--- a/addons/web/static/src/views/calendar/calendar_controller_mobile.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller_mobile.scss
@@ -38,10 +38,10 @@
             }
         }
 
-        .o_calendar_sidebar_container {
+        .o_calendar_sidepanel_container {
             height: 100%;
 
-            > .o_calendar_sidebar {
+            > .o_calendar_sidepanel {
                 width: auto;
             }
         }

--- a/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
+++ b/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.CalendarFilterSection">
         <div t-if="section.filters.length gt 0 or section.canAddFilter"
-             class="o_calendar_filter d-flex flex-column gap-1 mt-3 mb-2"
+             class="o_calendar_filter d-flex flex-column gap-1 my-2"
              t-att-data-name="section.fieldName"
         >
             <t t-if="section.label">

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -163,6 +163,7 @@
 
         .fc-scrollgrid {
             border-top: 0;
+            border-left: 0;
         }
 
         .fc-scrollgrid-section-header {
@@ -724,10 +725,6 @@
                     color: var(--o-event-bg, #{$info});
                 }
             }
-        }
-
-        &:has(.fc-dayGridYear-view){
-            border-right: $border-width solid $border-color;
         }
     }
 

--- a/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.js
+++ b/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.js
@@ -1,4 +1,5 @@
-import { Component, useEffect, useRef } from "@odoo/owl";
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 
 export class CalendarScheduleSection extends Component {
     static template = "web.CalendarScheduleSection";
@@ -8,6 +9,7 @@ export class CalendarScheduleSection extends Component {
     };
     setup() {
         this.rootRef = useRef("eventsToSchedule");
+        this.state = useState({ collapsed: false });
         useEffect(
             (el) => {
                 new FullCalendar.Interaction.Draggable(el, {
@@ -28,6 +30,14 @@ export class CalendarScheduleSection extends Component {
     get displayLoadMoreButton() {
         const { eventsToSchedule } = this.props.model.data;
         return eventsToSchedule && eventsToSchedule.records.length < eventsToSchedule.length;
+    }
+
+    get toScheduleString() {
+        const { eventsToSchedule } = this.props.model.data;
+        if (eventsToSchedule.length) {
+            return _t("%s to schedule", eventsToSchedule.length);
+        }
+        return _t("Nothing to schedule");
     }
 
     openRecord(event) {

--- a/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.scss
+++ b/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.scss
@@ -1,5 +1,0 @@
-.o_event_to_schedule_draggable {
-    // This is necessary because it lets fullcalendar override the display
-    // style when needed (unlike with bootstrap's d-flex)
-    display: flex;
-}

--- a/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.xml
+++ b/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.xml
@@ -2,9 +2,14 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CalendarScheduleSection">
-        <h5>To Schedule</h5>
-        <div t-if="!props.model.data.eventsToSchedule.records.length" class="text-muted">Good job, everything is scheduled!</div>
-        <div t-ref="eventsToSchedule" class="d-flex flex-column">
+        <div class="d-flex align-items-center cursor-pointer mt-3 mb-2" t-on-click="() => this.state.collapsed = !this.state.collapsed">
+            <h5 t-out="toScheduleString" class="flex-grow-1 m-0"/>
+            <i
+                class="fa"
+                t-attf-class="fa-caret-{{ state.collapsed ? 'left' : 'down' }}"
+            />
+        </div>
+        <div t-ref="eventsToSchedule" class="d-flex flex-column" t-att-class="{ 'd-none': this.state.collapsed }">
             <div 
                 class="align-items-center cursor-pointer o_event_to_schedule_draggable py-1"
                 t-foreach="props.model.data.eventsToSchedule.records"
@@ -13,7 +18,7 @@
                 t-att-data-res-id="event.id" 
                 t-on-click="() => this.openRecord(event)"
             >
-                <i class="text-muted oi oi-draggable"/>
+                <i class="oi oi-draggable o_event_to_schedule_handle"/>
                 <span class="ps-1 text-truncate" t-out="event.display_name" t-att-title="event.display_name"/>
             </div>
         </div>

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
@@ -1,5 +1,6 @@
 import { Component, useState } from "@odoo/owl";
 import { DateTimePicker } from "@web/core/datetime/datetime_picker";
+import { _t } from "@web/core/l10n/translation";
 import { useBus } from "@web/core/utils/hooks";
 import { CalendarFilterSection } from "@web/views/calendar/calendar_filter_section/calendar_filter_section";
 import { CalendarScheduleSection } from "@web/views/calendar/calendar_schedule_section/calendar_schedule_section";
@@ -11,7 +12,7 @@ export class CalendarSidePanel extends Component {
         ScheduleSection: CalendarScheduleSection,
     };
     static template = "web.CalendarSidePanel";
-    static props = ["model", "editRecord"];
+    static props = ["model", "editRecord", "sidePanelExpanded", "toggleSidePanel"];
 
     setup() {
         this.state = useState({ isDragging: false });
@@ -61,5 +62,25 @@ export class CalendarSidePanel extends Component {
 
     get showDatePicker() {
         return this.props.model.showDatePicker && !this.env.isSmall;
+    }
+
+    get toScheduleString() {
+        const { eventsToSchedule } = this.props.model.data;
+        if (eventsToSchedule.length) {
+            return _t("%s to schedule", eventsToSchedule.length);
+        }
+        return _t("Nothing to schedule");
+    }
+
+    get filters() {
+        const res = [];
+        for (const f of this.props.model.filterSections) {
+            const filter = { label: f.label, active: false };
+            if (f.filters.some((f) => f.active)) {
+                filter.active = true;
+            }
+            res.push(filter);
+        }
+        return res;
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.scss
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.scss
@@ -1,3 +1,0 @@
-.o_calendar_sidebar .o_time_picker input {
-    field-sizing: content;
-}

--- a/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/web/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -1,20 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.CalendarSidePanel">
-        <div class="o_calendar_sidebar_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
+        <div t-if="props.sidePanelExpanded" class="o_calendar_sidepanel_container d-print-none position-relative w-100 w-md-auto bg-view overflow-x-hidden overflow-y-auto">
             <div t-if="props.model.meta.canScheduleEvents and state.isDragging" class="d-flex o_calendar_unschedule_zone m-3 align-items-center justify-content-center">
                 <b>Drop here to unschedule</b>
             </div>
-            <div class="o_calendar_sidebar" t-att-class="{ 'd-none': props.model.meta.canScheduleEvents and state.isDragging }">
+            <div class="o_calendar_sidepanel" t-att-class="{ 'd-none': props.model.meta.canScheduleEvents and state.isDragging }">
+                <button t-if="!env.isSmall" class="btn btn-light btn-sm end-0 m-2 position-absolute px-2 py-1 top-0 z-1" t-on-click="() => this.props.toggleSidePanel()">
+                    <i class="oi oi-panel-right fa-flip-horizontal"/>
+                </button>
                 <DatePicker t-if="showDatePicker" t-props="datePickerProps" />
-                <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
-                    <FilterSection model="props.model" section="section"/>
+                <div class="o_calendar_sidepanel_content px-3">
+                    <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
+                        <FilterSection model="props.model" section="section"/>
+                    </t>
+                    <ScheduleSection
+                        t-if="props.model.meta.canScheduleEvents"
+                        model="props.model"
+                        editRecord="props.editRecord"
+                    />
+                </div>
+            </div>
+        </div>
+        <div t-elif="!env.isSmall" class="o_calendar_sidebar flex-grow-0 flex-shrink-0 bg-view h-100 cursor-pointer d-print-none" t-on-click="() => this.props.toggleSidePanel()">
+            <div class="d-flex">
+                <button class="btn btn-light btn-sm m-2 p-1 py-2">
+                    <i class="oi oi-panel-right fa-flip-horizontal"/>
+                </button>
+                <t t-foreach="filters" t-as="filter" t-key="filter_index">
+                    <div class="m-2 mt-0 p-1" t-att-class="{ 'text-muted': !filter.active }">
+                        <i class="fa fa-filter fa-rotate-90"/>
+                    </div>
+                    <div class="text-truncate mx-auto mb-2" t-out="filter.label" t-att-class="{ 'text-muted': !filter.active }"/>
                 </t>
-                <ScheduleSection
-                    t-if="props.model.meta.canScheduleEvents"
-                    model="props.model"
-                    editRecord="props.editRecord"
-                />
+                <div t-if="props.model.meta.canScheduleEvents" class="text-truncate mx-auto mb-2" t-out="toScheduleString"/>
             </div>
         </div>
     </t>

--- a/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.js
+++ b/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.js
@@ -6,11 +6,11 @@ export class CalendarMobileFilterPanel extends Component {
     static template = "web.CalendarMobileFilterPanel";
     static props = {
         model: Object,
-        sideBarShown: Boolean,
-        toggleSideBar: Function,
+        sidePanelShown: Boolean,
+        toggleSidePanel: Function,
     };
     get caretDirection() {
-        return this.props.sideBarShown ? "down" : "left";
+        return this.props.sidePanelShown ? "down" : "left";
     }
     getFilterColor(filter) {
         return `o_color_${getColor(filter.colorIndex)}`;

--- a/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CalendarMobileFilterPanel">
-        <div class="o_other_calendar_panel d-flex align-items-center d-print-none" t-on-click="props.toggleSideBar">
+        <div class="o_other_calendar_panel d-flex align-items-center d-print-none" t-on-click="props.toggleSidePanel">
             <div class="o_filter me-auto d-flex overflow-auto">
                 <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
                     <t t-if="section.filters.length gt 0">

--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -241,7 +241,7 @@ async function waitForSelection() {
         await advanceTime(TOUCH_SELECTION_THRESHOLD);
     }
     await animationFrame();
-};
+}
 
 /**
  * @param {string} date
@@ -388,13 +388,14 @@ export async function selectTimeRange(startDateTime, endDateTime) {
         queryFirst(`.fc-timegrid-slot[data-time="${midTime}"]:eq(1)`, { visible: false })
     );
 
+    const rendererRect = queryRect(`.o_calendar_widget:first`);
     const startColumnRect = queryRect(`.fc-col-header-cell.fc-day[data-date="${startDate}"]`);
     const startRow = queryFirst(`.fc-timegrid-slot[data-time="${startTime}"]:eq(1)`);
     const endColumnRect = queryRect(`.fc-col-header-cell.fc-day[data-date="${endDate}"]`);
     const endRow = queryFirst(`.fc-timegrid-slot[data-time="${endTime}"]:eq(1)`);
     const optionStart = {
         relative: true,
-        position: { y: 1, x: startColumnRect.left },
+        position: { y: 1, x: startColumnRect.left - rendererRect.left },
         pointerDownDuration: TOUCH_SELECTION_THRESHOLD,
     };
 
@@ -403,7 +404,7 @@ export async function selectTimeRange(startDateTime, endDateTime) {
     const { drop } = await drag(startRow, optionStart);
     await waitForSelection();
     await drop(endRow, {
-        position: { y: -1, x: endColumnRect.left },
+        position: { y: -1, x: endColumnRect.left - rendererRect.left },
         relative: true,
     });
 
@@ -424,7 +425,9 @@ export async function selectDateRange(startDate, endDate) {
     await hover(startCell);
     await animationFrame();
 
-    const { moveTo, drop } = await drag(startCell, {pointerDownDuration: TOUCH_SELECTION_THRESHOLD});
+    const { moveTo, drop } = await drag(startCell, {
+        pointerDownDuration: TOUCH_SELECTION_THRESHOLD,
+    });
     await waitForSelection();
 
     await moveTo(endCell);
@@ -448,7 +451,7 @@ export async function selectAllDayRange(startDate, endDate) {
     await hover(start);
     await animationFrame();
 
-    const { drop } = await drag(start, {pointerDownDuration: TOUCH_SELECTION_THRESHOLD});
+    const { drop } = await drag(start, { pointerDownDuration: TOUCH_SELECTION_THRESHOLD });
     await waitForSelection();
 
     await drop(end);
@@ -476,7 +479,9 @@ export async function moveEventToDate(eventId, date, options) {
     await hover(eventEl);
     await animationFrame();
 
-    const { drop, moveTo } = await drag(eventEl, {pointerDownDuration: TOUCH_SELECTION_THRESHOLD});
+    const { drop, moveTo } = await drag(eventEl, {
+        pointerDownDuration: TOUCH_SELECTION_THRESHOLD,
+    });
     await waitForSelection();
 
     await moveTo(cell);
@@ -510,7 +515,7 @@ export async function moveEventToTime(eventId, dateTime) {
     const { drop, moveTo } = await drag(eventEl, {
         position: { y: 1 },
         relative: true,
-        pointerDownDuration: TOUCH_SELECTION_THRESHOLD
+        pointerDownDuration: TOUCH_SELECTION_THRESHOLD,
     });
     await waitForSelection();
 
@@ -554,7 +559,7 @@ export async function moveEventToAllDaySlot(eventId, date) {
     const { drop, moveTo } = await drag(eventEl, {
         position: { y: 1 },
         relative: true,
-        pointerDownDuration: TOUCH_SELECTION_THRESHOLD
+        pointerDownDuration: TOUCH_SELECTION_THRESHOLD,
     });
     await waitForSelection();
 
@@ -596,6 +601,7 @@ export async function resizeEventToTime(eventId, dateTime) {
 
     const column = findDateColumn(date);
     const columnRect = queryRect(column);
+    const rendererRect = queryRect(`.o_calendar_widget:first`);
 
     if (hasTouch()) {
         const { drop } = await drag(eventEl, {
@@ -611,7 +617,7 @@ export async function resizeEventToTime(eventId, dateTime) {
     });
     await waitForSelection();
     await drop(row, {
-        position: { x: columnRect.x, y: -1 },
+        position: { x: columnRect.x - rendererRect.x, y: -1 },
         relative: true,
     });
     await advanceTime(500);
@@ -688,9 +694,9 @@ export async function hideCalendarPanel() {
 export async function navigate(direction) {
     if (hasTouch()) {
         if (direction === "next") {
-            await swipeLeft(".o_calendar_widget", {pointerDownDuration: 200});
+            await swipeLeft(".o_calendar_widget", { pointerDownDuration: 200 });
         } else {
-            await swipeRight(".o_calendar_widget", {pointerDownDuration: 200});
+            await swipeRight(".o_calendar_widget", { pointerDownDuration: 200 });
         }
         await advanceFrame(16);
     } else {

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -377,7 +377,7 @@ test(`simple calendar rendering on desktop`, async () => {
 
     await changeScale("day");
     expect(`.o_event`).toHaveCount(2);
-    expect(`.o_calendar_sidebar .o_datetime_picker .o_selected`).toHaveCount(1);
+    expect(`.o_calendar_sidepanel .o_datetime_picker .o_selected`).toHaveCount(1);
 
     await changeScale("month");
     await toggleSectionFilter("attendee_ids");
@@ -389,7 +389,7 @@ test(`simple calendar rendering on desktop`, async () => {
     });
 
     // test filters
-    expect(`.o_calendar_sidebar .o_calendar_filter`).toHaveCount(2);
+    expect(`.o_calendar_sidepanel .o_calendar_filter`).toHaveCount(2);
     expect(`.o_calendar_filter:eq(1)`).toBeVisible();
     expect(`.o_calendar_filter:eq(1) .o_calendar_filter_item`).toHaveCount(3);
 
@@ -410,14 +410,14 @@ test(`simple calendar rendering on desktop`, async () => {
     expect(`.o_event`).toHaveCount(0);
 
     // test search bar in filter
-    await contains(`.o_calendar_sidebar input[type=text]`).click();
+    await contains(`.o_calendar_sidepanel input[type=text]`).click();
     expect(`.dropdown-item`).toHaveCount(2);
     expect(queryAllTexts`.dropdown-item`).toEqual(["partner 3", "partner 4"]);
 
     await contains(`.dropdown-item:eq(0)`).click();
     expect(`.o_calendar_filter:eq(0) .o_calendar_filter_item`).toHaveCount(3);
 
-    await contains(`.o_calendar_sidebar input[type=text]`).click();
+    await contains(`.o_calendar_sidepanel input[type=text]`).click();
     expect(`.dropdown-item`).toHaveCount(1);
     expect(`.dropdown-item`).toHaveText("partner 4");
 
@@ -491,7 +491,7 @@ test(`simple calendar rendering on mobile`, async () => {
 
     // test filters
     await displayCalendarPanel();
-    expect(`.o_calendar_sidebar .o_calendar_filter`).toHaveCount(2);
+    expect(`.o_calendar_sidepanel .o_calendar_filter`).toHaveCount(2);
     expect(`.o_calendar_filter:eq(1)`).toBeVisible();
     expect(`.o_calendar_filter:eq(1) .o_calendar_filter_item`).toHaveCount(3);
 
@@ -513,14 +513,14 @@ test(`simple calendar rendering on mobile`, async () => {
 
     // test search bar in filter
     await displayCalendarPanel();
-    await contains(`.o_calendar_sidebar input[type=text]`).click();
+    await contains(`.o_calendar_sidepanel input[type=text]`).click();
     expect(`.dropdown-item`).toHaveCount(2);
     expect(queryAllTexts`.dropdown-item`).toEqual(["partner 3", "partner 4"]);
 
     await contains(`.dropdown-item:eq(0)`).click();
     expect(`.o_calendar_filter:eq(0) .o_calendar_filter_item`).toHaveCount(3);
 
-    await contains(`.o_calendar_sidebar input[type=text]`).click();
+    await contains(`.o_calendar_sidepanel input[type=text]`).click();
     expect(`.dropdown-item`).toHaveCount(1);
     expect(`.dropdown-item`).toHaveText("partner 4");
 
@@ -596,7 +596,7 @@ test(`check the avatar of the attendee in the calendar filter panel`, async () =
     await displayCalendarPanel();
     const section = `.o_calendar_filter[data-name="attendee_ids"]`;
 
-    expect(`.o_calendar_sidebar .o_calendar_filter`).toHaveCount(1);
+    expect(`.o_calendar_sidepanel .o_calendar_filter`).toHaveCount(1);
     expect(`.o_calendar_filter:eq(0) .o-autocomplete`).toHaveCount(1);
     expect(".o_calendar_filter_item:eq(-2)").not.toHaveText("partner 3");
 
@@ -640,7 +640,7 @@ test(`Select multiple attendees in the calendar filter panel autocomplete on des
     });
 
     const section = `.o_calendar_filter[data-name="attendee_ids"]`;
-    expect(`.o_calendar_sidebar .o_calendar_filter`).toHaveCount(1);
+    expect(`.o_calendar_sidepanel .o_calendar_filter`).toHaveCount(1);
     await checkFilterItems(2);
     expect(queryAllTexts`.o_calendar_filter_item`).toEqual(["partner 1", "partner 2"]);
 
@@ -667,7 +667,7 @@ test(`Select multiple attendees in the calendar filter panel autocomplete on des
     await contains(".o_dialog .o_select_button").click();
     expect("o_dialog").toHaveCount(0);
 
-    expect(`.o_calendar_sidebar .o_calendar_filter`).toHaveCount(1);
+    expect(`.o_calendar_sidepanel .o_calendar_filter`).toHaveCount(1);
     await checkFilterItems(4);
     expect(queryAllTexts`.o_calendar_filter_item`).toEqual([
         "partner 1",
@@ -770,7 +770,7 @@ test(`add a filter with the search more dialog on desktop`, async () => {
     await contains(".o_dialog .o_select_button").click();
     expect("o_dialog").toHaveCount(0);
 
-    expect(`.o_calendar_sidebar .o_calendar_filter`).toHaveCount(1);
+    expect(`.o_calendar_sidepanel .o_calendar_filter`).toHaveCount(1);
     await checkFilterItems(4);
     expect(queryAllTexts`.o_calendar_filter_item`).toEqual([
         "foo partner 5",
@@ -983,7 +983,7 @@ test(`add a filter with the search more dialog on mobile`, async () => {
     await contains(".o_data_row:eq(0)").click();
     expect("o_dialog").toHaveCount(0);
 
-    expect(`.o_calendar_sidebar .o_calendar_filter`).toHaveCount(1);
+    expect(`.o_calendar_sidepanel .o_calendar_filter`).toHaveCount(1);
     expect(`.o_calendar_filter_item`).toHaveCount(4);
     expect(queryAllTexts`.o_calendar_filter_item`).toEqual([
         "foo partner 5",
@@ -4939,8 +4939,7 @@ test(`calendar with option show_date_picker set to false and no filter`, async (
         `,
     });
     expect(`.o_datetime_picker`).toHaveCount(0);
-    expect(`.o_calendar_sidebar`).toHaveCount(0);
-    expect(`.o_sidebar_toggler`).toHaveCount(0);
+    expect(`.o_calendar_sidepanel`).toHaveCount(0);
 });
 
 test.tags("desktop");
@@ -4956,8 +4955,11 @@ test(`calendar with option show_date_picker set to false and filters`, async () 
         `,
     });
     expect(`.o_datetime_picker`).toHaveCount(0);
+    expect(`.o_calendar_sidepanel`).toHaveCount(1);
+    await contains(".o_calendar_sidepanel button").click();
+    expect(`.o_calendar_sidepanel`).toHaveCount(0);
     expect(`.o_calendar_sidebar`).toHaveCount(1);
-    expect(`.o_sidebar_toggler`).toHaveCount(1);
+    expect(`.o_calendar_sidebar`).toHaveText("Partner");
 });
 
 test(`calendar with option month_overflow not set (default)`, async () => {
@@ -5228,31 +5230,38 @@ test(`calendar show past events with background blur`, async () => {
 });
 
 test.tags("desktop");
-test(`calendar sidebar state is saved on session storage`, async () => {
-    patchWithCleanup(sessionStorage, {
+test(`calendar sidepanel can be collapsed/expanded`, async () => {
+    patchWithCleanup(localStorage, {
         setItem(key, value) {
-            if (key === "calendar.showSideBar") {
-                expect.step(`${key}-${value}`);
+            if (key.startsWith("calendar_sidepanel_expanded")) {
+                expect.step(["setItem", key, value]);
             }
-        },
-        getItem(key) {
-            if (key === "calendar.showSideBar") {
-                expect.step(`${key}-read`);
-                return false;
-            }
+            super.setItem(...arguments);
         },
     });
-
     await mountView({
         resModel: "event",
         type: "calendar",
         arch: `<calendar date_start="start" mode="week"/>`,
     });
     expect(`.o_calendar_sidebar`).toHaveCount(0);
+    await contains(`.o_calendar_sidepanel button`).click();
+    expect(`.o_calendar_sidepanel`).toHaveCount(0);
+    expect.verifySteps([["setItem", "calendar_sidepanel_expanded,-1,false", false]]);
+    await contains(`.o_calendar_sidebar button`).click();
+    expect(`.o_calendar_sidebar`).toHaveCount(0);
+    expect.verifySteps([["setItem", "calendar_sidepanel_expanded,-1,false", true]]);
+});
 
-    await contains(`.o_sidebar_toggler .oi-panel-right`).click();
-    expect(`.o_calendar_sidebar`).toHaveCount(1);
-    expect.verifySteps(["calendar.showSideBar-read", "calendar.showSideBar-true"]);
+test.tags("desktop");
+test(`calendar sidepanel can be collapsed by default if it was set in local storage beforehand`, async () => {
+    localStorage.setItem("calendar_sidepanel_expanded,-1,false", false);
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `<calendar date_start="start" mode="week"/>`,
+    });
+    expect(`.o_calendar_sidepanel`).toHaveCount(0);
 });
 
 test(`calendar should show date information on header`, async () => {
@@ -5519,13 +5528,13 @@ test("update time while drag and drop on month mode", async () => {
     await contains(".modal-body .o_field_widget[name=start] button").click();
     await contains(".modal-body .o_field_widget[name=start] input").edit("2016-12-20 08:00:00");
     await contains(".modal-body .o_field_widget[name=stop] button").click();
-    await contains(".modal-body .o_field_widget[name=stop] input").edit("2016-12-23 10:00:00");
+    await contains(".modal-body .o_field_widget[name=stop] input").edit("2016-12-24 10:00:00");
     await contains(".modal .o_form_button_save").click();
     await moveEventToDate(8, "2016-12-27");
     await clickEvent(8);
     await contains(".o_cw_popover_edit").click();
 
-    expect(".o_field_widget[name='start']").toHaveText("Dec 26, 8:00 AM");
+    expect(".o_field_widget[name='start']").toHaveText("Dec 25, 8:00 AM");
     expect(".o_field_widget[name='stop']").toHaveText("Dec 29, 10:00 AM");
 });
 
@@ -5649,7 +5658,7 @@ test("calendar: show and change other calendar", async () => {
         message: "should contain 2 child nodes -> 2 resources",
     });
 
-    expect(".o_calendar_sidebar").toHaveCount(1);
+    expect(".o_calendar_sidepanel").toHaveCount(1);
     expect(".o_calendar_renderer").toHaveCount(0);
     expect(".o_calendar_filter").toHaveCount(1);
     expect(".o_calendar_filter[data-name=partner_id]").toHaveCount(1);
@@ -5664,7 +5673,7 @@ test("calendar: show and change other calendar", async () => {
 
     // Toggle again the other calendar panel should hide the sidebar and show the calendar view
     await contains(".o_other_calendar_panel").click();
-    expect(".o_calendar_sidebar").toHaveCount(0);
+    expect(".o_calendar_sidepanel").toHaveCount(0);
     expect(".o_calendar_renderer").toHaveCount(1);
 });
 
@@ -6197,10 +6206,10 @@ test(`load more events to schedule`, async () => {
         `,
     });
     expect(".o_event_to_schedule_draggable").toHaveCount(20);
-    expect(".o_calendar_sidebar button:contains(Load More)").toHaveCount(1);
+    expect(".o_calendar_sidepanel button:contains(Load More)").toHaveCount(1);
     expect.verifySteps(["search_read", "fetch events to schedule"]);
     expectedLimit += 20;
-    await contains(".o_calendar_sidebar button:contains(Load More)").click();
+    await contains(".o_calendar_sidepanel button:contains(Load More)").click();
     expect.verifySteps(["fetch events to schedule"]);
     expect(".o_event_to_schedule_draggable").toHaveCount(33);
 });
@@ -6224,7 +6233,7 @@ test(`no event to schedule`, async () => {
         `,
     });
     expect(".o_event_to_schedule_draggable").toHaveCount(0);
-    expect(".o_calendar_sidebar div:contains(Good job, everything is scheduled!)").toHaveCount(1);
+    expect(".o_calendar_sidepanel h5").toHaveText("Nothing to schedule");
     expect.verifySteps(["search_read", "fetch events to schedule"]);
 });
 
@@ -6254,21 +6263,17 @@ test(`drag and drop to unschedule`, async () => {
         `,
     });
     expect(".o_calendar_unschedule_zone").toHaveCount(0);
-    expect(
-        ".o_calendar_sidebar div.text-muted:contains(Good job, everything is scheduled!)"
-    ).toBeVisible();
+    expect(".o_calendar_sidepanel h5").toBeVisible();
+    expect(".o_calendar_sidepanel h5").toHaveText("Nothing to schedule");
     expect.verifySteps(["search_read", "fetch events to schedule"]);
     const { drop } = await contains('.o_event[data-event-id="2"]').drag();
     expect(".o_calendar_unschedule_zone").toHaveCount(1);
     expect(".o_calendar_unschedule_zone").toHaveText("Drop here to unschedule");
-    expect(
-        ".o_calendar_sidebar div.text-muted:contains(Good job, everything is scheduled!)"
-    ).not.toBeVisible();
+    expect(".o_calendar_sidepanel h5").not.toBeVisible();
     await drop(queryFirst(".o_calendar_unschedule_zone"));
     expect.verifySteps(["write", "search_read", "fetch events to schedule"]);
     expect(".o_event_to_schedule_draggable").toHaveCount(1);
     expect(".o_event_to_schedule_draggable").toHaveText("event 2");
-    expect(
-        ".o_calendar_sidebar div.text-muted:contains(Good job, everything is scheduled!)"
-    ).toHaveCount(0);
+    expect(".o_calendar_sidepanel h5").toBeVisible();
+    expect(".o_calendar_sidepanel h5").toHaveText("1 to schedule");
 });


### PR DESCRIPTION
*: google_calendar, microsoft_calendar, hr_holidays, project

First commit applies CSS adjustments to the search panel toggler button to improve its sizing and alignment within the interface.

Second commit introduces several UI and behavioral improvements to the calendar side panel:

* **Relocation:** The side panel gets relocated to the left side of the screen to preserve consistency across all different side panels.
* **Responsive Width:** The datepicker and side panel now automatically reduce their width when week numbers are not displayed, optimizing screen space.
* **Collapsed State Summary:** When collapsed, the side panel now renders as a narrow sidebar (similar to the search panel). This sidebar keeps active filters and the "unscheduled events" counter visible.
* **Toggle Button:** The collapse/expand button has been moved inside the panel/sidebar for better accessibility.
* **State Persistence:** The collapsed/expanded state is now saved in `localStorage` (instead of `sessionStorage`) and is scoped by action/view. This ensures the user's preference is remembered across sessions and per specific view.

task-5807836
