### PR TITLE
[FIX] repair: Create missing production locations

### DIFF
--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -60,6 +60,13 @@ class StockWarehouse(models.Model):
             raise UserError(_("Can't find any production location."))
         return location
 
+    def _create_missing_locations(self, vals):
+        super()._create_missing_locations(vals)
+        for company_id in self.company_id:
+            location = self.env['stock.location'].search([('usage', '=', 'production'), ('company_id', '=', company_id.id)], limit=1)
+            if not location:
+                company_id._create_production_location()
+
     def _generate_global_route_rules_values(self):
         rules = super()._generate_global_route_rules_values()
         production_location = self._get_production_location()


### PR DESCRIPTION
The warehouses need at least a Production location[^2] to avoid triggering an error, but they are not considered a missing location. The function is borrowed from the `mrp` module[^mrp].

This error was found during upgrades. To reproduce:
- In 17, install repair and don't install mrp.
- Archive the production locations.
- Upgrade to 18.
- It will trigger an error[^1] while upgrading stock. 

[^1]:https://github.com/odoo/upgrade/blob/b46cf7ea8770c5d428ea3d569148eb76d16903b9/migrations/stock/saas~17.3.1.1/end-migrate.py#L16
[^2]:https://github.com/odoo/odoo/blob/ab3c2d52bcaee516eae319ccd20088eb48c819f1/addons/repair/models/stock_warehouse.py#L67
[^mrp]:https://github.com/odoo/odoo/blob/ab3c2d52bcaee516eae319ccd20088eb48c819f1/addons/mrp/models/stock_warehouse.py#L278-L283