### PR TITLE
[FIX] hr_work_entry: generation issue

### DIFF
--- a/addons/hr_work_entry/models/hr_version.py
+++ b/addons/hr_work_entry/models/hr_version.py
@@ -442,8 +442,6 @@ class HrVersion(models.Model):
                 version_start = tz.localize(fields.Datetime.to_datetime(version.date_start)).astimezone(pytz.utc).replace(tzinfo=None)
                 version_stop = tz.localize(datetime.combine(fields.Datetime.to_datetime(version.date_end or date_stop),
                                                  datetime.max.time())).astimezone(pytz.utc).replace(tzinfo=None)
-                if version_stop < date_start:
-                    continue
                 if version_stop < date_stop:
                     if version.date_generated_from != version.date_generated_to:
                         domain_to_nullify |= Domain([

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -93,17 +93,9 @@ class HrWorkEntry(models.Model):
     @api.model
     def _set_current_contract(self, vals):
         if not vals.get('version_id') and vals.get('date') and vals.get('employee_id'):
-            contract_start = fields.Datetime.to_datetime(vals.get('date'))
-            contract_end = contract_start
             employee = self.env['hr.employee'].browse(vals.get('employee_id'))
-            contracts = employee._get_versions_with_contract_overlap_with_period(contract_start, contract_end)
-            if not contracts:
-                raise ValidationError(_(
-                    "%(employee)s does not have a contract on %(date)s.",
-                    employee=employee.name,
-                    date=contract_start,
-                ))
-            return dict(vals, version_id=contracts[0].id)
+            active_version = employee._get_version(vals['date'])
+            return dict(vals, version_id=active_version.id)
         return vals
 
     @api.model

--- a/addons/hr_work_entry/tests/test_hr_work_entry.py
+++ b/addons/hr_work_entry/tests/test_hr_work_entry.py
@@ -24,6 +24,7 @@ class TestHrWorkEntry(TransactionCase):
             'contract_date_start': '2023-01-01',
             'date_version': '2023-01-01',
         })
+        cls.employee_a_first_version = cls.employee_a.version_ids[0]
         cls.employee_b = cls.env['hr.employee'].create({
             'name': 'Employee B',
             'company_id': cls.company_b.id,
@@ -138,3 +139,45 @@ class TestHrWorkEntry(TransactionCase):
             ('date', '<=', date(2024, 1, 31)),
         ])
         self.assertEqual(january_work_entries, new_january_work_entries)
+
+    def test_nullify_work_entry(self):
+        """
+        Test that we correctly nullify the work entries that were previously generated when we add a new version
+        """
+        january_work_entries = self.employee_a.generate_work_entries(date(2024, 1, 1), date(2024, 1, 31))
+        self.assertTrue(all(we.version_id == self.employee_a_first_version for we in january_work_entries))
+
+        second_version = self.employee_a.create_version({
+            'date_version': date(2023, 12, 1)
+        })
+        self.employee_a.generate_work_entries(date(2024, 1, 1), date(2024, 1, 31))
+
+        all_january_work_entries = self.env['hr.work.entry'].search([
+            ('employee_id', '=', self.employee_a.id),
+            ('date', '>=', date(2024, 1, 1)),
+            ('date', '<=', date(2024, 1, 31)),
+        ])
+
+        self.assertEqual(len(all_january_work_entries), 23)
+        self.assertTrue(all(we.version_id == second_version for we in all_january_work_entries))
+
+    def test_work_entry_version_id(self):
+        """
+        Test that we correctly set the version_id field of the work entry depending on the date
+        """
+        second_version = self.employee_a.create_version({
+            'date_version': date(2023, 12, 1)
+        })
+
+        v1_we, v2_we = self.env['hr.work.entry'].create([
+            {
+                'date': date(2023, 10, 1),
+                'employee_id': self.employee_a.id,
+            },
+            {
+                'date': date(2024, 1, 1),
+                'employee_id': self.employee_a.id,
+            }
+        ])
+        self.assertEqual(v1_we.version_id, self.employee_a_first_version)
+        self.assertEqual(v2_we.version_id, second_version)

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
@@ -95,7 +95,6 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
         return ['active']
 
     def regenerate_work_entries(self, slots=None, record_ids=None):
-        write_vals = {field: False for field in self._work_entry_fields_to_nullify()}
         if not slots:
             if not self.env.context.get('work_entry_skip_validation'):
                 if not self.search_criteria_completed:
@@ -123,8 +122,6 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
                         start = current
                     end = current
                 range_by_employee[start, end].append(employee_id)
-            work_entries = self.env['hr.work.entry'].browse(record_ids)
-            work_entries.write(write_vals)
             for (date_from, date_to), employee_ids in range_by_employee.items():
                 valid_employees = self.env["hr.employee"].browse(employee_ids)
                 valid_employees.generate_work_entries(date_from, date_to, True)


### PR DESCRIPTION
Problem
----------
3 issues :
- If you generate work entries for a new version it will not nullify the already generated work entries for the previous active version.
- The version_id on the work entry is not set to the active version at the date of the work entry
- The regenerate hasn't the same behavior if you call it from the wizard or from the front.

Fix
----------
Remove the skip of versions that ends before the date_start of the generation. To go through the nullify process. Remove the double nullify in the regenerate in the case we have slots (we don't come from the wizard) Correct the `_set_current_contract` to give the good version for the date.
