### PR TITLE
[IMP] project, crm: remove the color field from stages

### DIFF
--- a/addons/crm/data/crm_stage_data.xml
+++ b/addons/crm/data/crm_stage_data.xml
@@ -3,23 +3,19 @@
     <record model="crm.stage" id="stage_lead1" forcecreate="False">
         <field name="name">New</field>
         <field name="sequence">1</field>
-        <field name="color">11</field>
     </record>
     <record model="crm.stage" id="stage_lead2" forcecreate="False">
         <field name="name">Qualified</field>
         <field name="sequence">2</field>
-        <field name="color">5</field>
     </record>
     <record model="crm.stage" id="stage_lead3" forcecreate="False">
         <field name="name">Proposition</field>
         <field name="sequence">3</field>
-        <field name="color">8</field>
     </record>
     <record model="crm.stage" id="stage_lead4" forcecreate="False">
         <field name="name">Won</field>
         <field name="fold" eval="False"/>
         <field name="is_won">True</field>
         <field name="sequence">70</field>
-        <field name="color">10</field>
     </record>
 </odoo>

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -134,7 +134,6 @@ class CrmLead(models.Model):
         compute='_compute_stage_id', readonly=False, store=True,
         copy=False, group_expand='_read_group_stage_ids', ondelete='restrict',
         domain="['|', ('team_ids', '=', False), ('team_ids', 'in', team_id)]")
-    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     tag_ids = fields.Many2many(
         'crm.tag', 'crm_tag_rel', 'lead_id', 'tag_id', string='Tags',
         help="Classify and analyze your lead/opportunity categories like: Training, Service")

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -135,7 +135,6 @@ class CrmLead(models.Model):
         compute='_compute_stage_id', readonly=False, store=True,
         copy=False, group_expand='_read_group_stage_ids', ondelete='restrict',
         domain="['|', ('team_ids', '=', False), ('team_ids', 'in', team_id)]")
-    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     tag_ids = fields.Many2many(
         'crm.tag', 'crm_tag_rel', 'lead_id', 'tag_id', string='Tags',
         help="Classify and analyze your lead/opportunity categories like: Training, Service")

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -34,7 +34,6 @@ class CrmStage(models.Model):
         help='This stage is folded in the kanban view when there are no records in that stage to display.')
     # This field for interface only
     team_count = fields.Integer('team_count', compute='_compute_team_count')
-    color = fields.Integer(string='Color', export_string_translation=False)
 
     def _auto_init(self):
         # TODO stop hardcoding ids in tests and remove this

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -33,7 +33,6 @@ class CrmStage(models.Model):
         help='This stage is folded in the kanban view when there are no records in that stage to display.')
     # This field for interface only
     team_count = fields.Integer('team_count', compute='_compute_team_count')
-    color = fields.Integer(string='Color', export_string_translation=False)
 
     def _auto_init(self):
         # TODO stop hardcoding ids in tests and remove this

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -43,7 +43,6 @@
                     <field name="create_date" interval="month" type="row"/>
                     <field name="team_id" type="col"/>
                     <field name="color" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
                     <field name="automated_probability" invisible="1"/>
@@ -85,7 +84,6 @@
                     <field name="create_date" interval="month"/>
                     <field name="team_id"/>
                     <field name="color" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="automated_probability" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -473,8 +473,8 @@
                                 <div class="d-flex justify-content-between">
                                     <field name="partner_id" muted="1" display="full" class="o_text_block"/>
                                     <div class="m-1"/>
-                                    <field name="stage_id_color" invisible="1"/>
-                                    <field name="stage_id" widget="badge" options="{'color_field': 'stage_id_color'}"/>
+                                    <field name="color" invisible="1"/>
+                                    <field name="stage_id" widget="badge" options="{'color_field': 'color'}"/>
                                 </div>
                             </div>
                         </div>
@@ -728,7 +728,6 @@
                     <field name="recurring_revenue" sum="Recurring Revenue" optional="hide" widget="monetary"
                         options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
                     <field name="recurring_plan" optional="hide" groups="crm.group_use_recurring_revenues"/>
-                    <field name="stage_id_color" column_invisible="1"/>
                     <field name="stage_id" optional="show" widget="rotting" options="{'no_open': True}"/>
                     <field name="active" column_invisible="True"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
@@ -775,9 +774,8 @@
                     <field name="email_from" optional="show"/>
                     <field name="user_id" widget="many2one_avatar_user"/>
                     <field name="expected_revenue" optional="show"/>
