### PR TITLE
[FIX] sale_mrp{,_margin}: prevent cost reset on validating delivery

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -41,4 +41,4 @@ class StockMove(models.Model):
             price_unit = super(StockMove, valuated_moves)._get_price_unit()
             qty_per_kit = component_qty_per_kit[component] / kit_bom.product_qty
             total_price_unit += price_unit * qty_per_kit
-        return total_price_unit
+        return total_price_unit / valuated_quantity if not product.uom_id.is_zero(valuated_quantity) else 0

--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -9,7 +9,7 @@ class StockMove(models.Model):
     def _get_price_unit(self):
         order_line = self.sale_line_id
         if order_line and all(move.sale_line_id == order_line for move in self) and any(move.product_id != order_line.product_id for move in self):
-            product = self.product_id.with_company(order_line.company_id)
+            product = order_line.product_id.with_company(order_line.company_id)
             bom = product.env['mrp.bom']._bom_find(product, company_id=self.company_id.id, bom_type='phantom')[product]
             if bom:
                 return self._get_kit_price_unit(product, bom, order_line.qty_delivered)

--- a/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
@@ -109,14 +109,16 @@ class TestSaleMrpFlow(test_sale_mrp_flow.TestSaleMrpFlowCommon):
             'order_line': [Command.create({
                 'product_id': kit.id,
                 'product_uom_qty': 3,
-                'product_uom_id': self.uom_unit.id
+                'product_uom_id': self.uom_ten.id
             })]
         })
-        self.assertEqual(so.order_line.purchase_price, 60)
+        self.assertEqual(so.order_line.purchase_price, 600)
         so.action_confirm()
-        self.assertEqual(so.order_line.purchase_price, 60)
+        self.assertEqual(so.order_line.purchase_price, 600)
         for move in so.picking_ids.move_ids:
             move.quantity = move.product_uom_qty
+        self.assertRecordValues(so.order_line, [{'purchase_price': 600, 'qty_delivered': 0.0}])
         so.picking_ids.button_validate()
         self.assertEqual(so.picking_ids.state, 'done')
-        self.assertEqual(so.order_line.purchase_price, 60)
+        self.assertRecordValues(so.order_line, [{'purchase_price': 600, 'qty_delivered': 3.0}])
+        self.assertEqual(so.order_line.purchase_price, 600)


### PR DESCRIPTION
Currently when the user validates a sale order delivery which has a kit the cost
gets reset to 0.

<h2>Steps to produce:</h2>

* Install sale_margin, sale_management, mrp
* Create a product with an AVCO or FIFO product category
* Create a BOM of type ‘Kit’ for that product.
* Add components A and B to the BOM, each with an on-hand quantity and a cost of
  10.
* On the kit product compute the cost according to the BOM
* Create and confirm SO for 1 unit of the kit product
* Delivery > Validate the Delivery  and go back to the Sale Order

Replication video: [Link](https://drive.google.com/file/d/1PgAh1xwBZX7RsRQ5ZsQipqYjuxvex2CA/view?usp=sharing)
<h2>Observed Behavior:</h2>

The product cost on the sale order is set to 0, but it should be 20.

<h2>Root cause:</h2>

After commit [1], an override for `_get_price_unit` was added to correctly calculate kit prices for BOM products. 

The goal was to prevent the cost from being set to 0 after a delivery is validated. However, when this logic is triggered during 
delivery validation, it doesn’t behave as intended.

After the delivery is validated, compute [2] runs and calls function [3]. However, `self` at [3] refers to a stock move record, so we get the components of the kit instead of the kit product itself.

The function `_bom_find` expects the main kit product, not the components. Because of this, the kit’s unit price isn’t calculated, and the parent function [4] ends up setting the purchase price to 0.

<h2>Solution:</h2>

Use the kit product IDs from the sale order lines instead of the move lines, ensuring the main kit product (not its components) is used and the BOM is found properly.

Return unit price for kit products instead of total value for the function `_get_kit_price_unit`

Update the test case to account for delivered quantities:

  **Before:**
  The sales order used Units as the unit of measure while the product and stock moves use a pack of 10. Since only 3 units get delivered and one product equals 10 units, this was not counted as a full delivery. Therefore, the delivered quantity was treated as 0, which allowed the product cost to be set at [5] and pass the test case
 
 **After:**
 The test now covers the case where a full quantity is delivered by using a pack of 10 as the unit of measure on the sales order. This ensures the product cost is handled correctly when the delivered quantity is 1 or more.

[1]:
https://github.com/odoo/odoo/commit/5a44ae1ec71573c57a5d60903f9b81e842fc582b
[2]-
https://github.com/odoo/odoo/blob/d4b6897211c65ba6d6ba8132480627e6fa66c481/addons/sale_stock_margin/models/sale_order_line.py#L11-L34
[3]-
https://github.com/odoo/odoo/blob/d4b6897211c65ba6d6ba8132480627e6fa66c481/addons/sale_mrp/models/stock_move.py#L9-L16
[4]-
https://github.com/odoo/odoo/blob/d4b6897211c65ba6d6ba8132480627e6fa66c481/addons/stock_account/models/stock_move.py#L230-L233
[5]-
https://github.com/odoo/odoo/blob/d4b6897211c65ba6d6ba8132480627e6fa66c481/addons/sale_stock_margin/models/sale_order_line.py#L21-L22

opw-5479266