### PR TITLE
[FIX] web: prevent error on switching to superuser

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -168,7 +168,7 @@ class Home(http.Controller):
             uid = request.session.uid = odoo.SUPERUSER_ID
             # invalidate session token cache as we've changed the uid
             request.env.registry.clear_cache()
-            request.sesssion._update_session_token(request.env)
+            request.session._update_session_token(request.env)
 
         return request.redirect(self._login_redirect(uid))
 


### PR DESCRIPTION
Currently an error occurs when user tries to switch to superuser.

Steps to replicate:
- Make a DB and turn on debug mode.
- Click on the bug icon and click `Become Superuser`.

 Error:
`AttributeError: 'Request' object has no attribute 'sesssion'`

Cause:
- Session incorrectly spelled as `sesssion`.

Fix:
- Corrected `request.sesssion` to `request.session`.

No Id
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
