### PR TITLE
[FIX] base_geolocalize: use valid User-Agent for nominatim requests

### DIFF
--- a/addons/base_geolocalize/data/data.xml
+++ b/addons/base_geolocalize/data/data.xml
@@ -9,4 +9,8 @@
         <field name="tech_name">googlemap</field>
         <field name="name">Google Place Map</field>
     </record>
+    <record id="geolocalize_user_agent" model="ir.config_parameter">
+        <field name="key">base_geolocalize.user_agent</field>
+        <field name="value"></field>
+    </record>
 </odoo>

--- a/addons/base_geolocalize/models/base_geocoder.py
+++ b/addons/base_geolocalize/models/base_geocoder.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import requests
 import logging
 
-from odoo import api, fields, models, tools, _
+import requests
 from odoo.exceptions import UserError
 
+from odoo import _, api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -87,7 +87,8 @@ class GeoCoder(models.AbstractModel):
             return None
         url = 'https://nominatim.openstreetmap.org/search'
         try:
-            headers = {'User-Agent': 'Odoo (http://www.odoo.com/contactus)'}
+            headers = {'User-Agent': self.env['ir.config_parameter'].sudo().get_param('base_geolocalize.user_agent',
+                                                                               'Odoo (http://www.odoo.com/contactus)')}
             response = requests.get(url, headers=headers, params={'format': 'json', 'q': addr})
             _logger.info('openstreetmap nominatim service called')
             if response.status_code != 200:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Task created in odoo: https://www.odoo.com/my/tasks/5889105

Current behavior before PR:
openstreetmap is not working and rejecting every request because the user-agent header set in the module's code is blacklisted.

Desired behavior after PR is merged:
a new system parameter where one can set any user-agent string other than the harcoded one, to be sent in header of request so it won't be rejected. (The way it used to be before)

explanatory video: https://app.screencastify.com/watch/Peuh2gc4uRhoj9zUcLst?checkOrg=7e2a08f6-a226-473f-8073-034b0953a2e6


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
