### PR TITLE
[FIX] project_purchase : Check for AA anywhere in the analytic dist

### DIFF
--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -165,8 +165,7 @@ class ProjectProject(models.Model):
                         l.parent_state != 'cancel'
                         and l.analytic_distribution
                         and any(
-                            key == str(self.account_id.id)
-                            or key.startswith(str(self.account_id.id) + ",")
+                            str(self.account_id.id) in key.split(',')
                             for key in l.analytic_distribution
                         )
                     )

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -985,16 +985,28 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         purchase_order = self.env['purchase.order'].create({
             "name": "A purchase order",
             "partner_id": self.partner_a.id,
-            "order_line": [Command.create({
-                "analytic_distribution": {
-                    # this is the analytic_account that is linked to the project
-                    f"{self.analytic_account.id},{other_analytic_account.id}": 100,
-                },
-                "product_id": self.product_order.id,
-                "product_qty": 1,
-                "price_unit": self.product_order.standard_price,
-                "currency_id": self.env.company.currency_id.id,
-            })],
+            "order_line": [
+                Command.create({
+                    "analytic_distribution": {
+                        # this is the analytic_account that is linked to the project
+                        f"{self.analytic_account.id},{other_analytic_account.id}": 100,
+                    },
+                    "product_id": self.product_order.id,
+                    "product_qty": 1,
+                    "price_unit": self.product_order.standard_price,
+                    "currency_id": self.env.company.currency_id.id,
+                }),
+                Command.create({
+                    "analytic_distribution": {
+                        # this is the analytic_account that is linked to the project
+                        f"{other_analytic_account.id},{self.analytic_account.id}": 100,
+                    },
+                    "product_id": self.product_order.id,
+                    "product_qty": 1,
+                    "price_unit": self.product_order.standard_price,
+                    "currency_id": self.env.company.currency_id.id,
+                }),
+            ],
         })
         purchase_order.button_confirm()
 
@@ -1011,11 +1023,11 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
                     'id': 'purchase_order',
                     'sequence': self.project._get_profitability_sequence_per_invoice_type()['purchase_order'],
                     'to_bill': 0.0,
-                    'billed': -235.0,
+                    'billed': -470.0,
                 }],
                 'total': {
                     'to_bill': 0.0,
-                    'billed': -235.0,
+                    'billed': -470.0,
                 },
             },
         )


### PR DESCRIPTION
### Steps to reproduce:
	- Create a billable Project
	- Navigate to Accounting > Configuration > Analytic Accounting > Analytic Plans
	- Change the order of the project plan
	- Create a Purchase order and set the created project and a department in analytic distribution
	- Create a Vendor Bill with the same analytic distribution and match with the PO
	- Confirm the Vendor Bill
	- Check the project dashboard
	- Notice the amount is under To Bill not Billed

### Cause:
In this commit https://github.com/odoo/odoo/pull/241571/changes/ef080f94609f1057c6d86af68bee605dcaeb287b we introduced a fix to search for the analytic account in purchase lines' analytic distribution when we have multiple accounts for the same purchase line if it is shown as the first number of the key but since it is not mandatory to have the project account id at the start of the key

### Fix:
We now search for the id in the whole not only the start of it.

opw-5350246