### PR TITLE
[FIX] mail: rpc call when editing an edited message with no change

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -540,12 +540,11 @@ export class Message extends Record {
         attachments = [],
         { mentionedChannels = [], mentionedPartners = [], mentionedRoles = [] } = {}
     ) {
-        const bodyEl = createElementWithContent("div", this.body);
-        bodyEl.querySelector("span.o-mail-Message-edited")?.remove();
-        if (
-            createElementWithContent("div", body).innerHTML === bodyEl.innerHTML &&
-            attachments.length === 0
-        ) {
+        const messageBodyEl = createElementWithContent("div", this.body);
+        const updatedBodyEl = createElementWithContent("div", body);
+        messageBodyEl.querySelector("span.o-mail-Message-edited")?.remove();
+        updatedBodyEl.querySelector("span.o-mail-Message-edited")?.remove();
+        if (updatedBodyEl.innerHTML === messageBodyEl.innerHTML && attachments.length === 0) {
             return;
         }
         const validMentions = this.store.getMentionsFromText(body, {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -493,6 +493,13 @@ test("Do not call server on save if no changes", async () => {
     await click(".o-mail-Message [title='Edit']");
     await click(".o-mail-Message button", { text: "save" });
     await waitForSteps([]);
+    await click(".o-mail-Message [title='Edit']");
+    await insertText(".o-mail-Message .o-mail-Composer-input", " - updated");
+    await click(".o-mail-Message button", { text: "save" });
+    await waitForSteps(["update_content"]);
+    await click(".o-mail-Message [title='Edit']");
+    await click(".o-mail-Message button", { text: "save" });
+    await waitForSteps([]);
 });
 
 test("Update the link previews when a message is edited", async () => {


### PR DESCRIPTION
Since #224800, we've been removing the `edited` element from the current message
body in order to compare it with the updated body. However, the `edited`
element may also be present in the updated body. This change removes the
`edited` element from the updated body as well, ensuring a reliable comparison
when editing an edited message.

Steps to reproduce:
- Send a message.
- Click `edit`, change the message body and click `save`.
- Click `edit` again, don't change the message body this time, then click `save` .
- An RPC is made to update the message.
