### PR TITLE
[FIX] pos_self_order: reset active category after order confirmation

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -295,7 +295,16 @@ export class SelfOrder extends Reactive {
             screenMode: screen_mode,
         });
         this.printKioskChanges(access_token);
+        this.resetCategorySelection();
     }
+
+    resetCategorySelection() {
+        if (!this.kioskMode) {
+            return;
+        }
+        this.currentCategory = this.availableCategories[0];
+    }
+
     hasPaymentMethod() {
         return this.filterPaymentMethods(this.models["pos.payment.method"].getAll()).length > 0;
     }

--- a/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
@@ -338,3 +338,31 @@ test("cancelBackendOrder", async () => {
     expect(order.state).toBe("cancel");
     expect(store.router.activeSlot).toBe("default");
 });
+
+test("resetCategorySelection", async () => {
+    const store = await setupSelfPosEnv();
+    store.computeAvailableCategories();
+    const [ctg1, ctg2] = store.availableCategories.slice(0, 2);
+
+    // Kiosk Mode
+    store.config.self_ordering_mode = "kiosk";
+    expect(store.currentCategory.id).toBe(ctg1.id);
+    store.currentCategory = ctg2;
+    expect(store.currentCategory.id).toBe(ctg2.id);
+    store.resetCategorySelection();
+    expect(store.currentCategory.id).toBe(ctg1.id);
+
+    // Mobile Mode
+    store.config.self_ordering_mode = "mobile";
+    store.currentCategory = ctg2;
+    expect(store.currentCategory.id).toBe(ctg2.id);
+    store.resetCategorySelection();
+    expect(store.currentCategory.id).toBe(ctg2.id);
+
+    // On Order Confirmation
+    await getFilledSelfOrder(store);
+    store.config.self_ordering_mode = "kiosk";
+    expect(store.currentCategory.id).toBe(ctg2.id);
+    await store.confirmOrder();
+    expect(store.currentCategory.id).toBe(ctg1.id);
+});


### PR DESCRIPTION
The Product List page was keeping the previously selected category active after checkout in kiosk mode.

This commit resets the category selection on order confirmation.

Task-5877912