-                    <field name="stage_id_color" column_invisible="True"/>
-                    <field name="stage_id" widget="badge" options="{'color_field': 'stage_id_color'}" optional="show"/>
-                    <field name="team_id" optional="hide"/>
+                    <field name="color" column_invisible="True"/>
+                    <field name="stage_id" widget="badge" options="{'color_field': 'color'}" optional="show"/>
                 </list>
             </field>
         </record>
@@ -828,7 +826,6 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -851,7 +848,6 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -865,7 +861,6 @@
                     <field name="stage_id" type="col"/>
                     <field name="expected_revenue" type="measure"/>
                     <field name="color" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="automated_probability" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
@@ -896,7 +891,6 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                 </pivot>
             </field>
         </record>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -470,8 +470,8 @@
                                 <div class="d-flex justify-content-between">
                                     <field name="partner_id" muted="1" display="full" class="o_text_block"/>
                                     <div class="m-1"/>
-                                    <field name="stage_id_color" invisible="1"/>
-                                    <field name="stage_id" widget="badge" options="{'color_field': 'stage_id_color'}"/>
+                                    <field name="color" invisible="1"/>
+                                    <field name="stage_id" widget="badge" options="{'color_field': 'color'}"/>
                                 </div>
                             </div>
                         </div>
@@ -725,7 +725,6 @@
                     <field name="recurring_revenue" sum="Recurring Revenue" optional="hide" widget="monetary"
                         options="{'currency_field': 'company_currency'}" groups="crm.group_use_recurring_revenues"/>
                     <field name="recurring_plan" optional="hide" groups="crm.group_use_recurring_revenues"/>
-                    <field name="stage_id_color" column_invisible="1"/>
                     <field name="stage_id" optional="show" widget="rotting" options="{'no_open': True}"/>
                     <field name="active" column_invisible="True"/>
                     <field name="probability" string="Probability (%)" optional="hide"/>
@@ -772,9 +771,8 @@
                     <field name="email_from" optional="show"/>
                     <field name="user_id" widget="many2one_avatar_user"/>
                     <field name="expected_revenue" optional="show"/>
-                    <field name="stage_id_color" column_invisible="True"/>
-                    <field name="stage_id" widget="badge" options="{'color_field': 'stage_id_color'}" optional="show"/>
-                    <field name="team_id" optional="hide"/>
+                    <field name="color" column_invisible="True"/>
+                    <field name="stage_id" widget="badge" options="{'color_field': 'color'}" optional="show"/>
                 </list>
             </field>
         </record>
@@ -825,7 +823,6 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -848,7 +845,6 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -862,7 +858,6 @@
                     <field name="stage_id" type="col"/>
                     <field name="expected_revenue" type="measure"/>
                     <field name="color" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="automated_probability" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
@@ -893,7 +888,6 @@
                     <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                     <field name="recurring_revenue_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                 </pivot>
             </field>
         </record>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -25,7 +25,6 @@
                 <field name="is_won"/>
                 <field name="team_ids" widget="many2many_tags"/>
                 <field name="rotting_threshold_days" optional="hide"/>
-                <field name="color" optional="hide" widget="color_picker"/>
             </list>
         </field>
     </record>
@@ -56,7 +55,6 @@
                         </group>
                         <group>
                             <field name="fold" string="Fold by Default"/>
-                            <field name="color" widget="color_picker"/>
                         </group>
                     </group>
                     <separator string="Requirements"/>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -25,7 +25,6 @@
                 <field name="is_won"/>
                 <field name="team_ids" widget="many2many_tags"/>
                 <field name="rotting_threshold_days" optional="hide"/>
-                <field name="color" optional="hide" widget="color_picker"/>
             </list>
         </field>
     </record>
@@ -58,7 +57,6 @@
                         </group>
                         <group>
                             <field name="fold" string="Fold by Default"/>
-                            <field name="color" widget="color_picker"/>
                         </group>
                     </group>
                     <separator string="Requirements"/>

--- a/addons/crm/wizard/crm_merge_opportunities_views.xml
+++ b/addons/crm/wizard/crm_merge_opportunities_views.xml
@@ -25,8 +25,8 @@
                             <field name="email_from" optional="show"/>
                             <field name="phone" class="o_force_ltr" optional="hide"/>
                             <field name="user_id" widget="many2one_avatar_user"/>
