### PR TITLE
[FIX] UOM: corrections

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
+++ b/addons/l10n_tr_nilvera_edispatch/templates/l10n_tr_nilvera_edispatch.xml
@@ -61,7 +61,7 @@
         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" id="nilvera_dispatch_line">
         <cac:DespatchLine>
             <cbc:ID t-out="line_id"/>
-            <cbc:DeliveredQuantity t-att-unitCode="line.product_uom._get_unece_code()" t-out="line.quantity"/>
+            <cbc:DeliveredQuantity t-att-unitCode="line.uom_id._get_unece_code()" t-out="line.quantity"/>
             <cac:OrderLineReference>
                 <cbc:LineID t-out="line_id"/>
             </cac:OrderLineReference>

--- a/addons/mrp_account/report/report_mrp_templates.xml
+++ b/addons/mrp_account/report/report_mrp_templates.xml
@@ -44,7 +44,7 @@
                                                 <span t-field="line.unit_amount">5</span>
                                             </td>
                                             <td class="align-middle">
-                                                <span t-field="line.uom_id">Units</span>
+                                                <span t-field="line.product_uom_id">Units</span>
                                             </td>
                                             <td class="text-end align-middle">
                                                 <span t-field="line.amount">$1000</span>


### PR DESCRIPTION
Corrective patch for anything that was missed or broken by the initial uompocalypse PR.
- missed `product_uom`
- wrong change to `uom_id` on `account.analytic.line` model, this was breaking `test_reports` in the demo build

https://runbot.odoo.com/odoo/runbot.build.error/238413

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
