### PR TITLE
[FIX] hr_work_entry: generation issue

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -178,18 +178,9 @@ class HrWorkEntry(models.Model):
     @api.model
     def _set_current_contract(self, vals):
         if not vals.get('version_id') and vals.get('date_start') and vals.get('date_stop') and vals.get('employee_id'):
-            contract_start = fields.Datetime.to_datetime(vals.get('date_start')).date()
-            contract_end = fields.Datetime.to_datetime(vals.get('date_stop')).date()
             employee = self.env['hr.employee'].browse(vals.get('employee_id'))
-            contracts = employee._get_versions_with_contract_overlap_with_period(contract_start, contract_end)
-            if not contracts:
-                raise ValidationError(_(
-                    "%(employee)s does not have a contract from %(date_start)s to %(date_end)s.",
-                    employee=employee.name,
-                    date_start=contract_start,
-                    date_end=contract_end,
-                ))
-            return dict(vals, version_id=contracts[0].id)
+            active_version = employee._get_version(vals['date_start'])
+            return dict(vals, version_id=active_version.id)
         return vals
 
     def action_validate(self):

--- a/addons/hr_work_entry/tests/test_hr_work_entry.py
+++ b/addons/hr_work_entry/tests/test_hr_work_entry.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+from datetime import date, datetime
 from odoo.tests.common import TransactionCase
 
 
@@ -20,6 +20,7 @@ class TestHrWorkEntry(TransactionCase):
             'contract_date_start': '2023-01-01',
             'date_version': '2023-01-01',
         })
+        cls.employee_a_first_version = cls.employee_a.version_ids[0]
         cls.employee_b = cls.env['hr.employee'].create({
             'name': 'Employee B',
             'company_id': cls.company_b.id,
@@ -46,3 +47,47 @@ class TestHrWorkEntry(TransactionCase):
             work_entry.company_id, self.employee_b.company_id,
             "Work entry should use the employee's company not the current user's company.",
         )
+
+    def test_nullify_work_entry(self):
+        """
+        Test that we correctly nullify the work entries that were previously generated when we add a new version
+        """
+        january_work_entries = self.employee_a.generate_work_entries(date(2024, 1, 1), date(2024, 1, 31))
+        self.assertTrue(all(we.version_id == self.employee_a_first_version for we in january_work_entries))
+
+        second_version = self.employee_a.create_version({
+            'date_version': date(2023, 12, 1)
+        })
+        self.employee_a.generate_work_entries(date(2024, 1, 1), date(2024, 1, 31))
+
+        all_january_work_entries = self.env['hr.work.entry'].search([
+            ('employee_id', '=', self.employee_a.id),
+            ('date_start', '>=', date(2024, 1, 1)),
+            ('date_stop', '<=', date(2024, 1, 31)),
+        ])
+
+        self.assertEqual(len(all_january_work_entries), 46)
+        self.assertTrue(all(we.version_id == second_version for we in all_january_work_entries))
+
+    def test_work_entry_version_id(self):
+        """
+        Test that we correctly set the version_id field of the work entry depending on the date
+        """
+        second_version = self.employee_a.create_version({
+            'date_version': date(2023, 12, 1)
+        })
+
+        v1_we, v2_we = self.env['hr.work.entry'].create([
+            {
+                'date_start': datetime(2023, 10, 1, 8, 0),
+                'date_stop': datetime(2023, 10, 1, 17, 0),
+                'employee_id': self.employee_a.id,
+            },
+            {
+                'date_start': datetime(2024, 1, 1, 8, 0),
+                'date_stop': datetime(2024, 1, 1, 17, 0),
+                'employee_id': self.employee_a.id,
+            }
+        ])
+        self.assertEqual(v1_we.version_id, self.employee_a_first_version)
+        self.assertEqual(v2_we.version_id, second_version)

--- a/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
+++ b/addons/hr_work_entry/wizard/hr_work_entry_regeneration_wizard.py
@@ -101,12 +101,4 @@ class HrWorkEntryRegenerationWizard(models.TransientModel):
 
         date_from = max(self.date_from, self.earliest_available_date) if self.earliest_available_date else self.date_from
         date_to = min(self.date_to, self.latest_available_date) if self.latest_available_date else self.date_to
-        work_entries = self.env['hr.work.entry'].search([
-            ('employee_id', 'in', self.employee_ids.ids),
-            ('date_stop', '>=', date_from),
-            ('date_start', '<=', date_to),
-            ('state', '!=', 'validated')])
-
-        write_vals = {field: False for field in self._work_entry_fields_to_nullify()}
-        work_entries.write(write_vals)
         self.employee_ids.generate_work_entries(date_from, date_to, True)


### PR DESCRIPTION
Problem
----------
3 issues :
- If you generate work entries for a new version it will not nullify the already generated work entries for the previous active version.
- The version_id on the work entry is not set to the active version at the date of the work entry
- The regenerate hasn't the same behavior if you call it from the wizard or from the front.

Fix
----------
Remove the skip of versions that ends before the date_start of the generation. To go through the nullify process. Remove the double nullify in the regenerate in the case we have slots (we don't come from the wizard) Correct the `_set_current_contract` to give the good version for the date.
