### PR TITLE
[IMP] l10n_sa_edi: remove l10n_sa_is_retention field

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -76,7 +76,8 @@ class AccountEdiXmlUbl_21Zatca(models.AbstractModel):
 
         # Always ignore withholding taxes in the UBL
         def total_grouping_function(base_line, tax_data):
-            if tax_data and tax_data['tax'].l10n_sa_is_retention:
+            tax = tax_data and tax_data['tax']
+            if tax and tax.amount < 0:
                 return None
             return True
 
@@ -84,7 +85,7 @@ class AccountEdiXmlUbl_21Zatca(models.AbstractModel):
             tax = tax_data and tax_data['tax']
 
             # Ignore withholding taxes
-            if tax and tax.l10n_sa_is_retention:
+            if tax and tax.amount < 0:
                 return None
             return {
                 'tax_category_code': self._get_tax_category_code(vals['customer'].commercial_partner_id, vals['supplier'], tax),

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -332,17 +332,6 @@ class AccountMove(models.Model):
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    def _apply_retention_tax_filter(self, tax_values):
-        return tax_values['tax_id'].amount < 0
-
-    def _is_global_discount_line(self):
-        """
-            Any line that has a negative amount and is not linked to a down-payment is considered as a
-            global discount line. These can be created either manually, or through a promotions program.
-        """
-        self.ensure_one()
-        return not self._get_downpayment_lines() and self.price_subtotal < 0
-
     @api.depends('price_subtotal', 'price_total')
     def _compute_tax_amount(self):
         super()._compute_tax_amount()

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -333,7 +333,7 @@ class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
     def _apply_retention_tax_filter(self, tax_values):
-        return not tax_values['tax_id'].l10n_sa_is_retention
+        return tax_values['tax_id'].amount < 0
 
     def _is_global_discount_line(self):
         """
@@ -359,5 +359,5 @@ class AccountMoveLine(models.Model):
                 line.l10n_gcc_invoice_tax_amount = sum(
                     tax_data['tax_amount_currency']
                     for tax_data in base_line['tax_details']['taxes_data']
-                    if not tax_data['tax'].l10n_sa_is_retention
+                    if tax_data['tax'].amount > 0
                 )

--- a/addons/l10n_sa_edi/models/account_tax.py
+++ b/addons/l10n_sa_edi/models/account_tax.py
@@ -1,6 +1,4 @@
-from odoo import fields, models, api, _
-from odoo.exceptions import UserError
-
+from odoo import fields, models
 
 EXEMPTION_REASON_CODES = [
     ('VATEX-SA-29', 'VATEX-SA-29 Financial services mentioned in Article 29 of the VAT Regulations.'),
@@ -24,19 +22,5 @@ EXEMPTION_REASON_CODES = [
 class AccountTax(models.Model):
     _inherit = 'account.tax'
 
-    l10n_sa_is_retention = fields.Boolean("Is Retention", default=False,
-                                          help="Determines whether or not a tax counts as a Withholding Tax")
-
     l10n_sa_exemption_reason_code = fields.Selection(string="Exemption Reason Code",
                                                      selection=EXEMPTION_REASON_CODES, help="Tax Exemption Reason Code (ZATCA)")
-
-    @api.onchange('amount')
-    def onchange_amount(self):
-        super().onchange_amount()
-        self.l10n_sa_is_retention = False
-
-    @api.constrains("l10n_sa_is_retention", "amount", "type_tax_use")
-    def _l10n_sa_constrain_is_retention(self):
-        for tax in self:
-            if tax.amount >= 0 and tax.l10n_sa_is_retention and tax.type_tax_use == 'sale':
-                raise UserError(_("The tax is unable to be set as Retention as the Amount is greater than or equal to 0."))

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -302,7 +302,6 @@ class TestEdiZatca(TestSaEdiCommon):
         """Test standard invoice generation."""
 
         retention_tax = self.env['account.tax'].create({
-            'l10n_sa_is_retention': True,
             'name': 'Retention Tax',
             'amount_type': 'percent',
             'amount': -10.0,

--- a/addons/l10n_sa_edi/views/account_tax_views.xml
+++ b/addons/l10n_sa_edi/views/account_tax_views.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='country_id']" position="after">
-                <field name="l10n_sa_is_retention" invisible="type_tax_use != 'sale' or country_code != 'SA' or amount &gt;= 0"/>
                 <field name="l10n_sa_exemption_reason_code" invisible="type_tax_use != 'sale' or country_code != 'SA' or amount != 0"/>
             </xpath>
         </field>


### PR DESCRIPTION
Before this commit:
- The user needed to use the boolean field `l10n_sa_is_retention` on a negative tax for it to be considered a retention tax. This complicates the flow, as any negative tax is a retention tax by default, so the need for the checkbox is unnecessary.

After this commit:
- The boolean field `l10n_sa_is_retention` is removed.

Related: https://github.com/odoo/upgrade/pull/9351

Task [link](https://www.odoo.com/odoo/project.task/5865831)
task-5865831
