### PR TITLE
[FIX] mail: keep Jump to Present button visible in chatter

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -24,8 +24,7 @@ import { Transition } from "@web/core/transition";
 import { useBus, useRefListener, useService } from "@web/core/utils/hooks";
 import { escape } from "@web/core/utils/strings";
 
-export const PRESENT_VIEWPORT_THRESHOLD = 3;
-const PRESENT_MESSAGE_THRESHOLD = 10;
+export const PRESENT_VIEWPORT_THRESHOLD = 1;
 
 /**
  * @typedef {Object} Props
@@ -261,7 +260,7 @@ export class Thread extends Component {
             this.env.inChatter ? 22 : width - ps - pe - 22
         }px, ${
             this.env.inChatter && !this.env.inChatter.aside
-                ? 0
+                ? -22
                 : height - pt - pb - (this.env.inChatter?.aside ? 75 : 0)
         }px)`;
     }
@@ -494,13 +493,7 @@ export class Thread extends Component {
     }
 
     get PRESENT_THRESHOLD() {
-        const viewportHeight = (this.getViewportEl?.clientHeight ?? 0) * PRESENT_VIEWPORT_THRESHOLD;
-        const messagesHeight = [...this.props.thread.nonEmptyMessages]
-            .reverse()
-            .slice(0, PRESENT_MESSAGE_THRESHOLD)
-            .map((message) => this.refByMessageId.get(message.id))
-            .reduce((totalHeight, message) => totalHeight + (message?.el?.clientHeight ?? 0), 0);
-        const threshold = Math.max(viewportHeight, messagesHeight);
+        const threshold = (this.viewportEl?.clientHeight ?? 0) * PRESENT_VIEWPORT_THRESHOLD;
         return this.state.showJumpPresent ? threshold - 200 : threshold;
     }
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -62,7 +62,7 @@
 </t>
 
 <t t-name="mail.Thread.jumpPresent">
-    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light shadow-sm border border-secondary" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi text-muted" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
+    <button t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-fixed p-2 rounded-circle lh-1 m-n3 user-select-none btn btn-light shadow-sm border border-secondary" t-att-class="{ 'bottom-0': env.inChatter and !env.inChatter.aside }" t-ref="jump-present" t-on-click="() => this.jumpToPresent()" title="Jump to Present"><i class="oi text-muted" t-att-class="{ 'oi-chevron-down': props.order === 'asc', 'oi-chevron-up': props.order !== 'asc' }"/></button>
 </t>
 
 <t t-name="mail.Thread.jumpUnread">


### PR DESCRIPTION
**Description of the issue this PR addresses:**
----------------------------------------------
In 18.0, the Jump to Present button in chatter could fail to
appear when the user scrolled away from the latest messages.

**Current behavior before PR:**
----------------------------------------------
- The present detection threshold relied on both viewport height and the cumulative height of recent messages.
- In some chatter layouts, this threshold could exceed the visible area, preventing the Jump to Present button from appearing.

**Desired behavior after PR is merged:**
----------------------------------------------
- The present threshold is based only on the viewport height.
- The Jump to Present button appears consistently regardless of message size or chatter layout.

Task-5435586

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at https://www.odoo.com/submit-pr