### PR TITLE
[FIX] tests: WebGL disabled in Chrome Headless 144+

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1172,6 +1172,7 @@ class ChromeBrowser:
             '--disable-translate': '',
             '--no-sandbox': '',
             '--disable-gpu': '',
+            '--enable-unsafe-swiftshader': '',
             '--mute-audio': '',
         }
         switches = {


### PR DESCRIPTION
Since Chrome 144 disabled [^1] by default the WebGL fallback to the software renderer SwiftShader, this commit reenables [^2][^3] it when running in headless mode to allow to keep testing WebGL features (i.e. image filters in website builder).

Note: the SwiftShader implementation is considered deprecated and less safe than proper hardware based ones, hence not recommended for a regular usage with untrusted content. However, as tests are run in a more controlled environment, it looks reasonnable to opt-in to keep actually testing WebGL features.

[^1]: https://chromium-review.googlesource.com/c/chromium/src/+/7128438
[^2]: https://issues.chromium.org/issues/476172421
[^3]: https://chromestatus.com/feature/5166674414927872
