### PR TITLE
[FIX] html_editor: skip srcset generation on hover effect images

### DIFF
--- a/addons/html_editor/static/src/main/media/image_save_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_save_plugin.js
@@ -181,7 +181,12 @@ export class ImageSavePlugin extends Plugin {
                 }
             }
         }
-        if (!isImageField && !isBackground && el.dataset.mimetype !== "image/gif") {
+        if (
+            !isImageField &&
+            !isBackground &&
+            el.dataset.mimetype !== "image/gif" &&
+            !el.dataset.hoverEffect
+        ) {
             // We are using these sizes instead of the normally used 128, 256, ...
             // because we want to optimize smartphone data usage and loading time.
             // Each sizes in smallerSizes fits a certain category of smartphone,


### PR DESCRIPTION
Bug:
The on hover image animation in the website builder was not working properly. Once the image was saved, the animation would not play.

Steps to reproduce:
- in website, in edit mode
- Drop s_picture or add any image and set it's size to 1024 or more
- On the image, add on hover animation with any effect
- See that it works properly in edit mode
- Save
- Hover on the image, animation doesn't play

Why:
When adding an image to a certain size, a srcset is added for responsiveness. But because the hover interaction swaps the image `src` attribute, and not the srcset sources that are selected by the browser, the animation was not displayed even though it was correctly playing for the image `src`.

Fix:
If there is a `data-hover-effect` in the image attributes, then we skip the srcset generation. Doing so, there is only the image `src` to display and the animation plays correctly.

task-5891353
