### PR TITLE
[FIX] project: Group project template tasks with template tasks

### DIFF
--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -147,7 +147,6 @@ class ReportProjectTaskUser(models.Model):
     def _where(self):
         return """
                 t.project_id IS NOT NULL
-                AND p.is_template IS NOT TRUE
         """
 
     def init(self):

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -75,7 +75,7 @@
             <field name="name">Tasks Analysis</field>
             <field name="res_model">report.project.task.user</field>
             <field name="path">tasks-analysis</field>
-            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('has_template_ancestor', '=', False), ('project_id.is_template', '=', False)]</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
             <field name="context">{'group_by': [], 'graph_measure': '__count__'}</field>

--- a/addons/project/static/src/views/project_task_model_mixin.js
+++ b/addons/project/static/src/views/project_task_model_mixin.js
@@ -12,10 +12,16 @@ export const ProjectTaskModelMixin = (T) => class ProjectTaskModelMixin extends 
             ]).toList({});
         }
         if (this.env.searchModel.context?.render_task_templates) {
-            domain = Domain.and([
-                Domain.removeDomainLeaves(domain, ['has_template_ancestor']).toList(),
-                [['has_template_ancestor', '=', true]],
-            ]).toList({});
+            domain = Domain.removeDomainLeaves(domain, [
+                "has_template_ancestor",
+                "has_project_template",
+                "project_id.is_template",
+            ]);
+            const templateTaskDomain = Domain.or([[["has_template_ancestor", "=", true]],
+                "default_project_id" in this.env.searchModel.globalContext ?
+                        Domain.TRUE :
+                        [["project_id.is_template", "=", true]]]);
+            domain = Domain.and([domain, templateTaskDomain]).toList({});
         }
         return domain;
     }

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -28,7 +28,7 @@
                         <filter name="create_date_last_365_days" string="Last 365 Days" domain="[('date_last_stage_update', '&gt;=', 'today -365d +1d')]"/>
                     </filter>
                     <separator/>
-                    <filter string="Templates" context="{'render_task_templates': True}" name="templates" domain="[('has_template_ancestor', '=', True)]"/>
+                    <filter string="Templates" context="{'render_task_templates': True}" name="templates" domain="['|', ('has_template_ancestor', '=', True), ('project_id.is_template', '=', True)]"/>
                     <group>
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone" invisible="not context.get('allow_milestones', True)"/>
@@ -1047,7 +1047,7 @@
                 'default_user_ids': [(4, uid)],
             }</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="domain">[('user_ids', 'in', uid), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('user_ids', 'in', uid), ('has_template_ancestor', '=', False), ('has_project_template', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -1097,7 +1097,7 @@
             <field name="res_model">project.task</field>
             <field name="path">all-tasks</field>
             <field name="view_mode">list,kanban,form,calendar,activity,pivot,graph</field>
-            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('has_template_ancestor', '=', False), ('has_project_template', '=', False)]</field>
             <field name="context">{'search_default_open_tasks': 1, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">
@@ -1198,7 +1198,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">list,kanban,form,calendar,pivot,graph,activity</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('has_template_ancestor', '=', False), ('has_project_template', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -1238,7 +1238,7 @@
             <field name="name">Overpassed Tasks</field>
             <field name="res_model">project.task</field>
             <field name="view_mode">list,form,calendar,graph,kanban</field>
-            <field name="domain">[('is_closed', '=', False), ('date_deadline', '&lt;', 'today'), ('project_id', '!=', False), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('is_closed', '=', False), ('date_deadline', '&lt;', 'today'), ('project_id', '!=', False), ('has_template_ancestor', '=', False), ('has_project_template', '=', False)]</field>
             <field name="filter" eval="True"/>
             <field name="search_view_id" ref="view_task_search_form"/>
         </record>


### PR DESCRIPTION
## Current behavior before PR:
- When a user viewed All Tasks or My Tasks, tasks related to project templates were visible.
- When a user specifically selected the Template Tasks filter, tasks associated with template projects were not visible.

## Desired behavior after PR is merged:
- When a user views My Tasks or All Tasks, tasks related to template projects are hidden.
- When a user selects the Template Tasks filter, both template tasks and tasks associated with template projects are shown.

## Additional note

A modification to `project_report.py` was required because it inherits from the project task view and overrides the view’s reference model.

Task-[5485658](https://www.odoo.com/odoo/project/4105/tasks/5485658)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
