### PR TITLE
[FIX] website: Allow users with large image to add new font

### DIFF
--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -137,7 +137,7 @@ class Web_EditorAssets(models.AbstractModel):
             if regex.search(updatedFileContent):
                 updatedFileContent = re.sub(regex, replacement, updatedFileContent)
             else:
-                updatedFileContent = re.sub(r'( *)(.*hook.*)', r'\1%s\1\2' % replacement, updatedFileContent)
+                updatedFileContent = re.sub(r'^( *)(.*hook.*)', r'\1%s\1\2' % replacement, updatedFileContent, count=1, flags=re.MULTILINE)
 
         self.save_asset(url, 'web.assets_frontend', updatedFileContent, 'scss')
 


### PR DESCRIPTION
Steps:
- Install `website`
- Open website editor
- Themes -> Font Family -> Add a Custom font
- Choose a random font from the list
- Uncheck "Serve font from Google servers"
- Save and Reload
- Timeout in case of *.odoo.com because it can take a very long time (more than two minutes)

This commit improves `make_scss_customization`, because there is a regex that scans the file several times to find the user_values.scss hook in our case. This regex can easily be improved by checking only the beginning of lines after spaces instead of checking all characters.

from
```py
updatedFileContent = re.sub(r'( *)(.*hook.*)', r'\1%s\1\2' % replacement, updatedFileContent)
```
to
```py
updatedFileContent = re.sub(r'^( *)(.*hook.*)', r'\1%s\1\2' % replacement, updatedFileContent, count=1, flags=re.MULTILINE)
```

opw-5178930