-                            <field name="stage_id_color" column_invisible="1"/>
-                            <field name="stage_id" widget="badge" options="{'color_field': 'stage_id_color'}"/>
+                            <field name="color" column_invisible="1"/>
+                            <field name="stage_id" widget="badge" options="{'color_field': 'color'}"/>
                             <field name="team_id" optional="hide"/>
                         </list>
                     </field>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -161,7 +161,6 @@ class ProjectProject(models.Model):
     # Not `required` since this is an option to enable in project settings.
     stage_id = fields.Many2one('project.project.stage', string='Stage', ondelete='restrict', groups="project.group_project_stages",
         tracking=True, index=True, copy=False, default=_default_stage_id, group_expand='_read_group_expand_full')
-    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     duration_tracking = fields.Json(groups="project.group_project_stages")
     date_last_stage_update = fields.Datetime(string='Last Stage Update', index=True, default=fields.Datetime.now)
 

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -162,7 +162,6 @@ class ProjectProject(models.Model):
     # Not `required` since this is an option to enable in project settings.
     stage_id = fields.Many2one('project.project.stage', string='Stage', ondelete='restrict', groups="project.group_project_stages",
         tracking=True, index=True, copy=False, default=_default_stage_id, group_expand='_read_group_expand_full')
-    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     duration_tracking = fields.Json(groups="project.group_project_stages")
     rotting_days = fields.Integer(groups="project.group_project_stages")
     is_rotting = fields.Boolean(groups="project.group_project_stages")

--- a/addons/project/models/project_project_stage.py
+++ b/addons/project/models/project_project_stage.py
@@ -18,7 +18,6 @@ class ProjectProjectStage(models.Model):
     fold = fields.Boolean('Folded',
         help="If enabled, this stage will be displayed as folded in the Kanban and List views of your projects. Projects in a folded stage are considered as closed.")
     company_id = fields.Many2one('res.company', string="Company")
-    color = fields.Integer(string='Color', export_string_translation=False)
     rotting_threshold_days = fields.Integer('Days to rot', default=0, help='Day count before projects in this stage become stale. Set to 0 to disable.')
 
     def copy_data(self, default=None):

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -60,7 +60,6 @@ PROJECT_TASK_READABLE_FIELDS = {
     'is_template',
     'has_template_ancestor',
     'has_project_template',
-    'stage_id_color',
     'access_token',
     'access_url',
 }
@@ -164,7 +163,6 @@ class ProjectTask(models.Model):
        store=True, readonly=False, ondelete='restrict', tracking=True, index=True,
        default=_get_default_stage_id, group_expand='_read_group_stage_ids',
        domain="[('project_ids', '=', project_id)]")
