### PR TITLE
[FIX] web_editor: restore dynamic svg colors on reset

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9710,7 +9710,14 @@ registry.DynamicSvg = SnippetOptionWidget.extend({
                 return;
         }
         const newURL = new URL(target.src, window.location.origin);
-        newURL.searchParams.set(params.colorName, normalizeColor(widgetValue));
+        let color = widgetValue ? normalizeColor(widgetValue) : '';
+        if (!color) {
+            // Reset uses theme palette colors to keep dynamic SVGs valid.
+            const colorId = params.colorName.slice(1);
+            color = weUtils.getCSSVariableValue(`o-color-${colorId}`)
+                || weUtils.DEFAULT_PALETTE[colorId];
+        }
+        newURL.searchParams.set(params.colorName, color);
         const src = newURL.pathname + newURL.search;
         await loadImage(src);
         target.src = src;

--- a/addons/website/static/tests/tours/dynamic_svg_theme_colors.js
+++ b/addons/website/static/tests/tours/dynamic_svg_theme_colors.js
@@ -1,0 +1,99 @@
+/** @odoo-module **/
+
+import {
+    changeOption,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+const THEME_DOC = document.querySelector("iframe")?.contentDocument || document;
+const THEME_STYLE = THEME_DOC.defaultView.getComputedStyle(THEME_DOC.documentElement);
+const COLOR_1 = THEME_STYLE.getPropertyValue("--o-color-1");
+const COLOR_2 = THEME_STYLE.getPropertyValue("--o-color-2");
+const COLOR_3 = THEME_STYLE.getPropertyValue("--o-color-3");
+const COLOR_1_ENC = encodeURIComponent(COLOR_1);
+const COLOR_2_ENC = encodeURIComponent(COLOR_2);
+const COLOR_3_ENC = encodeURIComponent(COLOR_3);
+const IMG_SELECTOR =
+    ":iframe .s_text_image img[src^='/html_editor/shape/illustration/dynamic-svg-test']";
+const IMG_SELECTOR_C1C2 = `${IMG_SELECTOR}[src*='c1=${COLOR_1_ENC}'][src*='c2=${COLOR_2_ENC}']`;
+const IMG_SELECTOR_C3 = `${IMG_SELECTOR}[src*='c1=${COLOR_3_ENC}'][src*='c2=${COLOR_2_ENC}']`;
+
+async function assertSvgColors(img, color1, color2, errorMessage) {
+    const response = await fetch(img.src);
+    const svg = await response.text();
+    if (!svg.includes(color1) || !svg.includes(color2) || !svg.includes("#000000")) {
+        throw new Error(errorMessage);
+    }
+}
+
+registerWebsitePreviewTour(
+    "website_dynamic_svg_theme_colors",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_text_image",
+            name: "Text - Image",
+            groupName: "Content",
+        }),
+        {
+            content: "Set the dynamic SVG image",
+            trigger: ":iframe .s_text_image img",
+            run() {
+                this.anchor.setAttribute(
+                    "src",
+                    "/html_editor/shape/illustration/dynamic-svg-test" +
+                        `?c1=${COLOR_1_ENC}&c2=${COLOR_2_ENC}&unique=4a2363`
+                );
+            },
+        },
+        {
+            content: "Check the SVG uses theme colors",
+            trigger: IMG_SELECTOR_C1C2,
+            async run() {
+                await assertSvgColors(
+                    this.anchor,
+                    COLOR_1,
+                    COLOR_2,
+                    "Dynamic SVG theme colors were not applied."
+                );
+            },
+        },
+        {
+            content: "Select the dynamic SVG image",
+            trigger: IMG_SELECTOR_C1C2,
+            run: "click",
+        },
+        changeOption("DynamicSvg", "we-select.o_we_so_color_palette"),
+        changeOption("DynamicSvg", 'button[data-color="o-color-3"]', "", "bottom", true),
+        {
+            content: "Check the SVG uses the new theme color",
+            trigger: IMG_SELECTOR_C3,
+            async run() {
+                await assertSvgColors(
+                    this.anchor,
+                    COLOR_3,
+                    COLOR_2,
+                    "Dynamic SVG color did not update."
+                );
+            },
+        },
+        changeOption("DynamicSvg", "we-select.o_we_so_color_palette"),
+        changeOption("DynamicSvg", ".o_colorpicker_reset", "", "bottom", true),
+        {
+            content: "Check the SVG uses the theme colors on reset",
+            trigger: IMG_SELECTOR_C1C2,
+            async run() {
+                await assertSvgColors(
+                    this.anchor,
+                    COLOR_1,
+                    COLOR_2,
+                    "Dynamic SVG theme colors were not restored."
+                );
+            },
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -183,6 +183,24 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
 
         self.start_tour("/", 'website_media_dialog_undraw', login='admin')
 
+    def test_dynamic_svg_theme_colors(self):
+        svg = (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            '<rect width="10" height="4" fill="#3AADAA"/>'
+            '<rect y="4" width="10" height="4" fill="#7C6576"/>'
+            '<rect y="8" width="10" height="2" fill="#000000"/>'
+            '</svg>'
+        )
+        self.env['ir.attachment'].create({
+            'name': 'dynamic svg test',
+            'type': 'binary',
+            'mimetype': 'image/svg+xml',
+            'datas': base64.b64encode(svg.encode()),
+            'public': True,
+            'url': '/html_editor/shape/illustration/dynamic-svg-test',
+        })
+        self.start_tour("/", 'website_dynamic_svg_theme_colors', login='admin')
+
     def test_code_editor_usable(self):
         # TODO: enable debug mode when failing tests have been fixed (props validation)
         url = '/odoo/action-website.website_preview'


### PR DESCRIPTION
Steps to reproduce:

- Insert a media library SVG illustration.
- Change one of its Dynamic Colors.
- Click the reset button in the colorpicker. => The SVG disappears.

Before this commit, resetting a dynamic SVG color could send an empty color value and the image failed to render.

After this commit, resetting restores the theme palette colors so the SVG stays visible.

task-5868584