### PR TITLE
[FIX] hw_drivers: fix CUPS error when printer has too long name

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/PrinterInterface_L.py
@@ -57,10 +57,12 @@ class PrinterInterface(Interface):
     def get_identifier(self, path):
         """
         Necessary because the path is not always a valid Cups identifier,
-        as it may contain characters typically found in URLs or paths.
+        as it may contain characters typically found in URLs or paths,
+        or it may exceed the length limit.
 
           - Removes characters: ':', '/', '.', '\', and space.
           - Removes the exact strings: "uuid=" and "serial=".
+          - Truncates the string to 127 characters.
 
         Example 1:
             Input: "ipp://printers/printer1:1234/abcd"
@@ -70,4 +72,4 @@ class PrinterInterface(Interface):
             Input: "uuid=1234-5678-90ab-cdef"
             Output: "1234-5678-90ab-cdef
         """
-        return sub(r'[:\/\.\\ ]|(uuid=)|(serial=)', '', path)
+        return sub(r'[:\/\.\\ ]|(uuid=)|(serial=)', '', path)[:127]


### PR DESCRIPTION
CUPS has a limit on printer names of 127 characters, which means that if a device has a very long device URI, it can exceed this limit and cause an error when we try to add it to CUPS:

```
Failed to add printer 'dnssdPhotosmart%207520%20series%20%40%20Guillaume%E2%80%99s%20MacBook%20Air%20(2)_ipp_tcplocalcups?96d0de60-096c-3d08-5e2d-893393e10c2b'
Traceback (most recent call last):
  File "/home/pi/odoo/addons/iot_drivers/iot_handlers/interfaces/printer_interface_L.py", line 242, in set_up_printer_in_cups
    self.conn.addPrinter(name=device['identifier'], device=device['url'], **ppdname_argument)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cups.IPPError: (1024, 'client-error-bad-request')
```

We fix this error by truncating the identifier to 127 characters maximum.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
