### PR TITLE
[FIX] stock_account: Ensure product stock is accurate for a given to date

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -4,8 +4,8 @@ import operator as py_operator
 from ast import literal_eval
 from collections import defaultdict
 from collections.abc import Iterable
+from datetime import date, datetime, time
 from dateutil.relativedelta import relativedelta
-from datetime import datetime
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -166,9 +166,12 @@ class ProductProduct(models.Model):
         domain_quant = [('product_id', 'in', self.ids)] + domain_quant_loc
         dates_in_the_past = False
         # only to_date as to_date will correspond to qty_available
+        original_value = to_date
         to_date = fields.Datetime.to_datetime(to_date)
-        if to_date and to_date.time() == datetime.min.time():
-            to_date = datetime.combine(to_date, datetime.max.time())
+        if (isinstance(original_value, date) and not isinstance(original_value, datetime)) or \
+            (isinstance(original_value, str) and len(original_value) == 10):
+            to_date = datetime.combine(to_date.date(), time.max)
+
         if to_date and to_date < fields.Datetime.now():
             dates_in_the_past = True
 

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -210,7 +210,7 @@ class StockLot(models.Model):
     @api.depends('quant_ids', 'quant_ids.quantity')
     @api.depends_context('owner_id', 'package_id', 'to_date', 'location', 'warehouse_id', 'allowed_company_ids')
     def _product_qty(self):
-        domain_quant_loc, domain_move_in_loc, domain_move_out_loc = self.env['product.product']._get_domain_locations()
+        domain_quant_loc, domain_move_in_loc, domain_move_out_loc = self.env['product.product'].with_context(skip_in_progress=True)._get_domain_locations()
         owner_id = self.env.context.get('owner_id')
         package_id = self.env.context.get('package_id')
         to_date = fields.Datetime.to_datetime(self.env.context.get('to_date'))

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from bisect import bisect
 from collections import defaultdict
-from datetime import datetime
+from datetime import date, datetime, time
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
@@ -179,6 +179,18 @@ class ProductProduct(models.Model):
     def _compute_value(self):
         company_id = self.env.company
         self.company_currency_id = company_id.currency_id
+        products = self._with_valuation_context()
+
+        at_date = self.env.context.get('to_date')
+        original_value = at_date
+        at_date = fields.Datetime.to_datetime(at_date)
+        if (isinstance(original_value, date) and not isinstance(original_value, datetime)) or \
+            (isinstance(original_value, str) and len(original_value) == 10):
+            at_date = datetime.combine(at_date.date(), time.max)
+
+        if at_date:
+            products = products.with_context(at_date=at_date, to_date=at_date)
+
         # PERF: Pre-compute:the sum of 'total_value' of lots per product in go
         std_price_by_company_id = {}
         total_value_by_company_id = {}
@@ -189,11 +201,8 @@ class ProductProduct(models.Model):
 
             products = self.with_company(company.id).with_context(allowed_company_ids=company.ids)
             products = products._with_valuation_context()
-
-            at_date = fields.Datetime.to_datetime(self.env.context.get('to_date'))
             if at_date:
-                at_date = at_date.replace(hour=23, minute=59, second=59)
-                products = products.with_context(at_date=at_date)
+                products = products.with_context(at_date=at_date, to_date=at_date)
 
             env = products.env
 

--- a/addons/stock_account/static/src/stock_valuation/controller.js
+++ b/addons/stock_account/static/src/stock_valuation/controller.js
@@ -1,6 +1,6 @@
 import { reactive } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
-import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
+import { serializeDate } from "@web/core/l10n/dates";
 const { DateTime } = luxon;
 
 
