### PR TITLE
[FIX] l10n_sa: fix future invoicing bug

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -2,7 +2,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
 from datetime import datetime
-from odoo import api, fields, models
+from pytz import timezone, utc
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 from odoo.tools import float_repr, format_datetime
 
 
@@ -58,7 +61,7 @@ class AccountMove(models.Model):
             if move.country_code == 'SA' and move.is_sale_document():
                 vals = {}
                 if not move.l10n_sa_confirmation_datetime:
-                    vals['l10n_sa_confirmation_datetime'] = datetime.combine(move.invoice_date, fields.Datetime.now().time()).strftime(self._get_iso_format_asia_riyadh_date())
+                    vals['l10n_sa_confirmation_datetime'] = self._get_normalized_l10n_sa_confirmation_datetime(move.invoice_date)
                 if not move.delivery_date:
                     vals['delivery_date'] = move.invoice_date
                 if vals:
@@ -79,13 +82,25 @@ class AccountMove(models.Model):
             'total_tax': self.amount_tax_signed,
         }
 
+    def _get_normalized_l10n_sa_confirmation_datetime(self, invoice_date, invoice_time=None):
+        """
+            Ensures the confirmation datetime does not exceed the current time in Asia/Riyadh to prevent ZATCA rejections.
+        """
+        sa_tz = timezone('Asia/Riyadh')
+        now_sa = datetime.now(sa_tz)
+        selected_date = fields.Date.from_string(invoice_date) if isinstance(invoice_date, str) else invoice_date
+        if selected_date > now_sa.date():
+            raise UserError(_("Please set the Invoice Date to be either less than or equal to today as per the Asia/Riyadh time zone, since ZATCA does not allow future-dated invoicing."))
+        return min(now_sa, sa_tz.localize(datetime.combine(selected_date, invoice_time or now_sa.time()))).astimezone(utc).replace(tzinfo=None)
+
     def write(self, vals):
         result = super().write(vals)
         invoice_date = vals.get('invoice_date')
         if not invoice_date:
             return result
         for move in self.filtered('l10n_sa_confirmation_datetime'):
-            move.l10n_sa_confirmation_datetime = datetime.combine(fields.Date.from_string(invoice_date), move.l10n_sa_confirmation_datetime.time())
+            sa_time = move.l10n_sa_confirmation_datetime.replace(tzinfo=utc).astimezone(timezone('Asia/Riyadh')).time()
+            move.l10n_sa_confirmation_datetime = self._get_normalized_l10n_sa_confirmation_datetime(invoice_date, sa_time)
         return result
 
     def _l10n_sa_is_simplified(self):

--- a/addons/l10n_sa/tests/__init__.py
+++ b/addons/l10n_sa/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_move

--- a/addons/l10n_sa/tests/test_account_move.py
+++ b/addons/l10n_sa/tests/test_account_move.py
@@ -1,0 +1,43 @@
+from datetime import date, datetime, time
+from freezegun import freeze_time
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestSaAccountMove(AccountTestInvoicingCommon):
+
+    @freeze_time('2026-06-15 14:00:00')
+    def test_normalized_confirmation_datetime_future_date_rejected(self):
+        """
+            UTC time    -> 2026-06-15 14:00:00 (2026-06-15 17:00:00 in Asia/Riyadh)
+            Setting the invoice date to 2026-06-16 would make the
+            l10n_sa_confirmation_datetime -> 2026-06-16 14:00:00 UTC which is in the future
+            this should raise an exception
+        """
+        with self.assertRaises(UserError):
+            self.env['account.move']._get_normalized_l10n_sa_confirmation_datetime(date(2026, 6, 16))
+
+    @freeze_time('2026-06-15 14:00:00')
+    def test_normalized_confirmation_datetime_past_date(self):
+        """
+            UTC time    -> 2026-06-15 14:00:00 (2026-06-15 17:00:00 in Asia/Riyadh)
+            Setting the invoice date to 2026-06-14 would make the
+            l10n_sa_confirmation_datetime -> 2026-06-14 14:00:00 UTC which is in the past
+            this should be fine
+        """
+        result = self.env['account.move']._get_normalized_l10n_sa_confirmation_datetime(date(2026, 6, 14))
+        self.assertEqual(result, datetime(2026, 6, 14, 14, 0, 0))
+
+    @freeze_time('2026-06-15 23:00:00')
+    def test_normalized_confirmation_datetime_today_capped(self):
+        """
+            UTC time    -> 2026-06-15 23:00:00 (2026-06-16 02:00:00 in Asia/Riyadh)
+            Setting the invoice date to 2026-06-16 (the date in Saudi Arabia) with
+            invoice_time 05:00 SA (which is after now 02:00 SA), the min() should cap
+            the result to now_sa -> 2026-06-15 23:00:00 UTC
+        """
+        result = self.env['account.move']._get_normalized_l10n_sa_confirmation_datetime(date(2026, 6, 16), time(5, 0, 0))
+        self.assertEqual(result, datetime(2026, 6, 15, 23, 0, 0))

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -444,7 +444,7 @@ class AccountEdiFormat(models.Model):
         if customer_missing_info:
             errors.append(_set_missing_partner_fields(customer_missing_info, _("Customer")))
         if invoice.invoice_date > fields.Date.context_today(self.with_context(tz='Asia/Riyadh')):
-            errors.append(_("- Please, make sure the invoice date is set to either the same as or before Today."))
+            errors.append(_("- Please set the Invoice Date to be either less than or equal to today as per the Asia/Riyadh time zone, since ZATCA does not allow future-dated invoicing."))
         if invoice.move_type in ('in_refund', 'out_refund') and not invoice._l10n_sa_check_refund_reason():
             errors.append(
                 _("- Please, make sure either the Reversed Entry or the Reversal Reason are specified when confirming a Credit/Debit note"))


### PR DESCRIPTION
In odoo/odoo#236865 we decided to allow clients to backdate invoices by letting them use the `invoice_date` field for the invoice date and use the current time as the issue time because we are not supposed to use a dummy value for time.

This created an issue where if a user in a timezone before SA tries to invoice a document around midnight using the current date in SA the datetime created will be in the future which will lead to the invoice being rejected by ZATCA.

This commit makes sure we normalize the selected date wrt to the current datetime in saudi arabia so that we never accidentally invoice into the future.

task-5890423
opw-5373067
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
