### PR TITLE
[FIX] mrp_subcontracting_dropshipping: use correct account

### DIFF
--- a/addons/mrp_subcontracting/tests/common.py
+++ b/addons/mrp_subcontracting/tests/common.py
@@ -43,6 +43,11 @@ class TestMrpSubcontractingCommon(TransactionCase):
             bom_line.product_qty = 1
         cls.bom = bom_form.save()
 
+        cls.env['product.supplierinfo'].create({
+            'product_tmpl_id': cls.finished.product_tmpl_id.id,
+            'partner_id': cls.subcontractor_partner1.id,
+        })
+
         # Create a BoM for cls.comp2
         cls.comp2comp = cls.env['product.product'].create({
             'name': 'component for Component2',
@@ -55,10 +60,6 @@ class TestMrpSubcontractingCommon(TransactionCase):
             bom_line.product_id = cls.comp2comp
             bom_line.product_qty = 1
         cls.comp2_bom = bom_form.save()
-
-        cls.warehouse = cls.env['stock.warehouse'].search([
-            ('company_id', '=', cls.env.company.id),
-        ], limit=1)
 
     def _setup_category_stock_journals(self):
         """

--- a/addons/mrp_subcontracting_dropshipping/models/stock_move.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_move.py
@@ -13,10 +13,25 @@ class StockMove(models.Model):
 
     def _is_dropshipped(self):
         res = super()._is_dropshipped()
-        return res or (
+        return (
+            res
+            # subcontractor -> customer
+            or (
                 self.partner_id.property_stock_subcontractor.parent_path
-                and self.partner_id.property_stock_subcontractor.parent_path in self.location_id.parent_path
-                and self.location_dest_id.usage == 'customer'
+                and (
+                    (
+                        self.partner_id.property_stock_subcontractor.parent_path
+                        in self.location_id.parent_path
+                        and self.location_dest_id.usage == "customer"
+                    )
+                    # Vendor -> subcontractor location
+                    or (
+                        self.partner_id.property_stock_subcontractor.parent_path
+                        in self.location_dest_id.parent_path
+                        and self.location_id.usage == "supplier"
+                    )
+                )
+            )
         )
 
     def _is_dropshipped_returned(self):

--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -32,7 +32,7 @@ class AccountMoveLine(models.Model):
         if not self.product_id.is_storable:
             return False
         moves = self._get_stock_moves()
-        return all(not m.is_dropship for m in moves)
+        return all(not m._is_dropshipped() for m in moves)
 
     def _get_gross_unit_price(self):
         if self.product_uom_id.is_zero(self.quantity):


### PR DESCRIPTION
A component bought from a vendor and
dropshipped to a subcontractor should the valued into the stock valuation account and not the expense one. In case this component have its "Invoice Policy" set to "ordered quantity", the `_eligible_for_stock_account` method will test if the related stock move are dropshipped https://github.com/odoo/odoo/blob/7436e0cfaf8d4b0c0e0390e8d6a3df404ba240f6/addons/stock_account/models/account_move_line.py#L31-L35 The value `is_dropship` is only set at the validation of the stock move. Due to the invoice policy, the receipt is not validated yet.

close #243015
This commit will rather use the helper `_is_dropshipped()` that only rely on the location and not on the state.

This commit also clean and reenable the related tests.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
