### PR TITLE
[IMP] point_of_sale, pos_*: unify payment method integrations

### DIFF
--- a/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.js
+++ b/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.js
@@ -21,22 +21,7 @@ export class PosPaymentProviderCards extends Component {
         });
 
         onWillStart(async () => {
-            const res = await this.orm.call("pos.payment.method", "get_provider_status", [
-                providers.map((p) => p[1]),
-            ]);
-
-            this.state.providers = providers
-                .filter((prov) => res.state.some((moduleState) => moduleState.name === prov[1]))
-                .map((prov) => {
-                    const status = res.state.find((p) => p.name === prov[1]);
-                    return Object.assign(
-                        {
-                            selection: prov[0],
-                            provider: prov[2],
-                        },
-                        status
-                    );
-                });
+            this.state.providers = await this.orm.call("pos.payment.method", "get_provider_status");
         });
     }
 
@@ -68,29 +53,12 @@ export class PosPaymentProviderCards extends Component {
         if (provider) {
             this.props.record.update({
                 payment_method_type: "terminal",
-                use_payment_terminal: provider.selection,
-                name: provider.provider,
+                use_payment_terminal: provider.provider,
+                name: provider.name,
             });
         }
     }
 }
-
-// Selection, module_name, friendly name
-const providers = [
-    ["axepta_bnpp", "pos_iot_worldline", "Axepta BNP Paribas"],
-    ["six_iot", "pos_iot_six", "SIX"],
-    ["adyen", "pos_adyen", "Adyen"],
-    ["mercado_pago", "pos_mercado_pago", "Mercado Pago"],
-    ["razorpay", "pos_razorpay", "Razorpay"],
-    ["stripe", "pos_stripe", "Stripe"],
-    ["viva_com", "pos_viva_com", "Viva.com"],
-    ["worldline", "pos_iot_worldline", "Worldline"],
-    ["tyro", "pos_tyro", "Tyro"],
-    ["pine_labs", "pos_pine_labs", "Pine Labs"],
-    ["qfpay", "pos_qfpay", "QFPay"],
-    ["dpopay", "pos_dpopay", "DPO Pay"],
-    ["mollie", "pos_mollie", "Mollie"],
-];
 
 export const PosPaymentProviderCardsParams = {
     component: PosPaymentProviderCards,

--- a/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml
+++ b/addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="point_of_sale.PosPaymentProviderCards">
-        <div class="d-flex flex-wrap gap-1" t-ref="cards_container">
+        <div class="row g-1" t-ref="cards_container">
             <div t-foreach="state.providers"
                  t-as="provider"
-                 t-key="provider.selection"
-                 class="d-flex border rounded justify-content-between h-100 p-1 gap-1"
-                 t-att-class="this.env.inDialog ? 'col-12' : 'col-5 col-xl-5 col-xxl-4'">
-                <div class="d-inline-block position-relative opacity-trigger-hover">
-                    <img class="img" style="max-width: 65px;" t-att-alt="provider.provider" t-att-src="`/point_of_sale/static/img/providers/${provider.selection}.png`" />
-                </div>
-                <div class="d-flex flex-column justify-content-between w-100">
-                    <span class="mb-0 fs-6 fw-bold" t-esc="provider.provider" />
-                    <button t-if="provider.state === 'uninstalled'" t-on-click="() => this.installModule(provider.id)" class="btn btn-sm btn-primary ms-auto align-self-end" t-att-disabled="state.disabled">Activate</button>
-                    <button t-else="" t-on-click="() => this.setupProvider(provider.id)" class="btn btn-sm btn-secondary ms-auto align-self-end" t-att-disabled="state.disabled">Setup</button>
+                 t-att-class="this.env.inDialog ? 'col-12' : 'col-6 col-xl-4'"
+                 class="h-100"
+                 t-key="provider.provider">
+                 <div class="d-flex border rounded justify-content-between p-1 gap-1">
+                    <div class="d-inline-block position-relative opacity-trigger-hover">
+                        <img class="img" style="max-width: 65px;" t-att-alt="provider.name" t-att-src="`/point_of_sale/static/img/providers/${provider.provider}.png`" />
+                    </div>
+                    <div class="d-flex flex-column justify-content-between w-100">
+                        <span class="mb-0 fs-6 fw-bold" t-esc="provider.name" />
+                        <button t-if="provider.state === 'uninstalled'" t-on-click="() => this.installModule(provider.id)" class="btn btn-sm btn-primary ms-auto align-self-end" t-att-disabled="state.disabled">Activate</button>
+                        <button t-else="" t-on-click="() => this.setupProvider(provider.id)" class="btn btn-sm btn-secondary ms-auto align-self-end" t-att-disabled="state.disabled">Setup</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/addons/point_of_sale/views/pos_payment_method_views.xml
+++ b/addons/point_of_sale/views/pos_payment_method_views.xml
@@ -9,6 +9,7 @@
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="active" invisible="1"/>
                     <field name="type" invisible="1"/>
+                    <field name="all_providers_installed" invisible="1"/>
                     <field name="default_pos_receivable_account_name" invisible="1" />
                     <div class="d-flex justify-content-between">
                         <div class="oe_title">
@@ -31,10 +32,10 @@
                                 <field name="hide_use_payment_terminal" invisible="1"/>
                                 <field name="hide_qr_code_method" invisible="1"/>
                                 <field name="payment_method_type" />
-                                <field name="use_payment_terminal" string="Integrate with" invisible="hide_use_payment_terminal"/>
+                                <field name="use_payment_terminal" string="Integrate with" invisible="hide_use_payment_terminal" placeholder="None"/>
                                 <field name="qr_code_method" invisible="hide_qr_code_method" required="payment_method_type == 'qr_code'"/>
                             </group>
-                            <widget name="pos_payment_provider_cards" invisible="use_payment_terminal or payment_method_type != 'terminal'" />
+                            <widget name="pos_payment_provider_cards" invisible="all_providers_installed or use_payment_terminal or payment_method_type != 'terminal'" />
                         </div>
                     </group>
                 </sheet>

--- a/addons/pos_adyen/views/pos_payment_method_views.xml
+++ b/addons/pos_adyen/views/pos_payment_method_views.xml
@@ -5,13 +5,18 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <!-- Adyen -->
-                <field name="adyen_api_key" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'" password="True"/>
-                <field name="adyen_terminal_identifier" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
-                <field name="adyen_merchant_account" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
-                <field name="adyen_event_url" invisible="use_payment_terminal != 'adyen'" widget="CopyClipboardChar"/>
-                <field name="adyen_test_mode" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'adyen'">
+                    <page name="settings" string="Adyen">
+                        <group>
+                            <field name="adyen_api_key" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'" password="True"/>
+                            <field name="adyen_terminal_identifier" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+                            <field name="adyen_merchant_account" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+                            <field name="adyen_event_url" invisible="use_payment_terminal != 'adyen'" widget="CopyClipboardChar"/>
+                            <field name="adyen_test_mode" invisible="use_payment_terminal != 'adyen'" required="use_payment_terminal == 'adyen'"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/pos_mercado_pago/views/pos_payment_method_views.xml
+++ b/addons/pos_mercado_pago/views/pos_payment_method_views.xml
@@ -5,12 +5,17 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <!-- MercadoPago -->
-                <field name="mp_bearer_token" placeholder="APP_USR-..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <field name="mp_webhook_secret_key" placeholder="c2f3662..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <field name="mp_id_point_smart" placeholder="1494126963" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
-                <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'mercado_pago'">
+                    <page name="settings" string="Mercado Pago">
+                        <group>
+                            <field name="mp_bearer_token" placeholder="APP_USR-..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                            <field name="mp_webhook_secret_key" placeholder="c2f3662..." invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                            <field name="mp_id_point_smart" placeholder="1494126963" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                            <button string="Force PDV" type="object" name="force_pdv" groups="base.group_no_one" class="oe_highlight" invisible="use_payment_terminal != 'mercado_pago'" required="use_payment_terminal == 'mercado_pago'"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/pos_mollie/views/pos_payment_method_views.xml
+++ b/addons/pos_mollie/views/pos_payment_method_views.xml
@@ -5,9 +5,15 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <field name="mollie_payment_provider_id" invisible="use_payment_terminal != 'mollie'" required="use_payment_terminal == 'mollie'"/>
-                <field name="mollie_terminal_id" invisible="use_payment_terminal != 'mollie'" required="use_payment_terminal == 'mollie'"/>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'mollie'">
+                    <page name="settings" string="Mollie">
+                        <group>
+                            <field name="mollie_payment_provider_id" invisible="use_payment_terminal != 'mollie'" required="use_payment_terminal == 'mollie'"/>
+                            <field name="mollie_terminal_id" invisible="use_payment_terminal != 'mollie'" required="use_payment_terminal == 'mollie'"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/pos_pine_labs/views/pos_payment_method_views.xml
+++ b/addons/pos_pine_labs/views/pos_payment_method_views.xml
@@ -5,13 +5,19 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <field name="pine_labs_merchant" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
-                <field name="pine_labs_store" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
-                <field name="pine_labs_client" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
-                <field name="pine_labs_security_token" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'" password="True"/>
-                <field name="pine_labs_allowed_payment_mode" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
-                <field name="pine_labs_test_mode" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'pine_labs'">
+                    <page name="settings" string="Pine Labs">
+                        <group>
+                            <field name="pine_labs_merchant" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
+                            <field name="pine_labs_store" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
+                            <field name="pine_labs_client" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
+                            <field name="pine_labs_security_token" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'" password="True"/>
+                            <field name="pine_labs_allowed_payment_mode" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
+                            <field name="pine_labs_test_mode" invisible="use_payment_terminal != 'pine_labs'" required="use_payment_terminal == 'pine_labs'"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/pos_qfpay/views/pos_payment_method_views.xml
+++ b/addons/pos_qfpay/views/pos_payment_method_views.xml
@@ -5,19 +5,25 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <field name="qfpay_terminal_ip_address"
-                    invisible="use_payment_terminal != 'qfpay'"
-                    required="use_payment_terminal == 'qfpay'"/>
-                <field name="qfpay_pos_key"
-                    invisible="use_payment_terminal != 'qfpay'"
-                    required="use_payment_terminal == 'qfpay'"/>
-                <field name="qfpay_payment_type"
-                    invisible="use_payment_terminal != 'qfpay'"
-                    required="use_payment_terminal == 'qfpay'"/>
-                <field name="qfpay_notification_key"
-                    invisible="use_payment_terminal != 'qfpay'"
-                    required="use_payment_terminal == 'qfpay'"/>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'qfpay'">
+                    <page name="settings" string="QFPay">
+                        <group>
+                            <field name="qfpay_terminal_ip_address"
+                                invisible="use_payment_terminal != 'qfpay'"
+                                required="use_payment_terminal == 'qfpay'"/>
+                            <field name="qfpay_pos_key"
+                                invisible="use_payment_terminal != 'qfpay'"
+                                required="use_payment_terminal == 'qfpay'"/>
+                            <field name="qfpay_payment_type"
+                                invisible="use_payment_terminal != 'qfpay'"
+                                required="use_payment_terminal == 'qfpay'"/>
+                            <field name="qfpay_notification_key"
+                                invisible="use_payment_terminal != 'qfpay'"
+                                required="use_payment_terminal == 'qfpay'"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/pos_razorpay/views/pos_payment_method_views.xml
+++ b/addons/pos_razorpay/views/pos_payment_method_views.xml
@@ -5,12 +5,18 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <field name="razorpay_username" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_tid" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_api_key" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_test_mode" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
-                <field name="razorpay_allowed_payment_modes" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'razorpay'">
+                    <page name="settings" string="Razorpay">
+                        <group>
+                            <field name="razorpay_username" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                            <field name="razorpay_tid" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                            <field name="razorpay_api_key" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                            <field name="razorpay_test_mode" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                            <field name="razorpay_allowed_payment_modes" invisible="use_payment_terminal != 'razorpay'" required="use_payment_terminal == 'razorpay'"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/pos_stripe/views/pos_payment_method_views.xml
+++ b/addons/pos_stripe/views/pos_payment_method_views.xml
@@ -5,12 +5,17 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <!-- Stripe -->
-                <field name="stripe_serial_number" invisible="use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'"/>
-                <div colspan="2" class="mt16" invisible="use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'">
-                    <button name="action_stripe_key" type="object" icon="oi-arrow-right" string="Don't forget to complete Stripe connect before using this payment method." class="btn-link"/>
-                </div>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'stripe'">
+                    <page name="settings" string="Stripe">
+                        <group>
+                            <field name="stripe_serial_number" invisible="use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'"/>
+                            <div colspan="2" class="mt16" invisible="use_payment_terminal != 'stripe'" required="use_payment_terminal == 'stripe'">
+                                <button name="action_stripe_key" type="object" icon="oi-arrow-right" string="Don't forget to complete Stripe connect before using this payment method." class="btn-link"/>
+                            </div>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>

--- a/addons/pos_viva_com/views/pos_payment_method_views.xml
+++ b/addons/pos_viva_com/views/pos_payment_method_views.xml
@@ -5,15 +5,20 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
-                <!-- Viva.com -->
-                <field name="viva_com_merchant_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_api_key" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_client_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_client_secret" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_test_mode" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_terminal_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
-                <field name="viva_com_webhook_endpoint" invisible="use_payment_terminal != 'viva_com' or not id" required="use_payment_terminal == 'viva_com'" widget="CopyClipboardChar"/>
+            <xpath expr="//sheet" position="inside">
+                <notebook invisible="use_payment_terminal != 'viva_com'">
+                    <page name="settings" string="Viva Com">
+                        <group>
+                            <field name="viva_com_merchant_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
+                            <field name="viva_com_api_key" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
+                            <field name="viva_com_client_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
+                            <field name="viva_com_client_secret" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
+                            <field name="viva_com_test_mode" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
+                            <field name="viva_com_terminal_id" invisible="use_payment_terminal != 'viva_com'" required="use_payment_terminal == 'viva_com'"/>
+                            <field name="viva_com_webhook_endpoint" invisible="use_payment_terminal != 'viva_com' or not id" required="use_payment_terminal == 'viva_com'" widget="CopyClipboardChar"/>
+                        </group>
+                    </page>
+                </notebook>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
We currently support multiple payment platforms but trying to set them up is different for each platform in the POS payment method form screen.

This commit will standardize the setup process so they all behave the same even if the input they require is different

Task-[5887093](https://www.odoo.com/odoo/project/1737/tasks/5887093)
Enterprise PR-[#105873](https://github.com/odoo/enterprise/pull/105873)
Upgrade PR-[#9386](https://github.com/odoo/upgrade/pull/9386)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
