### PR TITLE
[FIX] html_editor, web: ensure color picker appears above link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -210,6 +210,10 @@ export class LinkPopover extends Component {
                     },
                     {
                         env: this.__owl__.childEnv,
+                        // `useOverlayServiceOffset` adds 1000 to each sequence value to solve
+                        // overlay visibility in `iframe`, here we increment default sequence (50)
+                        // by 1 and we add 1000 to have color picker always on top of all overlays.
+                        sequence: 1051,
                     }
                 );
             this.customTextColorPicker = createCustomColorPicker(

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -63,6 +63,7 @@ export const popoverService = {
                     env: options.env,
                     onRemove: options.onClose,
                     rootId: target.getRootNode()?.host?.id,
+                    sequence: options.sequence,
                 }
             );
 


### PR DESCRIPTION
Problem:
In Email Marketing, the color picker for custom links is hidden under the link popover, making it unusable.

Cause:
Overlays added in mass mailing use a default sequence of 1050, while the color picker uses the default sequence (50). As a result, the link popover overlays the color picker.

Solution:
Force the color picker sequence to 1051 (mass mailing default + 1) so it always appears above other overlays, including the link popover.

Steps to reproduce:
- Open Email Marketing.
- Add a link.
- Change its type to custom to enable text and fill color options.
- Open the color picker to change the text color.
- Observe that the color picker is hidden by the link popover.

opw-5866997

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
