### PR TITLE
[FIX] account_edi_ubl_cii: fix EPD on credit notes

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -576,9 +576,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         if invoice.invoice_payment_term_id.early_pay_discount_computation != 'mixed':
             return {}
         tax_to_discount = defaultdict(lambda: 0)
+        sign = -1 if invoice.move_type == 'out_refund' else 1
         for line in invoice.line_ids.filtered(lambda l: l.display_type == 'epd'):
             for tax in line.tax_ids:
-                tax_to_discount[tax.amount] += line.amount_currency
+                tax_to_discount[tax.amount] += line.amount_currency * sign
         return tax_to_discount
 
     def _split_fixed_taxes(self, taxes_vals):

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_credit_note_early_pay_discount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_credit_note_early_pay_discount.xml
@@ -1,13 +1,10 @@
-<CreditNote xmlns="urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+<CreditNote xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
 	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
 	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
 	<cbc:ID>___ignore___</cbc:ID>
-	<cbc:IssueDate>2017-01-01</cbc:IssueDate>
+	<cbc:IssueDate>___ignore___</cbc:IssueDate>
 	<cbc:CreditNoteTypeCode>381</cbc:CreditNoteTypeCode>
-	<cbc:Note>test narration</cbc:Note>
-	<cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
-	<cbc:TaxCurrencyCode>EUR</cbc:TaxCurrencyCode>
-	<cbc:BuyerReference>ref_partner_2</cbc:BuyerReference>
+	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
 	<cac:OrderReference>
 		<cbc:ID>___ignore___</cbc:ID>
 	</cac:OrderReference>
@@ -21,7 +18,7 @@
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
 			<cac:PartyName>
-				<cbc:Name>partner_1</cbc:Name>
+				<cbc:Name>company_1_data</cbc:Name>
 			</cac:PartyName>
 			<cac:PostalAddress>
 				<cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
@@ -38,11 +35,11 @@
 				</cac:TaxScheme>
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
-				<cbc:RegistrationName>partner_1</cbc:RegistrationName>
+				<cbc:RegistrationName>company_1_data</cbc:RegistrationName>
 				<cbc:CompanyID>BE0202239951</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
-				<cbc:Name>partner_1</cbc:Name>
+				<cbc:Name>company_1_data</cbc:Name>
 			</cac:Contact>
 		</cac:Party>
 	</cac:AccountingSupplierParty>
@@ -50,7 +47,7 @@
 		<cac:Party>
 			<cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
 			<cac:PartyName>
-				<cbc:Name>partner_2</cbc:Name>
+				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
 			<cac:PostalAddress>
 				<cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
@@ -67,11 +64,11 @@
 				</cac:TaxScheme>
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
-				<cbc:RegistrationName>partner_2</cbc:RegistrationName>
+				<cbc:RegistrationName>partner_be</cbc:RegistrationName>
 				<cbc:CompanyID>BE0477472701</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
-				<cbc:Name>partner_2</cbc:Name>
+				<cbc:Name>partner_be</cbc:Name>
 			</cac:Contact>
 		</cac:Party>
 	</cac:AccountingCustomerParty>
@@ -88,7 +85,7 @@
 		</cac:DeliveryLocation>
 		<cac:DeliveryParty>
 			<cac:PartyName>
-				<cbc:Name>partner_2</cbc:Name>
+				<cbc:Name>partner_be</cbc:Name>
 			</cac:PartyName>
 		</cac:DeliveryParty>
 	</cac:Delivery>
@@ -100,13 +97,13 @@
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
 	<cac:PaymentTerms>
-		<cbc:Note>10% discount if paid before 10 days</cbc:Note>
+		<cbc:Note>Payment terms: 30 Days, 2% Early Payment Discount under 7 days</cbc:Note>
 	</cac:PaymentTerms>
 	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
 		<cbc:AllowanceChargeReasonCode>64</cbc:AllowanceChargeReasonCode>
 		<cbc:AllowanceChargeReason>Conditional cash/payment discount</cbc:AllowanceChargeReason>
-		<cbc:Amount currencyID="USD">178.20</cbc:Amount>
+		<cbc:Amount currencyID="EUR">1.98</cbc:Amount>
 		<cac:TaxCategory>
 			<cbc:ID>S</cbc:ID>
 			<cbc:Percent>21.0</cbc:Percent>
@@ -116,23 +113,10 @@
 		</cac:TaxCategory>
 	</cac:AllowanceCharge>
 	<cac:AllowanceCharge>
-		<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-		<cbc:AllowanceChargeReasonCode>64</cbc:AllowanceChargeReasonCode>
-		<cbc:AllowanceChargeReason>Conditional cash/payment discount</cbc:AllowanceChargeReason>
-		<cbc:Amount currencyID="USD">90.00</cbc:Amount>
-		<cac:TaxCategory>
-			<cbc:ID>S</cbc:ID>
-			<cbc:Percent>12.0</cbc:Percent>
-			<cac:TaxScheme>
-				<cbc:ID>VAT</cbc:ID>
-			</cac:TaxScheme>
-		</cac:TaxCategory>
-	</cac:AllowanceCharge>
-	<cac:AllowanceCharge>
 		<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
 		<cbc:AllowanceChargeReasonCode>ZZZ</cbc:AllowanceChargeReasonCode>
 		<cbc:AllowanceChargeReason>Conditional cash/payment discount</cbc:AllowanceChargeReason>
-		<cbc:Amount currencyID="USD">268.20</cbc:Amount>
+		<cbc:Amount currencyID="EUR">1.98</cbc:Amount>
 		<cac:TaxCategory>
 			<cbc:ID>E</cbc:ID>
 			<cbc:Percent>0.0</cbc:Percent>
