### PR TITLE
[FIX] point_of_sale: use lna for printer test button

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -84,6 +84,7 @@
             'point_of_sale/static/src/app/hooks/hooks.js',
             'point_of_sale/static/src/backend/many2many_placeholder_list_view/*',
             'point_of_sale/static/src/backend/test_epos/*',
+            'point_of_sale/static/src/app/utils/init_lna.js',
         ],
         "web.assets_web_dark": [
             'point_of_sale/static/src/scss/pos_dashboard.dark.scss',

--- a/addons/point_of_sale/models/pos_printer.py
+++ b/addons/point_of_sale/models/pos_printer.py
@@ -61,6 +61,13 @@ class PosPrinter(models.Model):
     def _load_pos_data_fields(self, config):
         return ['id', 'name', 'proxy_ip', 'product_categories_ids', 'printer_type', 'epson_printer_ip']
 
+    @api.model
+    def use_local_network_access(self):
+        use_lna = bool(self.env['ir.config_parameter'].sudo().get_param('point_of_sale.use_lna'))
+        return {
+            'use_lna': use_lna
+        }
+
     @api.constrains('epson_printer_ip')
     def _constrains_epson_printer_ip(self):
         for record in self:


### PR DESCRIPTION
Ensure the printer and preparation printer Test buttons use LNA when triggered,
aligning behavior with `point_of_sale.use_lna` configuration.

Task-5886700

Related: https://github.com/odoo/enterprise/pull/106594