### PR TITLE
[FIX] project: allow creation of project from templates with stages enabled

### DIFF
--- a/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
@@ -18,6 +18,7 @@ export const projectProjectKanbanGroupStageView = {
     Controller: ProjectKanbanGroupStageController,
     Renderer: ProjectProjectKanbanGroupStageRenderer,
     Model: ProjectRelationalModel,
+    buttonTemplate: "project.ProjectKanbanView.Buttons",
 };
 
 registry.category("views").add("project_project_kanban", projectProjectKanbanView);


### PR DESCRIPTION
In a previous commit, the feature allowing to create a new project from project templates was mistakenly removed in kanban view, when project stages were enabled.

This commit resolves the issue, so to still be able to create a project from templates with project stages enabled.

task-5877215