### PR TITLE
[FIX] test_http: disable device check by default during testing

### DIFF
--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -621,10 +621,10 @@ class TestUsersIdentitycheck(HttpCase):
         self.env.user.password = "admin@odoo"
 
         # Create a first session that will be used to revoke other sessions
-        session = self.authenticate('admin', 'admin@odoo')
+        session = self.authenticate('admin', 'admin@odoo', session_extra={'_trace_disable': False})
 
         # Create a second session that will be used to check it has been revoked
-        self.authenticate('admin', 'admin@odoo')
+        self.authenticate('admin', 'admin@odoo', session_extra={'_trace_disable': False})
         # Test the session is valid
         # Valid session -> not redirected from /web to /web/login
         self.assertTrue(self.url_open('/web').url.endswith('/web'))

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -33,6 +33,9 @@ class TestDevice(TestHttpBase):
             'groups_id': [Command.set([self.env.ref('base.group_user').id])],
         })
 
+    def authenticate(self, login, password):
+        return super().authenticate(login, password, session_extra={'_trace_disable': False})
+
     def hit(self, time, endpoint, headers=None, ip=None):
         if ip:
             headers = headers or {}

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2104,13 +2104,25 @@ class HttpCase(TransactionCase):
         self.session.logout(keep_db=keep_db)
         odoo.http.root.session_store.save(self.session)
 
-    def authenticate(self, user, password, browser: ChromeBrowser = None):
+    def authenticate(self, user, password, *,
+        browser: ChromeBrowser = None, session_extra: dict | None = None):
         if getattr(self, 'session', None):
             odoo.http.root.session_store.delete(self.session)
 
         self.session = session = odoo.http.root.session_store.new()
-        session.update(odoo.http.get_default_session(), db=get_db_name())
+        session.update(
+            odoo.http.get_default_session(),
+            db=get_db_name(),
+            # In order to avoid perform a query to each first `url_open`
+            # in a test (insert `res.device.log`).
+            _trace_disable=True,
+        )
         session.context['lang'] = odoo.http.DEFAULT_LANG
+
+        if session_extra:
+            if extra_ctx := session_extra.pop('context', None):
+                session.context.update(extra_ctx)
+            session.update(session_extra)
 
         if user: # if authenticated
             # Flush and clear the current transaction.  This is useful, because


### PR DESCRIPTION
In tests, when using `authenticate`, we create a session. When this session is retrieved (for example because we use `url_open`), we detect a new device and insert a log.
The consequence is that a query is performed in many tests and that is not necessary.
The fix consists of disabling the `res.device.log` feature by default in tests.

task-5894825