### PR TITLE
[FIX] sale: use single wizard.res_id in compute_warning

### DIFF
--- a/addons/sale/wizard/payment_link_wizard.py
+++ b/addons/sale/wizard/payment_link_wizard.py
@@ -32,7 +32,7 @@ class PaymentLinkWizard(models.TransientModel):
     def _compute_warning_message(self):
         super()._compute_warning_message()
         for wizard in self.filtered(lambda w: w.res_model == 'sale.order'):
-            sale_order = self.env['sale.order'].browse(self.res_id)
+            sale_order = self.env['sale.order'].browse(wizard.res_id)
             if sale_order.is_expired:
                 wizard.warning_message = _("The sale order has expired.")
 


### PR DESCRIPTION
### Issue:
In #244061 changes, the expired so leads to warning message.
However, the batch `res_id` is used instead of single record which is an error.

opw-5478691

