### PR TITLE
[IMP] peppol: Add missing invoice type codes

### DIFF
--- a/addons/account_edi_ubl_cii/tools/ubl_21_debit_note.py
+++ b/addons/account_edi_ubl_cii/tools/ubl_21_debit_note.py
@@ -35,6 +35,7 @@ DebitNote = {
     'cbc:UUID': {},
     'cbc:IssueDate': {},
     'cbc:IssueTime': {},
+    'cbc:InvoiceTypeCode': {},
     'cbc:Note': {},
     'cbc:DocumentCurrencyCode': {},
     'cbc:TaxCurrencyCode': {},


### PR DESCRIPTION
Before this commit, when re-sending an invoice that was corrected the code for the invoice type code was incorrect, also if the invoice was a down payment and not a full invoice, the invoice type code was also incorrect.
When sending a debit note to a customer, a traceback occurred because the path was not set properly, and the code was also missing. task-5875689