### PR TITLE
[FIX] hr_recruitment: fix traceback when loading sample data

### DIFF
--- a/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
+++ b/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
@@ -80,7 +80,6 @@
             <field name="priority">2</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/helen.lee</field>
             <field name="job_id" ref="job_marketing" />
-            <field name="user_id" ref="base.user_admin" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">3100</field>
@@ -102,7 +101,6 @@
             <field name="priority">2</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/enrique.jones</field>
             <field name="job_id" ref="job_marketing" />
-            <field name="user_id" ref="base.user_admin" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">2900</field>
@@ -124,7 +122,6 @@
             <field name="priority">3</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/hannah.glover</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
 
             <field name="department_id" ref="dep_rd" />
@@ -147,7 +144,6 @@
             <field name="priority">0</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/simon.jones</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
             <field name="salary_expected">3000</field>
@@ -173,7 +169,6 @@
             <field name="priority">0</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/maria.rodriguez</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
             <field name="stage_id" ref="stage_job0" />


### PR DESCRIPTION
Version:
- saas-19.2

Steps to reproduce:
- Create a new database without demo data
- Install the Recruitment app
- Open it, and click on Load Demo Data

Issue:
- A traceback occurs when clicking the Load Demo Data button.

Cause:
- The user_id field was removed by PR :https://github.com/odoo/odoo/pull/229665.
- However, the sample data still references the removed user_id / user_ids field which causes the traceback.

Solution:
- Remove the user_ids field from the recruitment sample data to align with the changes introduced in PR : https://github.com/odoo/odoo/pull/229665

task-5890535