### PR TITLE
[FIX] web: switchView after page reload

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -1692,7 +1692,8 @@ export function makeActionManager(env, router = _router) {
             // This case would mostly happen when loadState detects a change in the URL.
             // Also, I guess we may need it when we have other monoRecord views
             index = controllerStack.findIndex(
-                (ct) => ct.action.jsId === controller.action.jsId && !ct.view.multiRecord
+                (ct) =>
+                    ct.action.jsId === controller.action.jsId && !ct.virtual && !ct.view.multiRecord
             );
             index = index > -1 ? index : controllerStack.length;
         }

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -1886,6 +1886,24 @@ describe(`new urls`, () => {
         // assert that we properly reload action and breacrumbs as lang changed
         expect.verifySteps(["/web/action/load_breadcrumbs", "/web/action/load"]);
     });
+
+    test(`switch to form view after reload`, async () => {
+        redirect("/odoo/action-3/2");
+
+        await mountWebClient();
+        expect(`.o_form_view`).toHaveCount(1);
+        expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
+            "Partners",
+            "Second record",
+        ]);
+
+        await getService("action").switchView("form", { resId: 5 });
+        expect(`.o_form_view`).toHaveCount(1);
+        expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
+            "Partners",
+            "Fifth record",
+        ]);
+    });
 });
 
 describe(`legacy urls`, () => {


### PR DESCRIPTION
Steps to reproduce:
- Open a project
- Create a task and convert it into a template
- Open another task (task A)
- Reload the page
- Create a task from the newly created template

Refreshing the page causes `loadState` to rebuild the controller stack from the URL to represent the breadcrumb history. In this case, a virtual form controller is injected for the opened task A, due to the lack of context in the URL to reconstruct it fully.

When creating the task from the template, a `switchView` to the new task's form view is triggered. However, only the controller for this new form view is fully populated with the relevant metadata, as the preceding ones are virtual (due to the above).

This commit ensures that virtual controllers are excluded from the check on the `multiRecord` field, preventing an error since the `view` is undefined for virtual controllers.

task-5876607