### PR TITLE
[FIX] mail: clear mail activities before testing KPIs

### DIFF
--- a/addons/mail/tests/test_kpi_provider.py
+++ b/addons/mail/tests/test_kpi_provider.py
@@ -11,7 +11,9 @@ class TestKpiProvider(TransactionCase):
         cls.user_someemployee = new_test_user(cls.env, name='Some Employee', login='someemployee')
         cls.user_anotheremployee = new_test_user(cls.env, name='AnotherEmployee', login='anotheremployee')
 
-        cls.env['mail.activity'].create([{
+        MailActivity = cls.env['mail.activity']
+        MailActivity.search([]).active = False
+        MailActivity.create([{
             'activity_type_id': cls.env.ref('mail.mail_activity_data_todo').id,
             'user_id': cls.user_someemployee.id,
         }, {


### PR DESCRIPTION
Commit ff941e6555c12918803db4a72511c9381cc58c31 introduced a test that counts the amount of mail activities grouped by type.
However, the test doesn't take into consideration that the demo data might have created some activities.

With this commit, we ensure the tests run with a clean state by removing any pre-existing mail activities so that we have consistent and expected results.

Runbot-build-error-id: [234966](https://runbot.odoo.com/odoo/runbot.build.error/234966)