### PR TITLE
[FIX] l10n_sa_edi: converted amount in invoice report

### DIFF
--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -28,12 +28,12 @@
                     </tr>
                     <tr>
                         <td><p class="m-0" t-esc="sar_rate" t-options='{"widget": "float", "precision": 5}'/></td>
-                        <td><p class="m-0" t-esc="o.amount_untaxed"
+                        <td><p class="m-0" t-esc="abs(o.amount_untaxed_signed)"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
                         <td><p class="m-0"
                             t-esc="o.currency_id._convert(o.amount_tax, o.company_id.currency_id, o.company_id, curr_date)"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
-                        <td><p class="m-0" t-esc="o.amount_total"
+                        <td><p class="m-0" t-esc="abs(o.amount_total_signed)"
                             t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></td>
                     </tr>
                 </table>


### PR DESCRIPTION
After 267a876451da8b39ab8c5885e7198ebfeb841573
invoice report will not show the correct amount in company currency

Steps to reproduce:
- With SA Company setup
- Create invoice in foreign currency
- Print

Issue:
Amount in company currency have not been rate adjusted. This occurs because amount_untaxed and amount_total are expressed in foreign currency.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
