### PR TITLE
[FIX] base: Prevent browsing falsy res_id `ir.model.data`

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2450,7 +2450,7 @@ class IrModelData(models.Model):
         selection_ids = []
         constraint_ids = []
 
-        module_data = self.search([('module', 'in', modules_to_remove)], order='id DESC')
+        module_data = self.search([('module', 'in', modules_to_remove), ('res_id', '!=', False)], order='id DESC')
         for data in module_data:
             if data.model == 'ir.model':
                 model_ids.append(data.res_id)

--- a/odoo/addons/base/tests/test_ir_module.py
+++ b/odoo/addons/base/tests/test_ir_module.py
@@ -45,3 +45,6 @@ class IrModuleCase(TransactionCase):
             "res_id": report.id,
         })
         self.assertEqual(module.reports_by_module, "good_data_report")
+        self.assertEqual(module.state, "installed")
+        module.module_uninstall()
+        self.assertEqual(module.state, "uninstalled")


### PR DESCRIPTION
linked to https://github.com/odoo/odoo/pull/245469, there is another case in the uninstallation flow that can raises a traceback in case of a `ir.model.data` where `res_id = 0`

This commit adds an additional filter to the domain used to browse `ir.model.data` in `_module_data_uninstall` in order to avoid selecting any that would contain a falsy `res_id` and thus cause the above-mentioned assertion to fail.

One way to reproduce this in a new trial:
- Create a new trial with several modules: `account`, `crm`, `project`, `sales`
- Install `web_studio`
- Uninstall `base_automation`
- Traceback
```
  File “/home/odoo/src/odoo/saas-19.1/odoo/orm/models.py”, line 5200, in browse
    assert all(ids) or all(isinstance(x, NewId) or x for x in ids), “Invalid falsy real id”
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Invalid falsy real id
```

This is due to an `ir.model.data` containing a falsy res_id in the internal code of `saas_trial` (`installed-17`)

This fix will avoid any additional traceback like this one.

opw-5865316