### PR TITLE
[FIX] point_of_sale: Fix indexedDB race condition on pos init

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -220,11 +220,33 @@ export default class IndexedDB {
     }
 
     reset() {
-        if (!this.dbInstance) {
-            return false;
-        }
-        this.dbInstance.deleteDatabase(this.dbName);
-        return true;
+        return new Promise((resolve) => {
+            if (this.db) {
+                this.db.close();
+            }
+
+            if (!this.dbInstance) {
+                return resolve(false);
+            }
+
+            const request = this.dbInstance.deleteDatabase(this.dbName);
+
+            request.onsuccess = () => {
+                logPosMessage("IndexedDB", "reset", "Database deleted successfully", CONSOLE_COLOR);
+                this.db = null;
+                resolve(true);
+            };
+
+            request.onerror = (event) => {
+                logPosMessage(
+                    "IndexedDB",
+                    "reset",
+                    `Error deleting DB: ${event.target.error}`,
+                    CONSOLE_COLOR
+                );
+            };
+            resolve(false);
+        });
     }
 
     create(storeName, arrData) {

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -292,7 +292,7 @@ export class PosData extends Reactive {
                 if (serverDateTime < lastConfigChange) {
                     await this.resetIndexedDB();
                     await this.initIndexedDB(this.relations);
-                    localData = [];
+                    localData = {};
                 }
 
                 const data = await this.orm.call(
@@ -339,7 +339,7 @@ export class PosData extends Reactive {
                     }
                 }
 
-                this.synchronizeServerDataInIndexedDB(localData);
+                await this.synchronizeServerDataInIndexedDB(localData);
             } catch (error) {
                 let message = _t("An error occurred while loading the Point of Sale: \n");
                 if (error instanceof RPCError) {


### PR DESCRIPTION
There were 2 issues when `serverDateTime` was lower than `lastConfigChange` which triggered a reset on the indexedDB. The first issue was that we would try to await dbInstance.deleteDatabase request. But it returns a request object and then executes the delete asynchronously. This would cause a race condition on the init where we would trigger the init of the indexedDB at the same time as we were trying to delete it and it would hang for ~10 seconds before finally launching the POS.

The second more important issue is that after the reset there is a `localData = []`. This would cause the line in `synchronizeServerDataInIndexedDB` `JSON.parse(JSON.stringify(serverData));` to return an empty array so no new models would get created in the indexedDB and the POS would launch with an empty indexedDB.

This commit changes the `indexed_db.reset()` method to return a promise and awaits it before reinitialising the indexedDB. And resets the `localData` to `{}` which fixes the `synchronizeServerDataInIndexedDB`


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
