### PR TITLE
19.0 fix pos receipt to pay

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -6,292 +6,323 @@ import { formatCurrency } from "@web/core/currency";
 const CONSOLE_COLOR = "#4EFF4D";
 
 export class PosOrderAccounting extends Base {
-    static accountingFields = new Set(["pricelist_id", "fiscal_position_id"]);
+  static accountingFields = new Set(["pricelist_id", "fiscal_position_id"]);
 
-    setup() {
-        super.setup();
+  setup() {
+    super.setup();
 
-        this._prices = {};
-        this.triggerRecomputeAllPrices();
+    this._prices = {};
+    this.triggerRecomputeAllPrices();
+  }
+
+  triggerRecomputeAllPrices() {
+    if (!this._prices) {
+      return;
+    }
+    this._prices.original = this._constructPriceData();
+    this._prices.unit = this._constructPriceData({
+      baseLineOpts: { quantity: 1 },
+    });
+  }
+
+  /**
+   * Currency formatted prices, these getters already handle included/excluded tax configuration.
+   * They must be used each time a price is displayed to the user.
+   */
+  get currencyDisplayPrice() {
+    return formatCurrency(this.displayPrice, this.currency.id);
+  }
+
+  get currencyDisplayPriceIncl() {
+    return formatCurrency(this.priceIncl, this.currency.id);
+  }
+
+  get currencyDisplayPriceExcl() {
+    return formatCurrency(this.priceExcl, this.currency.id);
+  }
+
+  get currencyAmountTaxes() {
+    return formatCurrency(this.amountTaxes, this.currency.id);
+  }
+
+  /**
+   * Display price depending on the tax configuration (included or excluded).
+   */
+  get displayPrice() {
+    return this.config.iface_tax_included === "total"
+      ? this.currency.round(this.priceIncl)
+      : this.currency.round(this.priceExcl);
+  }
+
+  /**
+   * Remaining due take into account the rounding of the order, the rounding can be configured
+   * in two different ways:
+   *
+   * 1) Rounding applied only on cash payments
+   *    In this case the remaining due is rounded only if there is at least one cash payment line.
+   *    and the remaining due is less than the rounding tolerance.
+   *
+   * 2) Rounding applied on all payment methods
+   *    In this case the remaining due is always rounded even if a card payment method is used.
+   *    The remaining due is rounded if it is less than the rounding tolerance. No payment method
+   *    is rounded in this case, the whole order is rounded instead.
+   *
+   * !!! Keep in mind that from 19.0 only one cash payment line can be used in an order !!!
+   */
+  get remainingDue() {
+    const isNegative = this.totalDue < 0;
+    const total = this.totalDue;
+    const remaining = total - this.amountPaid;
+
+    // Amount paid covers the total due
+    if ((isNegative && remaining >= 0) || (!isNegative && remaining <= 0)) {
+      return 0;
     }
 
-    triggerRecomputeAllPrices() {
-        if (!this._prices) {
-            return;
+    const amount =
+      this.orderIsRounded &&
+      this.config.rounding_method.asymmetricRound(
+        isNegative ? -remaining : remaining,
+      ) == 0
+        ? 0
+        : Math.abs(remaining);
+    return isNegative
+      ? this.currency.round(-amount)
+      : this.currency.round(amount);
+  }
+  get change() {
+    const isNegative = this.totalDue < 0;
+    const roundingSanatizer = this.orderIsRounded ? this.appliedRounding : 0;
+    const remaining = this.totalDue - this.amountPaid;
+
+    // Amount paid covers the total due
+    if ((isNegative && remaining <= 0) || (!isNegative && remaining >= 0)) {
+      return 0;
+    }
+
+    const total =
+      Math.abs(this.priceIncl) -
+      Math.abs(this.amountPaid) +
+      (isNegative ? -roundingSanatizer : roundingSanatizer);
+
+    const amount = isNegative
+      ? -this.currency.round(total)
+      : this.currency.round(total);
+    return this.config.cash_rounding
+      ? this.config.rounding_method.asymmetricRound(amount)
+      : amount;
+  }
+  get orderIsRounded() {
+    const cashPm = this.payment_ids.some(
+      (p) => p.payment_method_id.is_cash_count,
+    );
+    return (
+      this.config.hasGlobalRounding || (cashPm && this.config.hasCashRounding)
+    );
+  }
+  get appliedRounding() {
+    if (!this.orderIsRounded) {
+      return 0;
+    }
+    const total = this.prices.taxDetails.total_amount_no_rounding;
+    const rounded = this.config.rounding_method.asymmetricRound(total);
+    return this.currency.round(rounded - total);
+  }
+
+  /**
+   * Getters are preferred to methods because they are cached.
+   * These getters must be used each time the order prices are needed.
+   *
+   * Do not try to make your own price computation outside these getters.
+   */
+  get prices() {
+    return this._prices.original;
+  }
+  get unitPrices() {
+    return this._prices.unit;
+  }
+  get priceIncl() {
+    return this.prices.taxDetails.total_amount_no_rounding;
+  }
+  get priceExcl() {
+    return this.prices.taxDetails.base_amount;
+  }
+  get totalDue() {
+    return this.config.hasCashRounding
+      ? this.currency.round(this.prices.taxDetails.total_amount_no_rounding)
+      : this.currency.round(this.prices.taxDetails.total_amount);
+  }
+  get amountTaxes() {
+    return this.prices.taxDetails.tax_amount_currency;
+  }
+  get orderHasZeroRemaining() {
+    return this.currency.isZero(this.remainingDue);
+  }
+  get amountPaid() {
+    return this.currency.round(
+      this.payment_ids.reduce(function (sum, paymentLine) {
+        // Return lines are created after the sync, should not be taken into account in
+        // the paid amount otherwise, the change would be wrong.
+        if (paymentLine.isDone() && !paymentLine.is_change) {
+          sum += paymentLine.getAmount();
         }
-        this._prices.original = this._constructPriceData();
-        this._prices.unit = this._constructPriceData({ baseLineOpts: { quantity: 1 } });
+        return sum;
+      }, 0),
+    );
+  }
+  get orderSign() {
+    return this.prices.taxDetails.order_sign;
+  }
+
+  /**
+   * Determine if the amount to pay should be rounded depending on the payment method
+   * and the cash rounding configuration.
+   *
+   * Rounding on payment methods happen only when cash_rounding is enabled and
+   * only_round_cash_method is enabled too. In this case only cash payment methods
+   * will have a rounded amount to pay.
+   *
+   * If only_round_cash_method is disabled, no payment method will have a rounded amount to pay.
+   * The whole order is rounded instead.
+   */
+  shouldRound(paymentMethod) {
+    return paymentMethod.is_cash_count && this.config.hasCashRounding;
+  }
+
+  /**
+   * Get the amount to pay by default when creating a new payment.
+   * @param paymentMethod: The payment method of the payment to be created.
+   * @returns A monetary value.
+   */
+  getDefaultAmountDueToPayIn(paymentMethod) {
+    const amount = this.shouldRound(paymentMethod)
+      ? this.config_id.rounding_method.round(this.remainingDue)
+      : this.remainingDue;
+    return amount || this.change;
+  }
+
+  /**
+   * Since prices are computed on the fly, we need to set them before sending
+   * the order to the backend.
+   *
+   * This method is called when the order is pushed to the backend.
+   */
+  setOrderPrices() {
+    this.amount_paid = this.amountPaid; // Already rounded by the getter
+    this.amount_tax = this.amountTaxes; // Already rounded by the getter
+    this.amount_total = this.currency.round(this.priceIncl);
+    this.amount_return = this.change; // Already rounded by the getter
+    this.lines.forEach((line) => {
+      line.price_subtotal = line.priceExcl;
+      line.price_subtotal_incl = line.priceIncl;
+    });
+  }
+  /**
+   * This method is used when extra options need to be passed to the price computation.
+   * All these options will finally reach these methods:
+   * - prepareBaseLineForTaxesComputationExtraValues
+   * - prepare_base_line_for_taxes_computation (accounting helpers)
+   *
+   * For example you can pass a specific set of lines to compute the price of
+   * only these lines instead of the whole order.
+   */
+  getPriceWithOptions(opts = {}) {
+    return this._constructPriceData(opts);
+  }
+
+  /**
+   * @private
+   *
+   * Private method computing all prices and tax details.
+   * DO NOT USE THIS METHOD OUTSIDE THIS FILE !!!
+   */
+  _constructPriceData(opts = {}) {
+    const data = this._computeAllPrices(opts);
+    const noDiscount = this._computeAllPrices({
+      baseLineOpts: { discount: 0.0 },
+      ...opts,
+    });
+    const currency = this.currency;
+
+    for (const key of Object.keys(data.baseLineByLineUuids)) {
+      const ndData = noDiscount.baseLineByLineUuids[key].tax_details;
+      const dData = data.baseLineByLineUuids[key].tax_details;
+
+      Object.assign(data.baseLineByLineUuids[key].tax_details, {
+        discount_amount: currency.round(
+          ndData.total_included - dData.total_included,
+        ),
+        no_discount_total_excluded: ndData.total_excluded,
+        no_discount_total_included: ndData.total_included,
+        no_discount_total_included_currency: ndData.total_included_currency,
+        no_discount_total_excluded_currency: ndData.total_excluded_currency,
+        no_discount_taxes_data: ndData.taxes_data,
+        no_discount_delta_total_excluded: ndData.delta_total_excluded,
+        no_discount_delta_total_included: ndData.delta_total_included,
+      });
     }
 
-    /**
-     * Currency formatted prices, these getters already handle included/excluded tax configuration.
-     * They must be used each time a price is displayed to the user.
-     */
-    get currencyDisplayPrice() {
-        return formatCurrency(this.displayPrice, this.currency.id);
-    }
+    logPosMessage(
+      "Accounting",
+      "_constructPriceData",
+      "Recompute allPrices",
+      CONSOLE_COLOR,
+      [data],
+    );
+    return data;
+  }
 
-    get currencyDisplayPriceIncl() {
-        return formatCurrency(this.priceIncl, this.currency.id);
-    }
+  /**
+   * @private
+   *
+   * Private method computing all prices and tax details.
+   * DO NOT USE THIS METHOD OUTSIDE THIS FILE !!!
+   */
+  _computeAllPrices(opts = {}) {
+    const currency = this.currency;
+    const lines = opts.lines || this.lines;
+    const documentSign = this.isRefund ? -1 : 1;
+    const company = this.company;
+    const baseLines = lines.map((l) =>
+      l.getBaseLine({
+        quantity: l.qty,
+        price_unit: l.price_unit,
+        ...(opts.baseLineOpts || {}),
+      }),
+    );
 
-    get currencyDisplayPriceExcl() {
-        return formatCurrency(this.priceExcl, this.currency.id);
-    }
+    accountTaxHelpers.add_tax_details_in_base_lines(baseLines, company);
+    accountTaxHelpers.round_base_lines_tax_details(baseLines, company);
 
-    get currencyAmountTaxes() {
-        return formatCurrency(this.amountTaxes, this.currency.id);
-    }
+    // Cash rounding is added only if the document needs to be globaly rounded.
+    // See cash_rounding and only_round_cash_method config fields.
+    const cashRounding = this.config.cash_rounding
+      ? this.config.rounding_method
+      : null;
+    const data = accountTaxHelpers.get_tax_totals_summary(
+      baseLines,
+      currency,
+      company,
+      {
+        cash_rounding: cashRounding,
+      },
+    );
+    const total =
+      data.total_amount_currency -
+      (data.cash_rounding_base_amount_currency || 0.0);
 
-    /**
-     * Display price depending on the tax configuration (included or excluded).
-     */
-    get displayPrice() {
-        return this.config.iface_tax_included === "total"
-            ? this.currency.round(this.priceIncl)
-            : this.currency.round(this.priceExcl);
-    }
+    data.order_sign = documentSign;
+    data.total_amount_no_rounding = total;
 
-    /**
-     * Remaining due take into account the rounding of the order, the rounding can be configured
-     * in two different ways:
-     *
-     * 1) Rounding applied only on cash payments
-     *    In this case the remaining due is rounded only if there is at least one cash payment line.
-     *    and the remaining due is less than the rounding tolerance.
-     *
-     * 2) Rounding applied on all payment methods
-     *    In this case the remaining due is always rounded even if a card payment method is used.
-     *    The remaining due is rounded if it is less than the rounding tolerance. No payment method
-     *    is rounded in this case, the whole order is rounded instead.
-     *
-     * !!! Keep in mind that from 19.0 only one cash payment line can be used in an order !!!
-     */
-    get remainingDue() {
-        const isNegative = this.totalDue < 0;
-        const total = this.totalDue;
-        const remaining = total - this.amountPaid;
+    const baseLineByLineUuids = baseLines.reduce((acc, line) => {
+      acc[line.record.uuid] = line;
+      return acc;
+    }, {});
 
-        // Amount paid covers the total due
-        if ((isNegative && remaining >= 0) || (!isNegative && remaining <= 0)) {
-            return 0;
-        }
-
-        const amount =
-            this.orderIsRounded &&
-            this.config.rounding_method.asymmetricRound(isNegative ? -remaining : remaining) == 0
-                ? 0
-                : Math.abs(remaining);
-        return isNegative ? this.currency.round(-amount) : this.currency.round(amount);
-    }
-    get change() {
-        const isNegative = this.totalDue < 0;
-        const roundingSanatizer = this.orderIsRounded ? this.appliedRounding : 0;
-        const remaining = this.totalDue - this.amountPaid;
-
-        // Amount paid covers the total due
-        if ((isNegative && remaining <= 0) || (!isNegative && remaining >= 0)) {
-            return 0;
-        }
-
-        const total =
-            Math.abs(this.priceIncl) -
-            Math.abs(this.amountPaid) +
-            (isNegative ? -roundingSanatizer : roundingSanatizer);
-
-        const amount = isNegative ? -this.currency.round(total) : this.currency.round(total);
-        return this.config.cash_rounding
-            ? this.config.rounding_method.asymmetricRound(amount)
-            : amount;
-    }
-    get orderIsRounded() {
-        const cashPm = this.payment_ids.some((p) => p.payment_method_id.is_cash_count);
-        return this.config.hasGlobalRounding || (cashPm && this.config.hasCashRounding);
-    }
-    get appliedRounding() {
-        const total = this.prices.taxDetails.total_amount_no_rounding;
-        const isNegative = this.amountPaid > total;
-        const remaining = total - this.amountPaid;
-        const amount =
-            this.orderIsRounded &&
-            this.config.rounding_method.asymmetricRound(total < 0 ? -remaining : remaining) == 0
-                ? Math.abs(remaining)
-                : 0;
-        return isNegative ? this.currency.round(amount) : this.currency.round(-amount);
-    }
-
-    /**
-     * Getters are preferred to methods because they are cached.
-     * These getters must be used each time the order prices are needed.
-     *
-     * Do not try to make your own price computation outside these getters.
-     */
-    get prices() {
-        return this._prices.original;
-    }
-    get unitPrices() {
-        return this._prices.unit;
-    }
-    get priceIncl() {
-        return this.prices.taxDetails.total_amount_no_rounding;
-    }
-    get priceExcl() {
-        return this.prices.taxDetails.base_amount;
-    }
-    get totalDue() {
-        return this.config.hasCashRounding
-            ? this.currency.round(this.prices.taxDetails.total_amount_no_rounding)
-            : this.currency.round(this.prices.taxDetails.total_amount);
-    }
-    get amountTaxes() {
-        return this.prices.taxDetails.tax_amount_currency;
-    }
-    get orderHasZeroRemaining() {
-        return this.currency.isZero(this.remainingDue);
-    }
-    get amountPaid() {
-        return this.currency.round(
-            this.payment_ids.reduce(function (sum, paymentLine) {
-                // Return lines are created after the sync, should not be taken into account in
-                // the paid amount otherwise, the change would be wrong.
-                if (paymentLine.isDone() && !paymentLine.is_change) {
-                    sum += paymentLine.getAmount();
-                }
-                return sum;
-            }, 0)
-        );
-    }
-    get orderSign() {
-        return this.prices.taxDetails.order_sign;
-    }
-
-    /**
-     * Determine if the amount to pay should be rounded depending on the payment method
-     * and the cash rounding configuration.
-     *
-     * Rounding on payment methods happen only when cash_rounding is enabled and
-     * only_round_cash_method is enabled too. In this case only cash payment methods
-     * will have a rounded amount to pay.
-     *
-     * If only_round_cash_method is disabled, no payment method will have a rounded amount to pay.
-     * The whole order is rounded instead.
-     */
-    shouldRound(paymentMethod) {
-        return paymentMethod.is_cash_count && this.config.hasCashRounding;
-    }
-
-    /**
-     * Get the amount to pay by default when creating a new payment.
-     * @param paymentMethod: The payment method of the payment to be created.
-     * @returns A monetary value.
-     */
-    getDefaultAmountDueToPayIn(paymentMethod) {
-        const amount = this.shouldRound(paymentMethod)
-            ? this.config_id.rounding_method.round(this.remainingDue)
-            : this.remainingDue;
-        return amount || this.change;
-    }
-
-    /**
-     * Since prices are computed on the fly, we need to set them before sending
-     * the order to the backend.
-     *
-     * This method is called when the order is pushed to the backend.
-     */
-    setOrderPrices() {
-        this.amount_paid = this.amountPaid; // Already rounded by the getter
-        this.amount_tax = this.amountTaxes; // Already rounded by the getter
-        this.amount_total = this.currency.round(this.priceIncl);
-        this.amount_return = this.change; // Already rounded by the getter
-        this.lines.forEach((line) => {
-            line.price_subtotal = line.priceExcl;
-            line.price_subtotal_incl = line.priceIncl;
-        });
-    }
-    /**
-     * This method is used when extra options need to be passed to the price computation.
-     * All these options will finally reach these methods:
-     * - prepareBaseLineForTaxesComputationExtraValues
-     * - prepare_base_line_for_taxes_computation (accounting helpers)
-     *
-     * For example you can pass a specific set of lines to compute the price of
-     * only these lines instead of the whole order.
-     */
-    getPriceWithOptions(opts = {}) {
-        return this._constructPriceData(opts);
-    }
-
-    /**
-     * @private
-     *
-     * Private method computing all prices and tax details.
-     * DO NOT USE THIS METHOD OUTSIDE THIS FILE !!!
-     */
-    _constructPriceData(opts = {}) {
-        const data = this._computeAllPrices(opts);
-        const noDiscount = this._computeAllPrices({ baseLineOpts: { discount: 0.0 }, ...opts });
-        const currency = this.currency;
-
-        for (const key of Object.keys(data.baseLineByLineUuids)) {
-            const ndData = noDiscount.baseLineByLineUuids[key].tax_details;
-            const dData = data.baseLineByLineUuids[key].tax_details;
-
-            Object.assign(data.baseLineByLineUuids[key].tax_details, {
-                discount_amount: currency.round(ndData.total_included - dData.total_included),
-                no_discount_total_excluded: ndData.total_excluded,
-                no_discount_total_included: ndData.total_included,
-                no_discount_total_included_currency: ndData.total_included_currency,
-                no_discount_total_excluded_currency: ndData.total_excluded_currency,
-                no_discount_taxes_data: ndData.taxes_data,
-                no_discount_delta_total_excluded: ndData.delta_total_excluded,
-                no_discount_delta_total_included: ndData.delta_total_included,
-            });
-        }
-
-        logPosMessage("Accounting", "_constructPriceData", "Recompute allPrices", CONSOLE_COLOR, [
-            data,
-        ]);
-        return data;
-    }
-
-    /**
-     * @private
-     *
-     * Private method computing all prices and tax details.
-     * DO NOT USE THIS METHOD OUTSIDE THIS FILE !!!
-     */
-    _computeAllPrices(opts = {}) {
-        const currency = this.currency;
-        const lines = opts.lines || this.lines;
-        const documentSign = this.isRefund ? -1 : 1;
-        const company = this.company;
-        const baseLines = lines.map((l) =>
-            l.getBaseLine({
-                quantity: l.qty,
-                price_unit: l.price_unit,
-                ...(opts.baseLineOpts || {}),
-            })
-        );
-
-        accountTaxHelpers.add_tax_details_in_base_lines(baseLines, company);
-        accountTaxHelpers.round_base_lines_tax_details(baseLines, company);
-
-        // Cash rounding is added only if the document needs to be globaly rounded.
-        // See cash_rounding and only_round_cash_method config fields.
-        const cashRounding = this.config.cash_rounding ? this.config.rounding_method : null;
-        const data = accountTaxHelpers.get_tax_totals_summary(baseLines, currency, company, {
-            cash_rounding: cashRounding,
-        });
-        const total = data.total_amount_currency - (data.cash_rounding_base_amount_currency || 0.0);
-
-        data.order_sign = documentSign;
-        data.total_amount_no_rounding = total;
-
-        const baseLineByLineUuids = baseLines.reduce((acc, line) => {
-            acc[line.record.uuid] = line;
-            return acc;
-        }, {});
-
-        return { taxDetails: data, baseLines: baseLines, baseLineByLineUuids: baseLineByLineUuids };
-    }
+    return {
+      taxDetails: data,
+      baseLines: baseLines,
+      baseLineByLineUuids: baseLineByLineUuids,
+    };
+  }
 }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -44,14 +44,14 @@
                     <span class="label-total">Total</span>
                     <span t-out="order.currencyDisplayPriceIncl" class="pos-receipt-right-align font-monospace"/>
                 </div>
-                <t t-if="order.appliedRounding">
+                <t t-if="order.orderIsRounded">
                     <div class="pos-receipt-amount receipt-rounding">
                         <span class="label-rounding">Rounding</span>
                         <span t-out='formatCurrency(order.appliedRounding)' class="pos-receipt-right-align font-monospace"/>
                     </div>
                     <div class="pos-receipt-amount receipt-to-pay">
                         To Pay
-                        <span t-out='formatCurrency(order.totalDue)' class="pos-receipt-right-align font-monospace"/>
+                        <span t-out='formatCurrency(order.priceIncl + order.appliedRounding)' class="pos-receipt-right-align font-monospace"/>
                     </div>
                 </t>
 

--- a/addons/point_of_sale/static/tests/pos/tours/pos_cash_rounding_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_cash_rounding_tour.js
@@ -7,243 +7,249 @@ import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_sc
 import { registry } from "@web/core/registry";
 
 registry
-    .category("web_tour.tours")
-    .add("test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method", {
-        steps: () =>
-            [
-                Chrome.startPoS(),
-                Dialog.confirm("Open Register"),
+  .category("web_tour.tours")
+  .add("test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method", {
+    steps: () =>
+      [
+        Chrome.startPoS(),
+        Dialog.confirm("Open Register"),
 
-                // Order.
-                ProductScreen.addOrderline("random_product", "1"),
-                ProductScreen.checkTaxAmount("2.03"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("15.70"),
-                ProductScreen.clickPartnerButton(),
-                ProductScreen.clickCustomer("AAAAAA"),
-                ProductScreen.clickPayButton(),
+        // Order.
+        ProductScreen.addOrderline("random_product", "1"),
+        ProductScreen.checkTaxAmount("2.03"),
+        ProductScreen.checkRoundingAmountIsNotThere(),
+        ProductScreen.checkTotalAmount("15.70"),
+        ProductScreen.clickPartnerButton(),
+        ProductScreen.clickCustomer("AAAAAA"),
+        ProductScreen.clickPayButton(),
 
-                PaymentScreen.totalIs("15.70"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+        PaymentScreen.totalIs("15.70"),
+        PaymentScreen.clickPaymentMethod("Cash"),
+        PaymentScreen.remainingIs("0.0"),
+        PaymentScreen.clickInvoiceButton(),
+        PaymentScreen.clickValidate(),
 
-                ReceiptScreen.receiptAmountTotalIs("15.70"),
-                ReceiptScreen.receiptToPayAmountIsNotThere(),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
+        ReceiptScreen.receiptAmountTotalIs("15.70"),
+        ReceiptScreen.receiptToPayAmountIsNotThere(),
+        ReceiptScreen.receiptChangeAmountIsNotThere(),
+        ReceiptScreen.clickNextOrder(),
 
-                // Refund.
-                Chrome.clickOrders(),
-                TicketScreen.selectFilter("Active"),
-                TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
-                TicketScreen.confirmRefund(),
+        // Refund.
+        Chrome.clickOrders(),
+        TicketScreen.selectFilter("Active"),
+        TicketScreen.selectFilter("Paid"),
+        TicketScreen.selectOrder("0001"),
+        TicketScreen.confirmRefund(),
 
-                PaymentScreen.isShown(),
-                PaymentScreen.clickBack(),
+        PaymentScreen.isShown(),
+        PaymentScreen.clickBack(),
 
-                ProductScreen.checkTaxAmount("-2.03"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("-15.70"),
-                ProductScreen.clickPayButton(),
+        ProductScreen.checkTaxAmount("-2.03"),
+        ProductScreen.checkRoundingAmountIsNotThere(),
+        ProductScreen.checkTotalAmount("-15.70"),
+        ProductScreen.clickPayButton(),
 
-                PaymentScreen.totalIs("-15.70"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+        PaymentScreen.totalIs("-15.70"),
+        PaymentScreen.clickPaymentMethod("Cash"),
+        PaymentScreen.remainingIs("0.0"),
+        PaymentScreen.clickValidate(),
 
-                ReceiptScreen.receiptAmountTotalIs("-15.70"),
-                ReceiptScreen.receiptToPayAmountIsNotThere(),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
-            ].flat(),
-    });
-
-registry
-    .category("web_tour.tours")
-    .add("test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method_pay_by_bank_and_cash", {
-        steps: () =>
-            [
-                Chrome.startPoS(),
-                Dialog.confirm("Open Register"),
-
-                // Order.
-                ProductScreen.addOrderline("random_product", "1"),
-                ProductScreen.checkTaxAmount("2.03"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("15.70"),
-                ProductScreen.clickPartnerButton(),
-                ProductScreen.clickCustomer("AAAAAA"),
-                ProductScreen.clickPayButton(),
-
-                PaymentScreen.totalIs("15.70"),
-                PaymentScreen.clickPaymentMethod("Bank"),
-                PaymentScreen.clickNumpad("0 . 6 7"),
-                PaymentScreen.fillPaymentLineAmountMobile("Bank", "0.67"),
-                PaymentScreen.remainingIs("15.03"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
-
-                ReceiptScreen.receiptAmountTotalIs("15.70"),
-                ReceiptScreen.receiptRoundingAmountIs("0.02"),
-                ReceiptScreen.receiptToPayAmountIs("15.72"),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
-
-                // Refund.
-                Chrome.clickOrders(),
-                TicketScreen.selectFilter("Active"),
-                TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
-                TicketScreen.confirmRefund(),
-
-                PaymentScreen.isShown(),
-                PaymentScreen.clickBack(),
-
-                ProductScreen.checkTaxAmount("-2.03"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("-15.70"),
-                ProductScreen.clickPayButton(),
-
-                PaymentScreen.totalIs("-15.70"),
-                PaymentScreen.clickPaymentMethod("Bank"),
-                PaymentScreen.clickNumpad("0 . 6 7 +/-"),
-                PaymentScreen.fillPaymentLineAmountMobile("Bank", "-0.67"),
-                PaymentScreen.remainingIs("-15.03"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
-
-                ReceiptScreen.receiptAmountTotalIs("-15.70"),
-                ReceiptScreen.receiptRoundingAmountIs("-0.02"),
-                ReceiptScreen.receiptToPayAmountIs("-15.72"),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
-            ].flat(),
-    });
+        ReceiptScreen.receiptAmountTotalIs("-15.70"),
+        ReceiptScreen.receiptToPayAmountIsNotThere(),
+        ReceiptScreen.receiptChangeAmountIsNotThere(),
+        ReceiptScreen.clickNextOrder(),
+      ].flat(),
+  });
 
 registry
-    .category("web_tour.tours")
-    .add("test_cash_rounding_halfup_biggest_tax_only_round_cash_method", {
-        steps: () =>
-            [
-                Chrome.startPoS(),
-                Dialog.confirm("Open Register"),
+  .category("web_tour.tours")
+  .add(
+    "test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method_pay_by_bank_and_cash",
+    {
+      steps: () =>
+        [
+          Chrome.startPoS(),
+          Dialog.confirm("Open Register"),
 
-                // Order.
-                ProductScreen.addOrderline("random_product", "1"),
-                ProductScreen.checkTaxAmount("2.05"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("15.72"),
-                ProductScreen.clickPartnerButton(),
-                ProductScreen.clickCustomer("AAAAAA"),
-                ProductScreen.clickPayButton(),
+          // Order.
+          ProductScreen.addOrderline("random_product", "1"),
+          ProductScreen.checkTaxAmount("2.03"),
+          ProductScreen.checkRoundingAmountIsNotThere(),
+          ProductScreen.checkTotalAmount("15.70"),
+          ProductScreen.clickPartnerButton(),
+          ProductScreen.clickCustomer("AAAAAA"),
+          ProductScreen.clickPayButton(),
 
-                PaymentScreen.totalIs("15.72"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+          PaymentScreen.totalIs("15.70"),
+          PaymentScreen.clickPaymentMethod("Bank"),
+          PaymentScreen.clickNumpad("0 . 6 7"),
+          PaymentScreen.fillPaymentLineAmountMobile("Bank", "0.67"),
+          PaymentScreen.remainingIs("15.03"),
+          PaymentScreen.clickPaymentMethod("Cash"),
+          PaymentScreen.remainingIs("0.0"),
+          PaymentScreen.clickInvoiceButton(),
+          PaymentScreen.clickValidate(),
 
-                ReceiptScreen.receiptAmountTotalIs("15.72"),
-                ReceiptScreen.receiptRoundingAmountIs("-0.02"),
-                ReceiptScreen.receiptToPayAmountIs("15.70"),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
+          ReceiptScreen.receiptAmountTotalIs("15.70"),
+          ReceiptScreen.receiptRoundingAmountIs("0.02"),
+          ReceiptScreen.receiptToPayAmountIs("15.72"),
+          ReceiptScreen.receiptChangeAmountIsNotThere(),
+          ReceiptScreen.clickNextOrder(),
 
-                // Refund.
-                Chrome.clickOrders(),
-                TicketScreen.selectFilter("Active"),
-                TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
-                TicketScreen.confirmRefund(),
+          // Refund.
+          Chrome.clickOrders(),
+          TicketScreen.selectFilter("Active"),
+          TicketScreen.selectFilter("Paid"),
+          TicketScreen.selectOrder("0001"),
+          TicketScreen.confirmRefund(),
 
-                PaymentScreen.isShown(),
-                PaymentScreen.clickBack(),
+          PaymentScreen.isShown(),
+          PaymentScreen.clickBack(),
 
-                ProductScreen.checkTaxAmount("-2.05"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("-15.72"),
-                ProductScreen.clickPayButton(),
+          ProductScreen.checkTaxAmount("-2.03"),
+          ProductScreen.checkRoundingAmountIsNotThere(),
+          ProductScreen.checkTotalAmount("-15.70"),
+          ProductScreen.clickPayButton(),
 
-                PaymentScreen.totalIs("-15.72"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+          PaymentScreen.totalIs("-15.70"),
+          PaymentScreen.clickPaymentMethod("Bank"),
+          PaymentScreen.clickNumpad("0 . 6 7 +/-"),
+          PaymentScreen.fillPaymentLineAmountMobile("Bank", "-0.67"),
+          PaymentScreen.remainingIs("-15.03"),
+          PaymentScreen.clickPaymentMethod("Cash"),
+          PaymentScreen.remainingIs("0.0"),
+          PaymentScreen.clickValidate(),
 
-                ReceiptScreen.receiptAmountTotalIs("-15.72"),
-                ReceiptScreen.receiptRoundingAmountIs("0.02"),
-                ReceiptScreen.receiptToPayAmountIs("-15.70"),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
-            ].flat(),
-    });
+          ReceiptScreen.receiptAmountTotalIs("-15.70"),
+          ReceiptScreen.receiptRoundingAmountIs("-0.02"),
+          ReceiptScreen.receiptToPayAmountIs("-15.72"),
+          ReceiptScreen.receiptChangeAmountIsNotThere(),
+          ReceiptScreen.clickNextOrder(),
+        ].flat(),
+    },
+  );
 
 registry
-    .category("web_tour.tours")
-    .add("test_cash_rounding_halfup_biggest_tax_only_round_cash_method_pay_by_bank_and_cash", {
-        steps: () =>
-            [
-                Chrome.startPoS(),
-                Dialog.confirm("Open Register"),
+  .category("web_tour.tours")
+  .add("test_cash_rounding_halfup_biggest_tax_only_round_cash_method", {
+    steps: () =>
+      [
+        Chrome.startPoS(),
+        Dialog.confirm("Open Register"),
 
-                // Order.
-                ProductScreen.addOrderline("random_product", "1"),
-                ProductScreen.checkTaxAmount("2.05"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("15.72"),
-                ProductScreen.clickPartnerButton(),
-                ProductScreen.clickCustomer("AAAAAA"),
-                ProductScreen.clickPayButton(),
+        // Order.
+        ProductScreen.addOrderline("random_product", "1"),
+        ProductScreen.checkTaxAmount("2.05"),
+        ProductScreen.checkRoundingAmountIsNotThere(),
+        ProductScreen.checkTotalAmount("15.72"),
+        ProductScreen.clickPartnerButton(),
+        ProductScreen.clickCustomer("AAAAAA"),
+        ProductScreen.clickPayButton(),
 
-                PaymentScreen.totalIs("15.72"),
-                PaymentScreen.clickPaymentMethod("Bank"),
-                PaymentScreen.clickNumpad("0 . 6 8"),
-                PaymentScreen.fillPaymentLineAmountMobile("Bank", "0.68"),
-                PaymentScreen.remainingIs("15.04"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickInvoiceButton(),
-                PaymentScreen.clickValidate(),
+        PaymentScreen.totalIs("15.72"),
+        PaymentScreen.clickPaymentMethod("Cash"),
+        PaymentScreen.remainingIs("0.0"),
+        PaymentScreen.clickInvoiceButton(),
+        PaymentScreen.clickValidate(),
 
-                ReceiptScreen.receiptAmountTotalIs("15.72"),
-                ReceiptScreen.receiptRoundingAmountIs("0.01"),
-                ReceiptScreen.receiptToPayAmountIs("15.73"),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
+        ReceiptScreen.receiptAmountTotalIs("15.72"),
+        ReceiptScreen.receiptRoundingAmountIs("-0.02"),
+        ReceiptScreen.receiptToPayAmountIs("15.70"),
+        ReceiptScreen.receiptChangeAmountIsNotThere(),
+        ReceiptScreen.clickNextOrder(),
 
-                // Refund.
-                Chrome.clickOrders(),
-                TicketScreen.selectFilter("Active"),
-                TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
-                TicketScreen.confirmRefund(),
+        // Refund.
+        Chrome.clickOrders(),
+        TicketScreen.selectFilter("Active"),
+        TicketScreen.selectFilter("Paid"),
+        TicketScreen.selectOrder("0001"),
+        TicketScreen.confirmRefund(),
 
-                PaymentScreen.isShown(),
-                PaymentScreen.clickBack(),
+        PaymentScreen.isShown(),
+        PaymentScreen.clickBack(),
 
-                ProductScreen.checkTaxAmount("-2.05"),
-                ProductScreen.checkRoundingAmountIsNotThere(),
-                ProductScreen.checkTotalAmount("-15.72"),
-                ProductScreen.clickPayButton(),
+        ProductScreen.checkTaxAmount("-2.05"),
+        ProductScreen.checkRoundingAmountIsNotThere(),
+        ProductScreen.checkTotalAmount("-15.72"),
+        ProductScreen.clickPayButton(),
 
-                PaymentScreen.totalIs("-15.72"),
-                PaymentScreen.clickPaymentMethod("Bank"),
-                PaymentScreen.clickNumpad("0 . 6 8 +/-"),
-                PaymentScreen.fillPaymentLineAmountMobile("Bank", "-0.68"),
-                PaymentScreen.remainingIs("-15.04"),
-                PaymentScreen.clickPaymentMethod("Cash"),
-                PaymentScreen.remainingIs("0.0"),
-                PaymentScreen.clickValidate(),
+        PaymentScreen.totalIs("-15.72"),
+        PaymentScreen.clickPaymentMethod("Cash"),
+        PaymentScreen.remainingIs("0.0"),
+        PaymentScreen.clickValidate(),
 
-                ReceiptScreen.receiptAmountTotalIs("-15.72"),
-                ReceiptScreen.receiptRoundingAmountIs("-0.01"),
-                ReceiptScreen.receiptToPayAmountIs("-15.73"),
-                ReceiptScreen.receiptChangeAmountIsNotThere(),
-                ReceiptScreen.clickNextOrder(),
-            ].flat(),
-    });
+        ReceiptScreen.receiptAmountTotalIs("-15.72"),
+        ReceiptScreen.receiptRoundingAmountIs("0.02"),
+        ReceiptScreen.receiptToPayAmountIs("-15.70"),
+        ReceiptScreen.receiptChangeAmountIsNotThere(),
+        ReceiptScreen.clickNextOrder(),
+      ].flat(),
+  });
+
+registry
+  .category("web_tour.tours")
+  .add(
+    "test_cash_rounding_halfup_biggest_tax_only_round_cash_method_pay_by_bank_and_cash",
+    {
+      steps: () =>
+        [
+          Chrome.startPoS(),
+          Dialog.confirm("Open Register"),
+
+          // Order.
+          ProductScreen.addOrderline("random_product", "1"),
+          ProductScreen.checkTaxAmount("2.05"),
+          ProductScreen.checkRoundingAmountIsNotThere(),
+          ProductScreen.checkTotalAmount("15.72"),
+          ProductScreen.clickPartnerButton(),
+          ProductScreen.clickCustomer("AAAAAA"),
+          ProductScreen.clickPayButton(),
+
+          PaymentScreen.totalIs("15.72"),
+          PaymentScreen.clickPaymentMethod("Bank"),
+          PaymentScreen.clickNumpad("0 . 6 8"),
+          PaymentScreen.fillPaymentLineAmountMobile("Bank", "0.68"),
+          PaymentScreen.remainingIs("15.04"),
+          PaymentScreen.clickPaymentMethod("Cash"),
+          PaymentScreen.remainingIs("0.0"),
+          PaymentScreen.clickInvoiceButton(),
+          PaymentScreen.clickValidate(),
+
+          ReceiptScreen.receiptAmountTotalIs("15.72"),
+          ReceiptScreen.receiptRoundingAmountIs("0.01"),
+          ReceiptScreen.receiptToPayAmountIs("15.73"),
+          ReceiptScreen.receiptChangeAmountIsNotThere(),
+          ReceiptScreen.clickNextOrder(),
+
+          // Refund.
+          Chrome.clickOrders(),
+          TicketScreen.selectFilter("Active"),
+          TicketScreen.selectFilter("Paid"),
+          TicketScreen.selectOrder("0001"),
+          TicketScreen.confirmRefund(),
+
+          PaymentScreen.isShown(),
+          PaymentScreen.clickBack(),
+
+          ProductScreen.checkTaxAmount("-2.05"),
+          ProductScreen.checkRoundingAmountIsNotThere(),
+          ProductScreen.checkTotalAmount("-15.72"),
+          ProductScreen.clickPayButton(),
+
+          PaymentScreen.totalIs("-15.72"),
+          PaymentScreen.clickPaymentMethod("Bank"),
+          PaymentScreen.clickNumpad("0 . 6 8 +/-"),
+          PaymentScreen.fillPaymentLineAmountMobile("Bank", "-0.68"),
+          PaymentScreen.remainingIs("-15.04"),
+          PaymentScreen.clickPaymentMethod("Cash"),
+          PaymentScreen.remainingIs("0.0"),
+          PaymentScreen.clickValidate(),
+
+          ReceiptScreen.receiptAmountTotalIs("-15.72"),
+          ReceiptScreen.receiptRoundingAmountIs("-0.01"),
+          ReceiptScreen.receiptToPayAmountIs("-15.73"),
+          ReceiptScreen.receiptChangeAmountIsNotThere(),
+          ReceiptScreen.clickNextOrder(),
+        ].flat(),
+    },
+  );

--- a/addons/point_of_sale/tests/test_pos_cash_rounding.py
+++ b/addons/point_of_sale/tests/test_pos_cash_rounding.py
@@ -1,184 +1,302 @@
 from odoo import Command
-from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.tests import tagged
 
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 
-@tagged('post_install', '-at_install')
+
+@tagged("post_install", "-at_install")
 class TestPosCashRounding(TestPointOfSaleHttpCommon):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.partner_a.name = "AAAAAA"  # The POS only load the first 100 partners
-        cls.cash_rounding_add_invoice_line = cls.env['account.cash.rounding'].create({
-            'name': "cash_rounding_add_invoice_line",
-            'rounding': 0.05,
-            'rounding_method': 'HALF-UP',
-            'strategy': 'add_invoice_line',
-            'profit_account_id': cls.env.company.default_cash_difference_income_account_id.id,
-            'loss_account_id': cls.env.company.default_cash_difference_expense_account_id.id,
-        })
-        cls.cash_rounding_biggest_tax = cls.env['account.cash.rounding'].create({
-            'name': "cash_rounding_biggest_tax",
-            'rounding': 0.05,
-            'rounding_method': 'HALF-UP',
-            'strategy': 'biggest_tax',
-            'profit_account_id': cls.env.company.default_cash_difference_income_account_id.id,
-            'loss_account_id': cls.env.company.default_cash_difference_expense_account_id.id,
-        })
+        cls.cash_rounding_add_invoice_line = cls.env["account.cash.rounding"].create(
+            {
+                "name": "cash_rounding_add_invoice_line",
+                "rounding": 0.05,
+                "rounding_method": "HALF-UP",
+                "strategy": "add_invoice_line",
+                "profit_account_id": cls.env.company.default_cash_difference_income_account_id.id,
+                "loss_account_id": cls.env.company.default_cash_difference_expense_account_id.id,
+            }
+        )
+        cls.cash_rounding_biggest_tax = cls.env["account.cash.rounding"].create(
+            {
+                "name": "cash_rounding_biggest_tax",
+                "rounding": 0.05,
+                "rounding_method": "HALF-UP",
+                "strategy": "biggest_tax",
+                "profit_account_id": cls.env.company.default_cash_difference_income_account_id.id,
+                "loss_account_id": cls.env.company.default_cash_difference_expense_account_id.id,
+            }
+        )
 
-        cls.product = cls.env['product.product'].create({
-            'name': "random_product",
-            'available_in_pos': True,
-            'list_price': 13.67,
-            'taxes_id': [Command.set(cls.company_data['default_tax_sale'].ids)],
-            'pos_categ_ids': [Command.set(cls.pos_desk_misc_test.ids)],
-        })
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "random_product",
+                "available_in_pos": True,
+                "list_price": 13.67,
+                "taxes_id": [Command.set(cls.company_data["default_tax_sale"].ids)],
+                "pos_categ_ids": [Command.set(cls.pos_desk_misc_test.ids)],
+            }
+        )
 
     def test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method(self):
-        self.skipTest('To re-introduce when feature is ready')
-        self.main_pos_config.write({
-            'rounding_method': self.cash_rounding_biggest_tax.id,
-            'cash_rounding': True,
-            'only_round_cash_method': False,
-        })
+        self.skipTest("To re-introduce when feature is ready")
+        self.main_pos_config.write(
+            {
+                "rounding_method": self.cash_rounding_biggest_tax.id,
+                "cash_rounding": True,
+                "only_round_cash_method": False,
+            }
+        )
         with self.with_new_session(user=self.pos_user) as session:
-            self.start_pos_tour('test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method')
-            refund, order = self.env['pos.order'].search([('session_id', '=', session.id)], limit=2)
-            self.assertRecordValues(order, [{
-                'amount_tax': 2.03,
-                'amount_total': 15.7,
-                'amount_paid': 15.7,
-            }])
-            self.assertRecordValues(order.account_move, [{
-                'amount_untaxed': 13.67,
-                'amount_tax': 2.03,
-                'amount_total': 15.7,
-            }])
-            self.assertRecordValues(refund, [{
-                'amount_tax': -2.03,
-                'amount_total': -15.7,
-                'amount_paid': -15.7,
-            }])
-            self.assertRecordValues(refund.account_move, [{
-                'amount_untaxed': 13.67,
-                'amount_tax': 2.03,
-                'amount_total': 15.7,
-            }])
+            self.start_pos_tour(
+                "test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method"
+            )
+            refund, order = self.env["pos.order"].search(
+                [("session_id", "=", session.id)], limit=2
+            )
+            self.assertRecordValues(
+                order,
+                [
+                    {
+                        "amount_tax": 2.03,
+                        "amount_total": 15.7,
+                        "amount_paid": 15.7,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                order.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.67,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.7,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund,
+                [
+                    {
+                        "amount_tax": -2.03,
+                        "amount_total": -15.7,
+                        "amount_paid": -15.7,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.67,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.7,
+                    }
+                ],
+            )
 
-    def test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method_pay_by_bank_and_cash(self):
-        self.skipTest('To re-introduce when feature is ready')
-        self.main_pos_config.write({
-            'rounding_method': self.cash_rounding_biggest_tax.id,
-            'cash_rounding': True,
-            'only_round_cash_method': False,
-        })
+    def test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method_pay_by_bank_and_cash(
+        self,
+    ):
+        self.skipTest("To re-introduce when feature is ready")
+        self.main_pos_config.write(
+            {
+                "rounding_method": self.cash_rounding_biggest_tax.id,
+                "cash_rounding": True,
+                "only_round_cash_method": False,
+            }
+        )
         with self.with_new_session(user=self.pos_user) as session:
-            self.start_pos_tour('test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method_pay_by_bank_and_cash')
-            refund, order = self.env['pos.order'].search([('session_id', '=', session.id)], limit=2)
-            self.assertRecordValues(order, [{
-                'amount_tax': 2.03,
-                'amount_total': 15.7,
-                'amount_paid': 15.72,
-            }])
-            self.assertRecordValues(order.account_move, [{
-                'amount_untaxed': 13.69,
-                'amount_tax': 2.03,
-                'amount_total': 15.72,
-            }])
-            self.assertRecordValues(refund, [{
-                'amount_tax': -2.03,
-                'amount_total': -15.7,
-                'amount_paid': -15.72,
-            }])
-            self.assertRecordValues(refund.account_move, [{
-                'amount_untaxed': 13.69,
-                'amount_tax': 2.03,
-                'amount_total': 15.72,
-            }])
+            self.start_pos_tour(
+                "test_cash_rounding_halfup_biggest_tax_not_only_round_cash_method_pay_by_bank_and_cash"
+            )
+            refund, order = self.env["pos.order"].search(
+                [("session_id", "=", session.id)], limit=2
+            )
+            self.assertRecordValues(
+                order,
+                [
+                    {
+                        "amount_tax": 2.03,
+                        "amount_total": 15.7,
+                        "amount_paid": 15.72,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                order.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.69,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.72,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund,
+                [
+                    {
+                        "amount_tax": -2.03,
+                        "amount_total": -15.7,
+                        "amount_paid": -15.72,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.69,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.72,
+                    }
+                ],
+            )
 
     def test_cash_rounding_halfup_biggest_tax_only_round_cash_method(self):
-        self.skipTest('To re-introduce when feature is ready')
-        self.main_pos_config.write({
-            'rounding_method': self.cash_rounding_biggest_tax.id,
-            'cash_rounding': True,
-            'only_round_cash_method': True,
-        })
+        self.skipTest("To re-introduce when feature is ready")
+        self.main_pos_config.write(
+            {
+                "rounding_method": self.cash_rounding_biggest_tax.id,
+                "cash_rounding": True,
+                "only_round_cash_method": True,
+            }
+        )
         with self.with_new_session(user=self.pos_user) as session:
-            self.start_pos_tour('test_cash_rounding_halfup_biggest_tax_only_round_cash_method')
-            refund, order = self.env['pos.order'].search([('session_id', '=', session.id)], limit=2)
-            self.assertRecordValues(order, [{
-                'amount_tax': 2.05,
-                'amount_total': 15.72,
-                'amount_paid': 15.7,
-            }])
-            self.assertRecordValues(order.account_move, [{
-                'amount_untaxed': 13.67,
-                'amount_tax': 2.03,
-                'amount_total': 15.7,
-            }])
-            self.assertRecordValues(refund, [{
-                'amount_tax': -2.05,
-                'amount_total': -15.72,
-                'amount_paid': -15.7,
-            }])
-            self.assertRecordValues(refund.account_move, [{
-                'amount_untaxed': 13.67,
-                'amount_tax': 2.03,
-                'amount_total': 15.7,
-            }])
+            self.start_pos_tour(
+                "test_cash_rounding_halfup_biggest_tax_only_round_cash_method"
+            )
+            refund, order = self.env["pos.order"].search(
+                [("session_id", "=", session.id)], limit=2
+            )
+            self.assertRecordValues(
+                order,
+                [
+                    {
+                        "amount_tax": 2.05,
+                        "amount_total": 15.72,
+                        "amount_paid": 15.7,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                order.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.67,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.7,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund,
+                [
+                    {
+                        "amount_tax": -2.05,
+                        "amount_total": -15.72,
+                        "amount_paid": -15.7,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.67,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.7,
+                    }
+                ],
+            )
 
-    def test_cash_rounding_halfup_biggest_tax_only_round_cash_method_pay_by_bank_and_cash(self):
-        self.skipTest('To re-introduce when feature is ready')
-        self.main_pos_config.write({
-            'rounding_method': self.cash_rounding_biggest_tax.id,
-            'cash_rounding': True,
-            'only_round_cash_method': True,
-        })
+    def test_cash_rounding_halfup_biggest_tax_only_round_cash_method_pay_by_bank_and_cash(
+        self,
+    ):
+        self.skipTest("To re-introduce when feature is ready")
+        self.main_pos_config.write(
+            {
+                "rounding_method": self.cash_rounding_biggest_tax.id,
+                "cash_rounding": True,
+                "only_round_cash_method": True,
+            }
+        )
         with self.with_new_session(user=self.pos_user) as session:
-            self.start_pos_tour('test_cash_rounding_halfup_biggest_tax_only_round_cash_method_pay_by_bank_and_cash')
-            refund, order = self.env['pos.order'].search([('session_id', '=', session.id)], limit=2)
-            self.assertRecordValues(order, [{
-                'amount_tax': 2.05,
-                'amount_total': 15.72,
-                'amount_paid': 15.73,
-            }])
-            self.assertRecordValues(order.account_move, [{
-                'amount_untaxed': 13.70,
-                'amount_tax': 2.03,
-                'amount_total': 15.73,
-            }])
-            self.assertRecordValues(refund, [{
-                'amount_tax': -2.05,
-                'amount_total': -15.72,
-                'amount_paid': -15.73,
-            }])
-            self.assertRecordValues(refund.account_move, [{
-                'amount_untaxed': 13.70,
-                'amount_tax': 2.03,
-                'amount_total': 15.73,
-            }])
+            self.start_pos_tour(
+                "test_cash_rounding_halfup_biggest_tax_only_round_cash_method_pay_by_bank_and_cash"
+            )
+            refund, order = self.env["pos.order"].search(
+                [("session_id", "=", session.id)], limit=2
+            )
+            self.assertRecordValues(
+                order,
+                [
+                    {
+                        "amount_tax": 2.05,
+                        "amount_total": 15.72,
+                        "amount_paid": 15.73,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                order.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.70,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.73,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund,
+                [
+                    {
+                        "amount_tax": -2.05,
+                        "amount_total": -15.72,
+                        "amount_paid": -15.73,
+                    }
+                ],
+            )
+            self.assertRecordValues(
+                refund.account_move,
+                [
+                    {
+                        "amount_untaxed": 13.70,
+                        "amount_tax": 2.03,
+                        "amount_total": 15.73,
+                    }
+                ],
+            )
 
     def test_archived_product_removed_and_order_is_refunded(self):
         """
         Tests that once product is archived after order is created
         product is not shown but the order can still be refunded.
         """
-        self.pos_admin.write({
-            'group_ids': [
-                (4, self.env.ref('product.group_product_manager').id),
-                (4, self.env.ref('account.group_account_manager').id),
-            ]
-        })
-        self.env['product.product'].create({
-            'is_storable': True,
-            'name': 'A Test Product',
-            'available_in_pos': True,
-            'list_price': 1,
-        })
+        self.pos_admin.write(
+            {
+                "group_ids": [
+                    (4, self.env.ref("product.group_product_manager").id),
+                    (4, self.env.ref("account.group_account_manager").id),
+                ],
+            }
+        )
+        self.env["product.product"].create(
+            {
+                "is_storable": True,
+                "name": "A Test Product",
+                "available_in_pos": True,
+                "list_price": 1,
+            }
+        )
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
             "test_archived_product_removed_and_order_is_refunded",
-            login="pos_admin"
+            login="pos_admin",
         )

--- a/doc/cla/individual/borgbuster.md
+++ b/doc/cla/individual/borgbuster.md
@@ -1,0 +1,11 @@
+Indonesia, 29/01/2026
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Vasu Mahajan vasumahajan@proton.me https://github.com/borgbuster


### PR DESCRIPTION
Fix: POS Receipt To Pay and Rounding Display with Cash Rounding

ISSUE

When cash rounding is configured on POS receipts, two problems occur:

1. The To Pay line does not include the rounding adjustment
2. The Rounding and To Pay lines are hidden from the receipt when the customer pays more than the To Pay amount (i.e., when change is due)

CURRENT BEHAVIOR

With a 0.05 HALF-UP rounding method:

- Order total: 15.70
- Applied rounding: +0.02
- Receipt shows: To Pay 15.70 (missing rounding)
- On overpayment: Rounding and To Pay lines are hidden

EXPECTED BEHAVIOR

- To Pay should show: 15.72 (totalDue + appliedRounding)
- Rounding and To Pay lines should always display, even when change is due
- Receipt shows all payment breakdown consistently

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
