### PR TITLE
[FIX] l10n_fr_hr_holidays: correctly calculate time off with employee…

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -145,6 +145,12 @@ class HrLeave(models.Model):
                 for leave in leaves:
                     if leave.request_unit_half:
                         duration_by_leave_id.update(leave._get_durations(resource_calendar=company_cal))
+                        employee_holidays = public_holidays.filtered_domain([
+                            ('calendar_id', 'in', [self.employee_id.resource_calendar_id.id]),
+                            ('company_id', '=', company.id)
+                        ])
+                        _, hours = duration_by_leave_id.get(leave.id, (0.0, 0.0))
+                        duration_by_leave_id[leave.id] = (_ - len(employee_holidays), hours - (len(employee_holidays) * 8))
                         continue
                     # Extend the end date to next working day
                     date_start = leave.date_from


### PR DESCRIPTION
… specific holidays

Steps to reproduce:
1. Create a company in France
2. Create an employee with working hours that are different than the company default
3. Add a public holiday specific to that employee's working calendar
4. Ensure that the 'Company Paid Time Off Type' has 'Duration Type' set to 'Half Days'
5. Create a leave request for that employee that overlaps with the public holiday
6. Observe that the number of days off is incorrectly calculated, including the public holiday as a working day

The `if` condition that is hit skips the normal calculation that factors holidays into how much time off should be taken, resulting in more time off days being used then should be. This change adds logic into this `if` statement to correctly take into account holidays from the employees specific calendar, ensuring the correct amount of days are used.

