### PR TITLE
 [FIX] l10n_{in,fr}_hr_holidays: prevent error in time off by employee

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -109,7 +109,7 @@ class HrLeave(models.Model):
                 else:
                     leave.l10n_fr_date_to_changed = False
 
-    def _get_durations(self, check_leave_type=True, resource_calendar=None):
+    def _get_durations(self, check_leave_type=True, resource_calendar=None, additional_domain=[]):
         """
         In french time off laws, if an employee has a part time contract, when taking time off
         before one of his off day (compared to the company's calendar) it should also count the time
@@ -172,4 +172,4 @@ class HrLeave(models.Model):
                     duration_by_leave_id[leave.id] = (legal_days, hours)
 
             return duration_by_leave_id
-        return super()._get_durations(resource_calendar=resource_calendar)
+        return super()._get_durations(check_leave_type, resource_calendar, additional_domain)

--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -215,8 +215,8 @@ class HrLeave(models.Model):
             )
         return total_leaves
 
-    def _get_durations(self, check_leave_type=True, resource_calendar=None):
-        result = super()._get_durations(check_leave_type, resource_calendar)
+    def _get_durations(self, check_leave_type=True, resource_calendar=None, additional_domain=[]):
+        result = super()._get_durations(check_leave_type, resource_calendar, additional_domain)
 
         indian_leaves, leaves_dates_by_employee, public_holidays_date_by_company = self._l10n_in_prepare_sandwich_context()
         if not indian_leaves:


### PR DESCRIPTION
Currently, an error occurs when user opens Time Off per Employee Analysis.

**Steps to Reproduce:**
 - Install `l10n_fr_hr_holidays` with demo data.
 - Switch to a `French company`.
 - Create a time off for any employee (if none exists).
 - Go to `Time Off` > `Reporting` > `By Employee`.

`TypeError: HrLeave._get_durations() got an unexpected keyword argument 'additional_domain'`

After [this commit], _get_durations accepts an additional_domain parameter. However, this parameter is 
not defined in the _get_durations method in the French and Indian localizations. When a user opens 
Time Off by Employee in the French or Indian localization, the compute method is executed to calculate 
leave durations, and additional_domain is passed as an argument [1], which raises the error [2] [3].

This commit adds the additional_domain parameter to the Indian and French localizations. In the French 
localization, it also passes check_leave_type, as its value is passed internally within the method [4].

[this commit]: https://github.com/odoo/odoo/commit/1c3f5633ef87f6d9c5a6169eefd51cd42ef442d5#diff-38469def2f870bb866f971f57797dd7c21b6a95d52a8eae72f832f0eea2434f9R575

[1]- https://github.com/odoo/odoo/blob/8db5a8cf07fa9c2b677b061b5897f757cb1f7260/addons/hr_holidays/report/hr_leave_employee_report.py#L94

[2]: https://github.com/odoo/odoo/blob/80e29d864b3e54ea68d2731da4c0f2f917f5d56a/addons/l10n_in_hr_holidays/models/hr_leave.py#L218

[3]: https://github.com/odoo/odoo/blob/80e29d864b3e54ea68d2731da4c0f2f917f5d56a/addons/l10n_fr_hr_holidays/models/hr_leave.py#L112

[4]: https://github.com/odoo/odoo/blob/9d4103c061c5fbe9913fa721ea3e6d417bc89e93/addons/hr_holidays/models/hr_leave.py#L531

sentry-7213025295


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
