### PR TITLE
[FIX] mail,website,im_livechat: interpolation of custom property values

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.scss
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.scss
@@ -71,7 +71,7 @@
 
     button.active.o-waiting {
         --list-group-active-color: var(--body-color);
-        --list-group-active-border-color: map-get($o-theme-text-colors, 'warning');
+        --list-group-active-border-color: #{map-get($o-theme-text-colors, 'warning')};
 
         .form-check-input {
             background-color: map-get($o-theme-text-colors, 'warning');

--- a/addons/mail/static/src/discuss/call/common/device_select.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/device_select.dark.scss
@@ -1,3 +1,3 @@
 .o-mail-DeviceSelect-button {
-  --o-mail-device-select-button-color: $gray-300;
+  --o-mail-device-select-button-color: #{$gray-300};
 }

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.dark.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.dark.scss
@@ -1,3 +1,3 @@
 .o_website_preview {
-    --websitePreview-bg-color: $o-gray-200;
+    --websitePreview-bg-color: #{$o-gray-200};
 }


### PR DESCRIPTION
Older versions of LibSass and Ruby Sass parsed custom property declarations just like any other property declaration, allowing the full range of SassScript expressions as values. But this wasn’t compatible with CSS.

To provide maximum compatibility with plain CSS, since version 3.5.0, LibSass requires SassScript expressions in custom property values to be written within interpolation.

Reference:
https://sass-lang.com/documentation/breaking-changes/css-vars/
