### PR TITLE
[FIX] purchase: Fix access error

### DIFF
--- a/addons/purchase/security/ir.model.access.csv
+++ b/addons/purchase/security/ir.model.access.csv
@@ -34,3 +34,4 @@ access_account_account_purchase_manager,account.account purchase manager,account
 access_purchase_bill_union,access_purchase_bill_union,model_purchase_bill_union,purchase.group_purchase_user,1,0,0,0
 access_report_purchase_order,purchase.stock.report,model_purchase_report,purchase.group_purchase_manager,1,0,0,0
 access_report_purchase_order_user,purchase.stock.report user,model_purchase_report,purchase.group_purchase_user,1,0,0,0
+access_account_payment,account.payment,account.model_account_payment,group_purchase_user,1,0,0,0


### PR DESCRIPTION
Steps to Reproduce

1. Create a database on Odoo 19.0 with the Purchase module installed.
2. Create a user with Purchase/User access rights only (no Accounting rights).
3. Log in with this user and:
   * Create a Purchase Order
   * Confirm the Purchase Order
   * Upload a vendor bill
4. An Access Error occurs when upload bill.

```
Failed to read field account.move.matched_payment_ids
You are not allowed to access 'Payments' (account.payment) records.

This operation is allowed for the following groups:
	- Accounting/Invoicing
	- Show Accounting Features - Readonly

Contact your administrator to request access if necessary.
```
Issue:
The error occurs because the Purchase/User group does not have read access to the `account.payment` model. When the vendor bill (`account.move`) is opened:
https://github.com/odoo/odoo/blob/d4b6897211c65ba6d6ba8132480627e6fa66c481/addons/account/views/account_move_views.xml#L860

computes payment_count
https://github.com/odoo/odoo/blob/d4b6897211c65ba6d6ba8132480627e6fa66c481/addons/account/models/account_move.py#L1357
this triggers a read on `matched_payment_ids` https://github.com/odoo/odoo/blob/d4b6897211c65ba6d6ba8132480627e6fa66c481/addons/account/models/account_move.py#L2392
Which  accesses the `account.payment` model and the invoice fails to open.

Fix:
Grant read access on the `account.payment` model to the Purchase/User group.

opw-5420938
upg-3857107

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
