### PR TITLE
Master enhance partner page dtda

### DIFF
--- a/addons/website_crm_partner_assign/static/src/website_builder/website_crm_partner_assign_option.js
+++ b/addons/website_crm_partner_assign/static/src/website_builder/website_crm_partner_assign_option.js
@@ -1,12 +1,13 @@
 import { useState } from "@web/owl2/utils";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
-import { onWillStart } from "@odoo/owl";
+import { onMounted } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 
 export class WebsiteCRMPartnersPageOption extends BaseOptionComponent {
     static id = "website_crm_partners_page_option"
     static template = "website_crm_partner_assign.PartnersPageOption";
+    static hasApiKeyCache = null;
 
     setup() {
         super.setup();
@@ -15,8 +16,18 @@ export class WebsiteCRMPartnersPageOption extends BaseOptionComponent {
             has_google_maps_api_key: false,
         });
 
-        onWillStart(async () => {
-            this.state.has_google_maps_api_key = !!(await this.googleMaps.getGMapsAPIKey(false));
+        onMounted(async () => {
+            if (WebsiteCRMPartnersPageOption.hasApiKeyCache !== null) {
+                this.state.has_google_maps_api_key = WebsiteCRMPartnersPageOption.hasApiKeyCache;
+                return;
+            }
+
+            const hasKey = !!(await this.googleMaps.getGMapsAPIKey(true));
+            this.state.has_google_maps_api_key = hasKey;
+
+            if (hasKey) {
+                WebsiteCRMPartnersPageOption.hasApiKeyCache = true;
+            }
         });
     }
 }

--- a/addons/website_crm_partner_assign/static/src/website_builder/website_crm_partner_assign_option.xml
+++ b/addons/website_crm_partner_assign/static/src/website_builder/website_crm_partner_assign_option.xml
@@ -9,8 +9,13 @@
         </xpath>
     </t>
     <t t-name="website_crm_partner_assign.PartnersPageOption">
-        <BuilderRow t-if="this.state.has_google_maps_api_key" label.translate="World Map">
-            <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['website_crm_partner_assign.ref_country']}" />
+        <BuilderRow label.translate="World Map">
+            <BuilderCheckbox id="'partners_world_map_opt'" action="'websiteConfig'"
+                actionParam="{views: ['website_crm_partner_assign.ref_country']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Google Map" level="1"
+            t-if="isActiveItem('partners_world_map_opt') and !this.state.has_google_maps_api_key">
+            <BuilderButton title.translate="Custom Key" action="'configureApiKey'" preview="false">Custom Key</BuilderButton>
         </BuilderRow>
     </t>
 

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -140,32 +140,30 @@
     </xpath>
 </template>
 
-<template id="ref_country" inherit_id="website_partnership.search_setting" name="World Map">
-    <xpath expr="//div[hasclass('o_wcrm_search')]" position="inside">
-        <t t-if="google_maps_api_key">
-            <!-- modal for large map -->
-            <div role="dialog" class="modal fade partner_map_modal" tabindex="-1">
-              <div class="modal-dialog modal-lg">
-                <div class="modal-content">
-                    <header class="modal-header">
-                        <h4 class="modal-title">World Map</h4>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"/>
-                    </header>
-                    <iframe loading="lazy" t-attf-src="/google_map?height=485&amp;dom=website_crm_partner_assign.partners&amp;current_grade=#{ current_grade and current_grade.id }&amp;current_country=#{ current_country and current_country.id }&amp;partner_url=/partners/&amp;limit=1000"
-                    style="height:485px;"/>
-                </div>
-              </div>
+<template id="ref_country" inherit_id="website_crm_partner_assign.index_content" name="World Map" active="False" priority="20">
+    <xpath expr="//section[@id='page_top_section']" position="inside">
+        <!-- modal for large map -->
+        <div role="dialog" class="modal fade partner_map_modal">
+            <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <header class="modal-header">
+                    <h4 class="modal-title">World Map</h4>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"/>
+                </header>
+                <iframe loading="lazy" t-attf-src="/google_map?height=485&amp;dom=website_crm_partner_assign.partners&amp;current_grade=#{ current_grade and current_grade.id }&amp;current_country=#{ current_country and current_country.id }&amp;partner_url=/partners/&amp;limit=1000"
+                style="height:485px;"/>
             </div>
-            <!-- modal end -->
-            <div class="btn-group ms-2">
-                <button class="btn btn-light border-primary active">
-                    <i class="fa fa-th-large"/>
-                </button>
-                <button class="btn btn-light" data-bs-toggle="modal" data-bs-target=".partner_map_modal">
-                    <i class="fa fa-map-marker" role="img" aria-label="Open map" title="Open map"/>
-                </button>
             </div>
-        </t>
+        </div>
+        <!-- modal end -->
+        <div class="btn-group ms-2">
+            <button class="btn btn-light border-primary active">
+                <i class="fa fa-th-large"/>
+            </button>
+            <button class="btn btn-light" data-bs-toggle="modal" data-bs-target=".partner_map_modal">
+                <i class="fa fa-map-marker" role="img" aria-label="Open map" title="Open map"/>
+            </button>
+        </div>
     </xpath>
 </template>
 

