### PR TITLE
[FIX] orm: filter SQL queries with current_schema

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -6,6 +6,7 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tools import SQL, Query, unique
 from odoo.tools.float_utils import float_compare, float_round
+from odoo.tools.sql import table_exists
 
 
 class AnalyticMixin(models.AbstractModel):
@@ -30,11 +31,7 @@ class AnalyticMixin(models.AbstractModel):
 
     def init(self):
         # Add a gin index for json search on the keys, on the models that actually have a table
-        query = ''' SELECT table_name
-                    FROM information_schema.tables
-                    WHERE table_name=%s '''
-        self.env.cr.execute(query, [self._table])
-        if self.env.cr.dictfetchone() and self._fields['analytic_distribution'].store:
+        if table_exists(self.env.cr, self._table) and self._fields['analytic_distribution'].store:
             query = fr"""
                 CREATE INDEX IF NOT EXISTS {self._table}_analytic_distribution_accounts_gin_index
                                         ON {self._table} USING gin(regexp_split_to_array(jsonb_path_query_array(analytic_distribution, '$.keyvalue()."key"')::text, '\D+'));

--- a/addons/purchase/migrations/9.0.1.2/pre-create-properties.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-create-properties.py
@@ -7,6 +7,7 @@ def convert_field(cr, model, field, target_model):
                     FROM information_schema.columns
                    WHERE table_name = %s
                      AND column_name = %s
+                     AND table_schema = current_schema
                """, (table, field))
     if not cr.fetchone():
         return

--- a/odoo/addons/base/models/ir_logging.py
+++ b/odoo/addons/base/models/ir_logging.py
@@ -35,7 +35,8 @@ class IrLogging(models.Model):
 
     def init(self):
         super(IrLogging, self).init()
-        self.env.cr.execute("select 1 from information_schema.constraint_column_usage where table_name = 'ir_logging' and constraint_name = 'ir_logging_write_uid_fkey'")
+        self.env.cr.execute("select 1 from information_schema.constraint_column_usage where table_name = 'ir_logging' and constraint_name = 'ir_logging_write_uid_fkey'"
+                            " and table_schema = current_schema")
         if self.env.cr.rowcount:
             # DROP CONSTRAINT unconditionally takes an ACCESS EXCLUSIVE lock
             # on the table, even "IF EXISTS" is set and not matching; disabling

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1862,9 +1862,8 @@ class IrModelConstraint(models.Model):
                     FROM pg_constraint cs
                     JOIN pg_class cl
                     ON (cs.conrelid = cl.oid)
-                    JOIN pg_namespace n ON cl.relnamespace = n.oid
                     WHERE cs.contype IN %s AND cs.conname = %s AND cl.relname = %s
-                    AND n.nspname = current_schema
+                    AND cl.relnamespace = current_schema::regnamespace
                     """, ('c', 'u', 'x') if typ == 'u' else (typ,), hname, table
                 )):
                     self.env.execute_query(SQL(

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -34,9 +34,8 @@ def _alter_sequence(cr, seq_name, number_increment=None, number_next=None):
         raise UserError(_("Step must not be zero."))
     cr.execute(
         "SELECT relname FROM pg_class"
-        "  JOIN pg_namespace n ON pg_class.relnamespace = n.oid"
         " WHERE relkind = %s AND relname = %s"
-        "   AND n.nspname = current_schema",
+        "   AND relnamespace = current_schema::regnamespace",
         ('S', seq_name)
     )
     if not cr.fetchone():

--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -11,6 +11,7 @@ from odoo import api, fields, models
 from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Command
 from odoo.tools import mute_logger, SQL
+from odoo.tools.sql import table_columns
 
 _logger = logging.getLogger('odoo.addons.base.partner.merge')
 
@@ -82,21 +83,19 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
         """
         query = """
             SELECT cl1.relname as table, att1.attname as column
-            FROM pg_constraint as con, pg_class as cl1, pg_class as cl2, pg_attribute as att1, pg_attribute as att2,
-                 pg_namespace n
+            FROM pg_constraint as con, pg_class as cl1, pg_class as cl2, pg_attribute as att1, pg_attribute as att2
             WHERE con.conrelid = cl1.oid
                 AND con.confrelid = cl2.oid
                 AND array_lower(con.conkey, 1) = 1
                 AND con.conkey[1] = att1.attnum
                 AND att1.attrelid = cl1.oid
                 AND cl2.relname = %s
+                AND cl2.relnamespace = current_schema::regnamespace
                 AND att2.attname = 'id'
                 AND array_lower(con.confkey, 1) = 1
                 AND con.confkey[1] = att2.attnum
                 AND att2.attrelid = cl2.oid
                 AND con.contype = 'f'
-                AND cl2.relnamespace = n.oid
-                AND n.nspname = current_schema
         """
         self.env.cr.execute(query, (table,))
         return self.env.cr.fetchall()
