### PR TITLE
[FIX] mrp_subcontracting: use correct location for return for exchange

### DIFF
--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -1284,6 +1284,54 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
             {'product_id': self.comp1.id, 'location_id': stock_location.id, 'location_dest_id': supplier_location.id}
         ])
 
+    def test_subcontracting_order_returned_for_exchange(self):
+        """
+        Test the locations used when returning a receipt for exchange from a subcontractor
+        """
+        custom_subcontract_location = self.env['stock.location'].create({
+            'name': 'Custom Subcontractor Location',
+            'location_id': self.env.company.subcontracting_location_id.id,
+            'usage': 'internal',
+            'company_id': self.env.company.id,
+            'is_subcontracting_location': True,
+        })
+        self.subcontractor_partner1.property_stock_subcontractor = custom_subcontract_location.id
+        initial_receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.ref('stock.picking_type_in'),
+            'partner_id': self.subcontractor_partner1.id,
+            'location_id': self.ref('stock.stock_location_suppliers'),
+            'location_dest_id': self.warehouse.lot_stock_id.id,
+            'move_ids': [
+                Command.create({
+                    'name': self.finished.name,
+                    'product_id': self.finished.id,
+                })
+            ]
+        })
+        initial_receipt.action_confirm()
+        initial_receipt.move_ids.quantity = 1
+        initial_receipt.button_validate()
+        return_wizard = Form(
+            self.env['stock.return.picking'].with_context(active_id=initial_receipt.id, active_model='stock.picking')
+        ).save()
+        return_wizard.product_return_moves.quantity = 1
+        return_picking = Form.from_action(self.env, return_wizard.action_create_exchanges()).save()
+        exchange_picking = return_picking.return_ids
+        self.assertRecordValues(initial_receipt.move_ids, [{
+            'location_id': self.subcontractor_partner1.property_stock_subcontractor.id,
+            'location_dest_id': self.warehouse.lot_stock_id.id,
+        }])
+        self.assertEqual(return_picking.return_id, initial_receipt)
+        self.assertRecordValues(return_picking.move_ids, [{
+            'location_id': self.warehouse.lot_stock_id.id,
+            'location_dest_id': self.subcontractor_partner1.property_stock_subcontractor.id,
+        }])
+        self.assertEqual(exchange_picking.return_id.return_id, initial_receipt)
+        self.assertRecordValues(exchange_picking.move_ids, [{
+            'location_id': self.subcontractor_partner1.property_stock_subcontractor.id,
+            'location_dest_id': self.warehouse.lot_stock_id.id,
+        }])
+
 
 @tagged('post_install', '-at_install')
 class TestSubcontractingTracking(TransactionCase):

--- a/addons/mrp_subcontracting/wizard/stock_picking_return.py
+++ b/addons/mrp_subcontracting/wizard/stock_picking_return.py
@@ -19,7 +19,7 @@ class StockReturnPickingLine(models.TransientModel):
 
     def _prepare_move_default_values(self, new_picking):
         vals = super()._prepare_move_default_values(new_picking)
-        if self.move_id.is_subcontract:
+        if self.move_id.is_subcontract and new_picking.picking_type_code == 'outgoing':
             vals['location_dest_id'] = new_picking.partner_id.with_company(new_picking.company_id).property_stock_subcontractor.id
         vals['is_subcontract'] = False
         return vals


### PR DESCRIPTION
## Issue
When making a request for quotation for a subcontracted product and returning the delivery "for exchange", the new incoming delivery does not have the correct destination. Instead of having the stock of the user, the destination of the new incoming delivery is the same as its source: the subcontracting location.

<img width="1254" height="257" alt="5479900" src="https://github.com/user-attachments/assets/c7e6d392-8328-4a03-a71e-466e768f448b" />

## Steps to reproduce
1. Install MRP Subcontracting (`mrp_subcontracting`) and Purchase (`purchase`)
2. In Settings, enable *Subcontracting*
3. Create a Product P and a subcontracting BoM with Subcontractor S
4. Create a Request for Quotation
    - Vendor: Subcontractor S
    - Product: Product P (any quantity > 0)
5. Confirm the RFQ, receive the PO, validate the picking
6. On the validated picking, click *Return*, set the quantity of products to return, and click *Return for Exchange*
    - This creates two new pickings, one to return the product(s) we received, and one to receive new products
7. Validate the two new pickings
8. **In Inventory > Reporting > Moves History, the very last `stock.move.line` has the same location in the *From* (`location_id`) and the *To* (`location_dest_id`) columns**

## Cause
The `location_dest_id` of the new `stock.move` is updated in `StockReturnPickingLine._prepare_move_default_values`.

https://github.com/odoo/odoo/blob/fb534f1eadcb8ef74e2ee6fd5b68872dddb978e3/addons/mrp_subcontracting/wizard/stock_picking_return.py#L20-L25

The condition added by https://github.com/odoo/odoo/commit/5404b426aac9 sets the destination of all returned subcontracted moves to the subcontractor location. This is incorrect when using "return for exchange", as in this case, the return move is directed towards the user's stock. In fact, when using "return for exchange", the following pickings are created:

| id | name         | return_id |   |
|:--:|--------------|:---------:|---|
| 1  | WH/IN/00001  |           | Initial RFQ delivery |
| 2  | WH/OUT/00001 |     1     | Return of the initial RFQ delivery |
| 3  | WH/IN/00002  |     2     | New products delivery to replace the initial delivery. The stock.move.line of this stock.picking has a wrong `location_dest_id` |

## Fix
In the context of return for exchanges, the returned item must be directed to the *Subcontracting Location* while the new item must be directed to   the *Stock*. In the `_prepare_move_default_values`, we should only set   the `location_dest_it` to the subcontractor location for outgoing pickings.

opw-5479900