### PR TITLE
[FIX] mail: chat window fold/close buttons should have hover effect

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -42,7 +42,7 @@
         gap: map-get($spacers, 3);
 
         button:not(:hover):not(:focus-visible):not(:active):not(.btn-success) {
-            --o-mail-ActionList-Button-opacity: 1;
+            --o-mail-ActionList-Button-opacity: .5;
         }
 
         @include media-breakpoint-up(md) {


### PR DESCRIPTION
These 2 buttons had no hover effect, compared to other buttons like the "start a call". The lack of hover effect makes it harder to click on these buttons.

This commit reduces slightly the opacity of button when not hovered, so that they are highlighted on hover from change to 100% opacity. The reduced opacity also makes these buttons slightly less visible, which is actually an improvement.

Before / After (hover on "x")
<img width="383" height="48" alt="Screenshot 2026-01-26 at 17 25 10" src="https://github.com/user-attachments/assets/7d4578cc-fcde-44b6-91e9-e0956e789c54" />
<img width="380" height="49" alt="Screenshot 2026-01-26 at 17 14 40" src="https://github.com/user-attachments/assets/e8f3690e-4202-4afd-85a5-d1459b13946e" />
