### PR TITLE
[FIX] sale: conditional display of sections containing combos in sale preview

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1549,7 +1549,11 @@ class SaleOrderLine(models.Model):
         """
         self.ensure_one()
 
-        section_lines = self.order_id.order_line.filtered(self._is_line_in_section)
+        billable_lines = self.order_id.order_line.filtered(
+            lambda line:
+                line.product_type != 'combo'
+                and self._is_line_in_section(line)
+        )
 
         if display_taxes:
             res = [
@@ -1558,13 +1562,13 @@ class SaleOrderLine(models.Model):
                     'price_subtotal': sum(lines.mapped('price_subtotal')),
                     'price_total': sum(lines.mapped('price_total')),
                 }
-                for taxes, lines in section_lines.grouped('tax_ids').items()
+                for taxes, lines in billable_lines.grouped('tax_ids').items()
             ]
         else:
             res = [{
                 'tax_labels': [],
-                'price_subtotal': sum(section_lines.mapped('price_subtotal')),
-                'price_total': sum(section_lines.mapped('price_total')),
+                'price_subtotal': sum(billable_lines.mapped('price_subtotal')),
+                'price_total': sum(billable_lines.mapped('price_total')),
             }]
         return res or [{
             'tax_labels': [],


### PR DESCRIPTION
**Behavior:**
When a combo product is added under a section and the 'Hide Composition' option is selected the system will try to get a list of the prices grouped by different taxes, however since combo items usually don't cost anything and are not under any tax group, the quotation preview will try show the section's total prices under no tax which will likely amount to 0$ This results in a bloated preview.

Solution:
Only accept a grouping under a specific tax (be it no tax or a real tax) if the total price != 0$

**Steps to reproduce:**
- Create a combo product containing a product that is taxed
- Create a quote with a section
- Add the product under the section
- Check 'Hide Composition' in the section's options
- Preview the sale
- You'll notice the section duplicated with no tax and no price

opw-5481931