### PR TITLE
[FIX] point_of_sale: close session with SEPA first payment method

### DIFF
--- a/addons/point_of_sale/models/account_payment.py
+++ b/addons/point_of_sale/models/account_payment.py
@@ -36,4 +36,7 @@ class AccountPayment(models.Model):
             sepa_ct = self.env.ref('account_sepa.account_payment_method_sepa_ct', raise_if_not_found=False)
             if sepa_ct and 'pos_payment' in self.env.context and sepa_ct.code not in res:
                 res.append(sepa_ct.code)
+            sepa_sdd = self.env.ref('account_sepa_direct_debit.payment_method_sdd', raise_if_not_found=False)
+            if sepa_sdd and 'pos_payment' in self.env.context and sepa_sdd.code not in res:
+                res.append(sepa_sdd.code)
         return res


### PR DESCRIPTION
SEPA expects a partner and a bank account. But the POS allows the user to sell to generic customers without a partner id or bank account. When SEPA direct debit is selected as the first incoming/outgoint payment method for the journal, closing the POS session will try to pos a SEPA payment which will fail when no partner is selected for the payment.

We've identified this before and excluded SEPA credit transfer from point of sales for issues with closing sessions, but the issue is still happening with SEPA direct debit. This fix will exclude the SEPA DD from the list of payment methods the POS is trying to use to post the transactions.

Task-[5358590](https://www.odoo.com/odoo/project/1737/tasks/5358590)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
