### PR TITLE
[FIX] hr_recruitment: fix recruitment sample data

### DIFF
--- a/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
+++ b/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
@@ -80,7 +80,7 @@
             <field name="priority">2</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/helen.lee</field>
             <field name="job_id" ref="job_marketing" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">3100</field>
@@ -102,7 +102,7 @@
             <field name="priority">2</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/enrique.jones</field>
             <field name="job_id" ref="job_marketing" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">2900</field>
@@ -124,7 +124,7 @@
             <field name="priority">3</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/hannah.glover</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
 
             <field name="department_id" ref="dep_rd" />
@@ -147,7 +147,7 @@
             <field name="priority">0</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/simon.jones</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
             <field name="salary_expected">3000</field>
@@ -173,7 +173,7 @@
             <field name="priority">0</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/maria.rodriguez</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
             <field name="stage_id" ref="stage_job0" />

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -418,6 +418,17 @@ class HrJob(models.Model):
     @api.model
     def _action_load_recruitment_scenario(self):
 
+        admin_user = self.env.ref('base.user_admin')
+        employee_admin = self.env['hr.employee'].search([('user_id', '=', admin_user.id)], limit=1)
+
+        if not employee_admin:
+            self.env['hr.employee'].create({
+                'name': admin_user.name,
+                'user_id': admin_user.id,
+                'image_1920': admin_user.image_1920,
+                'structure_type_id': self.env.ref('hr.structure_type_employee').id,
+            })
+
         convert_file(
             self.sudo().env,
             "hr_recruitment",


### PR DESCRIPTION
Steps to reproduce:
1- Create an empty database with no demo data
2- Install recruitment app
3- Open recruitment app and click on "Load sample data"

Alternate steps to reproduce if the db has demo data: 1- Open recruitment app
2- Switch to list view
3- Select all jobs and delete them
4- Click on "Load sample data"

Issue:
You get a traceback that prevents the loading of the sample data

Cause:
In this [pr](https://github.com/odoo/odoo/pull/229665) the user_id field was replaced with recruiter_id but the sample data was changed to respect that change

Solution:
Replace user_id in the sample data with recruiter_id and use an employee as a value instead of a user. One additional detail is that since this is sample data that can potentially be applied on a db that already has some records. There is a case where creating an employee in the sample file and linking them to the admin user, but that can cause an exception if the admin user is already linked to an employee. To circumvent this, we first check if there is an employee linked to the admin user. If not we create a new one and make the sample data use whichever employee that is linked to the admin user.

Task-5891245
