### PR TITLE
[FIX] stock: fix quantities at past date for sub-locations

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -155,7 +155,7 @@ class ProductProduct(models.Model):
             product.with_context(skip_qty_available_update=True).update({key: val for key, val in res[product.id].items() if val})
 
     def _compute_quantities_dict(self, lot_id, owner_id, package_id, from_date=False, to_date=False):
-        domain_quant_loc, domain_move_in_loc, domain_move_out_loc = self._get_domain_locations()
+        domain_quant_loc, domain_move_in_loc, domain_move_out_loc, domain_move_in_loc_done, domain_move_out_loc_done = self._get_domain_locations()
         domain_quant = [('product_id', 'in', self.ids)] + domain_quant_loc
         dates_in_the_past = False
         # only to_date as to_date will correspond to qty_available
@@ -180,8 +180,12 @@ class ProductProduct(models.Model):
         if package_id is not None:
             domain_quant += [('package_id', '=', package_id)]
         if dates_in_the_past:
-            domain_move_in_done = list(domain_move_in)
-            domain_move_out_done = list(domain_move_out)
+            # Use the done location domains (simple location_dest_id) for move lines
+            domain_move_in_done = [('product_id', 'in', self.ids)] + domain_move_in_loc_done
+            domain_move_out_done = [('product_id', 'in', self.ids)] + domain_move_out_loc_done
+            if owner_id is not None:
+                domain_move_in_done += [('owner_id', '=', owner_id)]
+                domain_move_out_done += [('owner_id', '=', owner_id)]
         if from_date:
             date_date_expected_domain_from = [('date', '>=', from_date)]
             domain_move_in += date_date_expected_domain_from
@@ -191,6 +195,7 @@ class ProductProduct(models.Model):
             domain_move_in += date_date_expected_domain_to
             domain_move_out += date_date_expected_domain_to
         Move = self.env['stock.move'].with_context(active_test=False)
+        MoveLine = self.env['stock.move.line']
         Quant = self.env['stock.quant'].with_context(active_test=False)
         domain_move_in_todo = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))] + domain_move_in
         domain_move_out_todo = [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))] + domain_move_out
@@ -209,12 +214,11 @@ class ProductProduct(models.Model):
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
 
-            groupby = ['product_id', 'uom_id']
-            for product, uom, quantity in Move._read_group(domain_move_in_done, groupby, ['quantity:sum']):
-                moves_in_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
+            for product, quantity in MoveLine._read_group(domain_move_in_done, ['product_id'], ['quantity_product_uom:sum']):
+                moves_in_res_past[product.id] += quantity
 
-            for product, uom, quantity in Move._read_group(domain_move_out_done, groupby, ['quantity:sum']):
-                moves_out_res_past[product.id] += uom._compute_quantity(quantity, product.uom_id)
+            for product, quantity in MoveLine._read_group(domain_move_out_done, ['product_id'], ['quantity_product_uom:sum']):
+                moves_out_res_past[product.id] += quantity
 
         res = dict()
         for product in self.with_context(prefetch_fields=False):
@@ -374,9 +378,9 @@ class ProductProduct(models.Model):
 
         return self._get_domain_locations_new(location_ids)
 
-    def _get_domain_locations_new(self, location_ids) -> tuple[Domain, Domain, Domain]:
+    def _get_domain_locations_new(self, location_ids) -> tuple[Domain, Domain, Domain, Domain, Domain]:
         if not location_ids:
-            return (Domain.FALSE,) * 3
+            return (Domain.FALSE,) * 5
         locations = self.env['stock.location'].browse(location_ids)
         # TDE FIXME: should move the support of child_of + bypass_search_access directly in expression
         # this optimizes [('location_id', 'child_of', locations.ids)]
@@ -386,6 +390,7 @@ class ProductProduct(models.Model):
             loc_domain = Domain('location_id', 'in', locations.ids)
             dest_loc_domain = Domain('location_dest_id', 'in', locations.ids)
             dest_loc_domain_out = Domain('location_dest_id', 'not in', locations.ids)
+            dest_loc_domain_done = dest_loc_domain
         elif locations:
             paths_query = models.Query(locations)
             paths_query.add_where(SQL('%s LIKE ANY(%s)', paths_query.table.parent_path, [[loc.parent_path + '%' for loc in locations]]))
@@ -409,11 +414,14 @@ class ProductProduct(models.Model):
                     '&', ('state', '!=', 'done'), ~dest_loc_domain_in_progress,
             ])
 
