### PR TITLE
[REF] web,*: no more a[href="#"] in notebook

### DIFF
--- a/addons/account/static/src/components/account_move_form/account_move_form_notebook.xml
+++ b/addons/account/static/src/components/account_move_form/account_move_form_notebook.xml
@@ -2,8 +2,8 @@
 
 <templates xml:space="preserve">
     <t t-name="account.AccountMoveFormNotebook" t-inherit="web.Notebook" t-inherit-mode="primary">
-        <xpath expr="//a[@class='nav-link']" position="attributes">
-            <attribute name="t-on-click.prevent">() => this.changeTabTo(navItem[0])</attribute>
+        <xpath expr="//button[@class='nav-link']" position="attributes">
+            <attribute name="t-on-click">() => this.changeTabTo(navItem[0])</attribute>
             <attribute name="tabindex">-1</attribute>
         </xpath>
     </t>

--- a/addons/account/static/tests/account_move_form.test.js
+++ b/addons/account/static/tests/account_move_form.test.js
@@ -33,7 +33,7 @@ test("When I switch tabs, it saves", async () => {
     });
     await insertText("[name='name'] input", "somebody save me!");
     triggerHotkey("Enter");
-    await click('a[name="aml_tab"]');
+    await click('button[name="aml_tab"]');
     await expect.waitForSteps(["tab saved"]);
 });
 

