### PR TITLE
[FIX] sale_project: task creation message is logged multiple times in chatter

### DIFF
--- a/addons/sale_project/models/project_task.py
+++ b/addons/sale_project/models/project_task.py
@@ -180,6 +180,12 @@ class ProjectTask(models.Model):
             self._ensure_sale_order_linked([sol_id])
         return task
 
+    def _creation_message(self):
+        self.ensure_one()
+        if self.sale_order_id:
+            return ""
+        return super()._creation_message()
+
     # ---------------------------------------------------
     # Actions
     # ---------------------------------------------------


### PR DESCRIPTION
**Steps to Reproduce:**
- Create a Sales Order with a service product that creates a task.
- Confirm the Sales Order.
- Open the newly created task.
- Check the chatter messages.

**Issue:**
The “Task Created” message is logged multiples times in the chatter:
 - One  “Task Created” subtype.
 - One message from the custom _creation_message override.
 - One message indicating task created from sale order.

**Current behaviour:**
 Multiple messages are posted in the chatter when a task is created leading to
 noisy logs.

**Expected behaviour:**
1). When a task is created from a Sales Order, only:
   -The task creation subtype, and the message indicating the related
    Sales Order should be displayed in the chatter.

2).When a task is created manually from a Project, only:
   -The task creation subtype, and the message indicating the related Project
    should be displayed in the chatter.

**Fix:**
 Overrode _creation_message in sale_project to skip the default project creation
 message for tasks created from Sales Orders, keeping only the Sales
 Order–related chatter message.

**Task-5786980**