### PR TITLE
[IMP] im_livechat: remove chat hub options for public users

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_button.xml
+++ b/addons/im_livechat/static/src/embed/common/livechat_button.xml
@@ -9,7 +9,7 @@
         t-attf-style="color: {{livechatService.options.button_text_color}}; background-color: {{livechatService.options.button_background_color}};"
         t-ref="button"
         t-on-click="onClick"
-        title="Drag to Move"
+        title="Chat with us"
     >
         <i class="fa fa-commenting" style="font-size: 22px;"/>
         <div t-if="store.livechat_rule?.action === 'display_button_and_text'" class="o-livechat-LivechatButton-notification text-nowrap position-absolute bg-100 py-2 px-3 rounded" style="max-width: 75vw;" t-att-class="{'o-livechat-LivechatButton-animate': state.animateNotification}">

--- a/addons/im_livechat/static/tests/embed/feedback_panel.test.js
+++ b/addons/im_livechat/static/tests/embed/feedback_panel.test.js
@@ -116,7 +116,6 @@ test("Closing folded chat window should open it with feedback", async () => {
     await click(".o-mail-ChatBubble");
     await click("[title*='Close Chat Window']");
     await click(".o-livechat-CloseConfirmation-leave");
-    await click(".o-mail-ChatHub-bubbleBtn");
     await contains(".o-mail-ChatWindow p", { text: "Did we correctly answer your question?" });
 });
 

--- a/addons/im_livechat/static/tests/tours/support/im_livechat_basic_tour.js
+++ b/addons/im_livechat/static/tests/tours/support/im_livechat_basic_tour.js
@@ -6,7 +6,7 @@ registry.category("web_tour.tours").add("im_livechat.basic_tour", {
             trigger: ".channel_name:contains(Support Channel)",
         },
         {
-            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton[title='Chat with us']",
             run: "click",
         },
         {

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -73,28 +73,30 @@ export class ChatHub extends Component {
     get optionActions() {
         const actions = [];
         if (this.chatHub.showConversations && !this.chatHub.compact) {
-            actions.push(
-                new Action({
-                    owner: this,
-                    id: "hide-all",
-                    definition: {
-                        name: _t("Hide all conversations"),
-                        icon: "fa fa-eye-slash",
-                        onSelected: () => this.chatHub.hideAll(),
-                    },
-                    store: this.store,
-                }),
-                new Action({
-                    owner: this,
-                    id: "close-all",
-                    definition: {
-                        name: _t("Close all conversations"),
-                        icon: "oi oi-close",
-                        onSelected: () => this.chatHub.closeAll(),
-                    },
-                    store: this.store,
-                })
-            );
+            if (this.store.self_user?.share === false) {
+                actions.push(
+                    new Action({
+                        owner: this,
+                        id: "hide-all",
+                        definition: {
+                            name: _t("Hide all conversations"),
+                            icon: "fa fa-eye-slash",
+                            onSelected: () => this.chatHub.hideAll(),
+                        },
+                        store: this.store,
+                    }),
+                    new Action({
+                        owner: this,
+                        id: "close-all",
+                        definition: {
+                            name: _t("Close all conversations"),
+                            icon: "oi oi-close",
+                            onSelected: () => this.chatHub.closeAll(),
+                        },
+                        store: this.store,
+                    })
+                );
+            }
         }
         if (this.position.dragged) {
             actions.push(

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -1,6 +1,9 @@
 .o-mail-ChatHub-bubbles {
     width: $o-mail-ChatHub-bubblesWidth;
     z-index: $o-mail-NavigableList-zIndex - 1;
+}
+
+.o-mail-ChatHub:not(.o-dragged) .o-mail-ChatHub-bubbles {
     bottom: calc(#{var(--mail-ChatHub-bubbles-bottom, 0px)} + #{var(--mail-ChatHub-bubbles-bottomLift, 0px)});
 
     &.o-liftUp {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatHub">
-    <div class="o-mail-ChatHub d-print-none" t-ref="root">
+    <div class="o-mail-ChatHub d-print-none" t-att-class="{'o-dragged': position.dragged}" t-ref="root">
         <t t-set="visibleChatWindows" t-value="chatHub.compact ? chatHub.opened.filter(({ bypassCompact }) => bypassCompact) : chatHub.opened "/>
         <t t-foreach="visibleChatWindows" t-as="cw" t-key="cw.localId">
             <ChatWindow chatWindow="cw" t-if="cw.canShow" right="chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2)"/>
         </t>
         <div class="o-mail-ChatHub-bubbles position-fixed d-flex flex-column align-content-start justify-content-end align-items-center" t-attf-style="top: {{position.top}}; left: {{position.left}}; right: {{position.right}}; --mail-ChatHub-bubbles-bottom: {{position.bottom}}" t-att-class="{ 'o-liftUp': busMonitoring.hasConnectionIssues, 'o-mobile': isMobileOS }" t-ref="bubbles">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center o-gap-1_5">
-                <Dropdown t-if="(chatHub.showConversations and !chatHub.compact) or position.dragged" state="options" position="'top-end'" menuClass="'m-0 mb-1 ' + store.discussDropdownMenuClass(this)">
+                <Dropdown t-if="optionActions.length" state="options" position="'top-end'" menuClass="'m-0 mb-1 ' + store.discussDropdownMenuClass(this)">
                     <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn bg-100 mt-1" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !position.dragged and !options.isOpen and !isMobileOS, 'o-bubblesHover': (bubblesHover.isHover or position.dragged) and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"><i class="oi oi-ellipsis-h"/></button>
                     <t t-set-slot="content">
                         <ActionList actions="optionActions" dropdown="true"/>


### PR DESCRIPTION
Public users aren't supposed to have many chats active at a time.
For this reason, the chat hub options are overkill and more distracting
than helpful.

This commit removes the chat hub options for non-internal users.

At the same time, this commit fixes the chat hub drag feature that
was not working with `o-liftUp` since [1]. Once the chat hub has
been dragged, we should not move it programatically anymore.

part of task-5867464

[1]: https://github.com/odoo/odoo/pull/225757