@@ -106,13 +105,12 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
             SELECT 1
             FROM pg_constraint c
             JOIN pg_class r ON (c.conrelid = r.oid)
-            JOIN pg_namespace n ON r.relnamespace = n.oid
             CROSS JOIN LATERAL unnest(c.conkey) AS cattr(attnum)
             JOIN pg_attribute a ON (a.attrelid = c.conrelid AND a.attnum = cattr.attnum)
             WHERE c.contype IN ('c', 'u')
                 AND r.relname = %s
+                AND r.relnamespace = current_schema::regnamespace
                 AND a.attname = %s
-                AND n.nspname = current_schema
             LIMIT 1
         """, (table, column))
         return bool(self.env.cr.rowcount)
@@ -135,13 +133,8 @@ class BasePartnerMergeAutomaticWizard(models.TransientModel):
             if 'base_partner_merge_' in table:  # ignore two tables
                 continue
 
-            # get list of columns of current table (exept the current fk column)
-            query = "SELECT column_name FROM information_schema.columns WHERE table_name LIKE '%s'" % (table)
-            self.env.cr.execute(query, ())
-            columns = []
-            for data in self.env.cr.fetchall():
-                if data[0] != column:
-                    columns.append(data[0])
+            # get list of columns of current table (except the current fk column)
+            columns = [fld for fld in table_columns(self.env.cr, table) if fld != column]
 
             # do the update for the current table/column in SQL
             query_dic = {

--- a/odoo/cli/obfuscate.py
+++ b/odoo/cli/obfuscate.py
@@ -69,7 +69,7 @@ class Obfuscate(Command):
         return SQL("""CASE WHEN starts_with(%(field_name)s, 'odoo_cyph_') THEN pgp_sym_decrypt(decode(substring(%(field_name)s, 11)::text, 'base64'), %(pwd)s) ELSE %(field_name)s END""", field_name=sql_field, pwd=password)
 
     def check_field(self, table, field):
-        qry = "SELECT udt_name FROM information_schema.columns WHERE table_name=%s AND column_name=%s"
+        qry = "SELECT udt_name FROM information_schema.columns WHERE table_name=%s AND column_name=%s AND table_schema = current_schema"
         self.cr.execute(qry, [table, field])
         if self.cr.rowcount == 1:
             res = self.cr.fetchone()
@@ -81,7 +81,10 @@ class Obfuscate(Command):
         return False
 
     def get_all_fields(self):
-        qry = "SELECT table_name, column_name FROM information_schema.columns WHERE table_schema='public' AND udt_name IN ['text', 'varchar', 'jsonb'] AND NOT table_name LIKE 'ir_%' ORDER BY 1,2"
+        qry = (
+            "SELECT table_name, column_name FROM information_schema.columns"
+            " WHERE table_schema = current_schema AND udt_name IN ('text', 'varchar', 'jsonb') AND NOT table_name LIKE 'ir_%' ORDER BY 1,2"
+        )
         self.cr.execute(qry)
         return self.cr.fetchall()
 

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -174,10 +174,9 @@ def has_unaccent(cr: BaseCursor) -> FunctionStatus:
     cr.execute("""
         SELECT p.provolatile
         FROM pg_proc p
-            LEFT JOIN pg_catalog.pg_namespace ns ON p.pronamespace = ns.oid
         WHERE p.proname = 'unaccent'
+              AND p.pronamespace = current_schema::regnamespace
               AND p.pronargs = 1
