### PR TITLE
[IMP] survey: allow to set/unset mandatory question from list view

### DIFF
--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -238,7 +238,7 @@
                 <field name="title"/>
                 <field name="survey_id"/>
                 <field name="question_type"/>
-                <field name="constr_mandatory" optional="1"/>
+                <field name="constr_mandatory" optional="1" widget="boolean_toggle"/>
             </list>
         </field>
     </record>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -85,7 +85,7 @@
                                     <field name="time_limit" optional="hide" invisible="not is_time_limited"
                                         column_invisible="not parent.session_available"/>
                                     <field name="is_time_customized" column_invisible="True"/>
-                                    <field name="constr_mandatory" optional="hide"/>
+                                    <field name="constr_mandatory" optional="hide" widget="boolean_toggle"/>
                                     <field name="is_page" column_invisible="True"/>
                                     <field name="questions_selection" column_invisible="True"/>
                                     <field name="survey_id" column_invisible="True"/>


### PR DESCRIPTION
To change whether a survey question is mandatory or not, you had to open the question and modify it in the option section. Now with this change, we can modify it directly by switching the state in the question list views (you need first to show the "Mandatory Answer" column).

Task-5865119