### PR TITLE
[FIX][19.0] account: Ensure proper flushing of the database before audit trail checks

### DIFF
--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -64,6 +64,7 @@ class TestAuditTrail(AccountTestInvoicingCommon):
         self.env.company.restrictive_audit_trail = True
         self.move.action_post()
         audit_trail = self.get_trail(self.move)
+        self.env.cr.flush()
         with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail"):
             audit_trail.unlink()
 
@@ -71,6 +72,7 @@ class TestAuditTrail(AccountTestInvoicingCommon):
         self.env.company.restrictive_audit_trail = True
         self.move.action_post()
         audit_trail = self.get_trail(self.move)
+        self.env.cr.flush()
         with self.assertRaisesRegex(UserError, "remove parts of a restricted audit trail"):
             audit_trail.res_id = 0
 


### PR DESCRIPTION
During the testing of the `account` module, I encountered errors in two tests: test_cant_unlink_message and test_cant_unown_message.

The cause is that the function def _search_account_audit_log_restricted uses _search, while the tests are still running within a transaction. As a result, when _search is executed, the database has not yet been updated with the latest values computed during the tests. Therefore, I added self.env.cr.flush() to flush the pending changes and update the database with the newest values.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
