### PR TITLE
[IMP] point_of_sale: snooze products in POS

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -55,6 +55,7 @@
         'views/pos_session_sales_details.xml',
         'views/product_tag_views.xml',
         'views/stock_reference_views.xml',
+        'data/ir_cron_data.xml',
     ],
     'demo': [
         'data/demo_data.xml',

--- a/addons/point_of_sale/data/ir_cron_data.xml
+++ b/addons/point_of_sale/data/ir_cron_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="ir_cron_snooze_cleanup" model="ir.cron">
+        <field name="name">POS: Product Snooze cleanup</field>
+        <field name="model_id" ref="point_of_sale.model_pos_product_template_snooze"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_clean_records()</field>
+        <field name="active" eval="True"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="nextcall" eval="(DateTime.now().replace(hour=1, minute=0) + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
+
+</odoo>

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -219,6 +219,9 @@ class PosConfig(models.Model):
         return f"{year_2_digits}{device_identifier}-{self.id}-{next_number}", tracking_number
 
     def notify_synchronisation(self, session_id, device_identifier, records={}):
+        self._notify_synchronisation(session_id, device_identifier, records)
+
+    def _notify_synchronisation(self, session_id, device_identifier, records={}, deleted_record_ids=None):
         self.ensure_one()
         static_records = {}
 
@@ -228,6 +231,7 @@ class PosConfig(models.Model):
 
         self._notify('SYNCHRONISATION', {
             'static_records': static_records,
+            'deleted_record_ids': deleted_record_ids,
             'session_id': session_id,
             'device_identifier': device_identifier,
             'records': records

--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
@@ -27,6 +27,7 @@
                                 class="'flex-column h-100'"
                                 isComboPopup="true"
                                 productId="product.id"
+                                available="!pos.isProductSnoozed(product)"
                                 product="product"
                                 comboExtraPrice="formattedComboPrice(combo_item)"
                                 color="product.color || product.pos_categ_ids?.at(-1)?.color"

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -1,15 +1,44 @@
 import { _t } from "@web/core/l10n/translation";
 import { Dialog } from "@web/core/dialog/dialog";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
-import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { Component, useEffect, useState } from "@odoo/owl";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { serializeDateTime } from "@web/core/l10n/dates";
+import { SnoozeDialog } from "./snooze_dialog/snooze_dialog";
+
+const { DateTime } = luxon;
 
 export class ProductInfoPopup extends Component {
     static template = "point_of_sale.ProductInfoPopup";
-    static components = { Dialog };
+    static components = { Dialog, SnoozeDialog };
     static props = ["info", "productTemplate", "close"];
 
     setup() {
         this.pos = usePos();
+        this.ui = useService("ui");
+        this.dialog = useService("dialog");
+        this.state = useState({
+            countdown: "",
+            activeSnooze: this.getActiveSnooze(),
+        });
+
+        useEffect(
+            () => {
+                if (!this.state.activeSnooze) {
+                    return;
+                }
+
+                this.updateCountdown();
+                const interval = setInterval(() => {
+                    this.updateCountdown();
+                }, 1000);
+                return () => {
+                    clearInterval(interval);
+                };
+            },
+            () => [this.state.activeSnooze]
+        );
     }
     searchProduct(productName) {
         this.pos.setSelectedCategory(0);
@@ -36,5 +65,74 @@ export class ProductInfoPopup extends Component {
     }
     get vatLabel() {
         return this.pos.company.country_id.vat_label || _t("VAT");
+    }
+    updateCountdown() {
+        if (!this.state.activeSnooze) {
+            return;
+        }
+        const now = DateTime.now();
+        const endTime = this.state.activeSnooze.end_time;
+        if (!endTime) {
+            this.state.countdown = _t("Next session");
+            return;
+        }
+        const diff = endTime.diff(now, ["hours", "minutes", "seconds"]);
+        if (diff.as("seconds") <= 0) {
+            this.state.countdown = "";
+            this.state.activeSnooze = undefined;
+            return;
+        }
+
+        this.state.countdown = diff.toFormat("hh:mm:ss");
+        if (!this.ui.isSmall) {
+            this.state.countdown = _t("%s left", this.state.countdown);
+        }
+    }
+    async snooze(hours) {
+        const start_time = DateTime.now();
+        const end_time = hours ? serializeDateTime(start_time.plus({ hours: hours })) : null;
+        const snooze = {
+            start_time: serializeDateTime(start_time),
+            end_time: end_time,
+            pos_config_id: this.pos.config.id,
+            product_template_id: this.props.productTemplate.id,
+        };
+
+        this.state.activeSnooze = (
+            await this.pos.data.create("pos.product.template.snooze", [snooze])
+        )[0];
+    }
+    openSnoozeDialog() {
+        if (this.state.activeSnooze) {
+            this.dialog.add(ConfirmationDialog, {
+                title: _t("Stop Snooze"),
+                body: _t(
+                    "Do you want to stop the snooze early and make the product available again immediately?"
+                ),
+                confirmLabel: _t("Yes"),
+                confirm: () => {
+                    this.pos.data.delete("pos.product.template.snooze", [
+                        this.state.activeSnooze.id,
+                    ]);
+                    this.state.activeSnooze = undefined;
+                    this.state.countdown = "";
+                },
+                confirmClass: "btn-primary flex-grow-1 flex-sm-grow-0",
+                cancelLabel: _t("Cancel"),
+                cancel: () => {},
+            });
+            return;
+        }
+        this.dialog.add(SnoozeDialog, {
+            name: this.props.productTemplate.display_name,
+            onSave: async (hours) => {
+                await this.snooze(hours);
+            },
+        });
+    }
+
+    getActiveSnooze() {
+        const product = this.props.productTemplate;
+        return this.pos.getActiveSnooze(product);
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -18,31 +18,42 @@
                 <t t-out="props.productTemplate.productDescriptionMarkup" />
             </div>
             <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info?.productInfo?.warehouses?.length > 0">
-                <h3 class="section-title">
-                    Inventory
-                    <t t-if="pos.session.update_stock_at_closing">(as of opening)</t>
-                </h3>
-                <div class="section-inventory-body">
-                    <t t-foreach="props.info.productInfo.warehouses" t-as="warehouse" t-key="warehouse.name">
-                        <div class="d-flex flex-column flex-md-row gap-2">
-                            <div>
-                                <t t-esc="warehouse.name" class="table-name"/>
-                                :
-                            </div>
-                            <div>
-                                <span class="me-1 fw-bolder"><t t-esc="warehouse.free_qty" class="table-name"/></span>
-                                <t t-esc="warehouse.uom"/> available,
-                            </div>
-                            <div>
-                                <span class="me-1 fw-bolder"><t t-esc="warehouse.forecasted_quantity"/></span>
-                                forecasted
-                            </div>
+                <div class="d-flex align-items-center gap-2">
+                    <div class="d-flex flex-column">
+                        <h3 class="section-title">
+                            Inventory
+                            <t t-if="pos.session.update_stock_at_closing">(as of opening)</t>
+                        </h3>
+                        <div class="section-inventory-body">
+                            <t t-foreach="props.info.productInfo.warehouses" t-as="warehouse" t-key="warehouse.name">
+                                <div class="d-flex flex-column flex-md-row gap-2">
+                                    <div>
+                                        <t t-esc="warehouse.name" class="table-name"/>
+                                        :
+                                    </div>
+                                    <div>
+                                        <span class="me-1 fw-bolder"><t t-esc="warehouse.free_qty" class="table-name"/></span>
+                                        <t t-esc="warehouse.uom"/> available,
+                                    </div>
+                                    <div>
+                                        <span class="me-1 fw-bolder"><t t-esc="warehouse.forecasted_quantity"/></span>
+                                        forecasted
+                                    </div>
+                                </div>
+                                <div>
+                                    On hand: <span class="me-1 fw-bolder"><t t-out="warehouse.available_quantity"/></span>
+                                    <t t-out="warehouse.uom"/>
+                                </div>
+                            </t>
                         </div>
-                        <div>
-                            On hand: <span class="me-1 fw-bolder"><t t-out="warehouse.available_quantity"/></span>
-                            <t t-out="warehouse.uom"/>
-                        </div>
-                    </t>
+                    </div>
+                    <button class="btn btn-lg lh-lg ms-auto text-nowrap" t-on-click="openSnoozeDialog" t-attf-class="{{this.state.activeSnooze ? 'btn-warning' : 'btn-secondary'}}">
+                        <i class="fa fa-clock-o me-1" t-if="!(this.state.activeSnooze and this.ui.isSmall)" aria-hidden="true"></i>
+                        <span t-if="!this.state.activeSnooze and !this.ui.isSmall">Snooze</span>
+                        <span class="m-0" t-if="this.state.activeSnooze" style="font-variant-numeric: tabular-nums;">
+                            <t t-esc="state.countdown" />
+                        </span>
+                    </button>
                 </div>
             </div>
             <div class="section-supplier mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info?.productInfo?.suppliers?.length > 0">

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/snooze_dialog/snooze_dialog.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/snooze_dialog/snooze_dialog.js
@@ -1,0 +1,31 @@
+import { _t } from "@web/core/l10n/translation";
+import { Component, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class SnoozeDialog extends Component {
+    static components = { Dialog };
+    static props = ["close", "name", "onSave"];
+    static template = "point_of_sale.SnoozeDialog";
+
+    setup() {
+        this.state = useState({ hours: 1 });
+    }
+    select(hours) {
+        this.state.hours = hours;
+    }
+    save() {
+        this.props.onSave(this.state.hours);
+        this.props.close();
+    }
+    getSnoozeOptions() {
+        return [
+            { label: _t("1 Hour"), value: 1, id: "1hour" },
+            { label: _t("2 Hours"), value: 2, id: "2hour" },
+            { label: _t("4 Hours"), value: 4, id: "4hour" },
+            { label: _t("Session"), value: 0, id: "session" },
+        ];
+    }
+    get headerTitle() {
+        return _t("Make %s unavailable for:", this.props.name);
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/snooze_dialog/snooze_dialog.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/snooze_dialog/snooze_dialog.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.SnoozeDialog">
+        <Dialog size="'sm'">
+            <t t-set-slot="header">
+                <h3> <t t-esc="this.headerTitle " /> </h3>
+            </t>
+            <div class="btn-group d-flex flex-column gap-2" role="group">
+                <t t-foreach="getSnoozeOptions()" t-as="option" t-key="option.value">
+                    <div class="row">
+                        <label class="col form-check-label" t-attf-for="{{option.id}}"> <t t-esc="option.label" /> </label>
+                        <div class="col text-end pe-4">
+                            <input type="radio" class="form-check-input" name="btnradio" t-attf-for="{{option.id}}" t-on-click="() => this.select(option.value)" />
+                        </div>
+                    </div>
+                </t>
+
+            </div>
+            <t t-set-slot="footer">
+                <div class="d-flex flex-row gap-2 w-100">
+                    <button class="btn btn-primary flex-grow-1 flex-sm-grow-0" t-on-click="save">Apply</button>
+                    <button class="btn btn-secondary flex-grow-1 flex-sm-grow-0" t-on-click="props.close">Discard</button>
+                </div>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.js
@@ -5,6 +5,7 @@ export class ProductCard extends Component {
     static props = {
         class: { String, optional: true },
         name: String,
+        available: { Boolean, optional: true },
         product: Object,
         productId: Number | String,
         comboExtraPrice: { String, optional: true },
@@ -21,6 +22,7 @@ export class ProductCard extends Component {
         class: "",
         showWarning: false,
         isComboPopup: false,
+        available: true,
     };
 
     get productQty() {

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -3,7 +3,7 @@
 
     <t t-name="point_of_sale.ProductCard">
         <article tabindex="0"
-            t-attf-class="{{props.class}} {{props.color ? `o_colorlist_item_color_transparent_${props.color}` : ''}} product position-relative btn btn-light d-flex align-items-stretch p-0 rounded-3 text-start cursor-pointer {{ props.imgUrl ? 'd-flex align-items-stretch' : ''}}"
+            t-attf-class="{{props.class}} {{props.color ? `o_colorlist_item_color_transparent_${props.color}` : ''}} product position-relative btn btn-light d-flex align-items-stretch p-0 rounded-3 text-start cursor-pointer {{ props.imgUrl ? 'd-flex align-items-stretch' : ''}} {{ props.available ? '' : 'opacity-50' }}"
             t-on-keypress="(event) => event.code === 'Space' ? props.onClick(event) : ()=>{}"
             t-on-click.stop="props.onClick"
             t-att-data-product-id="props.productId"

--- a/addons/point_of_sale/static/src/app/models/utils/snooze_tracker.js
+++ b/addons/point_of_sale/static/src/app/models/utils/snooze_tracker.js
@@ -1,0 +1,86 @@
+const { DateTime } = luxon;
+import { reactive } from "@odoo/owl";
+
+const REFRESH_DELAY = 1000;
+
+export class SnoozedProductTracker {
+    constructor(snoozes) {
+        this.state = reactive({ activeSnoozes: new Set(), snoozedProductIds: new Set() });
+        if (snoozes) {
+            this.setSnoozes(snoozes);
+        }
+    }
+
+    setSnoozes(snoozes) {
+        this.snoozes = (snoozes || []).filter(Boolean);
+        this.refresh();
+    }
+
+    getSnoozes() {
+        return this.snoozes;
+    }
+
+    refresh() {
+        if (this.updateTimeout) {
+            clearTimeout(this.updateTimeout);
+            this.updateTimeout = null;
+        }
+
+        if (!this.snoozes || this.snoozes.length === 0) {
+            this.state.activeSnoozes = [];
+            this.state.snoozedProductIds = new Set();
+            return;
+        }
+
+        const now = DateTime.now();
+        this.state.activeSnoozes = this.snoozes.filter(
+            ({ start_time, end_time }) => start_time <= now && (!end_time || end_time >= now)
+        );
+        const snoozedProductIds = new Set();
+        this.state.activeSnoozes.forEach((snooze) => {
+            snoozedProductIds.add(snooze.raw.product_template_id);
+        });
+        this.state.snoozedProductIds = snoozedProductIds;
+
+        // Schedule next refresh at earliest relevant boundary:
+        // - earliest end among active snoozes
+        // - earliest start among future snoozes (so they can become active)
+        let earliestUpdate = Infinity;
+        const nowMs = now.toMillis();
+        for (const s of this.state.activeSnoozes) {
+            const endMs = s.end_time?.toMillis();
+            if (endMs && endMs < earliestUpdate) {
+                earliestUpdate = endMs;
+            }
+        }
+        for (const s of this.snoozes) {
+            const startMs = s.start_time.toMillis();
+            if (startMs > nowMs && startMs < earliestUpdate) {
+                earliestUpdate = startMs;
+            }
+        }
+
+        if (earliestUpdate === Infinity) {
+            return;
+        }
+
+        const delay = Math.max(0, earliestUpdate - nowMs);
+        this.updateTimeout = setTimeout(() => this.refresh(), delay + REFRESH_DELAY);
+    }
+
+    getActiveSnooze(product) {
+        if (!this.isProductSnoozed(product)) {
+            return null;
+        }
+        for (const snooze of this.state.activeSnoozes) {
+            if (snooze.product_template_id?.id === product.id) {
+                return snooze;
+            }
+        }
+        return null;
+    }
+
+    isProductSnoozed(product) {
+        return this.state.snoozedProductIds.has(product.id); // ensure reactivity is triggered when snoozedProductIds is updated
+    }
+}

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -34,6 +34,7 @@
                                 product="product"
                                 class="pos.productViewMode"
                                 name="getProductName(product)"
+                                available="!pos.isProductSnoozed(product)"
                                 color="product.color || product.pos_categ_ids?.at(-1)?.color"
                                 imageUrl="pos.config.show_product_images and this.getProductImage(product)"
                                 onClick.bind="() => this.addProductToOrder(product)"

--- a/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
@@ -62,7 +62,7 @@ export default class DevicesSynchronisation {
      * @param {Object} data.static_records - Records data that need to be synchronized.
      */
     async collect(data) {
-        const { static_records, session_id, device_identifier } = data;
+        const { static_records, deleted_record_ids, session_id, device_identifier } = data;
         const isSameDevice = isSamePosDevice(session_id, device_identifier, this.pos);
 
         logPosMessage(
@@ -78,6 +78,9 @@ export default class DevicesSynchronisation {
 
         if (Object.keys(static_records).length) {
             this.processStaticRecords(static_records);
+        }
+        if (deleted_record_ids && Object.keys(deleted_record_ids).length) {
+            this.processDeletedRecords(deleted_record_ids);
         }
 
         return await this.readDataFromServer();

--- a/addons/point_of_sale/static/tests/pos/tours/pos_snooze_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_snooze_tour.js
@@ -1,0 +1,38 @@
+import { registry } from "@web/core/registry";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as ProductInfoScreen from "@point_of_sale/../tests/pos/tours/utils/product_info_screen_util";
+
+registry.category("web_tour.tours").add("test_pos_snooze", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickInfoProduct("Desk Organizer", [
+                ProductInfoScreen.productIsAvailable(),
+                ProductInfoScreen.clickSnoozeButton(),
+                ProductInfoScreen.clickSnoozeDuration("1 Hour"),
+                Dialog.confirm("Apply"),
+                ProductInfoScreen.productIsSnoozed(),
+                Dialog.confirm("Close"),
+            ]),
+            ProductScreen.productIsSnoozed("Desk Organizer"),
+            ProductScreen.clickInfoProduct("Desk Organizer", [
+                ProductInfoScreen.clickSnoozeButton(),
+                Dialog.confirm("Yes"),
+                ProductInfoScreen.productIsAvailable(),
+                Dialog.confirm("Close"),
+            ]),
+            ProductScreen.productIsNotSnoozed("Desk Organizer"),
+            ProductScreen.clickInfoProduct("Desk Organizer", [
+                ProductInfoScreen.productIsAvailable(),
+                ProductInfoScreen.clickSnoozeButton(),
+                ProductInfoScreen.clickSnoozeDuration("Session"),
+                Dialog.confirm("Apply"),
+                ProductInfoScreen.productIsSnoozed(),
+                Dialog.confirm("Close"),
+            ]),
+            ProductScreen.productIsSnoozed("Desk Organizer"),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_info_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_info_screen_util.js
@@ -1,0 +1,33 @@
+export function productIsAvailable() {
+    return {
+        trigger: ".section-inventory .btn.btn-secondary",
+        content: "Verify that the product is available",
+    };
+}
+export function productIsSnoozed() {
+    return {
+        trigger: ".section-inventory .btn.btn-warning",
+        content: "Verify that the product is not available anymore",
+    };
+}
+export function clickSnoozeButton() {
+    return {
+        trigger: ".section-inventory .btn",
+        content: "Click the snooze button",
+        run: "click",
+    };
+}
+export function clickAvailabilitySwitch() {
+    return {
+        trigger: ".section-inventory .form-switch input[type='checkbox']:not(:checked)",
+        content: "Click the snooze button",
+        run: "click",
+    };
+}
+export function clickSnoozeDuration(button) {
+    return {
+        trigger: `.btn-group .row label:contains(${button})`,
+        content: `Click the ${button} button`,
+        run: "click",
+    };
+}

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -1107,3 +1107,19 @@ export function clickBreakCombo() {
         },
     ];
 }
+export function productIsSnoozed(product_name) {
+    return [
+        {
+            trigger: `article.product.opacity-50:has(.product-name:contains('${product_name}'))`,
+            content: "Check that the product card is grayed out",
+        },
+    ];
+}
+export function productIsNotSnoozed(product_name) {
+    return [
+        {
+            trigger: `article.product:not(.opacity-50):has(.product-name:contains('${product_name}'))`,
+            content: "Check that the product card is not grayed out",
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3653,6 +3653,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.start_pos_tour("test_refund_line_keep_attributes")
 
+    def test_pos_snooze(self):
+        """Test that the available switch is on for available products
+        and off for snoozed products. """
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_pos_snooze')
+
     def test_orderline_merge_with_higher_price_precision(self):
         """ Test that orderline merging works correctly when product price has a higher precision than the currency. """
         self.env['decimal.precision'].search([('name', '=', 'Product Price')]).digits = 3

--- a/addons/pos_self_order/models/pos_snooze.py
+++ b/addons/pos_self_order/models/pos_snooze.py
@@ -4,28 +4,11 @@ from odoo import api, models
 class PosSnooze(models.Model):
     _inherit = 'pos.product.template.snooze'
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        records = super().create(vals_list)
-        for record in records:
-            # Notify open self orders that a product is now snoozed
-            record._notify_availability_updated()
-
-        return records
-
-    def write(self, vals):
-        res = super().write(vals)
-        for record in self:
-            record._notify_availability_updated()
-        return res
-
-    @api.ondelete(at_uninstall=False)
-    def _notify_availability_deleted(self):
-        config = self.mapped('pos_config_id')
-        payload = {'deleted': [self.ids]}
-        config._notify('SNOOZE_CHANGED', payload)
-
-    def _notify_availability_updated(self):
-        config = self.pos_config_id
-        payload = {'pos.product.template.snooze': self._load_pos_self_data_read(self, config)}
+    @api.model
+    def _sync_snoozes(self, config, updated_records=None, deleted_record_ids=None):
+        super()._sync_snoozes(config, updated_records, deleted_record_ids)
+        payload = {
+            'deleted_ids': deleted_record_ids if deleted_record_ids else [],
+            'records':  self._load_pos_self_data_read(updated_records, config) if updated_records else [],
+        }
         config._notify('SNOOZE_CHANGED', payload)

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -120,6 +120,9 @@ export class ProductListPage extends Component {
         if (product.pos_categ_ids.length === 0) {
             return true;
         }
+        if (this.selfOrder.isProductSnoozed(product)) {
+            return false;
+        }
         return product.pos_categ_ids.some((categ) => this.selfOrder.isCategoryAvailable(categ.id));
     }
 

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -58,7 +58,7 @@
                          <div class="product_list grid" t-att-class="{'pt-sm-3 pt-lg-4': selfOrder.kioskMode, 'pb-2': !selfOrder.kioskMode}">
                             <div t-foreach="productList" t-as="product" t-key="product.id" class="o_self_product_box g-col-12 g-col-md-6 g-col-lg-3 rounded-4 p-3 p-lg-0 shadow-sm shadow-lg-none" t-att-class="{'g-col-kiosk-p-4': productList.length &lt;= 9 , 'g-col-kiosk-p-3': productList.length &gt; 9 }">
                                 <t t-set="not_available" t-value="!product.self_order_available || !isProductAvailable(product)" />
-                                <article t-on-click="(evt) => this.selectProduct(product, evt.target)" class="position-relative d-flex flex-row-reverse flex-lg-column align-items-start cursor-pointer" t-att-class="{'opacity-50' : not_available}">
+                                <article t-on-click="(evt) => this.selectProduct(product, evt.target)" class="position-relative d-flex flex-row-reverse flex-lg-column align-items-start cursor-pointer" t-att-class="{'opacity-25' : not_available}">
                                     <div class="product_img ratio ratio-1x1 w-lg-100 flex-shrink-0 ms-2 ms-lg-0">
                                         <img class="object-fit-cover rounded-4" t-attf-src="/web/image/product.template/#{product.id}/image_512?unique=#{product.write_date}" loading="lazy"/>
                                     </div>

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -24,6 +24,7 @@ import {
 } from "@point_of_sale/app/models/utils/order_change";
 import { EpsonPrinter } from "@point_of_sale/app/utils/printer/epson_printer";
 import { initLNA } from "@point_of_sale/app/utils/init_lna";
+import { SnoozedProductTracker } from "@point_of_sale/app/models/utils/snooze_tracker";
 
 export class SelfOrder extends Reactive {
     constructor(...args) {
@@ -69,6 +70,7 @@ export class SelfOrder extends Reactive {
         this.currentCategory = null;
         this.productByCategIds = {};
         this.availableCategories = [];
+        this.snoozedProductTracker = new SnoozedProductTracker();
 
         this.initData();
         if (this.config.self_ordering_mode === "kiosk") {
@@ -78,6 +80,19 @@ export class SelfOrder extends Reactive {
         }
 
         this.data.connectWebSocket("ORDER_STATE_CHANGED", () => this.getUserDataFromServer());
+        this.data.connectWebSocket("SNOOZE_CHANGED", async (payload) => {
+            const { deleted_ids, records } = payload;
+            if (deleted_ids) {
+                const snoozeModel = this.models["pos.product.template.snooze"];
+                snoozeModel.deleteMany(
+                    deleted_ids.map((id) => snoozeModel.get(id)).filter(Boolean)
+                );
+            }
+            if (records.length > 0) {
+                await this.models.connectNewData({ "pos.product.template.snooze": records });
+            }
+            this.snoozedProductTracker.setSnoozes(this.config.pos_snooze_ids);
+        });
         this.data.connectWebSocket("PRODUCT_CHANGED", (payload) => {
             const productTemplateIds = payload["product.template"].map((tmpl) => tmpl.id);
             const existingProductIds = this.models["product.template"].filter((tmpl) =>
@@ -493,6 +508,7 @@ export class SelfOrder extends Reactive {
     }
 
     initData() {
+        this.snoozedProductTracker.setSnoozes(this.config.pos_snooze_ids);
         this.initProducts();
         this._initLanguages();
         this.initHardware();
@@ -509,6 +525,10 @@ export class SelfOrder extends Reactive {
             lg.display_name = lg.name.split("/").pop();
         });
         cookie.set("frontend_lang", this.currentLanguage?.code || "en_US");
+    }
+
+    isProductSnoozed(product) {
+        return this.snoozedProductTracker.isProductSnoozed(product);
     }
 
     createPrinter(printer) {


### PR DESCRIPTION
The PR will add an extra availability section on the product info popup which shows whether a product is currently available. From that section the product can then be 'snoozed', which will make it unavailable for a specified period of time. (1, 2, 4 hours, or for the entire session).

When the product is unavailable there's a countdown timer on the popup showing when the product will be available again.

Products which are 'snoozed' still show up on the product screen, but grayed out. The effect is purely cosmetic, as they can still be added to new orders.

Task-[5170696](https://www.odoo.com/odoo/project/1737/tasks/5170696)

Previous discussion-[#232625](https://github.com/odoo/odoo/pull/232625)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