-    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     tag_ids = fields.Many2many('project.tags', string='Tags')
 
     state = fields.Selection([

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -59,7 +59,6 @@ PROJECT_TASK_READABLE_FIELDS = {
     'is_template',
     'has_template_ancestor',
     'has_project_template',
-    'stage_id_color',
     'access_token',
     'access_url',
 }
@@ -162,7 +161,6 @@ class ProjectTask(models.Model):
        store=True, readonly=False, ondelete='restrict', tracking=True, index=True,
        default=_get_default_stage_id, group_expand='_read_group_stage_ids',
        domain="[('project_ids', '=', project_id)]")
-    stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     tag_ids = fields.Many2many('project.tags', string='Tags')
 
     state = fields.Selection([

--- a/addons/project/models/project_task_type.py
+++ b/addons/project/models/project_task_type.py
@@ -32,7 +32,6 @@ class ProjectTaskType(models.Model):
         string='Email Template',
         domain=[('model', '=', 'project.task')],
         help="If set, an email will be automatically sent to the customer when the task reaches this stage.")
-    color = fields.Integer(string='Color', export_string_translation=False)
     fold = fields.Boolean(string='Folded')
     rating_template_id = fields.Many2one(
         'mail.template',

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -14,7 +14,7 @@
         />
     </template>
     <template id="portal_my_tasks_badge_widget_template" name="badge Widget Template">
-        <span t-attf-class="badge rounded-pill o_tag o_badge_color_#{task.stage_id_color}"
+        <span t-attf-class="badge rounded-pill o_tag o_badge_color_#{task.color}"
             t-attf-title="#{task.stage_id.name}" t-out="task.stage_id.name"
         />
     </template>

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -10,7 +10,6 @@
                 <field name="mail_template_id" optional="hide" context="{'default_model': 'project.project'}"/>
                 <field name="rotting_threshold_days" optional="hide"/>
                 <field name="company_id" optional="hide" groups="base.group_multi_company" options="{'no_create': True}"/>
-                <field name="color" optional="hide" widget="color_picker"/>
                 <field name="fold" optional="show"/>
             </list>
         </field>
@@ -55,7 +54,6 @@
                             <field name="company_id" groups="base.group_multi_company"
                                 placeholder="Show to all companies" options="{'no_create': True}"/>
                             <field name="fold" string="Fold by Default"/>
-                            <field name="color" widget="color_picker"/>
                         </group>
                     </group>
                 </sheet>
@@ -67,11 +65,8 @@
         <field name="name">project.project.stage.view.kanban</field>
         <field name="model">project.project.stage</field>
         <field name="arch" type="xml">
-            <kanban highlight_color="color" class="o_kanban_mobile" sample="1" quick_create_view="project.project_project_stage_view_form_quick_create">
+            <kanban class="o_kanban_mobile" sample="1" quick_create_view="project.project_project_stage_view_form_quick_create">
                 <templates>
-                    <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
-                        <field name="color" widget="kanban_color_picker"/>
-                    </t>
                     <t t-name="card">
                         <field name="name" class="fw-bolder mb-4"/>
                         <field name="mail_template_id" class="text-muted mb-2" invisible="not mail_template_id"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -291,8 +291,8 @@
                     <field name="last_update_color" column_invisible="True"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" optional="hide"/>
                     <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection" invisible="is_template"/>
-                    <field name="stage_id_color" column_invisible="1"/>
-                    <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'stage_id_color'}" />
+                    <field name="color" column_invisible="1"/>
+                    <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'color'}" />
                     <button string="View Tasks" name="action_view_tasks" type="object"/>
                 </list>
             </field>
@@ -631,12 +631,12 @@
                     scales="month,year"
                     event_open_popup="true"
                     quick_create="0"
-                    color="stage_id_color"
+                    color="color"
                     js_class="project_project_calendar">
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="user_id" widget="many2one_avatar_user" invisible="not user_id"/>
                     <field name="is_favorite" widget="project_is_favorite" nolabel="1" string="Favorite"/>
-                    <field name="stage_id_color" invisible="1"/>
+                    <field name="color" invisible="1"/>
                     <field name="stage_id" groups="project.group_project_stages" invisible="not stage_id"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="last_update_status" string="Status" widget="status_with_color" invisible="last_update_status == 'to_define'"/>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -288,8 +288,8 @@
                     <field name="last_update_color" column_invisible="True"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" optional="hide"/>
                     <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection" invisible="is_template"/>
-                    <field name="stage_id_color" column_invisible="1"/>
-                    <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'stage_id_color'}" />
+                    <field name="color" column_invisible="1"/>
+                    <field name="stage_id" domain="[('company_id', 'in', (company_id, False))]" optional="show" widget="badge" options="{'no_open': True, 'color_field': 'color'}" />
                     <button string="View Tasks" name="action_view_tasks" type="object"/>
                 </list>
             </field>
@@ -625,12 +625,12 @@
                     scales="month,year"
                     event_open_popup="true"
                     quick_create="0"
-                    color="stage_id_color"
+                    color="color"
                     js_class="project_project_calendar">
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="user_id" widget="many2one_avatar_user" invisible="not user_id"/>
                     <field name="is_favorite" widget="project_is_favorite" nolabel="1" string="Favorite"/>
-                    <field name="stage_id_color" invisible="1"/>
+                    <field name="color" invisible="1"/>
                     <field name="stage_id" groups="project.group_project_stages" invisible="not stage_id"/>
                     <field name="last_update_color" invisible="1"/>
                     <field name="last_update_status" string="Status" widget="status_with_color" invisible="last_update_status == 'to_define'"/>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -52,7 +52,6 @@
                                 <field name="project_ids" invisible="user_id" required="not user_id"
                                     widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'open_form'}"/>
                                 <field name="fold" string="Fold by Default" widget="boolean_toggle"/>
-                                <field name="color" widget="color_picker"/>
                                 <field name="sequence" groups="base.group_no_one"/>
                             </group>
                         </group>
@@ -71,7 +70,6 @@
                     <field name="rotting_threshold_days" optional="hide"/>
                     <field name="mail_template_id" optional="hide"/>
                     <field name="project_ids" required="1" optional="show" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"/>
