### PR TITLE
Fix: POS receipt To Pay amount calculation

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -51,7 +51,7 @@
                     </div>
                     <div class="pos-receipt-amount receipt-to-pay">
                         To Pay
-                        <span t-out='formatCurrency(order.totalDue)' class="pos-receipt-right-align font-monospace"/>
+                        <span t-out='formatCurrency(order.totalDue + order.appliedRounding)' class="pos-receipt-right-align font-monospace"/>
                     </div>
                 </t>
 

--- a/doc/cla/individual/borgbuster.md
+++ b/doc/cla/individual/borgbuster.md
@@ -1,0 +1,11 @@
+Indonesia, 2026-01-29
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Vasu Mahajan vasumahajan@proton.me https://github.com/borgbuster


### PR DESCRIPTION
The To Pay line should display the total amount after rounding adjustment
(totalDue + appliedRounding), not just the pre-rounded totalDue.

This ensures the receipt correctly shows the final amount customer needs to pay.

Example:
- Total: 106,502.00
- Rounding: +498.00
- To Pay: 107,000.00 (was incorrectly showing 106,502.00)

Fixes: Receipt rounding line not showing correct payment amount