### PR TITLE
[FIX] pos_loyalty: allow scan of customer not preloaded

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2940,6 +2940,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         )
 
     def test_scan_loyalty_card_select_customer(self):
+        self.env['ir.config_parameter'].sudo().set_param('point_of_sale.limited_customer_count', 0)
         self.env['loyalty.program'].search([]).write({'active': False})
         self.test_partner = self.env['res.partner'].create({'name': 'A Test Partner'})
 


### PR DESCRIPTION
When scanning a loyalty card in POS, the customer should be automatically selected. However, this fails when the customer is not in the initial preloaded customer list due to the limited_customer_count setting.

Partial backport of: https://github.com/odoo/odoo/commit/e2843355898d4cce953fba35504170c10910fc35

Steps to reproduce:
-------------------
* Open POS with limited_customer_count set to a low value (e.g., 5)
* Create a loyalty card for a customer that won't be in the top 5 preloaded
* Scan the loyalty card barcode in POS
> Observation:
Customer is not selected, shows "Invalid coupon code" error

Why the fix:
------------
The current implementation only searches for loyalty cards in the local POS cache. When a loyalty card's partner_id is not resolved (because the partner wasn't preloaded), the code fails to set the customer.

This fix backports the 19.0 solution which:
1. Uses server-side lookup via get_loyalty_card_partner_by_code() to find the partner ID from the loyalty card code
2. Explicitly loads the partner on-demand if not in the local cache
3. Works regardless of whether the customer was in the initial preload

The test didn't spot that previously because the default limited_customer_count was big enough.

opw-5778328