### PR TITLE
[FIX] mail: do not crop canned responses

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -457,8 +457,9 @@ export class Composer extends Component {
                     optionTemplate: "mail.Composer.suggestionCannedResponse",
                     options: suggestions.map((suggestion) => ({
                         cannedResponse: suggestion,
-                        source: suggestion.source,
                         label: suggestion.substitution,
+                        source: suggestion.source,
+                        title: suggestion.substitution,
                         classList: "o-mail-Composer-suggestion",
                     })),
                 };

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -170,7 +170,7 @@
                 'id': 'more-actions',
                 'name': moreName,
                 'tags': [],
-            }]"/> 
+            }]"/>
         </div>
     </div>
 </t>
@@ -233,10 +233,10 @@
     </t>
 
     <t t-name="mail.Composer.suggestionCannedResponse">
-        <strong class="px-2 py-1 align-self-center flex-shrink-1 text-truncate">
+        <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate mw-100">
             <t t-esc="option.source"/>
         </strong>
-        <span class="text-600 text-truncate align-self-center" style="flex-basis: 20%;">
+        <span class="text-600 text-truncate align-self-center">
             <t t-esc="option.label"/>
         </span>
     </t>

--- a/addons/mail/static/src/core/common/navigable_list.xml
+++ b/addons/mail/static/src/core/common/navigable_list.xml
@@ -11,6 +11,7 @@
                     t-foreach="sortedOptions" t-as="option" t-key="option_index"
                     class="o-mail-NavigableList-item"
                     t-att-class="option.classList"
+                    t-att-title="option.title"
                     t-on-mouseenter="() => this.onOptionMouseEnter(option_index)"
                     t-on-click="(ev) => this.selectOption(ev, option_index)"
                 >


### PR DESCRIPTION
Canned responses have an arbitrary small width limit in
the navigable list panel. Due to this restriction, the
description of the canned response is barely readable.

This commit makes it take the whole available width.

task-5873810

|| Before | After|
| ------------- | ------------- | -----|
|Discuss|<img width="832" height="318" alt="image" src="https://github.com/user-attachments/assets/4671ea44-7687-442a-a14c-1c56c3851930" /> |<img width="839" height="331" alt="image" src="https://github.com/user-attachments/assets/7fde9d8c-9682-43e5-b1b4-9a303331f445" />|
|Chat window|<img width="453" height="437" alt="image" src="https://github.com/user-attachments/assets/c2b255f6-2552-4739-9a5d-d22e8c257a07" />|<img width="410" height="610" alt="image" src="https://github.com/user-attachments/assets/b8097f1b-04f4-4a3e-b11f-021bfcb9398e" />|