### PR TITLE
[FIX] website: translate links inline on media replacement

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
@@ -7,10 +7,10 @@ export class DocumentAttachment extends Attachment {
 }
 
 export class DocumentSelector extends FileSelector {
-    static mediaSpecificClasses = ["o_image"];
+    static mediaSpecificClasses = ["o_file_box"];
     static mediaSpecificStyles = [];
     static mediaExtraClasses = [];
-    static tagNames = ["A"];
+    static tagNames = ["SPAN"];
     static attachmentsListTemplate = "html_editor.DocumentsListTemplate";
     static components = {
         ...FileSelector.components,
@@ -48,7 +48,7 @@ export class DocumentSelector extends FileSelector {
             for (const attachment of attachments) {
                 if (
                     `/web/content/${attachment.id}` ===
-                    this.props.media.getAttribute("href").replace(/[?].*/, "")
+                    this.props.media.querySelector("a").getAttribute("href").replace(/[?].*/, "")
                 ) {
                     this.selectAttachment(attachment);
                 }

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -91,9 +91,15 @@ export class MediaDialog extends Component {
             return this.props.activeTab;
         }
         if (this.props.media) {
-            const correspondingTab = Object.keys(this.tabs).find((id) =>
-                this.tabs[id].Component.tagNames.includes(this.props.media.tagName)
-            );
+            const correspondingTab =
+                Object.keys(this.tabs).find((id) =>
+                    this.tabs[id].Component.mediaSpecificClasses.some((cls) =>
+                        [...this.props.media.classList].includes(cls)
+                    )
+                ) ||
+                Object.keys(this.tabs).find((id) =>
+                    this.tabs[id].Component.tagNames.includes(this.props.media.tagName)
+                );
             if (correspondingTab) {
                 return correspondingTab;
             }

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -300,7 +300,7 @@ export const ICON_SELECTOR = iconTags
     .map((tag) => iconClasses.map((cls) => `${tag}.${cls}`).join(", "))
     .join(", ");
 
-export const MEDIA_SELECTOR = `${ICON_SELECTOR} , .o_image, .media_iframe_video`;
+export const MEDIA_SELECTOR = `${ICON_SELECTOR}, .media_iframe_video, .o_file_box`;
 
 export const EDITABLE_MEDIA_CLASS = "o_editable_media";
 
@@ -323,7 +323,7 @@ export function isMediaElement(node) {
     return (
         isIconElement(node) ||
         (node.classList &&
-            (node.classList.contains("o_image") ||
+            (node.classList.contains("o_file_box") ||
                 node.classList.contains("media_iframe_video"))) ||
         node.nodeName === "CANVAS"
     );

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -407,21 +407,27 @@ describe("Selection collapsed", () => {
 
         test("should unwrap a block next to an inline unbreakable element", async () => {
             await testEditor({
-                contentBefore: `<div><p>abc</p><div class="o_image"></div><p>[]def</p></div>`,
+                contentBefore: `<div><p>abc</p><span class="oe_unbreakable"></span><p>[]def</p></div>`,
                 stepFunction: async (editor) => {
                     deleteBackward(editor);
                 },
-                contentAfter: `<div><p>abc</p><div class="o_image"></div>[]def</div>`,
+                // After the deleteBackward, the automatic normalization of
+                // setSelection puts the cursor at the deepest position, that is
+                // in the span, rather than after it. While it might look a bit
+                // weird in this case, it makes more sense if one imagine that
+                // it is a style tag like bold or italic.
+                contentAfter: `<div><p>abc</p><span class="oe_unbreakable">[]</span>def</div>`,
             });
         });
 
         test("should remove an inline unbreakable contenteditable='false' sibling element", async () => {
             await testEditor({
-                contentBefore: `<div><p>abc</p><div class="o_image"></div>[]def</div>`,
+                contentBefore: `<div><p>abc</p><span class="oe_unbreakable" contenteditable="false">d</span>[]efg</div>`,
+                contentBeforeEdit: `<div><p>abc</p><span class="oe_unbreakable" contenteditable="false">d</span>[]efg</div>`,
                 stepFunction: async (editor) => {
                     deleteBackward(editor);
                 },
-                contentAfter: `<div><p>abc</p>[]def</div>`,
+                contentAfter: `<div><p>abc</p>[]efg</div>`,
             });
         });
 
@@ -495,16 +501,16 @@ describe("Selection collapsed", () => {
 
         test("should merge paragraph with previous one containing a media element", async () => {
             await testEditor({
-                contentBefore: `<p>abc</p><p style="margin-bottom: 0px;"><o-image class="o_image" contenteditable="false"></o-image></p><p>[]def</p>`,
+                contentBefore: `<p>abc</p><p style="margin-bottom: 0px;"><span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span></p><p>[]def</p>`,
                 stepFunction: deleteBackward,
-                contentAfterEdit: `<p>abc</p><p style="margin-bottom: 0px;"><o-image class="o_image" contenteditable="false"></o-image>[]def</p>`,
-                contentAfter: `<p>abc</p><p style="margin-bottom: 0px;"><o-image class="o_image"></o-image>[]def</p>`,
+                contentAfterEdit: `<p>abc</p><p style="margin-bottom: 0px;">\ufeff<span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>\ufeff[]def</p>`,
+                contentAfter: `<p>abc</p><p style="margin-bottom: 0px;"><span class="o_file_box"><a href="#" title="document" data-mimetype="application/pdf"></a></span>[]def</p>`,
             });
         });
 
         test("should remove a media element inside a p", async () => {
             await testEditor({
-                contentBefore: `<p>abc</p><p style="margin-bottom: 0px;"><o-image class="o_image" contenteditable="false"></o-image>[]def</p>`,
+                contentBefore: `<p>abc</p><p style="margin-bottom: 0px;"><span class="fa fa-icon" contenteditable="false"></span>[]def</p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>abc</p><p style="margin-bottom: 0px;">[]def</p>`,
             });
@@ -512,7 +518,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document", async () => {
             await testEditor({
-                contentBefore: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>`,
+                contentBefore: `<p>abc<span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>[]</p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>abc[]</p>`,
             });
@@ -520,7 +526,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document at the beginning of the editable", async () => {
             await testEditor({
-                contentBefore: `<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>`,
+                contentBefore: `<p><span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>[]</p>`,
                 stepFunction: deleteBackward,
                 contentAfter: `<p>[]<br></p>`,
             });

--- a/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
+++ b/addons/html_editor/static/tests/delete/find_adjacent_position.test.js
@@ -98,7 +98,7 @@ describe("findAdjacentPosition method", () => {
                 const [node, offset] = findAdjacentPosition(editor, "backward");
                 setSelection({ anchorNode: node, anchorOffset: offset });
                 expect(getContent(el)).toBe(
-                    `<div class="o-paragraph o-we-hint" o-we-hint-text='Type "/" for commands'>\ufeff[]<span contenteditable="false" class="o_file_box"></span>\ufeff<br></div>`
+                    `<div class="o-paragraph">\ufeff[]<span contenteditable="false" class="o_file_box"></span>\ufeff</div>`
                 );
             });
         });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -350,7 +350,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document", async () => {
             await testEditor({
-                contentBefore: `<p>[]<a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>abc</p>`,
+                contentBefore: `<p>[]<span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>abc</p>`,
                 stepFunction: deleteForward,
                 contentAfter: `<p>[]abc</p>`,
             });
@@ -358,7 +358,7 @@ describe("Selection collapsed", () => {
 
         test("should remove a link to uploaded document at the end of the editable", async () => {
             await testEditor({
-                contentBefore: `<p>[]<a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>`,
+                contentBefore: `<p>[]<span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span></p>`,
                 stepFunction: deleteForward,
                 contentAfter: `<p>[]<br></p>`,
             });

--- a/addons/html_editor/static/tests/file.test.js
+++ b/addons/html_editor/static/tests/file.test.js
@@ -346,15 +346,15 @@ describe("zero width no-break space", () => {
 
     test("should not add two contiguous ZWNBSP between two file cards (2)", async () => {
         const { el } = await setupEditor(
-            '<p>abc<span data-embedded="file" class="o_file_box"></span>x[]<span data-embedded="file" class="o_file_box"></span></p>',
+            '<p>abc<span data-embedded="file" class="o_file_box" contenteditable="false"></span>x[]<span data-embedded="file" class="o_file_box" contenteditable="false"></span></p>',
             { config: { ...configWithEmbeddedFile, resources: {} } } // disable embedded component rendering
         );
         expect(getContent(el)).toBe(
-            '<p>abc\ufeff<span data-embedded="file" class="o_file_box"></span>\ufeffx[]\ufeff<span data-embedded="file" class="o_file_box"></span>\ufeff</p>'
+            '<p>abc\ufeff<span data-embedded="file" class="o_file_box" contenteditable="false"></span>\ufeffx[]\ufeff<span data-embedded="file" class="o_file_box" contenteditable="false"></span>\ufeff</p>'
         );
         press("Backspace");
         expect(getContent(el)).toBe(
-            '<p>abc\ufeff<span data-embedded="file" class="o_file_box"></span>\ufeff[]<span data-embedded="file" class="o_file_box"></span>\ufeff</p>'
+            '<p>abc\ufeff<span data-embedded="file" class="o_file_box" contenteditable="false"></span>\ufeff[]<span data-embedded="file" class="o_file_box" contenteditable="false"></span>\ufeff</p>'
         );
     });
 });

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -59,18 +59,22 @@ test("placeholder must not be visible if there is content in the editor", async 
 
 test("placeholder must not be visible if there is content in the editor (2)", async () => {
     const content =
-        '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>';
+        '<p><span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span></p>';
     const { el } = await setupEditor(content, { config: { placeholder: "test" } });
     // Unchanged, no placeholder hint.
-    expect(getContent(el)).toBe(content);
+    expect(getContent(el)).toBe(
+        '<p>\ufeff<span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>\ufeff</p>'
+    );
 });
 
 test("should not display hint in paragraph with media content", async () => {
     const content =
-        '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a>[]</p>';
+        '<p><span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>[]</p>';
     const { el } = await setupEditor(content);
     // Unchanged, no empty paragraph hint.
-    expect(getContent(el)).toBe(content);
+    expect(getContent(el)).toBe(
+        '<p>\ufeff<span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>\ufeff[]</p>'
+    );
 });
 
 test("should not display hint in a non-editable paragraph", async () => {

--- a/addons/html_editor/static/tests/initialization.test.js
+++ b/addons/html_editor/static/tests/initialization.test.js
@@ -98,12 +98,14 @@ describe("No orphan inline elements compatibility mode", () => {
         });
     });
 
-    test("should wrap a div.o_image direct child of the editable into a block", async () => {
+    test("should wrap a div.o_file_box direct child of the editable into a block", async () => {
         await testEditor({
-            contentBefore: '<p>abc</p><div class="o_image"></div><p>def</p>',
+            contentBefore:
+                '<p>abc</p><span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span><p>def</p>',
             contentBeforeEdit:
-                '<p>abc</p><div><div class="o_image" contenteditable="false"></div></div><p>def</p>',
-            contentAfter: '<p>abc</p><div><div class="o_image"></div></div><p>def</p>',
+                '<p>abc</p><div class="o-paragraph">\ufeff<span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span>\ufeff</div><p>def</p>',
+            contentAfter:
+                '<p>abc</p><div><span class="o_file_box"><a href="#" title="document" data-mimetype="application/pdf"></a></span></div><p>def</p>',
         });
     });
 });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -96,16 +96,16 @@ describe("Selection collapsed", () => {
         });
         test("should split block without afecting the uploaded document link", async () => {
             await testEditor({
-                contentBefore: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a>[]def</p>`,
+                contentBefore: `<p>abc<span class="o_file_box"><a href="#" title="document" data-mimetype="application/pdf"></a></span>[]def</p>`,
                 stepFunction: splitBlock,
-                contentAfter: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a></p><p>[]def</p>`,
+                contentAfter: `<p>abc<span class="o_file_box"><a href="#" title="document" data-mimetype="application/pdf"></a></span></p><p>[]def</p>`,
             });
         });
         test("should split block without afecting the uploaded document link (2)", async () => {
             await testEditor({
-                contentBefore: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a>[]</p>`,
+                contentBefore: `<p>abc<span class="o_file_box"><a href="#" title="document" data-mimetype="application/pdf"></a></span>[]</p>`,
                 stepFunction: splitBlock,
-                contentAfter: `<p>abc<a href="#" title="document" data-mimetype="application/pdf" class="o_image"></a></p><p>[]<br></p>`,
+                contentAfter: `<p>abc<span class="o_file_box"><a href="#" title="document" data-mimetype="application/pdf"></a></span></p><p>[]<br></p>`,
             });
         });
         test("should not split block with conditional template", async () => {

--- a/addons/html_editor/static/tests/link/existing.test.js
+++ b/addons/html_editor/static/tests/link/existing.test.js
@@ -146,13 +146,13 @@ test("should not remove a link containing an image on save", async () => {
 test("should not remove a document link on save", async () => {
     await testEditor({
         contentBefore:
-            '<p>a<a href="exist" class="o_image" title="file.js.map" data-mimetype="text/plain"></a>b</p>',
+            '<p>a<span class="o_file_box"><a href="exist" title="file.js.map" data-mimetype="text/plain"></a></span>b</p>',
         contentBeforeEdit:
-            '<p>a<a href="exist" class="o_image" title="file.js.map" data-mimetype="text/plain" contenteditable="false"></a>b</p>',
+            '<p>a\ufeff<span class="o_file_box" contenteditable="false"><a href="exist" title="file.js.map" data-mimetype="text/plain"></a></span>\ufeffb</p>',
         contentAfterEdit:
-            '<p>a<a href="exist" class="o_image" title="file.js.map" data-mimetype="text/plain" contenteditable="false"></a>b</p>',
+            '<p>a\ufeff<span class="o_file_box" contenteditable="false"><a href="exist" title="file.js.map" data-mimetype="text/plain"></a></span>\ufeffb</p>',
         contentAfter:
-            '<p>a<a href="exist" class="o_image" title="file.js.map" data-mimetype="text/plain"></a>b</p>',
+            '<p>a<span class="o_file_box"><a href="exist" title="file.js.map" data-mimetype="text/plain"></a></span>b</p>',
     });
 });
 

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -590,7 +590,7 @@ describe("isEmptyBlock", () => {
 
     test("should return false for a p containing media element", () => {
         const [p] = insertTestHtml(
-            '<p><a href="#" title="document" data-mimetype="application/pdf" class="o_image" contenteditable="false"></a></p>'
+            '<p><span class="o_file_box" contenteditable="false"><a href="#" title="document" data-mimetype="application/pdf"></a></span></p>'
         );
         const result = isEmptyBlock(p);
         expect(result).toBe(false);

--- a/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
@@ -7,12 +7,19 @@ export class TranslateLinkInlinePlugin extends Plugin {
     resources = {
         create_link_handlers: (linkEl) => linkEl.classList.add("o_translate_inline"),
         before_insert_processors: (container) => {
-            for (const linkEl of container.querySelectorAll("a")) {
-                linkEl.classList.add("o_translate_inline");
-            }
+            this.markTranslateInline(container);
             return container;
         },
+        on_replaced_media_handlers: ({ newMediaEl }) => {
+            this.markTranslateInline(newMediaEl);
+        },
     };
+
+    markTranslateInline(containerEl) {
+        for (const linkEl of containerEl.querySelectorAll("a")) {
+            linkEl.classList.add("o_translate_inline");
+        }
+    }
 }
 
 registry.category("website-plugins").add(TranslateLinkInlinePlugin.id, TranslateLinkInlinePlugin);

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -223,3 +223,62 @@ registerWebsitePreviewTour("website_media_dialog_insert_media", {
         trigger: ":iframe .s_text_block p > span.fa",
     },
 ]);
+
+registerWebsitePreviewTour(
+    "website_media_dialog_insert_file",
+    {
+        url: "/",
+        edition: true,
+    },
+    () => [
+        ...insertSnippet({
+            id: "s_text_block",
+            name: "Text",
+            groupName: "Text",
+        }),
+        {
+            content: "Click on the first paragraph",
+            trigger: ":iframe .s_text_block p",
+            run: "editor test",
+        },
+        {
+            content: "Show the powerbox",
+            trigger: ":iframe .s_text_block p:last-child",
+            async run(actions) {
+                await actions.editor(`/`);
+                const wrapwrap = this.anchor.closest("#wrapwrap");
+                wrapwrap.dispatchEvent(
+                    new InputEvent("input", {
+                        inputType: "insertText",
+                        data: "/",
+                    })
+                );
+            },
+        },
+        {
+            content: "Click on the media item from powerbox",
+            trigger: "div.o-we-command-name:contains('Media')",
+            run: "click",
+        },
+        {
+            content: "Click on the 'Documents' tab",
+            trigger: ".o_select_media_dialog a.nav-link:contains('Documents')",
+            run: "click",
+        },
+        {
+            content: "Click on the first document",
+            trigger: ".o_select_media_dialog .o_existing_attachment_cell",
+            run: "click",
+        },
+        {
+            content:
+                "Verify that the document was inserted and reopen the media dialog with a double click",
+            trigger: ":iframe .s_text_block p > .o_file_box",
+            run: "dblclick",
+        },
+        {
+            content: "Verify that the dialog opened on the Documents tab",
+            trigger: ".o_select_media_dialog a.nav-link.active:contains('Documents')",
+        },
+    ]
+);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -570,6 +570,16 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_website_media_dialog_insert_media(self):
         self.start_tour("/", "website_media_dialog_insert_media", login="admin")
 
+    def test_website_media_dialog_insert_file(self):
+        # Ensure at least one document exists for the step that chooses one
+        self.env['ir.attachment'].create({
+            'name': 'doc.txt',
+            'raw': b'Text',
+            'mimetype': 'text/plain',
+            'public': True,
+        })
+        self.start_tour("/", "website_media_dialog_insert_file", login="admin")
+
     def test_website_text_font_size(self):
         self.start_tour('/@/', 'website_text_font_size', login='admin', timeout=300)
 


### PR DESCRIPTION
[FIX] website: translate links inline on media replacement
    
    On the website builder, files added through the `/file` command would go
    through the domPlugin `insert` method, which would call
    `before_insert_processors` and apply `.o_translate_inline` as expected.
    But there is another flow to add a document on the page: replace an
    image (or video, or icon), then select the "Documents" tab and upload
    a file. With this flow, `insert` is not called, so we have to add the
    class through some other resource.
    
[FIX] html_editor: target documents with right class
    
    The class `.o_image` was still associated with documents (in the context
    of the file selector) and the expected tag of a document was `A`, in
    spite of it not being true in `html_editor` since the introduction of
    the file box in [1].
    
    This has also been updated in the website builder since the introduction
    of the `html_builder` module in 18.4, which swapped uses of `web_editor`
    components for `html_editor`.
    
    As a side-effect, in website, a double click on a file did not open the
    media dialog on the "document" tab, unlike other media (images, videos,
    icons). In such a case, the file was also not shown as already selected
    in the media dialog (because it targetted the wrong tag name). Both of
    those behaviors were lost as we used the new file box design in 18.4.
    
    [1]: https://github.com/odoo/odoo/commit/7f9afa21dffba2f74f9fb8a68809db4af6c7c225
    
task-5876278