### PR TITLE
[FIX] point_of_sale: ensure prices are aligned between back & front

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -1,7 +1,6 @@
 from odoo import http, fields
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.tools import float_round
 from werkzeug.exceptions import NotFound, BadRequest, Unauthorized
 from odoo.exceptions import MissingError
 from odoo.tools import consteq
@@ -79,45 +78,80 @@ class PosSelfOrderController(http.Controller):
 
     def _verify_line_price(self, lines, pos_config, preset_id):
         pricelist = preset_id.pricelist_id or pos_config.pricelist_id if preset_id else pos_config.pricelist_id
-        sale_price_digits = pos_config.env['decimal.precision'].precision_get('Product Price')
 
         for line in lines:
+            if len(line.combo_line_ids) == 0:
+                continue
+
             product = line.product_id
             lst_price = pricelist._get_product_price(product, quantity=line.qty) if pricelist else product.lst_price
             selected_attributes = line.attribute_value_ids
-            lst_price += sum(selected_attributes.mapped('price_extra'))
-            price_extra = sum(attr.price_extra for attr in selected_attributes)
+            price_extra = sum(attr.price_extra for attr in selected_attributes if attr.attribute_id.create_variant != 'always')
             lst_price += price_extra
-
             fiscal_pos = preset_id.fiscal_position_id or pos_config.default_fiscal_position_id if preset_id else pos_config.default_fiscal_position_id
-            if len(line.combo_line_ids) > 0:
-                original_total = sum(line.combo_line_ids.mapped("combo_item_id").combo_id.mapped("base_price"))
-                remaining_total = lst_price
-                factor = lst_price / original_total if original_total > 0 else 1
+            self._compute_combo_price(line, pricelist, fiscal_pos)
 
-                for i, pos_order_line in enumerate(line.combo_line_ids):
-                    child_product = pos_order_line.product_id
-                    price_unit = float_round(pos_order_line.combo_item_id.combo_id.base_price * factor, precision_digits=sale_price_digits)
-                    remaining_total -= price_unit
+    def _compute_combo_price(self, parent_line, pricelist, fiscal_position):
+        """
+        This method is a python version of odoo/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+        It is used to compute the price of combo items on the server side when an order is received from
+        the POS frontend. In an accounting perspective, isn't correct but we still waiting the combo
+        computation from accounting side.
+        """
+        child_lines = parent_line.combo_line_ids
+        currency = parent_line.order_id.currency_id
+        taxes = fiscal_position.map_tax(parent_line.product_id.taxes_id)
+        parent_line.tax_ids = taxes
+        parent_lst_price = pricelist._get_product_price(parent_line.product_id, parent_line.qty)
+        child_line_free = []
+        child_line_extra = []
 
-                    if i == len(line.combo_line_ids) - 1:
-                        price_unit += remaining_total
+        child_lines_by_combo = {}
+        for line in child_lines:
+            combo = line.combo_item_id.combo_id
+            child_lines_by_combo.setdefault(combo, []).append(line)
 
-                    selected_attributes = pos_order_line.attribute_value_ids
-                    price_extra_child = sum(attr.price_extra for attr in selected_attributes)
-                    price_unit += pos_order_line.combo_item_id.extra_price + price_extra_child
+        for combo, child_lines in child_lines_by_combo.items():
+            free_count = 0
+            max_free = combo.qty_free
 
-                    taxes = fiscal_pos.map_tax(child_product.taxes_id) if fiscal_pos else child_product.taxes_id
-                    pdetails = taxes.compute_all(price_unit, pos_config.currency_id, pos_order_line.qty, child_product)
+            for line in child_lines:
+                qty_free = max(0, max_free - free_count)
+                free_qty = min(line.qty, qty_free)
+                extra_qty = line.qty - free_qty
 
