### PR TITLE
[FIX] mail: prevent local storage fields feedback loop

### DIFF
--- a/addons/mail/static/src/model/model_internal.js
+++ b/addons/mail/static/src/model/model_internal.js
@@ -77,7 +77,9 @@ export class ModelInternal {
                     const lse = record._.fieldsLocalStorage.get(fieldName);
                     const value = lse.get();
                     if (value === undefined) {
-                        lse.remove();
+                        if (!this._rawStore._.isUpdatingFromStorageEvent) {
+                            lse.remove();
+                        }
                         return this[fieldName];
                     }
                     return value;
@@ -89,6 +91,9 @@ export class ModelInternal {
                 /** @this {import("./record").Record}*/
                 function fieldLocalStorageOnChange(value) {
                     const record = toRaw(this)._raw;
+                    if (this._rawStore._.isUpdatingFromStorageEvent) {
+                        return;
+                    }
                     const lse = record._.fieldsLocalStorage.get(fieldName);
                     if (value === record._.fieldsDefault.get(fieldName)) {
                         lse.remove();


### PR DESCRIPTION
Diccuss fields have a `localStorage` option. The field updates via the `onUpdate` function in the current tab and writes to the local storage. Other tabs use the `storage` event to update their field.

This pattern can cause race conditions, leading to loops, high CPU usage, and freezes. When a tab receives a storage event, it may write back an outdated value, triggering further writes and conflicts across tabs.

This commit ensures we don't trigger `storage` events recursively: upon the reception of a `storage` event, field is updated but local storage is untouched.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
