### PR TITLE
[IMP] base: allow programmatic creation of API keys

### DIFF
--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -293,3 +293,49 @@ class TestAPIKeys(common.HttpCase):
                 self.env.cr.dbname, self._user.id, k,
                 'res.users', 'context_get', []
             ])
+
+    def test_renew_apikey(self):
+        self.env['ir.config_parameter'].set_param('base.enable_programmatic_api_keys', 1)
+        env = self.env(user=self._user)
+        key = env['res.users.apikeys.description'].create({'name': 'a'}).make_key()['context']['default_key']
+        apikey = self.env['res.users.apikeys'].search([('user_id', '=', self._user.id)])
+
+        in_ten_minutes = datetime.datetime.now() + datetime.timedelta(minutes=10)
+        in_twenty_minutes = datetime.datetime.now() + datetime.timedelta(minutes=20)
+
+        # an API key can be used to create a new one
+        key2 = model.dispatch('execute_kw', [
+            self.env.cr.dbname, self._user.id, key,
+            'res.users.apikeys', 'generate', [key, None, 'Second key', in_ten_minutes]
+        ])
+
+        apikeys = self.env['res.users.apikeys'].search([('user_id', '=', self._user.id)])
+        self.assertIn(apikey, apikeys)
+        self.assertRecordValues(apikeys - apikey, [
+            {'name': 'Second key', 'scope': False, 'expiration_date': in_ten_minutes},
+        ])
+
+        # the new key can be used to create a new one
+        model.dispatch('execute_kw', [
+            self.env.cr.dbname, self._user.id, key2,
+            'res.users.apikeys', 'generate', [key2, 'api', 'Third key', in_twenty_minutes]
+        ])
+
+        # revoke the previous one
+        model.dispatch('execute_kw', [
+            self.env.cr.dbname, self._user.id, key2,
+            'res.users.apikeys', 'revoke', [key2]
+        ])
+
+        # the second key is now revoked
+        with self.assertRaises(AccessDenied):
+            model.dispatch('execute_kw', [
+                self.env.cr.dbname, self._user.id, key2,
+                'res.users', 'context_get', []
+            ])
+
+        apikeys = self.env['res.users.apikeys'].search([('user_id', '=', self._user.id)])
+        self.assertIn(apikey, apikeys)
+        self.assertRecordValues(apikeys - apikey, [
+            {'name': 'Third key', 'scope': 'api', 'expiration_date': in_twenty_minutes},
+        ])

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -25,7 +25,7 @@ from odoo.api import SUPERUSER_ID
 from odoo.exceptions import AccessDenied, AccessError, UserError, ValidationError
 from odoo.fields import Command, Domain
 from odoo.http import request, DEFAULT_LANG
-from odoo.tools import email_domain_extract, is_html_empty, frozendict, reset_cached_properties, SQL
+from odoo.tools import email_domain_extract, is_html_empty, frozendict, reset_cached_properties, str2bool, SQL
 
 
 _logger = logging.getLogger(__name__)
@@ -1513,6 +1513,7 @@ KEY_CRYPT_CONTEXT = CryptContext(
     # attacks on API keys isn't much of a concern
     ['pbkdf2_sha512'], pbkdf2_sha512__rounds=6000,
 )
+DEFAULT_PROGRAMMATIC_API_KEYS_LIMIT = 10  # programmatic API key creation is refused if the user already has at least this amount of API keys
 
 
 class ResUsersApikeys(models.Model):
@@ -1566,6 +1567,7 @@ class ResUsersApikeys(models.Model):
             _logger.info("API key(s) removed: scope: <%s> for '%s' (#%s) from %s",
                self.mapped('scope'), self.env.user.login, self.env.uid, ip)
             self.sudo().unlink()
+            self.env.registry.clear_cache()
             return {'type': 'ir.actions.act_window_close'}
         raise AccessError(_("You can not remove API keys unless they're yours or you are a system user"))
 
@@ -1627,6 +1629,89 @@ class ResUsersApikeys(models.Model):
             self._description, scope, self.env.user.login, self.env.uid, ip)
 
         return k
