### PR TITLE
[FIX] sale_management: fix indeterministic sign tour

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { redirect } from "@web/core/utils/urls";
-import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 // This tour relies on data created on the Python test.
 registry.category("web_tour.tours").add('sale_signature', {
@@ -62,7 +61,10 @@ registry.category("web_tour.tours").add('sale_signature', {
 
 registry.category("web_tour.tours").add("sale_signature_without_name", {
     steps: () => [
-        stepUtils.waitIframeIsReady(),
+        {
+            content: "Wait for interactions to load",
+            trigger: `body[is-ready=true], :iframe body[is-ready=true]`,
+        },
         {
             content: "Sign & Pay",
             trigger:


### PR DESCRIPTION
This commit fixes an indeterministic sign tour that could run either inside an iframe or directly in the main page. Since the execution context was unpredictable, both selectors were added to handle both cases reliably.

runbot error-238443




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
