### PR TITLE
[IMP] orm: deprecate Cache view of fields

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -924,10 +924,11 @@ class AccountAccount(models.Model):
         super().copy_translations(new, excluded=tuple(excluded)+('name',))
         if new.name == self.env._('%s (copy)', self.name):
             name_field = self._fields['name']
-            self.env.cache.update_raw(new, name_field, [{
+            assert name_field.translate
+            name_field._update_cache(new.with_context(prefetch_langs=True), {
                 lang: self.env._('%s (copy)', tr)
                 for lang, tr in name_field._get_stored_translations(self).items()
-            }], dirty=True)
+            }, dirty=True)
 
     @api.model
     def _load_precommit_update_opening_move(self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -904,7 +904,7 @@ class AccountMove(models.Model):
         journal = None
         # the currency is not a hard dependence, it triggers via manual add_to_compute
         # avoid computing the currency before all it's dependences are set (like the journal...)
-        if self.env.cache.contains(self, self._fields['currency_id']):
+        if self.id in self._fields['currency_id']._get_cache(self.env):
             currency_id = self.currency_id.id or self.env.context.get('default_currency_id')
             if currency_id and currency_id != company.currency_id.id:
                 currency_domain = domain + [('currency_id', '=', currency_id)]

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -112,10 +112,10 @@ class AccountChartTemplate(models.AbstractModel):
         """
         # This function is called many times. Avoid doing a search every time by using the ORM's cache.
         # We assume that the field is always computed for all the modules at once (by this function)
-        field = self.env['ir.module.module']._fields['account_templates']
+        modules = self.env['ir.module.module'].sudo()
         modules = (
-            self.env.cache.get_records(self.env['ir.module.module'], field)
-            or self.env['ir.module.module'].sudo().search([('state', '!=', 'uninstallable')])
+            modules.browse(modules._fields['account_templates']._get_cache(self.env))
+            or modules.search([('state', '!=', 'uninstallable')])
         )
 
         return {

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -783,7 +783,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
     def _get_cache_count(self, model_name='account.move', field_name='name'):
         model = self.env[model_name]
         field = model._fields[field_name]
-        return len(self.env.cache.get_records(model, field))
+        return len(field._get_cache(self.env))
 
     def test_cache_invalidation(self):
         self.env.invalidate_all()

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -763,7 +763,7 @@ class CalendarEvent(models.Model):
             replacement = field.convert_to_cache(
                 _('Busy') if field.name == 'name' else False,
                 others_private_events)
-            self.env.cache.update(others_private_events, field, repeat(replacement))
+            field._update_cache(others_private_events, replacement)
 
         return events
 

--- a/addons/html_builder/models/ir_ui_view.py
+++ b/addons/html_builder/models/ir_ui_view.py
@@ -176,7 +176,7 @@ class IrUiView(models.Model):
             lang: field_to.translate(lambda term: translation_dictionary.get(term, {}).get(lang), record_to[name_field_to])
             for lang in langs
         }
-        record_to.env.cache.update_raw(record_to, field_to, [new_value], dirty=True)
+        field_to._update_cache(record_to.with_context(prefetch_langs=True), new_value, dirty=True)
         # Call `write` to trigger compute etc (`modified()`)
         record_to[name_field_to] = new_value[lang_env]
 

--- a/addons/iap/models/iap_account.py
+++ b/addons/iap/models/iap_account.py
@@ -261,7 +261,7 @@ class IapAccount(models.Model):
                 # as self's cursor cannot see this account
                 account_token = account.sudo().account_token
             account = self.browse(account.id)
-            self.env.cache.set(account, IapAccount._fields['account_token'], account_token)
+            account._fields['account_token']._update_cache(account, account_token)
             return account
         accounts_with_company = accounts.filtered(lambda acc: acc.company_ids)
         if accounts_with_company:

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1813,7 +1813,8 @@ class SaleOrder(models.Model):
         if (len(self) == 1
             # The method _track_finalize is sometimes called too early or too late and it
             # might cause a desynchronization with the cache, thus this condition is needed.
-            and self.env.cache.contains(self, self._fields['state']) and self._discard_tracking()):
+            and self.id in self._fields['state']._get_cache(self.env)
+            and self._discard_tracking()):
             self.env.cr.precommit.data.pop(f'mail.tracking.{self._name}', {})
             self.env.flush_all()
             return

--- a/addons/web/tests/test_assets.py
+++ b/addons/web/tests/test_assets.py
@@ -74,7 +74,7 @@ class TestPregenerateTime(HttpCase):
         self.env['ir.qweb']._pregenerate_assets_bundles()
         start = time.time()
         self.env.registry.clear_cache()
-        self.env.cache.invalidate()
+        self.env.transaction.invalidate_field_data()
         with self.profile(collectors=['sql', odoo.tools.profiler.PeriodicCollector(interval=0.01)], disable_gc=True):
             self.env['ir.qweb']._pregenerate_assets_bundles()
         duration = time.time() - start

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -33,20 +33,16 @@ class WebsiteSnippetFilter(models.Model):
         if hide_variants and self.filter_id.model_id == 'product.product':
             # When hiding variants, temporarily update cache to increase `self.limit`
             # so we hopefully end up with the correct amount of product templates
-            update_limit_cache = partial(
-                self.env.cache.set,
-                record=self,
-                field=self._fields['limit'],
-            )
+            update_limit_cache = partial(self._fields['limit']._update_cache, self)
             limit = product_limit ** 2  # heuristic, may still be inadequate in some cases
             stored_limit = self.limit
-            update_limit_cache(value=limit)
+            update_limit_cache(limit)
         res = super(
             WebsiteSnippetFilter,
             self.with_context(hide_variants=hide_variants, product_limit=product_limit),
         )._prepare_values(limit=limit, search_domain=search_domain, **kwargs)
         if update_limit_cache:
-            update_limit_cache(value=stored_limit)
+            update_limit_cache(stored_limit)
         return res
 
     @api.model

--- a/addons/website_sale/tests/test_pricelist.py
+++ b/addons/website_sale/tests/test_pricelist.py
@@ -758,8 +758,8 @@ class TestWebsitePriceListMultiCompany(TransactionCaseWithUserDemo):
         self.assertEqual(self.demo_user.partner_id.with_company(self.company2.id).property_product_pricelist, self.c2_pl)
         # property_product_pricelist has been cached
         field = self.env['res.partner']._fields['property_product_pricelist']
-        cache_rp1 = self.env.cache.get(self.demo_user.partner_id.with_company(self.company1.id), field)
-        cache_rp2 = self.env.cache.get(self.demo_user.partner_id.with_company(self.company2.id), field)
+        cache_rp1 = self.demo_user.partner_id.with_company(self.company1.id)._cache[field.name]
+        cache_rp2 = self.demo_user.partner_id.with_company(self.company2.id)._cache[field.name]
         self.assertEqual((cache_rp1, cache_rp2), (self.c1_pl.id, self.c2_pl.id), "Ensure the pricelist is the company specific one.")
 
     def test_property_product_pricelist_multi_company(self):

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -108,7 +108,7 @@ class BaseCommon(TransactionCase):
         # Enforce constant currency
         currency = cls._enable_currency(currency_code)
         if company.currency_id != currency:
-            cls.env.transaction.cache.set(cls.env.company, type(cls.env.company).currency_id, currency.id, dirty=True)
+            company.__class__.currency_id._update_cache(cls.env.company, currency.id, dirty=True)
             # this is equivalent to cls.env.company.currency_id = currency but without triggering buisness code checks.
             # The value is added in cache, and the cache value is set as dirty so that that
             # the value will be written to the database on next flush.

--- a/odoo/addons/base/tests/test_cache.py
+++ b/odoo/addons/base/tests/test_cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import os
@@ -7,7 +6,6 @@ import psutil
 import unittest
 
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
-from odoo.exceptions import CacheMiss
 from odoo.tests.common import tagged
 
 
@@ -16,22 +14,17 @@ class TestRecordCache(TransactionCaseWithUserDemo):
 
     def test_cache(self):
         """ Check the record cache object. """
+        env = self.env
         Model = self.env['res.partner']
-        name = type(Model).name
-        ref = type(Model).ref
-
-        cache = self.env.cache
+        name = Model._fields['name']
+        ref = Model._fields['ref']
 
         def check1(record, field, value):
             # value is None means no value in cache
-            self.assertEqual(cache.contains(record, field), value is not None)
-            try:
-                self.assertEqual(cache.get(record, field), value)
-                self.assertIsNotNone(value)
-            except CacheMiss:
-                self.assertIsNone(value)
-            self.assertEqual(field in cache.get_fields(record), value is not None)
-            self.assertEqual(record in cache.get_records(record, field), value is not None)
+            field_cache = field._get_cache(record.env)
+            self.assertEqual(record.id in field_cache, value is not None)
+            if value is not None:
+                self.assertEqual(field_cache.get(record.id), value)
 
         def check(record, name_val, ref_val):
             """ check the values of fields 'name' and 'ref' on record. """
@@ -43,64 +36,65 @@ class TestRecordCache(TransactionCaseWithUserDemo):
         self.assertNotEqual(foo1.env.uid, foo2.env.uid)
 
         # cache is empty
-        cache.invalidate()
+        env.invalidate_all()
         check(foo1, None, None)
         check(foo2, None, None)
         check(bar1, None, None)
         check(bar2, None, None)
 
-        self.assertCountEqual(cache.get_missing_ids(foo1 + bar1, name), [1, 2])
-        self.assertCountEqual(cache.get_missing_ids(foo2 + bar2, name), [1, 2])
+        self.assertCountEqual(name._cache_missing_ids(foo1 + bar1), [1, 2])
+        self.assertCountEqual(name._cache_missing_ids(foo2 + bar2), [1, 2])
 
         # set values in one environment only
-        cache.set(foo1, name, 'FOO1_NAME')
-        cache.set(foo1, ref, 'FOO1_REF')
-        cache.set(bar1, name, 'BAR1_NAME')
-        cache.set(bar1, ref, 'BAR1_REF')
+        name._update_cache(foo1, 'FOO1_NAME')
+        ref._update_cache(foo1, 'FOO1_REF')
+        name._update_cache(bar1, 'BAR1_NAME')
+        ref._update_cache(bar1, 'BAR1_REF')
         check(foo1, 'FOO1_NAME', 'FOO1_REF')
         check(foo2, 'FOO1_NAME', 'FOO1_REF')
         check(bar1, 'BAR1_NAME', 'BAR1_REF')
         check(bar2, 'BAR1_NAME', 'BAR1_REF')
-        self.assertCountEqual(cache.get_missing_ids(foo1 + bar1, name), [])
-        self.assertCountEqual(cache.get_missing_ids(foo2 + bar2, name), [])
+        self.assertCountEqual(name._cache_missing_ids(foo1 + bar1), [])
+        self.assertCountEqual(name._cache_missing_ids(foo2 + bar2), [])
 
         # set values in both environments
-        cache.set(foo2, name, 'FOO2_NAME')
-        cache.set(foo2, ref, 'FOO2_REF')
-        cache.set(bar2, name, 'BAR2_NAME')
-        cache.set(bar2, ref, 'BAR2_REF')
+        name._update_cache(foo2, 'FOO2_NAME')
+        ref._update_cache(foo2, 'FOO2_REF')
+        name._update_cache(bar2, 'BAR2_NAME')
+        ref._update_cache(bar2, 'BAR2_REF')
         check(foo1, 'FOO2_NAME', 'FOO2_REF')
         check(foo2, 'FOO2_NAME', 'FOO2_REF')
         check(bar1, 'BAR2_NAME', 'BAR2_REF')
         check(bar2, 'BAR2_NAME', 'BAR2_REF')
-        self.assertCountEqual(cache.get_missing_ids(foo1 + bar1, name), [])
-        self.assertCountEqual(cache.get_missing_ids(foo2 + bar2, name), [])
+        self.assertCountEqual(name._cache_missing_ids(foo1 + bar1), [])
+        self.assertCountEqual(name._cache_missing_ids(foo2 + bar2), [])
 
         # remove value in one environment
-        cache.remove(foo1, name)
+        del name._get_cache(foo1.env)[foo1.id]
         check(foo1, None, 'FOO2_REF')
         check(foo2, None, 'FOO2_REF')
         check(bar1, 'BAR2_NAME', 'BAR2_REF')
         check(bar2, 'BAR2_NAME', 'BAR2_REF')
-        self.assertCountEqual(cache.get_missing_ids(foo1 + bar1, name), [1])
-        self.assertCountEqual(cache.get_missing_ids(foo2 + bar2, name), [1])
+        self.assertCountEqual(name._cache_missing_ids(foo1 + bar1), [1])
+        self.assertCountEqual(name._cache_missing_ids(foo2 + bar2), [1])
 
         # partial invalidation
-        cache.invalidate([(name, None), (ref, foo1.ids)])
+        name._invalidate_cache(env)
+        ref._invalidate_cache(env, foo1.ids)
         check(foo1, None, None)
         check(foo2, None, None)
         check(bar1, None, 'BAR2_REF')
         check(bar2, None, 'BAR2_REF')
 
         # total invalidation
-        cache.invalidate()
+        env.transaction.invalidate_field_data()
         check(foo1, None, None)
         check(foo2, None, None)
         check(bar1, None, None)
         check(bar2, None, None)
 
     @unittest.skipIf(
-        not(platform.system() == 'Linux' and platform.machine() == 'x86_64'),
+        not (platform.system() == 'Linux' and platform.machine() == 'x86_64'),
         "This test only makes sense on 64-bit Linux-like systems",
     )
     def test_memory(self):
@@ -108,7 +102,6 @@ class TestRecordCache(TransactionCaseWithUserDemo):
         NB_RECORDS = 100000
         MAX_MEMORY = 100
 
-        cache = self.env.cache
         model = self.env['res.partner']
         records = [model.new() for index in range(NB_RECORDS)]
 
@@ -122,7 +115,7 @@ class TestRecordCache(TransactionCaseWithUserDemo):
         for name in char_names:
             field = model._fields[name]
             for record in records:
-                cache.set(record, field, 'test')
+                field._update_cache(record, 'test')
 
         mem_usage = process.memory_info().rss - rss0
         self.assertLess(

--- a/odoo/addons/base/tests/test_res_lang.py
+++ b/odoo/addons/base/tests/test_res_lang.py
@@ -95,7 +95,7 @@ class test_res_lang(TransactionCase):
         )
 
         # test performance
-        self.env.cache.clear()
+        self.env.transaction.clear()
         self.env.registry.clear_cache('stable')
         # 1 query for res_lang +
         # 1 query for ir_attachment to compute `flag_image_url`

--- a/odoo/addons/test_orm/tests/test_json_field.py
+++ b/odoo/addons/test_orm/tests/test_json_field.py
@@ -18,7 +18,7 @@ class JsonFieldTest(TransactionCase):
         self.assertEqual(self.discussion_1.history, {'delete_messages': []})
 
         # Check that it is not the value of the cache return by convert_to_record
-        self.assertIsNot(self.discussion_1.history, self.env.cache.get(self.discussion_1, type(self.discussion_1).history))
+        self.assertIsNot(self.discussion_1.history, self.discussion_1._cache['history'])
 
         self.assertEqual(self.discussion_1.history, {'delete_messages': []})
 

--- a/odoo/addons/test_web/tests/test_properties.py
+++ b/odoo/addons/test_web/tests/test_properties.py
@@ -194,7 +194,7 @@ class PropertiesCase(TestPropertiesMixin):
         self.assertEqual(message.attributes, {'state': 'draft'})
 
         # check cached value
-        cached_value = self.env.cache.get(message, message._fields['attributes'])
+        cached_value = message._cache['attributes']
         self.assertEqual(cached_value, {'state': 'draft'})
 
         # change the definition record, change the definition and add default values

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -563,8 +563,9 @@ class Environment(Mapping[str, "BaseModel"]):
 class Transaction:
     """ A object holding ORM data structures for a transaction. """
     __slots__ = (
-        '_Transaction__file_open_tmp_paths', '_recent_envs', '_weak_envs',
-        'access_read', 'cache', 'default_env',
+        '_Transaction__file_open_tmp_paths',
+        '_cache', '_recent_envs', '_weak_envs',
+        'access_read', 'default_env',
         'field_data', 'field_data_patches', 'field_dirty',
         'protected', 'registry', 'tocompute',
     )
@@ -594,13 +595,19 @@ class Transaction:
         # pending computations {field: ids}
         self.tocompute = defaultdict["Field", OrderedSet["IdType"]](OrderedSet)
         # backward-compatible view of the cache
-        self.cache = Cache(self)
+        self._cache = Cache(self)
 
         # permission cache for record access by user
         # {access_context: {model_name: {record_id: bool}}}
         self.access_read = defaultdict[tuple, defaultdict[str, dict["IdType", bool]]](lambda: defaultdict(dict))
         # temporary directories (managed in odoo.tools.file_open_temporary_directory)
         self.__file_open_tmp_paths = []  # type: ignore # noqa: PLE0237
+
+    @property
+    def cache(self):
+        import warnings  # noqa: PLC0415
+        warnings.warn("Since 20.0 use fields method directly for cache manipulation", DeprecationWarning, stacklevel=2)
+        return self._cache
 
     @property
     def envs(self):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5730,7 +5730,7 @@ class BaseModel(metaclass=MetaModel):
                 raise AssertionError(
                     f"Could not find all values of {record} to flush them\n"
                     f"    Context: {self.env.context}\n"
-                    f"    Cache: {self.env.cache!r}"
+                    f"    Cache: {dict(record._cache)!r}"
                 )
             model.browse(some_ids)._write_multi(vals_list)
 


### PR DESCRIPTION
The class ``Cache`` was an abstraction over the cache data that is located in the transaction. Since we refactored fields so that they manage the cache data on the transaction directly, ``transaction.cache`` is obsolete.

odoo/enterprise#105747

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
