### PR TITLE
[FIX] base, web: use dynamic precision when using minimal precision

### DIFF
--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -199,6 +199,7 @@ export function humanNumber(number, options = { decimals: 0, minDigits: 1 }) {
  * @param {Object} [options]
  * @param {number[]} [options.digits] the number of digits that should be used,
  *   instead of the default digits precision in the field.
+ * @param {nummber} [optinos.minDigits] the minimum number of decimal digits to display.
  * @param {boolean} [options.humanReadable] if true, large numbers are formatted
  *   to a human readable format.
  * @param {string} [options.decimalPoint] decimal separating character
@@ -215,9 +216,12 @@ export function formatFloat(value, options = {}) {
     if (options.digits && options.digits[1] !== undefined) {
         precision = options.digits[1];
     } else if (options.minDigits) {
-        // When no precision is set, 12 is chosen as the precision. It is high enough to keep it precise,
-        // but not too high in order to avoid rounding errors..
-        precision = 12;
+        const intDigitsCount = (value !== 0) ? Math.floor(Math.log10(Math.abs(value))) + 1 : 1;
+        // We estimate the maximum decimal digits we can display without showing rounding errors,
+        // by substracting the number of integer digits to 15, as floats have 15-16 digits precision.
+        const maxDecDigits = Math.max(15 - intDigitsCount, 0);
+        // We display maximum 6 digits or the number of significant digits (if it's lower)
+        precision = Math.min(6, maxDecDigits);
     } else {
         precision = 2;
     }

--- a/addons/web/static/tests/core/utils/numbers.test.js
+++ b/addons/web/static/tests/core/utils/numbers.test.js
@@ -252,6 +252,42 @@ test("floatIsZero", () => {
 });
 
 describe("formatFloat", () => {
+    test("precision", () => {
+        patchWithCleanup(localization, {
+            decimalPoint: ".",
+            grouping: [3, 0],
+            thousandsSep: ",",
+        });
+
+        let options = {};
+        expect(formatFloat(3, options)).toBe("3.00");
+        expect(formatFloat(3.1, options)).toBe("3.10");
+        expect(formatFloat(3.12, options)).toBe("3.12");
+        expect(formatFloat(3.129, options)).toBe("3.13");
+
+        options = { digits: [15, 3] };
+        expect(formatFloat(3, options)).toBe("3.000");
+        expect(formatFloat(3.1, options)).toBe("3.100");
+        expect(formatFloat(3.123, options)).toBe("3.123");
+        expect(formatFloat(3.1239, options)).toBe("3.124");
+
+        options = { minDigits: 3 };
+        expect(formatFloat(0, options)).toBe("0.000");
+        expect(formatFloat(3, options)).toBe("3.000");
+        expect(formatFloat(3.1, options)).toBe("3.100");
+        expect(formatFloat(3.123, options)).toBe("3.123");
+        expect(formatFloat(3.1239, options)).toBe("3.1239");
+        expect(formatFloat(3.1231239, options)).toBe("3.123124");
+        expect(formatFloat(1234567890.1234567890, options)).toBe("1,234,567,890.12346");
+
+        options = { minDigits: 3, digits: [15, 4] };
+        expect(formatFloat(3, options)).toBe("3.000");
+        expect(formatFloat(3.1, options)).toBe("3.100");
+        expect(formatFloat(3.123, options)).toBe("3.123");
+        expect(formatFloat(3.1239, options)).toBe("3.1239");
+        expect(formatFloat(3.1234567, options)).toBe("3.1235");
+    });
+
     test("localized", () => {
         patchWithCleanup(localization, {
             decimalPoint: ".",

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -3,6 +3,7 @@ import base64
 import binascii
 from datetime import time
 import logging
+import math
 import re
 from io import BytesIO
 
@@ -186,7 +187,10 @@ class FloatConverter(models.AbstractModel):
         if 'decimal_precision' in options:
             precision = self.env['decimal.precision'].precision_get(options['decimal_precision'])
         elif options.get('precision') is None:
-            precision = 6
+            int_digits = int(math.log10(abs(value))) + 1 if value != 0 else 1
+            max_dec_digits = max(15 - int_digits, 0)
+            # We display maximum 6 decimal digits or the number of significant decimal digits if it's lower
+            precision = min(6, max_dec_digits)
             min_precision = min_precision or 1
         else:
             precision = options['precision']

--- a/odoo/addons/base/tests/test_qweb_field.py
+++ b/odoo/addons/base/tests/test_qweb_field.py
@@ -78,11 +78,13 @@ class TestQwebFieldFloatConverter(common.TransactionCase):
 
     def test_float_value_to_html_with_min_precision(self):
         options = {'min_precision': 3}
+        self.assertEqual(self.value_to_html(0, options), '0.000')
         self.assertEqual(self.value_to_html(3, options), '3.000')
         self.assertEqual(self.value_to_html(3.1, options), '3.100')
         self.assertEqual(self.value_to_html(3.123, options), '3.123')
         self.assertEqual(self.value_to_html(3.1239, options), '3.1239')
         self.assertEqual(self.value_to_html(3.1231239, options), '3.123124')
+        self.assertEqual(self.value_to_html(1234567890.1234567890, options), '1,234,567,890.12346')
 
     def test_float_value_to_html_with_precision_and_min_precision(self):
         options = {'min_precision': 3, 'precision': 4}


### PR DESCRIPTION
8c199f7783527735b35c9fbda334cbdcd55a004f introduced minimum precision
for float fields, but it has a display issue.

Steps to reproduce:
- create an invoice, set the price of an an invoice line to `9417.2`
-> the web client displays `'9,417.200000000001'`

Issue:
In case of a minimum precision, the precision was set to 12.
But it should be dynamic in regards to the number of integer digits.

Solution:
The precision is set to: 15 - number of integer digits

--

Also implementing the same logic in qweb, but by keeping a maximum
precision of 6.

To reproduce in qweb:
- create a an invoice with an invoice line of `300000000031.3`
- post and print
-> the price unit on the pdf shows "300,000,000,031.300232"

opw-5880951