### PR TITLE
[FIX] website_sale: Prevent traceback for hidden product variant image

### DIFF
--- a/addons/website_sale/static/src/interactions/website_sale.js
+++ b/addons/website_sale/static/src/interactions/website_sale.js
@@ -245,7 +245,7 @@ export class WebsiteSale extends Interaction {
         // When using the web editor, don't reload this or the images won't
         // be able to be edited depending on if this is done loading before
         // or after the editor is ready.
-        if (images && !this._isEditorEnabled()) {
+        if (images && !this._isEditorEnabled() && newImages ) {
             images.insertAdjacentHTML('beforebegin', markup(newImages));
             images.remove();
 


### PR DESCRIPTION
When product images are hidden (image_width='none' or missing), switching
between product variants caused a traceback.

Steps to reproduce:
===================
- Go to a product page with variants
- Edit mode & change the image to hidden
- Change variant

-> Traceback

Cause:
======
- The server doesn't send `carousel` data when images are hidden
  (product_page_image_width='none')
- However, `_getProductImageContainerSelector()` still returned a valid
  selector ("#o-carousel-product" or "#o-grid-product")
- `querySelector` found the existing (but empty) image container in the DOM
- `_updateProductImage()` was called with `undefined` as newImages parameter
- the re-queried images element crashed

Solution:
=========
In old version it was jquery and it was only checking for the existance
of the Old images (See [1]).
Now it will check both old and new images.

[1]: https://github.com/odoo/odoo/blob/77bfe416d08eefc720f12899490d3d39efacb74a/addons/website_sale/static/src/js/website_sale.js#L294

opw-5499004