### PR TITLE
[FIX] account_peppol: neutralize should be consistent

### DIFF
--- a/addons/account_peppol/data/neutralize.sql
+++ b/addons/account_peppol/data/neutralize.sql
@@ -1,4 +1,4 @@
 INSERT INTO ir_config_parameter (key, value)
-     VALUES ('account_peppol.edi.mode', 'test')
+     VALUES ('account_peppol.edi.mode', 'demo')
 ON CONFLICT (key) DO UPDATE
-        SET VALUE = 'test';
+        SET VALUE = 'demo';


### PR DESCRIPTION
Currently, the proxy_client_user is neutralized as demo. But the edi_mode is set to test.
It's confusing for the users, and we should be consistent.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
