### PR TITLE
[FIX] l10n_gcc_pos: Add arabic text to receipts

### DIFF
--- a/addons/l10n_gcc_pos/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -14,7 +14,12 @@
                             <span id="title_ar" t-translation="off">الفاتورة الضريبية</span>
                         </t>
                         <t t-else="">
-                            <span name="title">Tax Invoice</span>
+                            <t t-if="order.user_id.partner_id.lang != 'ar_001'">
+                                <span name="title" t-translation="off">Tax Invoice</span>
+                            </t>
+                            <t t-else="">
+                                <span name="title" t-translation="off">الفاتورة الضريبية</span>
+                            </t>
                         </t>
                     </t>
                     <t t-else="">
@@ -23,7 +28,12 @@
                             <span name="title_simplified_ar" t-translation="off">فاتورة ضريبية مبسطة</span>
                         </t>
                         <t t-else="">
-                            <span name="title_simplified">Simplified Tax Invoice</span>
+                            <t t-if="order.user_id.partner_id.lang != 'ar_001'">
+                                <span name="title_simplified" t-translation="off">Simplified Tax Invoice</span>
+                            </t>
+                            <t t-else="">
+                                <span name="title_simplified" t-translation="off">فاتورة ضريبية مبسطة</span>
+                            </t>
                         </t>
                     </t>
                 </div>


### PR DESCRIPTION
Problem:
When printing a receipt in arabic using the l10n_gcc_pos module, some of the text is in English.

Cause:
Translation is not enabled for the module and the text is written in English only in the receipts XML.

Solution:
Add the arabic translations of texts to the receipts XML and choose the display language based on the user's language (same behaviour in other receipts).

Steps to reproduce:
- Install l10n_gcc_pos module
- Activate and choose Arabic as the language
- Open Point of Sale and validate an order
- See how some text (specifically "Tax Invoice" and "Simplified Tax Invoice") are printed in English although the rest of the receipt is printed in Arabic.

opw-5501464