### PR TITLE
[FIX] account: Adapt audit trail tests

### DIFF
--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -59,6 +59,7 @@ class TestAuditTrail(AccountTestInvoicingCommon):
     def test_cant_unlink_message(self):
         self.env.company.restrictive_audit_trail = True
         self.move.action_post()
+        self.env.cr.flush()
         audit_trail = self.get_trail(self.move)
         with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail"):
             audit_trail.unlink()
@@ -66,6 +67,7 @@ class TestAuditTrail(AccountTestInvoicingCommon):
     def test_cant_unown_message(self):
         self.env.company.restrictive_audit_trail = True
         self.move.action_post()
+        self.env.cr.flush()
         audit_trail = self.get_trail(self.move)
         with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail"):
             audit_trail.res_id = 0


### PR DESCRIPTION
Since this commit https://github.com/odoo/odoo/pull/242248/changes flushing inside `test_cant_unlink_message1`, `test_cant_unown_message` is now required.


https://runbot.odoo.com/odoo/runbot.build.error/237803
runbot/error-237803