### PR TITLE
[IMP] l10n_ro_edi: download official bill PDF from ANAF

### DIFF
--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -136,6 +136,11 @@ def _patch_request_ciusro_synchronize_invoices(company, session, nb_days=1):
     }
 
 
+def _patch_request_ciusro_xml_to_pdf(company, xml_data):
+    # Returns a minimal, valid PDF byte stream
+    return {'content': 'JVBERi0xLjEKMSAwIG9iaiA8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PiBlbmRvYmogMiAwIG9iaiA8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PiBlbmRvYmogMyAwIG9iaiA8PC9UeXBlL1BhZ2UvUGFyZW50IDIgMCBSL01lZGlhQm94WzAgMCAxIDEgXT4+IGVuZG9iaiB0cmFpbGVyIDw8L1Jvb3QgMSAwIFI+PiAlJUVPRg=='}
+
+
 @tagged('post_install_l10n', 'post_install', '-at_install')
 class TestUBLRO(TestUBLCommon):
 
@@ -471,3 +476,30 @@ class TestUBLRO(TestUBLCommon):
 
         self.assertEqual(invoice.l10n_ro_edi_state, 'invoice_validated')
         self.assertEqual(len(invoice.l10n_ro_edi_document_ids), 2)
+
+    @patch('odoo.addons.l10n_ro_edi.models.account_move._request_ciusro_xml_to_pdf', new=_patch_request_ciusro_xml_to_pdf)
+    @patch('odoo.addons.l10n_ro_edi.models.account_move._request_ciusro_synchronize_invoices', new=_patch_request_ciusro_synchronize_invoices)
+    def test_ciusro_pdf_generated(self):
+        """ Test the generation of a pdf requested from ANAF when the bill we retrieve doesn't already
+            have one embedded in the xml.
+        """
+        bills = self.env['account.move'].search([
+            ('move_type', 'in', self.env['account.move'].get_purchase_types()),
+            ('company_id', '=', self.env.company.id),
+        ])
+        self.assertEqual(len(bills), 0)
+
+        self.env['account.move']._l10n_ro_edi_fetch_invoices()
+
+        bill = self.env['account.move'].search([
+            ('move_type', 'in', self.env['account.move'].get_purchase_types()),
+            ('company_id', '=', self.env.company.id),
+        ])
+        self.assertEqual(len(bill), 1)
+
+        pdf_attachment = self.env['ir.attachment'].search([
+            ('res_id', '=', bill.id),
+            ('res_model', '=', 'account.move'),
+            ('mimetype', '=', 'application/pdf'),
+        ])
+        self.assertEqual(bill.message_main_attachment_id.id, pdf_attachment.id)


### PR DESCRIPTION
### Before

For bills from the Romanian ANAF we only downloaded an XML and imported the data. There is no visual aid for the accountant to see and compare the received document. 

### Now

We use the ANAF service to get the  official "PDF" version of the invoice. This is requested for any new bill we get through ANAF that doesn't already contain a pdf from the vendor and it is set as the main attachment. 

task-5877171