### PR TITLE
[FIX] point_of_sale: fix open cashbox click handler in payment screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -145,7 +145,7 @@
                     </t>
                 </button>
                 <button t-if="pos.config.iface_cashdrawer" class="button js_cashdrawer btn btn-secondary btn-lg py-3 rounded"
-                    t-on-click="pos.openCashbox">
+                    t-on-click="() => this.pos.openCashbox()">
                     <i class="fa fa-archive me-2" />Open Cashbox
                 </button>
                 <button t-if="pos.config.ship_later" class="button btn btn-secondary btn-lg d-flex justify-content-between align-items-baseline w-100 lh-lg" t-att-class="{ 'highlight active text-action': currentOrder.shipping_date }"


### PR DESCRIPTION
In this commit:
- Fixes a Traceback error when clicking "Open Cashbox" on the payment screen.
- Ensures the correct context by using an arrow function.
- Prevents `iface_cashdrawer` being undefined during the click event.

Task:5890341