### PR TITLE
[IMP] base: remove deprecated fallback for t-call QWeb directive

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -116,7 +116,7 @@
     </template>
 
     <template id="report_timesheet">
-        <t t-call="web.html_container">
+        <t t-call="web.html_container" docs="docs">
             <t t-set="show_task" t-value="bool(docs.task_id)"/>
             <t t-set="show_project" t-value="len(docs.project_id) > 1"/>
             <t t-call="web.internal_layout"
@@ -134,7 +134,7 @@
                             </h2>
                         </div>
                     </div>
-                    <t t-call="hr_timesheet.timesheet_table" lines="docs"/>
+                    <t t-call="hr_timesheet.timesheet_table" lines="docs" show_project="show_project" show_task="show_task"/>
                     <div class="oe_structure"/>
                 </div>
             </t>
@@ -143,7 +143,7 @@
 
     <!-- Project Task Timesheet Report for given timesheets -->
     <template id="report_timesheet_task">
-        <t t-call="web.html_container">
+        <t t-call="web.html_container" docs="docs">
             <t t-set="show_task" t-value="len(docs.task_id) > 1"/>
             <t t-set="show_project" t-value="False"/>
             <t t-call="web.internal_layout"
@@ -161,7 +161,7 @@
                             </h2>
                         </div>
                     </div>
-                    <t t-call="hr_timesheet.timesheet_table" lines="docs"/>
+                    <t t-call="hr_timesheet.timesheet_table" lines="docs" show_task="show_task" show_project="show_project"/>
                     <div class="oe_structure"/>
                 </div>
             </t>

--- a/addons/sale_timesheet/report/report_timesheet_templates.xml
+++ b/addons/sale_timesheet/report/report_timesheet_templates.xml
@@ -19,7 +19,7 @@
                                         <span>Timesheets for the <t t-out="doc_name">S0001</t> <t t-out="record_name">- Timesheet product</t>
                                         </span>
                                     </h2>
-                                    <t t-call="hr_timesheet.timesheet_table" lines="doc.timesheet_ids"/>
+                                    <t t-call="hr_timesheet.timesheet_table" lines="doc.timesheet_ids" show_project="show_project" show_task="show_task"/>
                                 </t>
                             </div>
                         </div>

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -2579,8 +2579,6 @@ class IrQweb(models.AbstractModel):
 
         # values from content (t-out="0")
         if bool(list(el) or el.text):
-            is_deprecated_version = not any(not key.startswith('t-') for key in el.attrib) and any(n.attrib.get('t-set') for n in el)
-
             def_name = compile_context['make_name']('t_call')
             code_content = [f"def {def_name}(self, values):"]
             code_content.append(indent_code('attrs = None', 1))
