### PR TITLE
[FIX] sale_project: prevent error on creation of sale order from project

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -225,7 +225,7 @@ class ProjectProject(models.Model):
         }
         if len(all_sale_order_lines) <= 1:
             action_window['res_id'] = all_sale_order_lines.id
-        else:
+        if len(all_sale_order_lines) > 1 or not self.partner_id:
             action_window.update({
                 'domain': [('id', 'in', all_sale_order_lines.ids)],
                 'views': [
@@ -233,6 +233,8 @@ class ProjectProject(models.Model):
                     (self.env.ref('sale_project.sale_order_line_view_form_editable').id, 'form'),
                 ],
             })
+            if not self.partner_id:
+                action_window['context'].update({'create': False})
         return action_window
 
     def action_view_sos(self):

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -38,7 +38,8 @@ class SaleOrderLine(models.Model):
                     del res['order_id']
 
             if 'order_id' in fields and not res.get('order_id'):
-                assert (partner_id := self.env.context.get('default_partner_id'))
+                if not (partner_id := self.env.context.get('default_partner_id')):
+                    pass
                 project_id = self.env.context.get('link_to_project')
                 sale_order = None
                 so_create_values = {


### PR DESCRIPTION
Currently, an assertion error is raised when opening "Sales Order Items" from a project without a customer.

**Steps to Reproduce:**
- Install `sale_project` module with demo data.
- Create a new project using "Sale Order" project template.
- Do not set a customer on project.
- Project > Task (Kanban) > Show _Top Menu_ > Show _Sales Order Items_.
- Click "**Sales Order Items**".

Video Ref: https://drive.google.com/file/d/1xgYHZBvIt5Ep9Gt-wALGIb9f7mj4NPh_/view?usp=drive_link

Error: AssertionError

**Cause:**
The sale order line depends on `default_partner_id` from the context to create a sale order when none exists. When the project has no customer set, this value is missing, causing an assertion failure.

**Fix:**
This commit returns the list view of SOLs and disables the creation when no partner is set for the project.

sentry-7220116560