### PR TITLE
[FIX] l10n_es: 2025 update for mod390

### DIFF
--- a/addons/l10n_es/data/mod390/mod390_section1.xml
+++ b/addons/l10n_es/data/mod390/mod390_section1.xml
@@ -1204,7 +1204,8 @@
                                 aeat_mod_390_685.balance + aeat_mod_390_23.balance + aeat_mod_390_25.balance +
                                 aeat_mod_390_720.balance + aeat_mod_390_687.balance + aeat_mod_390_545.balance +
                                 aeat_mod_390_722.balance + aeat_mod_390_689.balance + aeat_mod_390_547.balance +
-                                aeat_mod_390_551.balance
+                                aeat_mod_390_551.balance + aeat_mod_390_27.balance + aeat_mod_390_29.balance +
+                                aeat_mod_390_649.balance + aeat_mod_390_31.balance
                             </field>
                         </record>
                         <record id="mod_390_casilla_34" model="account.report.line">
@@ -1217,7 +1218,7 @@
                                 aeat_mod_390_501.balance + aeat_mod_390_707.balance + aeat_mod_390_674.balance +
                                 aeat_mod_390_503.balance + aeat_mod_390_505.balance + aeat_mod_390_709.balance +
                                 aeat_mod_390_676.balance + aeat_mod_390_644.balance + aeat_mod_390_711.balance +
-                                aeat_mod_390_678.balance + aeat_mod_390_646.balance + aeat_mod_390_648.balance +
+                                aeat_mod_390_678.balance + aeat_mod_390_46.balance + aeat_mod_390_648.balance +
                                 aeat_mod_390_713.balance + aeat_mod_390_680.balance + aeat_mod_390_08.balance +
                                 aeat_mod_390_715.balance + aeat_mod_390_682.balance + aeat_mod_390_10.balance +
                                 aeat_mod_390_12.balance + aeat_mod_390_14.balance + aeat_mod_390_717.balance +
@@ -1225,7 +1226,8 @@
                                 aeat_mod_390_686.balance + aeat_mod_390_24.balance + aeat_mod_390_26.balance +
                                 aeat_mod_390_721.balance + aeat_mod_390_688.balance + aeat_mod_390_546.balance +
                                 aeat_mod_390_723.balance + aeat_mod_390_690.balance + aeat_mod_390_548.balance +
-                                aeat_mod_390_552.balance
+                                aeat_mod_390_552.balance + aeat_mod_390_28.balance + aeat_mod_390_30.balance +
+                                aeat_mod_390_650.balance + aeat_mod_390_32.balance
                             </field>
                         </record>
                     </field>


### PR DESCRIPTION
Currently report line formulas for box 33 and 34 are wrong, as they are not according to the regulation.
https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G412/Instrucciones_modelo_390-2025.pdf 
Box 33 is missing the sum of 27, 29, 649 and 31
Box 34 is missing the sum of 28, 30, 650 and 32

Updating mod390 report for 2025

opw-5498345