### PR TITLE
[FIX] hr_recruitment: use template mail_from in refuse mail

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -169,13 +169,14 @@ class ApplicantGetRefuseReason(models.TransientModel):
         lang = self._render_lang(applicant.ids)[applicant.id]
         subject = self._render_field('subject', applicant.ids, set_lang=lang)[applicant.id]
         body = self._render_field('body', applicant.ids, set_lang=lang)[applicant.id]
+        email_from = self.template_id.email_from if self.template_id and self.template_id.email_from else self.env.user.email_formatted
         mail_values = {
             'attachment_ids': [(4, att.id) for att in self.attachment_ids],
             'author_id': self.env.user.partner_id.id,
             'auto_delete': True,
             'body_html': body,
             'email_to': applicant.email_from or applicant.partner_id.email,
-            'email_from': self.env.user.email_formatted,
+            'email_from': email_from,
             'model': None,
             'res_id': None,
             'subject': subject,


### PR DESCRIPTION
### Issue:
When refusing an application, the system will always use the user's email to send the refusal, even if the template specifies an email to send from.

### Steps to reproduce:
- Recruitment > Configuration > Refuse Reasons
- Go to one of their template (i.e. "Recruitment: Refuse")
- in Settings add a "Send From" email
- Recruitment > Applications, click on an application
- Click "Refuse"
- Select the refuse reason with the template
- Refuse
- The mail is sent with the user email

### Cause:
`_prepare_mail_values()` only returns `self.env.user.email_formatted`.

### Solution:
If there is a template with `email_from`, we use this, otherwise `self.env.user.email_formatted`

opw-5356662