### PR TITLE
[IMP] stock: improve search filter order in stock move reports

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -127,8 +127,8 @@
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
             <search string="Stock Moves">
-                <field name="location_id" string="Location" filter_domain="['|',('location_id', 'ilike', self),('location_dest_id', 'ilike', self)]" groups="stock.group_stock_multi_locations"/>
                 <field name="product_id"/>
+                <field name="location_id" string="Location" filter_domain="['|', ('location_id', 'ilike', self), ('location_dest_id', 'ilike', self)]" groups="stock.group_stock_multi_locations"/>
                 <field name="picking_id" string="Transfer"/>
                 <field name="reference" string="Reference"/>
                 <field name="product_category_id" string="Category"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -384,8 +384,8 @@
             <field eval="3" name="priority"/>
             <field name="arch" type="xml">
                 <search string="Stock Moves">
-                    <field name="reference" string="Location" filter_domain="['|',('location_id', 'ilike', self),('location_dest_id', 'ilike', self)]" groups="stock.group_stock_multi_locations"/>
                     <field name="product_id"/>
+                    <field name="reference" string="Location" filter_domain="['|', ('location_id', 'ilike', self), ('location_dest_id', 'ilike', self)]" groups="stock.group_stock_multi_locations"/>
                     <field name="origin" filter_domain="['|', '|', ('origin', 'ilike', self), ('reference', 'ilike', self), ('picking_id', 'ilike', self)]" string="Reference"/>
                     <field name="location_id" string="Source Location" groups="stock.group_stock_multi_locations"/>
                     <field name="location_dest_id" string="Destination Location" groups="stock.group_stock_multi_locations"/>


### PR DESCRIPTION
When filtering stock moves, users generally search for the `Product` more often than the `Location`, but `Location` appeared as the default filter, which led to incorrect filtering. This change reorders the filters in both `Moves History`
and `Moves Analysis` reports to show `Product` before `Location`.

task-5481588