### PR TITLE
[FIX] l10n_tw_edi_ecpay: Convert date time to TW time zone when

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move.py
@@ -7,7 +7,7 @@ import uuid
 from urllib.parse import urljoin
 
 from odoo import api, fields, models
-from odoo.addons.l10n_tw_edi_ecpay.utils import call_ecpay_api, transfer_time
+from odoo.addons.l10n_tw_edi_ecpay.utils import call_ecpay_api, transfer_time, convert_utc_time_to_tw_time
 from odoo.exceptions import UserError
 from odoo.tools import float_round
 
@@ -499,7 +499,7 @@ class AccountMove(models.Model):
             if self.l10n_tw_edi_is_b2b and is_allowance:
                 item_list.append({
                     "OriginalInvoiceNumber": self.l10n_tw_edi_ecpay_invoice_id,
-                    "OriginalInvoiceDate": self.l10n_tw_edi_invoice_create_date.strftime("%Y-%m-%d"),
+                    "OriginalInvoiceDate": convert_utc_time_to_tw_time(self.l10n_tw_edi_invoice_create_date),
                     "OriginalSequenceNumber": line.l10n_tw_edi_ecpay_item_sequence,
                     "ItemName": line.name[:100],
                     "ItemCount": quantity,
@@ -648,7 +648,7 @@ class AccountMove(models.Model):
 
             json_data.update({
                 "InvoiceNo": self.l10n_tw_edi_ecpay_invoice_id,
-                "InvoiceDate": self.l10n_tw_edi_invoice_create_date.strftime("%Y-%m-%d %H:%M:%S"),
+                "InvoiceDate": convert_utc_time_to_tw_time(self.l10n_tw_edi_invoice_create_date),
             })
         else:
             json_data.update({
@@ -733,7 +733,7 @@ class AccountMove(models.Model):
             json_data.update({
                 "InvoiceCategory": 0,
                 "InvoiceNumber": self.l10n_tw_edi_ecpay_invoice_id,
-                "InvoiceDate": self.l10n_tw_edi_invoice_create_date.strftime("%Y-%m-%d %H:%M:%S"),
+                "InvoiceDate": convert_utc_time_to_tw_time(self.l10n_tw_edi_invoice_create_date),
             })
 
         response_data = call_ecpay_api("/GetIssue", json_data, self.company_id, self.l10n_tw_edi_is_b2b)
@@ -760,7 +760,7 @@ class AccountMove(models.Model):
 
         json_data = {
             "MerchantID": self.company_id.sudo().l10n_tw_edi_ecpay_merchant_id,
-            "InvoiceDate": self.l10n_tw_edi_invoice_create_date.strftime("%Y-%m-%d %H:%M:%S"),
+            "InvoiceDate": convert_utc_time_to_tw_time(self.l10n_tw_edi_invoice_create_date),
             "Reason": self.l10n_tw_edi_invalidate_reason
         }
 

--- a/addons/l10n_tw_edi_ecpay/tests/test_edi.py
+++ b/addons/l10n_tw_edi_ecpay/tests/test_edi.py
@@ -442,6 +442,39 @@ class L10nTWITestEdi(TestAccountMoveSendCommon, HttpCase):
             "B2B Allowances should not include AllowanceDate to avoid >6 day limit errors."
         )
 
+    @freeze_time("2026-01-05 18:00:00")
+    def test_14_tw_datetime_conversion(self):
+        """Test that datetime conversion to TW timezone works correctly.
+
+        Scenario:
+        An invoice is created and send to ecpay at "2026-01-05 18:00:00" UTC.
+        In TW timezone, this corresponds to "2026-01-06 02:00:00" (UTC+8).
+
+        Ensure the convert_utc_time_to_tw_time function works to convert the 'InvoiceDate' in the allowance JSON to TW date
+        """
+        invoice = self.init_invoice("out_invoice", partner=self.partner_a, products=self.product_a)
+        invoice.write({
+            "l10n_tw_edi_invoice_create_date": datetime(2026, 1, 5, 18, 0, 0),
+            "l10n_tw_edi_ecpay_invoice_id": "AB11100099"  # simulate it was already sent
+        })
+        invoice.action_post()
+
+        wizard_vals = {
+            "journal_id": invoice.journal_id.id,
+            "reason": "Refund",
+            "l10n_tw_edi_refund_agreement_type": "offline",
+        }
+        wizard = self.env["account.move.reversal"].with_context(
+            active_ids=invoice.ids,
+            active_model="account.move"
+        ).create(wizard_vals)
+        wizard.reverse_moves()
+        credit_note = wizard.new_move_ids
+        credit_note.action_post()
+
+        json_data = credit_note._l10n_tw_edi_generate_issue_allowance_json()
+        self.assertEqual(json_data.get("InvoiceDate"), "2026-01-06")
+
     # -------------------------------------------------------------------------
     # Patched methods
     # -------------------------------------------------------------------------

--- a/addons/l10n_tw_edi_ecpay/utils.py
+++ b/addons/l10n_tw_edi_ecpay/utils.py
@@ -21,6 +21,22 @@ def transfer_time(time_before):
     return ecpay_time.astimezone(pytz.UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def convert_utc_time_to_tw_time(utc_datetime):
+    """
+        Converts UTC datetime object to a TW date string.
+
+        :param utc_datetime: datetime.datetime(2026, 1, 23, 18, 0, 0)
+        :return: "2026-01-24"
+    """
+    if utc_datetime.tzinfo is None:
+        utc_datetime = pytz.utc.localize(utc_datetime)
+
+    tw_tz = pytz.timezone('Asia/Taipei')
+    tw_time = utc_datetime.astimezone(tw_tz)
+
+    return tw_time.strftime("%Y-%m-%d")
+
+
 def encrypt(data, cipher):
     padder = padding.PKCS7(128).padder()
     padded_data = padder.update(data.encode("utf-8")) + padder.finalize()

--- a/addons/l10n_tw_edi_ecpay/wizard/l10n_tw_edi_invoice_print.py
+++ b/addons/l10n_tw_edi_ecpay/wizard/l10n_tw_edi_invoice_print.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
-from odoo.addons.l10n_tw_edi_ecpay.utils import call_ecpay_api
+from odoo.addons.l10n_tw_edi_ecpay.utils import call_ecpay_api, convert_utc_time_to_tw_time
 from odoo.exceptions import UserError
 
 
@@ -40,7 +40,7 @@ class L10nTwEDIInvoicePrint(models.TransientModel):
         json_data = {
             "MerchantID": self.invoice_id.company_id.sudo().l10n_tw_edi_ecpay_merchant_id,
             "InvoiceNo": self.invoice_id.l10n_tw_edi_ecpay_invoice_id,
-            "InvoiceDate": self.invoice_id.l10n_tw_edi_invoice_create_date.strftime("%Y-%m-%d"),
+            "InvoiceDate": convert_utc_time_to_tw_time(self.invoice_id.l10n_tw_edi_invoice_create_date),
             "PrintStyle": self.print_format_b2b if self.l10n_tw_edi_is_b2b else self.print_format_b2c,
             "IsShowingDetail": "1",
         }


### PR DESCRIPTION
sending to ECPay

The date store in Odoo is in utc format, we need to convert it to tw time when sending the date to ECPay. The APIs are using the date to search for the invoices, if the date is not correct, it cannot find the invoices and return error.

task-5884616

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