@@ -70,7 +70,7 @@ export class StockValuationReportController {
 
     async setDate(date) {
         this.state.date = date;
-        this.dateAsString = serializeDateTime(date);
+        this.dateAsString = serializeDate(date);
         await this.loadReportData();
     }
 

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import timedelta
+from datetime import date, timedelta
 from freezegun import freeze_time
 
 from odoo import Command
@@ -2213,6 +2213,58 @@ class TestStockValuation(TestStockValuationCommon):
         report_value_2 = report_for_company_2.get_report_values(docids=product.ids)
         self.assertEqual(report_value_1['docs']['value'], "U 50.00")
         self.assertEqual(report_value_2['docs']['value'], "48.00 DD")
+
+    @freeze_time("2024-01-10 10:00:00")
+    def test_product_qty_and_value_correct_at_to_date_with_timezone(self):
+        """
+        Ensure that qty_available, free_qty, avg_cost, and total_value are computed
+        correctly for products at a historical to_date, taking the user's timezone into account.
+        """
+        self.env.user.tz = 'Europe/Paris'
+        to_date = date(2024, 1, 10)
+
+        lot_product = self.env['product.product'].create([
+            {
+                'name': 'Product LOT',
+                'tracking': 'lot',
+                'categ_id': self.category_avco.id,
+                'is_storable': True,
+                'standard_price': 10.0,
+                'lot_valuated': True,
+            },
+        ])
+        lot = self.env['stock.lot'].create({
+            'name': 'lot',
+            'product_id': lot_product.id,
+        })
+
+        products = self.product_standard | self.product_avco | self.product_fifo | lot_product
+        for product in products:
+            self._make_in_move(
+                product=product,
+                quantity=10.0,
+                location_id=self.supplier_location.id,
+                location_dest_id=self.stock_location.id,
+                lot_ids=lot if product.tracking == 'lot' else self.env['stock.lot'],
+            )
+
+        expected_values = [
+            {
+                    'qty_available': 10.0,
+                    'free_qty': 10.0,
+                    'avg_cost': 10.0,
+                    'total_value': 100.0,
+            }
+            for _ in products
+        ]
+        self.assertRecordValues(
+            products.with_context(to_date=to_date),
+            expected_values,
+        )
+        self.assertRecordValues(
+            products.with_context(to_date="2024-01-10"),
+            expected_values,
+        )
 
     def test_stock_report_avco_warehouse_dependency(self):
         """ Create two warehouses and check that the total value and the on hand quantity


### PR DESCRIPTION
**Issue**
While performing stock valuation, when a `to_date` is selected, the resulting valuation may be incorrect depending on the user's timezone.

**Steps to reproduce**
- Set the user timezone to UTC+1
- Create a storable product with:
  - quantity: 10 (created today)
  - unit cost: 5
  - valuation method: AVCO
- Go to Accounting > Review > Inventory > Inventory Valuation
- Select today's date
- Click on "Ending Stock"

-> The total value and quantity in stock are 0 instead of respectively 50 and 10.

**Cause**
When selecting a date (e.g. 12/04), the `to_date` is initially set at 00:00 in the user's timezone. An attempt is then made to convert it to 23:59 to avoid excluding quantities created during that day: https://github.com/odoo/odoo/blob/87e176ad76c9d7b87cd622ae38a8b9a62813b1cb/addons/stock_account/models/product.py#L147-L150

However, this conversion is performed on a naive UTC datetime. For a user in UTC+1, this results in the following situation:
- 12/04 00:00 (user timezone) -> 11/04 23:00 UTC
- Converted to 23:59 UTC -> 12/04 00:59 in user timezone

As a consequence, most of the quantities created on 12/04 are excluded from the valuation.

This issue impacts AVCO (and FIFO as well), as `at_date` is used during cost computation: https://github.com/odoo/odoo/blob/87e176ad76c9d7b87cd622ae38a8b9a62813b1cb/addons/stock_account/models/product.py#L147-L150

In addition, `at_date` is added to the context, while `qty_available` relies on `to_date` instead: https://github.com/odoo/odoo/blob/87e176ad76c9d7b87cd622ae38a8b9a62813b1cb/addons/stock/models/product.py#L151-L153

This inconsistency leads to incorrect quantities and valuation results.

opw-5491743