### PR TITLE
[IMP] mail, *: Proper mask of IM status on Avatars

### DIFF
--- a/addons/hr_holidays/static/src/im_status_patch.xml
+++ b/addons/hr_holidays/static/src/im_status_patch.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ImStatus" t-inherit-mode="extension">
         <xpath expr="//*[@name='icon']" position="replace">
-            <i t-if="persona.im_status === 'leave_online'" class="fa fa-plane text-success" title="On Leave (Online)" role="img" aria-label="User is on leave and online"/>
-            <i t-elif="persona.im_status === 'leave_away'" class="fa fa-plane o-yellow" title="On Leave (Idle)" role="img" aria-label="User is on leave and idle"/>
-            <i t-elif="persona.im_status === 'leave_busy'" class="fa fa-fw fa-plane text-danger" title="On Leave (Busy)" role="img" aria-label="User is on leave and busy"/>
-            <i t-elif="persona.im_status === 'leave_offline'" class="fa fa-plane text-500" title="On Leave" role="img" aria-label="User is on leave"/>
+            <i t-if="persona.im_status === 'leave_online'" t-att="attr" class="fa fa-plane text-success" title="On Leave (Online)" role="img" aria-label="User is on leave and online"/>
+            <i t-elif="persona.im_status === 'leave_away'" t-att="attr" class="fa fa-plane o-yellow" title="On Leave (Idle)" role="img" aria-label="User is on leave and idle"/>
+            <i t-elif="persona.im_status === 'leave_busy'" t-att="attr" class="fa fa-fw fa-plane text-danger" title="On Leave (Busy)" role="img" aria-label="User is on leave and busy"/>
+            <i t-elif="persona.im_status === 'leave_offline'" t-att="attr" class="fa fa-plane text-500" title="On Leave" role="img" aria-label="User is on leave"/>
             <t t-else="">$0</t>
         </xpath>
     </t>

--- a/addons/hr_holidays/static/tests/im_status.test.js
+++ b/addons/hr_holidays/static/tests/im_status.test.js
@@ -18,21 +18,21 @@ test("change icon on change partner im_status for leave variants", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(
-        ".o-mail-DiscussContent-header .o-mail-ImStatus .fa-plane[title='On Leave (Online)']"
+        ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='On Leave (Online)']"
     );
     pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "leave_offline",
         presence_status: "offline",
     });
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus .fa-plane[title='On Leave']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='On Leave']");
     pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "leave_away",
         presence_status: "away",
     });
     await contains(
-        ".o-mail-DiscussContent-header .o-mail-ImStatus .fa-plane[title='On Leave (Idle)']"
+        ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='On Leave (Idle)']"
     );
     pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
@@ -40,6 +40,6 @@ test("change icon on change partner im_status for leave variants", async () => {
         presence_status: "online",
     });
     await contains(
-        ".o-mail-DiscussContent-header .o-mail-ImStatus .fa-plane[title='On Leave (Online)']"
+        ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='On Leave (Online)']"
     );
 });

--- a/addons/hr_holidays/static/tests/im_status_patch.test.js
+++ b/addons/hr_holidays/static/tests/im_status_patch.test.js
@@ -20,7 +20,7 @@ test("on leave & online", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(
-        ".o-mail-DiscussContent-header .o-mail-ImStatus i.fa-plane[title='On Leave (Online)']"
+        ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='On Leave (Online)']"
     );
 });
 
@@ -38,7 +38,7 @@ test("on leave & away", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(
-        ".o-mail-DiscussContent-header .o-mail-ImStatus i.fa-plane[title='On Leave (Idle)']"
+        ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='On Leave (Idle)']"
     );
 });
 
@@ -55,5 +55,5 @@ test("on leave & offline", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i.fa-plane[title='On Leave']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='On Leave']");
 });

--- a/addons/hr_holidays/static/tests/thread_icon_patch.test.js
+++ b/addons/hr_holidays/static/tests/thread_icon_patch.test.js
@@ -20,7 +20,7 @@ test("thread icon of a chat when correspondent is on leave & online", async () =
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", {
-        contains: [".o-mail-ThreadIcon .fa-plane[title='On Leave (Online)']"],
+        contains: [".o-mail-ThreadIcon.fa-plane[title='On Leave (Online)']"],
         text: "Demo",
     });
 });
@@ -39,7 +39,7 @@ test("thread icon of a chat when correspondent is on leave & away", async () => 
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", {
-        contains: [".o-mail-ThreadIcon .fa-plane[title='On Leave (Idle)']"],
+        contains: [".o-mail-ThreadIcon.fa-plane[title='On Leave (Idle)']"],
         text: "Demo",
     });
 });
@@ -58,7 +58,7 @@ test("thread icon of a chat when correspondent is on leave & offline", async () 
     await start();
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", {
-        contains: [".o-mail-ThreadIcon .fa-plane[title='On Leave']"],
+        contains: [".o-mail-ThreadIcon.fa-plane[title='On Leave']"],
         text: "Demo",
     });
 });

--- a/addons/im_livechat/static/src/core/public_web/discuss_app/sidebar/channel_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app/sidebar/channel_patch.js
@@ -1,8 +1,0 @@
-import { DiscussSidebarChannel } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel";
-import { patch } from "@web/core/utils/patch";
-
-patch(DiscussSidebarChannel.prototype, {
-    get showThreadIcon() {
-        return this.channel.channel_type === "livechat" || super.showThreadIcon;
-    },
-});

--- a/addons/im_livechat/static/src/core/public_web/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_channel_model_patch.js
@@ -127,5 +127,8 @@ const discussChannelPatch = {
             await super.leaveChannel(...arguments);
         }
     },
+    showThreadIcon(...args) {
+        return this.channel_type === "livechat" || super.showThreadIcon(...args);
+    },
 };
 patch(DiscussChannel.prototype, discussChannelPatch);

