### PR TITLE
[FIX] account: ignore internal user if supplier is not found

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6632,7 +6632,7 @@ class AccountMove(models.Model):
             # Search for partners in the mail's body.
             body_mail_addresses = set(email_re.findall(msg_dict.get('body')))
             partners = self._partner_find_from_emails_single(
-                body_mail_addresses, filter_found=lambda p: is_right_company(p) or p.partner_share, no_create=True,
+                body_mail_addresses, filter_found=lambda p: is_right_company(p) and p.partner_share, no_create=True,
             ) if body_mail_addresses else self.env['res.partner']
 
         # Little hack: Inject the mail's subject in the body.


### PR DESCRIPTION
Currently we have an issue with OCR flow, where if internal users forward an email from an internal email address, the internal user is added as vendor

Steps to reproduce:
- Setup email alias for journal "Purchases"
- From an internal user email, forward a supplier bill to the vendor bill alias

Issue:
If the supplier is not already a registered partner, the bill will be created with the internal user set as partner.
This will break OCR flow where the missing document fields will be auto populated from the bill

opw-5487368