### PR TITLE
[FIX] website_slides: add route to download slides documents

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -19,6 +19,7 @@ from odoo.exceptions import AccessError, ValidationError, UserError, MissingErro
 from odoo.http import request, Response
 from odoo.osv import expression
 from odoo.tools import consteq, email_split
+from odoo.addons.web.controllers.binary import Binary
 
 _logger = logging.getLogger(__name__)
 
@@ -1600,3 +1601,16 @@ class WebsiteSlides(WebsiteProfile):
         values.update(self._prepare_user_values(channel=channels[0] if len(channels) == 1 else True, **post))
         values.update(self._prepare_user_slides_profile(user))
         return values
+
+    # --------------------------------------------------
+    # FILE DOWNLOAD
+    # --------------------------------------------------
+
+    @http.route('/slides/content/<string:model>/<int:id>/<string:field>', type='http', auth="public")
+    def slide_content_common(self, xmlid=None, model='ir.attachment', id=None, field='raw',
+                    filename=None, filename_field='name', mimetype=None, unique=False,
+                    download=False, access_token=None, nocache=False):
+        return Binary.content_common(self, xmlid, model, id,
+                                        field, filename, filename_field,
+                                        mimetype, unique, download,
+                                    access_token, nocache)

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -107,8 +107,7 @@
                                         <span id="previous" class="mx-1 mx-sm-2" title="Previous slide" aria-label="Previous slide" role="button"><i class="fa fa-arrow-circle-left"/></span>
                                         <span id="next" class="mx-1 mx-sm-2" title="Next slide" aria-label="Next slide" role="button"><i class="fa fa-arrow-circle-right"/></span>
                                         <span id="last" class="mx-1 mx-sm-2" title="Last slide" aria-label="Last slide" role="button"><i class="fa fa-step-forward"/></span>
-                                        <a t-if="slide.slide_resource_downloadable" id="download" t-attf-href="/web/content/slide.slide/#{slide.id}/binary_content?download=true"
-                                           class="ms-1 ms-sm-2" title="Download Content" aria-label="Download" role="button">
+                                        <a t-if="slide.slide_resource_downloadable" id="download" t-attf-href="/slides/content/slide.slide/#{slide.id}/binary_content?download=true"                                           class="ms-1 ms-sm-2" title="Download Content" aria-label="Download" role="button">
                                             <i class="fa fa-download" />
                                         </a>
                                     </div>


### PR DESCRIPTION
Currently if you have a cdn configured to the route '/web/content' and you try to download files in a e-learning course as a portal user, you won't be able to. You get a not found  error instead since you are not logged in in the cdn server, so no access to the resource.

Given that configuring a cdn to this route is in our documentation and that other contents on that route are expected to be public (so available trough cdn) this is unexpected behaviour. This adds a route to slides that calls the same method as the old one, so that you can cdn that route and this will still work

opw-4918546
