### PR TITLE
[FIX] l10n_sa_edi: improve error-handling mechanism

### DIFF
--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -311,8 +311,11 @@ class AccountJournal(models.Model):
 
         CCSID_data = json.loads(self_sudo.l10n_sa_compliance_csid_json)
         PCSID_data = self_sudo._l10n_sa_request_production_csid(CCSID_data, renew, OTP)
-        if PCSID_data.get('error'):
-            raise UserError(_("Could not obtain Production CSID: %s", PCSID_data['error']))
+        if PCSID_data.get('error') or PCSID_data.get('errors'):
+            raise UserError(_(
+                "Could not obtain Production CSID: %s",
+                PCSID_data['errors'][0] if PCSID_data.get('errors') else PCSID_data['error']
+            ))
         self_sudo.l10n_sa_production_csid_json = json.dumps(PCSID_data)
 
     # ====== Compliance Checks =======


### PR DESCRIPTION
This PR is essentially a backport of
https://github.com/odoo/odoo/pull/242810.

Original comment:
Whenever an error occurs during the ZATCA onboarding steps—such as providing a company name that exceeds 127 bytes in binary representation (for example, 64 Arabic characters without whitespace result in exactly 127 bytes; see refs [1] and [2])—the system returns a traceback to the user instead of a clear and user-friendly error message.

Error:
`TypeError: argument should be a bytes-like object or ASCII string, not 'NoneType'

This is due to the check-in `_l10n_sa_get_production_CSID` for an 'error' key, not present in the response when an OTP is invalid because in these cases, the `_l10n_sa_call_api` returns the response_data directly.

This fix improves the behaviour by displaying a user-friendly alert message with the error returned by ZATCA, instead of a traceback.

This ensures a better experience and compliance with CCSID onboarding flows.

[1]: https://zatca1.discourse.group/t/organization-name-is-too-long-issue-csr/7571
[2]: https://zatca1.discourse.group/t/organisation-name-with-restriction-of-64-characters/960

opw-5228665
