### PR TITLE
[FIX] l10n_sa_edi: allow additional buyer ID for non-Saudi partners

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -104,7 +104,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
         """ Override to include/update values specific to ZATCA's UBL 2.1 specs """
         identification_number = partner.l10n_sa_additional_identification_number
         vat = re.sub(r'[^a-zA-Z0-9]', '', partner.vat or "")
-        if partner.country_code != "SA":
+        if partner.country_code != "SA" and vat:
             identification_number = vat
         elif partner.l10n_sa_additional_identification_scheme == 'TIN':
             # according to ZATCA, the TIN number is always the first 10 digits of the VAT number

--- a/addons/l10n_sa_edi/views/res_partner_views.xml
+++ b/addons/l10n_sa_edi/views/res_partner_views.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('o_address_format')]"  position="after">
                     <field name="l10n_sa_additional_identification_scheme" invisible="country_code != 'SA'"/>
-                    <field name="l10n_sa_additional_identification_number" invisible="country_code != 'SA' or l10n_sa_additional_identification_scheme == 'TIN'"/>
+                    <field name="l10n_sa_additional_identification_number" invisible="'SA' not in fiscal_country_codes and country_code != 'SA' or l10n_sa_additional_identification_scheme == 'TIN'"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
This commit makes l10n_sa_additional_identification_number visible for non-Saudi individuals and company partners when the active company is in Saudi Arabia and keeps the identification scheme fixed to OTH, keeping it invisible.

When generating ZATCA XML for non-Saudi partners, VAT is used as the primary buyer ID if present, and fall back to the additional identification number when VAT is missing.

task-4525956
