### PR TITLE
[IMP] orm: get now() when fetching sequences

### DIFF
--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -33,7 +33,7 @@ class TestCursor(BaseCursor):
     def __init__(self, cursor: Cursor, lock: threading.RLock, readonly: bool):
         assert isinstance(cursor, BaseCursor)
         super().__init__()
-        self._now: datetime | None = None
+        self._now = datetime.now()
         self._closed: bool = False
         self._cursor = cursor
         self.readonly = readonly


### PR DESCRIPTION
We can get the time for free avoiding a separate query later. We usually start after checking sequences and we often use the date in the same transaction.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