@@ -2596,14 +2594,6 @@ class IrQweb(models.AbstractModel):
                 qwebContent = QwebContent(self, QwebCallParameters(self.env.context, {compile_context['ref']!r}, {def_name!r}, t_call_content_values, 'root', 't-call-content', (template_options['ref'], {path!r}, {xml!r})))
                 t_call_values = {{ {T_CALL_SLOT}: qwebContent}}
             """, level))
-
-            if is_deprecated_version:
-                # force the loading of the content to get values from t-set
-                code.append(indent_code(f"""
-                    str(qwebContent)
-                    new_values = {{k: v for k, v in t_call_content_values.items() if k != {T_CALL_SLOT} and k != '__qweb_attrs__' and values.get(k) is not v}}
-                    t_call_values.update(new_values)
-                """, level))
         else:
             code.append(indent_code(f"t_call_values = {{ {T_CALL_SLOT}: '' }}", level))
 

--- a/odoo/upgrade_code/19.1-00-t-call.py
+++ b/odoo/upgrade_code/19.1-00-t-call.py
@@ -17,230 +17,245 @@ XPATH_TCALL_REG = re.compile(r'\[@(t-call|t-snippet-call)=[^\]]+\]$')
 log = logging.getLogger(__name__)
 
 
+def detach_node_tail(node):
+    if (prev := node.getprevious()) is not None:
+        prev.tail = (prev.tail or '').rstrip() + (node.tail or '')
+    else:
+        parent = node.getparent()
+        parent.text = (parent.text or '').rstrip() + (node.tail or '')
+
+
+def move_tset_before_tcall(tset, tcall):
+    parent = tcall.getparent()
+    previous_indent = get_indentation(tset)
+    indent = get_indentation(tcall)
+
+    detach_node_tail(tset)
+    tset.tail = indent
+
+    tset.set('__need_dedent__', str(len(previous_indent) - len(indent)))
+
+    parent.insert(parent.index(tcall), tset)
+
+
+def remove_tset_add_attribute(tset, tcall):
+    detach_node_tail(tset)
+
+    if 't-value' in tset.attrib:
+        value = tset.get('t-value')
+        if value.startswith("'") and value.endswith("'") and "{" not in value and "'" not in value[1:-1]:
+            tcall.set(f"{tset.get('t-set')}.f", value[1:-1])
+        else:
+            tcall.set(tset.get('t-set'), value)
+    elif 't-valuef' in tset.attrib:
+        tcall.set(f"{tset.get('t-set')}.f", tset.get('t-valuef'))
+    else:
+        tcall.set(f"{tset.get('t-set')}.translate", (tset.text or '').strip())
+
+    tset.getparent().remove(tset)
+
+
+def is_not_direct_children_of(tset, tcall):
+    closest_tcall = tset.xpath('ancestor::t[@t-call or @t-snippet-call or @t-if or @t-elif or @t-else or @t-set or @t-foreach]')
+    return closest_tcall and closest_tcall[-1] != tcall
+
+
+def varname_is_used_inside(tset, tcall):
+    n = tset
+    while (skip_to := n.getnext()) is None and n != tcall:
+        n = n.getparent()
+    if skip_to is None:
+        return set()
+    return _varname_is_used_inside(tset, tcall, skip_to)
+
+
+def _varname_is_used_inside(tset, container, skip_to):
+    used = set()
+    varname = tset.get('t-set')
+    REG = re.compile(rf"(^|[,({{ /*+-]){ varname }([\[\] .()}})/*+-]|$)")
+
+    for el in container.iter():
+        if skip_to is not None and el is not skip_to:
+            continue
+        skip_to = None
+        if not el.tag:
+            continue
+
+        # For the t-set using this value, we check if this new value is used
+        # in the template and continue to check the other usecases.
+        # If the varname is used, if is used by an other unused t-set, we
+        # need to move the current t-set before the t-call.
+        # If the varname is use only by attribute and t-set also used, the
+        # current t-set does'nt move.
+        for attr, value in el.attrib.items():
+            if not attr.startswith('t-'):
+                if el.attrib.get('t-call') and REG.search(value):
+                    used.add('used')
+            elif attr == 't-set' or attr == 't-as':
+                if value == varname:
+                    closest_tcall = el.xpath('ancestor::t[@t-call or @t-snippet-call]')
+                    if closest_tcall and closest_tcall[-1] == container:
+                        used.add('rewrite')
+            elif REG.search(value):
+                used.add('current-used')
+
+        is_tset = el.get('t-set')
+        if is_tset:
+            # get if the value is used inside an other t-set
+            if len(el) and _varname_is_used_inside(tset, el, el[0]):
+                used.add('current-used')
+            skip_to = el.getnext()
+
+        if 'current-used' in used:
+            used.remove('current-used')
+            if is_tset:
+                sub_used = varname_is_used_inside(el, container) - {'rewrite'}
+                if sub_used:
+                    used.update(sub_used)
+                else:
+                    if is_not_direct_children_of(tset, container):
+                        used.add('used')
+                    else:
+                        used.add('t-set')
+            else:
+                used.add('used')
+
+    return used
+
+
+def remove_tset_add_inherit_attribute(tset, container):
+    attribute = etree.Element('attribute')
+    if len(container):
+        container[-1].tail = container.text  # indent
+    container.append(attribute)
+
+    if 't-value' in tset.attrib:
+        value = tset.get('t-value')
+        if value.startswith("'") and value.endswith("'") and "{" not in value and "'" not in value[1:-1]:
+            attribute.attrib['name'] = f"{tset.get('t-set')}.f"
+            attribute.text = value[1:-1]
+        else:
+            attribute.attrib['name'] = tset.get('t-set')
+            attribute.text = value
+    elif 't-valuef' in tset.attrib:
+        attribute.attrib['name'] = f"{tset.get('t-set')}.f"
+        attribute.text = tset.get('t-valuef')
+    elif not len(tset):
+        attribute.attrib['name'] = f"{tset.get('t-set')}.translate"
+        attribute.text = (tset.text or '').strip()
+    else:
+        raise ValueError('Wrong conversion')
+
+    if tset.getparent() is not None:
+        tset.getparent().remove(tset)
+
+
+def change(root: etree._ElementTree) -> bool:
+    content_updated = False
+    for tcall in root.xpath('//*[@t-call or @t-snippet-call][not(@position="inside")]'):
+
+        if any(not att.startswith('t-') for att in tcall.attrib):
+            continue
+        if tcall.xpath('ancestor::kanban'):
+            continue
+
+        # every t-set children
+        for tset in tcall.xpath('.//*[@t-set]'):
+            if is_not_direct_children_of(tset, tcall):
+                # not in a directive (as t-if, t-foreach...) or an other
+                # t-set and not in an other t-call
+                continue
+
+            used = varname_is_used_inside(tset, tcall)
+
+            if 'used' in used:
+                # This set of characters is used within the current content.
+                # It is presumably not used by the t-call.
+                continue
+
+            if 'rewrite' in used:
+                raise ValueError(f"Can not determine the position of the rewrited t-set: {tset.get('t-set')!r}")
+
+            # Move the t-set if the are some content or if it's used for an
+            # other t-set else we can remove it and add as an attribute.
+            if ('t-set' in used or
+                (
+                    len(tset) or
+                    tset.get('groups') or
+                    tset.get('t-groups') or
+                    tset.get('t-if')
+                )):
+                # Move the t-set if the are some content or if it's used
+                # for an other t-set
+                move_tset_before_tcall(tset, tcall)
+                tcall.set(tset.get('t-set'), tset.get('t-set'))
+                content_updated = True
+            else:
+                # never used inside we can remove it and add as an attribute.
+                remove_tset_add_attribute(tset, tcall)
+                content_updated = True
+
+    # # if we need to have an idem potent change
+    # for tcall in root.xpath('//*[@t-call or t-snippet-call][not(@position="inside")]'):
+    #     if not any(not att.startswith('t-') for att in tcall.attrib) and tcall.xpath('*[@t-set]'):
+    #         tcall.set('true', 'True')
+
+    # inherit t-call
+    inherit_tcalls = (
+        root.xpath('//*[@t-call or t-snippet-call][@position="inside"]') +
+        [
+            tcall for tcall in root.xpath('//xpath[contains(@expr, "@t-call") or contains(@expr, "@t-snippet-call")][@position="inside"]')
+            if XPATH_TCALL_REG.search(tcall.get('expr'))
+        ]
+    )
+    for tcall in inherit_tcalls:
+        parent = tcall.getparent()
+        index = parent.index(tcall)
+        indent = get_indentation(tcall)
+        before = None
+        attributes = None
+        for tset in tcall.xpath('t[@t-set]'):
+            detach_node_tail(tset)
+            content_updated = True
+
+            if attributes is None:
+                attributes = etree.Element(tcall.tag, tcall.attrib)
+                attributes.attrib['position'] = 'attributes'
+                attributes.text = indent + ' ' * 4
+                attributes.tail = indent
+                parent.insert(index, attributes)
+
+            t_set_key = tset.get('t-set')
+            if len(tset) or varname_is_used_inside(tset, tcall):
+                if before is None:
+                    before = etree.Element(tcall.tag, tcall.attrib)
+                    before.attrib['position'] = 'before'
+                    before.text = indent + ' ' * 4
+                    before.tail = indent
+                    parent.insert(index, before)
+
+                before.append(tset)
+                tset = etree.Element('t', {'t-set': t_set_key, 't-value': t_set_key})
+
+            remove_tset_add_inherit_attribute(tset, attributes)
+
+        if before is not None:
+            before[-1].tail = indent
+        if attributes is not None:
+            attributes[-1].tail = indent
+
+        if not len(tcall):
+            detach_node_tail(tcall)
+            parent.remove(tcall)
+            content_updated = True
+
+    return content_updated
+
+
 def upgrade(file_manager: FileManager):
     files = [file for file in file_manager if file.path.suffix == '.xml' and '/static/' not in str(file.path)]
     if not files:
         return
-
-    def detach_node_tail(node):
-        if (prev := node.getprevious()) is not None:
-            prev.tail = (prev.tail or '').rstrip() + (node.tail or '')
-        else:
-            parent = node.getparent()
-            parent.text = (parent.text or '').rstrip() + (node.tail or '')
-
-    def move_tset_before_tcall(tset, tcall):
-        parent = tcall.getparent()
-        previous_indent = get_indentation(tset)
-        indent = get_indentation(tcall)
-
-        detach_node_tail(tset)
-        tset.tail = indent
-
-        tset.set('__need_dedent__', str(len(previous_indent) - len(indent)))
-
-        parent.insert(parent.index(tcall), tset)
-
-    def remove_tset_add_attribute(tset, tcall):
-        detach_node_tail(tset)
-
-        if 't-value' in tset.attrib:
-            value = tset.get('t-value')
-            if value.startswith("'") and value.endswith("'") and "{" not in value and "'" not in value[1:-1]:
-                tcall.set(f"{tset.get('t-set')}.f", value[1:-1])
-            else:
-                tcall.set(tset.get('t-set'), value)
-        elif 't-valuef' in tset.attrib:
-            tcall.set(f"{tset.get('t-set')}.f", tset.get('t-valuef'))
-        else:
-            tcall.set(f"{tset.get('t-set')}.translate", (tset.text or '').strip())
-
-        tset.getparent().remove(tset)
-
-    def is_not_direct_children_of(tset, tcall):
-        closest_tcall = tset.xpath('ancestor::t[@t-call or @t-snippet-call or @t-if or @t-elif or @t-else or @t-set or @t-foreach]')
-        return closest_tcall and closest_tcall[-1] != tcall
-
-    def varname_is_used_inside(tset, tcall):
-        n = tset
-        while (skip_to := n.getnext()) is None and n != tcall:
-            n = n.getparent()
-        if skip_to is None:
-            return set()
-        return _varname_is_used_inside(tset, tcall, skip_to)
-
-    def _varname_is_used_inside(tset, container, skip_to):
-        used = set()
-        varname = tset.get('t-set')
-        REG = re.compile(rf"(^|[,({{ /*+-]){ varname }([\[\] .()}})/*+-]|$)")
-
-        for el in container.iter():
-            if skip_to is not None and el is not skip_to:
-                continue
-            skip_to = None
-            if not el.tag:
-                continue
-
-            # For the t-set using this value, we check if this new value is used
-            # in the template and continue to check the other usecases.
-            # If the varname is used, if is used by an other unused t-set, we
-            # need to move the current t-set before the t-call.
-            # If the varname is use only by attribute and t-set also used, the
-            # current t-set does'nt move.
-            for attr, value in el.attrib.items():
-                if not attr.startswith('t-'):
-                    if el.attrib.get('t-call') and REG.search(value):
-                        used.add('used')
-                elif attr == 't-set' or attr == 't-as':
-                    if value == varname:
-                        closest_tcall = el.xpath('ancestor::t[@t-call or @t-snippet-call]')
-                        if closest_tcall and closest_tcall[-1] == container:
-                            used.add('rewrite')
-                elif REG.search(value):
-                    used.add('current-used')
-
-            is_tset = el.get('t-set')
-            if is_tset:
-                # get if the value is used inside an other t-set
-                if len(el) and _varname_is_used_inside(tset, el, el[0]):
-                    used.add('current-used')
-                skip_to = el.getnext()
-
-            if 'current-used' in used:
-                used.remove('current-used')
-                if is_tset:
-                    sub_used = varname_is_used_inside(el, container) - {'rewrite'}
-                    if sub_used:
-                        used.update(sub_used)
-                    else:
-                        if is_not_direct_children_of(tset, container):
-                            used.add('used')
-                        else:
-                            used.add('t-set')
-                else:
-                    used.add('used')
-
-        return used
-
-    def remove_tset_add_inherit_attribute(tset, container):
-        attribute = etree.Element('attribute')
-        if len(container):
-            container[-1].tail = container.text  # indent
-        container.append(attribute)
-
-        if 't-value' in tset.attrib:
-            value = tset.get('t-value')
-            if value.startswith("'") and value.endswith("'") and "{" not in value and "'" not in value[1:-1]:
-                attribute.attrib['name'] = f"{tset.get('t-set')}.f"
-                attribute.text = value[1:-1]
-            else:
-                attribute.attrib['name'] = tset.get('t-set')
-                attribute.text = value
-        elif 't-valuef' in tset.attrib:
-            attribute.attrib['name'] = f"{tset.get('t-set')}.f"
-            attribute.text = tset.get('t-valuef')
-        elif not len(tset):
-            attribute.attrib['name'] = f"{tset.get('t-set')}.translate"
-            attribute.text = (tset.text or '').strip()
-        else:
-            raise ValueError('Wrong conversion')
-
-        if tset.getparent() is not None:
-            tset.getparent().remove(tset)
-
-    def change(root: etree._ElementTree):
-        for tcall in root.xpath('//*[@t-call or @t-snippet-call][not(@position="inside")]'):
-
-            if any(not att.startswith('t-') for att in tcall.attrib):
-                continue
-            if tcall.xpath('ancestor::kanban'):
-                continue
-
-            # every t-set children
-            for tset in tcall.xpath('.//*[@t-set]'):
-                if is_not_direct_children_of(tset, tcall):
-                    # not in a directive (as t-if, t-foreach...) or an other
-                    # t-set and not in an other t-call
-                    continue
-
-                used = varname_is_used_inside(tset, tcall)
-
-                if 'used' in used:
-                    # This set of characters is used within the current content.
-                    # It is presumably not used by the t-call.
-                    continue
-
-                if 'rewrite' in used:
-                    raise ValueError(f"Can not determine the position of the rewrited t-set: {tset.get('t-set')!r}")
-
-                # Move the t-set if the are some content or if it's used for an
-                # other t-set else we can remove it and add as an attribute.
-                if ('t-set' in used or
-                   (
-                        len(tset) or
-                        tset.get('groups') or
-                        tset.get('t-groups') or
-                        tset.get('t-if')
-                   )):
-                    # Move the t-set if the are some content or if it's used
-                    # for an other t-set
-                    move_tset_before_tcall(tset, tcall)
-                    tcall.set(tset.get('t-set'), tset.get('t-set'))
-                else:
-                    # never used inside we can remove it and add as an attribute.
-                    remove_tset_add_attribute(tset, tcall)
-
-        # # if we need to have an idem potent change
-        # for tcall in root.xpath('//*[@t-call or t-snippet-call][not(@position="inside")]'):
-        #     if not any(not att.startswith('t-') for att in tcall.attrib) and tcall.xpath('*[@t-set]'):
-        #         tcall.set('true', 'True')
-
-        # inherit t-call
-        inherit_tcalls = (
-            root.xpath('//*[@t-call or t-snippet-call][@position="inside"]') +
-            [
-                tcall for tcall in root.xpath('//xpath[contains(@expr, "@t-call") or contains(@expr, "@t-snippet-call")][@position="inside"]')
-                if XPATH_TCALL_REG.search(tcall.get('expr'))
-            ]
-        )
-        for tcall in inherit_tcalls:
-            parent = tcall.getparent()
-            index = parent.index(tcall)
-            indent = get_indentation(tcall)
-            before = None
-            attributes = None
-            for tset in tcall.xpath('t[@t-set]'):
-                detach_node_tail(tset)
-
-                if attributes is None:
-                    attributes = etree.Element(tcall.tag, tcall.attrib)
-                    attributes.attrib['position'] = 'attributes'
-                    attributes.text = indent + ' ' * 4
-                    attributes.tail = indent
-                    parent.insert(index, attributes)
-
-                t_set_key = tset.get('t-set')
-                if len(tset) or varname_is_used_inside(tset, tcall):
-                    if before is None:
-                        before = etree.Element(tcall.tag, tcall.attrib)
-                        before.attrib['position'] = 'before'
-                        before.text = indent + ' ' * 4
-                        before.tail = indent
-                        parent.insert(index, before)
-
-                    before.append(tset)
-                    tset = etree.Element('t', {'t-set': t_set_key, 't-value': t_set_key})
-
-                remove_tset_add_inherit_attribute(tset, attributes)
-
-            if before is not None:
-                before[-1].tail = indent
-            if attributes is not None:
-                attributes[-1].tail = indent
-
-            if not len(tcall):
-                detach_node_tail(tcall)
-                parent.remove(tcall)
 
     for fileno, file in enumerate(files, start=1):
 

--- a/odoo/upgrade_code/19.1-00-t-call.py
+++ b/odoo/upgrade_code/19.1-00-t-call.py
@@ -150,7 +150,7 @@ def remove_tset_add_inherit_attribute(tset, container):
         tset.getparent().remove(tset)
 
 
-def change(root: etree._ElementTree) -> bool:
+def change(root: etree._ElementTree, path: str) -> bool:
     content_updated = False
     for tcall in root.xpath('//*[@t-call or @t-snippet-call][not(@position="inside")]'):
 
@@ -174,7 +174,8 @@ def change(root: etree._ElementTree) -> bool:
                 continue
 
             if 'rewrite' in used:
-                raise ValueError(f"Can not determine the position of the rewrited t-set: {tset.get('t-set')!r}")
+                log.info("Can not determine the position of the rewrited t-set: '%s' in '%s'", tset.get('t-set'), path)
+                break
 
             # Move the t-set if the are some content or if it's used for an
             # other t-set else we can remove it and add as an attribute.
@@ -263,7 +264,7 @@ def upgrade(file_manager: FileManager):
             content = file.content
 
             if ('t-call=' in content or 't-snippet-call=' in content) and 't-set=' in content:
-                content = update_etree(content, change)
+                content = update_etree(content, lambda root: change(root, str(file.path)))
                 content = AUTO_CLOSE_T.sub(r"\g<1>/>", content)
                 file.content = content
         except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
The `t-call` syntax is updated to use the new semantic, which passes
values *as attributes/parameters* on the `<t>` (with `t-call`) tag itself,
instead of relying on nested `t-set` directive.

- Old (Deprecated): Used nested `<t t-set="var_name" t-value="x"/>` tags
inside the calling element to define variables.
- New: Variables are passed as attributes directly on the element where
the `t-call` is located (e.g., `<t t-call="module.template" var_name="x"/>`).

A warning is added to alert developers when using the old deprecated
syntax.

see: https://github.com/odoo/odoo/pull/197296
see: https://github.com/odoo/odoo/pull/232539
The script to automate the process has been added to: https://github.com/odoo/odoo/pull/235469