### PR TITLE
[REF] web,*: no more a[href="#"] in autocomplete

### DIFF
--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -54,7 +54,7 @@ registry.category("web_tour.tours").add('account_tour', {
     },
     {
         isActive: ["auto"],
-        trigger: `body${accountTourSteps.draftInvoiceSelector} .o_m2o_dropdown_option a:contains('Create')`,
+        trigger: `body${accountTourSteps.draftInvoiceSelector} .o_m2o_dropdown_option button:contains('Create')`,
         content: _t("Select first partner"),
         run: "click",
     },
@@ -83,7 +83,7 @@ registry.category("web_tour.tours").add('account_tour', {
     },
     {
         isActive: ["auto"],
-        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id] .o_m2o_dropdown_option_create a:contains(create)`,
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id] .o_m2o_dropdown_option_create button:contains(create)`,
         content: _t("Create the product."),
         run: "click",
     },

--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -32,7 +32,7 @@ registry.category("web_tour.tours").add('account_tax_group', {
     },
     {
         content: "Valid vendor",
-        trigger: '.ui-menu-item a:contains("Account Tax Group Partner")',
+        trigger: '.ui-menu-item button:contains("Account Tax Group Partner")',
         run: "click",
     },
     // Show product column

--- a/addons/analytic/static/tests/analytic_widget.test.js
+++ b/addons/analytic/static/tests/analytic_widget.test.js
@@ -98,7 +98,7 @@ test("Analytic dynamic multi-edit", async () => {
     await contains(".analytic_distribution_popup tbody tr:first .o_field_many2one").click();
     await contains(".analytic_distribution_popup tbody tr:first .o_field_many2one input").edit("Brussels", {confirm: false});
     await runAllTimers();
-    await contains(".analytic_distribution_popup tbody tr:first .o_field_many2one .o_input_dropdown a").click();
+    await contains(".analytic_distribution_popup tbody tr:first .o_field_many2one .o_input_dropdown button").click();
     await contains(".o_list_renderer").click();  // close the widget
     // we don't change the value until it's saved
     expect(".o_list_table tbody tr:nth-child(1) .o_field_analytic_distribution .o_tag_badge_text").toHaveText("Los Angeles");

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -34,7 +34,7 @@ registry.category("web_tour.tours").add('crm_tour', {
     run: "edit Brandon Freeman",
 }, {
     isActive: ["auto"],
-    trigger: ".ui-menu-item > a:contains('Brandon Freeman')",
+    trigger: ".ui-menu-item > button:contains('Brandon Freeman')",
     run: "click",
 }, {
     trigger: ".o_kanban_quick_create .o_field_widget[name='name'] input:value('Brandon Freeman')",

--- a/addons/event_sale/static/tests/tours/event_configurator_ui.js
+++ b/addons/event_sale/static/tests/tours/event_configurator_ui.js
@@ -14,7 +14,7 @@ registry.category("web_tour.tours").add("event_configurator_tour", {
             run: "click",
         },
         {
-            trigger: "ul.ui-autocomplete a:text(Design Fair Los Angeles)",
+            trigger: "ul.ui-autocomplete button:text(Design Fair Los Angeles)",
             run: "click",
         },
         {
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add("event_configurator_tour", {
             run: "click",
         },
         {
-            trigger: "ul.ui-autocomplete a:contains(VIP)",
+            trigger: "ul.ui-autocomplete button:contains(VIP)",
             run: "click",
         },
         {
@@ -41,7 +41,7 @@ registry.category("web_tour.tours").add("event_configurator_tour", {
             run: "click",
         },
         {
-            trigger: "ul.ui-autocomplete a:contains(Standard)",
+            trigger: "ul.ui-autocomplete button:contains(Standard)",
             run: "click",
         },
         {

--- a/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
+++ b/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
@@ -114,7 +114,7 @@ test("correctly fill all standard fields", async () => {
     expect.verifySteps(["/autocomplete/address"]);
 
     await contains(
-        ".o_field_widget[name='street'] .o-autocomplete--dropdown-item a:contains(Bourlottes)"
+        ".o_field_widget[name='street'] .o-autocomplete--dropdown-item button:contains(Bourlottes)"
     ).click();
     expect.verifySteps(["/autocomplete/address_full"]);
     const expectedFields = {
@@ -155,7 +155,7 @@ test("fills current field with values of unknown ones", async () => {
     });
     await runAllTimers();
     await contains(
-        ".o_field_widget[name='some_char'] .o-autocomplete--dropdown-item a:contains(Bourlottes)"
+        ".o_field_widget[name='some_char'] .o-autocomplete--dropdown-item button:contains(Bourlottes)"
     ).click();
 
     const expectedFields = {
@@ -203,7 +203,7 @@ test("support field mapping in options", async () => {
     });
     await runAllTimers();
     await contains(
-        ".o_field_widget[name='some_char'] .o-autocomplete--dropdown-item a:contains(Bourlottes)"
+        ".o_field_widget[name='some_char'] .o-autocomplete--dropdown-item button:contains(Bourlottes)"
     ).click();
 
     const expectedFields = {

--- a/addons/hr_attendance/static/src/scss/kiosk/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/scss/kiosk/hr_attendance.scss
@@ -168,7 +168,7 @@
         }
     }
 
-    .o-autocomplete--dropdown-item a[aria-selected="true"]{
+    .o-autocomplete--dropdown-item button[aria-selected="true"]{
         background-color: #f0f0f0 !important;
     }
 

--- a/addons/hr_expense/static/tests/tours/expense_form_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_tours.js
@@ -27,7 +27,7 @@ registry.category("web_tour.tours").add('create_expense_no_employee_access_tour'
     },
     {
         content: "Select test expense employee",
-        trigger: 'a.dropdown-item:contains(expense_employee)',
+        trigger: 'button.dropdown-item:contains(expense_employee)',
         run: 'click',
     },
     {

--- a/addons/hr_expense/static/tests/tours/expense_upload_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_upload_tours.js
@@ -36,7 +36,7 @@
         },
         {
             isActive: ["auto"],
-            trigger: ".ui-autocomplete > li > a:contains('[COMM] Communication')",
+            trigger: ".ui-autocomplete > li > button:contains('[COMM] Communication')",
             run: "click",
         },
         {

--- a/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_holidays_tour.js
@@ -29,7 +29,7 @@ registry.category("web_tour.tours").add("hr_holidays_tour", {
             run: "click",
         },
         {
-            trigger: ".ui-autocomplete .ui-menu-item a:contains('Sick Time Off')",
+            trigger: ".ui-autocomplete .ui-menu-item button:contains('Sick Time Off')",
             tooltipPosition: "right",
             run: "click",
         },

--- a/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
+++ b/addons/hr_holidays/static/src/tours/hr_leave_type_tour.js
@@ -56,7 +56,7 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: `.ui-autocomplete .ui-menu-item a:contains("${leaveType1}")`,
+            trigger: `.ui-autocomplete .ui-menu-item button:contains("${leaveType1}")`,
             run: "click",
         },
         {
@@ -81,7 +81,7 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: `.ui-autocomplete .ui-menu-item a:contains("${leaveType3}")`,
+            trigger: `.ui-autocomplete .ui-menu-item button:contains("${leaveType3}")`,
             run: "click",
         },
         {
@@ -155,7 +155,7 @@ registry.category("web_tour.tours").add("hr_leave_type_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: `.ui-autocomplete .ui-menu-item a:contains("${leaveType2}")`,
+            trigger: `.ui-autocomplete .ui-menu-item button:contains("${leaveType2}")`,
             run: "click",
         },
         {

--- a/addons/hr_holidays/static/tests/tours/time_off_allocation_warning_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_allocation_warning_tour.js
@@ -37,7 +37,7 @@ registry.category("web_tour.tours").add("time_off_allocation_warning_tour", {
             run: "click",
         },
         {
-            trigger: ".o-autocomplete--dropdown-menu > li > a[id=holiday_status_id_0_0_0]",
+            trigger: ".o-autocomplete--dropdown-menu > li > button[id=holiday_status_id_0_0_0]",
             run: "click",
         },
         {

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -180,7 +180,7 @@ test("Manage expertises from channel info list", async () => {
     await openDiscuss(channelId);
     await contains(".o-livechat-ChannelInfoList .o_tag", { text: "pricing" });
     await insertText(".o-livechat-ExpertiseTagsAutocomplete input", "events");
-    await click("a", { text: 'Create "events"' });
+    await click("button", { text: 'Create "events"' });
     await contains(".o-livechat-ChannelInfoList .o_tag", { text: "events" });
     await click(".o-livechat-ExpertiseTagsAutocomplete input");
     await press("Backspace");
@@ -188,7 +188,7 @@ test("Manage expertises from channel info list", async () => {
     await press("Backspace");
     await contains(".o-livechat-ChannelInfoList .o_tag", { text: "pricing", count: 0 });
     await contains(".o-livechat-ExpertiseTagsAutocomplete input[placeholder='Add expertise']");
-    await click("a", { text: "events" });
+    await click("button", { text: "events" });
     await contains(".o-livechat-ChannelInfoList .o_tag", { text: "events" });
 });
 

--- a/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
@@ -168,7 +168,7 @@ registry.category("web_tour.tours").add("mail_template_dynamic_field_tour", {
         },
         {
             content: 'Select "Push Notification Device" model',
-            trigger: 'a.dropdown-item:contains("Push Notification Device")',
+            trigger: 'button.dropdown-item:contains("Push Notification Device")',
             run: "click",
         },
         {

--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -48,7 +48,7 @@ registry.category('web_tour.tours').add('mailing_campaign', {
         },
         {
             content: 'Pick "Newsletter" option',
-            trigger: '.o_input_dropdown a:contains(Newsletter)',
+            trigger: '.o_input_dropdown button:contains(Newsletter)',
             run: "click",
         },
         ...stepUtils.saveForm(),

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -29,7 +29,7 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         },
         {
             content: "Pick 'Newsletter' option",
-            trigger: '.o_input_dropdown a:contains(Newsletter)',
+            trigger: '.o_input_dropdown button:contains(Newsletter)',
             run: "click",
         },
         {
@@ -68,7 +68,7 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         },
         {
             content: "Pick 'Newsletter' option",
-            trigger: '.o_input_dropdown a:contains(Newsletter)',
+            trigger: '.o_input_dropdown button:contains(Newsletter)',
             run: "click",
         },
         {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -499,7 +499,7 @@ export function enterLotNumber(number, tracking = "serial", click = false) {
     steps.push(
         {
             trigger:
-                ".o-autocomplete--dropdown-item a:contains('No existing Lot/Serial number found...')",
+                ".o-autocomplete--dropdown-item button:contains('No existing Lot/Serial number found...')",
         },
         {
             content: "enter lot number",
@@ -507,7 +507,8 @@ export function enterLotNumber(number, tracking = "serial", click = false) {
             run: "edit " + number,
         },
         {
-            trigger: ".o-autocomplete--dropdown-item a:contains('Create Lot/Serial number...')",
+            trigger:
+                ".o-autocomplete--dropdown-item button:contains('Create Lot/Serial number...')",
         },
         {
             trigger: ".o-autocomplete input",
@@ -568,7 +569,8 @@ export function enterLotNumbers(numbers) {
                 run: "edit " + lot,
             },
             {
-                trigger: ".o-autocomplete--dropdown-item a:contains('Create Lot/Serial number...')",
+                trigger:
+                    ".o-autocomplete--dropdown-item button:contains('Create Lot/Serial number...')",
             },
             {
                 trigger: ".o-autocomplete input",

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -168,7 +168,7 @@ registry.category("web_tour.tours").add('project_tour', {
 },
 {
     isActive: ["desktop", "auto"],
-    trigger: "a.dropdown-item[id*='user_ids'] span",
+    trigger: "button.dropdown-item[id*='user_ids'] span",
     content: _t("Select an assignee from the menu"),
     run: "click",
 },

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -19,7 +19,7 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
     content: 'Select the user portal as collaborator to the "Project Sharing" project.',
     run: "edit Georges",
 }, {
-    trigger: '.ui-autocomplete a.dropdown-item:contains("Georges")',
+    trigger: '.ui-autocomplete button.dropdown-item:contains("Georges")',
     run: "click",
 }, {
     trigger: '.modal div[name="collaborator_ids"] div[name="access_mode"] input',

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -131,7 +131,7 @@ registry.category("web_tour.tours").add('project_test_tour', {
         content: 'Assign the task to you',
         run: 'click',
     }, {
-        trigger: 'ul.ui-autocomplete a .o_avatar_many2x_autocomplete',
+        trigger: 'ul.ui-autocomplete button .o_avatar_many2x_autocomplete',
         content: 'Assign the task to you',
         run: "click",
     }, {

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -125,7 +125,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
 },
 {
     isActive: ["auto"],
-    trigger: ".ui-autocomplete > li > a:not(:has(i.fa))",
+    trigger: ".ui-autocomplete > li > button:not(:has(i.fa))",
     run: "click",
 }, {
     trigger: '.o_field_widget[name="name"] textarea',
@@ -156,7 +156,7 @@ registry.category("web_tour.tours").add('project_todo_main_functions', {
     content: 'Create a new project that will be set to the task',
     run: "edit Project test 1",
 }, {
-    trigger: '.o_todo_conversion_form_view .o_field_many2one[name=project_id] li.o_m2o_dropdown_option_create a',
+    trigger: '.o_todo_conversion_form_view .o_field_many2one[name=project_id] li.o_m2o_dropdown_option_create button',
     content: 'Create the new project',
     run: "click",
 }, {

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -49,7 +49,7 @@ registry.category("web_tour.tours").add("purchase_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: ".ui-menu-item > a:contains('Azure Interior')",
+            trigger: ".ui-menu-item > button:contains('Azure Interior')",
             run: "click",
         },
         {
@@ -75,7 +75,7 @@ registry.category("web_tour.tours").add("purchase_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: "a:contains('DESK0001')",
+            trigger: "button:contains('DESK0001')",
             run: "click",
         },
         {

--- a/addons/purchase/static/tests/tours/tour_helper.js
+++ b/addons/purchase/static/tests/tours/tour_helper.js
@@ -79,7 +79,7 @@ export const purchaseForm = {
             {
                 content: "Select vendor from many to one",
                 isActive: ["auto"],
-                trigger: `.ui-menu-item > a:contains(${vendorName})`,
+                trigger: `.ui-menu-item > button:contains(${vendorName})`,
                 run: "click",
             },
         ];
@@ -99,7 +99,7 @@ export const purchaseForm = {
             {
                 content: "Select BaseWarehouse as PO WH",
                 isActive: ["auto"],
-                trigger: `.ui-menu-item > a:contains(${warehouseName})`,
+                trigger: `.ui-menu-item > button:contains(${warehouseName})`,
                 run: "click",
             },
         ];

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -18,7 +18,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
     run: "edit Agrolait",
 }, {
     isActive: ["auto"],
-    trigger: '.ui-menu-item > a:contains("Agrolait")',
+    trigger: '.ui-menu-item > button:contains("Agrolait")',
     run: "click",
 }, {
     trigger: "button:contains('Add a product')",
@@ -27,7 +27,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
     trigger: 'div[name="product_template_id"] input',
     run: "edit Matrix",
 }, {
-    trigger: 'ul.ui-autocomplete a:contains("Matrix")',
+    trigger: 'ul.ui-autocomplete button:contains("Matrix")',
     run: "click",
 }, {
     trigger: '.modal .o_matrix_input_table',
@@ -91,7 +91,7 @@ registry.category("web_tour.tours").add('purchase_matrix_tour', {
     trigger: 'div[name="product_template_id"] input',
     run: "edit Matrix",
 }, {
-    trigger: 'ul.ui-autocomplete a:contains("Matrix")',
+    trigger: 'ul.ui-autocomplete button:contains("Matrix")',
     run: "click",
 }, {
     trigger: 'input[value="4"]',

--- a/addons/repair/static/tests/tours/repair_order.js
+++ b/addons/repair/static/tests/tours/repair_order.js
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add('test_repair_without_product_in_parts', 
     // this could be done by modifying any other field.
     {
         content: "Select partner",
-        trigger: ".ui-menu-item > a:contains('A Partner')",
+        trigger: ".ui-menu-item > button:contains('A Partner')",
         run: "click",
     },
     {
@@ -32,7 +32,7 @@ registry.category("web_tour.tours").add('test_repair_without_product_in_parts', 
     },
     {
         content: "Select a product",
-        trigger:".ui-menu-item > a:contains('[1234] A Product')",
+        trigger:".ui-menu-item > button:contains('[1234] A Product')",
         run: "click",
     },
     {

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -41,7 +41,7 @@ registry.category("web_tour.tours").add("sale_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: ".ui-menu-item > a:contains('Agrolait')",
+            trigger: ".ui-menu-item > button:contains('Agrolait')",
             run: "click",
         },
         {
@@ -64,7 +64,7 @@ registry.category("web_tour.tours").add("sale_tour", {
         },
         {
             isActive: ["auto"],
-            trigger: "a:contains('DESK0001')",
+            trigger: "button:contains('DESK0001')",
             run: "click",
         },
         {

--- a/addons/sale/static/src/js/tours/tour_utils.js
+++ b/addons/sale/static/src/js/tours/tour_utils.js
@@ -18,7 +18,7 @@ export function selectCustomer(customerName) {
             run: `edit ${customerName}`,
         },
         {
-            trigger: `ul.ui-autocomplete > li > a:contains("${customerName}")`,
+            trigger: `ul.ui-autocomplete > li > button:contains("${customerName}")`,
             run: 'click',
         },
     ];
@@ -32,7 +32,7 @@ export function selectPricelist(pricelistName) {
             run: `edit ${pricelistName}`,
         },
         {
-            trigger: `ul.ui-autocomplete > li > a:contains("${pricelistName}")`,
+            trigger: `ul.ui-autocomplete > li > button:contains("${pricelistName}")`,
             run: 'click',
         },
     ];
@@ -54,7 +54,7 @@ export function addProduct(productName, rowNumber=1) {
             run: `edit ${productName}`,
         },
         {
-            trigger: `ul.ui-autocomplete a:contains("${productName}")`,
+            trigger: `ul.ui-autocomplete button:contains("${productName}")`,
             run: 'click',
         },
     ];

--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         run: "click",
     }, {
         isActive: ["auto"],
-        trigger: ".ui-autocomplete > li > a:not(:has(i.fa))",
+        trigger: ".ui-autocomplete > li > button:not(:has(i.fa))",
         content: "Select the customer in the autocomplete dropdown",
         run: "click",
     },
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         content: 'Add the Sales Order Item',
         run: "fill New Sale order line",
     }, {
-        trigger: ".o_field_widget[name=sale_line_id] .o-autocomplete--dropdown-menu .o_m2o_dropdown_option_create a",
+        trigger: ".o_field_widget[name=sale_line_id] .o-autocomplete--dropdown-menu .o_m2o_dropdown_option_create button",
         content: "Create an Sales Order Item in the autocomplete dropdown.",
         run: "click",
     },

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -97,7 +97,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: markup('Select the customer of your Sales Order <i>(e.g. Brandon Freeman)</i>. Since we have a Sales Order for this customer with a prepaid service product which the remaining hours to deliver is greater than 0, the Sales Order Item in the task should be contain the Sales Order Item containing this prepaid service product.'),
     run: "edit Brandon Freeman",
 }, {
-    trigger: 'div[name="partner_id"] ul > li:first-child > a:contains(Freeman)',
+    trigger: 'div[name="partner_id"] ul > li:first-child > button:contains(Freeman)',
     content: 'Select the customer in the autocomplete dropdown.',
     run: "click",
 },
@@ -197,7 +197,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: markup('Add the customer for this project to select an SO and SOL for this customer <i>(e.g. Brandon Freeman)</i>.'),
     run: "edit Brandon Freeman",
 }, {
-    trigger: 'div[name="partner_id"] ul > li:first-child > a:contains(Freeman)',
+    trigger: 'div[name="partner_id"] ul > li:first-child > button:contains(Freeman)',
     content: 'Select the customer in the autocomplete dropdown',
     run: "click",
 }, {
@@ -205,7 +205,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Select a Sales Order Item as Default Sales Order Item for each task in this project.',
     run: "edit S",
 }, {
-    trigger: '[name="sale_line_id"] ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
+    trigger: '[name="sale_line_id"] ul.ui-autocomplete > li:first-child > button:not(:has(i.fa))',
     content: 'Select the Sales Order Item in the autocomplete dropdown.',
     run: "click",
 },
@@ -225,7 +225,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Select an employee to link a Sales Order Item on his timesheets into this project.',
     run: 'click',
 }, {
-    trigger: '[name="employee_id"] ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
+    trigger: '[name="employee_id"] ul.ui-autocomplete > li:first-child > button:not(:has(i.fa))',
     content: 'Select the first employee in the autocomplete dropdown',
     run: "click",
 }, {
@@ -234,7 +234,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     tooltipPosition: 'bottom',
     run: "edit S",
 }, {
-    trigger: '[name=sale_line_id] ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
+    trigger: '[name=sale_line_id] ul.ui-autocomplete > li:first-child > button:not(:has(i.fa))',
     content: 'Select the first Sales Order Item in the autocomplete dropdown.',
     run: "click",
 }, {
@@ -256,7 +256,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: markup('Add the customer for this project to select an SO and SOL for this customer <i>(e.g. Brandon Freeman)</i>.'),
     run: "edit Brandon Freeman",
 }, {
-    trigger: 'div[name="partner_id"] ul > li:first-child > a:contains(Freeman)',
+    trigger: 'div[name="partner_id"] ul > li:first-child > button:contains(Freeman)',
     content: 'Select the customer in the autocomplete dropdown',
     run: "click",
 },
@@ -272,7 +272,7 @@ registry.category("web_tour.tours").add('sale_timesheet_tour', {
     content: 'Select the first sale order of the list',
     run: "edit Prepaid",
 }, {
-    trigger: 'ul.ui-autocomplete > li:first-child > a:not(:has(i.fa))',
+    trigger: 'ul.ui-autocomplete > li:first-child > button:not(:has(i.fa))',
     content: 'Select the first item on the autocomplete dropdown',
     run: "click",
 }, {

--- a/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
@@ -270,7 +270,7 @@ test("selection filter", async function () {
     });
     await mountFilterValueComponent({ model, filter: model.getters.getGlobalFilter("42") });
     await contains("input").click();
-    await contains("a:first").click();
+    await contains("button:first").click();
     expect(model.getters.getGlobalFilterValue("42")).toEqual({
         operator: "in",
         selectionValues: ["after"],

--- a/addons/spreadsheet/static/tests/global_filters/selection_filter_value.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/selection_filter_value.test.js
@@ -34,11 +34,11 @@ test("basic selection filter value", async function () {
     });
     expect.verifySteps([]);
     await contains("input").click();
-    const options = getFixture().querySelectorAll(".o-autocomplete a");
+    const options = getFixture().querySelectorAll(".o-autocomplete button");
     expect(options.length).toBe(2);
     expect(options[0].textContent).toBe("A");
     expect(options[1].textContent).toBe("B");
-    await contains("a:first").click();
+    await contains("button:first").click();
     expect.verifySteps(["onValueChanged"]);
 });
 
@@ -51,7 +51,7 @@ test("Autocomplete only provide values that are not selected", async function ()
         onValueChanged: () => {},
     });
     await contains("input").click();
-    const options = getFixture().querySelectorAll(".o-autocomplete a");
+    const options = getFixture().querySelectorAll(".o-autocomplete button");
     expect(options.length).toBe(1);
     expect(options[0].textContent).toBe("B");
 });

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -10,7 +10,7 @@ registry.category("web_tour.tours").add('test_generate_serial_1', {  steps: () =
         run: "edit Serial",
     },
     {
-        trigger: ".ui-menu-item > a:contains('Product Serial')",
+        trigger: ".ui-menu-item > button:contains('Product Serial')",
         run: "click",
     },
     {
@@ -105,7 +105,7 @@ registry.category("web_tour.tours").add('test_generate_serial_2', {  steps: () =
         run: "edit Lot",
     },
     {
-        trigger: ".ui-menu-item > a:contains('Product Lot 1')",
+        trigger: ".ui-menu-item > button:contains('Product Lot 1')",
         run: "click",
     },
     {
@@ -246,7 +246,7 @@ registry.category('web_tour.tours').add('test_inventory_adjustment_apply_all', {
         run: "edit Product 1",
     },
     {
-        trigger: '.ui-menu-item > a:contains("Product 1")',
+        trigger: '.ui-menu-item > button:contains("Product 1")',
         run: "click",
     },
     {
@@ -267,7 +267,7 @@ registry.category('web_tour.tours').add('test_inventory_adjustment_apply_all', {
         run: "edit Product 2",
     },
     {
-        trigger: '.ui-menu-item > a:contains("Product 2")',
+        trigger: '.ui-menu-item > button:contains("Product 2")',
         run: "click",
     },
     {

--- a/addons/survey/static/tests/tours/survey_form.js
+++ b/addons/survey/static/tests/tours/survey_form.js
@@ -41,7 +41,7 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         run: "click",
     }, {
         content: "Set the first question's first answer as trigger",
-        trigger: ".modal ul.ui-autocomplete a:contains(Question 1 : Answer A)",
+        trigger: ".modal ul.ui-autocomplete button:contains(Question 1 : Answer A)",
         run: 'click',
     },
     ...changeTab("answers"),
@@ -59,7 +59,7 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         run: "click",
     }, {
         content: "Set the second question's second answer as trigger",
-        trigger: ".modal ul.ui-autocomplete a:contains(Question 2 : Answer B)",
+        trigger: ".modal ul.ui-autocomplete button:contains(Question 2 : Answer B)",
         run: 'click',
     },
     {
@@ -104,7 +104,7 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         run: "click",
     }, {
         content: "Set the first question's second answer as trigger, then",
-        trigger: 'ul.ui-autocomplete a:contains("Question 1 : Answer B")',
+        trigger: 'ul.ui-autocomplete button:contains("Question 1 : Answer B")',
         run: 'click',
     },
     {
@@ -140,7 +140,7 @@ registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers',
         run: "click",
     }, {
         content: "Add the second question's second answer as trigger, then",
-        trigger: '.modal-content ul.ui-autocomplete a:contains("Question 2 : Answer B")',
+        trigger: '.modal-content ul.ui-autocomplete button:contains("Question 2 : Answer B")',
         run: "click",
     },
     {

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -30,7 +30,7 @@ registry.category("web_tour.tours").add("test_base_automation", {
         },
         {
             content: "Select model contact",
-            trigger: ".dropdown-menu li a:contains(Contact):not(:has(.fa-spin))",
+            trigger: ".dropdown-menu li button:contains(Contact):not(:has(.fa-spin))",
             run: "click",
         },
         {
@@ -105,7 +105,7 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
         },
         {
             trigger:
-                ".dropdown-menu li a:contains(test_base_automation.project):not(:has(.fa-spin))",
+                ".dropdown-menu li button:contains(test_base_automation.project):not(:has(.fa-spin))",
             run: "click",
         },
         {
@@ -148,7 +148,7 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
             run: "edit test",
         },
         {
-            trigger: ".dropdown-menu li a:contains(test):not(:has(.fa-spin))",
+            trigger: ".dropdown-menu li button:contains(test):not(:has(.fa-spin))",
             run: "click",
         },
         {
@@ -223,7 +223,7 @@ registry.category("web_tour.tours").add("test_base_automation_on_tag_added", {
             run: "edit High",
         },
         {
-            trigger: ".dropdown-menu li a:contains(High):not(:has(.fa-spin))",
+            trigger: ".dropdown-menu li button:contains(High):not(:has(.fa-spin))",
             run: "click",
         },
         {
@@ -443,7 +443,7 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
             run: "edit base.automation.line.test",
         },
         {
-            trigger: ".dropdown-menu li a:contains(Automated Rule Line Test)",
+            trigger: ".dropdown-menu li button:contains(Automated Rule Line Test)",
             run: "click",
         },
         {
@@ -472,7 +472,7 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
             run: "edit test_base_automation.project",
         },
         {
-            trigger: ".dropdown-menu li a:contains(test_base_automation.project)",
+            trigger: ".dropdown-menu li button:contains(test_base_automation.project)",
             run: "click",
         },
         {
@@ -514,7 +514,7 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
             run: "edit test_base_automation.project",
         },
         {
-            trigger: ".dropdown-menu li a:contains(test_base_automation.project)",
+            trigger: ".dropdown-menu li button:contains(test_base_automation.project)",
             run: "click",
         },
         {
@@ -535,7 +535,7 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
         },
         {
             trigger:
-                ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(a .fa-spin)",
+                ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(button .fa-spin)",
             run() {
                 assertEqual(this.anchor.innerText, "test stage\nSearch more...");
             },
@@ -559,7 +559,7 @@ registry.category("web_tour.tours").add("test_form_view_custom_reference_field",
         },
         {
             trigger:
-                ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(a .fa-spin)",
+                ".o_field_widget[name='trg_field_ref'] .o-autocomplete--dropdown-menu:not(:has(button .fa-spin)",
             run() {
                 assertEqual(this.anchor.innerText, "test tag\nSearch more...");
             },
@@ -582,7 +582,7 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
             run: "edit base.automation.lead.test",
         },
         {
-            trigger: ".dropdown-menu li a:contains(Automated Rule Test)",
+            trigger: ".dropdown-menu li button:contains(Automated Rule Test)",
             run: "click",
         },
         {
@@ -605,7 +605,7 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
             run: "edit base.automation.lead.thread.test",
         },
         {
-            trigger: ".dropdown-menu li a:contains(Threaded Lead Test)",
+            trigger: ".dropdown-menu li button:contains(Threaded Lead Test)",
             run: "click",
         },
         {
@@ -649,7 +649,7 @@ registry.category("web_tour.tours").add("base_automation.on_change_rule_creation
             run: "edit ir.ui.view",
         },
         {
-            trigger: ".ui-menu-item > a:text(View)",
+            trigger: ".ui-menu-item > button:text(View)",
             run: "click",
         },
         {
@@ -666,7 +666,7 @@ registry.category("web_tour.tours").add("base_automation.on_change_rule_creation
             run: "edit Active",
         },
         {
-            trigger: ".ui-menu-item > a:text(Active)",
+            trigger: ".ui-menu-item > button:text(Active)",
             run: "click",
         },
         ...stepUtils.saveForm(),

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -25,7 +25,7 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
             run: "edit Test",
         },
         {
-            trigger: '.modal ul.ui-autocomplete a:contains("TestEvent")',
+            trigger: '.modal ul.ui-autocomplete button:contains("TestEvent")',
             run: "click",
         },
         {
@@ -33,7 +33,7 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
             run: "click",
         },
         {
-            trigger: '.modal ul.ui-autocomplete a:contains("Kid + meal")',
+            trigger: '.modal ul.ui-autocomplete button:contains("Kid + meal")',
             run: "click",
         },
         {
@@ -68,7 +68,7 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
             run: "edit Test",
         },
         {
-            trigger: '.modal ul.ui-autocomplete a:contains("TestEvent")',
+            trigger: '.modal ul.ui-autocomplete button:contains("TestEvent")',
             run: "click",
         },
         {
@@ -76,7 +76,7 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
             run: "click",
         },
         {
-            trigger: '.modal ul.ui-autocomplete a:contains("Adult")',
+            trigger: '.modal ul.ui-autocomplete button:contains("Adult")',
             run: "click",
         },
         {
@@ -106,7 +106,7 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
             run: "edit Test",
         },
         {
-            trigger: '.modal ul.ui-autocomplete a:contains("TestEvent")',
+            trigger: '.modal ul.ui-autocomplete button:contains("TestEvent")',
             run: "click",
         },
         {
@@ -114,7 +114,7 @@ registry.category("web_tour.tours").add("event_sale_with_product_configurator_to
             run: "click",
         },
         {
-            trigger: '.modal ul.ui-autocomplete a:contains("VIP")',
+            trigger: '.modal ul.ui-autocomplete button:contains("VIP")',
             run: "click",
         },
         {

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -39,7 +39,7 @@ registry.category("web_tour.tours").add("configurator_flow", {
         },
         {
             content: "select a website industry from the autocomplete",
-            trigger: ".o_configurator_industry ul li a",
+            trigger: ".o_configurator_industry ul li button",
             run: "click",
         },
         {

--- a/addons/web/static/src/core/autocomplete/autocomplete.scss
+++ b/addons/web/static/src/core/autocomplete/autocomplete.scss
@@ -18,7 +18,7 @@
             --dropdown-link-hover-bg: var(--dropdown-bg);
         }
 
-        > a.ui-state-active {
+        > button.ui-state-active {
             margin: 0;
             border: none;
             font-weight: $font-weight-normal;
@@ -27,11 +27,13 @@
         }
 
         &.o_m2o_dropdown_option, &.o_m2o_start_typing, &.o_m2o_no_result {
-            text-indent: $o-dropdown-hpadding * .5;
+            > .dropdown-item {
+                text-indent: $o-dropdown-hpadding * .5;
+            }
         }
 
         &.o_m2o_dropdown_option, &.o_calendar_dropdown_option {
-            > a {
+            > button {
                 color: $link-color;
                 &.ui-state-active:not(.o_m2o_start_typing) {
                     color: $link-hover-color;
@@ -41,12 +43,12 @@
 
         &.o_m2o_start_typing, &.o_m2o_no_result {
             font-style: italic;
-            a.ui-menu-item-wrapper, a.ui-state-active, a.ui-state-active:hover {
+            button.ui-menu-item-wrapper, button.ui-state-active, button.ui-state-active:hover {
                 background: none;
             }
         }
 
-        &.o_m2o_start_typing > a.ui-state-active {
+        &.o_m2o_start_typing > button.ui-state-active {
             color: $dropdown-link-color;
         }
     }

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -36,15 +36,14 @@
                                     'o-autocomplete--dropdown-item': props.dropdown,
                                     'd-block': !props.dropdown
                                 }">
-                                <a
+                                <button
                                     t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_loading"
                                     role="option"
-                                    href="#"
                                     class="o_loading dropdown-item ui-menu-item-wrapper"
                                     aria-selected="true"
                                 >
                                     <i class="fa fa-spin fa-circle-o-notch" /> <t t-esc="source.placeholder" />
-                                </a>
+                                </button>
                             </li>
                         </t>
                         <t t-else="">
@@ -57,11 +56,10 @@
                                     t-on-click="() => this.onOptionClick(option)"
                                     t-on-pointerdown="(ev) => this.onOptionPointerDown(option, ev)"
                                 >
-                                    <t t-tag="option.unselectable ? 'span' : 'a'"
+                                    <t t-tag="option.unselectable ? 'span' : 'button'"
                                         class="dropdown-item ui-menu-item-wrapper text-truncate"
                                         t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_{{option_index}}"
                                         t-att-role="!option.unselectable and 'option'"
-                                        t-att-href="!option.unselectable and '#'"
                                         t-att-class="{ 'ui-state-active': isActiveSourceOption([source_index, option_index]) }"
                                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                                     >

--- a/addons/web/static/src/core/model_selector/model_selector.scss
+++ b/addons/web/static/src/core/model_selector/model_selector.scss
@@ -2,7 +2,7 @@
     .o-autocomplete--dropdown-menu {
         width: 25ch;
         max-height: 350px !important;
-        .o-autocomplete--dropdown-item a {
+        .o-autocomplete--dropdown-item button {
             text-overflow: ellipsis;
             width: inherit;
         }

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -2022,7 +2022,7 @@ export class ListRenderer extends Component {
         const focusableEls = getTabableElements(cell).filter(
             (el) =>
                 el === document.activeElement ||
-                ["INPUT", "BUTTON", "TEXTAREA"].includes(el.tagName)
+                (["INPUT", "BUTTON", "TEXTAREA"].includes(el.tagName) && !el.classList.contains("dropdown-item"))
         );
         const index = focusableEls.indexOf(document.activeElement);
         return (

--- a/addons/web/static/tests/core/autocomplete.test.js
+++ b/addons/web/static/tests/core/autocomplete.test.js
@@ -736,7 +736,7 @@ test("autocomplete scrolls when moving with arrows", async () => {
     expect(".o-autocomplete--dropdown-item").toHaveCount(5);
     expect(isScrollable(dropdownSelector)).toBe(true, { message: "dropdown should be scrollable" });
     // First element focused and visible (dropdown is not scrolled yet).
-    expect(".o-autocomplete--dropdown-item:first-child a").toHaveClass("ui-state-active");
+    expect(".o-autocomplete--dropdown-item:first-child button").toHaveClass("ui-state-active");
     expect(isInViewWithinScrollableY(activeItemSelector)).toBe(true, { message: msgInView });
     // Navigate with the arrow keys. Go to the last item.
     expect(isInViewWithinScrollableY(".o-autocomplete--dropdown-item:contains('Up')")).toBe(false, {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -1645,7 +1645,7 @@ test("many2one field on record with falsy display_name", async () => {
 
     await contains(".o-autocomplete--input").click();
 
-    expect("a.dropdown-item:first").toHaveText("Unnamed", {
+    expect("button.dropdown-item:first").toHaveText("Unnamed", {
         message: "should have a Unnamed as fallback of many2one display_name",
     });
 });

--- a/addons/web/static/tests/core/record_selectors/record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/record_selector.test.js
@@ -180,7 +180,7 @@ test("Support virtual record in props and custom quickCreate", async () => {
     await contains(".o-autocomplete--input").edit("I do not exist yet", { confirm: false });
     await runAllTimers();
 
-    await contains(".o_m2o_dropdown_option a:contains(Create I do not exist yet)").click();
+    await contains(".o_m2o_dropdown_option button:contains(Create I do not exist yet)").click();
     await waitFor(".o-autocomplete--input:value(I do not exist yet)");
     expect(virtualRecord).toEqual({
         id: false,

--- a/addons/web/static/tests/model/record.test.js
+++ b/addons/web/static/tests/model/record.test.js
@@ -359,7 +359,7 @@ test(`handles many2one fields: value is an object`, async () => {
     await runAllTimers();
     expect.verifySteps(["/web/dataset/call_kw/bar/web_name_search"]);
 
-    await contains(`.o-autocomplete--dropdown-item a:eq(0)`).click();
+    await contains(`.o-autocomplete--dropdown-item button:eq(0)`).click();
     expect.verifySteps(["record changed"]);
     expect(`.o_field_many2one_selection input`).toHaveValue("abc");
 });
@@ -419,7 +419,7 @@ test(`handles many2one fields: value is a pair id, display_name`, async () => {
     await runAllTimers();
     expect.verifySteps(["/web/dataset/call_kw/bar/web_name_search"]);
 
-    await contains(`.o-autocomplete--dropdown-item a:eq(0)`).click();
+    await contains(`.o-autocomplete--dropdown-item button:eq(0)`).click();
     expect.verifySteps(["record changed"]);
     expect(`.o_field_many2one_selection input`).toHaveValue("abc");
 });

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -2050,8 +2050,8 @@ test("highlight search in many2many", async () => {
     });
     await contains(".o_field_widget[name=p] input").edit("rec", { confirm: false });
     await runAllTimers();
-    expect(`.o-autocomplete.dropdown li a > span`).toHaveCount(2);
-    expect(`.o-autocomplete.dropdown li:eq(0) a > span`).toHaveInnerHTML(`
+    expect(`.o-autocomplete.dropdown li button > span`).toHaveCount(2);
+    expect(`.o-autocomplete.dropdown li:eq(0) button > span`).toHaveInnerHTML(`
     <span>
         first
         <span class="text-primary fw-bold">
@@ -2059,7 +2059,7 @@ test("highlight search in many2many", async () => {
         </span>
         ord
     </span>`);
-    expect(`.o-autocomplete.dropdown li:eq(1) a > span`).toHaveInnerHTML(`
+    expect(`.o-autocomplete.dropdown li:eq(1) button > span`).toHaveInnerHTML(`
     <span>
         second
         <span class="text-primary fw-bold">

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -258,9 +258,9 @@ test("Many2ManyTagsField with color: rendering and edition on desktop", async ()
     expect(`.dropdown-item .fw-bold`).toHaveCount(2);
     expect(queryAllTexts`.dropdown-item .fw-bold`).toEqual(["gold", "silver"]);
     expect(".o-autocomplete--dropdown-menu li").toHaveCount(4);
-    expect(".o-autocomplete--dropdown-menu li a:eq(2)").toHaveText("red");
+    expect(".o-autocomplete--dropdown-menu li button:eq(2)").toHaveText("red");
 
-    await contains(".o-autocomplete--dropdown-menu li a:eq(2)").click();
+    await contains(".o-autocomplete--dropdown-menu li button:eq(2)").click();
     expect(".o_field_many2many_tags .badge").toHaveCount(3);
     expect(".o_field_many2many_tags .badge .o_tag_badge_text:eq(2)").toHaveText("red");
     expect(".badge:eq(2)").toHaveClass("o_tag_color_8");
@@ -423,7 +423,7 @@ test("Many2ManyTagsField view a domain on desktop", async () => {
 
     expect(".o-autocomplete--dropdown-menu li").toHaveCount(3);
 
-    expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("gold");
+    expect(".o-autocomplete--dropdown-menu li button:eq(0)").toHaveText("gold");
 
     await clickFieldDropdownItem("timmy", "silver");
 
@@ -502,7 +502,7 @@ test("use binary field as the domain on desktop", async () => {
         "silver",
         "Search more...",
     ]);
-    expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("gold");
+    expect(".o-autocomplete--dropdown-menu li button:eq(0)").toHaveText("gold");
 
     await clickFieldDropdownItem("timmy", "silver");
 
@@ -564,13 +564,13 @@ test("Domain: allow python code domain in fieldInfo on desktop", async () => {
     // foo set => only silver (id=5) selectable
     await clickFieldDropdown("timmy");
     expect(".o-autocomplete--dropdown-menu li").toHaveCount(2);
-    expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("silver");
+    expect(".o-autocomplete--dropdown-menu li button:eq(0)").toHaveText("silver");
 
     // set foo = "" => only gold (id=2) selectable
     await contains("[name=foo] input").clear();
     await clickFieldDropdown("timmy");
     expect(".o-autocomplete--dropdown-menu li").toHaveCount(2);
-    expect(".o-autocomplete--dropdown-menu li a:eq(0)").toHaveText("gold");
+    expect(".o-autocomplete--dropdown-menu li button:eq(0)").toHaveText("gold");
 });
 
 test.tags("desktop");
@@ -1303,7 +1303,7 @@ test("Many2ManyTagsField: conditional create/delete attrs on desktop", async () 
     // only Search more option should be available
     expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
     expect(
-        ".o-autocomplete.dropdown li.o_m2o_dropdown_option a:contains(Search more...)"
+        ".o-autocomplete.dropdown li.o_m2o_dropdown_option button:contains(Search more...)"
     ).toHaveCount(1);
 
     await clickFieldDropdownItem("partner_ids", "Search more...");
@@ -1318,7 +1318,7 @@ test("Many2ManyTagsField: conditional create/delete attrs on desktop", async () 
 
     // only Search more option should be available
     expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option").toHaveCount(1);
-    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option a:contains(Search more)").toHaveCount(
+    expect(".o-autocomplete.dropdown li.o_m2o_dropdown_option button:contains(Search more)").toHaveCount(
         1
     );
 });
@@ -1846,19 +1846,19 @@ test("Many2ManyTagsField selected records still pickable and not duplicable on d
     // Check that records are correctly displayed in the dropdown
     await contains("div[name='turtles']").click();
     await contains("input[id=turtles_0]").click();
-    expect(`${"a.dropdown-item"}:eq(0)`).toHaveText("leonardo");
+    expect(`${"button.dropdown-item"}:eq(0)`).toHaveText("leonardo");
 
     // Check that selecting a record adds the corresponding tag
-    await contains(`${"a.dropdown-item"}:eq(0)`).click();
+    await contains(`${"button.dropdown-item"}:eq(0)`).click();
     expect(".o_tag").toHaveCount(1);
     expect(".o_tag:eq(0)").toHaveText("leonardo");
 
     // Check that a selected record is still shown in the dropdown
     await contains("input[id=turtles_0]").click();
-    expect(`${"a.dropdown-item"}:eq(0)`).toHaveText("leonardo");
+    expect(`${"button.dropdown-item"}:eq(0)`).toHaveText("leonardo");
 
     // Check that selecting an already selected record doesn't duplicate it
-    await contains(`${"a.dropdown-item"}:eq(0)`).click();
+    await contains(`${"button.dropdown-item"}:eq(0)`).click();
     expect(".o_tag").toHaveCount(1);
 
     // Check that deleting a record which was selected twice doens't leave one occurence

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -2945,12 +2945,12 @@ test("propagate can_create onto the search popup", async () => {
 
     await contains(".o_field_widget[name=product_id] input").click();
 
-    expect(".o-autocomplete a:contains(Start typing...)").toHaveCount(0);
+    expect(".o-autocomplete button:contains(Start typing...)").toHaveCount(0);
 
     await contains(".o_field_widget[name=product_id] input").edit("a", { confirm: false });
     await runAllTimers();
 
-    expect(".ui-autocomplete a:contains(Create and Edit)").toHaveCount(0);
+    expect(".ui-autocomplete button:contains(Create and Edit)").toHaveCount(0);
 
     await contains(".o_field_many2one[name=product_id] input").edit("", { confirm: false });
     await runAllTimers();
@@ -3990,7 +3990,7 @@ test("many2one search with false as name", async () => {
     });
 
     await contains(".o_field_many2one input").click();
-    expect(".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)").toHaveText(
+    expect(".o_field_many2one[name='trululu'] .dropdown-menu button.dropdown-item:eq(0)").toHaveText(
         "Unnamed"
     );
 });
@@ -4015,12 +4015,12 @@ test("many2one search with formatted name", async () => {
 
     await contains(".o_field_many2one input").click();
     expect(
-        ".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)"
+        ".o_field_many2one[name='trululu'] .dropdown-menu button.dropdown-item:eq(0)"
     ).toHaveInnerHTML(
         `Research & Development Test: <b>Paul</b> <span class="text-muted">Eric</span> <span class="o_tag position-relative d-inline-flex align-items-center align-baseline mw-100 o_badge badge rounded-pill lh-1 o_tag_color_0">good guy</span><br/><span style="margin-left: 2em"></span>More text`
     );
     await contains(
-        ".o_field_many2one[name='trululu'] .dropdown-menu a.dropdown-item:eq(0)"
+        ".o_field_many2one[name='trululu'] .dropdown-menu button.dropdown-item:eq(0)"
     ).click();
     expect(".o_field_many2one input").toHaveValue("Paul Eric");
 });
@@ -4082,15 +4082,15 @@ test("highlight search in many2one", async () => {
     });
     await contains(".o_field_widget[name=trululu] input").edit("rec", { confirm: false });
     await runAllTimers();
-    expect(`.o-autocomplete.dropdown li:not(.o_m2o_dropdown_option) a`).toHaveCount(2);
-    expect(`.o-autocomplete.dropdown li:eq(0) a`).toHaveInnerHTML(`
+    expect(`.o-autocomplete.dropdown li:not(.o_m2o_dropdown_option) button`).toHaveCount(2);
+    expect(`.o-autocomplete.dropdown li:eq(0) button`).toHaveInnerHTML(`
         first
         <span class="text-primary fw-bold">
             rec
         </span>
         ord
     `);
-    expect(`.o-autocomplete.dropdown li:eq(1) a`).toHaveInnerHTML(`
+    expect(`.o-autocomplete.dropdown li:eq(1) button`).toHaveInnerHTML(`
         second
         <span class="text-primary fw-bold">
             rec

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -13167,7 +13167,7 @@ test("add record in nested x2many with context depending on parent", async () =>
 
     await contains(".o_data_cell").click();
     await contains("div[name=turtles] .o-autocomplete.dropdown input").click();
-    await contains(".o-autocomplete--dropdown-menu li a").click();
+    await contains(".o-autocomplete--dropdown-menu li button").click();
 });
 
 test("one2many with default_order on id, but id not in view", async () => {

--- a/addons/web_tour/static/src/js/tour_recorder/tour_recorder.js
+++ b/addons/web_tour/static/src/js/tour_recorder/tour_recorder.js
@@ -241,7 +241,7 @@ export class TourRecorder extends Component {
                 root: this.state.editedElement.parentElement,
             });
             this.state.steps.push({
-                trigger: `.o-autocomplete--dropdown-item > a:contains('${selectedRow.textContent}'), .fa-circle-o-notch`,
+                trigger: `.o-autocomplete--dropdown-item > button:contains('${selectedRow.textContent}'), .fa-circle-o-notch`,
                 run: "click",
             });
             this.state.editedElement = undefined;

--- a/addons/web_tour/static/tests/tour_recorder.test.js
+++ b/addons/web_tour/static/tests/tour_recorder.test.js
@@ -389,7 +389,7 @@ test("Selecting item in autocomplete field through Enter", async () => {
     await press("Enter");
     checkTourSteps([
         ".o-autocomplete--input",
-        ".o-autocomplete--dropdown-item > a:contains('World'), .fa-circle-o-notch",
+        ".o-autocomplete--dropdown-item > button:contains('World'), .fa-circle-o-notch",
     ]);
     expect(tourRecorder.state.steps.map((s) => s.run)).toEqual(["click", "click"]);
 });

--- a/addons/website/static/src/client_actions/configurator/configurator.scss
+++ b/addons/website/static/src/client_actions/configurator/configurator.scss
@@ -172,7 +172,7 @@
                 }
             }
 
-            .dropdown-item, .fa-angle-down, .ui-menu-item a, .ui-menu-item a.ui-state-active {
+            .dropdown-item, .fa-angle-down, .ui-menu-item button, .ui-menu-item button.ui-state-active {
                 font-size: .5em;
                 font-weight: inherit;
             }
@@ -202,7 +202,7 @@
                 }
             }
 
-            .dropdown-item, .custom-ui-autocomplete .ui-menu-item a {
+            .dropdown-item, .custom-ui-autocomplete .ui-menu-item button {
                 &:hover, &:active, &.ui-state-active {
                     background-color: $dropdown-link-hover-bg;
                     color: $dropdown-link-color;

--- a/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
@@ -111,7 +111,7 @@ test("selects and commits value from dropdown", async () => {
 
     await contains(".we-bg-options-container input").edit("/");
     await contains(".we-bg-options-container input").click();
-    await contains(document.querySelector(".o_website_ui_autocomplete > li:first-child a")).click();
+    await contains(document.querySelector(".o_website_ui_autocomplete > li:first-child button")).click();
     expect(document.querySelector(".o_website_ui_autocomplete")).toBe(null);
     expect(".we-bg-options-container input").toHaveValue("/page1");
     expect(":iframe .test-options-target").toHaveAttribute("data-url", "/page1");
@@ -133,7 +133,7 @@ test("collects anchors in current page and suggests them", async () => {
     await contains(".we-bg-options-container input").click();
 
     // Check autocomplete suggests both anchors
-    const els = document.querySelectorAll(".o_website_ui_autocomplete > li a");
+    const els = document.querySelectorAll(".o_website_ui_autocomplete > li button");
     expect(els).toHaveLength(4); // Our anchors, #top and #bottom
     expect(els[1].innerText).toBe("#anchor1");
     expect(els[2].innerText).toBe("#anchor2");

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -37,7 +37,7 @@ function runConfiguratorFlow(industrySearchText, featureOrPageName) {
         },
         {
             content: "Select a website industry from the autocomplete",
-            trigger: `.o_configurator_industry_wrapper ul li a:contains(${industrySearchText})`,
+            trigger: `.o_configurator_industry_wrapper ul li button:contains(${industrySearchText})`,
             run: "click",
         },
         {

--- a/addons/website_sale/static/tests/tours/shop_mail.js
+++ b/addons/website_sale/static/tests/tours/shop_mail.js
@@ -42,7 +42,7 @@ registry.category("web_tour.tours").add('website_sale.so_mail', {
         },
         {
             content: "Select azure interior",
-            trigger: ".modal .ui-menu-item a:contains(Interior24)",
+            trigger: ".modal .ui-menu-item button:contains(Interior24)",
             run: "click",
         },
         {

--- a/addons/website_sale/static/tests/tours/website_sale_product_publish.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_publish.js
@@ -56,7 +56,7 @@ registerWebsitePreviewTour(
             run: 'edit Test',
         },
         {
-            trigger: '.ui-autocomplete a:contains("Test Category")',
+            trigger: '.ui-autocomplete button:contains("Test Category")',
             run: 'click',
         },
         {

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -29,7 +29,7 @@ registerWebsitePreviewTour('course_publisher', {
     run: "edit Gard",
 }, {
     content: 'eLearning: select gardener tag',
-    trigger: ".modal .ui-autocomplete a:contains(Gardener)",
+    trigger: ".modal .ui-autocomplete button:contains(Gardener)",
     run: "click",
 }, {
     content: 'eLearning: set description',

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -143,7 +143,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.component1",
 }, {
     isActive: ["auto", "desktop"],
-    trigger: ".ui-menu-item > a:contains('the_flow.component1')",
+    trigger: ".ui-menu-item > button:contains('the_flow.component1')",
     run: "click",
 }, {
     isActive: ["mobile"],
@@ -206,7 +206,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.vendor",
 }, {
     isActive: ["desktop"],
-    trigger: ".ui-menu-item > a:contains('the_flow.vendor')",
+    trigger: ".ui-menu-item > button:contains('the_flow.vendor')",
     run: "click",
 }, {
     isActive: ["mobile"],
@@ -367,7 +367,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.component2",
 }, {
     isActive: ["auto", "desktop"],
-    trigger: ".ui-menu-item > a:contains('the_flow.component2')",
+    trigger: ".ui-menu-item > button:contains('the_flow.component2')",
     run: "click",
 }, {
 // Edit second component
@@ -420,7 +420,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.vendor",
 }, {
     isActive: ["auto", "desktop"],
-    trigger: ".ui-menu-item > a:contains('the_flow.vendor')",
+    trigger: ".ui-menu-item > button:contains('the_flow.vendor')",
     run: "click",
 },
 {
@@ -599,7 +599,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.project",
 }, {
     isActive: ["auto", "desktop"],
-    trigger: ".o-autocomplete--dropdown-item > a:contains('the_flow.project')",
+    trigger: ".o-autocomplete--dropdown-item > button:contains('the_flow.project')",
     run: "click",
 },
 {
@@ -665,7 +665,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.customer",
 }, {
     isActive: ["auto", "desktop"],
-    trigger: ".ui-menu-item > a:contains('the_flow.customer')",
+    trigger: ".ui-menu-item > button:contains('the_flow.customer')",
     run: "click",
 },
 {
@@ -748,7 +748,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.product",
 }, {
     isActive: ["desktop"],
-    trigger: ".ui-menu-item > a:contains('the_flow.product')",
+    trigger: ".ui-menu-item > button:contains('the_flow.product')",
     run: "click",
 },
 {
@@ -809,7 +809,7 @@ stepUtils.autoExpandMoreButtons(),
     run: "edit the_flow.service",
 }, {
     isActive: ["desktop"],
-    trigger: ".ui-menu-item > a:contains('the_flow.service')",
+    trigger: ".ui-menu-item > button:contains('the_flow.service')",
     run: "click",
 }, {
     isActive: ["desktop"],
@@ -1235,7 +1235,7 @@ stepUtils.autoExpandMoreButtons(true),
     run: "edit the_flow.customer",
 }, {
     isActive: ["auto", "desktop", "enterprise"],
-    trigger: ".ui-menu-item > a:contains('the_flow.customer')",
+    trigger: ".ui-menu-item > button:contains('the_flow.customer')",
     run: "click",
 },
 {

--- a/odoo/addons/test_web/static/tests/tours/x2many.js
+++ b/odoo/addons/test_web/static/tests/tours/x2many.js
@@ -30,7 +30,7 @@
         run: "edit test",
     }, {
         content: "click on 'Create and Edit...'",
-        trigger: '.o_field_widget[name=moderator] .o-autocomplete--dropdown-menu .o_m2o_dropdown_option_create_edit a',
+        trigger: '.o_field_widget[name=moderator] .o-autocomplete--dropdown-menu .o_m2o_dropdown_option_create_edit button',
         run: "click",
     },
     {
@@ -453,7 +453,7 @@
         run: "edit Test",
     }, {
         content: "add a tag",
-        trigger: '.o_field_widget[name="categories"] .o-autocomplete--dropdown-menu li a:first',
+        trigger: '.o_field_widget[name="categories"] .o-autocomplete--dropdown-menu li button:first',
         run: "click",
     }, { // remove record
         content: "delete the last item in the editable list",


### PR DESCRIPTION
This commit properly uses `<button>` element for interactive DOM elements instead of relying on a "hacky" and non-semantic `<a href="#">` (tl;dr: `<a>` HTML tag are for navigation, `<button>` are for interactivity).

task-4380519

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
