### PR TITLE
[IMP] hr_holidays: Accural plan Anniversary Option

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan.py
@@ -57,6 +57,10 @@ class HrLeaveAccrualPlan(models.Model):
     ], export_string_translation=False, default=lambda self: str((fields.Date.today()).month))
     added_value_type = fields.Selection([('day', 'Days'), ('hour', 'Hours')],
         export_string_translation=False, default="day", store=True)
+    is_anniversary = fields.Boolean(
+        export_string_translation=False,
+        help="An anniversary plan will be based on the first contract date by default."
+    )
 
     @api.depends('level_ids')
     def _compute_show_transition_mode(self):

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -179,6 +179,11 @@
                                         <template id="is_based_on_worked_time_no">No, always consider the entire accrual period (whole calendar days).
                                         </template>
                                     </span>
+                                    <label class="fw-bold" for="is_anniversary"
+                                           string="Is it an anniversary plan?"/>
+                                    <span>
+                                        <field class="ms-1" name="is_anniversary"/>
+                                    </span>
                                     <label class="fw-bold" for="can_be_carryover"
                                            string="Do you need a carry-over of the accrued days from one year to another?"/>
                                     <span>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -139,6 +139,9 @@
                                 invisible="allocation_type == 'regular'"
                                 required="allocation_type == 'accrual'"
                                 readonly="not is_officer or state == 'validate'"/>
+                            <field name="employee_contract_date_start"
+                                invisible="allocation_type == 'regular' or not is_anniversary"
+                                />
                             <div class="o_td_label" name="validity_label" invisible="not is_officer">
                                 <label for="date_from" string="Validity Period"
                                     invisible="allocation_type == 'accrual' or state != 'confirm'"/>


### PR DESCRIPTION
This commit aims to add a new anniversary option on the accural plans that by default selects the start date of the accural plan as the start date of the contract.

task - 3965007

