### PR TITLE
[IMP] pos*: adjust payment method sequence

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -1019,6 +1019,7 @@ class PosConfig(models.Model):
             'name': _('Cash'),
             'journal_id': cash_journal.id,
             'company_id': self.env.company.id,
+            'sequence': 1,
         })
 
     def _create_journal_and_payment_methods(self, cash_ref=None, cash_journal_vals=None):
@@ -1057,18 +1058,18 @@ class PosConfig(models.Model):
                 'name': _('Card'),
                 'journal_id': bank_journal.id,
                 'company_id': self.env.company.id,
-                'sequence': 1,
+                'sequence': 2,
             })
 
         payment_methods |= bank_pm
 
-        pay_later_pm = self.env['pos.payment.method'].search([('journal_id', '=', False), ('company_id', 'in', self.env.company.parent_ids.ids)])
+        pay_later_pm = self.env['pos.payment.method'].search([('journal_id', '=', False), ('split_transactions', '=', True), ('company_id', 'in', self.env.company.parent_ids.ids)])
         if not pay_later_pm:
             pay_later_pm = self.env['pos.payment.method'].create({
                 'name': _('Customer Account'),
                 'company_id': self.env.company.id,
                 'split_transactions': True,
-                'sequence': 2,
+                'sequence': 4,
             })
 
         payment_methods |= pay_later_pm

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -11,6 +11,9 @@ class PosPaymentMethod(models.Model):
     _order = "sequence, id"
     _inherit = ['pos.load.mixin']
 
+    def _default_sequence(self):
+        return (self.search([], order="sequence desc", limit=1).sequence or 0) + 1
+
     def _get_terminal_provider_selection(self):
         return []
 
@@ -34,7 +37,7 @@ class PosPaymentMethod(models.Model):
         return False
 
     name = fields.Char(string="Method", required=True, translate=True, help='Defines the name of the payment method that will be displayed in the Point of Sale when the payments are selected.')
-    sequence = fields.Integer(copy=False)
+    sequence = fields.Integer(copy=False, default=_default_sequence)
     outstanding_account_id = fields.Many2one('account.account',
         string='Outstanding Account',
         ondelete='restrict',

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2202,6 +2202,16 @@ class TestPointOfSaleFlow(CommonPosTest):
             self.assertEqual(line.debit, reverse_line.credit)
             self.assertEqual(line.credit, reverse_line.debit)
 
+    def test_payment_method_sequence(self):
+        self.env['pos.payment.method'].search([]).write({'active': False})
+        _, pm_ids = self.pos_config_usd._create_journal_and_payment_methods()
+        # The 4th one is the online payment method, which is not created without demo data,
+        methods = self.env['pos.payment.method'].browse(pm_ids)[:3]
+        self.assertEqual(methods.mapped('name'), ['Cash', 'Card', 'Customer Account'])
+        self.assertEqual(methods.mapped('sequence'), [1, 2, 4])
+        new_pm = self.env['pos.payment.method'].create({'name': 'Quick Pay'})
+        self.assertEqual(new_pm.sequence, 5)
+
     def test_order_invoiced_customer_account_after_session_closed(self):
         """Test that an order paid via customer account can be invoiced after its session is closed.
            Then make sure that the reversal move is reconciled with the PoS session account move line so that only the invoice remains open.

--- a/addons/pos_online_payment/models/pos_config.py
+++ b/addons/pos_online_payment/models/pos_config.py
@@ -34,8 +34,12 @@ class PosConfig(models.Model):
             new_online_pm = self.env['pos.payment.method'].sudo()._get_or_create_online_payment_method(self.env.company.id, False)
             if demo_provider := self.env.ref('payment.payment_provider_demo', raise_if_not_found=False):
                 new_online_pm.write({'online_payment_provider_ids': [(6, 0, demo_provider.ids)]})
+            return new_online_pm
 
     @api.model
     def _create_journal_and_payment_methods(self, cash_ref=None, cash_journal_vals=None):
-        self._create_online_payment_demo()
-        return super()._create_journal_and_payment_methods(cash_ref, cash_journal_vals)
+        online_pm = self._create_online_payment_demo()
+        journal, payment_method_ids = super()._create_journal_and_payment_methods(cash_ref, cash_journal_vals)
+        if online_pm:
+            payment_method_ids.append(online_pm.id)
+        return journal, payment_method_ids

--- a/addons/pos_online_payment/models/pos_payment_method.py
+++ b/addons/pos_online_payment/models/pos_payment_method.py
@@ -132,6 +132,7 @@ class PosPaymentMethod(models.Model):
                     'name': _('Online Payment'),
                     'is_online_payment': True,
                     'company_id': company_id,
+                    'sequence': 3,
                 })
                 if not payment_method_id:
                     raise ValidationError(_(

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -241,6 +241,7 @@ registry.category("web_tour.tours").add("test_tip_after_payment", {
             ProductScreen.addOrderline("Minute Maid", "1", "3"),
             ProductScreen.clickPayButton(false),
             // case 1: remaining < 0 => increase PaymentLine amount
+            PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.enterPaymentLineAmount("Bank", "1"),
             PaymentScreen.clickTipButton(),
             {
@@ -251,6 +252,7 @@ registry.category("web_tour.tours").add("test_tip_after_payment", {
             Dialog.confirm(),
             PaymentScreen.selectedPaymentlineHas("Bank", "2.00"),
             // case 2: remaining >= 0 and remaining >= tip => don't change PaymentLine amount
+            PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickPaymentlineDelButton("Bank", "2.00"),
             PaymentScreen.enterPaymentLineAmount("Bank", "5"),
             PaymentScreen.clickTipButton(),
@@ -262,6 +264,7 @@ registry.category("web_tour.tours").add("test_tip_after_payment", {
             Dialog.confirm(),
             PaymentScreen.selectedPaymentlineHas("Bank", "5.00"),
             // case 3: remaining >= 0 and remaining < tip => increase by the difference
+            PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickPaymentlineDelButton("Bank", "5.00"),
             PaymentScreen.enterPaymentLineAmount("Bank", "5"),
             PaymentScreen.clickTipButton(),


### PR DESCRIPTION
Purpose
-------
Validation can be done instantly when a manual payment method is listed first.
Having an online payment method as the first option breaks this flow by 
requiring a scan before validation.

In this commit
--------------
The payment method sequence is updated so that manual methods remain first,
restoring fast validation:

1) Cash
2) Card
3) Online payment
4) Customer account

Additionally:
- When a new payment method is added, it will automatically get the
  next sequence
- Correct domain when searching for the “Customer Account”
  payment method to avoid incorrect matching.

Task-5713304

