### PR TITLE
[FIX] account: bank statement print action

### DIFF
--- a/addons/account/static/src/views/account_move_list/account_move_list_controller.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_controller.js
@@ -19,11 +19,14 @@ export class AccountMoveListController extends FileUploadListController {
     }
 
     get actionMenuProps() {
-        return {
+        const actionMenuProps = {
             ...super.actionMenuProps,
             printDropdownTitle: _t("Print"),
-            loadExtraPrintItems: this.loadExtraPrintItems.bind(this),
         };
+        if (this.props.resModel === "account.move") {
+            actionMenuProps.loadExtraPrintItems = this.loadExtraPrintItems.bind(this);
+        }
+        return actionMenuProps;
     }
 
     async loadExtraPrintItems() {


### PR DESCRIPTION
In Bank Statement list view users may select a statement and download a pdf report. However, currently, the load of extra print options may raise an error.

Steps to reproduce:
- In Accounting Dashboard, from a bank journal card, 3 dots > Statements
- Select a line (it needs to have an id not present in `account.move`)
- Click 'Print' button

Issue:
Access error may occur, stating the record has been deleted or it is inaccessible. This happens because backend method `get_extra_print_items` is called on `account.move` with the id of the `account.bank.statement` On accessing the record fields we get the error

A solution is to avoid loading extra print item with loadExtraPrintItems if we are not in the `account.move` model

opw-5500506
