### PR TITLE
[FIX] account: ensure CoA are loaded in parent before branch companies

### DIFF
--- a/addons/account/models/ir_module.py
+++ b/addons/account/models/ir_module.py
@@ -72,7 +72,7 @@ class IrModuleModule(models.Model):
         if not was_installed and is_installed:
             if self.name != 'account':
                 for demo in [False, True] if self.demo else [False]:
-                    for company in self.env['res.company'].search([('chart_template', '!=', False)]):
+                    for company in self.env['res.company'].search([('chart_template', '!=', False)], order="parent_path"):
                         ChartTemplate = self.env['account.chart.template'].with_company(company)
                         module_template_data = ChartTemplate._get_chart_template_data(company.chart_template, demo, self.name)
                         module_template_data.pop('template_data', None)


### PR DESCRIPTION
Issue:
Validation Error on installing some modules in companies with branches

Step to reproduce:
- Create a company in UK
- Create a branch to this company
- install l10n_uk
- install l10n_uk_reports_csi

Current behavior:
- raise validation error

Solution:
In AccountChartTemplate, `ref()` function allow searching object from company and parents company.
https://github.com/odoo/odoo/blob/468c25b924979f4614705fe43f909af13f83c6a3/addons/account/models/chart_template.py#L1262-L1266 
In `_load_data`, it tries to load existing record before creating new account.
Loading the parent company first prevent creating a second account in the branch which raise the error.

opw-5443912

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