--- a/addons/auth_passkey/static/tests/passkeys_delete.js
+++ b/addons/auth_passkey/static/tests/passkeys_delete.js
@@ -13,7 +13,7 @@ registry.category("web_tour.tours").add('passkeys_tour_delete', {
             run: 'click',
         }, {
             content: "Switch to security tab",
-            trigger: 'a[role=tab]:contains("Security")',
+            trigger: 'button[role=tab]:contains("Security")',
             run: 'click',
         }, {
             content: "Ensure there is only one passkey",
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add('passkeys_tour_delete', {
             trigger: 'label:contains("Email Signature")',
         }, {
             content: "Switch to security tab",
-            trigger: 'a[role=tab]:contains("Security")',
+            trigger: 'button[role=tab]:contains("Security")',
             run: 'click',
         }, {
             content: "Ensure there are no more passkeys",

--- a/addons/auth_passkey/static/tests/passkeys_registration.js
+++ b/addons/auth_passkey/static/tests/passkeys_registration.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add('passkeys_tour_registration', {
             run: 'click',
         }, {
             content: "Switch to security tab",
-            trigger: 'a[role=tab]:contains("Security")',
+            trigger: 'button[role=tab]:contains("Security")',
             run: 'click',
         }, {
             content: "Ensure there are no passkeys already",
@@ -103,7 +103,7 @@ registry.category("web_tour.tours").add('passkeys_tour_registration', {
             trigger: 'label:contains("Email Signature")',
         }, {
             content: "Switch to security tab",
-            trigger: 'a[role=tab]:contains("Security")',
+            trigger: 'button[role=tab]:contains("Security")',
             run: 'click',
         }, {
             content: "Ensure there is one passkey",

--- a/addons/auth_passkey/static/tests/passkeys_verify.js
+++ b/addons/auth_passkey/static/tests/passkeys_verify.js
@@ -17,7 +17,7 @@ registry.category("web_tour.tours").add('passkeys_tour_verify', {
             run: 'click',
         }, {
             content: "Switch to security tab",
-            trigger: 'a[role=tab]:contains("Security")',
+            trigger: 'button[role=tab]:contains("Security")',
             run: 'click',
         }, {
             content: "Ensure there is one passkey",

--- a/addons/auth_totp/static/tests/apikeys_flow.js
+++ b/addons/auth_totp/static/tests/apikeys_flow.js
@@ -11,7 +11,7 @@ const openUserPreferenceSecurity = () => [{
     run: 'click',
 }, {
     content: "Switch to security tab",
-    trigger: 'a[role=tab]:contains("Security")',
+    trigger: 'button[role=tab]:contains("Security")',
     run: 'click',
 }]
 
@@ -78,7 +78,7 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
     run: "click",
 }, {
     content: "Switch to security tab",
-    trigger: 'a[role=tab]:contains("Security")',
+    trigger: 'button[role=tab]:contains("Security")',
     run: 'click',
 }, {
     content: "Open kanban dropdown menu of the key",
@@ -105,7 +105,7 @@ registry.category("web_tour.tours").add('apikeys_tour_teardown', {
     run: "click",
 }, {
     content: "Switch to security tab",
-    trigger: 'a[role=tab]:contains("Security")',
+    trigger: 'button[role=tab]:contains("Security")',
     run: 'click',
 }, {
     content: "Check that there's no more keys",

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -29,10 +29,10 @@ function openUserPreferencesAtSecurityTab() {
         run: 'click',
     }, {
         content: "wait for security tab",
-        trigger: 'a[role=tab]:contains("Security")',
+        trigger: 'button[role=tab]:contains("Security")',
     }, {
         content: "Switch to security tab",
-        trigger: 'a[role=tab]:contains("Security")',
+        trigger: 'button[role=tab]:contains("Security")',
         run: 'click',
     }];
 }
@@ -55,7 +55,7 @@ function closePreferencesDialog({content, totp_state}) {
 
     return [{
         content,
-        trigger: 'a[role=tab]:contains("Security").active',
+        trigger: 'button[role=tab]:contains("Security").active',
     }, 
     {
         trigger,
@@ -78,7 +78,7 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
 ...openUserPreferencesAtSecurityTab(),
 {
     content: "Open totp wizard",
-    trigger: 'a[role=tab]:contains("Security").active',
+    trigger: 'button[role=tab]:contains("Security").active',
 },
 {
     trigger: "button[name=action_totp_enable_wizard]",
@@ -301,7 +301,7 @@ registry.category("web_tour.tours").add('totp_login_device', {
 ...openUserPreferencesAtSecurityTab(),
 {
     content: "Open totp wizard",
-    trigger: 'a[role=tab]:contains("Security").active',
+    trigger: 'button[role=tab]:contains("Security").active',
 },
 {
     trigger: "button[name=action_totp_disable]",
@@ -416,10 +416,10 @@ registry.category("web_tour.tours").add('totp_admin_disables', {
     run: "click",
 }, {
     content: "wait for Security Tab to appear",
-    trigger: "a.nav-link:contains(Security)",
+    trigger: "button.nav-link:contains(Security)",
 },{
     content: "go to Security Tab",
-    trigger: "a.nav-link:contains(Security)",
+    trigger: "button.nav-link:contains(Security)",
     run: "click",
 }, {
     content: "check 2FA button: should be disabled",

--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -43,7 +43,7 @@ registry.category("web_tour.tours").add('totp_admin_self_invite', {
     run: "click",
 }, {
     content: "go to Security Tab",
-    trigger: "a.nav-link:contains(Security)",
+    trigger: "button.nav-link:contains(Security)",
     run: "click",
 }, {
     content: "check that user cannot invite themselves to use 2FA.",
@@ -58,7 +58,7 @@ registry.category("web_tour.tours").add('totp_admin_invite', {
     run: "click",
 }, {
     content: "go to security Tab",
-    trigger: "a.nav-link:contains(Security)",
+    trigger: "button.nav-link:contains(Security)",
     run: "click",
 }, {
     content: "check that test_user user can be invited to use 2FA.",

--- a/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
+++ b/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add("version_timeline_auto_save_tour", {
         },
         {
             content: "Open Payroll Page",
-            trigger: ".o_notebook_headers a[name='payroll_information']",
+            trigger: ".o_notebook_headers button[name='payroll_information']",
             run: "click",
         },
         {

--- a/addons/html_builder/static/tests/editor.test.js
+++ b/addons/html_builder/static/tests/editor.test.js
@@ -32,7 +32,7 @@ test("should add an icon from the media modal dialog", async () => {
     await insertText(editor, "/image");
     await animationFrame();
     await contains(".o-we-command").click();
-    await contains(".modal .modal-body .nav-item:nth-child(3) a").click();
+    await contains(".modal .modal-body .nav-item:nth-child(3) button").click();
     await contains(".modal .modal-body .fa-heart").click();
     expect(p).toHaveInnerHTML(`x<span class="fa fa-heart" contenteditable="false">\u200b</span>`);
 });

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -230,7 +230,7 @@ test("Can replace icon using toolbar", async () => {
     await contains("button[name='icon_replace']").click();
     await animationFrame();
     expect("main.modal-body").toHaveCount(1);
-    expect("main.modal-body a.nav-link.active").toHaveText("Icons");
+    expect("main.modal-body button.nav-link.active").toHaveText("Icons");
     // Corresponding icon should be highlighted in dialog
     expect("main.modal-body span.fa-heart.o_we_attachment_selected").toHaveCount(1);
 

--- a/addons/mail/static/tests/inline/html_mail_field.test.js
+++ b/addons/mail/static/tests/inline/html_mail_field.test.js
@@ -149,7 +149,7 @@ test("HtmlMail add icon and save inline html", async function () {
     await insertText(htmlEditor, "/image");
     await press("enter");
 
-    await contains("a.nav-link:contains('Icons')").click();
+    await contains("button.nav-link:contains('Icons')").click();
     await contains("span.fa-glass").click();
 
     await clickSave();

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -178,7 +178,7 @@ registry.category("web_tour.tours").add('project_tour', {
     run: "click",
 }, {
     isActive: ["auto"],
-    trigger: 'a[name="sub_tasks_page"]',
+    trigger: 'button[name="sub_tasks_page"]',
     content: _t('Open sub-tasks notebook section'),
     run: 'click',
 }, {

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -159,7 +159,7 @@ registry.category("web_tour.tours").add("project_sharing_with_blocked_task_tour"
         content: 'Click on the task',
         run: "click",
     }, {
-        trigger: 'a:contains("Blocked By")',
+        trigger: 'button:contains("Blocked By")',
         content: 'Go to the Block by task tab',
         run: "click",
     }, {

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -258,11 +258,11 @@ registry.category("web_tour.tours").add("project_task_last_history_steps_tour", 
         ...stepUtils.saveForm(),
         ...insertEditorContent("4"),
     {
-        trigger: ".o_notebook_headers li:nth-of-type(2) a",
+        trigger: ".o_notebook_headers li:nth-of-type(2) button",
         run: "click",
     },
     {
-        trigger: ".o_notebook_headers li:nth-of-type(1) a",
+        trigger: ".o_notebook_headers li:nth-of-type(1) button",
         run: "click",
     },
         ...insertEditorContent("5"),

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -64,7 +64,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         trigger: '.o_kanban_record span:contains("New task")',
         run: "click",
     }, {
-        trigger: 'a[name="sub_tasks_page"]',
+        trigger: 'button[name="sub_tasks_page"]',
         content: 'Open sub-tasks notebook section',
         run: 'click',
     }, {
@@ -135,7 +135,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         content: 'Assign the task to you',
         run: "click",
     }, {
-        trigger: 'a[name="sub_tasks_page"]',
+        trigger: 'button[name="sub_tasks_page"]',
         content: 'Open sub-tasks notebook section',
         run: 'click',
     }, {

--- a/addons/sale/static/src/js/tours/tour_utils.js
+++ b/addons/sale/static/src/js/tours/tour_utils.js
@@ -65,7 +65,7 @@ export function clickSomewhereElse() {
         // TODO find a way for onchange to finish first ?
         {
             content: 'click somewhere else to exit cell focus',
-            trigger: 'a[name=order_lines]',  // click on notebook tab to stop the sol edit mode.
+            trigger: 'button[name=order_lines]',  // click on notebook tab to stop the sol edit mode.
             run: 'click',
         },
         {

--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -30,7 +30,7 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         trigger: 'div.o_notebook_headers',
     },
     {
-        trigger: 'a.nav-link[name="settings"]',
+        trigger: 'button.nav-link[name="settings"]',
         content: 'Click on Settings tab to configure this project.',
         run: "click",
     }, {

--- a/addons/sale_stock/static/tests/tours/barcode_duplication_tour.js
+++ b/addons/sale_stock/static/tests/tours/barcode_duplication_tour.js
@@ -2,7 +2,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_barcode_duplication_error", {steps: () => [
     {
-        trigger: "div.o_form_sheet div.o_notebook li a:contains('Sales')",
+        trigger: "div.o_form_sheet div.o_notebook li button:contains('Sales')",
         run: "click",
     },
     {

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -105,7 +105,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: "div.o_notebook_headers",
 },
 {
-    trigger: 'a.nav-link:contains(Timesheets)',
+    trigger: 'button.nav-link:contains(Timesheets)',
     content: 'Click on Timesheets page to log a timesheet',
     run: "click",
 }, {
@@ -181,7 +181,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: "div.o_notebook_headers",
 },
 {
-    trigger: 'a.nav-link[name="settings"]',
+    trigger: 'button.nav-link[name="settings"]',
     content: 'Click on Settings page to check the allow_billable checkbox',
     run: "click",
 }, {
@@ -213,7 +213,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: "div.o_notebook_headers",
 },
 {
-    trigger: 'a.nav-link[name="billing_employee_rate"]',
+    trigger: 'button.nav-link[name="billing_employee_rate"]',
     content: 'Click on Invoicing tab to configure the invoicing of this project.',
     run: "click",
 }, {
@@ -264,7 +264,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     trigger: "div.o_notebook_headers",
 },
 {
-    trigger: 'a.nav-link[name="settings"]',
+    trigger: 'button.nav-link[name="settings"]',
     content: 'Click on Settings tab to configure this project.',
     run: "click",
 }, {

--- a/addons/stock/static/tests/tours/stock_report_tests.js
+++ b/addons/stock/static/tests/tours/stock_report_tests.js
@@ -10,7 +10,7 @@ registry.category("web_tour.tours").add("test_stock_route_diagram_report", {
         run: "click",
     },
     {
-        trigger: '.nav-item > a:contains("Inventory")',
+        trigger: '.nav-item > button:contains("Inventory")',
         run: "click",
     },
     {

--- a/addons/survey/static/tests/tours/survey_form.js
+++ b/addons/survey/static/tests/tours/survey_form.js
@@ -278,12 +278,12 @@ function changeTab(tabName) {
     return [
         {
             content: `Go to ${tabName} tab`,
-            trigger: `.modal .modal-content a[name=${tabName}].nav-link`,
+            trigger: `.modal .modal-content button[name=${tabName}].nav-link`,
             run: "click",
         },
         {
             content: `Wait for tab ${tabName} tab`,
-            trigger: `.modal .modal-content a[name=${tabName}].nav-link.active`,
+            trigger: `.modal .modal-content button[name=${tabName}].nav-link.active`,
         },
     ];
 }

--- a/addons/web/static/src/core/notebook/notebook.xml
+++ b/addons/web/static/src/core/notebook/notebook.xml
@@ -6,10 +6,10 @@
             <div class="o_notebook_headers" t-att-class="{ 'm-0': props.orientation === 'vertical' }">
                 <ul t-attf-class="nav nav-tabs {{ props.orientation === 'horizontal' ? 'flex-row flex-nowrap' : 'flex-column p-0' }}">
                     <li t-foreach="navItems" t-as="navItem" t-key="navItem[0]" class="nav-item flex-nowrap" t-if="navItem[1].isVisible" t-attf-class="{{ navItem[1].isDisabled ? 'disabled' : '' }}">
-                        <a class="nav-link" t-att-class="{'active position-relative cursor-default z-1': navItem[0] === state.currentPage, 'p-3 rounded-0': props.orientation === 'vertical', 'o_page_invalid': invalidPages.has(navItem[0])}" t-attf-class="{{ navItem[1].className || '' }}" t-att-name="navItem[1].name" t-on-click.prevent="() => this.activatePage(navItem[0])" href="#" role="tab" tabindex="0">
+                        <button class="nav-link" t-att-class="{'active position-relative cursor-default z-1': navItem[0] === state.currentPage, 'p-3 rounded-0': props.orientation === 'vertical', 'o_page_invalid': invalidPages.has(navItem[0])}" t-attf-class="{{ navItem[1].className || '' }}" t-att-name="navItem[1].name" t-on-click="() => this.activatePage(navItem[0])" role="tab" tabindex="0">
                             <i t-if="props.icons and props.icons[navItem[0]]" t-attf-class="fa {{ props.icons[navItem[0]] }} me-2" />
                             <t t-esc="navItem[1].title" />
-                        </a>
+                        </button>
                     </li>
                 </ul>
             </div>

--- a/addons/web/static/tests/core/notebook.test.js
+++ b/addons/web/static/tests/core/notebook.test.js
@@ -39,19 +39,19 @@ test("notebook with multiple pages given as slots", async () => {
     expect(".nav").toHaveClass("flex-row", {
         message: "navigation container uses the right class to display as horizontal tabs",
     });
-    expect(".o_notebook_headers a.nav-link").toHaveCount(2, {
+    expect(".o_notebook_headers button.nav-link").toHaveCount(2, {
         message: "navigation link is present for each visible page",
     });
-    expect(".o_notebook_headers .nav-item:first-child a").toHaveClass("active", {
+    expect(".o_notebook_headers .nav-item:first-child .nav-link").toHaveClass("active", {
         message: "first page is selected by default",
     });
     expect(".active h3").toHaveText("About the bird", {
         message: "first page content is displayed by the notebook",
     });
 
-    await click(".o_notebook_headers .nav-item:nth-child(2) a");
+    await click(".o_notebook_headers .nav-item:nth-child(2) .nav-link");
     await animationFrame();
-    expect(".o_notebook_headers .nav-item:nth-child(2) a").toHaveClass("active", {
+    expect(".o_notebook_headers .nav-item:nth-child(2) .nav-link").toHaveClass("active", {
         message: "second page is now selected",
     });
     expect(".active h3").toHaveText("Their favorite activity: hunting", {
@@ -81,7 +81,7 @@ test("notebook with defaultPage props", async () => {
 
     await mountWithCleanup(Parent);
     expect("div.o_notebook").toHaveCount(1);
-    expect(".o_notebook_headers .nav-item:nth-child(2) a").toHaveClass("active", {
+    expect(".o_notebook_headers .nav-item:nth-child(2) .nav-link").toHaveClass("active", {
         message: "second page is selected by default",
     });
     expect(".active h3").toHaveText("Their favorite activity: hunting", {
@@ -111,7 +111,7 @@ test("notebook with defaultPage set on invisible page", async () => {
     }
 
     await mountWithCleanup(Parent);
-    expect(".o_notebook_headers .nav-item a.active").toHaveText("About", {
+    expect(".o_notebook_headers .nav-item .nav-link.active").toHaveText("About", {
         message: "The first page is selected",
     });
 });
@@ -194,11 +194,11 @@ test("notebook pages rendered by a template component", async () => {
 
     await mountWithCleanup(Parent);
     expect("div.o_notebook").toHaveCount(1);
-    expect(".o_notebook_headers .nav-item:nth-child(3) a").toHaveClass("active", {
+    expect(".o_notebook_headers .nav-item:nth-child(3) .nav-link").toHaveClass("active", {
         message: "third page is selected by default",
     });
 
-    await click(".o_notebook_headers .nav-item:nth-child(2) a");
+    await click(".o_notebook_headers .nav-item:nth-child(2) .nav-link");
     await animationFrame();
     expect(".o_notebook_content p").toHaveText("Second page rendered by a template component", {
         message: "displayed content corresponds to the current page",
@@ -235,7 +235,7 @@ test("each page is different", async () => {
     const firstPage = queryFirst("h3");
     expect(firstPage).toBeInstanceOf(HTMLElement);
 
-    await click(".o_notebook_headers .nav-item:nth-child(2) a");
+    await click(".o_notebook_headers .nav-item:nth-child(2) .nav-link");
     await animationFrame();
     const secondPage = queryFirst("h3");
     expect(secondPage).toBeInstanceOf(HTMLElement);
@@ -274,7 +274,7 @@ test("defaultPage recomputed when isVisible is dynamic", async () => {
     expect(".page3").toHaveCount(1);
     expect(".nav-link.active").toHaveText("page3");
 
-    await click(".o_notebook_headers .nav-item:nth-child(2) a");
+    await click(".o_notebook_headers .nav-item:nth-child(2) .nav-link");
     await animationFrame();
     expect(".page2").toHaveCount(1);
     expect(".nav-link.active").toHaveText("page2");

--- a/addons/web/static/tests/tours/test_user_group_settings_tour.js
+++ b/addons/web/static/tests/tours/test_user_group_settings_tour.js
@@ -56,7 +56,7 @@ registry.category("web_tour.tours").add("test_user_group_settings", {
             run: "edit Bar Manager",
         },
         {
-            trigger: 'a[name="inherit_groups"]',
+            trigger: 'button[name="inherit_groups"]',
             content: "get implied groups",
             run: "click",
         },

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -1429,8 +1429,8 @@ test(`invisible elements are properly hidden`, async () => {
         resId: 1,
     });
     expect(`.o_form_statusbar button:contains(coucou)`).toHaveCount(0);
-    expect(`.o_notebook li a:contains(visible)`).toHaveCount(1);
-    expect(`.o_notebook li a:contains(invisible)`).toHaveCount(0);
+    expect(`.o_notebook li button:contains(visible)`).toHaveCount(1);
+    expect(`.o_notebook li button:contains(invisible)`).toHaveCount(0);
     expect(`div.o_inner_group:contains(visgroup)`).toHaveCount(1);
     expect(`div.o_inner_group:contains(invgroup)`).toHaveCount(0);
 });

--- a/addons/web_unsplash/static/tests/unsplash.test.js
+++ b/addons/web_unsplash/static/tests/unsplash.test.js
@@ -112,6 +112,6 @@ test("Document tab does not crash with FileSelector extension", async () => {
     await animationFrame();
     await press("enter");
     await animationFrame();
-    await click("li:nth-child(2) > a.nav-link");
+    await click("li:nth-child(2) > button.nav-link");
     expect(".o_existing_attachment_cell").toHaveCount(1);
 });

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -191,7 +191,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on the 'Icons' tab",
-            trigger: '.o_select_media_dialog .o_notebook_headers .nav-item a:contains("Icons")',
+            trigger: '.o_select_media_dialog .o_notebook_headers .nav-item button:contains("Icons")',
             run: "click",
         },
         {
@@ -248,7 +248,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on the 'Icons' tab",
-            trigger: ".o_select_media_dialog a.nav-link:contains('Icons')",
+            trigger: ".o_select_media_dialog button.nav-link:contains('Icons')",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -36,7 +36,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on video button",
-            trigger: "a:contains('Videos')",
+            trigger: "button:contains('Videos')",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -44,7 +44,7 @@ const replaceIconByImage = function (url) {
         },
         {
             content: "Go to the Images tab in the media dialog",
-            trigger: ".o_select_media_dialog .o_notebook_headers .nav-item a:contains('Images')",
+            trigger: ".o_select_media_dialog .o_notebook_headers .nav-item button:contains('Images')",
             run: "click",
         },
         {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -1095,7 +1095,7 @@ stepUtils.autoExpandMoreButtons(true),
     trigger: '.o_form_view div.o_notebook_headers',
 },
 {
-    trigger: 'a.nav-link:contains(Timesheets)',
+    trigger: 'button.nav-link:contains(Timesheets)',
     content: 'Click on Timesheets page to log a timesheet',
     run: "click",
 }, {

--- a/odoo/addons/test_web/static/tests/tours/x2many.js
+++ b/odoo/addons/test_web/static/tests/tours/x2many.js
@@ -50,7 +50,7 @@
         trigger: '.o_field_widget[name=moderator] input:value(user_test)',
     }, {
         content: "go to Participants tab to check onchange",
-        trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Participants)',
         run: "click",
     }, {
         content: "check the onchange from the o2m to the m2m",
@@ -78,7 +78,7 @@
     ...stepUtils.saveForm(),
     { // add message a
         content: "Select First Tab",
-        trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Messages)',
         run: "click",
     }, {
         content: "create new message a",
@@ -154,7 +154,7 @@
     },
     { // add participants
         content: "change tab to Participants",
-        trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Participants)',
         run: "click",
     }, {
         content: "click to add participants",
@@ -178,7 +178,7 @@
         run: "click",
     }, {
         content: "go back to tab 1",
-        trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Messages)',
         run: "click",
     },
     {
@@ -192,7 +192,7 @@
         trigger: `.o_content:has(.o_field_widget[name=messages] tr:has(td:text(bbb)):has(td:text([test_trigger] Mitchell Admin)))`,
     }, {
         content: "go to tab 3",
-        trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Participants)',
         run: "click",
     },
     {
@@ -207,7 +207,7 @@
     },
     {
         content: "change tab to Messages",
-        trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Messages)',
         run: "click",
     },
     {
@@ -316,7 +316,7 @@
         trigger: `.o_content:has(.o_field_widget[name=messages] tbody tr:has(td:text([test_trigger] Mitchell Admin)):has(td:text(aaa)))`,
     }, {
         content: "go to Participants",
-        trigger: '.o_notebook_headers .nav-item a:contains(Participants)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Participants)',
         run: "click",
     },
     {
@@ -327,7 +327,7 @@
         trigger: '.o_content:has(.o_field_widget[name=participants] tbody .o_data_row:eq(2))',
     }, {
         content: "go to Messages",
-        trigger: '.o_notebook_headers .nav-item a:contains(Messages)',
+        trigger: '.o_notebook_headers .nav-item button:contains(Messages)',
         run: "click",
     },
     {


### PR DESCRIPTION
This commit properly uses `<button>` element for interactive DOM elements instead of relying on a "hacky" and non-semantic `<a href="#">` (tl;dr: `<a>` HTML tag are for navigation, `<button>` are for interactivity).

task-4380519

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
