### PR TITLE
[FIX] l10n_cy: correct vat payable/refundable formula

### DIFF
--- a/addons/l10n_cy/data/account_tax_report_data.xml
+++ b/addons/l10n_cy/data/account_tax_report_data.xml
@@ -59,13 +59,13 @@
                 </field>
             </record>
             <record id="tax_report_line_5" model="account.report.line">
-                <field name="name">5. VAT payable or refundable (difference between box 4 and 3)</field>
+                <field name="name">5. VAT payable or refundable (difference between box 3 and 4)</field>
                 <field name="code">cy_5</field>
                 <field name="expression_ids">
                     <record id="tax_report_line_5_amount" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">aggregation</field>
-                        <field name="formula">cy_4.balance - cy_3.balance</field>
+                        <field name="formula">cy_3.balance - cy_4.balance</field>
                         <field name="green_on_positive">False</field>
                     </record>
                 </field>


### PR DESCRIPTION
**Steps to produce:**
- Install the l10n_cy and accountant modules
- Switch to `CY Company`.
- Go to accounting > reports > Tax return.

**Issue:**
- The formula for VAT payable or refundable (difference between box 4 and 3)
  is incorrect.
- box 3 refers to `Total output VAT` and box 4 refers to `Input VAT`.
- Current formula: `cy_4.balance - cy_3.balance`

**Fix:**
- Formula for VAT payable or refundable should be output VAT - input VAT.
- Update the formula to: `cy_3.balance - cy_4.balance`

<img width="769" height="86" alt="image" src="https://github.com/user-attachments/assets/923a92f9-fc57-465a-9592-771730ee6870" />


opw-5751369
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
