### PR TITLE
[FIX] resource, project: apply leaves for WS with no company

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -583,10 +583,13 @@ class Task(models.Model):
         )
         for task in task_linked_to_calendar:
             dt_create_date = fields.Datetime.from_string(task.create_date)
+            leave_domain = [('time_type', '=', 'leave')]  # default used by get_work_duration_data if none provided
+            if task.project_id.company_id:
+                leave_domain += [('company_id', '=', task.project_id.company_id.id)]
 
             if task.date_assign:
                 dt_date_assign = fields.Datetime.from_string(task.date_assign)
-                duration_data = task.project_id.resource_calendar_id.get_work_duration_data(dt_create_date, dt_date_assign, compute_leaves=True)
+                duration_data = task.project_id.resource_calendar_id.get_work_duration_data(dt_create_date, dt_date_assign, domain=leave_domain, compute_leaves=True)
                 task.working_hours_open = duration_data['hours']
                 task.working_days_open = duration_data['days']
             else:
@@ -595,7 +598,7 @@ class Task(models.Model):
 
             if task.date_end:
                 dt_date_end = fields.Datetime.from_string(task.date_end)
-                duration_data = task.project_id.resource_calendar_id.get_work_duration_data(dt_create_date, dt_date_end, compute_leaves=True)
+                duration_data = task.project_id.resource_calendar_id.get_work_duration_data(dt_create_date, dt_date_end, domain=leave_domain, compute_leaves=True)
                 task.working_hours_close = duration_data['hours']
                 task.working_days_close = duration_data['days']
             else:

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -489,7 +489,6 @@ class ResourceCalendar(models.Model):
             ('resource_id', 'in', [False] + [r.id for r in resources_list]),
             ('date_from', '<=', datetime_to_string(end_dt)),
             ('date_to', '>=', datetime_to_string(start_dt)),
-            ('company_id', 'in', [False] + [self.company_id.id]),
         ]
 
         # retrieve leave intervals in (start_dt, end_dt)


### PR DESCRIPTION
**Steps to reproduce**
1. Remove the company of the Working Schedule (needs to be done in
a multi-company environment from the UI) used by an employee.
2. Using the company of this employee, create a Public Holiday
(for the employee's schedule or all schedules).

Issues:
- the public holiday doesn't appear in the Time Off dashboard
- when taking a time off on that day, the public holiday is
included in the duration

**Cause**
The fix in https://github.com/odoo/odoo/commit/a95af8b78a94a795e05a0adf299837adc0ef2117 will result
in a search domain for public holidays of `('company_id', 'in', [False])`
when the working schedule has no company, ignoring any public
holidays with a company set. This is especially problematic since the
company of the public holiday is always forced.
https://github.com/odoo/odoo/blob/7bce5f3f95429a4d4ba034a66c350ee2a5868567/addons/resource/models/resource_calendar_leaves.py#L49-L51

**Solution**
Since the intent of the original fix https://github.com/odoo/odoo/commit/d58ecdccb89401751c8ee056c4166427ea005f5e
was to correct an issue related to the computation of some `project.task`
fields calling resource methods, we can instead go for a safer solution
in `project` which doesn't affect `resource`/`hr` modules.

Code below the search already ensures that leaves are only applied
when their company matches the resource's company:
https://github.com/odoo/odoo/blob/fdd9edb6a4ef3aa18449be537c954a06b32578e3/addons/resource/models/resource_calendar.py#L409-L410
When `_leave_intervals_batch` is called without resources, existing code
adds a company domain (see `_get_unusual_days` for example).

opw-5496999
opw-5401425