### PR TITLE
[FIX] web_editor: fix carousel preview height in Firefox

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2946,7 +2946,7 @@ we-select.o_grid we-toggler {
             [data-snippet="s_carousel_intro"],
             [data-snippet="s_quotes_carousel_minimal"],
             [data-snippet="s_quotes_carousel"] {
-                .carousel-inner {
+                .carousel-inner, .carousel-inner > .carousel-item {
                     height: fit-content;
                 }
             }


### PR DESCRIPTION
Steps to reproduce (only with Firefox):

- Open the snippet dialog.
- Issue: The carousel snippets are too tall.

Bug introduced by this commit [1]

[1]: https://github.com/odoo/odoo/commit/78d33cf8b475f891dd95bec1b0c058446538824a

task-5156137