### PR TITLE
[FIX] *: round down amount to currency's minor unit in validate amount

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -15,6 +15,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tools import email_normalize_all, float_round, format_amount
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.const import CURRENCY_MINOR_UNITS
 
 
 _logger = logging.getLogger(__name__)
@@ -723,7 +724,11 @@ class PaymentTransaction(models.Model):
         # providers send a positive one.
         if self.operation == 'refund':
             amount = -amount
-        tx_amount = self.amount if precision_digits is None else float_round(
+        if precision_digits is None:
+            precision_digits = CURRENCY_MINOR_UNITS.get(
+                self.currency_id.name, self.currency_id.decimal_places
+            )
+        tx_amount = float_round(
             self.amount, precision_digits=precision_digits, rounding_method=rounding_method
         )
         if self.currency_id.compare_amounts(amount, tx_amount) != 0:

--- a/addons/payment/tests/test_payment_transaction.py
+++ b/addons/payment/tests/test_payment_transaction.py
@@ -294,3 +294,10 @@ class TestPaymentTransaction(PaymentCommon):
             'redirect', operation='validation', amount=0, reference='tx-validation',
         )
         validation_tx._validate_amount_and_currency(None, None)
+
+    def test_validate_amount_uses_payment_minor_unit(self):
+        self.currency_euro.rounding = 0.001
+        tx = self._create_transaction('direct', amount=123.452, currency_id=self.currency_euro.id)
+        self._assert_does_not_raise(
+            ValidationError, tx._validate_amount_and_currency, 123.45, self.currency_euro.name
+        )

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -404,7 +404,11 @@ class PaymentTransaction(models.Model):
             arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
         )
         currency_code = amount_data.get('currency')
-        self._validate_amount_and_currency(amount, currency_code)
+        self._validate_amount_and_currency(
+            amount,
+            currency_code,
+            precision_digits=const.CURRENCY_DECIMALS.get(self.currency_id.name),
+        )
 
     def _process_notification_data(self, notification_data):
         """ Override of payment to process the transaction based on Adyen data.

--- a/addons/payment_mercado_pago/models/payment_transaction.py
+++ b/addons/payment_mercado_pago/models/payment_transaction.py
@@ -10,6 +10,7 @@ from odoo import _, api, models
 from odoo.exceptions import ValidationError
 from odoo.tools import float_round
 
+from odoo.addons.payment.const import CURRENCY_MINOR_UNITS
 from odoo.addons.payment_mercado_pago import const
 from odoo.addons.payment_mercado_pago.controllers.main import MercadoPagoController
 
@@ -66,7 +67,9 @@ class PaymentTransaction(models.Model):
         )  # Append the reference to identify the transaction from the webhook notification data.
 
         unit_price = self.amount
-        decimal_places = const.CURRENCY_DECIMALS.get(self.currency_id.name)
+        decimal_places = const.CURRENCY_DECIMALS.get(
+            self.currency_id.name, CURRENCY_MINOR_UNITS.get(self.currency_id.name)
+        )
         if decimal_places is not None:
             unit_price = float_round(unit_price, decimal_places, rounding_method='DOWN')
 

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -9,7 +9,6 @@ from odoo import _, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.payment import utils as payment_utils
-from odoo.addons.payment.const import CURRENCY_MINOR_UNITS
 from odoo.addons.payment_stripe import const
 from odoo.addons.payment_stripe import utils as stripe_utils
 from odoo.addons.payment_stripe.controllers.main import StripeController
@@ -396,10 +395,11 @@ class PaymentTransaction(models.Model):
             arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
         )
         currency_code = payment_data.get('currency', '').upper()
-        precision_digits = CURRENCY_MINOR_UNITS.get(
-            self.currency_id.name, self.currency_id.decimal_places
+        self._validate_amount_and_currency(
+            amount,
+            currency_code,
+            precision_digits=const.CURRENCY_DECIMALS.get(self.currency_id.name),
         )
-        self._validate_amount_and_currency(amount, currency_code, precision_digits=precision_digits)
 
     def _process_notification_data(self, notification_data):
         """ Override of `payment` to process the transaction based on Stripe data.

--- a/addons/payment_stripe/tests/common.py
+++ b/addons/payment_stripe/tests/common.py
@@ -93,20 +93,3 @@ class StripeCommon(PaymentCommon):
             }},
             'status': 'succeeded',
         }
-
-    def _mock_payment_intent_request(self, *args, **kwargs):
-        return {
-            'object': 'payment_intent',
-            'id': 'pi_XXXX',
-            'customer': 'cus_XXXX',
-            'description': self.reference,
-            'payment_method': {
-                'id': 'pm_XXXX',
-                'type': 'card',
-                'card': {'brand': 'dummy'},
-            },
-            'amount': self.amount,
-            'amount_received': self.amount,
-            'status': 'succeeded',
-            'currency': self.currency.name.lower(),
-        }

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -202,21 +202,6 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
             for payload_param in ('account', 'return_url', 'refresh_url', 'type'):
                 self.assertIn(payload_param, call_args)
 
-    def test_compare_notification_data_uses_payment_minor_unit(self):
-        """
-        Test that the payment's minor unit precision is used to validate the amount, not the custom
-        currency rounding that customers may have configured.
-        """
-        self.amount = 20076
-        self.currency.rounding = 0.001
-        tx = self._create_transaction(
-            'dummy', operation='online_direct', tokenize=True, amount=200.769
-        )
-        data = self.notification_data['data']
-        data['payment_intent'] = self._mock_payment_intent_request()
-        tx._compare_notification_data(data)
-        self._assert_does_not_raise(ValidationError, tx._compare_notification_data, data)
-
     def test_compare_notification_data_succeeds_for_currencies_with_non_standard_decimals(self):
         for currency_code in const.CURRENCY_DECIMALS:
             currency = self.currency.search([('name', '=', currency_code)])


### PR DESCRIPTION
*: payment{,_adyen,_mercado_pago,_stripe}

### Issue:
The payment in some payment providers are failing to due setting
currency decimals.

#### Steps to reproduce:
1- In USD currency form in developer mode, set the rounding factor
   to `0.001000`, so we have 3 decimal places.
2- From `Decimal Accuracy` set Price Unit to 4 digits.
3- Refresh the page.
4- Create a SO and add a line. Set the price to `200.7647`.
5- Refresh the page again and generate a payment link.
6- Pay through Adyen. As you see payments fail.

### Cause and Fix:
This issue is the same as https://github.com/odoo/odoo/pull/245059. That fix only focused on Stripe, however, the same issue is reproducible on other providers e.g. `Adyen`. In order to avoid the same issue, we can have a general fix to round down all payment transaction amounts to currency's minor unit in `_validate_amount_and_currency`.

---

There is another issue in Mercado Pago which the if currency is not one of these currencies then it will not be sent to provider rounded:
https://github.com/odoo/odoo/blob/035b701cbf7bd654f56f07244e606e4038c4115a/addons/payment_mercado_pago/const.py#L39-L43

Mercado Pago rounds **up** in these cases, which will cause mismatch in `_validate_amount_and_currency`.

opw-5871470