### PR TITLE
[IMP] mail:  add button to open Discuss settings from GIF picker

### DIFF
--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
@@ -308,4 +308,8 @@ export class GifPicker extends Component {
         }
         this.closeCategories();
     }
+
+    onClickOpenDiscussSetting() {
+        this.env.services.action.doAction("mail.action_open_discuss_settings");
+    }
 }

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -4,7 +4,8 @@
         <div class="o-discuss-GifPicker d-flex flex-column" t-attf-class="{{ props.className }}" t-att-class="{ 'h-100': props.mobile }" t-on-focusin="() => state.focused = true" t-on-focusout="() => state.focused = false">
             <div t-if="!store.hasGifPickerFeature and store.self_user?.is_admin" class="d-flex flex-column align-items-center justify-content-center m-3 h-100">
                 <span class="o-discuss-GifPicker-bigEmoji">🧑‍🍳🌶️</span>
-                <span class="fs-5 text-muted">Want to spice up your conversations with GIFs? Activate the feature in the settings!</span>
+                <span class="fs-5 text-muted text-center">Want to spice up your conversations with GIFs? Turn on this feature in settings.</span>
+                <button class="btn btn-primary mt-3" t-on-click="onClickOpenDiscussSetting">Enable GIFs</button>
             </div>
             <t t-else="">
                 <div class="o-EmojiPicker-search d-flex align-items-center m-2 rounded">


### PR DESCRIPTION
Previously, when the GIF picker feature was disabled, system administrators had to navigate through the settings menus to manually locate the Discuss configuration section and configure the Tenor GIF API key.

This PR improves the user experience by adding a direct navigation path:
- Adds an 'Enable GIFs' button below the informational message in the GIF picker when the feature is disabled.
- Clicking the button redirects directly to the Discuss settings section, where the Tenor GIF API key can be configured.

task-5873804

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
