### PR TITLE
[FIX] mrp: mrp production kanban qty

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -575,8 +575,8 @@
                             <div class="d-flex mb-1">
                                 <field name="priority" widget="priority"/>
                                 <field name="product_id" class="fw-bolder fs-6 ms-1"/>
-                                <field name="product_qty" class="ms-auto"/>
-                                <field name="product_uom_id" class="small ms-1" groups="uom.group_uom"/>
+                                <field name="product_qty" class="ms-auto flex-shrink-0"/>
+                                <field name="product_uom_id" class="small ms-1 flex-shrink-0" groups="uom.group_uom"/>
                             </div>
                             <footer class="text-muted">
                                 <div class="d-flex">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On MRP production kanban, if the name of the
product is too long, `product_qty` and
`product_uom_id` fields on the card shrink and
become unreadable.

This adds proper classes to keep those fields from shrinking no matter how long product's name is.

Current behavior before PR:
<img width="1561" height="303" alt="image" src="https://github.com/user-attachments/assets/08e299be-c6e2-4241-b289-aaa2fab9a94f" />


Desired behavior after PR is merged:
- The size of the product's name should be fine no matter how long the name of the product is.
- The `product_qty` and `product_uom_id` should not shrink if the name of the product is long.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
