### PR TITLE
[FIX] registry: lock registry while loading

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -280,7 +280,7 @@ class IrCron(models.Model):
         # because the db has zombie states and we force a call to
         # reset_module_states.
         from odoo.modules.loading import reset_modules_state  # noqa: PLC0415
-        reset_modules_state(cr.dbname)
+        reset_modules_state(cr)
 
     @staticmethod
     def _get_ready_sql_condition(cr: BaseCursor) -> SQL:

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -618,13 +618,14 @@ class IrModuleModule(models.Model):
                 "for help."
             )
 
-        # raise error if database is updating for module operations
-        if self.search_count([('state', 'in', ('to install', 'to upgrade', 'to remove'))], limit=1):
-            raise UserError(_("Odoo is currently processing another module operation.\n"
-                               "Please try again later or contact your system administrator."))
+        self.env.cr.execute("SET LOCAL lock_timeout = '3s'")
+
         try:
+            # raise error if database is updating for module operations
+            # acquire the shared-lock for the current transaction only
+            self.env.cr.execute("SELECT pg_advisory_xact_lock_shared(hashtext('registry_loading')) NOWAIT")
             # raise error if another transaction is trying to schedule module operations concurrently
-            self.env.cr.execute("LOCK ir_module_module IN EXCLUSIVE MODE NOWAIT")
+            self.env.cr.execute("LOCK ir_module_module IN EXCLUSIVE MODE")
         except psycopg2.OperationalError:
             raise UserError(_("Odoo is currently processing another module operation.\n"
                                "Please try again later or contact your system administrator."))
@@ -633,7 +634,7 @@ class IrModuleModule(models.Model):
             # This is done because the installation/uninstallation/upgrade can modify a currently
             # running cron job and prevent it from finishing, and since the ir_cron table is locked
             # during execution, the lock won't be released until timeout.
