### PR TITLE
[FIX] point_of_sale: do not change price on lot change

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -303,7 +303,7 @@ export class PosOrderline extends Base {
         if (this.qty < 0) {
             valid_lots_quantity = -valid_lots_quantity;
         }
-        this.set_quantity(valid_lots_quantity);
+        this.set_quantity(valid_lots_quantity, !!this.combo_parent_id);
     }
 
     has_valid_product_lot() {

--- a/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/tours/pos_combo_tour.js
@@ -272,3 +272,26 @@ registry.category("web_tour.tours").add("test_combo_item_image_not_display", {
             Dialog.confirm(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_combo_price_unchanged_with_lot_tracked_product", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Combo"),
+            inLeftSide([
+                ...ProductScreen.selectedOrderlineHasDirect("Test Combo"),
+                ...ProductScreen.orderLineHas("Product A", "1.0", "8.05"),
+            ]),
+            ProductScreen.totalAmountIs("8.05"),
+            inLeftSide([
+                ...ProductScreen.clickLotIcon(),
+                ...ProductScreen.enterLotNumber("1"),
+                ...ProductScreen.orderLineHas("Product A", "1.0", "8.05"),
+                {
+                    trigger: ".info-list:contains('Lot Number 1')",
+                },
+            ]),
+            ProductScreen.totalAmountIs("8.05"),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2376,6 +2376,33 @@ class TestUi(TestPointOfSaleHttpCommon):
         created_order = self.env['pos.order'].search([('partner_id', '=', partner.id)], limit=1)
         self.assertNotEqual(created_order.pricelist_id, not_available_pricelist)
 
+    def test_combo_price_unchanged_with_lot_tracked_product(self):
+        """Test that assigning a lot to a combo item does not affect the combo price."""
+        lot_product = self.env['product.product'].create({
+            'name': 'Product A',
+            'is_storable': True,
+            'tracking': 'lot',
+            'available_in_pos': True,
+        })
+        combo = self.env["product.combo"].create({
+            "name": lot_product.name + " combo",
+            "combo_item_ids": [Command.create({"product_id": lot_product.id, "extra_price": 0})]
+        })
+        self.env["product.product"].create(
+            {
+                "available_in_pos": True,
+                "list_price": 7,
+                "name": "Test Combo",
+                "type": "combo",
+                "taxes_id": False,
+                "combo_ids": [
+                    (6, 0, [combo.id])
+                ],
+            }
+        )
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_pos_tour('test_combo_price_unchanged_with_lot_tracked_product', login="pos_admin")
+
     def test_amount_total_is_rounded(self):
         tax = self.env['account.tax'].create({
             'name': 'Tax 18% Included',


### PR DESCRIPTION
Step to reproduce:
- have a lot tracked product, product 1 (price = 10)
- create a combo product with product 1, with price (100)
- start a pos, add combo product in order,
- notice total price is 100
- change lot number of product 1,
- notice order price reset to 10.

Cause:
- When the lot number is changed, `set_quantity_by_lot` is triggered.
- This calls `set_quantity`, which resets the price and loses the combo pricing.

Fix:
- use `keep_price` = true parameter when calling `set_quantity` if orderline
has combo_parent_id

opw-5495409

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
