### PR TITLE
[FIX] stock_account: prevent traceback when user click produce all button in MO.

### DIFF
--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -171,6 +171,11 @@ class TestMrpAccount(TestBomPriceCommon):
         overview_values = self.env['report.mrp.report_mo_overview'].get_report_values(mo.id)
         self.assertEqual(round(overview_values['data']['summary']['mo_cost'], 2), 677.08)
 
+    def test_mrp_user_without_account_permissions_can_create_bom(self):
+        mrp_user = new_test_user(self.env, 'temp_mrp_user', 'mrp.group_mrp_user')
+        mo_1 = self._create_mo(self.bom_1, 1)
+        mo_1.with_user(mrp_user).button_mark_done()
+
 
 class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
 

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -183,7 +183,7 @@ class StockMove(models.Model):
                 move_to_link.add(move.id)
         if not aml_vals_list:
             return self.env['account.move']
-        account_move = self.env['account.move'].create({
+        account_move = self.env['account.move'].sudo().create({
             'journal_id': self.company_id.account_stock_journal_id.id,
             'line_ids': [Command.create(aml_vals) for aml_vals in aml_vals_list],
             'date': self.env.context.get('force_period_date') or fields.Date.context_today(self),


### PR DESCRIPTION
Issue before this commit:
=========================
Clicking Produce All on a Manufacturing Order as a user with Manufacturing 
rights raised an Access Error.
The button tried to create account.move and account.move.line records, which the
user had no permission to create.

Steps to Reproduce:
=========================
1. Install account and mrp modules.
2. Create a product with:
   - Track Inventory enabled
   - Product uses real-time valuation
   - A cost of production exists on production/inventory location
3. Create a user with only Manufacturing user rights.
4. Log in as that user.
5. Create a Manufacturing Order, confirm it, and click Produce All.

Cause of the Issue:
=========================
Stock valuation during production attempted to create accounting entries for
specific locations or analytics, but users lacked access to
account.move and account.move.line, causing an access error.

With This Commit:
=========================
This commit allows users to produce Manufacturing Orders
without changing the stock valuation logic.

Steps to Reproduce: [Video Link](https://drive.google.com/file/d/1--k6m_UvoTyFpavPn1JUOyhsKydeMbVL/view?usp=sharing)

opw-5487383