### PR TITLE
[IMP] html_editor: map pasted table cells into target table 

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -208,7 +208,7 @@ export class ClipboardPlugin extends Plugin {
         selection = this.dependencies.selection.getEditableSelection();
 
         this.handlePasteUnsupportedHtml(selection, ev.clipboardData) ||
-            this.handlePasteOdooEditorHtml(ev.clipboardData) ||
+            this.handlePasteOdooEditorHtml(selection, ev.clipboardData) ||
             this.handlePasteHtml(selection, ev.clipboardData) ||
             this.handlePasteText(selection, ev.clipboardData);
 
@@ -232,7 +232,7 @@ export class ClipboardPlugin extends Plugin {
     /**
      * @param {DataTransfer} clipboardData
      */
-    handlePasteOdooEditorHtml(clipboardData) {
+    handlePasteOdooEditorHtml(selection, clipboardData) {
         const odooEditorHtml = clipboardData.getData("application/vnd.odoo.odoo-editor");
         const textContent = clipboardData.getData("text/plain");
         if (ONLY_LINK_REGEX.test(textContent)) {
@@ -241,6 +241,9 @@ export class ClipboardPlugin extends Plugin {
         if (odooEditorHtml) {
             const fragment = parseHTML(this.document, odooEditorHtml);
             this.dependencies.sanitize.sanitize(fragment);
+            if (this.delegateTo("paste_odoo_editor_html_overrides", selection, fragment)) {
+                return true;
+            }
             if (fragment.hasChildNodes()) {
                 this.dependencies.dom.insert(fragment);
             }
@@ -263,6 +266,9 @@ export class ClipboardPlugin extends Plugin {
         }
         if (files.length || clipboardHtml) {
             const clipboardElem = this.prepareClipboardData(clipboardHtml);
+            if (this.delegateTo("paste_html_overrides", selection, clipboardElem)) {
+                return true;
+            }
             // @phoenix @todo: should it be handled in table plugin?
             // When copy pasting a table from the outside, a picture of the
             // table can be included in the clipboard as an image file. In that

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1375,9 +1375,9 @@ export class TablePlugin extends Plugin {
      * @param {import("@html_editor/core/selection_plugin").EditorSelection} selection
      */
     processContentForClipboard(clonedContents, selection) {
-        if (clonedContents.firstChild.nodeName === "TR" || isTableCell(clonedContents.firstChild)) {
+        const table = closestElement(selection.commonAncestorContainer, "table.o_selected_table");
+        if (table) {
             // We enter this case only if selection is within single table.
-            const table = closestElement(selection.commonAncestorContainer, "table");
             const tableClone = table.cloneNode(true);
             // A table is considered fully selected if it is nested inside a
             // cell that is itself selected, or if all its own cells are

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -269,97 +269,99 @@ export class TablePlugin extends Plugin {
     /**
      * @param {'before'|'after'} position
      * @param {HTMLTableCellElement} reference
+     * @param {number} [columnsToAdd=1]
      */
-    addColumn(position, reference) {
-        const columnIndex = getColumnIndex(reference);
+    addColumn(position, reference, columnsToAdd = 1) {
         const table = closestElement(reference, "table");
         const tableWidth = table.style.width && parseFloat(table.style.width);
-        const referenceColumn = table.querySelectorAll(
-            `tr :is(td, th):nth-of-type(${columnIndex + 1})`
-        );
-        const referenceCellWidth = reference.style.width
-            ? parseFloat(reference.style.width)
-            : reference.clientWidth;
-        // Temporarily set widths so proportions are respected.
-        const firstRow = table.querySelector("tr");
-        const firstRowCells = [...firstRow.children].filter(
-            (child) => child.nodeName === "TD" || child.nodeName === "TH"
-        );
-        let totalWidth = 0;
-        if (tableWidth) {
-            for (const cell of firstRowCells) {
-                const width = parseFloat(cell.style.width);
-                cell.style.width = width + "px";
-                // Spread the widths to preserve proportions.
-                // -1 for the width of the border of the new column.
-                const newWidth = Math.max(
-                    Math.round((width * tableWidth) / (tableWidth + referenceCellWidth - 1)),
-                    13
-                );
-                cell.style.width = newWidth + "px";
-                totalWidth += newWidth;
+        for (let columnOffset = 0; columnOffset < columnsToAdd; columnOffset++) {
+            const columnIndex = getColumnIndex(reference);
+            const referenceCellWidth = reference.style.width
+                ? parseFloat(reference.style.width)
+                : reference.clientWidth;
+
+            // Temporarily set widths so proportions are respected.
+            const firstRowCells = [...table.rows[0].cells];
+            let totalWidth = 0;
+            if (tableWidth) {
+                for (const cell of firstRowCells) {
+                    const width = parseFloat(cell.style.width);
+                    cell.style.width = width + "px";
+                    // Spread the widths to preserve proportions.
+                    // -1 for the width of the border of the new column.
+                    const newWidth = Math.max(
+                        Math.round((width * tableWidth) / (tableWidth + referenceCellWidth - 1)),
+                        13
+                    );
+                    cell.style.width = newWidth + "px";
+                    totalWidth += newWidth;
+                }
             }
-        }
-        referenceColumn.forEach((cell, rowIndex) => {
-            const newCell = this.document.createElement(cell.tagName);
-            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.append(this.document.createElement("br"));
-            newCell.append(baseContainer);
-            cell[position](newCell);
-            // If the first row is a header, ensure the new column's
-            // first cell is also marked as a header (<th>).
-            if (rowIndex === 0 && cell.classList.contains("o_table_header")) {
-                newCell.classList.add("o_table_header");
+
+            for (let rowIndex = 0; rowIndex < table.rows.length; rowIndex++) {
+                const row = table.rows[rowIndex];
+                const cell = row.cells[columnIndex];
+                const newCell = this.document.createElement(cell.tagName);
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                fillEmpty(baseContainer);
+                newCell.append(baseContainer);
+                cell[position](newCell);
+
+                if (rowIndex === 0) {
+                    // If the first row is a header, ensure the new column's
+                    // first cell is also marked as a header (<th>).
+                    if (cell.classList.contains("o_table_header")) {
+                        newCell.classList.add("o_table_header");
+                    }
+                    if (tableWidth) {
+                        newCell.style.width = cell.style.width;
+                        totalWidth += parseFloat(cell.style.width);
+                    }
+                }
             }
-            if (rowIndex === 0 && tableWidth) {
-                newCell.style.width = cell.style.width;
-                totalWidth += parseFloat(cell.style.width);
+
+            if (tableWidth) {
+                if (totalWidth !== tableWidth - 1) {
+                    // -1 for the width of the border of the new column.
+                    firstRowCells[firstRowCells.length - 1].style.width =
+                        parseFloat(firstRowCells[firstRowCells.length - 1].style.width) +
+                        (tableWidth - totalWidth - 1) +
+                        "px";
+                }
+                // Fix the table and row's width so it doesn't change.
+                table.style.width = tableWidth + "px";
             }
-        });
-        if (tableWidth) {
-            if (totalWidth !== tableWidth - 1) {
-                // -1 for the width of the border of the new column.
-                firstRowCells[firstRowCells.length - 1].style.width =
-                    parseFloat(firstRowCells[firstRowCells.length - 1].style.width) +
-                    (tableWidth - totalWidth - 1) +
-                    "px";
-            }
-            // Fix the table and row's width so it doesn't change.
-            table.style.width = tableWidth + "px";
         }
     }
     /**
      * @param {'before'|'after'} position
      * @param {HTMLTableRowElement} reference
+     * @param {number} [rowsToAdd=1]
      */
-    addRow(position, reference) {
+    addRow(position, reference, rowsToAdd = 1) {
         const referenceRowHeight = reference.style.height && parseFloat(reference.style.height);
-        const newRow = this.document.createElement("tr");
-        if (referenceRowHeight) {
-            newRow.style.height = referenceRowHeight + "px";
-        }
-        const cells = reference.querySelectorAll("td, th");
-        const referenceRowWidths = [...cells].map((cell) => cell.style.width);
-        newRow.append(
-            ...Array.from(cells).map(() => {
+        for (let rowOffset = 0; rowOffset < rowsToAdd; rowOffset++) {
+            const newRow = this.document.createElement("tr");
+            if (referenceRowHeight) {
+                newRow.style.height = referenceRowHeight + "px";
+            }
+
+            for (let columnIndex = 0; columnIndex < reference.cells.length; columnIndex++) {
                 const td = this.document.createElement("td");
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                baseContainer.append(this.document.createElement("br"));
+                fillEmpty(baseContainer);
                 td.append(baseContainer);
-                return td;
-            })
-        );
-        reference[position](newRow);
-        if (referenceRowHeight) {
-            newRow.style.height = referenceRowHeight + "px";
-        }
-        // Preserve the width of the columns (applied only on the first row).
-        if (getRowIndex(newRow) === 0) {
-            let columnIndex = 0;
-            for (const column of newRow.children) {
-                column.style.width = referenceRowWidths[columnIndex];
-                cells[columnIndex].style.width = "";
-                columnIndex++;
+                newRow.append(td);
+            }
+            reference[position](newRow);
+
+            // Preserve the width of the columns (applied only on the first row).
+            if (getRowIndex(newRow) === 0) {
+                for (let columnIndex = 0; columnIndex < reference.cells.length; columnIndex++) {
+                    newRow.cells[columnIndex].style.width =
+                        reference.cells[columnIndex].style.width;
+                    reference.cells[columnIndex].style.width = "";
+                }
             }
         }
     }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1,7 +1,12 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isBlock } from "@html_editor/utils/blocks";
-import { fillEmpty, fillShrunkPhrasingParent, removeClass } from "@html_editor/utils/dom";
+import {
+    fillEmpty,
+    fillShrunkPhrasingParent,
+    removeClass,
+    removeStyle,
+} from "@html_editor/utils/dom";
 import {
     getDeepestPosition,
     isProtected,
@@ -28,6 +33,7 @@ import { getColumnIndex, getRowIndex, getTableCells } from "@html_editor/utils/t
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
+import { BG_CLASSES_REGEX } from "@html_editor/utils/color";
 
 export const BORDER_SENSITIVITY = 5;
 
@@ -137,6 +143,8 @@ export class TablePlugin extends Plugin {
         shift_tab_overrides: withSequence(20, this.handleShiftTab.bind(this)),
         delete_range_overrides: this.handleDeleteRange.bind(this),
         color_apply_overrides: this.applyTableColor.bind(this),
+        paste_html_overrides: this.handlePasteTableIntoExistingTable.bind(this),
+        paste_odoo_editor_html_overrides: this.handlePasteTableIntoExistingTable.bind(this),
 
         /** Predicates */
         is_node_removable_predicates: (node, root) => {
@@ -196,6 +204,107 @@ export class TablePlugin extends Plugin {
             }
         });
         this.onMousemove = this.onMousemove.bind(this);
+    }
+
+    handlePasteTableIntoExistingTable(selection, clipboardRoot) {
+        // Clipboard must contain exactly one table.
+        const sourceTable = clipboardRoot.firstChild;
+        if (clipboardRoot.childNodes.length !== 1 || sourceTable?.nodeName !== "TABLE") {
+            return false;
+        }
+
+        // Source table size.
+        const sourceRows = sourceTable.rows;
+        const sourceRowCount = sourceRows.length;
+        const sourceColumnCount = sourceRows[0]?.cells.length || 0;
+        if (!sourceRowCount || !sourceColumnCount) {
+            return false;
+        }
+
+        // Selection must be fully inside the same target table.
+        const targetTable = closestElement(selection.anchorNode, "table");
+        if (!targetTable || closestElement(selection.focusNode, "table") !== targetTable) {
+            return false;
+        }
+
+        const anchorCell =
+            targetTable.querySelector(".o_selected_td") ||
+            closestElement(selection.anchorNode, isTableCell);
+        const anchorRowIndex = getRowIndex(anchorCell);
+        const anchorColumnIndex = getColumnIndex(anchorCell);
+
+        // Ensure target table has enough rows.
+        const targetRows = targetTable.rows;
+        const rowsToAdd = anchorRowIndex + sourceRowCount - targetRows.length;
+
+        if (rowsToAdd > 0) {
+            this.addRow("after", targetRows[targetRows.length - 1], rowsToAdd);
+        }
+
+        // Ensure target table has enough columns.
+        const targetCells = targetRows[0].cells;
+        const columnsToAdd = anchorColumnIndex + sourceColumnCount - targetCells.length;
+
+        if (columnsToAdd > 0) {
+            this.addColumn("after", targetCells[targetCells.length - 1], columnsToAdd);
+        }
+
+        for (let sourceRowIndex = 0; sourceRowIndex < sourceRowCount; sourceRowIndex++) {
+            const sourceCells = sourceRows[sourceRowIndex].cells;
+            const targetCells = targetTable.rows[anchorRowIndex + sourceRowIndex].cells;
+            for (
+                let sourceColumnIndex = 0;
+                sourceColumnIndex < sourceColumnCount;
+                sourceColumnIndex++
+            ) {
+                const sourceCell = sourceCells[sourceColumnIndex];
+                const targetCell = targetCells[anchorColumnIndex + sourceColumnIndex];
+                const clonedCell = sourceCell.cloneNode(true);
+                targetCell.replaceChildren(...clonedCell.childNodes);
+                // Remove any existing bg-* classes on the target cell.
+                const targetBgClasses = [...targetCell.classList].filter((cls) =>
+                    BG_CLASSES_REGEX.test(cls)
+                );
+                if (targetBgClasses.length) {
+                    removeClass(targetCell, ...targetBgClasses);
+                }
+                // Apply bg-* classes from the source cell.
+                const sourceBgClasses = [...sourceCell.classList].filter((cls) =>
+                    BG_CLASSES_REGEX.test(cls)
+                );
+                if (sourceBgClasses.length) {
+                    targetCell.classList.add(...sourceBgClasses);
+                }
+                // Apply source background if any else remove target background
+                const { backgroundColor, backgroundImage } = sourceCell.style;
+                if (backgroundColor) {
+                    targetCell.style.backgroundColor = backgroundColor;
+                } else {
+                    removeStyle(targetCell, "background-color");
+                }
+                if (backgroundImage) {
+                    targetCell.style.backgroundImage = backgroundImage;
+                } else {
+                    removeStyle(targetCell, "background-image");
+                }
+            }
+        }
+
+        const selectionStartNode =
+            targetTable.rows[anchorRowIndex].cells[anchorColumnIndex].firstChild;
+        const selectionEndNode =
+            targetTable.rows[anchorRowIndex + sourceRowCount - 1].cells[
+                anchorColumnIndex + sourceColumnCount - 1
+            ].lastChild;
+        // Select from the first source cell to the last source cell.
+        this.dependencies.selection.setSelection({
+            anchorNode: selectionStartNode,
+            anchorOffset: 0,
+            focusNode: selectionEndNode,
+            focusOffset: nodeSize(selectionEndNode),
+        });
+
+        return true;
     }
 
     handleTab() {

--- a/addons/html_editor/static/tests/copy.test.js
+++ b/addons/html_editor/static/tests/copy.test.js
@@ -44,6 +44,32 @@ describe("range not collapsed", () => {
     });
 
     test.tags("focus required");
+    test("should copy a single selected table cell as text/plain, text/html and application/vnd.odoo.odoo-editor", async () => {
+        await setupEditor(
+            `<table class="o_selected_table"><tbody><tr><td class="o_selected_td">[ab]</td></tr><tr><td>ab</td></tr></tbody></table>`,
+            // Exclude the selection placeholder plugin so we have a DOM that
+            // really starts with a table.
+            { config: { Plugins: MAIN_PLUGINS.filter((p) => p.id !== "selectionPlaceholder") } }
+        );
+
+        const clipboardData = new DataTransfer();
+        await press(["ctrl", "c"], { dataTransfer: clipboardData });
+
+        // Plain text should still be copied
+        expect(clipboardData.getData("text/plain")).toBe("ab");
+
+        // HTML should preserve table structure (1×1 table)
+        expect(clipboardData.getData("text/html")).toBe(
+            `<table class="o_selected_table"><tbody><tr><td class="o_selected_td">ab</td></tr></tbody></table>`
+        );
+
+        // Editor-specific format should also preserve the table
+        expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe(
+            `<table class="o_selected_table"><tbody><tr><td class="o_selected_td">ab</td></tr></tbody></table>`
+        );
+    });
+
+    test.tags("focus required");
     test("should copy a selection as text/plain, text/html and application/vnd.odoo.odoo-editor in table", async () => {
         const { el } = await setupEditor(
             `]<table><tbody><tr><td><ul><li>a[</li><li>b</li><li>c</li></ul></td><td><br></td></tr></tbody></table>`,

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -6,17 +6,17 @@ import { unformat } from "../_helpers/format";
 import { undo } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
 
-function addRow(position) {
+function addRow(position, rowsToAdd = 1) {
     return (editor) => {
         const selection = editor.shared.selection.getEditableSelection();
-        editor.shared.table.addRow(position, findInSelection(selection, "tr"));
+        editor.shared.table.addRow(position, findInSelection(selection, "tr"), rowsToAdd);
     };
 }
 
-function addColumn(position) {
+function addColumn(position, columnsToAdd = 1) {
     return (editor) => {
         const selection = editor.shared.selection.getEditableSelection();
-        editor.shared.table.addColumn(position, findInSelection(selection, "td, th"));
+        editor.shared.table.addColumn(position, findInSelection(selection, "td, th"), columnsToAdd);
     };
 }
 
@@ -213,6 +213,89 @@ describe("row", () => {
                     "<td>cd</td>" +
                     "<td>ef[]</td>" +
                     "</tr></tbody></table>",
+            });
+        });
+
+        test("should add two rows above the top row and preserve widths", async () => {
+            await testEditor({
+                contentBefore:
+                    "<table><tbody>" +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 20px;">ab</td>' +
+                    '<td style="width: 25px;">cd</td>' +
+                    '<td style="width: 30px;">ef[]</td>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>gh</td>" +
+                    "<td>ij</td>" +
+                    "<td>kl</td>" +
+                    "</tr>" +
+                    "</tbody></table>",
+                stepFunction: addRow("before", 2),
+                contentAfter:
+                    "<table><tbody>" +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 20px;"><p><br></p></td>' +
+                    '<td style="width: 25px;"><p><br></p></td>' +
+                    '<td style="width: 30px;"><p><br></p></td>' +
+                    "</tr>" +
+                    '<tr style="height: 20px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "</tr>" +
+                    '<tr style="height: 20px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef[]</td>" +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>gh</td>" +
+                    "<td>ij</td>" +
+                    "<td>kl</td>" +
+                    "</tr>" +
+                    "</tbody></table>",
+            });
+        });
+        test("should add two rows below the bottom row", async () => {
+            await testEditor({
+                contentBefore:
+                    "<table><tbody>" +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 20px;">ab</td>' +
+                    '<td style="width: 25px;">cd</td>' +
+                    '<td style="width: 30px;">ef</td>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>gh</td>" +
+                    "<td>ij</td>" +
+                    "<td>kl[]</td>" +
+                    "</tr>" +
+                    "</tbody></table>",
+                stepFunction: addRow("after", 2),
+                contentAfter:
+                    "<table><tbody>" +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 20px;">ab</td>' +
+                    '<td style="width: 25px;">cd</td>' +
+                    '<td style="width: 30px;">ef</td>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>gh</td>" +
+                    "<td>ij</td>" +
+                    "<td>kl[]</td>" +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "</tr>" +
+                    "</tbody></table>",
             });
         });
     });
@@ -541,6 +624,78 @@ describe("column", () => {
                     "<td>cd</td>" +
                     "<td>ef</td>" +
                     "</tr></tbody></table>",
+            });
+        });
+
+        test("should add two columns before the leftmost column and preserve table width", async () => {
+            await testEditor({
+                contentBefore:
+                    '<table style="width: 150px;"><tbody>' +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 40px;">ab[]</td>' +
+                    '<td style="width: 50px;">cd</td>' +
+                    '<td style="width: 60px;">ef</td>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
+                    "</tr>" +
+                    "</tbody></table>",
+                stepFunction: addColumn("before", 2),
+                contentAfter:
+                    '<table style="width: 150px;"><tbody>' +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 27px;"><p><br></p></td>' +
+                    '<td style="width: 27px;"><p><br></p></td>' +
+                    '<td style="width: 27px;">ab[]</td>' +
+                    '<td style="width: 33px;">cd</td>' +
+                    '<td style="width: 35px;">ef</td>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
+                    "</tr>" +
+                    "</tbody></table>",
+            });
+        });
+
+        test("should add two columns after the rightmost column and preserve table width", async () => {
+            await testEditor({
+                contentBefore:
+                    '<table style="width: 150px;"><tbody>' +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 40px;">ab</td>' +
+                    '<td style="width: 50px;">cd</td>' +
+                    '<td style="width: 60px;">ef[]</td>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
+                    "</tr>" +
+                    "</tbody></table>",
+                stepFunction: addColumn("after", 2),
+                contentAfter:
+                    '<table style="width: 150px;"><tbody>' +
+                    '<tr style="height: 20px;">' +
+                    '<td style="width: 23px;">ab</td>' +
+                    '<td style="width: 28px;">cd</td>' +
+                    '<td style="width: 32px;">ef[]</td>' +
+                    '<td style="width: 32px;"><p><br></p></td>' +
+                    '<td style="width: 34px;"><p><br></p></td>' +
+                    "</tr>" +
+                    '<tr style="height: 30px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "</tr>" +
+                    "</tbody></table>",
             });
         });
     });


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

- When pasting clipboard content that contains  table inside existing table, inserted the pasted table as a nested table element.

### Desired behavior after PR is merged:

- Extends `addRow()` and `addColumn()` to accept `rowsToAdd/columnsToAdd` parameters (default 1), allowing multiple rows/columns to be inserted in single call.
- The target cells are filled cell-by-cell using the pasted table cells content.
- Single-cell paste preserves inline formatting (bold, links, lists, etc.).
- If the pasted table requires more cells than available from paste anchor position, target table is expanded by adding the required rows and columns to fit the incoming content.
- After paste, the cells whose content was updated are selected to highlight the affected cells.
- This improved behavior is applied only when:
   - Clipboard content contains a single table only, and
   - The paste selection/cursor is inside a single target table.

task-5499414

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
