### PR TITLE
[IMP] pos_self_order: add back button on the attribute configuration

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -160,11 +160,10 @@
                             This combination does not exist.
                     </div>
                     <div class="d-flex justify-content-between align-items-center gap-2 gap-md-5">
-                        <button t-if="this.isBackVisible()" class="btn btn-lg btn-secondary" t-on-click="back">
+                        <button class="btn btn-lg btn-secondary" t-on-click="!this.isBackVisible() ? goBack : back">
                             <i class="oi oi-chevron-left d-md-none" />
                             <span class="d-none d-md-inline">Back</span>
                         </button>
-                        <div t-else=""/>
                         <div class="d-flex justify-content-between align-items-center  gap-2 gap-md-5">
                             <div class="ms-auto text-start">
                                 <h4 class="d-none d-sm-block text-muted opacity-75 mb-1">Combo</h4>

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -51,6 +51,10 @@
                         This combination does not exist.
                     </div>
                    <div class="d-flex justify-content-between align-items-center  gap-2 gap-md-5">
+                        <button class="btn btn-lg btn-secondary" t-on-click="() => this.goBack()">
+                            <i class="oi oi-chevron-left d-md-none" />
+                            <span class="d-none d-md-inline">Back</span>
+                        </button>
                         <div class="ms-auto text-start">
                             <h4 class="d-none d-sm-block text-muted opacity-75 mb-1">Selection</h4>
                             <div class="fs-2 fw-bold o-so-tabular-nums mx-2 text-primary" t-esc="selfOrder.formatMonetary(getProductPrice())" />


### PR DESCRIPTION
The goal of this pr was to always have a Back button visible on the combo product configuration.

I also change method name to be more readable.

task: 5877219

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
