### PR TITLE
[IMP] hr_*: remove sequence field

### DIFF
--- a/addons/hr/data/hr_data.xml
+++ b/addons/hr/data/hr_data.xml
@@ -74,62 +74,50 @@
 
         <record id="contract_type_permanent" model="hr.contract.type">
             <field name="name">Permanent</field>
-            <field name="sequence">1001</field>
         </record>
 
         <record id="contract_type_temporary" model="hr.contract.type">
             <field name="name">Temporary</field>
-            <field name="sequence">1002</field>
         </record>
 
         <record id="contract_type_interim" model="hr.contract.type" forcecreate="1">
             <field name="name">Interim</field>
-            <field name="sequence">1003</field>
         </record>
 
         <record id="contract_type_seasonal" model="hr.contract.type">
             <field name="name">Seasonal</field>
-            <field name="sequence">1004</field>
         </record>
 
         <record id="contract_type_full_time" model="hr.contract.type">
             <field name="name">Full-Time</field>
-            <field name="sequence">1005</field>
         </record>
 
         <record id="contract_type_part_time" model="hr.contract.type">
             <field name="name">Part-Time</field>
-            <field name="sequence">1006</field>
         </record>
 
         <record id="contract_type_intern" model="hr.contract.type">
             <field name="name">Intern</field>
-            <field name="sequence">1007</field>
         </record>
 
         <record id="contract_type_student" model="hr.contract.type">
             <field name="name">Student</field>
-            <field name="sequence">1008</field>
         </record>
 
         <record id="contract_type_apprenticeship" model="hr.contract.type">
             <field name="name">Apprenticeship</field>
-            <field name="sequence">1009</field>
         </record>
 
         <record id="contract_type_thesis" model="hr.contract.type">
             <field name="name">Thesis</field>
-            <field name="sequence">1010</field>
         </record>
 
         <record id="contract_type_statutory" model="hr.contract.type">
             <field name="name">Statutory</field>
-            <field name="sequence">1011</field>
         </record>
 
         <record id="contract_type_employee" model="hr.contract.type">
             <field name="name">Employee</field>
-            <field name="sequence">1012</field>
         </record>
 
         <record id="home_work_location" model="hr.work.location">

--- a/addons/hr/models/hr_contract_type.py
+++ b/addons/hr/models/hr_contract_type.py
@@ -11,7 +11,6 @@ class HrContractType(models.Model):
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(compute='_compute_code', store=True, readonly=False)
-    sequence = fields.Integer()
     country_id = fields.Many2one('res.country', domain=lambda self: [('id', 'in', self.env.companies.country_id.ids)])
 
     @api.depends('name')

--- a/addons/hr/views/hr_contract_type_views.xml
+++ b/addons/hr/views/hr_contract_type_views.xml
@@ -5,7 +5,6 @@
             <field name="model">hr.contract.type</field>
             <field name="arch" type="xml">
                 <list string="Contract Types" editable="bottom" default_order="name">
-                    <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="code" column_invisible="1"/>
                     <field name="country_id" optional="hide"/>


### PR DESCRIPTION
This commit removes the sequence field, as contract types are already ordered by name by default, making the sequence field unnecessary.

Task:5868349
