### PR TITLE
[FIX] {project_mrp,stock}_account: resurrect tests

### DIFF
--- a/addons/project_mrp_account/models/mrp_production.py
+++ b/addons/project_mrp_account/models/mrp_production.py
@@ -28,5 +28,6 @@ class MrpProduction(models.Model):
         res = super().write(vals)
         for production in self:
             if 'project_id' in vals and production.state != 'draft':
+                production.move_raw_ids._create_analytic_move()
                 production.workorder_ids._create_or_update_analytic_entry()
         return res

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -1,13 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from unittest import skip
-
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tests import Form
 
 
-@skip('Temporary to fast merge new valuation')
 class TestMrpAnalyticAccount(TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -11,6 +11,11 @@ class StockMoveLine(models.Model):
         return mls
 
     def write(self, vals):
+        analytic_move_to_recompute = set()
+        if 'quantity' in vals or 'move_id' in vals:
+            for move_line in self:
+                move_id = vals.get('move_id', move_line.move_id.id)
+                analytic_move_to_recompute.add(move_id)
         valuation_fields = ['quantity', 'location_id', 'location_dest_id', 'owner_id', 'quant_id', 'lot_id']
         valuation_trigger = any(field in vals for field in valuation_fields)
         qty_by_ml = {}
@@ -19,6 +24,14 @@ class StockMoveLine(models.Model):
         res = super().write(vals)
         if valuation_trigger and qty_by_ml:
             self._update_stock_move_value(qty_by_ml)
+        if analytic_move_to_recompute:
+            self.env['stock.move'].browse(analytic_move_to_recompute).sudo()._create_analytic_move()
+        return res
+
+    def unlink(self):
+        analytic_move_to_recompute = self.move_id
+        res = super().unlink()
+        analytic_move_to_recompute.sudo()._create_analytic_move()
         return res
 
     @api.model


### PR DESCRIPTION
Bring back all tests temporarily disabled by [1]. Below are the
explanations about the needed changes in the code.

---
Change in `/project_mrp_account:MrpProduction.write`
Tested by `/project_mrp_account.test_changing_mo_analytic_account`

In the test, when changing the project of the MO:
https://github.com/odoo/odoo/blob/08b62a4bbcc6f9a391b2cc00a621ef4c76100229/addons/project_mrp_account/tests/test_analytic_account.py#L211-L212
We reach the override in `project_mrp_account`. On Odoo 18.0, a line
calls the method `_account_analytic_entry_move`:
https://github.com/odoo/odoo/blob/706431510110a005618a2acaf6566f2bb61d5114/addons/project_mrp_account/models/mrp_production.py#L31
This line is in charge of creating AA/AAL related to the SM. However,
the commit [1] has removed `account_analytic_entry_move` and all its
calls. This is why the test fails in the first assert:
https://github.com/odoo/odoo/blob/08b62a4bbcc6f9a391b2cc00a621ef4c76100229/addons/project_mrp_account/tests/test_analytic_account.py#L210
It doesn't find anything. However, the commit [2] brings the method
back with a brand-new name: `_create_analytic_move`. We therefore
need to connect it again where it is needed.

---
Change in `/stock_account:StockMoveLine.write`
Tested by `/project_mrp_account.test_update_components_qty_to_0`

Quite the same as above. Commit [1] removes this while it's actually
needed. One difference, a `sudo` call, because a stock user doesn't
have any access to analytic world.

---
Change in `/stock_account:StockMoveLine.unlink`
Tested by `/project_mrp_account.test_mo_qty_analytics`

Same as above, also with a new `sudo`.

---

[1] https://github.com/odoo/odoo/commit/08b62a4bbcc6f9a391b2cc00a621ef4c76100229
[2] 35db55618fa70146afc89e662410aca95947e17b