-                    pos_order_line.write({
-                        'price_unit': price_unit,
-                        'price_subtotal': pdetails.get('total_excluded'),
-                        'price_subtotal_incl': pdetails.get('total_included'),
-                        'price_extra': price_extra_child,
-                        'tax_ids': child_product.taxes_id,
-                    })
-                lst_price = 0
+                if free_qty > 0:
+                    child_line_free.append(line)
+                    free_count += free_qty
+
+                if extra_qty > 0:
+                    child_line_extra.append(line)
+
+        original_total = sum(line.combo_item_id.combo_id.base_price * line.qty for line in child_line_free if line.combo_item_id.combo_id.qty_free > 0)
+        remaining_total = parent_lst_price
+
+        for index, child in enumerate(child_line_free):
+            combo_item = child.combo_item_id
+            combo = combo_item.combo_id
+            unit_devision_factor = original_total or 1
+            price_unit = currency.round(combo.base_price * parent_lst_price / unit_devision_factor)
+            remaining_total -= price_unit * child.qty
+
+            if index == len(child_line_free) - 1:
+                price_unit += remaining_total
+
+            selected_attributes = child.attribute_value_ids
+            price_extra = sum(attr.price_extra for attr in selected_attributes)
+            total_price = price_unit + price_extra + child.combo_item_id.extra_price
+            child.price_unit = total_price
+
+        for child in child_line_extra:
+            combo_item = child.combo_item_id
+            price_unit = currency.round(combo_item.combo_id.base_price)
+            selected_attributes = child.attribute_value_ids
+            price_extra = sum(attr.price_extra for attr in selected_attributes)
+            total_price = price_unit + price_extra + child.combo_item_id.extra_price
+            child.price_unit = total_price
 
     @http.route('/pos-self-order/validate-partner', auth='public', type='jsonrpc', website=True)
     def validate_partner(self, access_token, name, phone, street, zip, city, country_id, state_id=None, partner_id=None, email=None):

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_prices_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_prices_tour.js
@@ -1,0 +1,143 @@
+/* global posmodel */
+
+import { registry } from "@web/core/registry";
+import * as Utils from "@pos_self_order/../tests/tours/utils/common";
+import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
+
+const checkPricesInCombo = {
+    trigger: "body",
+    run: async () => {
+        const order = posmodel.currentOrder;
+        const orderTotal = order.displayPrice;
+        const allUnitPrices = order.lines.map((l) => l.price_unit);
+        await posmodel.sendDraftOrderToServer();
+        const orderTotalAfterSync = order.displayPrice;
+        const allUnitPricesAfterSync = order.lines.map((l) => l.price_unit);
+
+        if (orderTotal !== orderTotalAfterSync) {
+            throw new Error(
+                `The total price changed after sync: before=${orderTotal}, after=${orderTotalAfterSync}`
+            );
+        }
+
+        for (let i = 0; i < allUnitPrices.length; i++) {
+            if (allUnitPrices[i] !== allUnitPricesAfterSync[i]) {
+                throw new Error(
+                    `The unit price of line ${i} changed after sync: before=${allUnitPrices[i]}, after=${allUnitPricesAfterSync[i]}`
+                );
+            }
+        }
+    },
+};
+
+const forceCancel = {
+    trigger: "body",
+    run: () => {
+        posmodel.currentOrder.delete();
+    },
+};
+
+const commonSteps = [
+    Utils.clickBtn("Add to Cart"),
+    ProductPage.clickProduct("Random Product 1"),
+    ProductPage.clickProduct("Random Product 2"),
+    ProductPage.clickProduct("Random Product 3"),
+    Utils.clickBtn("Checkout"),
+    checkPricesInCombo,
+    Utils.clickBtn("Order"),
+    ConfirmationPage.orderNumberShown(),
+    Utils.clickBtn("Ok"),
+    Utils.checkBtn("My Order"),
+    forceCancel,
+];
+
+registry.category("web_tour.tours").add("test_combo_prices", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Big Combo"),
+        ...ProductPage.setupCombo([
+            { product: "Green 1", attributes: [] },
+            { product: "Green 2", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
+            { product: "Red 1", attributes: [] },
+            { product: "Red 2", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
+            { product: "Purple 1", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+        ]),
+        ...commonSteps,
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Big Combo"),
+        ...ProductPage.setupCombo([
+            { product: "Green 1", attributes: [] },
+            { product: "Green 2", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
+            { product: "Red 1", attributes: [] },
+            { product: "Red 1", attributes: [] },
+            { product: "Red 2", attributes: [] },
+            { product: "Red 2", attributes: [] },
+            { product: "Red 2", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
+            { product: "Purple 1", attributes: [] },
+            { product: "Purple 1", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+        ]),
+        ...commonSteps,
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Big Combo"),
+        ...ProductPage.setupCombo([
+            { product: "Green 1", attributes: [] },
+            {
+                product: "Green 3",
+                attributes: [
+                    { name: "Size", value: "Big" },
+                    { name: "Color", value: "Blue" },
+                ],
+            },
+        ]),
+        ...ProductPage.setupCombo([
+            { product: "Red 1", attributes: [] },
+            { product: "Red 1", attributes: [] },
+            {
+                product: "Red 3",
+                attributes: [
+                    { name: "Size", value: "Big" },
+                    { name: "Color", value: "Blue" },
+                ],
+            },
+            { product: "Red 3", attributes: [] },
+            { product: "Red 3", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
+            { product: "Purple 1", attributes: [] },
+            { product: "Purple 1", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            { product: "Purple 2", attributes: [] },
+            {
+                product: "Purple 3",
+                attributes: [
+                    { name: "Size", value: "Small" },
+                    { name: "Color", value: "Red" },
+                ],
+            },
+            { product: "Purple 3", attributes: [] },
+        ]),
+        ...commonSteps,
+    ],
+});

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_frontend
@@ -13,3 +12,4 @@ from . import test_self_order_sequence
 from . import test_self_order_preset
 from . import test_self_order_controller
 from . import test_takeaway_preset_mail
+from . import test_combo_prices

--- a/addons/pos_self_order/tests/test_combo_prices.py
+++ b/addons/pos_self_order/tests/test_combo_prices.py
@@ -1,0 +1,160 @@
+import odoo.tests
+
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
+
+@odoo.tests.tagged('post_install', '-at_install')
+class TestSelfOrderCombo(SelfOrderCommonTest):
+    def setUp(self):
+        super().setUp()
+
+        self.tax_6 = self.env['account.tax'].create({
+            'name': 'Test 6%',
+            'amount': 6,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+        self.tax_12 = self.env['account.tax'].create({
+            'name': 'Test 12%',
+            'amount': 12,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+            'price_include_override': 'tax_included',
+        })
+        self.tax_21 = self.env['account.tax'].create({
+            'name': 'Test 21%',
+            'amount': 21,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+            'price_include_override': 'tax_excluded',
+        })
+
+        self.combo_category = self.env['pos.category'].create({'name': 'Combo Category'})
+        self.combo1 = self.combo_generator('Green', [0.0, 5.0, 10.0], [50.0, 70.0, 90.0], 2, 1)
+        self.combo2 = self.combo_generator('Red', [0.0, 0.0, 0.0], [40.0, 60.0, 80.0], 5, 0)
+        self.combo3 = self.combo_generator('Purple', [10.0, 20.0, 30.0], [0, 0, 0], 10, 0)
+        self.big_combo = self.env['product.product'].create({
+            'name': 'Big Combo',
+            'type': 'combo',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'combo_ids': [(6, 0, [self.combo1.id, self.combo2.id, self.combo3.id])],
+            'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+        })
+
+        self.env['product.product'].create({
+            'name': 'Random Product 1',
+            'type': 'consu',
+            'lst_price': 15.0,
+            'taxes_id': [(6, 0, [self.tax_21.id])],
+            'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+        })
+        self.env['product.product'].create({
+            'name': 'Random Product 2',
+            'type': 'consu',
+            'lst_price': 25.0,
+            'taxes_id': [(6, 0, [self.tax_12.id])],
+            'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+        })
+        self.env['product.product'].create({
+            'name': 'Random Product 3',
+            'type': 'consu',
+            'lst_price': 35.0,
+            'taxes_id': [(6, 0, [self.tax_6.id])],
+            'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+        })
+
+        self.pos_config.write({
+            'self_ordering_default_user_id': self.pos_admin.id,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+            'available_preset_ids': [(5, 0)],
+            'iface_available_categ_ids': self.combo_category.ids,
+            'limit_categories': True,
+        })
+
+    def combo_generator(self, name, extra_price, lst_price, max=1, free=1):
+        product1 = self.env['product.product'].create({
+            'name': f'{name} 1',
+            'is_storable': True,
+            'available_in_pos': True,
+            'lst_price': lst_price[0],
+            'taxes_id': [(6, 0, [self.tax_6.id])],
+        })
+        product2 = self.env['product.product'].create({
+            'name': f'{name} 2',
+            'is_storable': True,
+            'available_in_pos': True,
+            'lst_price': lst_price[1],
+            'taxes_id': [(6, 0, [self.tax_12.id])],
+        })
+        product3 = self.env['product.product'].create({
+            'name': f'{name} 3',
+            'is_storable': True,
+            'available_in_pos': True,
+            'lst_price': lst_price[2],
+            'taxes_id': [(6, 0, [self.tax_21.id])],
+        })
+        size_attribute, color_attribute = self.env['product.attribute'].create([{
+            'name': 'Size',
+            'display_type': 'radio',
+            'create_variant': 'no_variant',
+        }, {
+            'name': 'Color',
+            'display_type': 'radio',
+            'create_variant': 'no_variant',
+        }])
+        size_attribute_values = self.env['product.attribute.value'].create([{
+            'name': 'Small',
+            'attribute_id': size_attribute.id,
+        }, {
+            'name': 'Big',
+            'attribute_id': size_attribute.id,
+            'default_extra_price': 5.0,
+        }])
+        color_attribute_values = self.env['product.attribute.value'].create([{
+            'name': 'Red',
+            'attribute_id': color_attribute.id,
+        }, {
+            'name': 'Blue',
+            'attribute_id': color_attribute.id,
+            'default_extra_price': 10.0,
+        }])
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product3.product_tmpl_id.id,
+            'attribute_id': size_attribute.id,
+            'value_ids': [(6, 0, size_attribute_values.ids)],
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product3.product_tmpl_id.id,
+            'attribute_id': color_attribute.id,
+            'value_ids': [(6, 0, color_attribute_values.ids)],
+        })
+
+        combo = self.env['product.combo'].create({
+            'name': f'Test Combo {name}',
+            'qty_max': max,
+            'qty_free': free,
+        })
+        self.env['product.combo.item'].create({
+            'product_id': product1.id,
+            'extra_price': extra_price[0],
+            'combo_id': combo.id,
+        })
+        self.env['product.combo.item'].create({
+            'product_id': product2.id,
+            'extra_price': extra_price[1],
+            'combo_id': combo.id,
+        })
+        self.env['product.combo.item'].create({
+            'product_id': product3.id,
+            'extra_price': extra_price[2],
+            'combo_id': combo.id,
+        })
+        return combo
+
+    def test_combo_prices(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, '')
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, 'test_combo_prices')


### PR DESCRIPTION
Before this commit, prices were not always aligned between the backend and the frontend, when syncing an order in Self Order mode the price of combo products could differ between backend and frontend.

This commit ensures that combo products prices are always aligned between backend and frontend in Self Order mode.


