### PR TITLE
[IMP] sale_timesheet: default upsell warning at 90%

### DIFF
--- a/addons/sale_timesheet/models/product_template.py
+++ b/addons/sale_timesheet/models/product_template.py
@@ -20,7 +20,7 @@ class ProductTemplate(models.Model):
     # override domain
     project_id = fields.Many2one(domain="['|', ('company_id', '=', False), '&', ('company_id', '=?', company_id), ('company_id', '=', current_company_id), ('allow_billable', '=', True), ('pricing_type', '=', 'task_rate'), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet', True]), ('is_template', '=', False)]")
     project_template_id = fields.Many2one(domain="['|', ('company_id', '=', False), '&', ('company_id', '=?', company_id), ('company_id', '=', current_company_id), ('allow_billable', '=', True), ('allow_timesheets', 'in', [service_policy == 'delivered_timesheet', True]), ('is_template', '=', True)]")
-    service_upsell_threshold = fields.Float('Threshold', default=1, help="Percentage of time delivered compared to the prepaid amount that must be reached for the upselling opportunity activity to be triggered.")
+    service_upsell_threshold = fields.Float('Threshold', default=0.9, help="Percentage of time delivered compared to the prepaid amount that must be reached for the upselling opportunity activity to be triggered.")
     service_upsell_threshold_ratio = fields.Char(compute='_compute_service_upsell_threshold_ratio', export_string_translation=False)
 
     @api.depends('uom_id', 'company_id')

--- a/addons/sale_timesheet/views/product_views.xml
+++ b/addons/sale_timesheet/views/product_views.xml
@@ -18,13 +18,13 @@
                         or service_tracking not in ['no', 'task_global_project', 'task_in_project', 'project_only']"
                     class="fst-italic text-muted"
                 >
-                    Warn the salesperson for an upsell when work done exceeds
+                    Notify the salesperson about an upsell opportunity when completed work exceeds
                     <field
                         name="service_upsell_threshold"
                         widget="percentage"
-                        class="oe_inline o_field_highlight"
+                        class="fst-normal oe_inline o_field_highlight text-body"
                     />
-                    of hours sold. <field name="service_upsell_threshold_ratio" class="oe_inline" invisible="not service_upsell_threshold_ratio"/>
+                    of the hours sold. <field name="service_upsell_threshold_ratio" class="oe_inline" invisible="not service_upsell_threshold_ratio"/>
                 </div>
             </field>
         </field>


### PR DESCRIPTION
In this commit, we change the default upsell warning to be 90%.

task-5416784