### PR TITLE
[IMP] web: Allow new lines in tooltip strings 

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip.scss
+++ b/addons/web/static/src/core/tooltip/tooltip.scss
@@ -33,7 +33,7 @@
         margin: map-get($spacers, 1) map-get($spacers, 2) map-get($spacers, 2);
     }
 
-    .o-tooltip--help, .o-tooltip--string {
+    .o-tooltip--help {
         white-space: pre-line;
         padding: 0 map-get($spacers, 2);
     }

--- a/addons/web/static/src/core/tooltip/tooltip.scss
+++ b/addons/web/static/src/core/tooltip/tooltip.scss
@@ -33,8 +33,9 @@
         margin: map-get($spacers, 1) map-get($spacers, 2) map-get($spacers, 2);
     }
 
+    white-space: pre-line;
+
     .o-tooltip--help {
-        white-space: pre-line;
         padding: 0 map-get($spacers, 2);
     }
 

--- a/addons/web/static/src/core/tooltip/tooltip.xml
+++ b/addons/web/static/src/core/tooltip/tooltip.xml
@@ -4,7 +4,7 @@
     <t t-name="web.Tooltip">
         <div class="o-tooltip tooltip-inner d-print-none text-start">
             <t t-if="props.template" t-call="{{props.template}}" t-call-context="{ env, ...props.info }"/>
-            <span t-else="" t-esc="props.tooltip" class="o-tooltip--string"/>
+            <span t-else="" t-esc="props.tooltip"/>
         </div>
     </t>
 


### PR DESCRIPTION
We need to have a new line in tooltips. related task-5367117

Allow to have a new line in tooltips strings

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
