### PR TITLE
[IMP] hr_payroll,resource: Sync the work time rate

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -80,11 +80,11 @@ class ResourceCalendar(models.Model):
     hours_per_week = fields.Float(
         string="Hours per Week",
         compute="_compute_hours_per_week", store=True, readonly=False, copy=False)
-    is_fulltime = fields.Boolean(compute='_compute_work_time_rate', string="Is Full Time")
+    is_fulltime = fields.Boolean(compute='_compute_is_fulltime', string="Is Full Time")
     two_weeks_calendar = fields.Boolean(string="Calendar in 2 weeks mode")
     two_weeks_explanation = fields.Char('Explanation', compute="_compute_two_weeks_explanation")
     work_resources_count = fields.Integer("Work Resources count", compute='_compute_work_resources_count')
-    work_time_rate = fields.Float(string='Work Time Rate', compute='_compute_work_time_rate', search='_search_work_time_rate',
+    work_time_rate = fields.Float(string='Work Time Rate', compute='_compute_work_time_rate', store=True,
         help='Work time rate versus full time working schedule, should be between 0 and 100 %.')
 
     # --------------------------------------------------
@@ -179,36 +179,17 @@ class ResourceCalendar(models.Model):
             calendar.work_resources_count = resources_per_calendar.get(calendar, 0)
 
     @api.depends('hours_per_week', 'full_time_required_hours')
+    def _compute_is_fulltime(self):
+        for calendar in self:
+            calendar.is_fulltime = float_compare(calendar.full_time_required_hours, calendar.hours_per_week, 3) == 0
+
+    @api.depends('hours_per_week', 'full_time_required_hours')
     def _compute_work_time_rate(self):
         for calendar in self:
             if calendar.full_time_required_hours:
-                calendar.work_time_rate = calendar.hours_per_week / calendar.full_time_required_hours * 100
+                calendar.work_time_rate = calendar.hours_per_week / calendar.full_time_required_hours
             else:
-                calendar.work_time_rate = 100
-
-            calendar.is_fulltime = float_compare(calendar.full_time_required_hours, calendar.hours_per_week, 3) == 0
-
-    @api.model
-    def _search_work_time_rate(self, operator, value):
-        if operator in ('in', 'not in'):
-            if not all(isinstance(v, int) for v in value):
-                return NotImplemented
-        elif operator in ('<', '>'):
-            if not isinstance(value, int):
-                return NotImplemented
-        else:
-            return NotImplemented
-
-        calendar_ids = self.env['resource.calendar'].search([])
-        if operator == 'in':
-            calender = calendar_ids.filtered(lambda m: m.work_time_rate in value)
-        elif operator == 'not in':
-            calender = calendar_ids.filtered(lambda m: m.work_time_rate not in value)
-        elif operator == '<':
-            calender = calendar_ids.filtered(lambda m: m.work_time_rate < value)
-        elif operator == '>':
-            calender = calendar_ids.filtered(lambda m: m.work_time_rate > value)
-        return [('id', 'in', calender.ids)]
+                calendar.work_time_rate = 1.0
 
     # --------------------------------------------------
     # Actions

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -9,7 +9,7 @@
                <field name="company_id" groups="base.group_multi_company"/>
                <separator/>
                <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
-               <filter string="Partial working schedules" name="partial_working_schedules" domain="[('work_time_rate', '&lt;', 100)]"/>
+               <filter string="Partial working schedules" name="partial_working_schedules" domain="[('work_time_rate', '&lt;', 1.0)]"/>
                <group>
                     <filter name="groupby_company" context="{'group_by': 'company_id'}"/>
                 </group>
@@ -75,8 +75,7 @@
                             </div>
                             <label for="work_time_rate" string="Work Time Rate" groups="base.group_no_one"/>
                             <div groups="base.group_no_one">
-                                <field name="work_time_rate" nolabel="1" style="width: 6ch;"/>
-                                <span class="ms-1">%</span>
+                                <field name="work_time_rate" nolabel="1" style="width: 6ch; " widget="percentage"/>
                             </div>
                         </group>
                     </group>
@@ -137,7 +136,7 @@
             <list string="Working Time">
                 <field name="name" string="Working Time"/>
                 <field name="hours_per_week" string="Schedule Total Time" optional="hide"/>
-                <field name="work_time_rate"/>
+                <field name="work_time_rate" widget="percentage"/>
                 <field name="full_time_required_hours" widget="float_time" optional="hide"/>
                 <field name="work_resources_count" string="# Work Resources" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>

--- a/addons/test_resource/tests/test_2_weeks_calendar.py
+++ b/addons/test_resource/tests/test_2_weeks_calendar.py
@@ -204,7 +204,7 @@ class Test2WeeksCalendar(TransactionCase):
             'full_time_required_hours': 40,
             'attendance_ids': create_attendance_ids(attendance_list),
         })
