### PR TITLE
[FIX] l10n_be_pos_restaurant: fix duplicate taxes on branches restaurant

### DIFF
--- a/addons/l10n_be_pos_restaurant/models/pos_config.py
+++ b/addons/l10n_be_pos_restaurant/models/pos_config.py
@@ -1,4 +1,5 @@
-from odoo import api, models, Command
+from odoo import Command, api, models
+
 
 class PosConfig(models.Model):
     _inherit = 'pos.config'
@@ -10,14 +11,28 @@ class PosConfig(models.Model):
         tax_6 = ChartTemplate.ref('attn_VAT-OUT-06-L', raise_if_not_found=False)
 
         if tax_21 and tax_12 and tax_6:
-            fp = self.env['account.fiscal.position'].create({
-                'name': 'Take out',
-            })
-            tax_6.copy({
-                'name': f"{tax_6.name} Take out",
-                'fiscal_position_ids': [Command.set(fp.ids)],
-                'original_tax_ids': [Command.set((tax_12 | tax_21).ids)],
-            })
+            fp = ChartTemplate.ref('pos_takeout_fp', raise_if_not_found=False)
+            if not fp:
+                fp = self.env['account.fiscal.position'].create({
+                    'name': 'Take out',
+                })
+                self.env['ir.model.data']._update_xmlids([{
+                    'xml_id': ChartTemplate.company_xmlid('pos_takeout_fp'),
+                    'record': fp,
+                    'noupdate': True,
+                }])
+            takeout_tax = ChartTemplate.ref('pos_takeout_tax', raise_if_not_found=False)
+            if not takeout_tax:
+                takeout_tax = tax_6.copy({
+                    'name': f"{tax_6.name} Take out",
+                    'fiscal_position_ids': [Command.set(fp.ids)],
+                    'original_tax_ids': [Command.set((tax_12 | tax_21).ids)],
+                })
+                self.env['ir.model.data']._update_xmlids([{
+                    'xml_id': ChartTemplate.company_xmlid('pos_takeout_tax'),
+                    'record': takeout_tax,
+                    'noupdate': True,
+                }])
             takeaway_preset = self.env.ref('pos_restaurant.pos_takeout_preset', raise_if_not_found=False)
             if takeaway_preset:
                 takeaway_preset.write({'fiscal_position_id': fp.id})


### PR DESCRIPTION
When creating a restaurant with the POS scenario on a company with the Belgian accounting package, we automatically create a new 'Take out' fiscal position and a 'Take out' 6% tax. But when creating a branch for the company and using the same scenario, it will duplicate the 'Take out' fiscal position, and then fail to create because it will try to create a duplicate Tax with the same name and then odoo will complain.

After the fix the scenario checks whether the fiscal position and tax already exist on the company, and if they do, it doesn't recreate them. This should let branches use the scenario and then they can use the already existing taxes and FPs.

Task [link](https://www.odoo.com/odoo/project.task/5502948)
Task-5502948