### PR TITLE
[IMP] l10n_in_hr_holidays: add sandwich leave policy options

### DIFF
--- a/addons/l10n_in_hr_holidays/models/hr_work_entry_type.py
+++ b/addons/l10n_in_hr_holidays/models/hr_work_entry_type.py
@@ -10,6 +10,17 @@ class HrWorkEntryType(models.Model):
         help="""If a leave is covering holidays, the holiday period will be included in the requested time.
         The time took in addition will have the same treatment (allocation, pay, reports) as the initial request.
         Holidays includes public holidays, national days, paid holidays and week-ends.""")
+    l10n_in_sandwich_policy = fields.Selection(
+        selection=[
+            ("full", "Full Sandwich Policy"),
+            ("weekend", "Weekend-Only Policy"),
+            ("public_holiday", "Public Holiday-Only Policy"),
+        ],
+        string="Sandwich Leave Policy",
+        default="full",
+        help="""Full Sandwich Policy – Count both weekends and public holidays between two leave days.
+        Weekend-Only Policy – Apply only if weekends fall between leave days.
+        Public Holiday-Only Policy – Apply only if public holidays fall between leave days.""")
     l10n_in_is_limited_to_optional_days = fields.Boolean(
         help="""Enable this option to restrict Flexi Leave to specific days, ensuring that only days marked as
         Optional Holidays can be selected. This helps validate that employees can only choose days from the designated

--- a/addons/l10n_in_hr_holidays/views/hr_work_entry_type_views.xml
+++ b/addons/l10n_in_hr_holidays/views/hr_work_entry_type_views.xml
@@ -9,13 +9,15 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='configuration']//label[@for='support_document']" position="after">
                 <label for="l10n_in_is_sandwich_leave" class="me-4"
-                    string="Sandwich Leaves" invisible="country_code and country_code != 'IN'"/>
+                    string="Sandwich Leave Policies" invisible="country_code and country_code != 'IN'"/>
                 <label for="l10n_in_is_limited_to_optional_days" class="me-4"
                     string="Limited to Optional Holidays" invisible="country_code and country_code != 'IN'"/>
             </xpath>
             <xpath expr="//group[@name='configuration']//field[@name='support_document']" position="after">
-                <field name="l10n_in_is_sandwich_leave" class="mb-2" nolabel="1"
-                    invisible="country_code and country_code != 'IN'"/>
+                <div class="row" invisible="country_code and country_code != 'IN'">
+                    <field name="l10n_in_is_sandwich_leave"/>
+                    <field name="l10n_in_sandwich_policy" class="w-75" invisible="not l10n_in_is_sandwich_leave"/>
+                </div>
                 <field name="l10n_in_is_limited_to_optional_days" class="mb-2" nolabel="1"
                     invisible="country_code and country_code != 'IN'"/>
             </xpath>


### PR DESCRIPTION
Before
Sandwich Leave could only be turned on or off.
When it was on, weekends and public holidays were always counted
between leave days.

After
When Sandwich Leave is turned on, a policy can be selected to decide
which extra days are counted.

Available policies:
- Full Sandwich Policy: count weekends and public holidays (default)
- Weekend-Only Policy: count only weekends
- Public Holiday-Only Policy: count only public holidays

task-5219132
