### PR TITLE
[IMP] account_edi_ubl_cii: Identify the correct tax at import

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -316,7 +316,7 @@ class AccountEdiCommon(models.AbstractModel):
 
         # Update the invoice.
         invoice.move_type = move_type
-        with invoice._get_edi_creation() as invoice:
+        with invoice.with_context(disable_onchange_name_predictive=True)._get_edi_creation() as invoice:
             logs = self._import_fill_invoice_form(invoice, tree, qty_factor)
         if invoice:
             body = Markup("<strong>%s</strong>") % \
@@ -332,7 +332,7 @@ class AccountEdiCommon(models.AbstractModel):
         # For UBL, we should override the computed tax amount if it is less than 0.05 different of the one in the xml.
         # In order to support use case where the tax total is adapted for rounding purpose.
         # This has to be done after the first import in order to let Odoo compute the taxes before overriding if needed.
-        with invoice._get_edi_creation() as invoice:
+        with invoice.with_context(disable_onchange_name_predictive=True)._get_edi_creation() as invoice:
             self._correct_invoice_tax_amount(tree, invoice)
 
         # === Import the embedded documents in the xml if some are found ===
@@ -771,7 +771,7 @@ class AccountEdiCommon(models.AbstractModel):
                 # company check is already done in the prediction query
                 predicted_tax_id = invoice_line\
                     ._predict_specific_tax('percent', amount, invoice_line.move_id.journal_id.type)
-                tax = self.env['account.tax'].browse(predicted_tax_id)
+                tax = self.env['account.tax'].browse(predicted_tax_id).filtered_domain(domain)[:1]
             if not tax:
                 tax = self.env['account.tax'].search(domain + [('price_include', '=', False)], limit=1)
             if not tax:


### PR DESCRIPTION
Context:
When importing an XML invoice or vendor bill, the tax prediction was based on the customer’s invoice history.

Example: if the imported invoice contains an item found in the history with two taxes (6% and 21%), the prediction would return both taxes (6% and 21%), even though only one tax is present in the XML file.

The actual tax data present in the imported XML was not taken into account.

After this commit, the prediction is more rigorous and correctly relies on the tax information provided in the XML (restricted search domain)

task-5503126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
