### PR TITLE
[IMP] website_blog, website_event: use social media / share snippets

### DIFF
--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_share" name="Share">
-    <div t-attf-class="s_share text-start o_no_link_popover #{_classes}">
+    <div t-attf-class="s_share text-start o_no_link_popover #{_classes}" t-ignore="#{_ignore}">   
         <h4 t-if="not _no_title" class="s_share_title d-none">Share</h4>
         <a t-if="not _exclude_share_links or not 'facebook' in _exclude_share_links" href="https://www.facebook.com/sharer/sharer.php?u={url}" t-attf-class="s_share_facebook #{_link_classes}" target="_blank" aria-label="Facebook">
             <i t-attf-class="fa fa-facebook #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>

--- a/addons/website/views/snippets/s_social_media.xml
+++ b/addons/website/views/snippets/s_social_media.xml
@@ -6,7 +6,7 @@ For the moment we hack the contenteditable system so that the social media
 title stay editable after a save (see SOCIAL_MEDIA_TITLE_CONTENTEDITABLE).
 -->
 <template id="s_social_media" name="Social Media">
-    <div class="s_social_media text-start o_not_editable" contenteditable="false">
+    <div t-attf-class="s_social_media text-start o_not_editable #{_classes}" contenteditable="false">
         <h4 class="s_social_media_title d-none" contenteditable="true">Social Media</h4>
         <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank" aria-label="Facebook">
             <i class="fa fa-facebook rounded shadow-sm o_editable_media small_social_icon"/>

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -227,7 +227,7 @@ Options:
             <div>
                 <h6 class="text-uppercase pb-2 mb-4 border-bottom fw-bold">Follow Us</h6>
             </div>
-            <t t-snippet-call="website.s_social_media"/>
+            <t t-snippet-call="website.s_social_media" string="Social Media" _classes.f="oe_unremovable"/>
 
             <t t-call="website_mail.follow" t-if="blog"
                 email="user_id.email"
@@ -306,12 +306,12 @@ Display a sidebar beside the post content.
 <!-- (Option) Post Sidebar: Share Links Display -->
 <template id="opt_blog_post_share_links_display" name="Share Links" inherit_id="website_blog.blog_post_sidebar" active="True" priority="2">
     <xpath expr="//div[@id='o_wblog_post_sidebar']" position="inside">
-        <div class="o_wblog_sidebar_block pb-5">
+        <div class="o_wblog_sidebar_block pb-5" t-ignore="true">
             <div>
                 <h6 class="text-uppercase pb-3 mb-4 border-bottom fw-bold">Share this post</h6>
             </div>
 
-            <t t-snippet-call="website.s_share"/>
+            <t t-snippet-call="website.s_share" string="Share" _classes.f="oe_unremovable"/>
         </div>
 
         <div class="oe_structure" id="oe_structure_blog_post_sidebar_3"/>

--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -1,22 +1,3 @@
-.o_wevent_sidebar_social > .o_wevent_social_link {
-    $o_link_size: 2.3em;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: $o_link_size;
-    height: $o_link_size;
-    margin: 0 0 ($spacer * .5) ($spacer * .25);
-    line-height: $o_link_size;
-    background-color: map-get($grays, '100');
-    border: $border-width solid $border-color;
-    border-radius: 50%;
-    text-align: center;
-    &:hover, &:focus {
-        background-color: map-get($grays, '300');
-        text-decoration: none;
-    }
-}
-
 // Index
 .o_wevent_index {
     // Events List

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -494,7 +494,7 @@
             <div>
                 <h6 class="o_wevent_sidebar_title">Follow Us</h6>
             </div>
-            <t t-snippet-call="website.s_social_media"/>
+            <t t-snippet-call="website.s_social_media" string="Social Media" _classes.f="oe_unremovable"/>
         </div>
         <div id="oe_structure_website_event_follow_us_1" class="oe_structure"/>
     </xpath>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -143,17 +143,6 @@
                             <div itemprop="name" class="mb-1" t-field="event.organizer_id"/>
                             <small t-field="event.organizer_id" t-options="{'widget': 'contact', 'fields': ['phone', 'mobile', 'email'], 'with_microdata': True,}"/>
                         </div>
-                        <!-- Social -->
-                        <div t-if="opt_event_share_block" class="o_wevent_sidebar_block">
-                            <div>
-                                <h6 class="o_wevent_sidebar_title">Share</h6>
-                                <p>Find out what people see and say about this event, and join the conversation.</p>
-                            </div>
-                            <t t-snippet-call="website.s_share"
-                                _no_title="True"
-                                _classes.f="o_wevent_sidebar_social mx-n1"
-                                _link_classes.f="o_wevent_social_link"/>
-                        </div>
                     </aside>
                 </div>
             </div>
@@ -738,7 +727,18 @@
 <template id="opt_event_calendar_block" name="Calendar links" inherit_id="website_event.event_description_full" active="True"/>
 <template id="opt_event_location_block" name="Location" inherit_id="website_event.event_description_full" active="True"/>
 <template id="opt_event_organizer_block" name="Organizer" inherit_id="website_event.event_description_full" active="True"/>
-<template id="opt_event_share_block" name="Share" inherit_id="website_event.event_description_full" active="True"/>
+<template id="opt_event_share_block" name="Share" inherit_id="website_event.event_description_full" active="True">
+    <xpath expr="//aside[@id='o_wevent_event_main_sidebar']" position="inside">
+        <div t-if="opt_event_share_block" class="o_wevent_sidebar_block" t-ignore="true">
+            <div>
+                <h6 class="o_wevent_sidebar_title">Share</h6>
+                <p>Find out what people see and say about this event, and join the conversation.</p>
+            </div>
+            <t t-snippet-call="website.s_share" string="Share" _classes.f="oe_unremovable" _ignore="true"/>
+        </div>
+    </xpath>
+</template>
+
 <!-- Sidebar Position Option -->
 <template id="opt_event_fixed_sidebar" name="Fixed Sidebar Option" inherit_id="website_event.event_description_full" active="False"/>
 


### PR DESCRIPTION
Since the user might want to customize the "Follow Us" and "Share" sections of its blog pages and event pages, we use the social media and share snippets and make them editable.

task-5144955