### PR TITLE
[FIX] stock: avoid recompute to draft state on pickings

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -814,15 +814,15 @@ class StockPicking(models.Model):
         '''
         picking_moves_state_map = defaultdict(dict)
         picking_move_lines = defaultdict(set)
-        for move in self.move_ids:
+        for move in self.env['stock.move'].search([('picking_id', 'in', self.ids)]):
             picking_id = move.picking_id
             move_state = move.state
             picking_moves_state_map[picking_id.id].update({
                 'any_draft': picking_moves_state_map[picking_id.id].get('any_draft', False) or move_state == 'draft',
                 'all_cancel': picking_moves_state_map[picking_id.id].get('all_cancel', True) and move_state == 'cancel',
                 'all_cancel_done': picking_moves_state_map[picking_id.id].get('all_cancel_done', True) and move_state in ('cancel', 'done'),
-                'all_done_are_scrapped': picking_moves_state_map[picking_id.id].get('all_done_are_scrapped', True) and (move.location_dest_usage == 'inventory' if move_state == 'done' else True),
-                'any_cancel_and_not_scrapped': picking_moves_state_map[picking_id.id].get('any_cancel_and_not_scrapped', False) or (move_state == 'cancel' and move.location_dest_usage != 'inventory'),
+                'all_done_are_scrapped': picking_moves_state_map[picking_id.id].get('all_done_are_scrapped', True) and (move.is_scrap if move_state == 'done' else True),
+                'any_cancel_and_not_scrapped': picking_moves_state_map[picking_id.id].get('any_cancel_and_not_scrapped', False) or (move_state == 'cancel' and not move.is_scrap),
             })
             picking_move_lines[picking_id.id].add(move.id)
         for picking in self:


### PR DESCRIPTION
Steps to reproduce:
- Create a delivery with a reserved move
- Click on the "picked" checkbox on the move

Issue:
The picking is visibly reset to draft

This happens due to #210299, which used `self.move_ids` instead of the previously used `search()`. This means that rather than having proper ids to use, now the moves are `stock.move(<NewId origin=X>)` records, and their related picking as well.
This implies that the dict uses these `NewId` as keys as well.

However, below we use `picking.ids` which contains the "real" ids (i.e. int) and not the `NewId`. So no picking is found within the dict and the returned state is always `draft`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
