### PR TITLE
[FIX] payment: allow zero minor amount in express checkout form

### DIFF
--- a/addons/payment_stripe/static/src/js/express_checkout_form.js
+++ b/addons/payment_stripe/static/src/js/express_checkout_form.js
@@ -17,7 +17,7 @@ paymentExpressCheckoutForm.include({
      */
     _getOrderDetails(deliveryAmount, amountFreeShipping) {
         const pending = this.paymentContext['shippingInfoRequired'] && deliveryAmount === undefined;
-        let minorAmount = parseInt(this.paymentContext['minorAmount'])
+        let minorAmount = parseInt(this.paymentContext['minorAmount'] || 0)
         const displayItems = [
             {
                 label: _t("Your order"),


### PR DESCRIPTION
### Issue:
Due to this issue, there is a traceback, in express stripe checkout when there is a 100% discount and shipping cost.

Steps to reproduce:
1- Setup `Stripe` as the only payment provider in the db.
2- Create a discount code with 100% discount on order.
3- Set a fixed price on the delivery method.
4- On shop, add a product to cart, and then enter the discount code.
5- Refresh the page.

There is a traceback.

#### Cause:
This issue is introduced after #209103, which set `minor_amount` to amount excluding delivery. In the case it's 0, it's not going to be rendered on express_checkout view as it is false.

Which cause a traceback here:
https://github.com/odoo/odoo/blob/8f7e3d588c6c1189e64442a33037666d5d70aae7/addons/payment_stripe/static/src/js/express_checkout_form.js#L73-L81

opw-5482646
