### PR TITLE
[FIX] web: align arrow direction of date picker in RTL

### DIFF
--- a/addons/web/static/src/core/main_components_container.js
+++ b/addons/web/static/src/core/main_components_container.js
@@ -2,6 +2,7 @@ import { Component, xml } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { useRegistry } from "@web/core/registry_hook";
 import { ErrorHandler } from "@web/core/utils/components";
+import { localization } from "@web/core/l10n/localization";
 
 const mainComponents = registry.category("main_components");
 
@@ -14,7 +15,7 @@ export class MainComponentsContainer extends Component {
     static components = { ErrorHandler };
     static props = {};
     static template = xml`
-    <div class="o-main-components-container">
+    <div class="o-main-components-container" t-att-class="{'o_rtl': this.isRTL}">
         <t t-foreach="Components.entries" t-as="C" t-key="C[0]">
             <ErrorHandler onError="error => this.handleComponentError(error, C)">
                 <t t-component="C[1].Component" t-props="C[1].props"/>
@@ -25,6 +26,7 @@ export class MainComponentsContainer extends Component {
 
     setup() {
         this.Components = useRegistry(mainComponents);
+        this.isRTL = localization.direction === "rtl";
     }
 
     handleComponentError(error, C) {


### PR DESCRIPTION
### Steps to reproduce:
- Download Rental and eCommerce apps.
- Install an RTL language (e.g., Arabic) on the website.
- Create a rental and go to website.
- Try to pick a date for the rental.

### Issue:
When the website is viewed in an RTL language, the navigation arrows of the date picker are displayed in the wrong direction. This happens because the date picker is not inside `o_rtl` component, but inside `o-main-components-container` component. So, when `o_rtl` is called in css (for example):
https://github.com/odoo/odoo/blob/2264f330859b79010b227e3a9fda1075de8ed4e8/addons/web/static/lib/odoo_ui_icons/style.css#L67-L76
Since the arrows are not inside `o_rtl`, the transformation doesn't apply to them.

### Solution:
The `o_rtl` class has been appended to `o-main-components-container` class in case of a RTL language, so that had the css file contain rules for `o_rtl`, they would be applied automatically.

opw-5498615