### PR TITLE
[FIX] account: payment widget title hover

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1476,7 +1476,7 @@ class AccountMove(models.Model):
                     'move_id': line.move_id.id,
                     'date': fields.Date.to_string(line.date),
                     'account_payment_id': line.payment_id.id,
-                    'move_ref': line.ref or "",
+                    'ref': line.ref or "",
                 })
 
             if payments_widget_vals['content']:

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -19,7 +19,7 @@
                         <t t-if="info.outstanding">
                             <td t-out="line.formattedDate"/>
                             <td style="max-width: 9rem;">
-                                <a t-att-title="(line.bank_label ? line.bank_label + ' - ' : '') + (line.move_ref ? line.move_ref : '')"
+                                <a t-att-title="line.bank_label ? (line.ref ? line.bank_label + ' - ' + line.ref : line.bank_label) : (line.ref or '')"
                                    role="button"
                                    class="open_account_move oe_form_field btn btn-link w-100 text-start"
                                    t-on-click="() => this.openMove(line.move_id)"
@@ -30,7 +30,7 @@
                             <td class="ps-2">
                                 <a title="assign to invoice"
                                    role="button"
-                                   class="oe_form_field btn btn-secondary outstanding_credit_assign d-print-none text-truncate w-100 text-start"
+                                   class="oe_form_field btn btn-secondary outstanding_credit_assign d-print-none"
                                    t-att-data-id="line.id"
                                    href="#"
                                    data-bs-toggle="tooltip"
@@ -99,7 +99,7 @@
                         <tr>
                             <td class="fw-bolder">Journal:</td>
                             <td class="ps-1">
-                                <t t-out="props.move_name"/>
+                                <t t-out="props.journal_name"/>
                                 <span t-if="props.payment_method_name">
                                     (<t t-out="props.payment_method_name"/>)
                                 </span>


### PR DESCRIPTION
the forward port https://github.com/odoo/odoo/commit/2490d32f2a28cc05c7cd5d8450701232aede2c29 introduced some minor issues in the payment widget on the
account move form view, such as the title on hover. When
viewing a Bill, for example, with a possible match on a bank
statement, on hovering, we should see both the ref and the line name.

This commit also removes useless added classes in the template.

Finally, when viewing the reconciled widget (click on the
info popup beside the "Paid on ..."), the "Journal" section
was missing.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