-                    <field name="color" optional="hide" widget="color_picker"/>
                     <field name="fold" optional="show"/>
                 </list>
             </field>
@@ -93,14 +91,11 @@
             <field name="name">project.task.type.kanban</field>
             <field name="model">project.task.type</field>
             <field name="arch" type="xml">
-                <kanban highlight_color="color" class="o_kanban_mobile" sample="1" default_group_by="project_ids">
+                <kanban class="o_kanban_mobile" sample="1" default_group_by="project_ids">
                     <templates>
-                        <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
-                            <field name="color" widget="kanban_color_picker"/>
-                        </t>
                         <t t-name="card">
                             <field name="name" class="fw-bolder text-truncate"/>
-                            <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"/>
+                            <field name="project_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         </t>
                     </templates>
                 </kanban>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -147,7 +147,6 @@
                     <field name="working_hours_close" widget="float_time"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="rating_last_value" string="Rating (/5)"/>
                 </graph>
             </field>
@@ -178,7 +177,6 @@
                     <field name="project_id" type="row"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="allocated_hours" widget="float_time"/>
                     <field name="working_hours_close" widget="float_time"/>
                     <field name="working_hours_open" widget="float_time"/>
@@ -798,7 +796,6 @@
                     <field name="create_date" optional="hide"/>
                     <field name="date_last_stage_update" optional="hide" column_invisible="context.get('template_project')"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
-                    <field name="stage_id_color" column_invisible="1"/>
                     <field name="is_rotting" column_invisible="True"/>
                     <field name="rotting_days" column_invisible="True"/>
                     <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show" widget="rotting" options="{'no_open': True}"/>
@@ -860,8 +857,7 @@
             <field name="model">project.task</field>
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
-                <calendar date_start="date_deadline" string="Tasks" mode="month"
-                          color="stage_id_color" event_limit="5" hide_time="true"
+                <calendar date_start="date_deadline" string="Tasks" mode="month" color="color" event_limit="5" hide_time="true"
                           event_open_popup="true" quick_create="0" show_unusual_days="True"
                           js_class="project_task_calendar" schedule="1"
                           scales="day,week,month,year">
@@ -874,7 +870,6 @@
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="priority" widget="priority" readonly="1"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" invisible="not tag_ids"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection" filters="1"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>
                     <field name="task_properties" invisible="not task_properties"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -147,7 +147,6 @@
                     <field name="working_hours_close" widget="float_time"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="rating_last_value" string="Rating (/5)"/>
                 </graph>
             </field>
@@ -178,7 +177,6 @@
                     <field name="project_id" type="row"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="allocated_hours" widget="float_time"/>
                     <field name="working_hours_close" widget="float_time"/>
                     <field name="working_hours_open" widget="float_time"/>
@@ -794,7 +792,6 @@
                     <field name="create_date" optional="hide"/>
                     <field name="date_last_stage_update" optional="hide" column_invisible="context.get('template_project')"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
-                    <field name="stage_id_color" column_invisible="1"/>
                     <field name="is_rotting" column_invisible="True"/>
                     <field name="rotting_days" column_invisible="True"/>
                     <field name="stage_id" column_invisible="context.get('set_visible', False)" optional="show" widget="rotting" options="{'no_open': True}"/>
@@ -856,8 +853,7 @@
             <field name="model">project.task</field>
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
-                <calendar date_start="date_deadline" string="Tasks" mode="month"
-                          color="stage_id_color" event_limit="5" hide_time="true"
+                <calendar date_start="date_deadline" string="Tasks" mode="month" color="color" event_limit="5" hide_time="true"
                           event_open_popup="true" quick_create="0" show_unusual_days="True"
                           js_class="project_task_calendar" schedule="1"
                           scales="day,week,month,year">
@@ -870,7 +866,6 @@
                     <field name="partner_id" invisible="not partner_id"/>
                     <field name="priority" widget="priority" readonly="1"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" invisible="not tag_ids"/>
-                    <field name="stage_id_color" invisible="1"/>
                     <field name="stage_id" invisible="not project_id or not stage_id" widget="task_stage_with_state_selection" filters="1"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>
                     <field name="task_properties" invisible="not task_properties"/>


### PR DESCRIPTION
We used the rotting widget in the stage field, so the stage color field is unused, as explained below in the commit. https://github.com/odoo/odoo/commit/cd9ed578803605550135cb6fd6d4c267b433abbc

task-5485507