### PR TITLE
[FIX] website: wait for interactions start in test

### DIFF
--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -110,8 +110,7 @@ describe("Popup options: popup in page before edit", () => {
         await expectToTriggerEvent(":iframe .s_popup .modal", "shown.bs.modal", () =>
             contains(".o_we_invisible_entry .fa-eye-slash").click()
         );
-        // Sometimes bootstrap.js takes a bit of time to display the popup
-        await waitFor(":iframe .s_popup .modal", { timeout: 1000, visible: true });
+        await waitFor(":iframe .s_popup .modal", { visible: true });
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
         await expectToTriggerEvent(":iframe .s_popup .modal", "hidden.bs.modal", () =>
@@ -129,8 +128,7 @@ describe("Popup options: popup in page before edit", () => {
         await expectToTriggerEvent(":iframe .s_popup .modal", "shown.bs.modal", () =>
             contains(".o_we_invisible_entry .fa-eye-slash").click()
         );
-        // Sometimes bootstrap.js takes a bit of time to display the popup
-        await waitFor(":iframe .s_popup .modal", { timeout: 1000, visible: true });
+        await waitFor(":iframe .s_popup .modal", { visible: true });
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
         setSelection({ anchorNode: queryOne(":iframe .s_popup section p"), anchorOffset: 0 });
@@ -166,8 +164,7 @@ describe("Popup options: popup in page before edit", () => {
         await expectToTriggerEvent(":iframe .s_popup .modal", "shown.bs.modal", () =>
             contains(".o_we_invisible_entry .fa-eye-slash").click()
         );
-        // Sometimes bootstrap.js takes a bit of time to display the popup
-        await waitFor(":iframe .s_popup .modal", { timeout: 1000, visible: true });
+        await waitFor(":iframe .s_popup .modal", { visible: true });
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
 

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -130,7 +130,7 @@ export async function setupWebsiteBuilder(
     let editableContent;
     const comp = await mountWithCleanup(WebClient);
     let originalIframeLoaded;
-    let resolveIframeLoaded = () => {};
+    let resolveIframeLoaded = async () => {};
     const bodyHTML = `${beforeWrapwrapContent}
         <div id="wrapwrap">${headerContent} <div id="wrap" class="oe_structure oe_empty" ${
         translateMode
@@ -138,7 +138,7 @@ export async function setupWebsiteBuilder(
             : `data-oe-model="ir.ui.view" data-oe-id="${setupWebsiteBuilderOeId}" data-oe-field="arch"`
     }>${websiteContent}</div></div>`;
     const iframeLoaded = new Promise((resolve) => {
-        resolveIframeLoaded = (el) => {
+        resolveIframeLoaded = async (el) => {
             const iframe = el;
             const styleEl = iframe.contentDocument.createElement("style");
             styleEl.textContent = /*css*/ `* { transition: none !important; } `;
@@ -151,10 +151,17 @@ export async function setupWebsiteBuilder(
                 "website.page(4,)"
             );
             iframe.contentDocument.body.innerHTML = bodyHTML;
-            // we artificially set the is-ready attribute to trick the rest of
-            // the code into thinking that the js inside the iframe is properly
-            // loaded
-            iframe.contentDocument.body.setAttribute("is-ready", "true");
+            if (loadIframeBundles && loadAssetsFrontendJS) {
+                await waitFor("body[is-ready=true]", {
+                    timeout: 1000,
+                    root: iframe.contentDocument,
+                });
+            } else {
+                // If we don't include the iframe JS, we artificially set the
+                // is-ready attribute to trick the rest of the code into
+                // thinking that it has been loaded.
+                iframe.contentDocument.body.setAttribute("is-ready", "true");
+            }
 
             onIframeLoaded(iframe);
             resolve(el);
@@ -298,7 +305,7 @@ export async function setupWebsiteBuilder(
             js: loadAssetsFrontendJS,
         });
     }
-    resolveIframeLoaded(iframe);
+    await resolveIframeLoaded(iframe);
     await animationFrame();
     if (openEditor) {
         await openBuilderSidebar(editAssetsLoaded);


### PR DESCRIPTION
__Before commit__

Hoot tests using interactions inside the iframe may fail because we do not wait for the interaction service to be ready before executing the tests.

In particular, the `SharedPopup` interaction is sometimes started after we trigger a click to display it in the test. Since it has not had time to register the proper listener, the `d-none` class is never removed from the popup, so the test is stuck waiting for it to appear.

__Fix__

When the JavaScript assets are included inside the iframe, the attribute `is-ready` is added to the iframe body. In this case, we wait for it to appear instead of uselessly adding it artificially.

Waiting for all interactions to load may take a bit of time, so a large timeout is set to wait for the `is-ready` attribute.

The timeouts inside the tests are now removed since they were there to fix this bug without success.

runbot-237554
