### PR TITLE
[REF] product: extract document domain and reuse document count logic

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -402,16 +402,7 @@ class ProductProduct(models.Model):
     def _compute_product_document_count(self):
         for product in self:
             product.product_document_count = product.env['product.document'].search_count(
-                Domain.OR([
-                    Domain.AND([
-                        Domain('res_model', '=', 'product.product'),
-                        Domain('res_id', 'in', product.ids),
-                    ]),
-                    Domain.AND([
-                        Domain('res_model', '=', 'product.template'),
-                        Domain('res_id', 'in', product.product_tmpl_id.ids),
-                    ]),
-                ])
+                product._get_product_document_domain()
             )
 
     @api.depends('product_tag_ids', 'additional_product_tag_ids')
@@ -1165,6 +1156,11 @@ class ProductProduct(models.Model):
 
     def get_contextual_price(self):
         return self._get_contextual_price()
+
+    def _get_product_document_domain(self):
+        self.ensure_one()
+        return (Domain('res_model', '=', 'product.template') & Domain('res_id', 'in', self.product_tmpl_id.ids)) \
+            | (Domain('res_model', '=', 'product.product') & Domain('res_id', 'in', self.ids))
 
     def _get_contextual_price(self):
         # FIXME VFE this won't consider ptavs extra prices, since we rely on the template price

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -227,9 +227,9 @@ class ProductTemplate(models.Model):
 
     def _compute_product_document_count(self):
         for template in self:
-            template.product_document_count = template.env['product.document'].search_count(
-                template._get_product_document_domain()
-            )
+            template.product_document_count = template.env[
+                'product.document'
+            ].search_count(template._get_product_document_domain())
 
     @api.depends('image_1920', 'image_1024')
     def _compute_can_image_1024_be_zoomed(self):


### PR DESCRIPTION
Description:
- Refactor document-related helpers in the product module.

- Extend document count methods on product.product and product.template

- Extract document domain definition into a dedicated helper method

- Make document counting logic reusable by the Documents module

- Reuse the same domain when opening the Documents app from products

This refactor avoids duplication and ensures consistent document behavior across modules. No functional change intended.

task-5408513

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
