### PR TITLE
[FIX] hr: add empty page for certification view

### DIFF
--- a/addons/hr_skills/models/hr_employee_skill.py
+++ b/addons/hr_skills/models/hr_employee_skill.py
@@ -45,5 +45,27 @@ class HrEmployeeSkill(models.Model):
             'views': [(self.env.ref('hr_skills.employee_skill_view_inherit_certificate_form').id, 'form')],
         }
 
+    def action_hr_employee_skill_certification(self):
+        skill_type = self.env["hr.skill.type"].search(
+            [("is_certification", "=", True)], limit=1
+        )
+        show_certificate_button = bool(skill_type)
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "hr_skills.action_hr_employee_skill_certification"
+        )
+        action["context"] = {"show_certificate": show_certificate_button}
+        if self.env.user.has_group("hr.group_hr_manager"):
+            action["help"] = (
+                self.env._("""<p class="o_view_nocontent_smiling_face">No Certifications available. Navigate to Skill types!</p>
+                <a type="action" name="hr_skills.hr_skill_type_action" class="btn btn-primary">
+                Show Skill Types
+                </a>""")
+            )
+        else:
+            action["help"] = self.env._(
+                """<p class="o_view_nocontent_smiling_face">No Certifications available!</p>"""
+            )
+        return action
+
     def action_save(self):
         return {'type': 'ir.actions.act_window_close'}

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -541,7 +541,7 @@
                 decoration-danger="valid_to and valid_to &lt;= (context_today() + relativedelta(days=7)).strftime('%Y-%m-%d') and valid_to &gt; context_today().strftime('%Y-%m-%d')"
                 decoration-warning="valid_to and valid_to &lt;= (context_today() + relativedelta(months=3)).strftime('%Y-%m-%d') and valid_to &gt; (context_today() + relativedelta(days=7)).strftime('%Y-%m-%d')">
                 <header>
-                    <button name="open_hr_employee_skill_modal" string="New" type="object" class="btn-primary" display="always"/>
+                    <button name="open_hr_employee_skill_modal" string="New" type="object" class="btn-primary" display="always" invisible="not context.get('show_certificate')"/>
                 </header>
                 <field name="employee_id" widget="many2one_avatar_employee"/>
                 <field name="skill_id" string="Certification"/>
@@ -576,6 +576,15 @@
         </field>
     </record>
 
+    <record id="action_server_hr_employee_skill_certification" model="ir.actions.server">
+        <field name="name">Certifications</field>
+        <field name="model_id" ref="model_hr_employee_skill"/>
+        <field name="state">code</field>
+        <field name="code">
+            action = model.action_hr_employee_skill_certification()
+        </field>
+    </record>
+
     <record id="action_hr_employee_skill_certification" model="ir.actions.act_window">
         <field name="name">Certifications</field>
         <field name="res_model">hr.employee.skill</field>
@@ -607,7 +616,7 @@
             id="hr_certification_menu"
             name="Certifications"
             parent="hr_skill_learning_menu"
-            action="action_hr_employee_skill_certification"
+            action="action_server_hr_employee_skill_certification"
             sequence="94"/>
 
         <menuitem


### PR DESCRIPTION
[FIX] hr: add empty page for certification view

**Issue:**
-Creating a new Certification triggers a validation error if no Skill Type has "is_certification" checked.

**To reproduce:**
1-Navigate to Skill Types in Configuration Menu.
2-Disable "is_certificate" for all types.
3-Navigate to Certifications menu.
4-Try to create a new Certification for any Employee.

**Solution:**
-Empty page will show, with a button guiding to the Skill Types list view for adjustment / creation if no certifications available.

-**Task**: #5350163

