### PR TITLE
[FIX] tools: never consider a node with directive as translatable

### DIFF
--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -153,6 +153,74 @@ class TranslationToolsTestCase(BaseCase):
         self.assertEqual(result, source)
         self.assertItemsEqual(terms, ['Form stuff'])
 
+    def test_translate_xml_o_translate_inline_on_block(self):
+        """ Test xml_translate() with non-inline elements with o_translate_inline. """
+        terms = []
+        source = """<div>
+                        <h1 class="o_translate_inline">Blah</h1>more text
+                        <h1 class="o_translate_inline" t-if="True">Other Blah</h1>even more text
+                    </div>"""
+        result = xml_translate(terms.append, source)
+        self.assertEqual(result, source)
+        self.assertItemsEqual(terms,
+            ['<h1 class="o_translate_inline">Blah</h1>more text', 'Other Blah', 'even more text'])
+
+    def test_translate_xml_o_translate_inline_on_parent(self):
+        """ Test xml_translate() with non-inline elements inside o_translate_inline. """
+        terms = []
+        source = """<div>
+                        <span class="o_translate_inline">Blah<h1>more text</h1></span>
+                        <span class="o_translate_inline">Other Blah<h1 t-if="True">even more text</h1></span>
+                    </div>"""
+        result = xml_translate(terms.append, source)
+        self.assertEqual(result, source)
+        self.assertItemsEqual(terms,
+            ['<span class="o_translate_inline">Blah<h1>more text</h1></span>', 'Other Blah', 'even more text'])
+
+    def test_translate_xml_highlight(self):
+        """ Test xml_translate() with highlight span (with o_translate_inline). """
+        terms = []
+        source = """<div>
+                        <span class="o_text_highlight o_translate_inline">
+                            <a>solo link</a>
+                        </span>
+                    </div>
+                    <div>
+                        <span class="o_text_highlight o_translate_inline">
+                            <span>Here is a <a>nested link</a> in highlight</span>
+                        </span>
+                    </div>"""
+        result = xml_translate(terms.append, source)
+        self.assertEqual(result, source)
+        self.assertItemsEqual(terms, ["""<span class="o_text_highlight o_translate_inline">
+                            <a>solo link</a>
+                        </span>""", """<span class="o_text_highlight o_translate_inline">
+                            <span>Here is a <a>nested link</a> in highlight</span>
+                        </span>"""])
+
+    def test_translate_xml_o_translate_inline_with_groups(self):
+        """ Test xml_translate() with groups attribute and with o_translate_inline. """
+        terms = []
+        source = """<div>
+                        <a class="o_translate_inline" href="#" groups="anyone">Skip</a>
+                    </div>"""
+        result = xml_translate(terms.append, source)
+        self.assertEqual(result, source)
+        self.assertItemsEqual(terms, ['Skip'])
+
+    def test_translate_xml_groups(self):
+        """ Test xml_translate() with groups attributes. """
+        terms = []
+        source = """<t t-name="stuff">
+                        stuff before
+                        <span groups="anyone"/>
+                        stuff after
+                    </t>"""
+        result = xml_translate(terms.append, source)
+        self.assertEqual(result, source)
+        self.assertItemsEqual(terms,
+            ['stuff before', 'stuff after'])
+
     def test_translate_xml_t(self):
         """ Test xml_translate() with t-* attributes. """
         terms = []

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -210,40 +210,50 @@ def translate_xml_node(node, callback, parse, serialize):
         """ Return whether ``text`` is a string with non-space characters. """
         return bool(text) and not space_pattern.fullmatch(text)
 
-    def translatable(node):
+    def is_force_inline(node):
+        """ Return whether ``node`` is marked as it should be translated as
+            one term.
+        """
+        return "o_translate_inline" in node.attrib.get("class", "").split()
+
+    def translatable(node, force_inline=False):
         """ Return whether the given node can be translated as a whole. """
+        # Some specific nodes (e.g., text highlights) have an auto-updated DOM
+        # structure that makes them impossible to translate.
+        # The introduction of a translation `<span>` in the middle of their
+        # hierarchy breaks their functionalities. We need to force them to be
+        # translated as a whole using the `o_translate_inline` class.
+        force_inline = force_inline or is_force_inline(node)
         return (
-            # Some specific nodes (e.g., text highlights) have an auto-updated
-            # DOM structure that makes them impossible to translate.
-            # The introduction of a translation `<span>` in the middle of their
-            # hierarchy breaks their functionalities. We need to force them to
-            # be translated as a whole using the `o_translate_inline` class.
-            "o_translate_inline" in node.attrib.get("class", "").split()
-            or node.tag in TRANSLATED_ELEMENTS
-            and not any(key.startswith("t-") for key in node.attrib)
-            and all(translatable(child) for child in node)
+            (force_inline or node.tag in TRANSLATED_ELEMENTS)
+            # Nodes with directives are not translatable. Directives usually
+            # start with `t-`, but this prefix is optional for `groups` (see
+            # `_compile_directive_groups` which reads `t-groups` and `groups`)
+            and not any(key.startswith("t-") or key == 'groups' for key in node.attrib)
+            and all(translatable(child, force_inline) for child in node)
         )
 
-    def hastext(node, pos=0):
+    def hastext(node, pos=0, force_inline=False):
         """ Return whether the given node contains some text to translate at the
             given child node position.  The text may be before the child node,
             inside it, or after it.
         """
+        force_inline = force_inline or is_force_inline(node)
         return (
             # there is some text before node[pos]
             nonspace(node[pos-1].tail if pos else node.text)
             or (
                 pos < len(node)
-                and translatable(node[pos])
+                and translatable(node[pos], force_inline)
                 and (
                     any(  # attribute to translate
                         val and key in TRANSLATED_ATTRS and TRANSLATED_ATTRS[key](node[pos])
                         for key, val in node[pos].attrib.items()
                     )
                     # node[pos] contains some text to translate
-                    or hastext(node[pos])
+                    or hastext(node[pos], 0, force_inline)
                     # node[pos] has no text, but there is some text after it
-                    or hastext(node, pos + 1)
+                    or hastext(node, pos + 1, force_inline)
                 )
             )
         )
@@ -267,7 +277,7 @@ def translate_xml_node(node, callback, parse, serialize):
                 # into a <div> element
                 div = etree.Element('div')
                 div.text = (node[pos-1].tail if pos else node.text) or ''
-                while pos < len(node) and translatable(node[pos]):
+                while pos < len(node) and translatable(node[pos], is_force_inline(node)):
                     div.append(node[pos])
 
                 # translate the content of the <div> element as a whole


### PR DESCRIPTION
Nodes with directives must not be included inside a translatable span. But the function `translatable` missed the directive `groups` (without `t-`), and the class `o_translate_inline` should only override the predicate about the element's tag.
