### PR TITLE
[FIX] website, *: preview dynamic content of custom snippet

### DIFF
--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -80,6 +80,8 @@ export class WebsiteBuilder extends Component {
     setup() {
         this.websiteService = useService("website");
         this.dialog = useService("dialog");
+        this.websiteEditService =
+            this.websiteService.websiteRootInstance?.bindService("website_edit");
         useSetupAction({
             beforeUnload: (ev) => this.onBeforeUnload(ev),
             beforeLeave: () => this.onBeforeLeave(),
@@ -93,6 +95,7 @@ export class WebsiteBuilder extends Component {
             if (this.props.translation && !browser.localStorage.getItem(localStorageNoDialogKey)) {
                 this.dialog.add(TranslatorInfoDialog);
             }
+            this.websiteEditService?.clearRpcCache();
         });
     }
 

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -5,6 +5,8 @@ import { Interaction } from "@web/public/interaction";
 import { patch } from "@web/core/utils/patch";
 import { setupIgnoreDOMMutations } from "@website/js/content/auto_hide_menu";
 import { omit } from "@web/core/utils/objects";
+import { Cache } from "@web/core/utils/cache";
+import { rpc } from "@web/core/network/rpc";
 
 export function buildEditableInteractions(builders) {
     const result = [];
@@ -54,6 +56,13 @@ export const websiteEditService = {
         const patches = [];
         const historyCallbacks = {};
         const shared = {};
+        // A cached rpc to be used for edit/preview mode interactions
+        // (e.g., when dynamic snippets are loading content with the
+        // same config: filter, template, number of records,...).
+        const _rpcCall = async (params) => rpc(params.url, params);
+        const cache = new Cache(_rpcCall, JSON.stringify);
+        const clearRpcCache = () => cache.invalidate();
+        const rpcCache = async (params) => cache.read(params);
 
         const update = (target, mode) => {
             // editMode = true;
@@ -295,6 +304,8 @@ export const websiteEditService = {
             uninstallPatches,
             applyAction,
             callShared,
+            rpcCache,
+            clearRpcCache,
         };
 
         const handleEditPage = (ev) => {

--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -146,6 +146,9 @@ export class DynamicSnippet extends Interaction {
     }
 
     render() {
+        if (!this.isConfigComplete()) {
+            return;
+        }
         if (this.data.length > 0 || this.withSample) {
             this.toggleVisibility(true);
             this.prepareContent();

--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -48,6 +48,7 @@ export class DynamicSnippet extends Interaction {
         this.uniqueId = uniqueId("s_dynamic_snippet_");
         this.templateKey = "website.s_dynamic_snippet.grid";
         this.withSample = false;
+        this.rpc = rpc;
     }
 
     async willStart() {
@@ -92,7 +93,7 @@ export class DynamicSnippet extends Interaction {
     async fetchData() {
         if (this.isConfigComplete()) {
             const nodeData = this.el.dataset;
-            const filterFragments = await this.waitFor(rpc(
+            const filterFragments = await this.waitFor(this.rpc(
                 "/website/snippet/filters",
                 Object.assign({
                     "filter_id": parseInt(nodeData.filterId),
@@ -204,6 +205,19 @@ export class DynamicSnippet extends Interaction {
     }
 }
 
+export const DynamicSnippetCached = (I) =>
+    class extends I {
+        setup() {
+            super.setup();
+            this.rpc = (url, params) => this.services.website_edit.rpcCache({ ...params, url });
+        }
+    };
+
 registry
     .category("public.interactions")
     .add("website.dynamic_snippet", DynamicSnippet);
+
+registry.category("public.interactions.preview").add("website.dynamic_snippet", {
+    Interaction: DynamicSnippet,
+    mixin: DynamicSnippetCached,
+});

--- a/addons/website_blog/static/src/snippets/s_blog_posts/blog_posts.js
+++ b/addons/website_blog/static/src/snippets/s_blog_posts/blog_posts.js
@@ -26,3 +26,9 @@ registry
     .add("website_blog.blog_posts", {
         Interaction: BlogPosts,
     });
+
+registry
+    .category("public.interactions.preview")
+    .add("website_blog.blog_posts", {
+        Interaction: BlogPosts,
+    });

--- a/addons/website_event/static/src/snippets/s_events/events.js
+++ b/addons/website_event/static/src/snippets/s_events/events.js
@@ -34,3 +34,9 @@ registry
     .add("website_event.events", {
         Interaction: Events,
     });
+
+registry
+    .category("public.interactions.preview")
+    .add("website_event.events", {
+        Interaction: Events,
+    });

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/dynamic_snippet_products.js
@@ -101,3 +101,9 @@ registry
     .add("website_sale.dynamic_snippet_products", {
         Interaction: DynamicSnippetProducts,
     });
+
+registry
+    .category("public.interactions.preview")
+    .add("website_sale.dynamic_snippet_products", {
+        Interaction: DynamicSnippetProducts,
+    });


### PR DESCRIPTION
*: website_blog, website_event, website_sale

The interaction for filling the dynamic content of dynamic snippets did not run inside the iframe to preview the snippet to add. This is not an issue for the initial dynamic snippet, as they are filled with fake content. But when saving a custom snippet, the dynamic content is cleared, and they seem empty when previewed. This is the case since the [website builder refactor] as the previous builder re-used the preview of the initial snippet.

This commit adds the interaction to fill dynamic content in the preview iframe, and changes the interaction to avoid emptying the fake content from initial dynamic snippets during preview.

Steps to reproduce:
- Open website builder
- Add a dynamic snippet (for example "Events")
- Save the snippet as a custom snippet
- Click on "Custom" snippet category
- Bug: The preview for the custom snippet does not have the dynamic part (there is no event, just the title)

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-5427353