### PR TITLE
[FIX] hr_attendance: fix broken Buy an RFID Device link in Kiosk Mode

### DIFF
--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -104,7 +104,7 @@
                         <div>
                             Connect an RFID reader, and scan a token.
                             <DocumentationLink path="'/applications/hr/attendances/hardware.html'" label.translate="'Read the Documentation'" alertLink="true"/>/
-                            <DocumentationLink path="'https://www.amazon.fr/s?i=merchant-items&amp;me=A8A1OT6EFYV9W'" label.translate="'Buy an RFID Device'" alertLink="true"/>
+                            <DocumentationLink path="'https://duckduckgo.com/?q=rfid+reader'" label.translate="'Buy an RFID Device'" alertLink="true"/>
                         </div>
                         <button t-on-click="removeDemoMessage" type="button" class="btn-close float-end ms-2" title="Close"/>
                 </div>


### PR DESCRIPTION
Steps to reproduce:
-----------------------------------
1. Install the Attendance module with demo data
2. Go to Kiosk Mode > click on the link to 'Buy an RFID Device'
3. On the opened Amazon page, change the delivery country to United States

Observation:
-----------------------------------
The Amazon product page becomes blank after switching the delivery country to the United States

Issue:
-----------------------------------
The link redirects to the French Amazon website (`amazon.fr`) with a merchant that does not ship RFID devices to the United States

Solution:
-----------------------------------
Update the link to use `amazon.com` instead of `amazon.fr`. Change the merchant ID to one with broader delivery availability, including the United States.

opw-5479568