### PR TITLE
[FIX] point_of_sale:include settled order payments

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1096,6 +1096,9 @@ class PosOrder(models.Model):
     def _get_invoice_post_context(self):
         return {"skip_invoice_sync": True}
 
+    def _get_payments(self):
+        return self.payment_ids.sudo().with_company(self.company_id)
+
     def _generate_pos_order_invoice(self):
         if not self.env['res.company']._with_locked_records(self, allow_raising=False):
             raise UserError(_("Some orders are already being invoiced. Please try again later."))
@@ -1112,7 +1115,7 @@ class PosOrder(models.Model):
         for session, orders in self.grouped('session_id').items():
             is_session_closed = session.state == 'closed'
             for order in orders:
-                order_payments = order.payment_ids.sudo().with_company(company)
+                order_payments = order._get_payments()
                 payment_moves = order_payments._create_payment_moves(is_session_closed)
                 all_payment_moves |= payment_moves
                 if is_session_closed:


### PR DESCRIPTION
If you made a PoS order paid with the customer account payment method, and then you created a settle due order to settle the previous one. If you then create the invoice for the original order, the invoice would appear as unpaid, because the payments of the settle due order were not taken into account.

Steps to reproduce:
-------------------
* Create a PoS order and pay with the customer account payment method
* Settle the order that you just created with a settle due order
* Close the session
* Go on the original order and create the invoice
> Observation: The invoice appears as unpaid when it should be paid.

Why the fix:
------------
When creating the invoice we gather all the payments of the order to create the corresponding journal entries. But the payment of the settle due order were not included. So the order was considered as unpaid.

opw-5268042