### PR TITLE
[FIX] purchase: Check for downpayment when calculating Unit Price Pro…

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -158,7 +158,7 @@ class PurchaseOrderLine(models.Model):
     @api.depends('product_uom_id', 'price_unit')
     def _compute_price_unit_product_uom(self):
         for line in self:
-            line.price_unit_product_uom = not line.display_type and line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
+            line.price_unit_product_uom = not line.display_type and not line.is_downpayment and line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'qty_received', 'product_uom_qty', 'order_id.state')
     def _compute_qty_invoiced(self):


### PR DESCRIPTION
…duct UoM

According to the constraint `_accountable_required_fields`, the field `product_uom_id` is not required when `display_type` is set or when the line is a downpayment. The first case has been patched, but not the second, which can lead to errors during upgrades.

```
ValueError: Expected singleton: uom.uom()
```