+
+    def _ensure_can_manage_keys_programmatically(self):
+        # Administrators would not be restricted by the ICP check alone,
+        # as they could temporarily enable the setting via set_param().
+        # However, this is considered bad practice because it would create a time window
+        # where anyone could manage API keys programmatically.
+        # Additionally, the enable / call / restore process involves three distinct calls,
+        # which is not atomic and prone to errors (e.g., server unavailability during restore),
+        # potentially leaving the configuration enabled for all users.
+        # To avoid this, an exception is made for Administrators.
+        # However, if programmatic API key management were to be enabled by default,
+        # this exception should be removed, as disabling the feature should be global.
+        ICP = self.env['ir.config_parameter'].sudo()
+        programmatic_api_keys_enabled = str2bool(ICP.get_param('base.enable_programmatic_api_keys'), False)
+        if not (self.env.is_system() or programmatic_api_keys_enabled):
+            raise UserError(_("Programmatic API keys are not enabled"))
+
+    @api.model
+    def generate(self, key, scope, name, expiration_date):
+        """
+        Generate a new API key with an existing API key.
+        The provided `key` must be an existing API key that belongs to the current user.
+        Its scope must be compatible with `scope`.
+        The `expiration_date` must be allowed for the user's group.
+
+        To renew a key, generate the new one, store it, and then call `revoke` on the previous one.
+        """
+        self._ensure_can_manage_keys_programmatically()
+
+        with self.env['res.users']._assert_can_auth(user=key[:INDEX_SIZE]):
+            if not isinstance(expiration_date, datetime.datetime):
+                expiration_date = fields.Datetime.from_string(expiration_date)
+
+            nb_keys = self.search_count([('user_id', '=', self.env.uid),
+                                         '|', ('expiration_date', '=', False), ('expiration_date', '>=', self.env.cr.now())])
+            try:
+                ICP = self.env['ir.config_parameter'].sudo()
+                nb_keys_limit = int(ICP.get_param('base.programmatic_api_keys_limit', DEFAULT_PROGRAMMATIC_API_KEYS_LIMIT))
+            except ValueError:
+                _logger.warning("Invalid value for 'base.programmatic_api_keys_limit', using default value.")
+                nb_keys_limit = DEFAULT_PROGRAMMATIC_API_KEYS_LIMIT
+            if nb_keys >= nb_keys_limit:
+                raise UserError(_('Limit of %s API keys is reached for programmatic creation', nb_keys_limit))
+
+            # Scope compatibility rules:
+            # - A global key can generate credentials for any scope (including global).
+            # - A scoped key can only generate credentials for its own scope.
+            #
+            # This is enforced in _check_credentials by validating scope usage,
+            # and the validated scope is then reused when calling _generate.
+
+            uid = self.env['res.users.apikeys']._check_credentials(scope=scope or 'rpc', key=key)
+            if not uid or uid != self.env.uid:
+                raise AccessDenied(_("The provided API key is invalid or does not belong to the current user."))
+            new_key = self._generate(scope, name, expiration_date)
+            _logger.info("%s %r generated from %r", self._description, new_key[:INDEX_SIZE], key[:INDEX_SIZE])
+
+            return new_key
+
+    @api.model
+    def revoke(self, key):
+        """
+        Revoke an existing API key.
+        If it exists, the `key` will be removed from the server.
+        """
+        self._ensure_can_manage_keys_programmatically()
+        assert key, "key required"
+        with self.env['res.users']._assert_can_auth(user=key[:INDEX_SIZE]):
+            self.env.cr.execute(SQL('''
+                SELECT id, key
+                FROM %(table)s
+                WHERE
+                    index = %(index)s
+                    AND (
+                        expiration_date IS NULL OR
+                        expiration_date >= now() at time zone 'utc'
+                    )
+            ''', table=SQL.identifier(self._table), index=key[:INDEX_SIZE]))
+            for key_id, current_key in self.env.cr.fetchall():
+                if key and KEY_CRYPT_CONTEXT.verify(key, current_key):
+                    self.env['res.users.apikeys'].browse(key_id)._remove()
+                    return True
+            raise AccessDenied(_("The provided API key is invalid."))
 
     @api.autovacuum
     def _gc_user_apikeys(self):

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -668,3 +669,77 @@ class TestUsersIdentitycheck(HttpCase):
 
         # In addition, the password must have been emptied from the wizard
         self.assertFalse(user_identity_check.password)
