### PR TITLE
[FIX] l10n_tw_edi_ecpay_website_sale: Fix disabled input box for

### DIFF
--- a/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
@@ -80,14 +80,14 @@ class WebsiteSaleL10nTW(WebsiteSale):
         }
         if kw.get('l10n_tw_edi_is_donate') != 'on':
             if kw.get('l10n_tw_edi_carrier_type') == '2' and not kw.get('l10n_tw_edi_carrier_number'):
-                errors['carrier_number'] = request.env._('Please enter the carrier number')
+                errors['carrier_number'] = request.env._('Please enter the storage code')
             if kw.get('l10n_tw_edi_carrier_type') == '3' \
                     and not self._is_valid_mobile_barcode(kw.get('l10n_tw_edi_carrier_number'), order):
                 errors['carrier_number'] = request.env._('Mobile Barcode is invalid')
             if kw.get('l10n_tw_edi_carrier_type') in ['4', '5'] and (not kw.get('l10n_tw_edi_carrier_number') or not kw.get('l10n_tw_edi_carrier_number_2')):
-                errors['carrier_number'] = request.env._('Please enter the carrier number and carrier number 2')
+                errors['carrier_number'] = request.env._('Please enter the storage code and storage code 2')
         elif kw.get('l10n_tw_edi_is_donate') == 'on' and not self._is_valid_love_code(kw.get('l10n_tw_edi_love_code'), order):
