### PR TITLE
[FIX] purchase_stock: correctly check valuation qty

### DIFF
--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -53,6 +53,6 @@ class StockMove(models.Model):
             }
             valuation_total_qty = self._compute_kit_quantities(related_aml.product_id, order_qty, kit_bom, filters)
             valuation_total_qty = kit_bom.product_uom_id._compute_quantity(valuation_total_qty, related_aml.product_id.uom_id)
-            if related_aml.product_uom_id.rounding or related_aml.product_id.uom_id.is_zero(valuation_total_qty):
+            if (related_aml.product_uom_id or related_aml.product_id.uom_id).is_zero(valuation_total_qty):
                 raise UserError(_('Odoo is not able to generate the anglo saxon entries. The total valuation of %s is zero.', related_aml.product_id.display_name))
         return valuation_price_unit_total, valuation_total_qty

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -348,7 +348,7 @@ class StockMove(models.Model):
                 layers_values, to_curr, related_aml.company_id, valuation_date, round=False,
             )
             valuation_total_qty += layers_qty
-        if related_aml.product_uom_id.rounding or related_aml.product_id.uom_id.is_zero(valuation_total_qty):
+        if (related_aml.product_uom_id or related_aml.product_id.uom_id).is_zero(valuation_total_qty):
             raise UserError(
                 _('Odoo is not able to generate the anglo saxon entries. The total valuation of %s is zero.',
                   related_aml.product_id.display_name))


### PR DESCRIPTION
During the changes made in #192123 to use the float utils directly from the `uom.uom` rather than importing the float utils, this line was mistakingly changed.
With that change, the condition would always be truthy.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
