### PR TITLE
[FIX] base,web: prevent phone input collapse on mobile

### DIFF
--- a/addons/web/static/src/views/fields/phone/phone_field.scss
+++ b/addons/web/static/src/views/fields/phone/phone_field.scss
@@ -10,4 +10,9 @@ body:not(.o_touch_device) .o_field_phone {
 .o_phone_content small {
     overflow-wrap: normal;
     word-break: normal;
+
+    /* On small screens, hide the text labels inside the phone buttons */
+    @include media-breakpoint-down(md) {
+        display: none;
+    }
 }

--- a/addons/web/static/tests/views/fields/phone_field.test.js
+++ b/addons/web/static/tests/views/fields/phone_field.test.js
@@ -219,3 +219,21 @@ test("New record, fill in phone field, then click on call icon and save", async 
     expect(".o_field_widget[name=foo] input").toHaveValue("+12345678900");
     expect(`.o_form_status_indicator_buttons`).toHaveClass("invisible");
 });
+
+test.tags("mobile");
+test("PhoneField in form view shows only icon on mobile screens", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="foo" widget="phone"/>
+                    </group>
+                </sheet>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_field_phone .o_phone_form_link small").not.toBeVisible();
+});

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -138,11 +138,11 @@
                                     <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Lumber Inc" invisible="not is_company" required="type == 'contact'"/>
                                     <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="type == 'contact'"/>
                                 </h1>
-                                <div class="d-flex align-items-baseline w-50">
+                                <div class="d-flex align-items-baseline w-md-50">
                                     <i class="fa fa-fw me-1 fa-envelope text-primary" title="Email"/>
                                     <field name="email" class="w-100" widget="email" required="user_ids" placeholder="Email"/>
                                 </div>
-                                <div class="d-flex align-items-baseline w-50">
+                                <div class="d-flex align-items-baseline w-md-50">
                                     <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone"/>
                                     <field name="phone" class="w-100" widget="phone" placeholder="Phone"/>
                                 </div>


### PR DESCRIPTION
Steps to reproduce:
1. Install `contacts`
2. Create an individual contact with a phone number
3. Try to edit the phone number on the mobile

Issue:
- Unable to edit in mobile view

Cause:
- On mobile devices, the utility buttons (Call, SMS, WhatsApp) inside the phone widget consume significant horizontal space. Due to the flex layout, this forces the actual phone input field to shrink too much, making it hard/impossible to view or edit the number.

Solution:
- Hide the text labels of the utility buttons to save space, showing only the icons
- make input's width 100% on mobile screens in partner form

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center">
        <img
          src="https://github.com/user-attachments/assets/a620d417-119e-4e28-a62b-f63031e72598"
          alt="Before"
          width="500"
        />
      </td>
      <td align="center">
       <img width="500" height="354" alt="image" src="https://github.com/user-attachments/assets/6adc4c77-767d-491d-a468-8463c0f77666" />
      </td>
    </tr>
  </tbody>
</table>

opw-5489021