### PR TITLE
[FIX] stock: consider MO for daily demand in forecasting

### DIFF
--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta
+from json import loads
 
 from odoo import Command, fields
 from odoo.tests import Form
@@ -400,7 +401,8 @@ class TestProcurement(TestMrpCommon):
         3. Add an extra manufactured component (not in stock) to 1st MO => auto-create 3rd MO
         4. When 2nd MO is completed => auto-assign to 1st MO
         5. When 1st MO is completed => auto-assign to picking
-        6. Additionally check that a MO that has component in stock auto-reserves when MO is confirmed (since default setting = 'at_confirm')"""
+        6. Additionally check that a MO that has component in stock auto-reserves when MO is confirmed (since default setting = 'at_confirm')
+        7. Check daily demand fluctuations for products entering or leaving production."""
 
         self.picking_type_out.reservation_method = 'at_confirm'
         route_manufacture = self.warehouse_1.manufacture_pull_id.route_id
@@ -471,7 +473,7 @@ class TestProcurement(TestMrpCommon):
             'product_max_qty': 5,
         })
 
-        self.env['stock.warehouse.orderpoint'].create({
+        orderpoint_p2 = self.env['stock.warehouse.orderpoint'].create({
             'name': 'Cake Mix RR',
             'location_id': self.stock_location.id,
             'product_id': product_2.id,
@@ -486,6 +488,13 @@ class TestProcurement(TestMrpCommon):
             'product_min_qty': 0,
             'product_max_qty': 5,
         })
+
+        info_p2 = self.env['stock.replenishment.info'].create({'orderpoint_id': orderpoint_p2.id})
+        info_p2.write({
+            'based_on': 'one_week',
+        })
+        graph_data = loads(info_p2.json_replenishment_graph)
+        self.assertEqual(graph_data['daily_demand'], 0.0)
 
         # create picking output to trigger creating MO for reordering product_1
         pick_output = self.env['stock.picking'].create({
@@ -504,6 +513,10 @@ class TestProcurement(TestMrpCommon):
         })
         pick_output.action_confirm()  # should trigger orderpoint to create and confirm 1st MO
         pick_output.action_assign()
+
+        info_p2._compute_json_replenishment_graph()
+        graph_data = loads(info_p2.json_replenishment_graph)
+        self.assertEqual(graph_data['daily_demand'], 2.14)
 
         mo = self.env['mrp.production'].search([
             ('product_id', '=', product_1.id),
@@ -563,6 +576,10 @@ class TestProcurement(TestMrpCommon):
         mo_form.product_uom_id = product_1.uom_id
         mo_assign_at_confirm = mo_form.save()
         mo_assign_at_confirm.action_confirm()
+
+        info_p2._compute_json_replenishment_graph()
+        graph_data = loads(info_p2.json_replenishment_graph)
+        self.assertEqual(graph_data['daily_demand'], 2.86)
 
         self.assertEqual(mo_assign_at_confirm.move_raw_ids.quantity, 5, "Components should have been auto-reserved")
 

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -162,7 +162,7 @@ class StockReplenishmentInfo(models.TransientModel):
                 [('company_id', '=', replenishment_report.orderpoint_id.company_id.id)],
             ])
             quantity_out = self.env['stock.move']._read_group(
-                Domain.AND([domain, [('location_dest_id.usage', '=', 'customer')]]),
+                Domain.AND([domain, [('location_dest_id.usage', 'in', ['customer', 'production'])]]),
                 aggregates=['product_qty:sum'],
             )[0][0] or 0.0
             quantity_returned = self.env['stock.move']._read_group(


### PR DESCRIPTION
The daily demand in forecasting does not take into consideration the product that are used for production.

Steps to reproduce:
-------------------
* Install stock and mrp
* Create a tracked Product "Component" with RR
* Add some "on hand quantity" 
* Create Product "Product" with a BOM that use "Component"
* Create a manufacturing order for "Product" and confirm it
* Go back on the RR of "Component" and use "resplenishment information" button (small i) 
-> Daily demand does not reflect the "Component" used for manufacturing.

Observation:
-------------
When Opening the resplenishment information, the daily_demand is calculated: https://github.com/odoo/odoo/blob/c38346ccc3e44670b76bfb010795bdfa7004b532/addons/stock/wizard/stock_replenishment_info.py#L177 For that calculation quantity_out is used, obtained just before: https://github.com/odoo/odoo/blob/c38346ccc3e44670b76bfb010795bdfa7004b532/addons/stock/wizard/stock_replenishment_info.py#L164-L167 Since it only consider moves that goes directly to the client, it will not take into consideration products that are used for production.

opw-5497584
