### PR TITLE
[FIX] hr_holidays_attendance: compute employee_overtime on leave allocations

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -35,50 +35,18 @@ class HrLeave(models.Model):
 
     @api.model
     def _get_deductible_employee_overtime(self, employees):
-        # return dict {employee: number of hours}
-        diff_by_employee = defaultdict(lambda: 0)
-        for employee, hours in self.env['hr.attendance.overtime.line'].sudo()._read_group(
-            domain=[
-                ('compensable_as_leave', '=', True),
-                ('employee_id', 'in', employees.ids),
-                ('status', '=', 'approved'),
-            ],
-            groupby=['employee_id'],
-            aggregates=['manual_duration:sum'],
-        ):
-            diff_by_employee[employee] += hours
-        for employee, hours in self._read_group(
-            domain=[
-                ('holiday_status_id.overtime_deductible', '=', True),
-                ('holiday_status_id.requires_allocation', '=', False),
-                ('employee_id', 'in', employees.ids),
-                ('state', 'not in', ['refuse', 'cancel']),
-            ],
-            groupby=['employee_id'],
-            aggregates=['number_of_hours:sum'],
-        ):
-            diff_by_employee[employee] -= hours
-        for employee, hours in self.env['hr.leave.allocation']._read_group(
-            domain=[
-                ('holiday_status_id.overtime_deductible', '=', True),
-                ('employee_id', 'in', employees.ids),
-                ('state', 'in', ['confirm', 'validate', 'validate1']),
-            ],
-            groupby=['employee_id'],
-            aggregates=['number_of_hours_display:sum'],
-        ):
-            diff_by_employee[employee] -= hours
-        return diff_by_employee
+        # Uses the calculation logic now located in the hr.employee model.
+        return employees._get_deductible_employee_overtime()
 
     @api.depends('number_of_hours', 'employee_id', 'holiday_status_id')
     def _compute_employee_overtime(self):
-        diff_by_employee = self._get_deductible_employee_overtime(self.employee_id)
+        diff_by_employee = self.employee_id._get_deductible_employee_overtime()
         for leave in self:
             leave.employee_overtime = diff_by_employee[leave.employee_id]
 
     def _check_overtime_deductible(self, leaves):
         # If the type of leave is overtime deductible, we have to check that the employee has enough extra hours
-        hours = self._get_deductible_employee_overtime(leaves.employee_id)
+        hours = leaves.employee_id._get_deductible_employee_overtime()
         for leave in leaves.filtered('overtime_deductible'):
             if hours[leave.employee_id] < 0:
                 if leave.employee_id.user_id == self.env.user:

--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -19,7 +19,7 @@ class HrLeaveType(models.Model):
             return super()._compute_display_name()
 
         employee = self.env['hr.employee'].browse(self.env.context.get('employee_id')).sudo()
-        unspent_overtime = self.env['hr.leave']._get_deductible_employee_overtime(employee)[employee]
+        unspent_overtime = employee._get_deductible_employee_overtime()[employee]
         if not unspent_overtime:
             return super()._compute_display_name()
 
@@ -37,7 +37,7 @@ class HrLeaveType(models.Model):
         deductible_time_off_types = self.env['hr.leave.type'].search([
             ('overtime_deductible', '=', True),
             ('requires_allocation', '=', False)])
-        unspent_overtime = self.env['hr.leave']._get_deductible_employee_overtime(employees)
+        unspent_overtime = employees._get_deductible_employee_overtime()
         for employee in employees:
             for leave_type in deductible_time_off_types:
                 if leave_type in self and employee.sudo().total_overtime > 0:

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -77,7 +77,7 @@ class TestHolidaysOvertime(TransactionCase):
         })
 
     def _check_deductible(self, expected_hours):
-        ded = self.env['hr.leave']._get_deductible_employee_overtime(self.employee)
+        ded = self.employee._get_deductible_employee_overtime()
         self.assertAlmostEqual(ded[self.employee], expected_hours, 5)
 
     def test_check_overtime(self):


### PR DESCRIPTION
Issue :
-
After commit odoo/odoo@6d7f4012cfa06b35089e7557522fcbf658978b37, the `employee_overtime` field in `hr_holidays_attendance` was converted to a computed field on `hr.leave` model to use the new overtime deduction logic. However, the same change was not applied to `hr.leave.allocation` model.

Steps to Reproduce:
-
1. Create a Leave Allocation for an employee who has extra overtime hours.
2. Set the allocation less than the available extra hours.
3. In 19.0, when saving the allocation and creating a new allocation for the same employee:
   - The `employee_overtime` value did not update.
   - Even though the actual extra hours were reduced, the field still showed the old value.

Fix:
-
After this fix, the `employee_overtime` field in `hr.leave.allocation` is computed correctly, reflecting the actual available overtime hours.
This commit updates `hr.leave.allocation` by:
   - Converting `employee_overtime` to a computed field.
   - Computing its value using `_get_deductible_employee_overtime`.
This aligns the overtime computation between leave requests (`hr.leave`) and leave allocations (`hr.leave.allocation`).

Before Fix:
-
<img width="1898" height="659" alt="before_fix" src="https://github.com/user-attachments/assets/e4797a17-1031-4ba7-81c8-9ab09494134d" />

After Fix:
-
<img width="1902" height="623" alt="after_fix" src="https://github.com/user-attachments/assets/9d592795-20f6-40ce-bf42-a157769589a5" />

opw-5479200

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
