### PR TITLE
[FIX] pos_qfpay: addapt refund notification type

### DIFF
--- a/addons/pos_qfpay/static/src/app/payment_qfpay.js
+++ b/addons/pos_qfpay/static/src/app/payment_qfpay.js
@@ -109,7 +109,7 @@ export class PaymentQFpay extends PaymentInterface {
         const response = data.response;
         const line = this.pendingQFpayline;
         let lineMismatch = false;
-        if (response.notify_type === "cancel") {
+        if (response.notify_type === "refund") {
             lineMismatch =
                 !line ||
                 !line.pos_order_id.refunded_order_id.payment_ids.find(

--- a/addons/pos_qfpay/static/tests/tours/utils/common.js
+++ b/addons/pos_qfpay/static/tests/tours/utils/common.js
@@ -38,7 +38,7 @@ const response_from_qfpay_on_pos_refund_webhook = (uuid, sessionID, paymentMetho
     out_trade_no: "2cccf6c02d4835bdb79d7c96beb95cbf",
     syssn: "20250821155400847635342115",
     respcd: "0000",
-    notify_type: "cancel",
+    notify_type: "refund",
 });
 
 // Once request for payment/refund has been sent to the qfpay terminal


### PR DESCRIPTION
QFPay changed the notify_type for refund notifications from "cancel" to "refund".

https://sdk.qfapi.com/docs/common-api/async-notifications/


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
