### PR TITLE
[FIX] account_peppol: get_participant_status should archive proxy_user

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -290,6 +290,7 @@ class AccountEdiProxyClientUser(models.Model):
                 if e.code == 'client_gone':
                     # reset the connection if it was archived/deleted on IAP side
                     edi_user.sudo().company_id._reset_peppol_configuration()
+                    edi_user.action_archive()
                 else:
                     # don't auto-deregister users on any other errors to avoid settings client-side to states
                     # that are not recoverable without user action if an error on IAP side ever occurs


### PR DESCRIPTION
Currently, if the participant_status gets a client_gone, we call the _reset_peppol_configuration method.
But while we reset, we don't archive the proxy_user. 
We should do so, so the user can re-register




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
