### PR TITLE
[IMP] web: list column widths: wider columns in mobile

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -1,3 +1,5 @@
+import { browser } from "@web/core/browser/browser";
+import { utils } from "@web/core/ui/ui_service";
 import { renderToElement } from "@web/core/utils/render";
 import { useDebounced } from "@web/core/utils/timing";
 import {
@@ -266,12 +268,15 @@ function computeWidths(table, state, allowedWidth, startingWidths) {
         // Case 1: table overflows its parent => shrink some columns
         const shrinkableColumns = [];
         let totalAvailableSpace = 0; // total space we can gain by shrinking columns
+        // In mobile, we don't want to shrink columns more than 80% of the viewport
+        const minShrinkWidth = utils.isSmall() ? browser.innerWidth * 0.8 : null;
         for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
             const thIndex = columnIndex + columnOffset;
             const { minWidth, canShrink } = columnWidthSpecs[columnIndex];
-            if (_columnWidths[thIndex] > minWidth && canShrink) {
-                shrinkableColumns.push({ thIndex, minWidth });
-                totalAvailableSpace += _columnWidths[thIndex] - minWidth;
+            const targetWidth = minShrinkWidth || minWidth;
+            if (_columnWidths[thIndex] > targetWidth && canShrink) {
+                shrinkableColumns.push({ thIndex, minWidth: targetWidth });
+                totalAvailableSpace += _columnWidths[thIndex] - targetWidth;
             }
         }
         if (diff > totalAvailableSpace) {

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -337,6 +337,34 @@ test(`width computation: with records, lot of fields, long texts`, async () => {
     expectedColumnWidthsToBeCloseTo([40, 29, 89, 80, 102, 99, 89, 188, 114, 100]);
 });
 
+test(`width computation: with records, lot of fields, long texts (mobile)`, async () => {
+    resize({ width: 400 });
+
+    Foo._records[0].text =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt";
+    Foo._records[1].foo = "Duis aute irure dolor in reprehenderit in voluptate velit esse cillumt";
+    Bar._records[1].name = "Lorem Ipsum is not simply random text.";
+
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <list>
+                <field name="bar"/>
+                <field name="foo"/>
+                <field name="int_field"/>
+                <field name="m2o"/>
+                <field name="qux"/>
+                <field name="date"/>
+                <field name="text"/>
+                <field name="datetime"/>
+                <field name="amount"/>
+                <field name="currency_id"/>
+            </list>`,
+    });
+    expectedColumnWidthsToBeCloseTo([67, 329, 80, 263, 102, 99, 329, 188, 114, 100]);
+});
+
 test(`width computation: editable list, overflowing table`, async () => {
     class Abc extends models.Model {
         titi = fields.Char();
@@ -786,7 +814,7 @@ test(`width computation: button columns don't have a max width`, async () => {
     expect(tableWidth).toBeLessThan(800);
     columnWidths = getColumnWidths();
     // indices 0 and 1 because selectors aren't displayed on small screens
-    expect(columnWidths[0]).toBe(100);
+    expect(columnWidths[0]).toBe(210);
     expect(columnWidths[1]).toBeGreaterThan(330);
 });
 


### PR DESCRIPTION
The list view column widths logic aims, among other things, at avoiding to have an horizontal scrollbar. To achieve it, it shrinks columns up to a mininum width depending on the column field type.

However, on small screens, the scrollbar is in general unavoidable, and we often end up with all columns being displaying with their minimal width, which implies a lot of truncated texts.

This commit introduces a slight change in the logic for small screens only: the minimal width of a column when it has to be shrinked is now 80% of the viewport. That means that if the content of the column is smaller than that, the width will be such that the content exactly fits the column, and if the content is larger, it will be truncated, but it will take 80% of the viewport.

Task~5249329

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
