### PR TITLE
[FIX] orm: avoid groupby on models with custom `_select`

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -389,6 +389,8 @@ class MailActivity(models.Model):
         # Rules do not apply to administrator
         if self.env.is_superuser() or bypass_access:
             return super()._search(domain, offset, limit, order, bypass_access=True, **kwargs)
+        if self.env.context.get('_read_groupby'):
+            raise ValueError("Cannot group by mail.activity")
 
         # retrieve activities and their corresponding res_model, res_id
         # Don't use the ORM to avoid cache pollution

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -170,7 +170,7 @@ class MailActivityMixin(models.AbstractModel):
 
     def _compute_sql_activity_state(self, table):
         # find activities
-        act_query = self.activity_ids._search(Domain('res_model', '=', self._name) & Domain('active', '=', True))
+        act_query = self.activity_ids._search(Domain('res_model', '=', self._name) & Domain('active', '=', True), bypass_access=True)
         activity_t = act_query.table
         res_id_sql = activity_t.res_id
         # group them by res_id and compute the state (as int)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -344,6 +344,8 @@ class MailMessage(models.Model):
         # Rules do not apply to administrator
         if self.env.is_superuser() or bypass_access:
             return super()._search(domain, offset, limit, order, bypass_access=True, **kwargs)
+        if self.env.context.get('_read_groupby'):
+            raise ValueError("Cannot group by mail.message")
 
         # Non-employee see only messages with a subtype and not internal
         if not self.env.user._is_internal():

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -613,6 +613,8 @@ class IrAttachment(models.Model):
         domain = domain.optimize(self)
         if self.env.su or bypass_access or domain.is_false():
             return super()._search(domain, offset, limit, order, active_test=active_test, bypass_access=bypass_access)
+        if self.env.context.get('_read_groupby'):
+            raise ValueError("Cannot group by ir.attachment")
 
         # General access rules
         # - public == True are always accessible

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1996,6 +1996,7 @@ class BaseModel(metaclass=MetaModel):
         if not func:
             raise ValueError(f"Aggregate method is mandatory for {fname!r}")
 
+        table = table._with_model(table._model.with_context(_read_groupby=True))
         field = self._fields[fname]
         if func == 'sum_currency':
             if field.type != 'monetary':
@@ -2036,6 +2037,7 @@ class BaseModel(metaclass=MetaModel):
         if fname not in self._fields:
             raise ValueError(f"Invalid field {fname!r} on model {self._name!r}")
         field = self._fields[fname]
+        table = table._with_model(table._model.with_context(_read_groupby=True))
 
         if field.type == 'properties':
             sql_expr = table[fname][seq_fnames]


### PR DESCRIPTION
Add a context to know if we are grouppnig. This allows us to stop `_search` methods which need to search and filter manually all records.

For example, when asking if a field is groupable,
`_description_groupable` will run a dummy search for many2many fields, for a normal user searching on ir.attachment, it would search for all attachments and try to filter them in memory leading to OOM error.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
