### PR TITLE
[FIX] payment_stripe: prevent crash on webhooks for unknown transactions

### DIFF
--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -85,6 +85,10 @@ class StripeController(http.Controller):
                 tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference(
                     'stripe', data
                 )
+
+                if not tx_sudo:
+                    return request.make_json_response('')
+
                 self._verify_signature(tx_sudo)
 
                 if event['type'].startswith('payment_intent'):  # Payment operation.

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -147,6 +147,20 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
             self.assertEqual(signature_check_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_stripe.controllers.main')
+    @mute_logger('odoo.addons.payment_stripe.models.payment_transaction')
+    def test_webhook_notification_skips_signature_verification_for_missing_transactions(self):
+        """ Test that the webhook ignores signature verification for unknown transactions (e.g. POS). """
+        url = self._build_url(StripeController._webhook_url)
+        payload = dict(self.payment_data)
+        payload['data']['object']['description'] = None
+
+        with patch(
+            'odoo.addons.payment_stripe.controllers.main.StripeController._verify_signature'
+        ) as signature_check_mock:
+            self._make_json_request(url, data=payload)
+            self.assertEqual(signature_check_mock.call_count, 0)
+
+    @mute_logger('odoo.addons.payment_stripe.controllers.main')
     def test_return_from_tokenization_request(self):
         tx = self._create_transaction('direct', amount=0, operation='validation', tokenize=True)
         url = self._build_url(StripeController._return_url)


### PR DESCRIPTION
Prior to this commit, receiving a Stripe webhook notification for a transaction that does not exist in Odoo (e.g., Point of Sale "card_present" payments) would cause an Internal Server Error (500).

The issue occurred because the controller attempted to call `_verify_signature(tx_sudo)` even when `tx_sudo` was empty. Inside `_verify_signature`, accessing `tx_sudo.provider_id` on an empty record triggered a "ValueError: Expected singleton" crash.

Consequently, Stripe would interpret these 500 errors as a server failure and automatically disable the webhook endpoint, breaking online payments.

This commit fixes the issue by checking if `tx_sudo` exists before proceeding with signature verification. If no transaction is found, Odoo now logs a warning and returns a 200 OK status to gracefully acknowledge and ignore the extraneous event.

opw-5439528

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
