### PR TITLE
[FIX] account: UserError in linking of bills at import

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4539,7 +4539,10 @@ class AccountMove(models.Model):
         if new_lines := (self.invoice_line_ids - existing_lines):
             new_lines.is_imported = True
             if not existing_lines:
-                self.with_context(default_move_type=self.move_type)._link_bill_origin_to_purchase_orders(timeout=4)
+                try:
+                    self.with_context(default_move_type=self.move_type)._link_bill_origin_to_purchase_orders(timeout=4)
+                except (UserError, ValueError):
+                    _logger.exception("Failed to link bill to purchase order")
 
         return res
 

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -151,16 +151,19 @@ class Account_Edi_Proxy_ClientUser(models.Model):
         })
         if 'is_in_extractable_state' in move._fields:
             move.is_in_extractable_state = False
+        try:
+            move._extend_with_attachments(move._to_files_data(attachment), new=True)
+            move._message_log(
+                body=_(
+                    "Peppol document (UUID: %(uuid)s) has been received successfully",
+                    uuid=uuid,
+                ),
+                attachment_ids=attachment.ids,
+            )
+            move._autopost_bill()
+        except Exception:
+            _logger.exception("Unexpected error occurred during the import of bill with id %s", move.id)
 
-        move._extend_with_attachments(move._to_files_data(attachment), new=True)
-        move._message_log(
-            body=_(
-                "Peppol document (UUID: %(uuid)s) has been received successfully",
-                uuid=uuid,
-            ),
-            attachment_ids=attachment.ids,
-        )
-        move._autopost_bill()
         attachment.write({'res_model': 'account.move', 'res_id': move.id})
         return {'uuid': uuid, 'move': move}
 


### PR DESCRIPTION
A UserError there can cause duplicates in peppol fetching.
It should never block an ack.
We can leave them unlinked
We also do the same for any unexpected error that occurs after we've created the move.

opw-5492092





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
