### PR TITLE
[FIX] l10n_it_edi: Prevent base64 exceptions when importing TXT.

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1556,11 +1556,13 @@ class AccountMove(models.Model):
                     message_to_log += self._l10n_it_edi_import_line(element, move_line, extra_info)
 
             for element in tree.xpath('.//Allegati'):
-                self.l10n_it_edi_attachment_name = get_text(element, './/NomeAttachment')
-                self.l10n_it_edi_attachment_file = b64decode(get_text(element, './/Attachment'))
+                raw_name = get_text(element, './/NomeAttachment') or ''
+                raw_ext = get_text(element, './/FormatoAttachment') or ''
+                self.l10n_it_edi_attachment_name = f"{raw_name}.{raw_ext}" if raw_ext else raw_name
+                self.l10n_it_edi_attachment_file = get_text(element, './/Attachment')
                 self.sudo().message_post(
                     body=(_("Attachment from XML")),
-                    attachments=[(self.l10n_it_edi_attachment_name, self.l10n_it_edi_attachment_file)],
+                    attachments=[(self.l10n_it_edi_attachment_name, b64decode(self.l10n_it_edi_attachment_file))],
                 )
 
             global_enasarco_lines = []


### PR DESCRIPTION
When importing invoices, some text files encoded in `<Attachments>` cause a traceback and prevent the XML from importing. This error appears to be the direct result of decoding the text files twice, introduced in PR #212726.

Steps to reproduce:

1. Install `l10n_it_edi`.
2. Create a customer invoice for Biscotti Oslengi, then send the xml to the SDI. Download the XML file.
3. In a text editor, replace the base64-encoded PDF information inside `<Attachments>` with `VGhpcyBpcyBhIHRlc3Qgc3RyaW5nLg0K`. This is the base64 encoded string `"This is a test string.\r\n"`.
4. Change the `<FormatoAttachment>` from `PDF` to `TXT`.
5. Upload the edited invoice file to Accounting > Customers > Invoices.
6. The exception `Invalid base64-encoded string` is raised.

[opw-5388360](https://www.odoo.com/odoo/unassigned-tasks/5388360)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