+
+
+@tagged('post_install', '-at_install')
+class TestApiKeys(UsersCommonCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.env['ir.config_parameter'].set_param('base.enable_programmatic_api_keys', 1)
+        UsersApiKeys = cls.env['res.users.apikeys'].with_user(cls.user_internal)
+        cls.tomorrow = datetime.now() + timedelta(days=1)
+        cls.unscoped_key = UsersApiKeys._generate(None, 'Key without a scope', cls.tomorrow)
+        cls.scoped_key = UsersApiKeys._generate('scope', 'Key with a scope', cls.tomorrow)
+
+    def test_programmatic_apikey_management_is_deactivated_by_default(self):
+        self.env['ir.config_parameter'].set_param('base.enable_programmatic_api_keys', None)
+
+        # Attempting to create a key raises an error
+        with self.assertRaisesRegex(UserError, 'Programmatic API keys are not enabled'):
+            self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+                self.unscoped_key, None, 'Another key without a scope', self.tomorrow)
+
+        # Attempting to revoke a key raises an error
+        with self.assertRaisesRegex(UserError, 'Programmatic API keys are not enabled'):
+            self.env['res.users.apikeys'].with_user(self.user_internal).revoke(self.unscoped_key)
+
+    def test_generate_apikey_is_limited(self):
+        # create 8 new keys, which makes 10 keys in total for user_internal
+        for i in range(8):
+            self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+                self.unscoped_key, None, 'Another key without a scope', self.tomorrow)
+
+        with self.assertRaisesRegex(UserError, 'Limit of 10 API keys is reached'):
+            self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+                self.unscoped_key, None, 'Another key without a scope', self.tomorrow)
+
+        # This ICP can change the limit
+        self.env['ir.config_parameter'].set_param('base.programmatic_api_keys_limit', 11)
+        self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+            self.unscoped_key, None, 'Another key without a scope', self.tomorrow)
+
+    def test_generate_apikey_raises_when_creating_unscoped_key_from_scoped_key(self):
+        # Creating an unscoped key from a scoped key raises an error
+        with self.assertRaisesRegex(UserError, 'The provided API key is invalid or does not belong to the current user'):
+            self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+                self.scoped_key, None, 'Another key without a scope', self.tomorrow)
+
+    def test_generate_apikey_raises_when_creating_key_from_differently_scoped_key(self):
+        # Creating a key with a different scope raises an error
+        with self.assertRaisesRegex(UserError, 'The provided API key is invalid or does not belong to the current user'):
+            self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+                self.scoped_key, 'other', 'Another key with another scope', self.tomorrow)
+
+    def test_generate_apikey_accepts_creating_key_from_identically_scoped_key(self):
+        # Creating a key with the same scope doesn't raise
+        self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+            self.scoped_key, 'scope', 'Another key with a scope', self.tomorrow)
+
+    def test_generate_apikey_accepts_creating_scoped_key_from_unscoped_key(self):
+        # Creating a key with a scope from an unscoped key doesn't raise
+        self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+            self.unscoped_key, 'scope', 'Another key with a scope', self.tomorrow)
+
+    def test_generate_apikey_accepts_creating_unscoped_key_from_unscoped_key(self):
+        # Creating an unscoped key from another unscoped key doesn't raise
+        self.env['res.users.apikeys'].with_user(self.user_internal).generate(
+            self.unscoped_key, None, 'Another key without a scope', self.tomorrow)
+
+    def test_generate_apikey_checks_ownership(self):
+        # Check that an API key cannot be generated from another user's API key
+        with self.assertRaisesRegex(UserError, 'The provided API key is invalid or does not belong to the current user'):
+            self.env['res.users.apikeys'].with_user(SUPERUSER_ID).generate(
+                self.unscoped_key, None, 'Another key without a scope', self.tomorrow)


### PR DESCRIPTION
Previously, API keys could only be created interactively: the method required an interactive session and a recently typed password.

This commit adds a new method on `res.users.apikeys` that allows creating an API key when an existing one is provided. Optionally, in the case of a renewal, the new key can replace the old one, and the provided one is unlinked.