-        # returns: (domain_quant_loc, domain_move_in_loc, domain_move_out_loc)
+        # returns: (domain_quant_loc, domain_move_in_loc, domain_move_out_loc,
+        #           domain_move_in_loc_done, domain_move_out_loc_done)
         return (
             loc_domain,
             dest_loc_domain & ~loc_domain,
             loc_domain & dest_loc_domain_out,
+            dest_loc_domain_done & ~loc_domain,
+            loc_domain & ~dest_loc_domain_done,
         )
 
     def _search_qty_available(self, operator, value):

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -141,7 +141,7 @@ class StockWarehouseOrderpoint(models.Model):
         for company in orderpoints_to_compute.company_id:
             company_orderpoints = orderpoints_to_compute.filtered(lambda c: c.company_id == company)
             horizon_date = fields.Date.today() + relativedelta.relativedelta(days=company_orderpoints.get_horizon_days())
-            _, domain_move_in, domain_move_out = company_orderpoints.product_id._get_domain_locations()
+            _, domain_move_in, domain_move_out, __, __ = company_orderpoints.product_id._get_domain_locations()
             domain_move_in = Domain.AND([
                 [('product_id', 'in', company_orderpoints.product_id.ids)],
                 [('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))],
@@ -529,7 +529,7 @@ class StockWarehouseOrderpoint(models.Model):
 
         Move = self.env['stock.move'].with_context(active_test=False)
         Quant = self.env['stock.quant'].with_context(active_test=False)
-        domain_quant, domain_move_in_loc, domain_move_out_loc = all_product_ids._get_domain_locations_new(all_replenish_location_ids.ids)
+        domain_quant, domain_move_in_loc, domain_move_out_loc, __, __ = all_product_ids._get_domain_locations_new(all_replenish_location_ids.ids)
         domain_state = Domain('state', 'in', ('waiting', 'confirmed', 'assigned', 'partially_available'))
         domain_product = Domain('product_id', 'in', all_product_ids.ids)
 

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -2069,22 +2069,22 @@ class TestStockValuation(TestStockValuationCommon):
         self.assertEqual(product.with_context(to_date=Datetime.to_string(date5)).total_value, 1275)
 
         # Edit the quantity done of move1, increase it.
-        # Test a limitation, you can keep the old value but you can't keep the quantity in past
+        # The additional quantity is recorded at date6, not retroactively at date1.
         with freeze_time(date6):
             self._set_quantity(move1, 20)
         self.assertEqual(product.qty_available, 95)
         self.assertEqual(product.total_value, 1425)
 
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date1)).qty_available, 20)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date1)).total_value, 100)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date2)).qty_available, 30)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date2)).total_value, 220)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date3)).qty_available, 15)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date3)).total_value, 145)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date4)).qty_available, -5)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date4)).total_value, -60)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date5)).qty_available, 95)
-        self.assertEqual(product.with_context(to_date=Datetime.to_string(date5)).total_value, 1425)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date1)).qty_available, 10)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date1)).total_value, 50)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date2)).qty_available, 20)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date2)).total_value, 170)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date3)).qty_available, 5)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date3)).total_value, 60)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date4)).qty_available, -15)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date4)).total_value, -180)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date5)).qty_available, 85)
+        self.assertEqual(product.with_context(to_date=Datetime.to_string(date5)).total_value, 1275)
 
     def test_inventory_fifo_1(self):
         """ Make an inventory from a location with a company set, and ensure the product has a stock


### PR DESCRIPTION
Bug:
When querying product quantities at a past date using `to_date` context, the computed qty_available was incorrect for sub-locations. If a single stock.move had multiple stock.move.line records going to different sub-locations, the quantities would be attributed to the move's destination location (parent) rather than the actual sub-locations where the goods were placed via move lines.

Example: A receipt move with location_dest=Stock and product_qty=5, split into two move lines (3 units to Stock/Shelf-A, 2 units to Stock/Shelf-B), would show 5 units at Stock and 0 at each sub-location when querying past quantities, instead of 3 and 2 respectively.

Expected behavior:
Querying qty_available with `to_date` context for a specific location should return the actual quantity that was moved to that location, respecting the move line destinations.

Solution:
In `_compute_quantities_dict`, changed the past date calculation from aggregating `product_qty` on stock.move to aggregating `qty_done` on stock.move.line. This correctly accounts for the actual quantities moved per location.

