### PR TITLE
[FIX] web, project, payment: Fix extractProps and update props in CopyClipboardField

### DIFF
--- a/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
+++ b/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
@@ -22,10 +22,6 @@ class PaymentWizardCopyClipboardButtonField extends CopyClipboardButtonField {
 const paymentWizardCopyClipboardButtonField = {
     ...copyClipboardButtonField,
     component: PaymentWizardCopyClipboardButtonField,
-    extractProps: (fieldInfo, dynamicInfo) => ({
-        ...copyClipboardButtonField.extractProps(fieldInfo, dynamicInfo),
-        copyText: fieldInfo.string,
-    }),
 };
 
 registry

--- a/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
+++ b/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
@@ -24,7 +24,7 @@ const paymentWizardCopyClipboardButtonField = {
     component: PaymentWizardCopyClipboardButtonField,
     extractProps: (fieldInfo, dynamicInfo) => ({
         ...copyClipboardButtonField.extractProps(fieldInfo, dynamicInfo),
-        string: fieldInfo.string,
+        copyText: fieldInfo.string,
     }),
 };
 

--- a/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
+++ b/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
@@ -43,9 +43,9 @@ QUnit.test("copy link immediatly after entering the amount", async (assert) => {
                 <group>
                     <field name="amount"/>
                      <field
-                        string="Generate and Copy Payment Link"
                         name="link"
                         widget="PaymentWizardCopyClipboardButtonField"
+                        options="{'copyText': 'Generate and Copy Payment Link'}"
                     />
                 </group>
             </group>

--- a/addons/payment/wizards/payment_link_wizard_views.xml
+++ b/addons/payment/wizards/payment_link_wizard_views.xml
@@ -32,10 +32,10 @@
                 </div>
                 <footer>
                     <field name="link"
-                           string="Generate and Copy Payment Link"
                            readonly="1"
                            disabled="bool(warning_message)"
                            widget="PaymentWizardCopyClipboardButtonField"
+                           options="{'copyText': 'Generate and Copy Payment Link'}"
                            data-hotkey="q"/>
                     <button string="Close"
                             class="btn btn-secondary rounded-2"

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -20,7 +20,7 @@
                 <p class="alert alert-warning" invisible="access_warning == ''" role="alert"><field name="access_warning"/></p>
                 <group>
                     <field options="{'horizontal': true}" name="access_mode" widget="radio" invisible="not display_access_mode" class="mb-4"/>
-                    <field name="share_link" widget="CopyClipboardChar" options="{'string': 'Copy Link'}" invisible="access_mode == 'edit'" string="Link" class="mb-4"/>
+                    <field name="share_link" widget="CopyClipboardChar" options="{'copyText': 'Copy Link'}" invisible="access_mode == 'edit'" string="Link" class="mb-4"/>
                     <div class="o_td_label mb-4">
                         <label for="partner_ids" string="Invite People" invisible="access_mode == 'read'"/>
                         <label for="partner_ids" invisible="access_mode == 'edit'"/>

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -17,12 +17,12 @@ class CopyClipboardField extends Component {
     static template = "web.CopyClipboardField";
     static props = {
         ...standardFieldProps,
-        string: { type: String, optional: true },
+        copyText: { type: String, optional: true },
         disabledExpr: { type: String, optional: true },
     };
 
     setup() {
-        this.copyText = this.props.string || _t("Copy");
+        this.copyText = this.props.copyText || _t("Copy");
         this.successText = _t("Copied");
     }
 
@@ -30,7 +30,7 @@ class CopyClipboardField extends Component {
         return `o_btn_${this.type}_copy btn-sm`;
     }
     get fieldProps() {
-        return omit(this.props, "string", "disabledExpr");
+        return omit(this.props, "copyText", "disabledExpr");
     }
     get type() {
         return this.props.record.fields[this.props.name].type;
@@ -68,9 +68,9 @@ export class CopyClipboardURLField extends CopyClipboardField {
 
 // ----------------------------------------------------------------------------
 
-function extractProps({ attrs }) {
+function extractProps({ attrs, options}) {
     return {
-        string: attrs.string,
+        copyText: options.copyText,
         disabledExpr: attrs.disabled,
     };
 }

--- a/addons/web/static/tests/views/fields/copy_clipboard_field_tests.js
+++ b/addons/web/static/tests/views/fields/copy_clipboard_field_tests.js
@@ -195,6 +195,29 @@ QUnit.module("Fields", (hooks) => {
         assert.verifySteps(["copied tooltip"]);
     });
 
+    QUnit.test("CopyClipboardField: use custom copy text from options", async function (assert) {
+        await makeView({
+            serverData,
+            type: "form",
+            resModel: "partner",
+            arch: `
+                <form>
+                    <sheet>
+                        <field name="char_field" 
+                               widget="CopyClipboardChar" 
+                               options="{'copyText': 'Custom Copy Text'}"/>
+                    </sheet>
+                </form>`,
+            resId: 1,
+        });
+
+        assert.strictEqual(
+            target.querySelector(".o_clipboard_button").textContent,
+            "Custom Copy Text",
+            "The button should display the copy text from the options"
+        );
+    });
+
     QUnit.module("CopyClipboardButtonField");
 
     QUnit.test("CopyClipboardButtonField in form view", async function (assert) {

--- a/doc/cla/individual/Mazen-Ghaleb.md
+++ b/doc/cla/individual/Mazen-Ghaleb.md
@@ -1,0 +1,11 @@
+Egypt, 2026-01-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mazen Ghaleb mazenghaleb@outlook.com https://github.com/Mazen-Ghaleb


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**  
The `CopyClipboardField` widget previously relied on the `string` attribute inside `attributes` to determine the text of copy button. In Odoo 17+, the `string` attribute is no longer inside `attributes` but defined outside, causing the widget to break. Additionally, using `string` for copy text caused confusion between the field label and the text to copy (`copyText`). The correct approach is to use widget options for defining `copyText`, as intended in the project share link. In the Payment Wizard button, the widget was inherited and `extractProps` was overridden to handle the `string` attribute manually, which is no longer necessary with the new approach.

**Current behavior before PR:**  
- `CopyClipboardField.extractProps` reads the removed `string` attribute from `attributes`.  
- The copy text could be confused with the field label (`string`).  
- Project share link usage fails to read copy text correctly because the widget does not read options.  
- `PaymentWizardCopyClipboardButtonField` overrides `extractProps` unnecessarily to fix copy text handling.

**Desired behavior after PR is merged:**  
- `CopyClipboardField` reads `copyText` from widget options, no longer relying on the removed `string` attribute.  
- Copy text is clearly separated from field labels.  
- Project share link now works correctly using the new `copyText` option.  
- `PaymentWizardCopyClipboardButtonField` no longer needs to override `extractProps` and copy text is set directly in field options  

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
