### PR TITLE
[FIX] sale: integrate customer addresses setting in quote pdfs

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -12,9 +12,10 @@
                 <t t-else="">Tax ID</t>: <span t-field="doc.partner_id.vat"/>
             </p>
         </t>
-        <t t-if="doc.partner_shipping_id == doc.partner_invoice_id
+        <t t-if="env.user.has_group('account.group_delivery_invoice_address')
+                             and (doc.partner_shipping_id == doc.partner_invoice_id
                              and doc.partner_invoice_id != doc.partner_id
-                             or doc.partner_shipping_id != doc.partner_invoice_id">
+                             or doc.partner_shipping_id != doc.partner_invoice_id)">
             <t t-set="information_block">
                 <strong>
                     <t t-if="doc.partner_shipping_id == doc.partner_invoice_id">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -458,7 +458,8 @@
                 <!-- ======  Customer Information  ====== -->
                 <div id="customer_info" class="col-12 col-lg-6 mb-4">
                     <h4 class="mb-1">
-                        <t t-if="sale_order.partner_shipping_id == sale_order.partner_invoice_id">
+                        <t t-if="not env.user.has_group('account.group_delivery_invoice_address')
+                                 or sale_order.partner_shipping_id == sale_order.partner_invoice_id">
                             Invoicing and Shipping Address
                         </t>
                         <t t-else="">
@@ -472,7 +473,8 @@
                     </h4>
                     <hr class="mt-1 mb-2"/>
                     <div t-field="sale_order.partner_invoice_id" t-options="{'widget': 'contact', 'fields': ['name', 'address', 'phone', 'email']}"/>
-                    <span t-if="sale_order.partner_shipping_id != sale_order.partner_invoice_id"
+                    <span t-if="env.user.has_group('account.group_delivery_invoice_address')
+                                and sale_order.partner_shipping_id != sale_order.partner_invoice_id"
                             id="shipping_address"
                             class="col-lg-6">
                         <br/>


### PR DESCRIPTION
## Versions
17.0+
16.0 too but template change is not worth risking stable policy.

## Issue
There is a behavior mismatch between invoices and quotes/orders addresses display. Disabling "Customer Addresses" setting should only display one address on generated documents. Yet, it has no effect on quotes and orders while it has on invoices.

## Steps to reproduce
- Go to Settings:
  - Look for "Customer Addresses";
  - Ensure the box is checked (and save).
- Go to Sales / Orders / Customers:
  - Create a new customer and add addresses under the "Contacts & Addresses" tab:
    - Add one "Delivery Address";
    - Add one "Invoice Address" (with different values).
- Click the "Sales" smart button to create a new quote for that customer:
  - Add any product;
  - From the cog, click Print > PDF Quote.
  - Confirm the order (deliver if needed);
  - Create regular invoice;
  - Confirm the invoice;
  - From the cog, click Print > Invoices.
  - Both documents display a shipping address.

Start again with "Customer Addresses" setting disabled and watch the shipping address disappear from the invoice while still present on the quote document.
*N.B.: Same behavior with the preview*

## Fix
Mimic invoices' behavior in https://github.com/odoo/odoo/blob/1bd2d63eb80020e6e213c889e83cca2950d4dcd4/addons/account/views/report_invoice.xml#L12

opw-5400368