### PR TITLE
[PERF] stock: Improve inventory product import

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -98,6 +98,7 @@ class StockLocation(models.Model):
         'check(cyclic_inventory_frequency >= 0)',
         'The inventory frequency (days) for a location must be non-negative',
     )
+    _parent_path_id_idx = models.Index("(parent_path, id)")
 
     @api.depends('name', 'location_id.complete_name', 'usage')
     @api.depends_context('formatted_display_name')

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -191,10 +191,11 @@ class ProductProduct(models.Model):
     # -------------------------------------------------------------------------
 
     def _change_standard_price(self, old_price):
+        product_values = []
         for product in self:
             if product.cost_method == 'fifo' or product.standard_price == old_price.get(product):
                 continue
-            self.env['product.value'].sudo().create({
+            product_values.append({
                 'product_id': product.id,
                 'value': product.standard_price,
                 'company_id': product.company_id.id or self.env.company.id,
@@ -202,6 +203,7 @@ class ProductProduct(models.Model):
                 'description': _('Price update from %(old_price)s to %(new_price)s by %(user)s',
                     old_price=old_price.get(product), new_price=product.standard_price, user=self.env.user.name)
             })
+        self.env['product.value'].sudo().create(product_values)
         return
 
     def _get_standard_price_at_date(self, date=None):

--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -101,11 +101,12 @@ class StockLot(models.Model):
 
         :param new_price: new standard price
         """
+        product_values = []
         for lot in self:
             if lot.product_id.cost_method != 'average' or lot.standard_price == old_price:
                 continue
             product = lot.product_id
-            self.env['product.value'].sudo().create({
+            product_values.append({
                 'product_id': product.id,
                 'lot_id': lot.id,
                 'value': lot.standard_price,
@@ -114,3 +115,5 @@ class StockLot(models.Model):
                 'description': _('%(lot)s price update from %(old_price)s to %(new_price)s by %(user)s',
                     lot=lot.name, old_price=old_price, new_price=lot.standard_price, user=self.env.user.name)
             })
+
+        self.env['product.value'].sudo().create(product_values)


### PR DESCRIPTION
Problem:
When importing products in Inventory, _compute_quantities_dict fetches
data from all internal stock.location. For databases with many internal
locations (e.g., 37K), the query using LIKE ANY with a large array of
parent paths is very slow.

Solution:
- Replace LIKE ANY(%s) pattern matching with a semi-join subquery using
  EXISTS, allowing the query to terminate on the first match.
- Add an index on (parent_path, id) to convert sequential scans into
  index-only scans.

Benchmark:
|Number of rows| Before | After |
|--------------|--------|-------|
|37K           | 4.xxs  | 1.xxs |

Simplied plan (a few hundred records instead of 37K)
|Before|After|
|-|-|
|https://explain.dalibo.com/plan/8gb1257c6712age5|https://explain.dalibo.com/plan/5ef9c3g7aab3dfag|

Related ticket:
opw-5500169

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
