### PR TITLE
[FIX] point_of_sale: prevent infinite recursion in product models

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -32,7 +32,7 @@ const ProductProductTemplateProxy = new Proxy(ProductProduct, {
             get(target, prop) {
                 const val = Reflect.get(target, prop);
 
-                if (val || target.model.fields[prop] || typeof prop === "symbol") {
+                if (val !== undefined || target.model.fields[prop] || typeof prop === "symbol") {
                     return val;
                 }
 

--- a/addons/point_of_sale/static/tests/unit/models/product_product.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/product_product.test.js
@@ -1,0 +1,27 @@
+import { test, expect } from "@odoo/hoot";
+import { setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { ProductProduct } from "@point_of_sale/app/models/product_product";
+import { ProductTemplate } from "@point_of_sale/app/models/product_template";
+
+definePosModels();
+
+test("product template and product product override", async () => {
+    const store = await setupPosEnv();
+    const product = store.models["product.template"].get(18);
+
+    patchWithCleanup(ProductProduct.prototype, {
+        get allBarcodes() {
+            return this.barcode || "";
+        },
+    });
+    patchWithCleanup(ProductTemplate.prototype, {
+        get allBarcodes() {
+            return (
+                (this.barcode || "") + this.product_variant_ids.map((p) => p.allBarcodes).join(",")
+            );
+        },
+    });
+    expect(product.allBarcodes).toBe("");
+});


### PR DESCRIPTION
Before this commit, if a getter was defined in both product.product and product.template models, and the getter returned a falsy value (like false or an empty string), it could lead to infinite recursion when accessing the property. This was due to the way the models fell back to each other to retrieve the property value.

opw-5886320

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
