### PR TITLE
[IMP] project: change module description

### DIFF
--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -6,7 +6,7 @@
     'website': 'https://www.odoo.com/app/project',
     'category': 'Services/Project',
     'sequence': 45,
-    'summary': 'Organize and plan your projects',
+    'summary': 'Manage tasks and collaborate on projects',
     'depends': [
         'analytic',
         'base_setup',


### PR DESCRIPTION
In this commit, we change the module description so that searching for "task" in the Apps displays Project instead of Timesheets alone.

task-5397021