-        self.assertAlmostEqual(resource_calendar.work_time_rate, 50, 2)
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 0.5, 2)
 
         attendance_list = [
             {'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'},
@@ -217,7 +217,7 @@ class Test2WeeksCalendar(TransactionCase):
             'name': 'Calendar (4 / 5)',
             'attendance_ids': create_attendance_ids(attendance_list),
         })
-        self.assertAlmostEqual(resource_calendar.work_time_rate, 80, 2)
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 0.8, 2)
 
         # Define a 9/10
         resource_calendar.write({
@@ -226,7 +226,7 @@ class Test2WeeksCalendar(TransactionCase):
                 {'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'},
             ]),
         })
-        self.assertAlmostEqual(resource_calendar.work_time_rate, 90, 2)
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 0.9, 2)
 
     def test_empty_working_hours_for_two_weeks_resource(self):
         calendar = self.env['resource.calendar'].create([

--- a/addons/test_resource/tests/test_calendar.py
+++ b/addons/test_resource/tests/test_calendar.py
@@ -340,7 +340,7 @@ class TestCalendar(TestResourceCommon):
                 (0, 0, {'dayofweek': '2', 'hour_from': 8, 'hour_to': 12}),
             ],
         })
-        self.assertAlmostEqual(resource_calendar.work_time_rate, 50, 2)
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 0.5, 2)
 
         # Define a 4/5
         resource_calendar.write({
@@ -351,18 +351,18 @@ class TestCalendar(TestResourceCommon):
                 (0, 0, {'dayofweek': '3', 'hour_from': 13, 'hour_to': 17}),
             ],
         })
-        self.assertAlmostEqual(resource_calendar.work_time_rate, 80, 2)
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 0.8, 2)
 
         # Define a 9/10
         resource_calendar.write({
             'name': 'Calendar (9 / 10)',
             'attendance_ids': [(0, 0, {'dayofweek': '4', 'hour_from': 8, 'hour_to': 12})],
         })
-        self.assertAlmostEqual(resource_calendar.work_time_rate, 90, 2)
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 0.9, 2)
 
         # Define a Full-Time
         resource_calendar.write({
             'name': 'Calendar Full-Time',
             'attendance_ids': [(0, 0, {'dayofweek': '4', 'hour_from': 13, 'hour_to': 17})],
         })
-        self.assertAlmostEqual(resource_calendar.work_time_rate, 100, 2)
+        self.assertAlmostEqual(resource_calendar.work_time_rate, 1.0, 2)


### PR DESCRIPTION
Current behavior before PR:
. The work time rate is currently computed separately in two different modules: hr_payroll (version model) and resource (resource_calendar model). Although they are calculated independently, both values represent the same concept and are functionally equivalent. This duplication can lead to inconsistencies and unnecessary complexity in maintenance

`resource/resource_calendar` model -> work_time_rate is not stored computed field with range=[0-100]
`hr_payroll/hr_version` model -> work_time_rate is stored computed field with range=[0-1]


Desired behavior after PR is merged:
. Synchronize the work time rate fields between the hr_payroll and resource modules to ensure they are related consistent
`resource/resource_calendar` model -> Modify work_time_rate range to be [0-1] and keep the same computation   
->  calendar.hours_per_week / calendar.full_time_required_hours

`hr_payroll/hr_version` model -> work_time_rate is `version.resource_calendar_id.work_time_rate` incase of Non-Flexible, 
While incase of Flexible versions it's 
->  version.hours_per_week / version.company_id.resource_calendar_id.hours_per_week

task-5429287


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
