### PR TITLE
[FIX] mail: prevent traceback on free activities

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -609,12 +609,14 @@ class MailActivity(models.Model):
          access to the related record."""
         self.ensure_one()
         if not self.res_model:
+            view_id = self.env.ref('mail.mail_activity_view_form_popup').id
             return {
                 'res_id': self.id,
                 'type': 'ir.actions.act_window',
                 'view_mode': 'form',
                 'res_model': 'mail.activity',
-                'view_id': self.env.ref('mail.mail_activity_view_form_popup').id,
+                'view_id': view_id,
+                'views': [(view_id, 'form')],
                 'target': 'new',
             }
         if not self.env[self.res_model].browse(self.res_id).has_access('read'):

--- a/addons/mail/static/src/views/web/calendar/calendar_common/activity_calendar_common_popover.js
+++ b/addons/mail/static/src/views/web/calendar/calendar_common/activity_calendar_common_popover.js
@@ -15,6 +15,7 @@ export class ActivityCalendarCommonPopover extends CalendarCommonPopover {
         const action = await this.orm.call("mail.activity", "action_open_document", [
             this.props.record.rawRecord.id,
         ]);
-        this.actionService.doAction(action);
+        this.actionService.doAction(action, { onClose: () => this.props.model.load() });
+        this.props.close();
     }
 }

--- a/addons/mail/static/src/views/web/calendar/calendar_year/activity_calendar_year_popover.js
+++ b/addons/mail/static/src/views/web/calendar/calendar_year/activity_calendar_year_popover.js
@@ -12,6 +12,7 @@ export class ActivityCalendarYearPopover extends CalendarYearPopover {
         const action = await this.orm.call("mail.activity", "action_open_document", [
             record.rawRecord.id,
         ]);
-        this.actionService.doAction(action);
+        this.actionService.doAction(action, { onClose: () => this.props.model.load() });
+        this.props.close();
     }
 }


### PR DESCRIPTION
Steps to reproduce
=================
1. Go to “View all activities”.
2. Switch to calendar view.
3. Click on an activity not linked to any model
(e.g. “Eat cookies”, “Send Email to Alfred”).
4. Click “View” in the popover.
=> Traceback

Reason
======
The commit [1] allow activities without a linked model and from commit [2]
such activities can be opened in the activity form view.

In the calendar view, the action is retrieved from the model and executed
using `doAction`. Since the action does not define `views`, and the `doAction`
depends on `action['views']`, an error occurs when the action service attempts
to copy it.

After this commit
==================
This commit fixes the issue by modifying the action returned from `action_open_document`
for non-linked models to include `views`, similar structure used when a model is present.

[1] https://github.com/odoo/odoo/commit/165b060473be8a5d33d62d311f0dc55ed6332d69
[2] https://github.com/odoo/odoo/commit/abeac135b9bb7aec4bcddd84fb0705743297f80d

Task-5857887