### PR TITLE
[FIX] web: introduce folded column mobile layout

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -285,50 +285,53 @@
 
     // Kanban Grouped Layout - Column Folded
     .o_kanban_group.o_column_folded {
+        --KanbanGroup-padding-h: 0;
+
+        @include media-breakpoint-down(md) {
+            min-width: 2.5rem;
+        }
 
         // don't fill the width of record for a folded column
         .o_kanban_record.o_draggable {
             display: none !important;
         }
-        // don't visually fold on smaller screens (aka. mobile)
-        @include media-breakpoint-up(md) {
-            --KanbanGroup-padding-h: 0;
 
+        @include media-breakpoint-up(md) {
             &, .o_column_unfold {
                 cursor: col-resize;
             }
+        }
 
-            & + .o_kanban_group.o_column_folded {
-                margin-left: 1px;
+        & + .o_kanban_group.o_column_folded {
+            margin-left: 1px;
+        }
+
+        .o_kanban_header {
+            padding: 0 floor($o-kanban-group-padding * 0.7);
+        }
+
+        button.o_column_unfold {
+            padding: 0 .15rem;
+            height: map-get($font-sizes, 4) * $line-height-lg;
+
+            .fa-caret-left {
+                margin-right: 0.2rem;
             }
+        }
 
-            .o_kanban_header {
-                padding: 0 floor($o-kanban-group-padding * 0.7);
+        &:hover button.o_column_unfold {
+            padding: 0;
+
+            .fa-caret-left {
+                margin-right: 0.5rem;
             }
+        }
 
-            button.o_column_unfold {
-                padding: 0 .15rem;
-                height: map-get($font-sizes, 4) * $line-height-lg;
-
-                .fa-caret-left {
-                    margin-right: 0.2rem;
-                }
-            }
-
-            &:hover button.o_column_unfold {
-                padding: 0;
-
-                .fa-caret-left {
-                    margin-right: 0.5rem;
-                }
-            }
-
-            .o_column_title {
-                @include o-position-absolute(map-get($spacers, 3));
-                transform-origin: left bottom 0;
-                transform: rotate(90deg);
-                overflow: visible;
-            }
+        .o_column_title {
+            @include o-position-absolute(map-get($spacers, 3));
+            transform-origin: left bottom 0;
+            transform: rotate(90deg);
+            overflow: visible;
         }
     }
 

--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -4,7 +4,7 @@
     <t t-name="web.KanbanHeader">
         <div class="o_kanban_header position-sticky top-0 z-1" t-ref="root" t-attf-class="{{ !env.isSmall and group.isFolded ? 'd-print-none pt-2' : 'py-2 pt-print-0' }}">
             <div class="o_kanban_header_title position-relative d-flex lh-lg">
-                <div t-if="group.isFolded" class="o_column_title d-flex align-items-center pt-1 fs-4 lh-1 text-nowrap opacity-50 opacity-100-hover flex-grow-1 gap-1"
+                <div t-if="group.isFolded" class="o_column_title d-flex align-items-center pt-1 fs-4 lh-1 text-nowrap opacity-50 flex-grow-1 gap-1"
                      t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave">
                     <t t-esc="group.displayName"></t>
                     <span t-if="group.count > 0 and !props.list.model.useSampleModel" t-esc="'(' + group.count + ')'"/>
@@ -17,17 +17,17 @@
                     <span t-if="!progressBar and !props.list.model.useSampleModel" t-esc="'(' + group.count + ')'"/>
                 </div>
                 <t t-if="env.isSmall or !group.isFolded">
-                    <GroupConfigMenu t-props="configMenuProps"/>
-                    <button t-if="canQuickCreate()" class="o_kanban_quick_add d-print-none btn pe-2 me-n2" t-on-click="() => this.quickCreate()">
+                    <GroupConfigMenu t-props="configMenuProps" t-if="!group.isFolded"/>
+                    <button t-if="canQuickCreate() and !group.isFolded" class="o_kanban_quick_add d-print-none btn pe-2 me-n2" t-on-click="() => this.quickCreate()">
                         <i class="fa fa-plus opacity-75 opacity-100-hover" role="img" aria-label="Quick add" title="Quick add"/>
                     </button>
                 </t>
-                <button t-else="" class="o_column_unfold btn d-flex align-items-center justify-content-between flex-nowrap transition-base">
+                <button t-else="" class="o_column_unfold btn d-none d-md-flex align-items-center justify-content-between flex-nowrap transition-base">
                     <i class="fa fa-caret-left transition-base" role="img" aria-label="Unfold" title="Unfold" />
                     <i class="fa fa-caret-right" role="img" aria-label="Unfold" title="Unfold" />
                 </button>
             </div>
-            <div t-if="(env.isSmall or !group.isFolded) and progressBar" class="o_kanban_counter position-relative d-flex align-items-center justify-content-between" t-att-class="{ 'opacity-25': !group.count }">
+            <div t-if="((env.isSmall and !group.isFolded) or !group.isFolded) and progressBar" class="o_kanban_counter position-relative d-flex align-items-center justify-content-between" t-att-class="{ 'opacity-25': !group.count }">
                 <ColumnProgress group="group" progressBar="progressBar" aggregate="groupAggregate" onBarClicked.bind="onBarClicked" />
             </div>
         </div>

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -19,6 +19,7 @@ import { KanbanRecord } from "./kanban_record";
 import { KanbanRecordQuickCreate } from "./kanban_record_quick_create";
 import { Widget } from "@web/views/widgets/widget";
 import { ActionHelper } from "@web/views/action_helper";
+import { useDebounced } from '@web/core/utils/timing';
 
 const DRAGGABLE_GROUP_TYPES = ["many2one"];
 
@@ -82,6 +83,7 @@ export class KanbanRenderer extends Component {
             processedIds: [],
             columnQuickCreateIsFolded:
                 !this.props.list.isGrouped || this.props.list.groups.length > 0,
+            isSmall: this.env.isSmall,
         });
         this.dialog = useService("dialog");
         this.exampleData = registry
@@ -236,15 +238,19 @@ export class KanbanRenderer extends Component {
         const handleAltKeyUp = () => {
             this.state.selectionAvailable = false;
         };
+
+        this.debouncedOnResize = useDebounced(this.updateSize, 300);
         useEffect(
             () => {
                 window.addEventListener("keydown", handleAltKeyDown);
                 window.addEventListener("keyup", handleAltKeyUp);
                 window.addEventListener("blur", handleAltKeyUp);
+                window.addEventListener('resize', this.debouncedOnResize);
                 return () => {
                     window.removeEventListener("keydown", handleAltKeyDown);
                     window.removeEventListener("keyup", handleAltKeyUp);
                     window.removeEventListener("blur", handleAltKeyUp);
+                    window.removeEventListener('resize', this.debouncedOnResize);
                 };
             },
             () => []
@@ -284,7 +290,7 @@ export class KanbanRenderer extends Component {
     // ------------------------------------------------------------------------
 
     get canUseSortable() {
-        return !this.env.isSmall;
+        return !this.state.isSmall;
     }
 
     get canMoveRecords() {
@@ -387,13 +393,13 @@ export class KanbanRenderer extends Component {
      */
     getGroupClasses(group, isGroupProcessing) {
         const classes = [];
-        if (!isGroupProcessing && this.canResequenceGroups && group.value) {
+        if (!isGroupProcessing && this.canResequenceGroups && group.value && !this.state.isSmall) {
             classes.push("o_group_draggable");
         }
         if (!group.count) {
             classes.push("o_kanban_no_records");
         }
-        if (!this.env.isSmall && group.isFolded) {
+        if (group.isFolded) {
             classes.push("o_column_folded", "flex-basis-0");
         }
         if (this.props.progressBarState && !group.isFolded) {
@@ -528,7 +534,7 @@ export class KanbanRenderer extends Component {
     // ------------------------------------------------------------------------
 
     async onGroupClick(group, ev) {
-        if (!this.env.isSmall && group.isFolded) {
+        if (!this.state.isSmall && group.isFolded) {
             this.lastOpenedGroupId = group.id;
             await group.toggle();
             this.props.scrollTop();
@@ -709,5 +715,13 @@ export class KanbanRenderer extends Component {
             nextCard.focus();
             return true;
         }
+    }
+
+    /**
+     *
+     * @return {void}
+     */
+    updateSize() {
+        this.state.isSmall = this.env.isSmall;
     }
 }

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -12,7 +12,7 @@
                     <t t-set="isGroupProcessing" t-value="isProcessing(group.id)" />
                     <div class="o_kanban_group"
                         t-att-class="getGroupClasses(group, isGroupProcessing)"
-                        t-attf-class="{{ !env.isSmall and group.isFolded ? 'opacity-trigger-hover' : '' }}"
+                        t-attf-class="{{ !this.state.isSmall and group.isFolded ? 'opacity-trigger-hover' : '' }}"
                         t-att-data-id="group.id"
                         t-on-click="(ev) => this.onGroupClick(group, ev)"
                     >
@@ -61,7 +61,7 @@
                                 <button class="btn btn-outline-primary w-100 mt-4" t-on-click="() => this.loadMore(group)">Load more... (<t t-out="unloadedCount"/> remaining)</button>
                             </div>
                         </t>
-                        <t t-elif="env.isSmall">
+                        <t t-elif="this.state.isSmall">
                             <t t-set="unloadedCount" t-value="getGroupUnloadedCount(group)" />
                             <div t-if="unloadedCount > 0" class="o_kanban_load_more">
                                 <button class="btn btn-outline-primary w-100 mt-4" t-on-click="() => this.toggleGroup(group)">Load more... (<t t-out="unloadedCount"/> remaining)</button>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -13466,7 +13466,7 @@ test("Should load grouped kanban with folded column", async () => {
                 </kanban>`,
         groupBy: ["product_id"],
     });
-    expect(".o_column_progress").toHaveCount(2, { message: "Should have 2 progress bar" });
+    expect(".o_column_progress").toHaveCount(1, { message: "Should have 1 progress bar" });
     expect(".o_kanban_group").toHaveCount(2, { message: "Should have 2 grouped column" });
     expect(".o_kanban_record").toHaveCount(2, { message: "Should have 2 loaded record" });
     expect(".o_kanban_load_more").toHaveCount(1, {


### PR DESCRIPTION
Before this PR, when a user pinned the browser window to one side (using another app side by side), any folded column would still be displayed empty and with a large size, even though the folding functionality is not available on mobile.

With this update, the folded column layout is fixed on mobile and the unfold button is now hidden, as this functionality is not available.

task-5391942

ent-PR: https://github.com/odoo/enterprise/pull/107144

| Before | After |
|--------|--------|
| <img width="390" height="844" alt="Pipeline-02-11-2026_01_20_PM" src="https://github.com/user-attachments/assets/08012e1c-ce22-4ead-ad9d-1a67bc6877f7" /> | <img width="390" height="844" alt="Pipeline-02-11-2026_02_41_PM" src="https://github.com/user-attachments/assets/f5ab3997-ebdc-4d50-af0d-77279d0f77d2" /> |

---





I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
