### PR TITLE
[FIX] website_sale: allow eu vat fix in address submit

### DIFF
--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -658,6 +658,51 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             "Tax should no longer change after order confirmation",
         )
 
+    def test_13_shop_address_submit_eu_vat_number(self):
+        if not hasattr(self.env['res.partner'], 'check_vat'):
+            self.skipTest("base_vat is not installed")
+
+        partner = self.env['res.partner'].create({
+            'name': 'test partner',
+            'vat': '0477472701',
+            'country_id': self.country_id,
+        })
+        user = self.env['res.users'].create({
+            'name': 'test user',
+            'login': 'test',
+            'email': 'test@test.com',
+            'partner_id': partner.id,
+        })
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': partner.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product.id,
+                })
+            ],
+        })
+        invoice.action_post()
+        self.assertFalse(partner.can_edit_vat())
+
+        so = self._create_so(partner_id=partner.id)
+        address_values = {
+            **self.default_address_values,
+            'vat': '0477472701',
+            'name': partner.name,
+            'email': partner.email,
+        }
+        env = api.Environment(self.env.cr, user.id, {})
+        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+            req.httprequest.method = "POST"
+            self.WebsiteSaleController.shop_address_submit(
+                partner_id=partner.id,
+                **address_values,
+            )
+
+        self.assertEqual(partner.vat, 'BE0477472701')
+
     def test_imported_user_with_trailing_name_can_checkout(self):
         """Ensure that an imported user with trailing spaces in their name can complete checkout without error."""
 


### PR DESCRIPTION
### Issue:
EU vat fix cause address submission to fail.

#### Steps to reproduce:
1- `base_vat` should be installed.
2- In portal contact, set the country to BE and VAT to `0477472701`.
3- Create an invoice for portal user.
4- Navigate to shop and add a product to cart, then checkout.
5- Edit address.
6- After filling, click on save address.

Even though the VAT is not modified in form, and it is not modifiable
the address fails to save with error:
`Changing VAT Number is not allowed.`

### Cause:
After address submission The vat is fixed in here:
https://github.com/odoo/odoo/blob/82a2c5305d65027ffb263f90c4e00f7e95f98b05/addons/website_sale/controllers/main.py#L1396-L1406

This converts given vat `0477472701` to `BE0477472701`.

Which makes `address_values['vat'] != partner_sudo.vat`:
https://github.com/odoo/odoo/blob/82a2c5305d65027ffb263f90c4e00f7e95f98b05/addons/website_sale/controllers/main.py#L1472-L1482

opw-5437586