### PR TITLE
[IMP] website_sale_stock: validate product availability for stock notifications

### DIFF
--- a/addons/website_sale_stock/controllers/main.py
+++ b/addons/website_sale_stock/controllers/main.py
@@ -5,28 +5,37 @@ from odoo.addons.website_sale.controllers import main as website_sale_controller
 from odoo.tools import email_re
 from odoo import http, _
 from odoo.http import request
-from werkzeug.exceptions import BadRequest
+from odoo.exceptions import AccessError, ValidationError
 
 
 class WebsiteSale(website_sale_controller.WebsiteSale):
-    @http.route(['/shop/add/stock_notification'], type="json", auth="public", website=True)
     def add_stock_email_notification(self, email, product_id):
         if not email_re.match(email):
-            raise BadRequest(_("Invalid Email"))
+            raise ValidationError(_("Invalid Email"))
 
+        is_public_user = request.website.is_public_user()
         product = request.env['product.product'].browse(int(product_id))
+
+        # check if product available
+        if not product.exists() or not product._is_add_to_cart_allowed():
+            raise ValidationError(_("The given product does not exist."))
+
         partners = request.env['res.partner'].sudo()._mail_find_partner_from_emails([email], force_create=True)
         partner = partners[0]
+
+        if is_public_user and partner.user_ids.exists():
+            raise AccessError(_("Please sign in to proceed, then try again."))
 
         if not product._has_stock_notification(partner):
             product.sudo().stock_notification_partner_ids += partner
 
-        if request.website.is_public_user():
+        if is_public_user:
             request.session['product_with_stock_notification_enabled'] = request.session.get(
                 'product_with_stock_notification_enabled',
                 set()
             ) | {product_id}
             request.session['stock_notification_email'] = email
+
 
     def _prepare_product_values(self, product, category='', search='', **kwargs):
         values = super()._prepare_product_values(product, category, search, **kwargs)

--- a/addons/website_sale_stock/static/src/js/website_sale.js
+++ b/addons/website_sale_stock/static/src/js/website_sale.js
@@ -2,6 +2,8 @@
 
 import { WebsiteSale } from '@website_sale/js/website_sale';
 import { isEmail } from '@web/core/utils/strings';
+import { _t } from "@web/core/l10n/translation";
+import { RPCError } from "@web/core/network/rpc_service";
 
 WebsiteSale.include({
     events: Object.assign({}, WebsiteSale.prototype.events, {
@@ -33,9 +35,10 @@ WebsiteSale.include({
         const stockNotificationEl = ev.currentTarget.closest('#stock_notification_div');
         const formEl = stockNotificationEl.querySelector('#stock_notification_form');
         const email = stockNotificationEl.querySelector('#stock_notification_input').value.trim();
+        const defaultMessage = _t('Invalid email');
 
         if (!isEmail(email)) {
-            return this._displayEmailIncorrectMessage(stockNotificationEl);
+            return this._displayEmailIncorrectMessage(defaultMessage, stockNotificationEl);
         }
 
         this.rpc("/shop/add/stock_notification", {
@@ -47,12 +50,14 @@ WebsiteSale.include({
             message.classList.remove('d-none');
             formEl.classList.add('d-none');
         }).catch((error) => {
-            this._displayEmailIncorrectMessage(stockNotificationEl);
+            let message = error instanceof RPCError ? error.data.message : defaultMessage;
+            this._displayEmailIncorrectMessage(message, stockNotificationEl);
         });
     },
 
-    _displayEmailIncorrectMessage(stockNotificationEl) {
+    _displayEmailIncorrectMessage(message, stockNotificationEl) {
         const incorrectIconEl = stockNotificationEl.querySelector('#stock_notification_input_incorrect');
+        incorrectIconEl.htmlContent = `<i class="fa fa-times text-danger"/> ${message}`;
         incorrectIconEl.classList.remove('d-none');
     }
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently, in the website_sale_stock module, there is no backend validation when subscribing to notifications for products without stock. This allows public users to potentially use emails that belong to registered accounts.

Current behavior before PR:
- Users could subscribe to stock notifications for products that don’t exist or cannot be added (no stock).
- Public users could use emails already associated with registered accounts, allowing them to subscribe on behalf of another user.
- No validation is enforced, leading to potential security issues.

Desired behavior after PR is merged:
- Adding a subscription for a non-existent or unavailable product raises a ValidationError.
- Public users trying to subscribe with an email that belongs to a registered user receive an AccessError prompting them to sign in first.
- Backend validation prevents misuse of registered user emails and improves security.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
