### PR TITLE
[IMP] mail: disable chat renaming

### DIFF
--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -37,7 +37,7 @@ const discussChannelPatch = {
         return super._computeCanHide(...arguments);
     },
     get displayName() {
-        if (this.channel_type !== "livechat" || this.self_member_id?.custom_channel_name) {
+        if (this.channel_type !== "livechat") {
             return super.displayName;
         }
         const selfMemberType = this.isTransient

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -5,7 +5,6 @@ import {
     openDiscuss,
     start,
     startServer,
-    triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test, waitFor } from "@odoo/hoot";
 import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
@@ -44,26 +43,6 @@ test("Thread name unchanged when inviting new users", async () => {
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
     await contains(".o-discuss-ChannelMember", { text: "James" });
     await contains(".o-mail-DiscussContent-threadName[title='Visitor #20']");
-});
-
-test("Can set a custom name to livechat conversation", async () => {
-    const pyEnv = await startServer();
-    const guestId = pyEnv["mail.guest"].create({ name: "Visitor #20" });
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_member_ids: [
-            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
-            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
-        ],
-        channel_type: "livechat",
-    });
-    await start();
-    await openDiscuss(channelId);
-    await click(".o-mail-DiscussSidebar-item:contains('Visitor #20')");
-    await contains(".o-mail-DiscussContent-threadName[title='Visitor #20']");
-    await insertText(".o-mail-DiscussContent-threadName", "New Name", { replace: true });
-    await triggerHotkey("Enter");
-    await contains(".o-mail-DiscussContent-threadName[title='New Name']");
-    await contains(".o-mail-DiscussSidebar-item:contains('New Name')");
 });
 
 test("Display livechat custom username if defined", async () => {

--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -12,7 +12,8 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
             run: "click",
         },
         {
-            trigger: ".o-mail-DiscussContent-threadName[title='Visitor']",
+            trigger:
+                ".o-mail-DiscussContent-header:has(.o-mail-DiscussContent-threadName[title='Visitor'])",
             async run() {
                 await delay(1000);
                 history.back();
@@ -26,7 +27,8 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
             },
         },
         {
-            trigger: ".o-mail-DiscussContent-threadName[title='Visitor']",
+            trigger:
+                ".o-mail-DiscussContent-header:has(.o-mail-DiscussContent-threadName[title='Visitor'])",
             async run() {
                 await delay(1000);
                 history.back();

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -191,7 +191,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "create_date": fields.Datetime.to_string(visitor_member.create_date),
-                    "custom_channel_name": False,
                     "custom_notifications": False,
                     "id": visitor_member.id,
                     "livechat_member_type": "visitor",
@@ -265,7 +264,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             [
                 {
                     "create_date": fields.Datetime.to_string(operator_member.create_date),
-                    "custom_channel_name": False,
                     "custom_notifications": False,
                     "id": operator_member.id,
                     "livechat_member_type": "agent",

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1264,7 +1264,7 @@ class DiscussChannel(models.Model):
                 "self_member_id",
                 lambda res: (
                     res.from_method("_store_member_fields"),
-                    res.extend(["custom_channel_name", "custom_notifications"]),
+                    res.extend(["custom_notifications"]),
                     res.extend(["last_interest_dt", "message_unread_counter"]),
                     res.attr("message_unread_counter_bus_id", bus_last_id),
                     res.extend(["mute_until_dt", "new_message_separator"]),
@@ -1379,13 +1379,6 @@ class DiscussChannel(models.Model):
     def _lazy_load_members_channel_types(self):
         """ Return the channel types that load members lazily. """
         return ["channel", "group"]
-
-    def channel_set_custom_name(self, name):
-        self.ensure_one()
-        self.self_member_id.custom_channel_name = name
-        store = Store(bus_channel=self.self_member_id._bus_channel())
-        store.add(self.self_member_id, ["custom_channel_name"])
-        store.bus_send()
 
     def channel_rename(self, name):
         self.ensure_one()

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -41,7 +41,6 @@ class DiscussChannelMember(models.Model):
         groups="base.group_system",
     )
     # state
-    custom_channel_name = fields.Char('Custom channel name')
     is_favorite = fields.Boolean("Favorite")
     seen_message_id = fields.Many2one('mail.message', string='Last Seen', index="btree_not_null")
     new_message_separator = fields.Integer(help="Message id before which the separator should be displayed", default=0, required=True)
@@ -275,7 +274,7 @@ class DiscussChannelMember(models.Model):
         super()._sync_field_names(res)
         # sudo: discuss.channel.member - reading channel ownership related to a member is considered acceptable
         res["channel_id", None].attr("channel_role", sudo=True)
-        res[None].extend(["custom_channel_name", "custom_notifications", "is_favorite"])
+        res[None].extend(["custom_notifications", "is_favorite"])
         res[None].extend(["is_pinned", "last_interest_dt", "message_unread_counter"])
         res[None].extend(["mute_until_dt", "new_message_separator"])
         # sudo: discuss.channel.rtc.session - each member can see who is inviting them

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -36,8 +36,8 @@ registerThreadAction("fold-chat-window", {
 registerThreadAction("rename-thread", {
     condition: ({ channel, owner, thread }) =>
         channel &&
+        channel.isAllowedToRename &&
         owner.props.chatWindow?.isOpen &&
-        (thread.is_editable || channel.channel_type === "chat") &&
         !owner.isDiscussSidebarChannelActions,
     icon: "fa fa-fw fa-pencil",
     name: _t("Rename Thread"),

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -289,10 +289,6 @@ export class Thread extends Record {
         return persona?.displayName || persona?.name;
     }
 
-    get supportsCustomChannelName() {
-        return this.channel?.isChatChannel && this.channel?.channel_type !== "group";
-    }
-
     get displayName() {
         return this.channel?.displayName ?? this.display_name;
     }

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -27,7 +27,7 @@
                         </div>
                         <AutoresizeInput
                             className="'o-mail-DiscussContent-threadName fw-bold flex-shrink-1 py-0 ' + (showsChatLocalDateTime ? 'fs-5' : 'fs-4')"
-                            enabled="thread.is_editable or thread.channel?.channel_type === 'chat'"
+                            enabled="thread.channel?.isAllowedToRename"
                             onValidate.bind="renameThread"
                             value="thread.displayName || ''"
                         />

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -13,8 +13,6 @@ export class ChannelMember extends Record {
 
     /** @type {string} */
     create_date;
-    /** @type {string} */
-    custom_channel_name;
     /**
      * false means using the custom_notifications from user settings.
      *

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -406,21 +406,6 @@ test("show date separator above mesages of similar date", async () => {
     });
 });
 
-test("sidebar: chat custom name", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "Marc Demo" });
-    pyEnv["discuss.channel"].create({
-        channel_member_ids: [
-            Command.create({ custom_channel_name: "Marc", partner_id: serverState.partnerId }),
-            Command.create({ partner_id: partnerId }),
-        ],
-        channel_type: "chat",
-    });
-    await start();
-    await openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel-itemName:text('Marc')");
-});
-
 test.tags("focus required");
 test("reply to message from inbox (message linked to document)", async () => {
     const pyEnv = await startServer();
@@ -1862,15 +1847,18 @@ test("Thread avatar is not editable in DM chat", async () => {
     await contains(".o-mail-DiscussContent-threadAvatar .fa-pencil", { count: 0 });
 });
 
-test("Do not trigger chat name server update when it is unchanged", async () => {
+test("Do not trigger channel name server update when it is unchanged", async () => {
     const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "General",
+    });
 
-    onRpc("discuss.channel", "channel_set_custom_name", ({ method }) => expect.step(method));
+    onRpc("discuss.channel", "channel_rename", ({ method }) => expect.step(method));
 
     await start();
     await openDiscuss(channelId);
-    await insertText("input.o-mail-DiscussContent-threadName:enabled", "Mitchell Admin", {
+    await insertText("input.o-mail-DiscussContent-threadName:enabled", "General", {
         replace: true,
     });
     triggerHotkey("Enter");

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -414,7 +414,6 @@ export class DiscussChannel extends models.ServerModel {
                         DiscussChannelMember.browse(memberOfCurrentUser.id),
                         makeKwArgs({
                             extra_fields: [
-                                "custom_channel_name",
                                 "last_interest_dt",
                                 "message_unread_counter",
                                 mailDataHelpers.Store.one("rtc_inviting_session_id"),
@@ -473,37 +472,6 @@ export class DiscussChannel extends models.ServerModel {
      * @param {number[]} ids
      * @param {string} name
      */
-    channel_set_custom_name(ids, name) {
-        const kwargs = getKwArgs(arguments, "ids", "name");
-        ids = kwargs.ids;
-        delete kwargs.ids;
-        name = kwargs.name || "";
-
-        /** @type {import("mock_models").BusBus} */
-        const BusBus = this.env["bus.bus"];
-        /** @type {import("mock_models").DiscussChannelMember} */
-        const DiscussChannelMember = this.env["discuss.channel.member"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
-
-        const channelId = ids[0]; // simulate ensure_one.
-        const [memberIdOfCurrentUser] = DiscussChannelMember.search([
-            ["partner_id", "=", this.env.user.partner_id],
-            ["channel_id", "=", channelId],
-        ]);
-        DiscussChannelMember.write([memberIdOfCurrentUser], {
-            custom_channel_name: name,
-        });
-        const [partner] = ResPartner.read(this.env.user.partner_id);
-        BusBus._sendone(
-            partner,
-            "mail.record/insert",
-            new mailDataHelpers.Store(DiscussChannelMember.browse(memberIdOfCurrentUser), {
-                custom_channel_name: name,
-            }).get_result()
-        );
-    }
-
     /**
      * @param {number[]} partners_to
      * @param {string} [default_display_mode=undefined]

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -563,8 +563,8 @@ class TestDiscussChannelAccess(MailCommon):
             self.assertEqual(len(member), 1, "should find the target member")
             if operation == "read":
                 self.assertEqual(len(ChannelMemberAsUser.search(domain)), 1 if result else 0)
-                member.read(["custom_channel_name"])
+                member.read(["custom_notifications"])
             elif operation == "write":
-                member.write({"custom_channel_name": "new name"})
+                member.write({"custom_notifications": "mentions"})
             elif operation == "unlink":
                 member.unlink()

--- a/addons/mail/views/discuss_channel_member_views.xml
+++ b/addons/mail/views/discuss_channel_member_views.xml
@@ -27,7 +27,6 @@
                         <field name="channel_id" readonly="id"/>
                         <field name="partner_id" readonly="id or guest_id" required="not guest_id"/>
                         <field name="guest_id" readonly="id or partner_id" required="not partner_id"/>
-                        <field name="custom_channel_name"/>
                         <field name="seen_message_id"/>
                         <field name="new_message_separator"/>
                         <field name="message_unread_counter"/>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -935,7 +935,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": False,
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -955,7 +954,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": "owner",
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -975,7 +973,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": "owner",
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -995,7 +992,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": "owner",
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1021,7 +1017,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": "owner",
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1041,7 +1036,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": "owner",
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1071,7 +1065,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": False,
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1101,7 +1094,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": False,
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1131,7 +1123,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": False,
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1161,7 +1152,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": False,
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1191,7 +1181,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": False,
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,
@@ -1223,7 +1212,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {
                 "channel_role": False,
                 "create_date": member_0_create_date,
-                "custom_channel_name": False,
                 "custom_notifications": False,
                 "id": member_0.id,
                 "is_favorite": False,

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -361,7 +361,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     "channel_id": channel.id,
                     "channel_role": False,
                     "create_date": fields.Datetime.to_string(guest_member.create_date),
-                    "custom_channel_name": False,
                     "custom_notifications": False,
                     "guest_id": guest.id,
                     "id": guest_member.id,


### PR DESCRIPTION
**Purpose of this PR:**

disabled rename of direct messages since its professional unethical.
- also we are removing `custom_channel_name` feature from everywhere since the feature was intended for "chat" specifically, having it in whatsapp and livechat is accidental.
there is task for whatsapp to have name shared among all agents, so it's removal of custom_channel_name for whatsapp.

related PR: https://github.com/odoo/upgrade/pull/9358

[`enterprise pr`](https://github.com/odoo/enterprise/pull/105963)

[`task`](https://www.odoo.com/odoo/project/1519/tasks/5873798)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