-              AND ns.nspname = current_schema
     """)
     result = cr.fetchone()
     if not result:

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -612,8 +612,7 @@ def reset_modules_state(db_name: str) -> None:
     # of time
     db = odoo.sql_db.db_connect(db_name)
     with db.cursor() as cr:
-        cr.execute("SELECT 1 FROM information_schema.tables WHERE table_name='ir_module_module'")
-        if not cr.fetchall():
+        if not odoo.tools.sql.table_exists(cr, 'ir_module_module'):
             _logger.info('skipping reset_modules_state, ir_module_module table does not exists')
             return
         cr.execute(

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -53,7 +53,7 @@ class PostgreSQLHandler(logging.Handler):
         self._support_metadata = False
         if tools.config['log_db'] != '%d':
             with contextlib.suppress(Exception), tools.mute_logger('odoo.sql_db'), sql_db.db_connect(tools.config['log_db'], allow_uri=True).cursor() as cr:
-                cr.execute("""SELECT 1 FROM information_schema.columns WHERE table_name='ir_logging' and column_name='metadata'""")
+                cr.execute("""SELECT 1 FROM information_schema.columns WHERE table_name='ir_logging' and column_name='metadata' AND table_schema = current_schema""")
                 self._support_metadata = bool(cr.fetchone())
 
     def emit(self, record):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3117,10 +3117,9 @@ class BaseModel(metaclass=MetaModel):
                      if field.store and field.column_type]
         cr.execute(SQL(
             """ SELECT a.attname, a.attnotnull
-                  FROM pg_class c, pg_attribute a, pg_namespace n
+                  FROM pg_class c, pg_attribute a
                  WHERE c.relname=%s
-                   AND c.relnamespace = n.oid
-                   AND n.nspname = current_schema
+                   AND c.relnamespace = current_schema::regnamespace
                    AND c.oid=a.attrelid
                    AND a.attisdropped=%s
                    AND pg_catalog.format_type(a.atttypid, a.atttypmod) NOT IN ('cid', 'tid', 'oid', 'xid')
@@ -7117,10 +7116,9 @@ def get_columns_from_sql_diagnostics(cr, diagnostics, *, check_registry=False) -
             ) as "columns"
         FROM pg_constraint
         JOIN pg_class t ON t.oid = conrelid
-        JOIN pg_namespace n ON t.relnamespace = n.oid
         WHERE conname = %s
             AND t.relname = %s
-            AND n.nspname = current_schema
+            AND t.relnamespace = current_schema::regnamespace
     """, diagnostics.constraint_name, diagnostics.table_name))
     columns = cr.fetchone()
     return columns[0] if columns else []

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -782,8 +782,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
             SELECT c.relname, a.attname
             FROM pg_attribute a
             JOIN pg_class c ON a.attrelid = c.oid
-            JOIN pg_namespace n ON c.relnamespace = n.oid
-            WHERE n.nspname = current_schema
+            WHERE c.relnamespace = current_schema::regnamespace
             AND a.attnotnull = true
             AND a.attnum > 0
             AND a.attname != 'id';
@@ -818,7 +817,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
             return
 
         # retrieve existing indexes with their corresponding table
-        cr.execute("SELECT indexname, tablename FROM pg_indexes WHERE indexname IN %s",
+        cr.execute("SELECT indexname, tablename FROM pg_indexes WHERE indexname IN %s"
+                   "   AND schemaname = current_schema",
                    [tuple(row[0] for row in expected)])
         existing = dict(cr.fetchall())
 
@@ -897,9 +897,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
             JOIN pg_class AS c2 ON fk.confrelid = c2.oid
             JOIN pg_attribute AS a1 ON a1.attrelid = c1.oid AND fk.conkey[1] = a1.attnum
             JOIN pg_attribute AS a2 ON a2.attrelid = c2.oid AND fk.confkey[1] = a2.attnum
-            JOIN pg_namespace n ON c1.relnamespace = n.oid
             WHERE fk.contype = 'f' AND c1.relname IN %s
-              AND n.nspname = current_schema
+            AND c1.relnamespace = current_schema::regnamespace
         """
         cr.execute(query, [tuple({table for table, column in self._foreign_keys})])
         existing = {
@@ -986,10 +985,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
             query = """
                 SELECT c.relname
                   FROM pg_class c
-                  JOIN pg_namespace n ON (n.oid = c.relnamespace)
                  WHERE c.relname IN %s
                    AND c.relkind = 'r'
-                   AND n.nspname = current_schema
+                   AND c.relnamespace = current_schema::regnamespace
             """
             tables = tuple(m._table for m in self.models.values())
             cr.execute(query, [tables])
@@ -1023,7 +1021,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
             # The `orm_signaling_...` sequences indicates when caches must
             # be invalidated (i.e. cleared).
             signaling_tables = tuple(f'orm_signaling_{cache_name}' for cache_name in ['registry', *_CACHES_BY_KEY])
-            cr.execute("SELECT table_name FROM information_schema.tables WHERE table_name IN %s", [signaling_tables])
+            cr.execute("SELECT table_name FROM information_schema.tables"
+                       " WHERE table_name IN %s AND table_schema = current_schema", [signaling_tables])
 
             existing_sig_tables = tuple(s[0] for s in cr.fetchall())  # could be a set but not efficient with such a little list
             # signaling was previously using sequence but this doesn't work with replication

--- a/odoo/tools/populate.py
+++ b/odoo/tools/populate.py
@@ -124,6 +124,7 @@ class PopulateContext:
             SELECT indexname AS name, indexdef AS definition
               FROM pg_indexes
              WHERE tablename = %s
+               AND schemaname = current_schema
                AND indexname NOT LIKE %s
                AND indexdef NOT LIKE %s
         """, model._table, '%pkey', '%UNIQUE%'))
@@ -180,10 +181,9 @@ def field_needs_variation(model: Model, field: Field) -> bool:
                    JOIN pg_class t ON t.oid = idx.indrelid
                    JOIN pg_class i ON i.oid = idx.indexrelid
                    JOIN pg_attribute a ON a.attnum = ANY (idx.indkey) AND a.attrelid = t.oid
-                   JOIN pg_namespace n ON t.relnamespace = n.oid
               WHERE t.relname = %s  -- tablename
                 AND a.attname = %s  -- column
-                AND n.nspname = current_schema
+                AND t.relnamespace = current_schema::regnamespace
                 AND idx.indisunique = TRUE) AS is_unique;
         """, model_._table, field_.name)
         return model_.env.execute_query(query)[0][0]

