### PR TITLE
[FIX] website: delete dialog links

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1314,14 +1314,14 @@ class Website(models.Model):
             if model_name == 'ir.ui.view':
                 dependency_records = _handle_views_and_pages(dependency_records)
             if dependency_records:
-                model_name = self.env['ir.model']._display_name_for([model_name])[0]['display_name']
+                model_display_name = self.env['ir.model']._display_name_for([model_name])[0]['display_name']
                 field_string = Model.fields_get()[field_name]['string']
-                dependencies.setdefault(model_name, [])
-                dependencies[model_name] += [{
+                dependencies.setdefault(model_display_name, [])
+                dependencies[model_display_name] += [{
                     'field_name': field_string,
                     'record_name': rec.display_name,
                     'link': 'website_url' in rec and rec.website_url or f'/odoo/{model_name}/{rec.id}',
-                    'model_name': model_name,
+                    'model_name': model_display_name,
                 } for rec in dependency_records]
 
         return dependencies


### PR DESCRIPTION
**Steps to reproduce:**

1. Go to the list view of website pages.
2. Select the page "ContactUs".
3. Click Delete.
4. A warning dialog appears.
5. Unfold one of the lists of records where the page is used.

**Issue**

Clicking on a record link (for example, "View") does not redirect anywhere. This is due to the use of the model display name in url. caused by https://github.com/odoo/odoo/commit/de302c2d36305c0d7562572a30587641eabfe914

**Fix**

Use the model_name instead of the display name in the URL.

task-5880458