### PR TITLE
[IMP] point_of_sale: refund button class based on quantity

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -513,6 +513,9 @@ export class TicketScreen extends Component {
             );
         }
     }
+    get buttonClasses() {
+        return this.getHasItemsToRefund() ? "btn-primary" : "btn-secondary disabled";
+    }
     getDate(order) {
         return this.pos.getDate(order.date_order);
     }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -191,7 +191,7 @@
                                     <Numpad class="'pb-2'" buttons="getNumpadButtons()"/>
                                         <ActionpadWidget
                                             partner="getSelectedOrder()?.getPartner()"
-                                            buttonClasses="!getHasItemsToRefund() ? 'disabled' : ''"
+                                            buttonClasses="buttonClasses"
                                             actionName.translate="Refund"
                                             actionToTrigger.bind="onDoRefund"
                                         />

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -263,6 +263,10 @@ registry.category("web_tour.tours").add("RefundFewQuantities", {
             FeedbackScreen.clickNextOrder(),
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("001"),
+            {
+                trigger: ".ticket-screen .btn-secondary.pay-order-button",
+                isActive: ["desktop"],
+            },
             ProductScreen.clickNumpad("0", "."),
             ProductScreen.clickNumpad("0", "2"),
             TicketScreen.toRefundTextContains("0.02"),


### PR DESCRIPTION
Before this commit:
--------
- On the ticket screen, when no quantity was selected for refund, the Refund button was still shown as primary.

After this commit:
--------
- Show the Refund button as secondary when no quantity is selected.
- Switch the button to primary only when at least one item quantity is selected.

task-5490812



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
