### PR TITLE
[FIX] website: avoid using `request` in `check_existing_page`

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1737,7 +1737,7 @@ class Website(models.Model):
         if len(self.env['website.rewrite'].search(redirects_domain, limit=1)) > 0:
             return True
 
-        router = request.env['ir.http'].routing_map().bind_to_environ(request.httprequest.environ)
+        router = self.env['ir.http'].routing_map().bind('')
         # If there is no rules matching this page, it does not exists
         if not router.test(path_info=page, method='GET'):
             return False


### PR DESCRIPTION
The `request` global object should not be used from models, as it may be invalid. This commit remove its uses from the method `check_exsiting_page` that was introduced in commit 45e15673a70cf770d8e343a0a3b805eccdbed0d1.

task-5888297