### PR TITLE
[FIX] website_sale: prevent error when opening a product on the website

### DIFF
--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -327,6 +327,7 @@ export class ProductPage extends Interaction {
         if (!parent) return Promise.resolve();
         const combination = wSaleUtils.getSelectedAttributeValues(parent);
         const addToCart = parent.querySelector('button[name="add_to_cart"]');
+        if (!addToCart) return Promise.resolve();
 
         const combinationInfo = await this.waitFor(rpc('/website_sale/get_combination_info', {
             'product_template_id': parseInt(addToCart?.dataset?.productTemplateId),


### PR DESCRIPTION
Steps to reproduce:
- Install `real_estate` module(industry)
- Website > Properties > Open any product

Traceback:
`ValueError: Expected singleton: product.template()`

This error occurs when the [addToCart] value is `null`. We get `null` because the code is trying to find a button with the name `add_to_cart` inside the `parent`, but that button does not exist in the [template].

[addToCart]: https://github.com/odoo/odoo/blob/61bdc119bca73a7e9ee946d0695c6acc1453adbd/addons/website_sale/static/src/interactions/product_page.js#L329

[template]: https://github.com/odoo/industry/blob/92ff34e33cd166479449dae7ce37e37c9e409db2/real_estate/data/website_view.xml#L336-L344

sentry-7212605657

