### PR TITLE
[FIX] point_of_sale: show order time in order tab according to locale

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -40,6 +40,7 @@ import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
 import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
 import { formatDate } from "@web/core/l10n/dates";
+import { localization } from "@web/core/l10n/localization";
 import { ProductInfoPopup } from "@point_of_sale/app/components/popups/product_info_popup/product_info_popup";
 import { RetryPrintPopup } from "@point_of_sale/app/components/popups/retry_print_popup/retry_print_popup";
 import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
@@ -2862,7 +2863,7 @@ export class PosStore extends WithLazyGetterTrap {
         }
     }
     getTime(date) {
-        return date.toFormat("hh:mm");
+        return date.toFormat(localization.timeFormat);
     }
 
     orderDone(order) {


### PR DESCRIPTION
In POS, when using a 24h language, the time shown in the order tab (TicketScreen) was always in 12h/AM-PM format instead of 24h.

Steps to reproduce:
-------------------
Set the POS (or user) language to a 24h locale (e.g. French, Spanish) Open POS and create an order
Open the Orders tab and look at the time shown for the order

> Observation:
Time is displayed in 12h (e.g. 4:30) instead of 24h (e.g. 16:30).

Why the fix:
------------
The order tab time was formatted with a hardcoded 12h format ("hh:mm"), ignoring the user’s locale. It now uses the locale’s time format (e.g. localization.timeFormat) so the order tab shows time in 24h or 12h according to the language.

opw-5742177