### PR TITLE
[IMP] mail: clarify notification text and remove redundant notification

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -581,12 +581,12 @@ export class Message extends Record {
     }
 
     async copyLink() {
-        let notification = _t("Message Link Copied!");
-        let type = "info";
+        let notification = _t("Message Link Copied");
+        let type = "success";
         try {
             await browser.navigator.clipboard.writeText(url(`/mail/message/${this.id}`));
         } catch {
-            notification = _t("Message Link Copy Failed (Permission denied?)!");
+            notification = _t("Message Link Copy Failed (Permission denied?)");
             type = "danger";
         }
         this.store.env.services.notification.add(notification, { type });
@@ -597,12 +597,11 @@ export class Message extends Record {
         try {
             await browser.navigator.clipboard.writeText(messageBody);
         } catch {
-            this.store.env.services.notification.add(
-                _t("Message Copy Failed (Permission denied?)!"),
-                { type: "danger" }
-            );
+            this.store.env.services.notification.add(_t("Text Copy Failed (Permission denied?)"), {
+                type: "danger",
+            });
         }
-        this.store.env.services.notification.add(_t("Message Copied!"), { type: "info" });
+        this.store.env.services.notification.add(_t("Text copied"), { type: "success" });
     }
 
     async edit(

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -11,7 +11,6 @@ import { useDynamicInterval } from "@mail/utils/common/misc";
 import { formatLocalDateTime } from "@mail/utils/common/dates";
 import { attClassObjectToString } from "@mail/utils/common/format";
 
-import { _t } from "@web/core/l10n/translation";
 import { FileUploader } from "@web/views/fields/file_handler";
 import { useService } from "@web/core/utils/hooks";
 
@@ -95,7 +94,6 @@ export class DiscussContent extends Component {
 
     async onFileUploaded(file) {
         await this.thread.channel?.notifyAvatarToServer(file.data);
-        this.notification.add(_t("The avatar has been updated!"), { type: "success" });
     }
 
     async renameGuest(name) {


### PR DESCRIPTION
Purpose of this PR:

- Update notification text and type for "Copy text" and "Copy link"
actions so they reflect the accurate information.
- Remove redundant notification shown when an avatar is changed.

task-5873868


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
