### PR TITLE
[FIX] mass_mailing: prevent blockquote content loss

### DIFF
--- a/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
+++ b/addons/mass_mailing/views/snippets/mass_mailing_people_snippets.xml
@@ -259,7 +259,7 @@
     <blockquote class="s_mail_blockquote s_blockquote o_mail_snippet_general o_cc o_cc2 pt16 pb16 mb-0 w-100">
         <div class="container">
             <div class="row fst-normal">
-                <div>
+                <div class="col-12">
                     <p>" Write a quote here from one of your customers. Quotes are a great way to build confidence in your products or services. "</p>
                     <div class="row ms-0 pt8">
                         <div class="px-0 col-md-1 col-2 o_not_editable">


### PR DESCRIPTION
Problem:
When sending an email containing a blockquote, its content is missing in the received email.

Cause:
The `bootstrapToTable` conversion logic strictly filters the children of `.row` elements and only keeps nodes that have valid Bootstrap column classes.
In the `s_blockquote` snippet, the content was wrapped in a plain `<div>` placed directly inside a `.row`, so it was ignored during conversion.

Solution:
Add the `col-12` class to the inner `<div>` of the blockquote snippet so it is recognized as a valid Bootstrap column and preserved during conversion.

Steps to reproduce:
- Create a new email marketing.
- Add the "Blockquote" snippet.
- Send the email.
- Observe that the received email loses the blockquote content.

opw-5883624

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