@@ -142,10 +126,10 @@
 		</cac:TaxCategory>
 	</cac:AllowanceCharge>
 	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="USD">434.00</cbc:TaxAmount>
+		<cbc:TaxAmount currencyID="EUR">20.37</cbc:TaxAmount>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="USD">1603.80</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="USD">336.80</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">97.02</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">20.37</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>21.0</cbc:Percent>
@@ -155,19 +139,8 @@
 			</cac:TaxCategory>
 		</cac:TaxSubtotal>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="USD">810.00</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="USD">97.20</cbc:TaxAmount>
-			<cac:TaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>12.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:TaxCategory>
-		</cac:TaxSubtotal>
-		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="USD">268.20</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="USD">0.00</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">1.98</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0.0</cbc:Percent>
@@ -178,33 +151,22 @@
 			</cac:TaxCategory>
 		</cac:TaxSubtotal>
 	</cac:TaxTotal>
-	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="EUR">217.00</cbc:TaxAmount>
-	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
-		<cbc:LineExtensionAmount currencyID="USD">2682.00</cbc:LineExtensionAmount>
-		<cbc:TaxExclusiveAmount currencyID="USD">2682.00</cbc:TaxExclusiveAmount>
-		<cbc:TaxInclusiveAmount currencyID="USD">3116.00</cbc:TaxInclusiveAmount>
-		<cbc:AllowanceTotalAmount currencyID="USD">268.20</cbc:AllowanceTotalAmount>
-		<cbc:ChargeTotalAmount currencyID="USD">268.20</cbc:ChargeTotalAmount>
-		<cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
-		<cbc:PayableAmount currencyID="USD">3116.00</cbc:PayableAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">99.00</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">99.00</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">119.37</cbc:TaxInclusiveAmount>
+		<cbc:AllowanceTotalAmount currencyID="EUR">1.98</cbc:AllowanceTotalAmount>
+		<cbc:ChargeTotalAmount currencyID="EUR">1.98</cbc:ChargeTotalAmount>
+		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+		<cbc:PayableAmount currencyID="EUR">119.37</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:CreditNoteLine>
 		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:CreditedQuantity unitCode="DZN">2.0</cbc:CreditedQuantity>
-		<cbc:LineExtensionAmount currencyID="USD">1782.00</cbc:LineExtensionAmount>
-		<cac:AllowanceCharge>
-			<cbc:ChargeIndicator>false</cbc:ChargeIndicator>
-			<cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
-			<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
-			<cbc:MultiplierFactorNumeric>10.0</cbc:MultiplierFactorNumeric>
-			<cbc:Amount currencyID="USD">198.00</cbc:Amount>
-			<cbc:BaseAmount currencyID="USD">1980.00</cbc:BaseAmount>
-		</cac:AllowanceCharge>
+		<cbc:CreditedQuantity unitCode="C62">1.0</cbc:CreditedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">99.00</cbc:LineExtensionAmount>
 		<cac:Item>
-			<cbc:Description>product_a</cbc:Description>
-			<cbc:Name>product_a</cbc:Name>
+			<cbc:Description>Test Product</cbc:Description>
+			<cbc:Name>Test Product</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>21.0</cbc:Percent>
@@ -214,45 +176,7 @@
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="USD">990.0</cbc:PriceAmount>
-		</cac:Price>
-	</cac:CreditNoteLine>
-	<cac:CreditNoteLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:CreditedQuantity unitCode="C62">10.0</cbc:CreditedQuantity>
-		<cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>product_b</cbc:Description>
-			<cbc:Name>product_b</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>12.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="USD">100.0</cbc:PriceAmount>
-		</cac:Price>
-	</cac:CreditNoteLine>
-	<cac:CreditNoteLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:CreditedQuantity unitCode="C62">-1.0</cbc:CreditedQuantity>
-		<cbc:LineExtensionAmount currencyID="USD">-100.00</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>product_b</cbc:Description>
-			<cbc:Name>product_b</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>12.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="USD">100.0</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">99.0</cbc:PriceAmount>
 		</cac:Price>
 	</cac:CreditNoteLine>
 </CreditNote>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -306,6 +306,21 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_early_pay_discount_with_recycling_contribution_tax')
 
+    def test_credit_note_early_pay_discount(self):
+        tax_21 = self.percent_tax(21.0)
+        product = self._create_product(lst_price=99.0, taxes_id=tax_21)
+        mixed_early_payment_term = self._create_mixed_early_payment_term()
+        credit_note = self._create_invoice_one_line(
+            product_id=product,
+            partner_id=self.partner_be,
+            invoice_payment_term_id=mixed_early_payment_term.id,
+            post=True,
+            move_type='out_refund',
+        )
+
+        self._generate_invoice_ubl_file(credit_note)
+        self._assert_invoice_ubl_file(credit_note, 'test_credit_note_early_pay_discount')
+
     def test_invoice_early_pay_discount_with_discount_on_lines(self):
         tax_21 = self.percent_tax(21.0)
         mixed_early_payment_term = self._create_mixed_early_payment_term()


### PR DESCRIPTION
Submitting a credit note with an early payment discount fails with schematron errors `BR-CO-17` and `BR-S-09`.

The issue occurs because
`_get_early_payment_discount_grouped_by_tax_rate`
returns negative values for credit notes, which is not accepted by the Peppol validation rules since we will increase the `TaxableAmount` instead of decreasing them.

Steps to reproduce:
- Create a payment term with a 2% discount (always)
- Create a credit note using this payment term
- Submit the document to Peppol
- Observe the schematron validation error

opw-5357180
opw-5499252