### PR TITLE
[IMP] Project: Added week/month days selection to recurrence

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -41,6 +41,7 @@ REPEAT_UNIT_SELECTION = [
     ('year', 'Years'),
 ]
 
+
 class ProjectTaskRecurrence(models.Model):
     _name = 'project.task.recurrence'
     _description = 'Task Recurrence'

--- a/addons/project/static/src/views/widget/project_week_days.js
+++ b/addons/project/static/src/views/widget/project_week_days.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+import { WeekDays, weekDays } from "@web/views/widgets/week_days/week_days";
+
+export class ProjectWeekDays extends WeekDays {
+    static template = "project.WeekDays";
+    onChange(day) {
+        this.props.record.update({ [day]: !this.data[day] });
+    }
+};
+
+export const projectWeekDays = {
+    component: ProjectWeekDays,
+    fieldDependencies: weekDays.fieldDependencies,
+};
+
+registry.category("view_widgets").add("project_week_days", projectWeekDays);

--- a/addons/project/static/src/views/widget/project_week_days.scss
+++ b/addons/project/static/src/views/widget/project_week_days.scss
@@ -1,0 +1,10 @@
+.o_project_week_days_rounded {
+    border-radius: 50%;
+    margin-right: 8px;
+    width: 24px;
+    height: 24px;
+    justify-content: center;
+    display: flex;
+    cursor: pointer;
+    align-items: center;
+}

--- a/addons/project/static/src/views/widget/project_week_days.xml
+++ b/addons/project/static/src/views/widget/project_week_days.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="project.WeekDays">
+        <div class="o_recurrent_weekdays mb-2 d-flex">
+        <t t-foreach="weekdays" t-as="day" t-key="day">
+                <div t-attf-class="o_project_week_days_rounded {{data[day] ? 'text-bg-action' : 'btn-secondary'}}"
+                    t-on-click="this.props.readonly? () => {} : () => this.onChange(day)">
+                    <t t-esc="props.record.fields[day].string[0]"/>
+                </div>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -463,15 +463,35 @@
                             </div>
                             <label for="repeat_interval" groups="project.group_project_recurring_tasks" invisible="not recurring_task or not allow_recurring_tasks"/>
                             <div invisible="not recurring_task or not allow_recurring_tasks" class="d-flex" groups="project.group_project_recurring_tasks" name="repeat_intervals">
-                                <field name="repeat_interval" required="recurring_task"
+                                <field name="repeat_interval" invisible="repeat_unit in ['weekday','monthday'] " required="recurring_task and not repeat_unit in ['weekday','monthday']"
                                        class="me-2" style="max-width: 2rem !important;" />
                                 <field name="repeat_unit" required="recurring_task"
-                                       class="me-2" style="max-width: 4rem !important;" />
+                                       class="me-2" style="max-width: 6rem !important;" />
                                 <field name="repeat_type" required="recurring_task"
                                        class="me-2" style="max-width: 15rem !important;" />
                                 <field name="repeat_until" invisible="repeat_type != 'until'" required="repeat_type == 'until'"
                                        class="me-2" />
                             </div>
+                            <span class="fw-bold text-nowrap" invisible="not repeat_unit in ['weekday']">Repeat on</span>
+                            <div invisible="repeat_unit !='weekday'">
+                                    <widget  name="project_week_days"/>
+                            </div>
+                             <label string="Day of Month" for="month_by" class="fw-bold text-900" style="width: fit-content;" invisible="repeat_unit != 'monthday'"/>
+                                <div class="d-flex gap-2" invisible="repeat_unit != 'monthday'">
+                                    <field name="month_by" nolabel="1" class="oe_inline w-auto" required="repeat_unit != 'monthday'"/>
+                                    <field name="repeat_date_of_month" nolabel="1" class="oe_inline w-auto"
+                                        required=" repeat_unit == 'monthday' and month_by == 'date'"
+                                        invisible="month_by != 'date'"
+                                    />
+                                    <field name="repeat_by_day_month" string="The" class="oe_inline w-auto" nolabel="1"
+                                        required="repeat_unit == 'monthday' and month_by == 'day'"
+                                        invisible="month_by != 'day'"
+                                    />
+                                    <field name="repeat_by_weekday_month" nolabel="1" class="oe_inline w-auto"
+                                        required="repeat_unit == 'monthday' and month_by == 'day'"
+                                        invisible="month_by != 'day'"
+                                    />
+                                </div>
                             <!-- Field needed to trigger its compute in project_enterprise, but will be replaced in an override defined in hr_timesheet module -->
                             <field name="allocated_hours" invisible="1"/>
                         </group>


### PR DESCRIPTION
## Current behavior before PR:
Users had no option to make a task recur on specific days of the week or month.

## Desired behavior after PR is merged:
Users can select the days of the week or the days of the month on which a task should recur.

## Explanations:
- To schedule recurring tasks on specific days of the week or month, the `project_task_recurrence.py` script uses the `rrule` library. This approach was chosen to keep the code consistent with other similar implementations, such as in `calendar.event`.
- Two dates are calculated from the `rrule` call, even though only one is ultimately needed. This is intentional because, in some cases, `rrule` returns the starting date as the first valid result. Since we are interested in the next possible occurrence, that first result can not be suitable in certain use cases.

- In the **Enterprise** version of Odoo, scheduling is based on the task’s start date (`planned_date_begin`). Example: If a task is set to recur every Monday and takes two days to complete, planned_date_begin will be set to Monday morning at the first working hour, and the deadline will be set two days later. This approach is more logical, as it is clearer to define a recurring start date rather than an end date.

- In the **Community** version of Odoo, planned_date_begin does not exist. Therefore, the date used to plan the next task is the task's deadline. Example: If a task is set to recur every Friday, the newly created recurring task will have its deadline set on Friday, regardless of the task’s duration.

Task : [5164409](https://www.odoo.com/odoo/project/4105/tasks/5164409)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