-            errors['love_code'] = request.env._('Love Code is invalid')
+            errors['love_code'] = request.env._('Donation Code is invalid')
 
         vals_to_write = {
             'l10n_tw_edi_is_print': False,

--- a/addons/l10n_tw_edi_ecpay_website_sale/models/sale_order.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/models/sale_order.py
@@ -11,7 +11,7 @@ class SaleOrder(models.Model):
     l10n_tw_edi_carrier_type = fields.Selection(
         string="Carrier Type",
         selection=[
-            ("1", "ECpay e-invoice carrier"),
+            ("1", "Member Account"),
             ("2", "Citizen Digital Certificate"),
             ("3", "Mobile Barcode"),
             ("4", "EasyCard"),

--- a/addons/l10n_tw_edi_ecpay_website_sale/static/src/js/website_sale.js
+++ b/addons/l10n_tw_edi_ecpay_website_sale/static/src/js/website_sale.js
@@ -103,6 +103,7 @@ publicWidget.registry.knowledgeBaseAutocomplete = publicWidget.Widget.extend({
     _onChangeCarrierType(ev) {
         const carrierType = ev.target.value;
         const carrierNumberField = document.querySelector("#l10n_tw_edi_carrier_number")
+        carrierNumberField.removeAttribute("readonly");
         if (carrierType === "2") {
             carrierNumberField.placeholder = _t(
                 "Example: TP03000001234567"
@@ -169,12 +170,11 @@ publicWidget.registry.knowledgeBaseAutocomplete = publicWidget.Widget.extend({
                 this.validCarrierNumber = true;
                 this.showValidateCarrierNumber = false;
                 this.showReenterCarrierNumber = true;
-                this.el.querySelector("#l10n_tw_edi_carrier_type").disabled = true;
                 this.el.querySelector("#l10n_tw_edi_carrier_number").setAttribute("readonly", true);
             } else {
                 this.call("dialog", "add", WarningDialog, {
                     title: _t("Error"),
-                    message: _t("Carrier number is invalid"),
+                    message: _t("Storage Code is invalid"),
                 });
             }
         } catch (error) {
@@ -218,7 +218,6 @@ publicWidget.registry.knowledgeBaseAutocomplete = publicWidget.Widget.extend({
         this.validCarrierNumber = false;
         this.showValidateCarrierNumber = true;
         this.showReenterCarrierNumber = false;
-        this.el.querySelector("#l10n_tw_edi_carrier_type").disabled = false;
         this.el.querySelector("#l10n_tw_edi_carrier_number").removeAttribute("readonly");
         this.showInvoiceItems();
     },

--- a/addons/l10n_tw_edi_ecpay_website_sale/static/tests/tours/test_checkout.js
+++ b/addons/l10n_tw_edi_ecpay_website_sale/static/tests/tours/test_checkout.js
@@ -286,3 +286,83 @@ registry.category("web_tour.tours").add("test_checkout_b2b", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("test_checkout_b2c_mobile_barcode", {
+    url: "/shop",
+    steps: () => [
+        ...tourUtils.addToCart({ productName: "Test Product", expectUnloadPage: true }),
+        tourUtils.goToCart({ quantity: 1 }),
+        {
+            content: "Go to checkout",
+            trigger: "a[name='website_sale_main_button']",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            trigger: "select[name=country_id]",
+            run: "selectByLabel Taiwan",
+        },
+        {
+            trigger: "input[name=name]",
+            run: "edit Test Customer B2C",
+        },
+        {
+            trigger: "input[name=phone]",
+            run: "edit +886 123 456 789",
+        },
+        {
+            trigger: "input[name=email]",
+            run: "edit test@odoo.com",
+        },
+        {
+            trigger: "input[name=street]",
+            run: "edit Xinyi Road 33",
+        },
+        {
+            trigger: "input[name=zip]",
+            run: "edit 10000",
+        },
+        {
+            trigger: "input[name=city]",
+            run: "edit Taipei",
+        },
+        {
+            trigger: "select[name=l10n_tw_edi_require_paper_format]",
+            run: "selectByLabel No",
+        },
+        {
+            content: "Continue Checkout",
+            trigger: '.btn-primary:contains("Continue checkout")',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Confirm",
+            trigger: "a[name='website_sale_main_button']",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        // E-invoice info
+        {
+            trigger: "select[name=l10n_tw_edi_carrier_type]",
+            run: "selectByLabel Mobile Barcode",
+        },
+        {
+            trigger: "input[name=l10n_tw_edi_carrier_number]",
+            run: "edit /1234567",
+        },
+        // Valid mobile barcode, after the fix the l10n_tw_edi_carrier_type should remain "3"
+        {
+            content: "Validate Mobile Barcode",
+            trigger: "#validate_carrier_number",
+            run: "click",
+            expectUnloadPage: false,
+        },
+        {
+            content: "Continue checkout",
+            trigger: "a[name='website_sale_main_button']",
+            run: "click",
+            expectUnloadPage: true,
+        },
+    ],
+});

--- a/addons/l10n_tw_edi_ecpay_website_sale/tests/test_l10n_tw_edi_website_sale.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/tests/test_l10n_tw_edi_website_sale.py
@@ -61,6 +61,16 @@ class TestUi(HttpCase):
             'l10n_tw_edi_is_print': True,
         }])
 
+    def test_checkout_b2c_mobile_barcode(self):
+        with patch(CALL_API_METHOD, new=self._test_checkout_b2c_mobile_barcode_mock):
+            self.start_tour("/shop", "test_checkout_b2c_mobile_barcode")
+        # Check the invoice info is updated on the sale order
+        sale_order = self.env['sale.order'].search([], limit=1, order="create_date desc")
+        self.assertRecordValues(sale_order, [{
+            'l10n_tw_edi_carrier_type': "3",
+            'l10n_tw_edi_carrier_number': "/1234567",
+        }])
+
     # -------------------------------------------------------------------------
     # Patched methods
     # -------------------------------------------------------------------------
@@ -87,6 +97,15 @@ class TestUi(HttpCase):
             return {
                 "RtnCode": 1,
                 "CompanyName": "Test Company",
+            }
+        else:
+            raise UserError('Unexpected endpoint called during a test: %s with params %s.' % (endpoint, params))
+
+    def _test_checkout_b2c_mobile_barcode_mock(self, endpoint, params, company_id, is_b2b=False):
+        if endpoint == "/CheckBarcode":
+            return {
+                "RtnCode": 1,
+                "IsExist": "Y",
             }
         else:
             raise UserError('Unexpected endpoint called during a test: %s with params %s.' % (endpoint, params))

--- a/addons/l10n_tw_edi_ecpay_website_sale/views/templates.xml
+++ b/addons/l10n_tw_edi_ecpay_website_sale/views/templates.xml
@@ -36,7 +36,7 @@
                             <div id="ecpay_carrier_type_group" t-att-class="'d-none' if default_vals['is_donate'] == 'on' else ''">
                                 <div class="row">
                                     <div id="carrier_type_selection" class="mt-3 col-md-7">
-                                        <label for="l10n_tw_edi_carrier_type" class="form-label">Carrier</label>
+                                        <label for="l10n_tw_edi_carrier_type" class="form-label">Storage Type</label>
                                         <select class="form-select" id="l10n_tw_edi_carrier_type" name="l10n_tw_edi_carrier_type">
                                             <t t-foreach="carrier_choices" t-as="choice">
                                                 <option t-attf-value="{{choice[0]}}"
@@ -49,7 +49,7 @@
                                 </div>
                                 <div id="ecpay_invoice_carrier_number" t-att-class="'d-none' if default_vals['carrier_type'] in ['0', '1'] else ''" class="row">
                                     <div class="mt-3 col-md-7">
-                                        <label for="l10n_tw_edi_carrier_number" class="form-label">Carrier Number</label>
+                                        <label for="l10n_tw_edi_carrier_number" class="form-label">Storage Code</label>
                                         <div class="d-flex">
                                             <input
                                                 class="form-control"
@@ -70,7 +70,7 @@
                                 </div>
                                 <div id="ecpay_invoice_carrier_number_2" t-att-class="'d-none' if default_vals['carrier_type'] in ['0', '1', '2', '3'] else ''" class="row">
                                     <div class="mt-3 col-md-7">
-                                        <label for="l10n_tw_edi_carrier_number_2" class="form-label">Carrier Number 2</label>
+                                        <label for="l10n_tw_edi_carrier_number_2" class="form-label">Storage Code 2</label>
                                         <div class="d-flex">
                                             <input
                                                 class="form-control"
@@ -86,7 +86,7 @@
                             </div>
                             <div id="ecpay_invoice_love_code" t-att-class="'d-none' if default_vals['is_donate'] != 'on' else ''" class="row">
                                 <div class="mt-3 col-md-7">
-                                    <label for="l10n_tw_edi_love_code" class="form-label">Love Code</label>
+                                    <label for="l10n_tw_edi_love_code" class="form-label">Donation Code</label>
                                     <div class="d-flex">
                                         <input
                                             class="form-control"


### PR DESCRIPTION
carrier type

After the user clicks on "Validate" button to validate the mobile barcode, the carrier type selection is disabled and the carrier type pass to the SO is None.

This commit fixes the issue by instead of disabling the carrier type selection, we just set the input box of carrier number to readonly and set back the carrier number to not readonly when the user changes the carrier type to ensure the carrier number input is editable.

task-5880421

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
