### PR TITLE
[IMP] hr_skills_event: restrict onsite course selection to employee

### DIFF
--- a/addons/hr_skills_event/models/hr_resume_line.py
+++ b/addons/hr_skills_event/models/hr_resume_line.py
@@ -9,7 +9,7 @@ class HrResumeLine(models.Model):
     event_id = fields.Many2one(
         'event.event', string="Onsite Course", compute='_compute_event_id',
         store=True, readonly=True, index='btree_not_null',
-        domain="[('is_multi_slots', '=', True), ('registration_ids', 'any', [('partner_id.employee', '=', True)])]"
+        domain="[('registration_ids', 'any', [('partner_id.employee_ids', '=', employee_id)])]"
     )
     course_type = fields.Selection(
         selection_add=[('onsite', 'Onsite')],

--- a/addons/hr_skills_event/views/hr_resume_line_views.xml
+++ b/addons/hr_skills_event/views/hr_resume_line_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='external_url']" position="before">
                 <field name="event_id" readonly="0"/>
+                <field name="employee_id" invisible="1"/>  <!-- for the employee's default value in domain-->
             </xpath>
             <xpath expr="//field[@name='course_type']" position="attributes">
                 <attribute name="invisible">0</attribute>


### PR DESCRIPTION
## Purpose
- Previously when adding an onsite course in a resume line then we were unable to see the created online courses attended by that employee.

## Reason
- The conditions must be satisfied:
   - Multi slot
   - Employee has attended atleast one event

## Steps to reproduce
1. Open any employee.
2. Try to add resume line.
3. Add a training having onsite course.
4. Create one new course and make that employee registered for that onsite course.

## Solution
- Modified the domain to show all the registered events linked to that employee.

task-5427310

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
