### PR TITLE
[FIX] account_peppol: id error for branch company in demo mode

### DIFF
--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -103,7 +103,7 @@ def _mock_check_peppol_participant_exists(func, self, *args, **kwargs):
 
 def _mock_create_connection(func, self, *args, **kwargs):
     peppol_identifier, _db_uuid, company = args
-    dummy_response = {'id_client': 'demo4peppol', 'refresh_token': 'demo', 'peppol_state': 'receiver'}
+    dummy_response = {'id_client': f'demo4peppol_{company.id}', 'refresh_token': 'demo', 'peppol_state': 'receiver'}
     private_key_sudo = self.env['certificate.key'].sudo()._generate_rsa_private_key(
         company,
         name=f"peppol_demo_{company.id}.key",


### PR DESCRIPTION
Steps to reproduce in demo:
1.  Activate Peppol in the main company for both sending and receiving;
2. Create a branch company (with same VAT number as the main company);
3. Activate Peppol in the branch and select "Send from parent company";
4. Error message: "This id_client is already used on another user.".

In demo edi_mode, when trying to connect a branch company with the same VAT than the parent company, the demo function took the same id_client for every company, which violates the unique constraint on id_client.

task-5888203


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
