### PR TITLE
[FIX] orm: skip access on join of a delegated field

### DIFF
--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -549,7 +549,7 @@ class Many2one(_Relational):
         model = table._model
         comodel = model.env[self.comodel_name]
         can_be_null = self not in model.env.registry.not_null_fields
-        if self.compute_sudo or self.inherited or model.env.su:
+        if self.compute_sudo or self.delegate or model.env.su:
             coquery = None
         else:
             coquery = comodel._search(Domain.TRUE, active_test=False)


### PR DESCRIPTION
When building the SQL for a related field, we join the table for the comodel and may apply user access to that comodel. Using *inherits* already adds record rules for that field, so joining on the field on which "delegates" access to fields, can be done without additional permissions.

```py
class M1(Model): ...
class M2(Model):
  _inherits = {'m1': 'm1_id'}
  m1_id = fields.Many2one(...)
```

Consider the following, `Query(m2_record).m1_id` should join without additional access rules. This is fine because the query usually comes from a `_search` (which has added the necessary permissions).


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
