### PR TITLE
[IMP] peppol: Add missing invoice type codes

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -307,11 +307,25 @@ class AccountEdiXmlUBL20(models.AbstractModel):
 
     def _add_invoice_header_nodes(self, document_node, vals):
         invoice = vals['invoice']
+        code = None
+        if vals['process_type'] == 'selfbilling':
+            code = 389
+        # if an invoice was sent before, it has a message uuid, so it's a 'corrected invoice'
+        elif 'peppol_message_uuid' in invoice._fields and invoice.peppol_message_uuid:
+            code = 384
+        elif vals['document_type'] == 'debit_note':
+            code = 383
+        elif any(line.is_downpayment for line in invoice['invoice_line_ids']):
+            code = 386
+        elif vals['document_type'] == 'invoice':
+            code = 380
+        invoiceTypeCode = {'_text': code}
+
         document_node.update({
             'cbc:UBLVersionID': {'_text': '2.0'},
             'cbc:ID': {'_text': invoice.name},
             'cbc:IssueDate': {'_text': invoice.invoice_date},
-            'cbc:InvoiceTypeCode': {'_text': 389 if vals['process_type'] == 'selfbilling' else 380} if vals['document_type'] == 'invoice' else None,
+            'cbc:InvoiceTypeCode': invoiceTypeCode,
             'cbc:Note': {'_text': html2plaintext(invoice.narration)} if invoice.narration else None,
             'cbc:DocumentCurrencyCode': {'_text': invoice.currency_id.name},
             'cac:OrderReference': {

--- a/addons/account_edi_ubl_cii/tools/ubl_21_debit_note.py
+++ b/addons/account_edi_ubl_cii/tools/ubl_21_debit_note.py
@@ -35,6 +35,7 @@ DebitNote = {
     'cbc:UUID': {},
     'cbc:IssueDate': {},
     'cbc:IssueTime': {},
+    'cbc:InvoiceTypeCode': {},
     'cbc:Note': {},
     'cbc:DocumentCurrencyCode': {},
     'cbc:TaxCurrencyCode': {},


### PR DESCRIPTION
Before this commit, when sending an invoice that was corrected (posted, sent, reset to draft, modified and resent) the code for the invoice type code was incorrect, also if the invoice was a down payment and not a full invoice, the invoice type code was also incorrect.
task-5875689