-            self.env.cr.execute("SELECT FROM ir_cron FOR UPDATE NOWAIT")
+            self.env.cr.execute("SELECT FROM ir_cron FOR UPDATE")
         except psycopg2.OperationalError:
             raise UserError(_("Odoo is currently processing a scheduled action.\n"
                               "Module operations are not possible at this time, "

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -15,7 +15,6 @@ import traceback
 
 import odoo.sql_db
 import odoo.tools.sql
-import odoo.tools.translate
 from odoo import api, tools
 from odoo.tools import OrderedSet
 from odoo.tools.convert import convert_file, IdRef, ConvertMode as LoadMode
@@ -267,6 +266,7 @@ def load_module_graph(
             package.state = 'installed'
             module.env.flush_all()
             module.env.cr.commit()
+            registry.signal_changes()
 
         test_time = 0.0
         test_queries = 0
@@ -335,6 +335,7 @@ def _check_module_names(cr: BaseCursor, module_names: Iterable[str]) -> None:
 
 def load_modules(
     registry: Registry,
+    cr: BaseCursor,
     *,
     update_module: bool = False,
     upgrade_modules: Collection[str] = (),
@@ -355,248 +356,237 @@ def load_modules(
 
     initialize_sys_path()
 
-    with registry.cursor() as cr:
-        # prevent endless wait for locks on schema changes (during online
-        # installs) if a concurrent transaction has accessed the table;
-        # connection settings are automatically reset when the connection is
-        # borrowed from the pool
-        cr.execute("SET SESSION lock_timeout = '15s'")
-        if not modules_db.is_initialized(cr):
-            if not update_module:
-                _logger.error("Database %s not initialized, you can force it with `-i base`", cr.dbname)
-                return
-            _logger.info("Initializing database %s", cr.dbname)
-            modules_db.initialize(cr)
-        elif 'base' in reinit_modules:
-            registry._reinit_modules.add('base')
+    # prevent endless wait for locks on schema changes (during online
+    # installs) if a concurrent transaction has accessed the table;
+    # connection settings are automatically reset when the connection is
+    # borrowed from the pool
+    cr.execute("SET SESSION lock_timeout = '15s'")
+    if not modules_db.is_initialized(cr):
+        if not update_module:
+            _logger.error("Database %s not initialized, you can force it with `-i base`", cr.dbname)
+            return
+        _logger.info("Initializing database %s", cr.dbname)
+        modules_db.initialize(cr)
+    elif 'base' in reinit_modules:
+        registry._reinit_modules.add('base')
 
-        if 'base' in upgrade_modules:
-            cr.execute("update ir_module_module set state=%s where name=%s and state=%s", ('to upgrade', 'base', 'installed'))
+    if 'base' in upgrade_modules:
+        cr.execute("update ir_module_module set state=%s where name=%s and state=%s", ('to upgrade', 'base', 'installed'))
 
-        # STEP 1: LOAD BASE (must be done before module dependencies can be computed for later steps)
-        graph = ModuleGraph(cr, mode='update' if update_module else 'load')
-        graph.extend(['base'])
-        if not graph:
-            _logger.critical('module base cannot be loaded! (hint: verify addons-path)')
-            raise ImportError('Module `base` cannot be loaded! (hint: verify addons-path)')
-        if update_module and upgrade_modules:
-            for pyfile in tools.config['pre_upgrade_scripts']:
-                odoo.modules.migration.exec_script(cr, graph['base'].installed_version, pyfile, 'base', 'pre')
+    # STEP 1: LOAD BASE (must be done before module dependencies can be computed for later steps)
+    graph = ModuleGraph(cr, mode='update' if update_module else 'load')
+    graph.extend(['base'])
+    if not graph:
+        _logger.critical('module base cannot be loaded! (hint: verify addons-path)')
+        raise ImportError('Module `base` cannot be loaded! (hint: verify addons-path)')
+    if update_module and upgrade_modules:
+        for pyfile in tools.config['pre_upgrade_scripts']:
+            odoo.modules.migration.exec_script(cr, graph['base'].installed_version, pyfile, 'base', 'pre')
 
-        if update_module and tools.sql.table_exists(cr, 'ir_model_fields'):
-            # determine the fields which are currently translated in the database
-            cr.execute("SELECT model || '.' || name, translate FROM ir_model_fields WHERE translate IS NOT NULL")
-            registry._database_translated_fields = dict(cr.fetchall())
+    if update_module and tools.sql.table_exists(cr, 'ir_model_fields'):
+        # determine the fields which are currently translated in the database
+        cr.execute("SELECT model || '.' || name, translate FROM ir_model_fields WHERE translate IS NOT NULL")
+        registry._database_translated_fields = dict(cr.fetchall())
 
-            # determine the fields which are currently company dependent in the database
-            if odoo.tools.sql.column_exists(cr, 'ir_model_fields', 'company_dependent'):
-                cr.execute("SELECT model || '.' || name FROM ir_model_fields WHERE company_dependent IS TRUE")
-                registry._database_company_dependent_fields = {row[0] for row in cr.fetchall()}
+        # determine the fields which are currently company dependent in the database
+        if odoo.tools.sql.column_exists(cr, 'ir_model_fields', 'company_dependent'):
+            cr.execute("SELECT model || '.' || name FROM ir_model_fields WHERE company_dependent IS TRUE")
+            registry._database_company_dependent_fields = {row[0] for row in cr.fetchall()}
 
-        report = registry._assertion_report
-        env = api.Environment(cr, api.SUPERUSER_ID, {})
-        load_module_graph(
-            env,
-            graph,
-            update_module=update_module,
-            report=report,
-            install_demo=new_db_demo,
-        )
+    report = registry._assertion_report
+    env = api.Environment(cr, api.SUPERUSER_ID, {})
+    load_module_graph(
+        env,
+        graph,
+        update_module=update_module,
+        report=report,
+        install_demo=new_db_demo,
+    )
 
-        load_lang = tools.config._cli_options.pop('load_language', None)
-        if load_lang or update_module:
-            # some base models are used below, so make sure they are set up
-            registry._setup_models__(cr, [])  # incremental setup
+    load_lang = tools.config._cli_options.pop('load_language', None)
+    if load_lang or update_module:
+        # some base models are used below, so make sure they are set up
+        registry._setup_models__(cr, [])  # incremental setup
 
-        if load_lang:
-            for lang in load_lang.split(','):
-                tools.translate.load_language(cr, lang)
+    if load_lang:
+        for lang in load_lang.split(','):
+            tools.translate.load_language(cr, lang)
 
-        # STEP 2: Mark other modules to be loaded/updated
-        if update_module:
-            Module = env['ir.module.module']
-            _logger.info('updating modules list')
-            Module.update_list()
-
-            _check_module_names(cr, itertools.chain(install_modules, upgrade_modules))
-
-            if install_modules:
-                modules = Module.search([('state', '=', 'uninstalled'), ('name', 'in', tuple(install_modules))])
-                if modules:
-                    modules.button_install()
-
-            if upgrade_modules:
-                modules = Module.search([('state', 'in', ('installed', 'to upgrade')), ('name', 'in', tuple(upgrade_modules))])
-                if modules:
-                    modules.button_upgrade()
-
-            if reinit_modules:
-                modules = Module.search([('state', 'in', ('installed', 'to upgrade')), ('name', 'in', tuple(reinit_modules))])
-                reinit_modules = modules.downstream_dependencies(exclude_states=('uninstalled', 'uninstallable', 'to remove', 'to install')) + modules
-                registry._reinit_modules.update(m for m in reinit_modules.mapped('name') if m not in graph._imported_modules)
-
-            env.flush_all()
-            cr.execute("update ir_module_module set state=%s where name=%s", ('installed', 'base'))
-            Module.invalidate_model(['state'])
-
-        # STEP 3: Load marked modules (skipping base which was done in STEP 1)
-        # loop this step in case extra modules' states are changed to 'to install'/'to update' during loading
-        while True:
-            if update_module:
-                states = ('installed', 'to upgrade', 'to remove', 'to install')
-            else:
-                states = ('installed', 'to upgrade', 'to remove')
-            env.cr.execute("SELECT name from ir_module_module WHERE state IN %s", [states])
-            module_list = [name for (name,) in env.cr.fetchall() if name not in graph]
-            if not module_list:
-                break
-            graph.extend(module_list)
-            _logger.debug('Updating graph with %d more modules', len(module_list))
-            updated_modules_count = len(registry.updated_modules)
-            load_module_graph(
-                env, graph, update_module=update_module,
-                report=report)
-            if len(registry.updated_modules) == updated_modules_count:
-                break
-
-        if update_module:
-            # set up the registry without the patch for translated fields
-            database_translated_fields = registry._database_translated_fields
-            registry._database_translated_fields = {}
-            registry._setup_models__(cr, [])  # incremental setup
-            # determine which translated fields should no longer be translated,
-            # and make their model fix the database schema
-            models_to_untranslate = set()
-            for full_name in database_translated_fields:
-                model_name, field_name = full_name.rsplit('.', 1)
-                if model_name in registry:
-                    field = registry[model_name]._fields.get(field_name)
-                    if field and not field.translate:
-                        _logger.debug("Making field %s non-translated", field)
-                        models_to_untranslate.add(model_name)
-            registry.init_models(cr, list(models_to_untranslate), {'models_to_check': True})
-
-        registry.loaded = True
-        registry._setup_models__(cr)
-
-        # check that all installed modules have been loaded by the registry
+    # STEP 2: Mark other modules to be loaded/updated
+    if update_module:
         Module = env['ir.module.module']
-        modules = Module.search_fetch(Module._get_modules_to_load_domain(), ['name'], order='name')
-        missing = [name for name in modules.mapped('name') if name not in graph]
-        if missing:
-            _logger.error("Some modules are not loaded, some dependencies or manifest may be missing: %s", missing)
+        _logger.info('updating modules list')
+        Module.update_list()
 
-        # STEP 3.5: execute migration end-scripts
+        _check_module_names(cr, itertools.chain(install_modules, upgrade_modules))
+
+        if install_modules:
+            modules = Module.search([('state', '=', 'uninstalled'), ('name', 'in', tuple(install_modules))])
+            if modules:
+                modules.button_install()
+
+        if upgrade_modules:
+            modules = Module.search([('state', 'in', ('installed', 'to upgrade')), ('name', 'in', tuple(upgrade_modules))])
+            if modules:
+                modules.button_upgrade()
+
+        if reinit_modules:
+            modules = Module.search([('state', 'in', ('installed', 'to upgrade')), ('name', 'in', tuple(reinit_modules))])
+            reinit_modules = modules.downstream_dependencies(exclude_states=('uninstalled', 'uninstallable', 'to remove', 'to install')) + modules
+            registry._reinit_modules.update(m for m in reinit_modules.mapped('name') if m not in graph._imported_modules)
+
+        env.flush_all()
+        cr.execute("update ir_module_module set state=%s where name=%s", ('installed', 'base'))
+        Module.invalidate_model(['state'])
+
+    # STEP 3: Load marked modules (skipping base which was done in STEP 1)
+    # loop this step in case extra modules' states are changed to 'to install'/'to update' during loading
+    while True:
         if update_module:
-            migrations = MigrationManager(cr, graph)
-            for package in graph:
-                migrations.migrate_module(package, 'end')
-
-        # check that new module dependencies have been properly installed after a migration/upgrade
-        cr.execute("SELECT name from ir_module_module WHERE state IN ('to install', 'to upgrade')")
-        module_list = [name for (name,) in cr.fetchall()]
-        if module_list:
-            _logger.error("Some modules have inconsistent states, some dependencies may be missing: %s", sorted(module_list))
-
-        # STEP 3.6: apply remaining constraints in case of an upgrade
-        registry.finalize_constraints(cr)
-
-        # STEP 4: Finish and cleanup installations
-        if registry.updated_modules:
-
-            cr.execute("SELECT model from ir_model")
-            for (model,) in cr.fetchall():
-                if model in registry:
-                    env[model]._check_removed_columns(log=True)
-                elif _logger.isEnabledFor(logging.INFO):    # more an info that a warning...
-                    _logger.runbot("Model %s is declared but cannot be loaded! (Perhaps a module was partially removed or renamed)", model)
-
-            # Cleanup orphan records
-            env['ir.model.data']._process_end(registry.updated_modules)
-            # Cleanup cron
-            vacuum_cron = env.ref('base.autovacuum_job', raise_if_not_found=False)
-            if vacuum_cron:
-                # trigger after a small delay to give time for assets to regenerate
-                vacuum_cron._trigger(at=datetime.datetime.now() + datetime.timedelta(minutes=1))
-
-            env.flush_all()
-
-        # STEP 5: Uninstall modules to remove
-        if update_module:
-            # Remove records referenced from ir_model_data for modules to be
-            # removed (and removed the references from ir_model_data).
-            cr.execute("SELECT name, id FROM ir_module_module WHERE state=%s", ('to remove',))
-            modules_to_remove = dict(cr.fetchall())
-            if modules_to_remove:
-                registry.uninstalling_modules = set(modules_to_remove)
-                pkgs = reversed([p for p in graph if p.name in modules_to_remove])
-                for pkg in pkgs:
-                    uninstall_hook = pkg.manifest.get('uninstall_hook')
-                    if uninstall_hook:
-                        py_module = sys.modules['odoo.addons.%s' % (pkg.name,)]
-                        getattr(py_module, uninstall_hook)(env)
-                        env.flush_all()
-
-                Module = env['ir.module.module']
-                Module.browse(modules_to_remove.values()).module_uninstall()
-                registry.loaded = False
-                _logger.info('Reloading registry once more after uninstalling modules')
-                return
-
-        # STEP 5.5: Verify extended fields on every model
-        # This will fix the schema of all models in a situation such as:
-        #   - module A is loaded and defines model M;
-        #   - module B is installed/upgraded and extends model M;
-        #   - module C is loaded and extends model M;
-        #   - module B and C depend on A but not on each other;
-        # The changes introduced by module C are not taken into account by the upgrade of B.
-        if update_module:
-            # We need to fix custom fields for which we have dropped the not-null constraint.
-            cr.execute("""SELECT DISTINCT model FROM ir_model_fields WHERE state = 'manual'""")
-            registry._models_to_check.update(model_name for model_name, in cr.fetchall() if model_name in registry)
-        if registry._models_to_check:
-            # Doesn't check models that didn't exist anymore, it might happen during uninstallation
-            registry._models_to_check = OrderedSet(model for model in registry._models_to_check if model in registry)
-            registry.init_models(cr, registry._models_to_check, {'models_to_check': True, 'update_custom_fields': True})
-
-        # STEP 6: verify custom views on every model
-        if update_module:
-            View = env['ir.ui.view']
-            for model in registry:
-                try:
-                    View._validate_custom_views(model)
-                except Exception as e:
-                    _logger.warning('invalid custom view(s) for model %s: %s', model, e)
-
-        if not registry._assertion_report or registry._assertion_report.wasSuccessful():
-            _logger.info('Modules loaded.')
+            states = ('installed', 'to upgrade', 'to remove', 'to install')
         else:
-            _logger.error('At least one test failed when loading the modules.')
+            states = ('installed', 'to upgrade', 'to remove')
+        env.cr.execute("SELECT name from ir_module_module WHERE state IN %s", [states])
+        module_list = [name for (name,) in env.cr.fetchall() if name not in graph]
+        if not module_list:
+            break
+        graph.extend(module_list)
+        _logger.debug('Updating graph with %d more modules', len(module_list))
+        updated_modules_count = len(registry.updated_modules)
+        load_module_graph(
+            env, graph, update_module=update_module,
+            report=report)
+        if len(registry.updated_modules) == updated_modules_count:
+            break
 
-        # STEP 9: call _register_hook on every model
-        # This is done *exactly once* when the registry is being loaded. See the
-        # management of those hooks in `Registry._setup_models__`: all the calls to
-        # _setup_models__() done here do not mess up with hooks, as registry.ready
-        # is False.
-        for model in env.values():
-            model._register_hook()
+    if update_module:
+        # set up the registry without the patch for translated fields
+        database_translated_fields = registry._database_translated_fields
+        registry._database_translated_fields = {}
+        registry._setup_models__(cr, [])  # incremental setup
+        # determine which translated fields should no longer be translated,
+        # and make their model fix the database schema
+        models_to_untranslate = set()
+        for full_name in database_translated_fields:
+            model_name, field_name = full_name.rsplit('.', 1)
+            if model_name in registry:
+                field = registry[model_name]._fields.get(field_name)
+                if field and not field.translate:
+                    _logger.debug("Making field %s non-translated", field)
+                    models_to_untranslate.add(model_name)
+        registry.init_models(cr, list(models_to_untranslate), {'models_to_check': True})
+
+    registry.loaded = True
+    registry._setup_models__(cr)
+
+    # check that all installed modules have been loaded by the registry
+    Module = env['ir.module.module']
+    modules = Module.search_fetch(Module._get_modules_to_load_domain(), ['name'], order='name')
+    missing = [name for name in modules.mapped('name') if name not in graph]
+    if missing:
+        _logger.error("Some modules are not loaded, some dependencies or manifest may be missing: %s", missing)
+
+    # STEP 3.5: execute migration end-scripts
+    if update_module:
+        migrations = MigrationManager(cr, graph)
+        for package in graph:
+            migrations.migrate_module(package, 'end')
+
+    # check that new module dependencies have been properly installed after a migration/upgrade
+    cr.execute("SELECT name from ir_module_module WHERE state IN ('to install', 'to upgrade')")
+    module_list = [name for (name,) in cr.fetchall()]
+    if module_list:
+        _logger.error("Some modules have inconsistent states, some dependencies may be missing: %s", sorted(module_list))
+
+    # STEP 3.6: apply remaining constraints in case of an upgrade
+    registry.finalize_constraints(cr)
+
+    # STEP 4: Finish and cleanup installations
+    if registry.updated_modules:
+
+        cr.execute("SELECT model from ir_model")
+        for (model,) in cr.fetchall():
+            if model in registry:
+                env[model]._check_removed_columns(log=True)
+            elif _logger.isEnabledFor(logging.INFO):    # more an info that a warning...
+                _logger.runbot("Model %s is declared but cannot be loaded! (Perhaps a module was partially removed or renamed)", model)
+
+        # Cleanup orphan records
+        env['ir.model.data']._process_end(registry.updated_modules)
+        # Cleanup cron
+        vacuum_cron = env.ref('base.autovacuum_job', raise_if_not_found=False)
+        if vacuum_cron:
+            # trigger after a small delay to give time for assets to regenerate
+            vacuum_cron._trigger(at=datetime.datetime.now() + datetime.timedelta(minutes=1))
+
         env.flush_all()
 
-        # STEP 10: check that we can trust nullable columns
-        registry.check_null_constraints(cr)
+    # STEP 5: Uninstall modules to remove
+    if update_module:
+        # Remove records referenced from ir_model_data for modules to be
+        # removed (and removed the references from ir_model_data).
+        cr.execute("SELECT name, id FROM ir_module_module WHERE state=%s", ('to remove',))
+        modules_to_remove = dict(cr.fetchall())
+        if modules_to_remove:
+            registry.uninstalling_modules = set(modules_to_remove)
+            pkgs = reversed([p for p in graph if p.name in modules_to_remove])
+            for pkg in pkgs:
+                uninstall_hook = pkg.manifest.get('uninstall_hook')
+                if uninstall_hook:
+                    py_module = sys.modules['odoo.addons.%s' % (pkg.name,)]
+                    getattr(py_module, uninstall_hook)(env)
+                    env.flush_all()
 
-        if update_module:
-            cr.execute(
-                """
-                INSERT INTO ir_config_parameter(key, value)
-                SELECT 'base.partially_updated_database', '1'
-                WHERE EXISTS(SELECT FROM ir_module_module WHERE state IN ('to upgrade', 'to install', 'to remove'))
-                ON CONFLICT DO NOTHING
-                """
-            )
+            Module = env['ir.module.module']
+            Module.browse(modules_to_remove.values()).module_uninstall()
+            registry.loaded = False
+            _logger.info('Reloading registry once more after uninstalling modules')
+            return
+
+    # STEP 5.5: Verify extended fields on every model
+    # This will fix the schema of all models in a situation such as:
+    #   - module A is loaded and defines model M;
+    #   - module B is installed/upgraded and extends model M;
+    #   - module C is loaded and extends model M;
+    #   - module B and C depend on A but not on each other;
+    # The changes introduced by module C are not taken into account by the upgrade of B.
+    if update_module:
+        # We need to fix custom fields for which we have dropped the not-null constraint.
+        cr.execute("""SELECT DISTINCT model FROM ir_model_fields WHERE state = 'manual'""")
+        registry._models_to_check.update(model_name for model_name, in cr.fetchall() if model_name in registry)
+    if registry._models_to_check:
+        # Doesn't check models that didn't exist anymore, it might happen during uninstallation
+        registry._models_to_check = OrderedSet(model for model in registry._models_to_check if model in registry)
+        registry.init_models(cr, registry._models_to_check, {'models_to_check': True, 'update_custom_fields': True})
+
+    # STEP 6: verify custom views on every model
+    if update_module:
+        View = env['ir.ui.view']
+        for model in registry:
+            try:
+                View._validate_custom_views(model)
+            except Exception as e:  # noqa: BLE001
+                _logger.warning('invalid custom view(s) for model %s: %s', model, e)
+
+    if not registry._assertion_report or registry._assertion_report.wasSuccessful():
+        _logger.info('Modules loaded.')
+    else:
+        _logger.error('At least one test failed when loading the modules.')
+
+    # STEP 9: call _register_hook on every model
+    # This is done *exactly once* when the registry is being loaded. See the
+    # management of those hooks in `Registry._setup_models__`: all the calls to
+    # _setup_models__() done here do not mess up with hooks, as registry.ready
+    # is False.
+    for model in env.values():
+        model._register_hook()
+    env.flush_all()
+
+    # STEP 10: check that we can trust nullable columns
+    registry.check_null_constraints(cr)
 
 
-def reset_modules_state(db_name: str) -> None:
+def reset_modules_state(cr: BaseCursor) -> None:
     """
     Resets modules flagged as "to x" to their original state
     """
@@ -606,15 +596,13 @@ def reset_modules_state(db_name: str) -> None:
     # installation/upgrade/uninstallation fails, which is the only known case
     # for which modules can stay marked as 'to %' for an indefinite amount
     # of time
-    db = odoo.sql_db.db_connect(db_name)
-    with db.cursor() as cr:
-        if not odoo.tools.sql.table_exists(cr, 'ir_module_module'):
-            _logger.info('skipping reset_modules_state, ir_module_module table does not exists')
-            return
-        cr.execute(
-            "UPDATE ir_module_module SET state='installed' WHERE state IN ('to remove', 'to upgrade')"
-        )
-        cr.execute(
-            "UPDATE ir_module_module SET state='uninstalled' WHERE state='to install'"
-        )
-        _logger.warning("Transient module states were reset")
+    if not odoo.tools.sql.table_exists(cr, 'ir_module_module'):
+        _logger.info('skipping reset_modules_state, ir_module_module table does not exists')
+        return
+    cr.execute(
+        "UPDATE ir_module_module SET state='installed' WHERE state IN ('to remove', 'to upgrade')"
+    )
+    cr.execute(
+        "UPDATE ir_module_module SET state='uninstalled' WHERE state='to install'"
+    )
+    _logger.warning("Transient module states were reset")

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -196,12 +196,16 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 if not update_module:
                     cr.execute("SELECT pg_advisory_lock_shared(hashtext('registry_loading'))")
                     if db.is_initialized(cr):
-                        # check whether module updates are pending
-                        cr.execute("DELETE FROM ir_config_parameter WHERE key='base.partially_updated_database'")
+                        # check whether we have a partially upgraded database that needs updating;
+                        # PostgreSQL will detect deadlocks if several processes have the shared
+                        # lock and try to acquire the exclusive lock
+                        cr.execute("""
+                            SELECT FROM ir_module_module
+                            WHERE state IN ('to upgrade', 'to install', 'to remove')
+                            LIMIT 1
+                        """)
                         if cr.rowcount:
-                            _logger.debug("Database %s initialized, removing upgrade marker", cr.dbname)
-                            # We are updating modules, so we must acquire the exclusive lock. The
-                            # upgrade marker (config parameter above) is deleted while loading modules.
+                            _logger.info("Force module updates, some modules must be installed/uninstalled/upgraded")
                             update_module = True
                 if update_module:
                     cr.execute("SELECT pg_advisory_lock(hashtext('registry_loading'))")
@@ -214,7 +218,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 retries = 5 if update_module else 1
                 for _ in range(retries):
                     # load_modules multiple times in case there are modules to be uninstalled
-                    cr.commit()  # start a new transaction
                     try:
                         load_modules(
                             registry,
@@ -225,19 +228,11 @@ class Registry(Mapping[str, type["BaseModel"]]):
                             reinit_modules=reinit_modules,
                             new_db_demo=new_db_demo,
                         )
+                        cr.commit()
                     except Exception:
                         cr.rollback()
                         reset_modules_state(cr)
                         raise
-                    if update_module:
-                        cr.execute(
-                            """
-                            INSERT INTO ir_config_parameter(key, value)
-                            SELECT 'base.partially_updated_database', '1'
-                            WHERE EXISTS(SELECT FROM ir_module_module WHERE state IN ('to upgrade', 'to install', 'to remove'))
-                            ON CONFLICT DO NOTHING
-                            """
-                        )
                     if registry.loaded:
                         break
                     models_to_check = registry._models_to_check

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -15,7 +15,7 @@ import typing
 import warnings
 from collections import defaultdict, deque
 from collections.abc import Mapping
-from contextlib import closing, contextmanager, nullcontext, ExitStack
+from contextlib import closing, nullcontext, ExitStack
 from functools import partial
 from operator import attrgetter
 
@@ -137,6 +137,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         upgrade_modules: Collection[str] = (),
         reinit_modules: Collection[str] = (),
         new_db_demo: bool | None = None,
+        lock_wait: int = 15,
     ) -> Registry:
         """Create and return a new registry for the given database name.
 
@@ -159,9 +160,13 @@ class Registry(Mapping[str, type["BaseModel"]]):
 
         :param new_db_demo: Whether to install demo data for the new database. If set to ``None``, the value will be
           determined by the ``config['with_demo']``. Defaults to ``None``
+        :param lock_wait: How long to wait to acquire the lock on the database (in seconds).
         """
         if (registry := cls.registries.get(db_name)) and not registry.ready:
             raise Exception('Registry for database %s can not be loaded recursively' % db_name)
+
+        from odoo.modules import db  # noqa: PLC0415
+        from odoo.modules.loading import load_modules, reset_modules_state  # noqa: PLC0415
 
         t0 = time.time()
         registry: Registry = object.__new__(cls)
@@ -175,25 +180,33 @@ class Registry(Mapping[str, type["BaseModel"]]):
         cls.registries[db_name] = registry  # pylint: disable=unsupported-assignment-operation
         try:
             registry.setup_signaling()
-            with registry.cursor() as cr:
-                # This transaction defines a critical section for multi-worker concurrency control.
-                # When the transaction commits, the first worker proceeds to upgrade modules. Other workers
-                # encounter a serialization error and retry, finding no upgrade marker in the database.
-                # This significantly reduces the likelihood of concurrent module upgrades across workers.
-                # NOTE: This block is intentionally outside the try-except below to prevent workers that fail
-                # due to serialization errors from calling `reset_modules_state` while the first worker is
-                # actively upgrading modules.
-                from odoo.modules import db  # noqa: PLC0415
-                if db.is_initialized(cr):
-                    cr.execute("DELETE FROM ir_config_parameter WHERE key='base.partially_updated_database'")
-                    if cr.rowcount:
-                        update_module = True
-            # This should be a method on Registry
-            from odoo.modules.loading import load_modules, reset_modules_state  # noqa: PLC0415
-            exit_stack = ExitStack()
-            try:
-                if upgrade_modules or install_modules or reinit_modules:
-                    update_module = True
+            if upgrade_modules or install_modules or reinit_modules:
+                update_module = True
+
+            with ExitStack() as exit_stack:
+                # The transaction 'cr' defines a critical section for multi-worker concurrency
+                # control. It uses a shared lock to avoid registry updates while loading modules,
+                # and an exclusive lock when updating the registry.
+                cr = exit_stack.enter_context(registry.cursor())
+                assert lock_wait >= 0
+                cr.execute(f"SET SESSION lock_timeout = '{int(lock_wait)}s'")
+
+                # acquire the exclusive or shared lock at the session level; this enables to guard
+                # several transactions under the lock until the cursor is closed
+                if not update_module:
+                    cr.execute("SELECT pg_advisory_lock_shared(hashtext('registry_loading'))")
+                    if db.is_initialized(cr):
+                        # check whether module updates are pending
+                        cr.execute("DELETE FROM ir_config_parameter WHERE key='base.partially_updated_database'")
+                        if cr.rowcount:
+                            _logger.debug("Database %s initialized, removing upgrade marker", cr.dbname)
+                            # We are updating modules, so we must acquire the exclusive lock. The
+                            # upgrade marker (config parameter above) is deleted while loading modules.
+                            update_module = True
+                if update_module:
+                    cr.execute("SELECT pg_advisory_lock(hashtext('registry_loading'))")
+
+                # now load modules
                 if new_db_demo is None:
                     new_db_demo = config['with_demo']
                 if first_registry and not update_module:
@@ -201,14 +214,30 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 retries = 5 if update_module else 1
                 for _ in range(retries):
                     # load_modules multiple times in case there are modules to be uninstalled
-                    load_modules(
-                        registry,
-                        update_module=update_module,
-                        upgrade_modules=upgrade_modules,
-                        install_modules=install_modules,
-                        reinit_modules=reinit_modules,
-                        new_db_demo=new_db_demo,
-                    )
+                    cr.commit()  # start a new transaction
+                    try:
+                        load_modules(
+                            registry,
+                            cr=cr,
+                            update_module=update_module,
+                            upgrade_modules=upgrade_modules,
+                            install_modules=install_modules,
+                            reinit_modules=reinit_modules,
+                            new_db_demo=new_db_demo,
+                        )
+                    except Exception:
+                        cr.rollback()
+                        reset_modules_state(cr)
+                        raise
+                    if update_module:
+                        cr.execute(
+                            """
+                            INSERT INTO ir_config_parameter(key, value)
+                            SELECT 'base.partially_updated_database', '1'
+                            WHERE EXISTS(SELECT FROM ir_module_module WHERE state IN ('to upgrade', 'to install', 'to remove'))
+                            ON CONFLICT DO NOTHING
+                            """
+                        )
                     if registry.loaded:
                         break
                     models_to_check = registry._models_to_check
@@ -218,11 +247,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     upgrade_modules = install_modules = reinit_modules = ()
                 else:
                     raise Exception(f'Failed to load registry after {retries} attempts')  # noqa: TRY301
-            except Exception:
-                reset_modules_state(db_name)
-                raise
-            finally:
-                exit_stack.close()
         except Exception:
             _logger.error('Failed to load registry')
             del cls.registries[db_name]     # pylint: disable=unsupported-delete-operation
@@ -1088,10 +1112,10 @@ class Registry(Mapping[str, type["BaseModel"]]):
             # Check if the model registry must be reloaded
             if self.registry_sequence != db_registry_sequence:
                 _logger.info("Reloading the model registry after database signaling.")
+                old_sequence = self.registry_sequence
                 self = Registry.new(self.db_name)
-                self.registry_sequence = db_registry_sequence
                 if _logger.isEnabledFor(logging.DEBUG):
-                    changes += "[Registry - %s -> %s]" % (self.registry_sequence, db_registry_sequence)
+                    changes += "[Registry - %s -> %s]" % (old_sequence, self.registry_sequence)
             # Check if the model caches must be invalidated.
             else:
                 invalidated = []
@@ -1113,10 +1137,6 @@ class Registry(Mapping[str, type["BaseModel"]]):
 
     def signal_changes(self) -> None:
         """ Notifies other processes if registry or cache has been invalidated. """
-        if not self.ready:
-            _logger.warning('Calling signal_changes when registry is not ready is not suported')
-            return
-
         if self.registry_invalidated:
             _logger.info("Registry changed, signaling through the database")
             with self.cursor() as cr:


### PR DESCRIPTION
This commit ensures that a registry can only be updated by one process at a time. It solves potential registry/cache inconsistency while a module is being installed.

Implementation detail in commit message.
TLDR: use a shared lock when loading registry and an exclusive lock when updating it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
