### PR TITLE
[FIX] l10n_es: fix mod 390 computation

### DIFF
--- a/addons/l10n_es/data/mod390/mod390_section1.xml
+++ b/addons/l10n_es/data/mod390/mod390_section1.xml
@@ -1204,7 +1204,8 @@
                                 aeat_mod_390_685.balance + aeat_mod_390_23.balance + aeat_mod_390_25.balance +
                                 aeat_mod_390_720.balance + aeat_mod_390_687.balance + aeat_mod_390_545.balance +
                                 aeat_mod_390_722.balance + aeat_mod_390_689.balance + aeat_mod_390_547.balance +
-                                aeat_mod_390_551.balance
+                                aeat_mod_390_551.balance + aeat_mod_390_27.balance + aeat_mod_390_29.balance +
+                                aeat_mod_390_649.balance + aeat_mod_390_31.balance
                             </field>
                         </record>
                         <record id="mod_390_casilla_34" model="account.report.line">
@@ -1225,7 +1226,8 @@
                                 aeat_mod_390_686.balance + aeat_mod_390_24.balance + aeat_mod_390_26.balance +
                                 aeat_mod_390_721.balance + aeat_mod_390_688.balance + aeat_mod_390_546.balance +
                                 aeat_mod_390_723.balance + aeat_mod_390_690.balance + aeat_mod_390_548.balance +
-                                aeat_mod_390_552.balance
+                                aeat_mod_390_552.balance + aeat_mod_390_28.balance + aeat_mod_390_30.balance +
+                                aeat_mod_390_650.balance + aeat_mod_390_32.balance
                             </field>
                         </record>
                     </field>


### PR DESCRIPTION
In this commit:
Fixing 390 computation:
- Add balance from 27, 29, 649 and 31 to casilla 33.
- Add balance from 28, 30, 650 and 32 to casilla 34.

Related PR : https://github.com/odoo/enterprise/pull/105597

task-5732679
