### PR TITLE
[FIX] mrp_subcontracting_purchase: fix invoice creation

### DIFF
--- a/addons/mrp_subcontracting_purchase/models/account_move_line.py
+++ b/addons/mrp_subcontracting_purchase/models/account_move_line.py
@@ -26,5 +26,5 @@ class AccountMoveLine(models.Model):
         finished_moves = set()
         for m in moves:
             if mo := m._get_subcontract_production():
-                finished_moves.add(mo.move_finished_ids.filtered(lambda mf: mf.product_id == m.product_id).id)
+                finished_moves |= set(mo.move_finished_ids.filtered(lambda mf: mf.product_id == m.product_id).ids)
         return moves | self.env['stock.move'].browse(finished_moves)


### PR DESCRIPTION
Before this commit, creating an invoice for a purchase order with a subcontracted tracked product triggered a singleton error.

This commit fixes the issue by properly handling multiple finished move lines for the same product, which occurs with tracked products, some back order flows, and possibly upgrade scripts.

OPW-5712931