### PR TITLE
[FIX] hr_recruitment: Rename "Initial Qualification" to "Qualification"

### DIFF
--- a/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
+++ b/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
@@ -258,7 +258,7 @@
         <record id="scenario_applicant_macm_helen_mtv_1" model="mail.tracking.value">
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
-            <field name="new_value_char">Initial Qualification</field>
+            <field name="new_value_char">Qualification</field>
             <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
             <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
             <field name="mail_message_id" ref="scenario_applicant_macm_helen_mm_1" />
@@ -290,7 +290,7 @@
         </record>
         <record id="scenario_applicant_macm_helen_mtv_2" model="mail.tracking.value">
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
-            <field name="old_value_char">Initial Qualification</field>
+            <field name="old_value_char">Qualification</field>
             <field name="new_value_char">First Interview</field>
             <field name="old_value_integer" eval="ref('hr_recruitment.stage_job1')" />
             <field name="new_value_integer" eval="ref('hr_recruitment.stage_job2')" />
@@ -412,7 +412,7 @@
         <record id="scenario_applicant_macm_enrique_mtv_1" model="mail.tracking.value">
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
-            <field name="new_value_char">Initial Qualification</field>
+            <field name="new_value_char">Qualification</field>
             <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
             <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
             <field name="mail_message_id" ref="scenario_applicant_macm_enrique_mm_1" />
@@ -447,7 +447,7 @@
         </record>
         <record id="scenario_applicant_macm_enrique_mtv_2" model="mail.tracking.value">
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
-            <field name="old_value_char">Initial Qualification</field>
+            <field name="old_value_char">Qualification</field>
             <field name="new_value_char">First Interview</field>
             <field name="old_value_integer" eval="ref('hr_recruitment.stage_job1')" />
             <field name="new_value_integer" eval="ref('hr_recruitment.stage_job2')" />
@@ -526,7 +526,7 @@
         <record id="scenario_applicant_fsd_hannah_mtv_1" model="mail.tracking.value">
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
-            <field name="new_value_char">Initial Qualification</field>
+            <field name="new_value_char">Qualification</field>
             <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
             <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
             <field name="mail_message_id" ref="scenario_applicant_fsd_hannah_mm_1" />
@@ -569,7 +569,7 @@
         <record id="scenario_applicant_fsd_simon_mtv_1" model="mail.tracking.value">
             <field name="field_id" ref="hr_recruitment.field_hr_applicant__stage_id" />
             <field name="old_value_char">New</field>
-            <field name="new_value_char">Initial Qualification</field>
+            <field name="new_value_char">Qualification</field>
             <field name="old_value_integer" eval="ref('hr_recruitment.stage_job0')" />
             <field name="new_value_integer" eval="ref('hr_recruitment.stage_job1')" />
             <field name="mail_message_id" ref="scenario_applicant_fsd_simon_mm_1" />


### PR DESCRIPTION
This is a small follow-up PR to the original PR to simply rename a stage label.

See https://github.com/odoo/enterprise/pull/105278

Task-ID: 5454691

