### PR TITLE
[FIX] product: print product barcodes correctly

### DIFF
--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -193,16 +193,16 @@
         </template>
 
         <template id="report_productlabel_dymo">
-            <t t-call="web.html_container"
-                barcode_size.f="width:45.5mm;height:7.5mm"
-                table_style.f="width:100%;height:32mm;"
-                padding_page.f="padding: 2mm">
+            <t t-call="web.html_container">
                 <t t-foreach="quantity.items()" t-as="barcode_and_qty_by_product">
                     <t t-set="product" t-value="barcode_and_qty_by_product[0]"/>
                     <t t-foreach="barcode_and_qty_by_product[1]" t-as="barcode_and_qty">
                         <t t-set="barcode" t-value="barcode_and_qty[0]"/>
                         <t t-foreach="range(barcode_and_qty[1])" t-as="qty">
-                            <t t-call="product.report_simple_label_dymo"/>
+                            <t t-call="product.report_simple_label_dymo"
+                                barcode_size.f="width:45.5mm;height:7.5mm"
+                                table_style.f="width:100%;height:32mm;"
+                                padding_page.f="padding: 2mm"/>
                         </t>
                     </t>
                 </t>

--- a/addons/product/report/product_template_templates.xml
+++ b/addons/product/report/product_template_templates.xml
@@ -3,39 +3,33 @@
 
 <!-- IMPORTANT: explictly include col/row otherwise studio won't load report correctly -->
 <template id="report_producttemplatelabel2x7">
-    <t t-call="web.basic_layout" columns="2" rows="7">
+    <t t-call="web.basic_layout">
         <div class="page">
-            <t t-call="product.report_productlabel"/>
+            <t t-call="product.report_productlabel" columns="2" rows="7"/>
         </div>
     </t>
 </template>
 
 <template id="report_producttemplatelabel4x7">
-    <t t-call="web.basic_layout" columns="4" rows="7">
+    <t t-call="web.basic_layout">
         <div class="page">
-            <t t-call="product.report_productlabel"/>
+            <t t-call="product.report_productlabel" columns="4" rows="7"/>
         </div>
     </t>
 </template>
 
 <template id="report_producttemplatelabel4x12">
-    <t t-call="web.basic_layout"
-        columns="4"
-        rows="12"
-        price_included="True">
+    <t t-call="web.basic_layout">
         <div class="page">
-            <t t-call="product.report_productlabel"/>
+            <t t-call="product.report_productlabel" columns="4" rows="12" price_included="True"/>
         </div>
     </t>
 </template>
 
 <template id="report_producttemplatelabel4x12noprice">
-    <t t-call="web.basic_layout"
-        columns="4"
-        rows="12"
-        price_included="False">
+    <t t-call="web.basic_layout">
         <div class="page">
-            <t t-call="product.report_productlabel"/>
+            <t t-call="product.report_productlabel" columns="4" rows="12" price_included="False"/>
         </div>
     </t>
 </template>


### PR DESCRIPTION
## Issue
When printing the barcode for a product, only a blank page would be printed.

## Steps to reproduce
1. Install Barcode (`stock_barcode`)
2. Create a product and set a barcode
3. On the product page, click Actions (cog wheel) > Print Labels
4. Print with any of the following format:
    - Dymo
    - 2 x 7 with price
    - 4 x 7 with price
    - 4 x 12
    - 4 x 12 with price
5. **For the Dymo format, the barcode is not displayed properly. For the four other formats, a blank page is printed**

## Cause
[This commit](https://github.com/odoo/odoo/commit/b7ec60d68c6ee23f7684960e33e5bd6290c9d829) made the `t-call` tag parametric, replacing the `t-set` and `t-value` pairs in various contexts. In this case, the parameters were not added to the correct `t-call`. Without `columns` and `rows` defined, the `report_productlabel` template would not produce anything:

https://github.com/odoo/odoo/blob/b6598c11a3580cfc6ff1ffeb67b0d388c55383d1/addons/product/report/product_product_templates.xml#L129-L131

opw-5877421