### PR TITLE
[Feedback] odoo.tools: mail html sanitizer not sanitizing background shorthands.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -97,3 +97,4 @@ xlwt==1.3.0
 zeep==4.1.0 ; python_version < '3.11'  # (jammy)
 zeep==4.2.1 ; python_version >= '3.11' and python_version < '3.13'
 zeep==4.3.1 ; python_version >= '3.13'
+tinycss2==1.5.1


### PR DESCRIPTION
Issue: When the customer sends an email with shorthand background it stripes the styling.
"background" isnt being striped into their longhand terms for xss.
    
Fix: I am using https://pypi.org/project/tinycss2/ to tokinize and identify the longhand terms inside the background shorthand and replace them with the longhand terms.
    
 opw-5391098




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