--- a/addons/website_partnership/__manifest__.py
+++ b/addons/website_partnership/__manifest__.py
@@ -22,6 +22,12 @@ To publish a member, set a *Level* in their contact form and click the *Publish*
         'demo/res_partner_demo.xml',
     ],
     'assets': {
+        'web._assets_primary_variables': [
+            'website_partnership/static/src/scss/primary_variable.scss',
+        ],
+        'web.assets_frontend': [
+            'website_partnership/static/src/scss/website_partnership.scss',
+        ],
         'website.website_builder_assets': [
             'website_partnership/static/src/website_builder/**/*',
         ],

--- a/addons/website_partnership/static/src/scss/primary_variable.scss
+++ b/addons/website_partnership/static/src/scss/primary_variable.scss
@@ -1,0 +1,6 @@
+$o-base-website-values-palette: map-merge(
+    $o-base-website-values-palette,
+    (
+        'website_partnership_card_roundness': 10% / 5%,
+    )
+);

--- a/addons/website_partnership/static/src/scss/website_partnership.scss
+++ b/addons/website_partnership/static/src/scss/website_partnership.scss
@@ -1,0 +1,5 @@
+$radius: o-website-value('website_partnership_card_roundness');
+
+.o_wpartners_card {
+  border-radius: #{$radius * 1%} / #{$radius * 0.5%};
+}

--- a/addons/website_partnership/static/src/website_builder/website_partnership_option.xml
+++ b/addons/website_partnership/static/src/website_builder/website_partnership_option.xml
@@ -23,6 +23,16 @@
         <BuilderRow label.translate="Categories" id="'categories_option'">
             <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['website_partnership.categories_setting']}" />
         </BuilderRow>
+        <hr/>
+        <BuilderRow label.translate="Cards Design">
+            Global options for all inner cards.
+        </BuilderRow>
+        <BuilderRow label.translate="Roundness" tooltip.translate="Applies to all cards" level="1">
+            <BuilderRange action="'customizeWebsiteVariable'" actionParam="'website_partnership_card_roundness'" default="10" max="50"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Shadows" tooltip.translate="Applies to all cards" level="1">
+            <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['website_partnership.partners_card_shadow']}" />
+        </BuilderRow>
     </t>
 
     <t t-inherit="website.BuilderOptions" t-inherit-mode="extension">

--- a/addons/website_partnership/views/website_partnership_templates.xml
+++ b/addons/website_partnership/views/website_partnership_templates.xml
@@ -141,7 +141,7 @@
     </xpath>
 </template>
 
-<template id="search_setting" inherit_id="website_partnership.index" name="Search">
+<template id="search_setting" inherit_id="website_partnership.index" name="Search" priority="10">
     <xpath expr="//section[@id='page_top_section']" position="inside">
         <div class="o_wcrm_search d-flex w-100 w-lg-25">
             <form class="flex-grow-1" action="" method="get">

--- a/addons/website_partnership/views/website_partnership_templates.xml
+++ b/addons/website_partnership/views/website_partnership_templates.xml
@@ -81,10 +81,11 @@
                     <span t-out="partner.grade_id.name"/>
                     <t t-call="website.publish_management" object="partner.grade_id" action="'partnership.res_partner_grade_action'" publish_edit="True"/>
                 </h5>
+                <t t-set="partner_card_shadow" t-value="False"/>
                 <t t-set="last_grade" t-value="partner.grade_id.id"/>
             </t>
             <div class="col-md-4 col-xl-3 col-12 mb-4">
-                <div class="card h-100 text-decoration-none">
+                <div t-attf-class="o_wpartners_card card h-100 text-decoration-none #{partner_card_shadow and 'shadow-lg'}">
                     <a id="partner_link_card" class="text-decoration-none" aria-label="Go to partner">
                         <div t-field="partner.avatar_1920"
                             class="card-img-top border-bottom"
@@ -227,6 +228,12 @@
 <template id="image_four_five_partner_page" inherit_id="website_partnership.index" name="Partner page">
     <xpath expr="//div[hasclass('card-img-top')]" position="attributes">
         <attribute name="t-options">{"widget": "image", "qweb_img_responsive": False, "class": "img img-fluid h-100 w-100 mw-100", "style": "max-height: 375px; min-height: 375px; object-fit: cover"}</attribute>
+    </xpath>
+</template>
+<template name="Partner Card Shadow" id="website_partnership.partners_card_shadow"
+    inherit_id="website_partnership.index">
+    <xpath expr="//t[@t-set='partner_card_shadow']" position="attributes">
+        <attribute name="t-value">True</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
# Enhance Partners Page Customisation and Map Configuration

This PR improves the partner/reseller pages across `website_partnership` and `website_crm_partner_assign` by enhancing map configuration, expanding card customisation options, clarifying visibility controls, and simplifying template rendering order.

### Map Builder Improvements

* Display the **Map View** option by default, even when no Google Maps API key is configured.
* Add a conditional API key input that becomes visible when the map option is enabled.

### Partner Card Design Options

* Add a new option to enable or disable **card shadows** on partner/reseller cards.
* Add a **border radius slider** to customize card roundness.

### Contact Details Visibility Refactor

* Split the previous **Contact Details** option into two distinct controls:

  * **State & Country**: Controls visibility of state and country information on the `/partners` listing page.
  * **Contact Details**: Controls visibility of address/contact information on individual `/partner/<id>` pages.
* Fix the issue where disabling contact details on the listing page unintentionally hid address information on partner detail pages.
* Remove the unused `partner_page` template from `website_partnership`, as it was never rendered.

### Template Rendering Order Improvements

* Replace the class-based inherited view positioning mechanism with a **priority-based rendering order**.
* Remove the obsolete `top_section_button_middle_pos` placeholder element.
* Add explicit view priorities for inherited content rendered within the `page_top_section`.


TASK - 5156311
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