--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -206,10 +206,9 @@ def existing_tables(cr, tablenames):
     cr.execute(SQL("""
         SELECT c.relname
           FROM pg_class c
-          JOIN pg_namespace n ON (n.oid = c.relnamespace)
          WHERE c.relname IN %s
            AND c.relkind IN ('r', 'v', 'm')
-           AND n.nspname = current_schema
+           AND c.relnamespace = current_schema::regnamespace
     """, tuple(tablenames)))
     return [row[0] for row in cr.fetchall()]
 
@@ -236,9 +235,8 @@ def table_kind(cr, tablename: str) -> TableKind | None:
     cr.execute(SQL("""
         SELECT c.relkind, c.relpersistence
           FROM pg_class c
-          JOIN pg_namespace n ON (n.oid = c.relnamespace)
          WHERE c.relname = %s
-           AND n.nspname = current_schema
+           AND c.relnamespace = current_schema::regnamespace
     """, tablename))
     if not cr.rowcount:
         return None
@@ -307,7 +305,8 @@ def table_columns(cr, tablename):
     # might prevent a postgres user to read this field.
     cr.execute(SQL(
         ''' SELECT column_name, udt_name, character_maximum_length, is_nullable
-            FROM information_schema.columns WHERE table_name=%s ''',
+            FROM information_schema.columns WHERE table_name=%s
+            AND table_schema = current_schema ''',
         tablename,
     ))
     return {row['column_name']: row for row in cr.dictfetchall()}
@@ -317,7 +316,8 @@ def column_exists(cr, tablename, columnname):
     """ Return whether the given column exists. """
     cr.execute(SQL(
         """ SELECT 1 FROM information_schema.columns
-            WHERE table_name=%s AND column_name=%s """,
+            WHERE table_name=%s AND column_name=%s
+            AND table_schema = current_schema """,
         tablename, columnname,
     ))
     return cr.rowcount
@@ -407,12 +407,11 @@ def get_depending_views(cr, table, column):
         JOIN pg_class as dependent ON pg_depend.refobjid = dependent.oid
         JOIN pg_attribute ON pg_depend.refobjid = pg_attribute.attrelid
             AND pg_depend.refobjsubid = pg_attribute.attnum
-        JOIN pg_namespace n ON dependee.relnamespace = n.oid
         WHERE dependent.relname = %s
+        AND dependent.relnamespace = current_schema::regnamespace
         AND pg_attribute.attnum > 0
         AND pg_attribute.attname = %s
         AND dependee.relkind in ('v', 'm')
-        AND n.nspname = current_schema
     """, table, column))
     return cr.fetchall()
 
@@ -442,10 +441,9 @@ def constraint_definition(cr, tablename, constraintname):
         SELECT COALESCE(d.description, pg_get_constraintdef(c.oid))
         FROM pg_constraint c
         JOIN pg_class t ON t.oid = c.conrelid
-        JOIN pg_namespace n ON t.relnamespace = n.oid
         LEFT JOIN pg_description d ON c.oid = d.objoid
         WHERE t.relname = %s AND conname = %s
-          AND n.nspname = current_schema
+        AND t.relnamespace = current_schema::regnamespace
     """, tablename, constraintname))
     return cr.fetchone()[0] if cr.rowcount else None
 
@@ -496,14 +494,13 @@ def get_foreign_keys(cr, tablename1, columnname1, tablename2, columnname2, ondel
             JOIN pg_class AS c2 ON fk.confrelid = c2.oid
             JOIN pg_attribute AS a1 ON a1.attrelid = c1.oid AND fk.conkey[1] = a1.attnum
             JOIN pg_attribute AS a2 ON a2.attrelid = c2.oid AND fk.confkey[1] = a2.attnum
-            JOIN pg_namespace n ON c1.relnamespace = n.oid
             WHERE fk.contype = 'f'
             AND c1.relname = %s
             AND a1.attname = %s
             AND c2.relname = %s
             AND a2.attname = %s
+            AND c1.relnamespace = current_schema::regnamespace
             AND fk.confdeltype = %s
-            AND n.nspname = current_schema
         """,
         tablename1, columnname1, tablename2, columnname2, deltype,
     ))
@@ -519,14 +516,13 @@ def fix_foreign_key(cr, tablename1, columnname1, tablename2, columnname2, ondele
     cr.execute(SQL(
         """ SELECT con.conname, c2.relname, a2.attname, con.confdeltype as deltype
               FROM pg_constraint as con, pg_class as c1, pg_class as c2,
-                   pg_attribute as a1, pg_attribute as a2, pg_namespace n
+                   pg_attribute as a1, pg_attribute as a2
              WHERE con.contype='f' AND con.conrelid=c1.oid AND con.confrelid=c2.oid
                AND array_lower(con.conkey, 1)=1 AND con.conkey[1]=a1.attnum
                AND array_lower(con.confkey, 1)=1 AND con.confkey[1]=a2.attnum
                AND a1.attrelid=c1.oid AND a2.attrelid=c2.oid
                AND c1.relname=%s AND a1.attname=%s
-               AND c1.relnamespace = n.oid
-               AND n.nspname = current_schema """,
+               AND c1.relnamespace = current_schema::regnamespace """,
         tablename1, columnname1,
     ))
     found = False
@@ -543,7 +539,8 @@ def fix_foreign_key(cr, tablename1, columnname1, tablename2, columnname2, ondele
 
 def index_exists(cr, indexname):
     """ Return whether the given index exists. """
-    cr.execute(SQL("SELECT 1 FROM pg_indexes WHERE indexname=%s", indexname))
+    cr.execute(SQL("SELECT 1 FROM pg_indexes WHERE indexname=%s"
+                   " AND schemaname = current_schema", indexname))
     return cr.rowcount
 
 
@@ -557,10 +554,9 @@ def index_definition(cr, indexname):
         SELECT idx.indexdef, d.description
         FROM pg_class c
         JOIN pg_indexes idx ON c.relname = idx.indexname
-        JOIN pg_namespace n ON c.relnamespace = n.oid
         LEFT JOIN pg_description d ON c.oid = d.objoid
         WHERE c.relname = %s AND c.relkind = 'i'
-          AND n.nspname = current_schema
+          AND c.relnamespace = current_schema::regnamespace
     """, indexname))
     return cr.fetchone() if cr.rowcount else (None, None)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This is an addition to:
- [x] #243833
- [x] #243967

Current behavior before PR (use case):
- in database `odoodb` there's 2 PG schema `odoo_data` and `data_backup`
- schema `data_backup` contains tables from an old version of Odoo
- search_path is set to `odoo_data, "$user", public` (seen with `SHOW search_path;`)
- so the `data_backup` schema should be ignored

Then when you start Odoo, or install add-ons:
- you experience inconsistent behavior, and strange bugs
- this is due to SQL queries having access to the tables, and indexes in the other schema `data_backup`

Desired behavior after PR is merged:

- Odoo should ignore tables, indexes and objects which are not in the `current_schema`.


@kmagusiak 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
