### PR TITLE
[FIX] purchase_stock,*: correct route domain for stock replenishment wizard

### DIFF
--- a/addons/purchase_mrp/tests/test_replenishment.py
+++ b/addons/purchase_mrp/tests/test_replenishment.py
@@ -104,11 +104,16 @@ class TestReplenishment(TestStockCommon):
         })
         manufacture_route = self.warehouse_1.route_ids.filtered(lambda r: any(rule.action == 'manufacture' for rule in r.rule_ids))
         buy_route = self.warehouse_1.route_ids.filtered(lambda r: any(rule.action == 'buy' for rule in r.rule_ids))
+        self.productA.route_ids = False
 
         # No resupply methods should be set for Product A
         self.assertRecordValues(self.productA, [{'route_ids': self.env['stock.route'], 'seller_ids': self.env['product.supplierinfo'], 'bom_ids': self.env['mrp.bom']}])
         replenish_empty = create_replenish_wizard(self.warehouse_1, self.productA)
         self.assertFalse(replenish_empty.allowed_route_ids)
+
+        # Add the MTO route to the product, it should never show in allowed_route_ids
+        self.warehouse_1.mto_pull_id.route_id.active = True
+        self.productA.route_ids = self.warehouse_1.mto_pull_id.route_id
 
         # Add a BoM for Product A. This should make it eligible for Manufacture routes
         self.env['mrp.bom'].create({

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -90,7 +90,8 @@ class ProductReplenish(models.TransientModel):
 
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
-        buy_route = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)
-        if buy_route and not product_tmpl_id.seller_ids:
-            domain = Domain.AND([domain, Domain('id', '!=', buy_route.id)])
+        company = product_tmpl_id.company_id or self.env.company
+        buy_route = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', company.id)]).route_id
+        if buy_route and product_tmpl_id.seller_ids:
+            domain = Domain.OR([domain, Domain('id', '=', buy_route.id)])
         return domain

--- a/addons/stock/models/stock_replenish_mixin.py
+++ b/addons/stock/models/stock_replenish_mixin.py
@@ -36,4 +36,5 @@ class StockReplenishMixin(models.AbstractModel):
             base_domain,
             Domain('rule_ids.location_src_id', '!=', stock_location_inter_company_id),
             Domain('rule_ids.location_dest_id', '!=', stock_location_inter_company_id),
+            Domain('rule_ids.location_dest_id.warehouse_id', '!=', False),
         ])


### PR DESCRIPTION
*mrp,purchase_mrp,stock

Issue
-----
MTO gets suggested by default as the replenishment route for products.

Steps to reproduce
-----
- Enable routes
- Unarchive MTO
- Create a product with a vendor and MTO route
- Open the replenishment wizard

> The default/suggested replenishment route is MTO

Cause
-----
When creating the widget, we go through its' `default_get` to set its' default route

https://github.com/odoo/odoo/blob/310897cf07ebbf484ea6877fb329215e45c481d7/addons/stock/wizard/product_replenish.py#L76-L77

the domain is computed by `_get_route_domain`, which in turn calls `_get_allowed_route_domain`

https://github.com/odoo/odoo/blob/310897cf07ebbf484ea6877fb329215e45c481d7/addons/stock/wizard/product_replenish.py#L165-L170

However, since we are creating a new, it does not have a `warehouse_id` yet, so we don't go into the `if` condition.

https://github.com/odoo/odoo/blob/310897cf07ebbf484ea6877fb329215e45c481d7/addons/stock/models/stock_replenish_mixin.py#L26-L39

We only get routes from the product, but since buy is set on the warehouse and not the product anymore, it doesn't get included.

Solution
-----
There is an override of `_get_route_domain` in `purchase_stock`

https://github.com/odoo/odoo/blob/310897cf07ebbf484ea6877fb329215e45c481d7/addons/purchase_stock/wizard/product_replenish.py#L91-L96

it filters out the buy route if there is no `seller_ids` for the product, but since the buy route cannot be a part of the domain anymore, the condition should be changed to include buy if the product has a seller.

Note: `_get_route_domain` is only ever called in `default_get`.

Other changes
-----
The same change is also applied for the manufacture route, as the logic is the same.

It makes no sens to include route that do not lead to an internal location.

-----
Ticket:
opw-5388728