--- a/addons/im_livechat/static/tests/thread_icon_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_icon_patch.test.js
@@ -21,7 +21,7 @@ test("Public website visitor is typing", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-DiscussContent-header .o-mail-ThreadIcon .fa.fa-circle-o");
+    await contains(".o-mail-DiscussContent-header .o-mail-ThreadIcon.fa.fa-circle-o");
     const channel = pyEnv["discuss.channel"].search_read([["id", "=", channelId]])[0];
     // simulate receive typing notification from livechat visitor "is typing"
     withGuest(guestId, () =>

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -1,4 +1,4 @@
-import { ThreadIcon } from "@mail/core/common/thread_icon";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
 
 import { Component, useEffect, useRef, useState, useSubEnv } from "@odoo/owl";
@@ -33,7 +33,7 @@ class ChatBubblePreview extends Component {
  * @extends {Component<Props, Env>}
  */
 export class ChatBubble extends Component {
-    static components = { CountryFlag, ThreadIcon };
+    static components = { CountryFlag, DiscussAvatar };
     static props = ["chatWindow"];
     static template = "mail.ChatBubble";
 
@@ -78,12 +78,5 @@ export class ChatBubble extends Component {
     /** @returns {import("models").Channel} */
     get channel() {
         return this.props.chatWindow.channel;
-    }
-
-    get showThreadIcon() {
-        return (
-            this.channel.channel_type === "chat" ||
-            (this.channel.channel_type === "group" && this.channel.hasOtherMembersTyping)
-        );
     }
 }

--- a/addons/mail/static/src/core/common/chat_bubble.scss
+++ b/addons/mail/static/src/core/common/chat_bubble.scss
@@ -28,16 +28,6 @@
 
 }
 
-.o-mail-ChatBubble-avatar {
-    width: $o-mail-ChatBubble-size;
-    height: $o-mail-ChatBubble-size;
-
-    &.o-big {
-        width: $o-mail-ChatBubble-sizeBig;
-        height: $o-mail-ChatBubble-sizeBig;
-    }
-}
-
 .o-mail-ChatBubble-close {
     right: -3px;
     top: -5px;

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -5,10 +5,9 @@
             <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-0': !channel.isUnread or channel.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="channel.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="channel.importantCounter"/>
             <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.requestClose()"><i class="oi oi-close"/></button>
-            <ThreadIcon t-if="showThreadIcon" thread="channel.thread" size="'large'" className="'o-mail-ChatBubble-status position-absolute'"/>
             <CountryFlag t-if="channel.showCorrespondentCountry" country="channel.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border shadow-sm'"/>
             <button class="o-mail-ChatHub-bubbleBtn btn shadow">
-                <img class="o-mail-ChatBubble-avatar bg-view rounded-circle object-fit-cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="channel.avatarUrl" alt="Channel image" draggable="false"/>
+                <DiscussAvatar channel="channel" size="42" imgRoundedClass="'rounded-circle'"/>
             </button>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -1,11 +1,10 @@
 import { ActionList } from "@mail/core/common/action_list";
 import { Composer } from "@mail/core/common/composer";
-import { ImStatus } from "@mail/core/common/im_status";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { Thread } from "@mail/core/common/thread";
 import { AutoresizeInput } from "@mail/core/common/autoresize_input";
 import { CountryFlag } from "@mail/core/common/country_flag";
 import { useThreadActions } from "@mail/core/common/thread_actions";
-import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { useHover, useMessageScrolling } from "@mail/utils/common/hooks";
 import { isEventHandled } from "@web/core/utils/misc";
 
@@ -29,11 +28,10 @@ export class ChatWindow extends Component {
     static components = {
         ActionList,
         CountryFlag,
+        DiscussAvatar,
         Dropdown,
         Thread,
         Composer,
-        ThreadIcon,
-        ImStatus,
         AutoresizeInput,
         Typing,
     };

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -87,8 +87,7 @@
         'py-2': threadActions.actions.length lte 3,
         'ps-2': !hasActionsMenu,
     }" name="threadAvatar">
-        <img class="rounded-3 object-fit-cover" t-att-src="channel.parent_channel_id?.avatarUrl ?? channel.avatarUrl" alt="Channel Image"/>
-        <ImStatus t-if="channel.showImStatus" className="'o-mail-ChatWindow-imStatus position-absolute'" member="channel.correspondent" size="'sm'" withIsTyping="false"/>
+        <DiscussAvatar channel="channel" size="24" typing="false"/>
     </div>
     <t t-if="channel.parent_channel_id">
         <span class="fw-bold small o-mx-0_5 opacity-75 opacity-100-hover cursor-pointer o-hover-text-underline rounded fs-6" t-esc="channel.parent_channel_id.displayName" title="Open Channel" t-ref="parentChannel" t-on-click.stop="() => this.channel.parent_channel_id.open({ focus: true })"/>

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -196,7 +196,7 @@
 
     <t t-name="mail.Composer.suggestionPartner">
         <t t-set="partner" t-value="option.partner"/>
-        <ImStatus t-if="partner" persona="partner"/>
+        <DiscussAvatar t-if="partner" persona="partner" size="24"/>
         <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
             <t t-esc="partner.name"/>
             <t t-if="option.thread and partner.name !== option.thread.getPersonaName(partner)">

--- a/addons/mail/static/src/core/common/discuss_avatar.js
+++ b/addons/mail/static/src/core/common/discuss_avatar.js
@@ -1,0 +1,58 @@
+import { ImStatus } from "@mail/core/common/im_status";
+import { ThreadIcon } from "@mail/core/common/thread_icon";
+
+import { Component } from "@odoo/owl";
+
+let nextId = 0;
+
+export class DiscussAvatar extends Component {
+    static template = "mail.DiscussAvatar";
+    static props = [
+        "channel?",
+        "member?",
+        "persona?",
+        "thread?",
+        "size?",
+        "typing?",
+        "className?",
+        "imgRoundedClass?",
+    ];
+    static defaultProps = { className: "", size: 32, typing: true };
+    static components = { ImStatus, ThreadIcon };
+
+    setup() {
+        super.setup();
+        this.uniqueId = `mail.DiscussAvatar.${nextId++}`;
+    }
+
+    get channel() {
+        return this.props.channel ?? this.props.thread?.channel;
+    }
+
+    get thread() {
+        return this.props.thread ?? this.props.channel?.thread;
+    }
+
+    get isTyping() {
+        if (!this.props.typing) {
+            return false;
+        }
+        if (this.channel) {
+            return this.channel.hasOtherMembersTyping;
+        }
+        if (this.props.member) {
+            return this.props.member.isTyping;
+        }
+        return false;
+    }
+
+    get showIcon() {
+        if (this.channel) {
+            return this.channel.showThreadIcon({ ignoreTyping: !this.props.typing });
+        }
+        if (this.props.member || this.props.persona) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/addons/mail/static/src/core/common/discuss_avatar.xml
+++ b/addons/mail/static/src/core/common/discuss_avatar.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.DiscussAvatar">
+        <svg t-att-width="props.size" t-att-height="props.size" viewBox="0 0 32 32" class="overflow-visible">
+            <mask t-att-id="uniqueId" width="32" height="32">
+                <rect x="0" y="0" height="32" width="32" fill="white"/>
+                <rect t-if="showIcon" color="black" t-att-x="isTyping ? 15 : 19" y="19" t-att-width="isTyping ? 24 : 16" t-att-height="isTyping ? 15 : 16" rx="8" ry="8"/>
+            </mask>
+            <foreignObject x="0" y="0" width="32" height="32" t-att-mask="'url(#' + uniqueId + ')'">
+                <t t-call="mail.DiscussAvatar.avatarImg"/> <!-- FIXME: owl doesn't like and load immediate <img> below <foreignObject>, hence t-call shenanigans -->
+            </foreignObject>
+            <g t-if="showIcon" t-att-transform="'translate(' + (isTyping ? 16 : 21) + ', 20)'">
+                <svg width="25" height="15" viewBox="0 0 25 15">
+                    <foreignObject x="0" y="0" width="25" height="15">
+                        <ThreadIcon t-if="thread" thread="thread" typing="props.typing"/>
+                        <ImStatus t-elif="props.member" member="props.member" className="'d-flex'" size="'md'" typing="props.typing"/>
+                        <ImStatus t-elif="props.persona" persona="props.persona" typing="props.typing"/>
+                    </foreignObject>
+                </svg>
+            </g>
+        </svg>
+    </t>
+
+    <t t-name="mail.DiscussAvatar.avatarImg">
+        <img t-if="thread" class="w-100 h-100 object-fit-cover" t-att-class="{ [props.imgRoundedClass]: props.imgRoundedClass, 'rounded-2': !props.imgRoundedClass }" t-att-src="thread.channel?.parent_channel_id?.avatarUrl ?? thread.channel?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
+        <img t-elif="props.member" alt="" class="w-100 h-100 object-fit-cover" t-att-class="{ [props.imgRoundedClass]: props.imgRoundedClass, 'rounded-3': !props.imgRoundedClass }" t-att-src="props.member.avatarUrl"/>
+        <img t-elif="props.persona" alt="" class="w-100 h-100 object-fit-cover" t-att-class="{ [props.imgRoundedClass]: props.imgRoundedClass, 'rounded': !props.imgRoundedClass }" t-att-src="props.persona.avatarUrl"/>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/im_status.js
+++ b/addons/mail/static/src/core/common/im_status.js
@@ -1,25 +1,36 @@
 import { Component } from "@odoo/owl";
 import { Typing } from "@mail/discuss/typing/common/typing";
+import { attClassObjectToString } from "@mail/utils/common/format";
 
 export class ImStatus extends Component {
-    static props = [
-        "persona?",
-        "className?",
-        "style?",
-        "member?",
-        "slots?",
-        "size?",
-        "withIsTyping?",
-    ];
+    static props = ["persona?", "className?", "style?", "member?", "slots?", "size?", "typing?"];
     static template = "mail.ImStatus";
-    static defaultProps = { className: "", style: "", size: "lg", withIsTyping: true };
+    static defaultProps = { className: "", style: "", size: "lg", typing: true };
     static components = { Typing };
+
+    setup() {
+        super.setup();
+        this.attClassObjectToString = attClassObjectToString;
+    }
 
     get persona() {
         return this.props.persona ?? this.props.member?.persona;
     }
 
     get showTypingIndicator() {
-        return this.props.withIsTyping && this.props.member?.isTyping;
+        return this.props.typing && this.props.member?.isTyping;
+    }
+
+    get attr() {
+        return { class: this.class, style: this.props.style };
+    }
+
+    get class() {
+        return attClassObjectToString({
+            [`o-mail-ImStatus d-flex ${this.props.className}`]: true,
+            "o-fs-small": this.persona?.im_status !== "bot",
+            "rounded-circle bg-transparent": !this.showTypingIndicator,
+            "rounded-pill": this.showTypingIndicator,
+        });
     }
 }

--- a/addons/mail/static/src/core/common/im_status.scss
+++ b/addons/mail/static/src/core/common/im_status.scss
@@ -2,9 +2,6 @@
 .o-mail-ImStatus {
 
     i {
-        padding-left: 1px;
-        padding-right: 1px;
-
         &.fa-heart {
             transform: scale(.8); // Deviation: handle icon inconsistent size
         }
@@ -14,4 +11,12 @@
         width: 0.65rem; // matches .o-xsmaller
         height: 0.65rem;
     }
+}
+
+.o-mail-ImStatus-typingBg {
+    padding: 2px;
+}
+
+.o-mail-ImStatus-typingContainer {
+    padding: 1px;
 }

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -2,34 +2,22 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ImStatus">
-        <div class="o-mail-ImStatus d-flex justify-content-center flex-shrink-0 align-items-center bg-white bg-opacity-100" t-attf-class="{{ props.className }}" t-att-style="props.style" t-att-class="{
-            'o-md': props.size === 'md' or props.size === 'medium',
-            'o-sm': props.size === 'sm' or props.size === 'small',
-            'rounded-circle': !showTypingIndicator,
-            'rounded-pill': showTypingIndicator,
-        }">
-            <span class="d-flex flex-column" t-att-class="{
-                'smaller': props.size === 'md' or props.size === 'medium',
-                'o-xsmaller': props.size === 'sm' or props.size === 'small',
-            }">
-                <t t-slot="pre_icon"/>
-                <t name="icon">
-                    <t t-if="(!props.member or !showTypingIndicator) and persona">
-                        <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" title="Online" role="img" aria-label="User is online"/>
-                        <i t-elif="persona.im_status === 'away'" class="fa fa-adjust o-yellow" title="Idle" role="img" aria-label="User is idle"/>
-                        <i t-elif="persona.im_status === 'busy'" class="fa fa-minus-circle text-danger" title="Busy" role="img" aria-label="User is busy"/>
-                        <i t-elif="persona.im_status === 'offline'" class="fa fa-circle-o text-700 opacity-75" title="Offline" role="img" aria-label="User is offline"/>
-                        <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success" title="Bot" role="img" aria-label="User is a bot"/>
-                        <i t-else="" class="fa fa-question-circle opacity-75" title="No IM status available"/>
-                    </t>
-                    <div t-if="showTypingIndicator" class="rounded-pill" style="padding: 1px;" t-att-class="{ 'bg-300': env.inChatBubble, 'bg-inherit': !env.inChatBubble }">
-                        <div class="bg-success rounded-pill" style="padding: 3px;">
-                            <Typing member="props.member" size="['sm', 'smaller'].includes(props.size) ? 'sm' : 'md'" displayText="false" />
-                        </div>
-                    </div>
-                </t>
-            </span>
-        </div>
+        <t t-slot="pre_icon"/>
+        <t name="icon">
+            <t t-if="(!props.member or !showTypingIndicator) and persona">
+                <i t-if="persona.im_status === 'online'" class="fa fa-circle text-success" t-att="attr" title="Online" role="img" aria-label="User is online"/>
+                <i t-elif="persona.im_status === 'away'" class="fa fa-adjust o-yellow" t-att="attr" title="Idle" role="img" aria-label="User is idle"/>
+                <i t-elif="persona.im_status === 'busy'" class="fa fa-minus-circle text-danger" t-att="attr" title="Busy" role="img" aria-label="User is busy"/>
+                <i t-elif="persona.im_status === 'offline'" class="fa fa-circle-o text-700 opacity-75" t-att="attr" title="Offline" role="img" aria-label="User is offline"/>
+                <i t-elif="persona.im_status === 'bot'" class="fa fa-heart text-success o-xsmaller o-pt-0_5" t-att="attr" title="Bot" role="img" aria-label="User is a bot"/>
+                <i t-else="" class="fa fa-question-circle opacity-75" t-att="attr" title="No IM status available"/>
+            </t>
+            <div t-if="showTypingIndicator" class="o-mail-ImStatus-typingContainer rounded-pill" t-att="attr">
+                <div class="o-mail-ImStatus-typingBg bg-success rounded-pill">
+                    <Typing member="props.member" size="['sm', 'smaller'].includes(props.size) ? 'sm' : 'md'" displayText="false" />
+                </div>
+            </div>
+        </t>
     </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -1,4 +1,4 @@
-import { ImStatus } from "@mail/core/common/im_status";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { onExternalClick } from "@mail/utils/common/hooks";
 import { markEventHandled, isEventHandled } from "@web/core/utils/misc";
 
@@ -9,7 +9,7 @@ import { usePosition } from "@web/core/position/position_hook";
 import { useService } from "@web/core/utils/hooks";
 
 export class NavigableList extends Component {
-    static components = { ImStatus };
+    static components = { DiscussAvatar };
     static template = "mail.NavigableList";
     static props = {
         anchorRef: { optional: true },

--- a/addons/mail/static/src/core/common/thread_icon.js
+++ b/addons/mail/static/src/core/common/thread_icon.js
@@ -4,6 +4,7 @@ import { Component } from "@odoo/owl";
 import { Thread } from "./thread_model";
 import { _t } from "@web/core/l10n/translation";
 import { ImStatus } from "./im_status";
+import { attClassObjectToString } from "@mail/utils/common/format";
 
 /**
  * @typedef {Object} Props
@@ -20,6 +21,7 @@ export class ThreadIcon extends Component {
         size: { optional: true, validate: (size) => ["small", "medium", "large"].includes(size) },
         className: { type: String, optional: true },
         title: { type: Boolean, optional: true },
+        typing: { type: Boolean, optional: true },
     };
     static defaultProps = {
         size: "medium",
@@ -30,6 +32,7 @@ export class ThreadIcon extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
+        this.attClassObjectToString = attClassObjectToString;
     }
 
     get channel() {

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -2,30 +2,33 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.ThreadIcon">
-        <div class="o-mail-ThreadIcon d-flex justify-content-center flex-shrink-0" t-att-class="props.className">
-            <t t-set="sizeClass" t-value="props.size === 'large' ? 'fa-lg' : props.size === 'small' ? 'o-xsmaller' : ''"/>
-            <t t-if="channel?.channel_type === 'channel'">
-                <div t-if="!channel.group_public_id" class="fa fa-fw fa-globe" t-att-class="sizeClass" title="Public Channel"/>
-            </t>
-            <t t-elif="channel?.channel_type === 'group'">
-                <t name="group"/>
-            </t>
-            <t t-elif="channel?.channel_type?.includes('chat') and correspondent">
-                <t name="chat">
-                    <t name="chat_static">
-                        <ImStatus t-if="correspondent.im_status" member="correspondent" size="props.size"/>
-                        <div t-else="" class="d-flex rounded-circle bg-inherit">
-                            <i class="fa-fw" t-att-class="sizeClass" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/>
-                        </div>
-                    </t>
+        <t t-set="class" t-value="'o-mail-ThreadIcon d-flex ' + props.className + ' ' + attClassObjectToString({
+            'fa-lg': props.size === 'lg' or props.size === 'large',
+            'o-xsmaller': props.size === 'sm' or props.size === 'small',
+        })"/>
+        <t t-set="attr" t-value="{ 'class': class }"/>
+        <t name="extra"/>
+        <t t-if="channel?.channel_type === 'channel'">
+            <div t-if="!channel.group_public_id" class="fa fa-globe o-fs-small" t-att="attr" title="Public Channel"/>
+        </t>
+        <t t-elif="channel?.channel_type === 'group'">
+            <t name="group"/>
+        </t>
+        <t t-elif="channel?.channel_type?.includes('chat') and correspondent">
+            <t name="chat">
+                <t name="chat_static">
+                    <ImStatus t-if="correspondent.im_status" className="class" member="correspondent" size="props.size" typing="props.typing"/>
+                    <div t-else="" class="d-flex rounded-circle bg-inherit">
+                        <i class="fa-fw" t-att="attr" t-attf-class="#{ defaultChatIcon.class }" t-att-title="defaultChatIcon.title"/>
+                    </div>
                 </t>
             </t>
-            <t t-elif="props.thread.model === 'mail.box'">
-                <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="sizeClass"/>
-                <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="sizeClass"/>
-                <div t-elif="props.thread.id === 'history'" class="fa fa-fw fa-history" t-att-class="sizeClass"/>
-            </t>
-        </div>
+        </t>
+        <t t-elif="props.thread.model === 'mail.box'">
+            <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att="attr"/>
+            <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att="attr"/>
+            <div t-elif="props.thread.id === 'history'" class="fa fa-fw fa-history" t-att="attr"/>
+        </t>
     </t>
 
 </templates>

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -3,10 +3,10 @@ import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { useThreadActions } from "@mail/core/common/thread_actions";
 import { AutoresizeInput } from "@mail/core/common/autoresize_input";
 import { ActionList } from "@mail/core/common/action_list";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { Thread } from "@mail/core/common/thread";
 import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { Composer } from "@mail/core/common/composer";
-import { ImStatus } from "@mail/core/common/im_status";
 import { useDynamicInterval } from "@mail/utils/common/misc";
 import { formatLocalDateTime } from "@mail/utils/common/dates";
 import { attClassObjectToString } from "@mail/utils/common/format";
@@ -19,11 +19,11 @@ export class DiscussContent extends Component {
     static components = {
         ActionList,
         AutoresizeInput,
+        DiscussAvatar,
         Thread,
         ThreadIcon,
         Composer,
         FileUploader,
-        ImStatus,
     };
     static props = ["thread?"];
     static template = "mail.DiscussContent";

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -7,7 +7,7 @@
         <div class="o-mail-DiscussContent-header ps-3 d-flex flex-shrink-0 align-items-center border-bottom border-dark o-border-opacity-15 gap-1 z-1 flex-grow-0" t-ref="header" t-att-class="{ 'py-1': !state.correspondentLocalDateTimeFormatted }">
             <t t-if="thread">
                 <div t-if="showThreadAvatar" class="o-mail-DiscussContent-threadAvatar position-relative align-self-center align-items-center bg-inherit">
-                    <img class="rounded-2 object-fit-cover" t-att-src="thread.channel?.parent_channel_id?.avatarUrl ?? thread.channel?.avatarUrl" alt="Thread Image"/>
+                    <DiscussAvatar thread="thread" size="26"/>
                     <FileUploader t-if="isThreadAvatarEditable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                         <t t-set-slot="toggler">
                             <a href="#" class="position-absolute z-1 h-100 w-100 rounded-2 start-0 bottom-0" title="Upload Avatar">
@@ -15,7 +15,6 @@
                             </a>
                         </t>
                     </FileUploader>
-                    <ImStatus t-if="thread.channel?.showImStatus" className="'o-mail-DiscussContent-headerImStatus position-absolute'" member="thread.channel.correspondent"/>
                 </div>
                 <t t-else="">
                     <ThreadIcon className="'align-self-center fs-3 my-2 opacity-75'" size="'large'" thread="thread"/>

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -65,7 +65,6 @@
                         <span t-else="" t-out="message?.previewText" t-att-class="{ 'opacity-75': message?.isEmpty }"/>
                     </t>
                     <t t-set-slot="icon">
-                        <ImStatus t-if="thread.channel?.channel_type === 'chat' and thread.channel.correspondent" member="thread.channel.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ' + (thread.channel.correspondent.isTyping ? 'ms-n2' : 'ms-n1')"/>
                         <CountryFlag t-if="thread.channel?.showCorrespondentCountry" country="thread.channel.correspondentCountry" class="'o-mail-NotificationItem-country position-absolute border shadow-sm'"/>
                     </t>
                 </NotificationItem>

--- a/addons/mail/static/src/core/public_web/notification_item.js
+++ b/addons/mail/static/src/core/public_web/notification_item.js
@@ -1,3 +1,4 @@
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { isToday } from "@mail/utils/common/dates";
 import { useHover } from "@mail/utils/common/hooks";
 import { MessageSeenIndicator } from "@mail/discuss/core/common/message_seen_indicator";
@@ -10,7 +11,7 @@ import { useService } from "@web/core/utils/hooks";
 const { DateTime } = luxon;
 
 export class NotificationItem extends Component {
-    static components = { ActionSwiper, MessageSeenIndicator };
+    static components = { ActionSwiper, DiscussAvatar, MessageSeenIndicator };
     static props = [
         "counter?",
         "datetime?",
@@ -25,6 +26,7 @@ export class NotificationItem extends Component {
         "slots?",
         "isActive?",
         "nameMaxLine?",
+        "persona?",
         "textMaxLine?",
         "thread?",
     ];

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -1,4 +1,5 @@
 .o-mail-NotificationItem {
+    --list-group-bg: transparent;
     outline: 1px solid transparent;
     outline-offset: -1px;
 

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 position-relative bg-transparent" t-on-click="onClick" t-ref="root" t-att-class="{
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 position-relative" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.important,
             'o-interest': props.muted === 0,
             'border-secondary': props.muted === 1,
@@ -13,8 +13,9 @@
             'o-px-2_5 o-py-1_5 gap-2': !ui.isSmall,
             'o-active': props.isActive,
         }">
-            <div class="o-mail-NotificationItem-avatarContainer position-relative bg-inherit flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
-                <img t-if="props.iconSrc" class="o_avatar w-100 h-100" t-att-class="{ 'rounded-3': ui.isSmall, 'rounded': !ui.isSmall }" alt="Notification Item Image" t-att-src="props.iconSrc"/>
+            <div class="o-mail-NotificationItem-avatarContainer position-relative flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
+                <DiscussAvatar t-if="props.thread or props.persona" thread="props.thread" persona="props.persona" size="ui.isSmall ? 52 : undefined"/>
+                <img t-else="" class="o_avatar w-100 h-100" t-att-class="{ 'rounded-3': ui.isSmall, 'rounded': !ui.isSmall }" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-if="props.slots and props.slots.icon" t-slot="icon"/>
             </div>
             <div class="d-flex flex-column flex-grow-1 align-self-start overflow-auto o-scrollbar-thin" t-att-class="{ 'o-ps-1_5': ui.isSmall, 'ps-1': !ui.isSmall }">

--- a/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
@@ -36,7 +36,7 @@
             t-on-click="(ev) => this.openThread(ev)"
             t-ref="root"
         >
-            <ThreadIcon className="'bg-inherit opacity-75 ' + (store.discuss.isSidebarCompact ? '' : 'o-ms-1_5 me-2 pt-1')" thread="mailbox" size="store.discuss.isSidebarCompact ? 'large' : 'medium'"/>
+            <ThreadIcon className="'bg-inherit opacity-75 justify-content-center ' + (store.discuss.isSidebarCompact ? '' : 'o-ms-1_5 me-2 pt-1')" thread="mailbox" size="store.discuss.isSidebarCompact ? 'large' : 'medium'"/>
             <t t-if="!store.discuss.isSidebarCompact">
                 <div class="me-2 text-truncate small opacity-75 opacity-100-hover" t-esc="mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ mailbox.counter === 0 ? 'me-3': '' }}"/>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -1,3 +1,4 @@
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { MessagingMenu } from "@mail/core/public_web/messaging_menu";
 import { onExternalClick } from "@mail/utils/common/hooks";
 import { useEffect } from "@odoo/owl";
@@ -7,7 +8,7 @@ import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { MessagingMenuQuickSearch } from "@mail/core/web/messaging_menu_quick_search";
 
-Object.assign(MessagingMenu.components, { MessagingMenuQuickSearch });
+Object.assign(MessagingMenu.components, { DiscussAvatar, MessagingMenuQuickSearch });
 
 patch(MessagingMenu.prototype, {
     setup() {
@@ -77,7 +78,6 @@ patch(MessagingMenu.prototype, {
             onClick: () => {
                 this.pwa.show();
             },
-            iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
             isShown: this.store.discuss.activeTab === "notification" && this.canPromptToInstall,
         };
@@ -86,7 +86,6 @@ patch(MessagingMenu.prototype, {
         return {
             body: _t("Stay tuned! Enable push notifications to never miss a message."),
             displayName: _t("Turn on notifications"),
-            iconSrc: this.store.odoobot.avatarUrl,
             partner: this.store.odoobot,
             isShown:
                 this.store.discuss.activeTab === "notification" && this.shouldAskPushPermission,

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -41,15 +41,12 @@
                 <NotificationItem
                     important="1"
                     isActive="state.activeIndex === itemIndex"
-                    iconSrc="installationRequest.iconSrc"
                     onClick="installationRequest.onClick"
                     onSwipeRight="hasTouch() ? { action: () => this.pwa.decline(), icon: 'fa-times-circle', bgColor: 'bg-warning' } : undefined"
+                    persona="installationRequest.partner"
                 >
                     <t t-set-slot="body" t-esc="installationRequest.body"/>
                     <t t-set-slot="name"><t  t-esc="installationRequest.displayName"/></t>
-                    <t t-set-slot="icon">
-                        <ImStatus persona="installationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
-                    </t>
                     <t t-set-slot="sideContent">
                         <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'o-pe-0_5': !ui.isSmall }">
                             <a t-if="ui.isSmall" class="btn fa fa-cloud-download px-0"/>
@@ -66,14 +63,11 @@
                 <NotificationItem
                     important="1"
                     isActive="state.activeIndex === itemIndex"
-                    iconSrc="notificationRequest.iconSrc"
                     onClick="() => notification.requestPermission()"
+                    persona="notificationRequest.partner"
                 >
                     <t t-set-slot="body" t-esc="notificationRequest.body"/>
                     <t t-set-slot="name"><t t-esc="notificationRequest.displayName"/></t>
-                    <t t-set-slot="icon">
-                        <ImStatus persona="notificationRequest.partner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
-                    </t>
                     <t t-set-slot="sideContent">
                         <div class="d-flex align-items-center justify-content-center o-gap-1_5" t-att-class="{ 'o-pe-0_5': !ui.isSmall }">
                             <a t-if="ui.isSmall" class="btn fa fa-bell px-0"/>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -1,4 +1,4 @@
-import { ImStatus } from "@mail/core/common/im_status";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 
 import { Component, onWillStart, useState } from "@odoo/owl";
@@ -9,7 +9,7 @@ import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
 
 export class ChannelInvitation extends Component {
-    static components = { ImStatus, ActionPanel };
+    static components = { ActionPanel, DiscussAvatar };
     static defaultProps = { hasSizeConstraints: false };
     static props = [
         "autofocus?",

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.scss
@@ -31,11 +31,6 @@
     }
 }
 
-.o-discuss-ChannelInvitation-avatar {
-    width: 32px;
-    aspect-ratio: 1;
-}
-
 .o-discuss-ChannelInvitation-invitationBox {
     position: sticky;
     bottom: - map-get($spacers, 2); // Ignore p-2 class of ActionPanel

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -75,11 +75,8 @@
             t-on-click="() => selectablePartner ? this.onClickSelectablePartner(selectablePartner) : this.onClickSelectableEmail(selectableEmailAddress) "
         >
             <div class="d-flex align-items-center p-1 bg-inherit">
-                <div class="o-discuss-ChannelInvitation-avatar position-relative d-flex flex-shrink-0 bg-inherit">
-                    <t t-if="selectablePartner">
-                        <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="selectablePartner.avatarUrl"/>
-                        <ImStatus persona="selectablePartner" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'" size="'md'"/>
-                    </t>
+                <div class="position-relative d-flex flex-shrink-0 bg-inherit">
+                    <DiscussAvatar t-if="selectablePartner" persona="selectablePartner"/>
                     <div t-else="" class="w-100 h-100 d-flex align-items-center justify-content-center rounded-3 bg-primary text-white">
                         <i class="fa fa-envelope"/>
                     </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member.js
@@ -1,4 +1,4 @@
-import { ImStatus } from "@mail/core/common/im_status";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 
 import { Component, useState } from "@odoo/owl";
@@ -6,7 +6,7 @@ import { Component, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 export class ChannelMember extends Component {
-    static components = { ImStatus, ActionPanel };
+    static components = { ActionPanel, DiscussAvatar };
     static props = ["member"];
     static template = "discuss.ChannelMember";
 

--- a/addons/mail/static/src/discuss/core/common/channel_member.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_member.scss
@@ -12,8 +12,3 @@
         background-color: var(--discuss-ChannelMember-hoverBg, mix($gray-100, $gray-200));
     }
 }
-
-.o-discuss-ChannelMember-avatar {
-    width: 32px;
-    aspect-ratio: 1;
-}

--- a/addons/mail/static/src/discuss/core/common/channel_member.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member.xml
@@ -2,10 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="discuss.ChannelMember">
         <div class="o-discuss-ChannelMember d-flex align-items-center p-1 bg-inherit rounded-3" t-att-class="attClass" t-on-click.stop="(ev) => this.onClickAvatar(ev)">
-            <div class="bg-inherit o-discuss-ChannelMember-avatar position-relative d-flex flex-shrink-0 rounded-3">
-                <img class="w-100 h-100 rounded-3 object-fit-cover" t-att-src="member.avatarUrl"/>
-                <ImStatus member="member" className="'position-absolute top-100 start-100 translate-middle mt-n1 ' + (member.isTyping ? 'ms-n2' : 'ms-n1')" size="'md'"/>
-            </div>
+            <DiscussAvatar member="member"/>
             <div t-ref="displayName" class="d-flex overflow-hidden flex-column lh-sm">
                 <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name" t-att-title="member.name"/>
             </div>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -435,6 +435,20 @@ export class DiscussChannel extends Record {
     get showImStatus() {
         return this.channel_type === "chat" && this.correspondent;
     }
+    /**
+     * @param {Object} [param0={}]
+     * @param {boolean} [param0.ignoreTyping=false] Whether the "is typing" should be ignored.
+     *   If the condition for showing of thread icon is independent of "is typing", this has no effect.
+     */
+    showThreadIcon({ ignoreTyping = false } = {}) {
+        return (
+            this.channel.channel_type === "chat" ||
+            (this.channel.channel_type === "channel" && !this.channel.group_public_id) ||
+            (this.channel.channel_type === "group" &&
+                !ignoreTyping &&
+                this.channel.hasOtherMembersTyping)
+        );
+    }
     get showUnreadBanner() {
         return this.self_member_id?.message_unread_counter_ui > 0;
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -1,8 +1,7 @@
 import { CountryFlag } from "@mail/core/common/country_flag";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { DiscussSidebarChannelActions } from "@mail/discuss/core/public_web/discuss_app/sidebar/channel_actions";
 import { DiscussSidebarSubchannel } from "@mail/discuss/core/public_web/discuss_app/sidebar/subchannel";
-import { ImStatus } from "@mail/core/common/im_status";
-import { ThreadIcon } from "@mail/core/common/thread_icon";
 import { useHover, UseHoverOverlay } from "@mail/utils/common/hooks";
 
 import { useService } from "@web/core/utils/hooks";
@@ -23,11 +22,10 @@ export class DiscussSidebarChannel extends Component {
     static props = ["channel"];
     static components = {
         CountryFlag,
+        DiscussAvatar,
         DiscussSidebarChannelActions,
         DiscussSidebarSubchannel,
         Dropdown,
-        ImStatus,
-        ThreadIcon,
         UseHoverOverlay,
     };
 
@@ -131,14 +129,6 @@ export class DiscussSidebarChannel extends Component {
         return (
             this.isSelfOrThreadActive &&
             !(this.channel.self_member_id?.mute_until_dt && sub.self_member_id?.mute_until_dt)
-        );
-    }
-
-    get showThreadIcon() {
-        return (
-            this.channel.channel_type === "chat" ||
-            (this.channel.channel_type === "channel" && !this.channel.group_public_id) ||
-            (this.channel.channel_type === "group" && this.channel.hasOtherMembersTyping)
         );
     }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -31,9 +31,8 @@
             t-ref="root"
         >
             <div class="o-mail-DiscussSidebarChannel-itemMain border-0 rounded-start-2 text-reset d-flex align-items-center p-0 flex-grow-1" t-att-class="{ 'justify-content-center': store.discuss.isSidebarCompact, 'overflow-hidden': !store.discuss.isSidebarCompact }" t-att-title="store.discuss.isSidebarCompact ? undefined : channel.displayName">
-                <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" style="width:26px;height:26px;" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
-                    <img class="w-100 h-100 rounded-2 object-fit-cover" t-att-class="threadAvatarAttClass" t-att-src="channel.avatarUrl" alt="Thread Image"/>
-                    <ThreadIcon t-if="showThreadIcon" thread="channel.thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
+                <div class="position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
+                    <DiscussAvatar channel="channel" size="26"/>
                 </div>
                 <div t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden mx-2 text-start flex-grow-1" t-att-class="itemNameAttClass">
                     <div class="d-flex justify-content-between align-items-baseline o-min-width-0">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -4,9 +4,9 @@ import { Component, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { ImStatus } from "@mail/core/common/im_status";
 import { useService } from "@web/core/utils/hooks";
 import { Dialog } from "@web/core/dialog/dialog";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation";
 
 const commandSetupRegistry = registry.category("command_setup");
@@ -86,7 +86,7 @@ class CreateChannelDialog extends Component {
 }
 
 class DiscussCommand extends Component {
-    static components = { ImStatus };
+    static components = { DiscussAvatar };
     static template = "mail.DiscussCommand";
     static props = {
         counter: { type: Number, optional: true },

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -5,8 +5,7 @@
         <div class="o-mail-DiscussCommand o_command_default d-flex align-items-center ps-3 pe-4" t-att-class="{ 'o-uiSmall': ui.isSmall }">
             <i t-if="props.channel" class="fa-fw opacity-75 text-muted me-2" t-att-class="props.channel.parent_channel_id ? 'fa fa-comments-o' : props.channel.discussAppCategory?.icon ?? 'oi oi-user opacity-0'"/>
             <i t-elif="props.persona" class="oi fa-fw oi-user opacity-75 text-muted me-2"/>
-            <img class="o-mail-DiscussCommand-img rounded-3 me-2 object-fit-cover shadow-sm" t-if="props.imgUrl" t-att-src="props.imgUrl" t-att-class="{ 'o-uiSmall': ui.isSmall }"/>
-            <ImStatus t-if="props.persona" className="'me-1'" persona="props.persona"/>
+            <DiscussAvatar t-if="props.channel or props.persona" channel="props.channel" persona="props.persona" size="ui.isSmall ? 32 : 26" className="'me-2'"/>
             <span class="o-mail-DiscussCommand-nameContainer pe-1 text-ellipsis d-flex align-items-center fw-bold" t-att-class="{ 'o-action': props.action }">
                 <t t-if="props.channel?.parent_channel_id">
                     <span class="text-truncate flex-shrink-0 opacity-75 mw-50 small" t-esc="props.channel?.parent_channel_id.displayName"/>

--- a/addons/mail/static/src/discuss/core/web/burger_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/web/burger_menu_patch.js
@@ -1,9 +1,9 @@
-import { ImStatus } from "@mail/core/common/im_status";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { BurgerMenu } from "@web/webclient/burger_menu/burger_menu";
 
-Object.assign(BurgerMenu.components, { ImStatus });
+Object.assign(BurgerMenu.components, { DiscussAvatar });
 
 patch(BurgerMenu.prototype, {
     setup() {

--- a/addons/mail/static/src/discuss/core/web/burger_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/burger_menu_patch.xml
@@ -2,10 +2,7 @@
 <templates xml:space="preserve">  
     <t t-inherit="web.BurgerMenu" t-inherit-mode="extension">
         <xpath expr="//img[hasclass('o_burger_menu_avatar')]" position="replace">
-            <div class="position-relative d-flex flex-shrink-0 bg-inherit">
-                <t>$0</t>
-                <ImStatus className="'o-web-UserMenu-imStatus position-absolute'" persona="store.self" size="'md'"/>
-            </div>
+            <DiscussAvatar persona="store.self" size="26"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/web/user_menu_patch.js
+++ b/addons/mail/static/src/discuss/core/web/user_menu_patch.js
@@ -1,9 +1,9 @@
-import { ImStatus } from "@mail/core/common/im_status";
+import { DiscussAvatar } from "@mail/core/common/discuss_avatar";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { UserMenu } from "@web/webclient/user_menu/user_menu";
 
-Object.assign(UserMenu.components, { ImStatus });
+Object.assign(UserMenu.components, { DiscussAvatar });
 
 patch(UserMenu.prototype, {
     setup() {

--- a/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<templates xml:space="preserve">  
+<templates xml:space="preserve">
     <t t-inherit="web.UserMenu" t-inherit-mode="extension">
         <xpath expr="//img[hasclass('o_user_avatar')]" position="replace">
-            <div class="position-relative d-flex flex-shrink-0">
-                <t>$0</t>
-                <ImStatus className="'o-web-UserMenu-imStatus position-absolute'" persona="store.self" size="'md'"/>
-            </div>
+            <DiscussAvatar persona="store.self" size="26"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/typing/common/thread_icon_patch.scss
+++ b/addons/mail/static/src/discuss/typing/common/thread_icon_patch.scss
@@ -1,0 +1,7 @@
+.o-mail-ThreadIcon-typingBg {
+    padding: 2px;
+}
+
+.o-mail-ThreadIcon-typingContainer {
+    padding: 1px;
+}

--- a/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
+++ b/addons/mail/static/src/discuss/typing/common/thread_icon_patch.xml
@@ -2,17 +2,17 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.ThreadIcon" t-inherit-mode="extension">
         <xpath expr="//*[@name='group']" position="replace">
-            <t t-if="channel.hasOtherMembersTyping" t-call="mail.ThreadIcon.typing"/>
+            <t t-if="channel.hasOtherMembersTyping and props.typing" t-call="mail.ThreadIcon.typing"/>
             <t t-else="">$0</t>
         </xpath>
         <xpath expr="//t[@name='chat']" position="replace">
-            <t t-if="channel.hasOtherMembersTyping" t-call="mail.ThreadIcon.typing"/>
+            <t t-if="channel.hasOtherMembersTyping and props.typing" t-call="mail.ThreadIcon.typing"/>
             <t t-else="">$0</t>
         </xpath>
     </t>
     <t t-name="mail.ThreadIcon.typing">
-        <div t-if="channel.hasOtherMembersTyping" class="bg-inherit rounded-pill" style="padding: 1px;">
-            <div class="bg-success rounded-pill" style="padding: 3px;">
+        <div class="o-mail-ThreadIcon-typingContainer rounded-pill" t-att="attr">
+            <div class="o-mail-ThreadIcon-typingBg bg-success rounded-pill">
                 <Typing channel="channel" size="['sm', 'smaller'].includes(props.size) ? 'sm' : 'md'" displayText="false" />
             </div>
         </div>

--- a/addons/mail/static/src/discuss/typing/common/typing.scss
+++ b/addons/mail/static/src/discuss/typing/common/typing.scss
@@ -1,5 +1,6 @@
 .o-discuss-Typing-dot {
     animation: o_mail_Typing_animation 1.5s linear infinite;
+    filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, .25));
     background-color: $gray-500;
 
     .o-mail-ImStatus &, .o-mail-ThreadIcon & {
@@ -7,34 +8,39 @@
     }
 
     &.o-sizeMedium {
-        width: 5px;
-        height: 5px;
-    }
-
-    &.o-sizeSmall {
         width: 4px;
         height: 4px;
     }
 
+    &.o-sizeSmall {
+        width: 3px;
+        height: 3px;
+    }
+
     &.o-discuss-Typing-dot2 {
-        animation-delay: -1.35s;
+        animation-delay: 0.25s;
     }
 
     &.o-discuss-Typing-dot3 {
-        animation-delay: -1.2s;
+        animation-delay: .5s;
     }
 }
 
 .o-discuss-Typing-icon {
+    padding: 1px 0px;
     gap: 1px;
 }
 
 @keyframes o_mail_Typing_animation {
-    0%, 40%, 100% {
+    0%, 25%, 75% {
         opacity: initial;
+        transform: scale(1);
+        filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, .15));
     }
-    20% {
-        opacity: 25%;
+    50% {
+        opacity: 75%;
+        transform: scale(.85) translateY(-1px);
+        filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, .15));
     }
 }
 

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -494,7 +494,7 @@ test("chat window should open when receiving a new DM", async () => {
     );
     await contains(".o-mail-ChatBubble");
     await contains(".o-mail-ChatBubble-counter:text('1')");
-    await contains(".o-mail-ChatBubble .o-mail-ImStatus [title='Online']");
+    await contains(".o-mail-ChatBubble .o-mail-ImStatus[title='Online']");
     await assertChatBubbleAndWindowImStatus("DemoUser", 1);
 });
 

--- a/addons/mail/static/tests/discuss/typing/typing.test.js
+++ b/addons/mail/static/tests/discuss/typing/typing.test.js
@@ -633,7 +633,7 @@ test("[text composer] chat: correspondent is typing", async () => {
     });
     await start();
     await openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-threadIcon");
+    await contains(".o-mail-DiscussSidebarChannel .o-mail-ThreadIcon");
     await contains(".fa-circle.text-success");
     // simulate receive typing notification from demo "is typing"
     withUser(userId, () =>
@@ -673,7 +673,7 @@ test("chat: correspondent is typing", async () => {
     const composerService = getService("mail.composer");
     composerService.setHtmlComposer();
     await openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel .o-mail-DiscussSidebarChannel-threadIcon");
+    await contains(".o-mail-DiscussSidebarChannel .o-mail-ThreadIcon");
     await contains(".fa-circle.text-success");
     withUser(userId, () =>
         rpc("/discuss/channel/notify_typing", {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -347,15 +347,15 @@ test("sidebar: chat im_status rendering", async () => {
     ]);
     await start();
     await openDiscuss();
-    await contains(".o-mail-DiscussSidebarChannel-threadIcon", { count: 3 });
+    await contains(".o-mail-DiscussSidebarChannel .o-mail-ThreadIcon", { count: 3 });
     await contains(".o-mail-DiscussSidebarChannel:has(:text('Partner1'))", {
-        contains: [".o-mail-ThreadIcon [title='Offline']"],
+        contains: [".o-mail-ThreadIcon[title='Offline']"],
     });
     await contains(".o-mail-DiscussSidebarChannel:has(:text('Partner2'))", {
         contains: [".fa-circle.text-success"],
     });
     await contains(".o-mail-DiscussSidebarChannel:has(:text('Partner3'))", {
-        contains: [".o-mail-ThreadIcon [title='Idle']"],
+        contains: [".o-mail-ThreadIcon[title='Idle']"],
     });
 });
 
@@ -1818,17 +1818,17 @@ test("Partner IM status is displayed as thread icon in top bar of channels of ty
     await start();
     await openDiscuss();
     await click(".o-mail-DiscussSidebarChannel-itemName:text('Michel Online')");
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus [title='Online']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Online']");
     await click(".o-mail-DiscussSidebarChannel-itemName:text('Jacqueline Offline')");
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus [title='Offline']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Offline']");
     await click(".o-mail-DiscussSidebarChannel-itemName:text('Nabuchodonosor Idle')");
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus [title='Idle']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Idle']");
     await click(".o-mail-DiscussSidebarChannel-itemName:text('Robert Fired')");
     await contains(
-        ".o-mail-DiscussContent-header .o-mail-ImStatus [title='No IM status available']"
+        ".o-mail-DiscussContent-header .o-mail-ImStatus[title='No IM status available']"
     );
     await click(".o-mail-DiscussSidebarChannel-itemName:text('OdooBot')");
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus [title='Bot']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Bot']");
 });
 
 test("Thread avatar image is displayed in top bar of channels of type 'group'", async () => {

--- a/addons/mail/static/tests/discuss_app/im_status.test.js
+++ b/addons/mail/static/tests/discuss_app/im_status.test.js
@@ -25,7 +25,7 @@ test("initially online", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i[title='Online']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Online']");
 });
 
 test("initially offline", async () => {
@@ -40,7 +40,7 @@ test("initially offline", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i[title='Offline']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Offline']");
 });
 
 test("initially away", async () => {
@@ -55,7 +55,7 @@ test("initially away", async () => {
     });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i[title='Idle']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Idle']");
 });
 
 test("change icon on change partner im_status", async () => {
@@ -65,28 +65,28 @@ test("change icon on change partner im_status", async () => {
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i[title='Online']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Online']");
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "offline" });
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "offline",
         presence_status: "offline",
     });
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i[title='Offline']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Offline']");
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "away" });
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "away",
         presence_status: "away",
     });
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i[title='Idle']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Idle']");
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
     pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
         partner_id: serverState.partnerId,
         im_status: "online",
         presence_status: "online",
     });
-    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus i[title='Online']");
+    await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='Online']");
 });
 
 test("show im status in messaging menu preview of chat", async () => {


### PR DESCRIPTION
*: hr_holidays, im_livechat

Before this commit, IM status and thread icon were used a lot as bottom-right floating icon on a conversation or user avatar. Each context that wanted this visual of avatar + floating icon had to craft by hand the avatar sizing and icon position, which has many drawbacks:

- image and icon sizing and positioning needs manual tweak in each context, requiring lots of effort.
- very-prone to inconsistencies due to high maintenance to make each context work. Current state had many inconsistencies.
- handling of mask of floating icon is poor, with `.bg-inherit` on parented chaining that is hard to enforce and in some cases, just don't work at all

This commit improves by introducing a new component `DiscussAvatar`, that accepts `channel`, `thread`, channel's `member` or `persona` to display avatar and conversation / person icon in the bottom-right corner. This new component has the following benefits:

- one component to handle all the cases of conversation / person avatar with floating icon / im status, drastically reducing maintenance effort and increasing significantly UI consistency.
- new technique to mask image with floating icon that works all the time thanks to the use of `SVG`'s mask.

Part of Task-5867464

https://github.com/odoo/enterprise/pull/105814

Before / After
<img width="2032" height="1038" alt="Screenshot 2026-01-30 at 18 41 29" src="https://github.com/user-attachments/assets/472e9e99-3dd1-4053-8f47-ba5a604eedf4" />
<img width="2032" height="1036" alt="Screenshot 2026-01-30 at 18 49 51" src="https://github.com/user-attachments/assets/2d289710-c33e-4034-84ca-e624e8a1ff51" />

Improvements to Discuss command:
<img width="621" height="606" alt="Screenshot 2026-01-30 at 18 53 22" src="https://github.com/user-attachments/assets/afc145d1-3af0-49bf-b73e-dc16b6120a93" />

To user mentions:
<img width="386" height="121" alt="Screenshot 2026-01-30 at 18 53 47" src="https://github.com/user-attachments/assets/89638307-86b9-4a46-b4b7-372c818dc52c" />

+ typing icon has been slightly improved.