### PR TITLE
[FIX] mass_mailing: fix columns block layout in received emails

### DIFF
--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -332,7 +332,12 @@ export class MassMailingHtmlField extends HtmlField {
         const shouldRestoreDisplayNone = this.iframeRef.el.classList.contains("d-none");
         // d-none must be removed for style computation.
         this.iframeRef.el.classList.remove("d-none");
-        this.iframeRef.el.style.width = "1320px";
+        // The browser resets the size of the `iframe` inside `toInline`
+        // if we just set `width`. So as a workaround we set both `min-width`
+        // and `max-width` to force the size of the `iframe` for a proper
+        // inline conversion.
+        this.iframeRef.el.style.setProperty("min-width", "1320px", "important");
+        this.iframeRef.el.style.setProperty("max-width", "1320px", "important");
         const processingEl = this.iframeRef.el.contentDocument.createElement("DIV");
         processingEl.append(parseHTML(this.iframeRef.el.contentDocument, value));
         const processingContainer = this.iframeRef.el.contentDocument.querySelector(
@@ -346,7 +351,8 @@ export class MassMailingHtmlField extends HtmlField {
         const inlineValue = processingEl.innerHTML;
         processingEl.remove();
         bundleControls["mass_mailing.assets_inside_builder_iframe"]?.toggle(true);
-        this.iframeRef.el.style.width = "";
+        this.iframeRef.el.style.minWidth = "";
+        this.iframeRef.el.style.maxWidth = "";
         if (shouldRestoreDisplayNone) {
             this.iframeRef.el.classList.add("d-none");
         }


### PR DESCRIPTION
Problem:
When adding a Columns block, the received email layout differs from the editor preview and appears broken.

Cause:
The iframe used for processing the editable content did not have its size properly set before conversion. This leads to incorrect calculations during the conversion to inline styles, resulting in extra spacing and misaligned columns.

Solution:
Force the iframe to the correct size before running the conversion. This ensures that the inline-styled email matches the editor layout.

Steps to reproduce:
- Add a Columns block in email marketing.
- Send the email.
- Observe that the received email shows columns with extra space and misalignment.

opw-5490792

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
