### PR TITLE
[FIX] mrp: fix test workcenter timezone

### DIFF
--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -131,16 +131,19 @@ class TestMrpCommon(TestStockCommon):
                 'time_start': 10,
                 'time_stop': 5,
                 'time_efficiency': 80,
+                'tz': 'UTC',
             }, {
                 'name': 'Simple Workcenter',
                 'time_start': 0,
                 'time_stop': 0,
                 'time_efficiency': 100,
+                'tz': 'UTC',
             }, {
                 'name': 'Double Workcenter',
                 'time_start': 0,
                 'time_stop': 0,
                 'time_efficiency': 100,
+                'tz': 'UTC',
             }
         ])
         for (workcenter, default_capacity) in [(cls.workcenter_1, 2), (cls.workcenter_2, 1), (cls.workcenter_3, 2)]:


### PR DESCRIPTION
This commit fixes a timezone wrongly setup in a test.

Related Runbot Build Error: https://runbot.odoo.com/odoo/runbot.build.error/238020

task-5890477

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
