### PR TITLE
[FIX] account{_peppol,_edi_ubl_cii,}: allow sending via Peppol after PDF or XML generation

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -55,7 +55,6 @@ class AccountMove(models.Model):
 
     def _need_ubl_cii_xml(self):
         self.ensure_one()
-        return not self.invoice_pdf_report_id \
-            and not self.ubl_cii_xml_id \
+        return not self.ubl_cii_xml_id \
             and self.is_sale_document() \
             and bool(self.partner_id.commercial_partner_id.ubl_cii_format)

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -236,6 +236,8 @@ class AccountMoveSend(models.TransientModel):
                         for key in ['pdf_attachment_values', 'ubl_cii_xml_attachment_values']
                         if invoice_data.get(key)
                     ]
+                    if not base_attachments and invoice.ubl_cii_xml_id:
+                        base_attachments.append((invoice.ubl_cii_xml_id.name, invoice.ubl_cii_xml_id.raw))
                     attachments_embedded = [
                         (attachment.name, attachment.raw)
                         for attachment in attachments_linked


### PR DESCRIPTION
### Issue:
In 17.0, the `Send via Peppol` option becomes unavailable after using `Send by email` on an invoice

### Cause:
The `Send via Peppol` action depends on the UBL-CII XML file
However, the XML generation was conditioned on the absence of a PDF document

After generating the PDF, the invoice was considered as already having all required documents, so no additional EDI documents (including the UBL-CII XML) were generated, which disabled the `Peppol` option

### Note:
If the XML was already generated, it should still be possible to `Send via Peppol`
However, the XML was not attached because it wasn't generated during Peppol sending
This issue is also fixed in this PR

### Steps to reproduce:
- Install `l10n_be` and switch to BE Company
- Enable Peppol and activate the Demo mode in Settings
- Create an invoice for the BE Company
- Add any product with a Tax
- Confirm -> Send & Print -> Email
- Open Send & Print again Before the fix, the `Send via Peppol` option is no longer available

opw-5490217