### PR TITLE
[FIX] stock: prevent crash in forecast report with archived variants

### DIFF
--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -24,7 +24,7 @@ class StockForecasted_Product_Product(models.AbstractModel):
 
     def _product_domain(self, product_template_ids, product_ids):
         if product_template_ids:
-            return [('product_tmpl_id', 'in', product_template_ids)]
+            return [('product_tmpl_id', 'in', product_template_ids), ('product_id.active', '=', True)]
         return [('product_id', 'in', product_ids)]
 
     def _move_domain(self, product_template_ids, product_ids, wh_location_ids):

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -1041,8 +1041,9 @@ class TestReports(TestReportsCommon):
         delivery = delivery_form.save()
         delivery.action_confirm()
 
+        gamejoy_pocket_blue.action_archive()
         report_values, docs, lines = self.get_report_forecast(product_template_ids=product_template.ids)
-        self.assertEqual(len(lines), 8, "Still must have 8 lines.")
+        self.assertEqual(len(lines), 6, "Must exclude the archived product and therefore have 6 lines")
         self.assertEqual(docs['product_variants_ids'], product_template.product_variant_ids.ids)
         # 2 lines should be about the "Game Joy Pocket (gray)"
         # and must link the delivery with the two receipt lines.


### PR DESCRIPTION
Currently, accessing the Forecast report on a Product Template causes a crash if the template contains an archived variant that still has active stock moves (e.g., a pending delivery).

## **Steps to Reproduce:**
1) Install `stock` with demo data.
2) Create a Delivery orders(stock picking) for product `conference chair(E-COM12)`
   with demand of 40 qty, click on `Mark as todo`.
3) Navigate to `stock>products>products` and open `conference chair` product form
   view.
4) From the variant smart button archive `E-COM12` variant.
5) Navigate back to product form view and click on `forecast` smart button.

## **Error:**
`TypeError: Cannot read properties of undefined (reading 'free_qty')`

## **Root Cause:**
`this.props.docs.product[line]` at [1] is undefined because the server did not
include an entry for that product id in the report header.

### **Complete Flow:**

On clicking the Forecast button an ORM call is made to [_get_report_values](https://github.com/odoo/odoo/blob/0dd40ede75f68b18192738f0d20aadaac9f348c7/addons/stock/report/stock_forecasted.py#L512-L519),
which calls [_get_report_data](https://github.com/odoo/odoo/blob/0dd40ede75f68b18192738f0d20aadaac9f348c7/addons/stock/report/stock_forecasted.py#L156-L172) to build the report data.

#### **Header Part:**
- [_get_report_header](https://github.com/odoo/odoo/blob/0dd40ede75f68b18192738f0d20aadaac9f348c7/addons/stock/report/stock_forecasted.py#L112-L144) returns metadata only for active variants because,
  [_get_product_quantity](https://github.com/odoo/odoo/blob/0dd40ede75f68b18192738f0d20aadaac9f348c7/addons/stock/report/stock_forecasted.py#L69-L72) is called which calls _get_products(see[2]), and _get_products only
  returns active variants for the product template.

#### **Lines Part:**
- [_get_product_lines](https://github.com/odoo/odoo/blob/82fe034509a6b401e86c345a82aa7b8948294e52/addons/stock/report/stock_forecasted.py#L239) iterates over products coming from the move search
  and it includes both archived and unarchived variants.
  [_move_confirmed_domain](https://github.com/odoo/odoo/blob/82fe034509a6b401e86c345a82aa7b8948294e52/addons/stock/report/stock_forecasted.py#L55-L56) calls _move_domain(see[3]), which searches stock.move using
  product_tmpl_id when given a template id and therefore returns moves for
  every variant of the template (archived or not).

#### **Why the mismatch happens:**
- `_get_products` fetches variants using `browse()` which by default excludes archived variants.
  `_product_domain`(see[3]) uses product_tmpl_id when given product_template_ids,
  which matches moves for all variants of the template. As a result, moves can reference
  archived variant ids that the header never listed.

[1]- https://github.com/odoo/odoo/blob/0dd40ede75f68b18192738f0d20aadaac9f348c7/addons/stock/static/src/stock_forecasted/forecasted_details.js#L188

[2]- https://github.com/odoo/odoo/blob/82fe034509a6b401e86c345a82aa7b8948294e52/addons/stock/report/stock_forecasted.py#L61-L67

[3]- https://github.com/odoo/odoo/blob/82fe034509a6b401e86c345a82aa7b8948294e52/addons/stock/report/stock_forecasted.py#L25-L31

## **Fix:**
- This commit ensures that archived product variants are excluded directly
  at move search level by appending `('product_id.active', '=', True)` to
  the product domain used by the forecast report. This ensures that only
  active product variants are considered when fetching stock moves.

### **opw-5440872**