### PR TITLE
[IMP] crm: update tour

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -50,7 +50,7 @@ registry.category("web_tour.tours").add('crm_tour', {
     trigger: ".o_opportunity_kanban:not(:has(.o_view_sample_data)) .o_kanban_group .o_kanban_record:last-of-type",
     content: markup(_t("<b>Drag &amp; drop opportunities</b> between columns as you progress in your sales cycle.")),
     tooltipPosition: "right",
-    run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(2))",
+    run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(1))",
 },
 {
     trigger: ".o_opportunity_kanban .o_kanban_renderer",
@@ -76,25 +76,24 @@ registry.category("web_tour.tours").add('crm_tour', {
     tooltipPosition: "top",  // dot NOT move to bottom, it would cause a resize flicker, see task-2476595
     run: "click",
 }, {
-    id: "drag_opportunity_to_won_step",
-    trigger: ".o_opportunity_kanban .o_kanban_record:last-of-type",
-    content: markup(_t("Drag your opportunity to <b>Won</b> when you get the deal. Congrats!")),
-    tooltipPosition: "right",
-    run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(3))",
-},
-{
     trigger: ".o_kanban_record",
     content: _t("Let’s have a look at an Opportunity."),
     tooltipPosition: "right",
     run: "click",
 }, {
     trigger: ".o_lead_opportunity_form .o_statusbar_status",
-    content: _t("You can make your opportunity advance through your pipeline from here."),
+    content: _t("You can make your opportunity advance through your pipeline by clicking on stages here. Try sending it to the next stage!"),
     tooltipPosition: "bottom",
     run: "click",
 }, {
     trigger: ".breadcrumb-item:not(.active):first",
-    content: _t("Click on the breadcrumb to go back to your Pipeline. Odoo will save all modifications as you navigate."),
+    content: _t("Click on the breadcrumbs to go back to your Pipeline. Odoo will save all your changes as you navigate."),
     tooltipPosition: "bottom",
     run: "click .breadcrumb-item:not(.active):last",
-}]});
+}, {
+    id: "drag_opportunity_to_won_step",
+    trigger: ".o_opportunity_kanban .o_kanban_record:last-of-type",
+    content: markup(_t("Drag your opportunity to <b>Won</b> when you get the deal. Congrats!")),
+    tooltipPosition: "right",
+    run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(3))",
+},]});

--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -31,7 +31,7 @@ class CrmIapLeadMiningRequest(models.Model):
             return 'opportunity'
 
     def _default_country_ids(self):
-        return self.env.user.company_id.country_id
+        return self.env.company.country_id
 
     name = fields.Char(string='Request Number', required=True, readonly=True, default=lambda self: _('New'), copy=False)
     state = fields.Selection([('draft', 'Draft'), ('error', 'Error'), ('done', 'Done')], string='Status', required=True, default='draft')


### PR DESCRIPTION
Reorder the crm tour steps so that the user goes through all the stages.

Before:
New -> Proposition -> Won -> inspect lead (skipped qualified)
After:
New -> Qualified -> inspect lead -> Move to Proposition via the form -> Won

Changed the default country in the lead generation dialog, to be based on the active company instead of the user's default.

Task-5386684
