### PR TITLE
[FIX] website_sale: adapt checkout color contrast

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -737,6 +737,10 @@ a.no-decoration {
                 border-radius: 0;
                 background-color: var(--o-cc1-bg) !important;
                 color: inherit;
+
+                .text-muted {
+                    color: adjust-color-to-background($text-muted, $body-bg, mute-color($color-contrast-light), mute-color($color-contrast-dark)) !important;
+                }
             }
         }
     }


### PR DESCRIPTION
Prior to this commit, when a dark background color was defined, some text elements in the checkout card were not readable on mobile.

Steps to reproduce:
- Switch the website background to a dark color.
- Add a product to the cart.
- Go to the cart checkout page.
- Switch to mobile view.
- Observe the text next to the amounts (Subtotal, Taxes, Total) inside the cart summary card.

This commit adjusts the colors of muted text inside the checkout card to ensure sufficient contrast, regardless of the background color.

task-5881568


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
