### PR TITLE
[FIX] point_of_sale: Restrict cost and margin visibility

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -17,9 +17,10 @@ export class ProductInfoPopup extends Component {
         this.props.close();
     }
     _hasMarginsCostsAccessRights() {
-        const isAccessibleToEveryUser = this.pos.config.is_margins_costs_accessible_to_every_user;
-        const isCashierManager = this.pos.get_cashier()._role === "manager";
-        return isAccessibleToEveryUser || isCashierManager;
+        if (!this.pos.config.is_margins_costs_accessible_to_every_user) {
+            return false;
+        }
+        return this.pos.get_cashier()._role === "manager";
     }
     editProduct() {
         this.pos.editProduct(this.props.product);

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -679,6 +679,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         '''Consider this test method to contain a test tour with miscellaneous tests/checks that require admin access.
         '''
         self.product_a.available_in_pos = True
+        self.main_pos_config.write({
+            'is_margins_costs_accessible_to_every_user': True,
+        })
         self.assertFalse(self.product_a.is_storable)
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -318,3 +318,46 @@ registry.category("web_tour.tours").add("test_scan_employee_barcode_with_pos_hr_
             ProductScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_cost_and_margin_visibility", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickInfoProduct("product_a"),
+            {
+                trigger: ".section-financials :contains('Margin')",
+            },
+            Dialog.confirm("Ok"),
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Employee 3", { run: "click" }),
+            ProductScreen.clickInfoProduct("product_a"),
+            {
+                trigger: negate(".section-financials :contains('Margin')"),
+            },
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_cost_and_margin_visibility_no_access", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Unlock Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Mitchell Admin", { run: "click" }),
+            ProductScreen.clickInfoProduct("product_a"),
+            {
+                trigger: negate(".section-financials :contains('Margin')"),
+            },
+            Dialog.confirm("Ok"),
+            PosHr.clickCashierName(),
+            SelectionPopup.has("Test Employee 3", { run: "click" }),
+            ProductScreen.clickInfoProduct("product_a"),
+            {
+                trigger: negate(".section-financials :contains('Margin')"),
+            },
+        ].flat(),
+});

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -205,3 +205,26 @@ class TestUi(TestPosHrHttpCommon):
             "test_scan_employee_barcode_with_pos_hr_disabled",
             login="pos_admin"
         )
+
+    def test_cost_and_margin_visibility(self):
+        self.product_a.available_in_pos = True
+        self.main_pos_config.write({
+            'is_margins_costs_accessible_to_every_user': True,
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_cost_and_margin_visibility",
+            login="pos_admin",
+        )
+
+        self.main_pos_config.write({
+            'is_margins_costs_accessible_to_every_user': False,
+        })
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_cost_and_margin_visibility_no_access",
+            login="pos_admin",
+        )


### PR DESCRIPTION
Before this commit, the "Show margins & costs" setting did not correctly enforce visibility. When enabled, cost and margin information was displayed to all users, regardless of their cashier rights. Furthermore, even when this setting was disabled, this sensitive information was still visible to cashiers with advanced and minimal rights.

This commit modifies the behavior:
- If "Show margins & costs" is enabled, cost and margin details are visible in the PoS UI only for employees with 'advanced' cashier rights, and hidden from those with 'basic' rights.
- If "Show margins & costs" is not checked, this information is hidden from all users in the PoS UI.

opw-4899231

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
