### PR TITLE
[FIX] pos_discount: re-appllying global discount fixes

### DIFF
--- a/addons/pos_discount/static/src/app/services/pos_store.js
+++ b/addons/pos_discount/static/src/app/services/pos_store.js
@@ -92,6 +92,7 @@ patch(PosStore.prototype, {
             const existingLine = discountLinesMap[key];
 
             if (existingLine) {
+                existingLine.extra_tax_data = extra_tax_data;
                 existingLine.price_unit = baseLine.price_unit;
                 delete discountLinesMap[key];
             } else {

--- a/addons/pos_discount/static/tests/unit/components/product_screen.test.js
+++ b/addons/pos_discount/static/tests/unit/components/product_screen.test.js
@@ -1,6 +1,6 @@
 import { animationFrame, expect, test } from "@odoo/hoot";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
-import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { setupPosEnv, expectFormattedPrice } from "@point_of_sale/../tests/unit/utils";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
 
@@ -40,4 +40,32 @@ test("getNumpadButtons", async () => {
             (order.lines[0].priceIncl * 0.1).toPrecision(2)
         );
     }, 100);
+});
+
+test("addProductToOrder reapplies the global discount", async () => {
+    const store = await setupPosEnv();
+    const order = store.addNewOrder();
+    const product = store.models["product.template"].get(5);
+    const productScreen = await mountWithCleanup(ProductScreen, {
+        props: { orderUuid: order.uuid },
+    });
+
+    await productScreen.addProductToOrder(product);
+    expectFormattedPrice(productScreen.total, "$ 3.45");
+    expect(order.priceIncl).toBe(3.45);
+    expect(order.priceExcl).toBe(3);
+    expect(order.amountTaxes).toBe(0.45);
+
+    await store.applyDiscount(10);
+    expectFormattedPrice(productScreen.total, "$ 3.10");
+    expect(order.priceIncl).toBe(3.1);
+    expect(order.priceExcl).toBe(2.7);
+    expect(order.amountTaxes).toBe(0.4);
+
+    await productScreen.addProductToOrder(product);
+    await animationFrame();
+    expectFormattedPrice(productScreen.total, "$ 6.21");
+    expect(order.priceIncl).toBeCloseTo(6.21, { margin: 1e-12 });
+    expect(order.priceExcl).toBe(5.4);
+    expect(order.amountTaxes).toBe(0.81);
 });

--- a/addons/pos_discount/static/tests/unit/services/pos_service.test.js
+++ b/addons/pos_discount/static/tests/unit/services/pos_service.test.js
@@ -1,0 +1,52 @@
+import { test, describe, expect } from "@odoo/hoot";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+definePosModels();
+
+describe("PoS Discount", () => {
+    test("changing fiscal positions reapplies the global discount", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+
+        const product = store.models["product.template"].get(5);
+
+        await store.addLineToOrder({ product_tmpl_id: product, qty: 10 }, order);
+        expect(order.priceIncl).toBe(34.5);
+        expect(order.priceExcl).toBe(30);
+        expect(order.amountTaxes).toBe(4.5);
+
+        await store.applyDiscount(10);
+        expect(order.priceIncl).toBe(31.05);
+        expect(order.priceExcl).toBe(27);
+        expect(order.amountTaxes).toBe(4.05);
+
+        let [productLine, discountLine] = order.lines;
+        expect(productLine.priceIncl).toBe(34.5);
+        expect(discountLine.priceIncl).toBe(-3.45);
+
+        let resolveReapplyDiscount = null;
+        const reapplyDiscountPromise = new Promise((resolve) => {
+            resolveReapplyDiscount = resolve;
+        });
+
+        patchWithCleanup(store, {
+            async debouncedDiscount() {
+                await super.applyDiscount(...arguments);
+                resolveReapplyDiscount();
+            },
+        });
+
+        const nonTaxFP = store.models["account.fiscal.position"].get(2);
+        order.fiscal_position_id = nonTaxFP;
+
+        await reapplyDiscountPromise;
+        expect(order.priceIncl).toBe(27);
+        expect(order.priceExcl).toBe(27);
+        expect(order.amountTaxes).toBe(0);
+
+        [productLine, discountLine] = order.lines;
+        expect(productLine.priceIncl).toBe(30);
+        expect(discountLine.priceIncl).toBe(-3);
+    });
+});


### PR DESCRIPTION
Steps to reproduce
------------------
1. Make two fiscal positions, one applying taxes, and the other not.
2. Open pos, select the FP that applies taxes, and add a product
3. Now apply a global discount of 10%
4. Chagne to the FP that does not apply any taxes.

Notice that the discount line amount is still computed based on the the taxes from the old FP.

Also, another "unrelated" bug, when adding products, the global discount was not always updating.

Please see the individual commits' messages for more details on each fix.

opw-5443716