### PR TITLE
[IMP] survey: prevent adding opacity on images

### DIFF
--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -26,8 +26,7 @@ $dynamic-text-color: if(lightness($body-bg) > 50%, $gray-900, $gray-100);
     background-size: cover;
     color: $dynamic-text-color !important;
     .text-muted {
-        opacity: 0.7;
-        color: $dynamic-text-color !important;
+        color: rgba($dynamic-text-color, 0.7) !important;
     }
     &.o_survey_background_shadow {
         box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7);


### PR DESCRIPTION
Purpose
=======
Prevent adding opacity on the images in the question descriptions.

Specification
=============
The css rule "opacity" adds opacity on everything. But some elements like images, banners, buttons, file uploads, ... shouldn't have this opacity layer. Images and banners look dull. Buttons and file uploads look disabled.

Changing the css rule to use rgba with the opacity parameter. This makes sure the opacity is only applied on relevant elements: test, lists, quotes, headers, emojis, ...

Task-5468647


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
