### PR TITLE
[FIX] uom: _check_qty precision based on uom rounding

### DIFF
--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -648,6 +648,25 @@ class StockQuant(TransactionCase):
         self.assertEqual(quant.lot_id.id, lot1.id)
         self.assertEqual(quant.in_date, in_date2)
 
+    def test_quant_rounding(self):
+        """ In the case where the product group has the Reserve Only Full Packagings selected,
+        then another check occurs calling _check_qty. This method rounds the available quantity
+        which will cause issues if the package uom is the same as the product uom. Test to see the
+        quantity is correct if the uoms are the same.
+        """
+        QUANTITY = 22.43
+        product = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+            'categ_id': self.env.ref('product.product_category_goods').id,
+        })
+        product.product_tmpl_id.categ_id.packaging_reserve_method = 'full'
+        self.env['stock.quant']._update_available_quantity(product, self.stock_location, QUANTITY)
+
+        quants = self.env['stock.quant'].with_context(packaging_uom_id=product.uom_id)._get_reserve_quantity(product, self.stock_location, QUANTITY)
+
+        self.assertEqual(quants[0][1], QUANTITY, 'Reserved Quantity should be rounded to UOM precision.')
+
     def test_closest_removal_strategy_tracked(self):
         """ Check that the Closest location strategy correctly applies when you have multiple lot received
         at different locations for a tracked product.

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -147,6 +147,8 @@ class UomUom(models.Model):
         """
         self.ensure_one()
         packaging_qty = self._compute_quantity(1, uom_id)
+        if self == uom_id:
+            return product_qty
         # We do not use the modulo operator to check if qty is a mltiple of q. Indeed the quantity
         # per package might be a float, leading to incorrect results. For example:
         # 8 % 1.6 = 1.5999999999999996

--- a/addons/uom/tests/test_uom.py
+++ b/addons/uom/tests/test_uom.py
@@ -36,3 +36,15 @@ class TestUom(UomCommon):
 
         qty = self.uom_unit._compute_quantity(2, product_uom)
         self.assertEqual(qty, 1, "Converted quantity should be rounded up.")
+
+    def test_30_quantity(self):
+        """ _check_qty rounds the available quantity of a product. To prevent rounding issue,
+        there should be no rounding if the product uom is the same as the package uom.
+        """
+        uom = self.uom_unit
+        quantity = 22.43
+        rounding_method = 'DOWN'
+
+        result = self.uom_unit._check_qty(quantity, uom, rounding_method)
+
+        self.assertEqual(result, quantity, 'Quantity should not be rounded.')


### PR DESCRIPTION
When a product is part of a group with Reserve Only Full Packagings
enabled, another check occurs in _check_qty. This rounds with a precision
of 1.0 the down rounding method. In the case that the quantity was a
decimal, such as 22.4, this would be rounded to 22. In the next transfer
the quantity would then only be 22 instead of the expected 22.4. This
would also cause any packages to not be added as the quantity and demand
are not equal.

If the uom of the product and package are the same we dont need this
package check. Which also prevents the rounding issue.

This fix insures the _check_qty method does not round in cases it does
not need to. (self == uom_id)

How to reproduce:

    In Settings:
        Enable Units of Measure & Packagings
        Enable Multi-Step Routes
    In Warehouses
        Set Outgoing Shipments to Pick then Deliver (2 steps)
    In Inventory
        Create a new product
        Give the product a category
        Set category Reserve Packagings to Reserve Only Full Packagings
        Set on-hand amount

    Workflow:
    Create a sales order
        Create a new Company
        Add product with decimal quantity (1.3)
        Confirm SO
    Go to the sale order delivery
        Validate
    Go to the next transfer
        Quantity will now be rounded (1.0)

opw-5486932
