### PR TITLE
[FIX] base: fix issue with res.partner create on a non-empty recordset

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -901,7 +901,7 @@ class ResPartner(models.Model):
             return partners
 
         for partner, vals in zip(partners, vals_list):
-            vals = self._add_missing_default_values(vals)
+            vals = self.env['res.partner']._add_missing_default_values(vals)
             partner._fields_sync(vals)
         return partners
 

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -455,7 +455,8 @@ class TestPartnerAddressCompany(TransactionCase):
         self.assertEqual(inv_1.street, 'Invoice Child Street', 'Should take parent address')
         self.assertFalse(inv_1.vat)
         # test it also works with default_parent_id value in context
-        inv_2 = self.env['res.partner'].with_context(default_parent_id=inv.id).create({
+        # also ensure it works directly on a non-empty recordset
+        inv_2 = (ct1_1 | inv_1).with_context(default_parent_id=inv.id).create({
             'name': 'Address, Child of Invoice',
         })
         self.assertEqual(inv_2.street, 'Invoice Child Street', 'Should take parent address')


### PR DESCRIPTION
**Issue:**
`ValueError: Expected singleton` when creating new partners on a non empty (no singleton) recordset due to the `_add_missing_default_values` call.

The default create method uses `self = self.browse()` to remove the records, but the `res.partner` override was still using its original `self`.

**Fix:**
Properly call the method on an empty recordset.

related: https://github.com/odoo/odoo/commit/79486ec3fc553845cac14fb135c16fe0b093e3b4

opw-4932114
