### PR TITLE
[IMP] mail: proper store versioning

### DIFF
--- a/addons/cloud_storage/controllers/attachment.py
+++ b/addons/cloud_storage/controllers/attachment.py
@@ -1,14 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _
-from odoo.http import route, request
+from odoo.http import request
 from odoo.addons.mail.controllers.attachment import AttachmentController
-from odoo.addons.mail.tools.discuss import add_guest_to_context
+from odoo.addons.mail.tools.discuss import mail_route
 
 
 class CloudAttachmentController(AttachmentController):
-    @route()
-    @add_guest_to_context
+    @mail_route(type="http")
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
         is_cloud_storage = kwargs.get('cloud_storage')
         if (is_cloud_storage and not request.env['ir.config_parameter'].sudo().get_str('cloud_storage_provider')):

--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
@@ -45,13 +45,16 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                 res.raise_for_status()
                 attachment = self.env["ir.attachment"].search([], order="id desc", limit=1)
                 # ignore signature in url
-                content = re.sub(
-                    r'"url": "https://accountname\.blob\.core\.windows\.net/.*?"',
-                    '"url": "[url]"',
-                    res.content.decode("utf-8"),
+                content = json.loads(
+                    re.sub(
+                        r'"url": "https://accountname\.blob\.core\.windows\.net/.*?"',
+                        '"url": "[url]"',
+                        res.content.decode("utf-8"),
+                    )
                 )
+                content["data"]["store_data"].pop("__store_version__")
                 self.assertEqual(
-                    json.loads(content),
+                    content,
                     {
                         "data": {
                             "attachment_id": attachment.id,

--- a/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
+++ b/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
@@ -30,13 +30,16 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
             res.raise_for_status()
             attachment = self.env["ir.attachment"].search([], order="id desc", limit=1)
             # ignore signature in url
-            content = re.sub(
-                r'"url": "https://storage\.googleapis\.com/.*?"',
-                '"url": "[url]"',
-                res.content.decode("utf-8"),
+            content = json.loads(
+                re.sub(
+                    r'"url": "https://storage\.googleapis\.com/.*?"',
+                    '"url": "[url]"',
+                    res.content.decode("utf-8"),
+                )
             )
+            content["data"]["store_data"].pop("__store_version__")
             self.assertEqual(
-                json.loads(content),
+                content,
                 {
                     "data": {
                         "attachment_id": attachment.id,

--- a/addons/im_livechat/controllers/attachment.py
+++ b/addons/im_livechat/controllers/attachment.py
@@ -3,15 +3,14 @@
 from werkzeug.exceptions import NotFound
 
 from odoo import _
-from odoo.http import route, request
+from odoo.http import request
 from odoo.exceptions import AccessError
 from odoo.addons.mail.controllers.attachment import AttachmentController
-from odoo.addons.mail.tools.discuss import add_guest_to_context
+from odoo.addons.mail.tools.discuss import mail_route
 
 
 class LivechatAttachmentController(AttachmentController):
-    @route()
-    @add_guest_to_context
+    @mail_route(type="http")
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
         thread = self._get_thread_with_access_for_post(thread_model, thread_id, **kwargs)
         if not thread:

--- a/addons/im_livechat/controllers/channel.py
+++ b/addons/im_livechat/controllers/channel.py
@@ -4,13 +4,14 @@ from markupsafe import Markup
 from werkzeug.exceptions import BadRequest, NotFound
 
 from odoo.fields import Command
-from odoo.http import request, route
+from odoo.http import request
 
 from odoo.addons.mail.controllers.discuss.channel import ChannelController
+from odoo.addons.mail.tools.discuss import mail_route
 
 
 class LivechatChannelController(ChannelController):
-    @route("/im_livechat/session/update_note", auth="user", methods=["POST"], type="jsonrpc")
+    @mail_route("/im_livechat/session/update_note", auth="user", methods=["POST"], type="jsonrpc")
     def livechat_session_update_note(self, channel_id, note):
         """Internal users having the rights to read the session can update its note."""
         if self.env.user.share:
@@ -22,7 +23,7 @@ class LivechatChannelController(ChannelController):
         # Markup: note sanitized when written on the field
         channel.sudo().livechat_note = Markup(note)
 
-    @route("/im_livechat/session/update_status", auth="user", methods=["POST"], type="jsonrpc")
+    @mail_route("/im_livechat/session/update_status", auth="user", methods=["POST"], type="jsonrpc")
     def livechat_session_update_status(self, channel_id, livechat_status):
         """Internal users having the rights to read the session can update its status."""
         if self.env.user.share:
@@ -33,7 +34,7 @@ class LivechatChannelController(ChannelController):
         # sudo: discuss.channel - internal users having the rights to read the session can update its status
         channel.sudo().livechat_status = livechat_status
 
-    @route(
+    @mail_route(
         "/im_livechat/conversation/write_expertises", auth="user", methods=["POST"], type="jsonrpc"
     )
     def livechat_conversation_write_expertises(self, channel_id, orm_commands):
@@ -49,7 +50,7 @@ class LivechatChannelController(ChannelController):
             # sudo: discuss.channel - live chat users can update the expertises of any live chat.
             channel.sudo().livechat_expertise_ids = orm_commands
 
-    @route(
+    @mail_route(
         "/im_livechat/conversation/create_and_link_expertise",
         auth="user",
         methods=["POST"],

--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -2,12 +2,11 @@
 
 from odoo import fields, http
 from odoo.http import request
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import mail_route, Store
 
 
 class LivechatChatbotScriptController(http.Controller):
-    @http.route("/chatbot/restart", type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/chatbot/restart", type="jsonrpc", auth="public")
     def chatbot_restart(self, channel_id, chatbot_script_id):
         discuss_channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         chatbot = request.env['chatbot.script'].browse(chatbot_script_id)
@@ -18,8 +17,7 @@ class LivechatChatbotScriptController(http.Controller):
         store = Store().add(message, "_store_message_fields")
         return {"message_id": message.id, "store_data": store.get_result()}
 
-    @http.route("/chatbot/answer/save", type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/chatbot/answer/save", type="jsonrpc", auth="public")
     def chatbot_save_answer(self, channel_id, message_id, selected_answer_id):
         discuss_channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         chatbot_message = request.env['chatbot.message'].sudo().search([
@@ -34,8 +32,7 @@ class LivechatChatbotScriptController(http.Controller):
         if selected_answer in chatbot_message.script_step_id.answer_ids:
             chatbot_message.write({'user_script_answer_id': selected_answer_id})
 
-    @http.route("/chatbot/step/trigger", type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/chatbot/step/trigger", type="jsonrpc", auth="public")
     def chatbot_trigger_step(self, channel_id, chatbot_script_id=None, data_id=None):
         chatbot_language = self.env["chatbot.script"]._get_chatbot_language()
         discuss_channel = request.env["discuss.channel"].with_context(lang=chatbot_language).search([("id", "=", channel_id)])
@@ -118,8 +115,7 @@ class LivechatChatbotScriptController(http.Controller):
         )
         store.bus_send()
 
-    @http.route("/chatbot/step/validate_contact_info", type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/chatbot/step/validate_contact_info", type="jsonrpc", auth="public")
     def chatbot_validate_contact_info(self, channel_id):
         discuss_channel = (
             request.env["discuss.channel"]

--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -10,7 +10,7 @@ from odoo.http import request
 from odoo.http.stream import Stream, content_disposition
 from odoo.tools import format_list
 
-from odoo.addons.mail.tools.discuss import Store, add_guest_to_context
+from odoo.addons.mail.tools.discuss import add_guest_to_context, mail_route, Store
 
 
 class LivechatController(http.Controller):
@@ -81,8 +81,7 @@ class LivechatController(http.Controller):
     def _get_guest_name(self):
         return _("Visitor")
 
-    @http.route('/im_livechat/get_session', methods=["POST"], type="jsonrpc", auth='public')
-    @add_guest_to_context
+    @mail_route('/im_livechat/get_session', methods=["POST"], type="jsonrpc", auth='public')
     def get_session(self, channel_id, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs):
         channel = request.env["discuss.channel"]
         country = request.env["res.country"]
@@ -195,8 +194,7 @@ class LivechatController(http.Controller):
             store.add(request.env.user.partner_id, ["email"])
         return {"store_data": store.get_result(), "channel_id": channel_id}
 
-    @http.route("/im_livechat/feedback", type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/im_livechat/feedback", type="jsonrpc", auth="public")
     def feedback(self, channel_id, rate, reason=None, **kwargs):
         if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
             return channel._apply_livechat_feedback(rate, reason, **kwargs)
@@ -252,8 +250,7 @@ class LivechatController(http.Controller):
         ]
         return request.make_response(pdf, headers=headers)
 
-    @http.route("/im_livechat/visitor_leave_session", type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/im_livechat/visitor_leave_session", type="jsonrpc", auth="public")
     def visitor_leave_session(self, channel_id):
         """Called when the livechat visitor leaves the conversation.
         This will clean the chat request and warn the operator that the conversation is over.

--- a/addons/im_livechat/controllers/rtc.py
+++ b/addons/im_livechat/controllers/rtc.py
@@ -2,14 +2,13 @@
 
 from werkzeug.exceptions import NotFound
 
-from odoo.http import route, request
+from odoo.http import request
 from odoo.addons.mail.controllers.discuss.rtc import RtcController
-from odoo.addons.mail.tools.discuss import add_guest_to_context
+from odoo.addons.mail.tools.discuss import mail_route
 
 
 class LivechatRtcController(RtcController):
-    @route()
-    @add_guest_to_context
+    @mail_route(type="jsonrpc")
     def channel_call_join(self, channel_id, check_rtc_session_ids=None, camera=False):
         # sudo: discuss.channel - visitor can check if there is an ongoing call
         if not request.env.user._is_internal() and request.env["discuss.channel"].sudo().search([

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -73,9 +73,13 @@ class TestImLivechatReport(TestImLivechatCommon):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["time_to_answer:avg"], 7800 / 3600)
         self.assertEqual(int(result[0]['duration:avg']), 195)
-        channel = self.env["discuss.channel"].search([("livechat_channel_id", "=", self.livechat_channel.id)])
-        rated_channel = channel.copy({"rating_last_value": 5})
-        self._create_message(rated_channel, self.operator, "2023-03-18 11:00:00")
+        rated_channel_id = self.make_jsonrpc_request(
+            "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
+        )["channel_id"]
+        self.make_jsonrpc_request(
+            "/im_livechat/feedback", {"channel_id": rated_channel_id, "rate": 5},
+        )
+        self._create_message(self.env["discuss.channel"].browse(rated_channel_id), self.operator, "2023-03-18 11:00:00")
         result = self.env["im_livechat.report.channel"].formatted_read_group([], aggregates=["rating:avg"])
         self.assertEqual(result[0]["rating:avg"], 5, "Rating average should be 5, excluding unrated sessions")
 

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -15,7 +15,7 @@ from odoo.tools import BinaryBytes, file_open
 from odoo.tools.pdf import DependencyError, PdfReadError, extract_page
 
 from odoo.addons.mail.controllers.thread import ThreadController
-from odoo.addons.mail.tools.discuss import Store, add_guest_to_context
+from odoo.addons.mail.tools.discuss import Store, add_guest_to_context, mail_route
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +48,7 @@ class AttachmentController(ThreadController):
         ]
         return request.make_response(content, headers)
 
-    @http.route("/mail/attachment/upload", methods=["POST"], type="http", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/attachment/upload", methods=["POST"], type="http", auth="public")
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
         thread = self._get_thread_with_access_for_post(thread_model, thread_id, **kwargs)
         if not thread:
@@ -83,10 +82,9 @@ class AttachmentController(ThreadController):
             res = {"data": {"store_data": store.get_result(), "attachment_id": attachment.id}}
         except AccessError:
             res = {"error": _("You are not allowed to upload an attachment here.")}
-        return request.make_json_response(res)
+        return res
 
-    @http.route("/mail/attachment/delete", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/attachment/delete", methods=["POST"], type="jsonrpc", auth="public")
     def mail_attachment_delete(self, attachment_id, access_token=None):
         attachment = request.env["ir.attachment"].browse(int(attachment_id)).exists()
         if not attachment or not attachment._has_attachments_ownership([access_token]):
@@ -100,7 +98,7 @@ class AttachmentController(ThreadController):
         # sudo: ir.attachment: access is validated with _has_attachments_ownership
         attachment.sudo()._delete_and_notify(message)
 
-    @http.route(['/mail/attachment/zip'], methods=["POST"], type="http", auth="public")
+    @mail_route(['/mail/attachment/zip'], methods=["POST"], type="http", auth="public")
     def mail_attachment_get_zip(self, file_ids, zip_name, **kw):
         """route to get the zip file of the attachments.
         :param file_ids: ids of the files to zip.
@@ -129,13 +127,12 @@ class AttachmentController(ThreadController):
         # sudo: ir.attachment: access check is done above, sudo necessary for guests
         return self._get_pdf_first_page_response(attachment.sudo())
 
-    @http.route(
+    @mail_route(
         "/mail/attachment/update_thumbnail",
         auth="public",
         methods=["POST"],
         type="jsonrpc",
     )
-    @add_guest_to_context
     def mail_attachement_update_thumbnail(self, attachment_id, thumbnail=None, access_token=None):
         """Updates the thumbnail of an attachment."""
         attachment = request.env["ir.attachment"].browse(int(attachment_id)).exists()

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -6,7 +6,7 @@ from werkzeug.exceptions import NotFound
 from odoo import fields, http
 from odoo.http import request
 from odoo.addons.mail.controllers.webclient import WebclientController
-from odoo.addons.mail.tools.discuss import Store, add_guest_to_context
+from odoo.addons.mail.tools.discuss import mail_route, Store
 from odoo.exceptions import AccessError
 
 
@@ -116,8 +116,7 @@ class DiscussChannelWebclientController(WebclientController):
 
 
 class ChannelController(http.Controller):
-    @http.route("/discuss/channel/members", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
-    @add_guest_to_context
+    @mail_route("/discuss/channel/members", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     def discuss_channel_members(self, channel_id, known_member_ids):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
@@ -131,15 +130,14 @@ class ChannelController(http.Controller):
         store.add(unknown_members, "_store_member_fields")
         return store.get_result()
 
-    @http.route("/discuss/channel/update_avatar", methods=["POST"], type="jsonrpc")
+    @mail_route("/discuss/channel/update_avatar", methods=["POST"], type="jsonrpc")
     def discuss_channel_avatar_update(self, channel_id, data):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel or not data:
             raise NotFound()
         channel.write({"image_128": data})
 
-    @http.route("/discuss/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/discuss/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_mark_as_read(self, channel_id, last_message_id):
         member = request.env["discuss.channel.member"].search([
             ("channel_id", "=", channel_id),
@@ -149,8 +147,7 @@ class ChannelController(http.Controller):
             return  # ignore if the member left in the meantime
         member._mark_as_read(last_message_id)
 
-    @http.route("/discuss/channel/set_new_message_separator", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/discuss/channel/set_new_message_separator", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_set_new_message_separator(self, channel_id, message_id):
         member = request.env["discuss.channel.member"].search([
             ("channel_id", "=", channel_id),
@@ -160,8 +157,7 @@ class ChannelController(http.Controller):
             raise NotFound()
         return member._set_new_message_separator(message_id)
 
-    @http.route("/discuss/channel/notify_typing", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/discuss/channel/notify_typing", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_notify_typing(self, channel_id, is_typing):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
@@ -180,8 +176,7 @@ class ChannelController(http.Controller):
         if member:
             member._notify_typing(is_typing)
 
-    @http.route("/discuss/channel/attachments", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
-    @add_guest_to_context
+    @mail_route("/discuss/channel/attachments", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     def load_attachments(self, channel_id, limit=30, before=None):
         """Load attachments of a channel. If before is set, load attachments
         older than the given id.
@@ -203,7 +198,7 @@ class ChannelController(http.Controller):
         store = Store().add(attachments, "_store_attachment_fields")
         return {"store_data": store.get_result(), "count": len(attachments)}
 
-    @http.route("/discuss/channel/sub_channel/create", methods=["POST"], type="jsonrpc", auth="public")
+    @mail_route("/discuss/channel/sub_channel/create", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_sub_channel_create(self, parent_channel_id, from_message_id=None, name=None):
         channel = request.env["discuss.channel"].search([("id", "=", parent_channel_id)])
         if not channel:
@@ -218,8 +213,7 @@ class ChannelController(http.Controller):
         store = Store().add(sub_channel, "_store_channel_fields")
         return {"store_data": store.get_result(), "sub_channel": sub_channel.id}
 
-    @http.route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/discuss/channel/sub_channel/fetch", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_sub_channel_fetch(self, parent_channel_id, search_term=None, before=None, limit=30):
         channel = request.env["discuss.channel"].search([("id", "=", parent_channel_id)])
         if not channel:
@@ -256,7 +250,7 @@ class ChannelController(http.Controller):
             "sub_channel_ids": sub_channels.ids,
         }
 
-    @http.route("/discuss/channel/sub_channel/delete", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/discuss/channel/sub_channel/delete", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_delete_sub_channel(self, sub_channel_id):
         channel = request.env["discuss.channel"].search_fetch([("id", "=", sub_channel_id)])
         if not channel or not channel.parent_channel_id or channel.create_uid != request.env.user:
@@ -266,14 +260,14 @@ class ChannelController(http.Controller):
         # sudo: discuss.channel - skipping ACL for users who created the thread
         channel.sudo().unlink()
 
-    @http.route("/discuss/channel/remove_member", methods=["POST"], type="jsonrpc", auth="public")
+    @mail_route("/discuss/channel/remove_member", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_remove_member(self, member_id):
         channel_member = request.env["discuss.channel.member"].search([("id", "=", member_id)])
         if not channel_member:
             raise NotFound()
         channel_member.unlink()
 
-    @http.route("/discuss/channel/member/set_role", methods=["POST"], type="jsonrpc", auth="public")
+    @mail_route("/discuss/channel/member/set_role", methods=["POST"], type="jsonrpc", auth="public")
     def discuss_channel_set_channel_member_role(self, member_id, channel_role):
         channel_member = request.env["discuss.channel.member"].search([("id", "=", member_id)])
         if not channel_member:

--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -7,11 +7,11 @@ from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.tools import consteq, email_normalize, replace_exceptions
 from odoo.tools.misc import verify_hash_signed
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import mail_route, Store
 
 
 class PublicPageController(http.Controller):
-    @http.route(
+    @mail_route(
         [
             "/chat/<string:create_token>",
             "/chat/<string:create_token>/<string:channel_name>",
@@ -20,11 +20,10 @@ class PublicPageController(http.Controller):
         type="http",
         auth="public",
     )
-    @add_guest_to_context
     def discuss_channel_chat_from_token(self, create_token, channel_name=None):
         return self._response_discuss_channel_from_token(create_token=create_token, channel_name=channel_name)
 
-    @http.route(
+    @mail_route(
         [
             "/meet/<string:create_token>",
             "/meet/<string:create_token>/<string:channel_name>",
@@ -33,14 +32,12 @@ class PublicPageController(http.Controller):
         type="http",
         auth="public",
     )
-    @add_guest_to_context
     def discuss_channel_meet_from_token(self, create_token, channel_name=None):
         return self._response_discuss_channel_from_token(
             create_token=create_token, channel_name=channel_name, default_display_mode="video_full_screen"
         )
 
-    @http.route("/chat/<int:channel_id>/<string:invitation_token>", methods=["GET"], type="http", auth="public")
-    @add_guest_to_context
+    @mail_route("/chat/<int:channel_id>/<string:invitation_token>", methods=["GET"], type="http", auth="public")
     def discuss_channel_invitation(self, channel_id, invitation_token, email_token=None):
         guest_email = email_token and verify_hash_signed(
             self.env(su=True), "mail.invite_email", email_token
@@ -53,8 +50,7 @@ class PublicPageController(http.Controller):
         store = Store().add_global_values(isChannelTokenSecret=True)
         return self._response_discuss_channel_invitation(store, channel, guest_email)
 
-    @http.route("/discuss/channel/<int:channel_id>", methods=["GET"], type="http", auth="public")
-    @add_guest_to_context
+    @mail_route("/discuss/channel/<int:channel_id>", methods=["GET"], type="http", auth="public")
     def discuss_channel(self, channel_id, *, highlight_message_id=None):
         # highlight_message_id is used JS side by parsing the query string
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -9,7 +9,7 @@ from odoo.http import Controller, request, route
 from odoo.http.stream import STATIC_CACHE
 from odoo.tools import file_open
 
-from odoo.addons.mail.tools.discuss import Store, add_guest_to_context
+from odoo.addons.mail.tools.discuss import add_guest_to_context, mail_route, Store
 
 
 class RtcController(Controller):
@@ -39,8 +39,7 @@ class RtcController(Controller):
         for session_sudo, notifications in notifications_by_session.items():
             session_sudo._notify_peers(notifications)
 
-    @route("/mail/rtc/session/update_and_broadcast", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/rtc/session/update_and_broadcast", methods=["POST"], type="jsonrpc", auth="public")
     def session_update_and_broadcast(self, session_id, values):
         """Update a RTC session and broadcasts the changes to the members of its channel,
         only works of the user is the user of that session.
@@ -61,8 +60,7 @@ class RtcController(Controller):
         if session and session.partner_id == request.env.user.partner_id:
             session._update_and_broadcast(values)
 
-    @route("/mail/rtc/channel/join_call", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/rtc/channel/join_call", methods=["POST"], type="jsonrpc", auth="public")
     def channel_call_join(self, channel_id, check_rtc_session_ids=None, camera=False):
         """Joins the RTC call of a channel if the user is a member of that channel
         :param int channel_id: id of the channel to join
@@ -80,8 +78,7 @@ class RtcController(Controller):
         member.sudo()._rtc_join_call(store, check_rtc_session_ids=check_rtc_session_ids, camera=camera)
         return store.get_result()
 
-    @route("/mail/rtc/channel/leave_call", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/rtc/channel/leave_call", methods=["POST"], type="jsonrpc", auth="public")
     def channel_call_leave(self, channel_id, session_id=None):
         """Disconnects the current user from a rtc call and clears any invitation sent to that user on this channel
         :param int channel_id: id of the channel from which to disconnect
@@ -100,8 +97,7 @@ class RtcController(Controller):
             raise NotFound()
         member.sudo()._join_sfu(force=True)
 
-    @route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/rtc/channel/cancel_call_invitation", methods=["POST"], type="jsonrpc", auth="public")
     def channel_call_cancel_invitation(self, channel_id, member_ids=None):
         """
         :param member_ids: members whose invitation is to cancel
@@ -129,8 +125,7 @@ class RtcController(Controller):
             ],
         )
 
-    @route("/discuss/channel/ping", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/discuss/channel/ping", methods=["POST"], type="jsonrpc", auth="public")
     def channel_ping(self, channel_id, rtc_session_id=None, check_rtc_session_ids=None):
         member = request.env["discuss.channel.member"].search([("channel_id", "=", channel_id), ("is_self", "=", True)])
         if not member:

--- a/addons/mail/controllers/discuss/search.py
+++ b/addons/mail/controllers/discuss/search.py
@@ -3,12 +3,11 @@
 from odoo import http
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import mail_route, Store
 
 
 class SearchController(http.Controller):
-    @http.route("/discuss/search", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/discuss/search", methods=["POST"], type="jsonrpc", auth="public")
     def search(self, term, category_id=None, limit=10):
         store = Store()
         base_domain = Domain("name", "ilike", term) & Domain("channel_type", "!=", "chat")

--- a/addons/mail/controllers/discuss/settings.py
+++ b/addons/mail/controllers/discuss/settings.py
@@ -4,11 +4,12 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
-from odoo.http import request, route, Controller
+from odoo.http import request, Controller
+from odoo.addons.mail.tools.discuss import mail_route
 
 
 class DiscussSettingsController(Controller):
-    @route("/discuss/settings/mute", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/discuss/settings/mute", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_mute(self, minutes, channel_id):
         """Mute notifications for the given number of minutes.
         :param minutes: (integer) number of minutes to mute notifications, -1 means mute until the user unmutes
@@ -28,7 +29,7 @@ class DiscussSettingsController(Controller):
             member.mute_until_dt = False
         member._notify_mute()
 
-    @route("/discuss/settings/custom_notifications", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/discuss/settings/custom_notifications", methods=["POST"], type="jsonrpc", auth="user")
     def discuss_custom_notifications(self, custom_notifications, channel_id=None):
         """Set custom notifications for the given channel or general user settings.
         :param custom_notifications: (false|all|mentions|no_notif) custom notifications to set

--- a/addons/mail/controllers/guest.py
+++ b/addons/mail/controllers/guest.py
@@ -4,12 +4,11 @@ from werkzeug.exceptions import NotFound
 
 from odoo import http
 from odoo.http import request
-from odoo.addons.mail.tools.discuss import add_guest_to_context
+from odoo.addons.mail.tools.discuss import mail_route
 
 
 class GuestController(http.Controller):
-    @http.route("/mail/guest/update_name", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/guest/update_name", methods=["POST"], type="jsonrpc", auth="public")
     def mail_guest_update_name(self, guest_id, name):
         guest = request.env["mail.guest"]._get_guest_from_context()
         guest_to_rename_sudo = guest.env["mail.guest"].browse(guest_id).sudo().exists()

--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -2,12 +2,11 @@
 
 from odoo import http
 from odoo.http import request
-from odoo.addons.mail.tools.discuss import add_guest_to_context
+from odoo.addons.mail.tools.discuss import mail_route
 
 
 class LinkPreviewController(http.Controller):
-    @http.route("/mail/link_preview", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/link_preview", methods=["POST"], type="jsonrpc", auth="public")
     def mail_link_preview(self, message_id):
         if not request.env["mail.link.preview"]._is_link_preview_enabled():
             return
@@ -21,8 +20,7 @@ class LinkPreviewController(http.Controller):
             message, request_url=request.httprequest.url_root
         )
 
-    @http.route("/mail/link_preview/hide", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/link_preview/hide", methods=["POST"], type="jsonrpc", auth="public")
     def mail_link_preview_hide(self, message_link_preview_ids):
         guest = request.env["mail.guest"]._get_guest_from_context()
         # sudo: access check is done below using message_id

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -2,15 +2,13 @@
 
 from werkzeug.exceptions import NotFound
 
-from odoo import http
 from odoo.http import request
 from odoo.addons.mail.controllers.thread import ThreadController
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import mail_route, Store
 
 
 class MessageReactionController(ThreadController):
-    @http.route("/mail/message/reaction", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/message/reaction", methods=["POST"], type="jsonrpc", auth="public")
     def mail_message_reaction(self, message_id, content, action, **kwargs):
         message_sudo = request.env["mail.message"].sudo().search_fetch([("id", "=", message_id)])
         if not message_sudo:

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -8,7 +8,7 @@ from odoo import http
 from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.tools.misc import verify_limited_field_access_token
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import mail_route, Store
 
 
 class ThreadController(http.Controller):
@@ -65,7 +65,7 @@ class ThreadController(http.Controller):
     # main routes
     # ------------------------------------------------------------
 
-    @http.route("/mail/thread/recipients", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/mail/thread/recipients", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_recipients(self, thread_model, thread_id, message_id=None):
         """ Fetch discussion-based suggested recipients, creating partners on the fly """
         thread = self._get_thread_with_access(thread_model, thread_id, mode='read')
@@ -83,7 +83,7 @@ class ThreadController(http.Controller):
             for info in suggested if info['partner_id']
         ]
 
-    @http.route("/mail/thread/recipients/get_suggested_recipients", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/mail/thread/recipients/get_suggested_recipients", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_recipients_get_suggested_recipients(self, thread_model, thread_id, partner_ids=None, main_email=False):
         """This method returns the suggested recipients with updates coming from the frontend.
         :param thread_model: Model on which we are currently working on.
@@ -99,7 +99,7 @@ class ThreadController(http.Controller):
             recipients = list(filter(lambda rec: rec.get('partner_id') not in old_customer_ids, recipients))
         return [{key: recipient[key] for key in recipient if key in ['name', 'email', 'partner_id']} for recipient in recipients]
 
-    @http.route("/mail/partner/from_email", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/mail/partner/from_email", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_partner_from_email(self, thread_model, thread_id, emails):
         partners = [
             {"id": partner.id, "name": partner.name, "email": partner.email}
@@ -109,7 +109,7 @@ class ThreadController(http.Controller):
         ]
         return partners
 
-    @http.route("/mail/read_subscription_data", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/mail/read_subscription_data", methods=["POST"], type="jsonrpc", auth="user")
     def read_subscription_data(self, follower_id):
         """Computes:
         - message_subtype_data: data about document subtypes: which are
@@ -184,8 +184,7 @@ class ThreadController(http.Controller):
         res.setdefault("message_type", "comment")
         return res
 
-    @http.route("/mail/message/post", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/message/post", methods=["POST"], type="jsonrpc", auth="public")
     def mail_message_post(self, thread_model, thread_id, post_data, context=None, **kwargs):
         store = Store()
         request.update_context(message_post_store=store)
@@ -217,8 +216,7 @@ class ThreadController(http.Controller):
         store.add(message, "_store_message_fields")
         return {"store_data": store.get_result(), "message_id": message.id}
 
-    @http.route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/message/update_content", methods=["POST"], type="jsonrpc", auth="public")
     def mail_message_update_content(self, message_id, update_data, **kwargs):
         message = self._get_message_with_access(message_id, mode="write", **kwargs)
         if not message or not self._can_edit_message(message, **kwargs):
@@ -239,13 +237,13 @@ class ThreadController(http.Controller):
     def _can_edit_message(cls, message, **kwargs):
         return message.sudo().is_current_user_or_guest_author or request.env.user._is_admin()
 
-    @http.route("/mail/thread/unsubscribe", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/mail/thread/unsubscribe", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_unsubscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_unsubscribe(partner_ids)
         return Store().add(thread, self._store_thread_follow_fields, as_thread=True).get_result()
 
-    @http.route("/mail/thread/subscribe", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/mail/thread/subscribe", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_subscribe(self, res_model, res_id, partner_ids):
         thread = self.env[res_model].browse(res_id)
         thread.message_subscribe(partner_ids)

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -2,25 +2,22 @@
 
 from collections import defaultdict
 
-from odoo import http
 from odoo.http import request
 from odoo.addons.mail.controllers.thread import ThreadController
-from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
+from odoo.addons.mail.tools.discuss import mail_route, Store
 
 
 class WebclientController(ThreadController):
     """Routes for the web client."""
 
-    @http.route("/mail/action", methods=["POST"], type="jsonrpc", auth="public")
-    @add_guest_to_context
+    @mail_route("/mail/action", methods=["POST"], type="jsonrpc", auth="public")
     def mail_action(self, fetch_params, context=None):
         """Execute actions and returns data depending on request parameters.
         This is similar to /mail/data except this method can have side effects.
         """
         return self._process_request(fetch_params, context=context)
 
-    @http.route("/mail/data", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
-    @add_guest_to_context
+    @mail_route("/mail/data", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
     def mail_data(self, fetch_params, context=None):
         """Returns data depending on request parameters.
         This is similar to /mail/action except this method should be read-only.

--- a/addons/mail/models/discuss/__init__.py
+++ b/addons/mail/models/discuss/__init__.py
@@ -4,6 +4,7 @@
 from . import mail_message
 
 # discuss
+from . import bus
 from . import bus_sync_mixin
 from . import discuss_call_history
 from . import discuss_category

--- a/addons/mail/models/discuss/bus.py
+++ b/addons/mail/models/discuss/bus.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class BusBus(models.Model):
+    _inherit = "bus.bus"
+
+    @api.model
+    def _sendone(self, target, notification_type, message):
+        if mail_store := self.env.context.get("mail_store"):
+            mail_store.enqueue_bus_notification(target, notification_type, message)
+        else:
+            super()._sendone(target, notification_type, message)

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -24,6 +24,13 @@ class Base(models.AbstractModel):
     # ORM
     # ------------------------------------------------------------
 
+    def _flush(self):
+        if mail_store := self.env.context.get("mail_store"):
+            for field in self._fields.values():
+                if ids := self.env._field_dirty.get(field):
+                    mail_store.mark_field_as_written(field.model_name, ids, field.name)
+        return super()._flush()
+
     def _valid_field_parameter(self, field, name):
         # allow tracking on abstract models; see also 'mail.thread'
         return (

--- a/addons/mail/static/src/model/field_version.js
+++ b/addons/mail/static/src/model/field_version.js
@@ -1,0 +1,280 @@
+/**
+ * A nested mapping of fields, modified during a request. Organized by `model_name` ->
+ * `record_id` -> `field_names[]`.
+ * @typedef {{[model_name: string]: {[record_id: number]: string[]}}} WrittenFieldsByRecord
+ */
+
+/**
+ * Represents a PostgreSQL transaction snapshot. See:
+ * https://www.postgresql.org/docs/13/functions-info.html#FUNCTIONS-PG-SNAPSHOT-PARTS
+ *
+ * @typedef {Object} IPgSnapshot
+ * @property {string} xmin The lowest active transaction ID at the time this snapshot was
+ * taken. Lower transaction IDs are completed.
+ *
+ * @property {string} xmax The upper bound of transaction IDs for this snapshot. Greater
+ * or equals transaction IDs are invisible by this snapshot.
+ *
+ * @property {string} xip_bitmap A bitmap representing in progress transactions in the
+ * range [xmin, xmax). Each bit corresponds to a transaction ID within this range. If the
+ * bit is set, the transaction was in progress at the time this snapshot was taken.
+ *
+ * @property {string|null} current_xact_id The current transaction ID, assigned when a
+ * transaction modify the database.
+ *
+ * A versioned field value tied to a database snapshot. It tracks what this revision "saw"
+ * when this value was set, allowing the client to correctly order updates and ignore late
+ * arriving, stale data.
+ *
+ * @typedef {Object} FieldRevision
+ * @property {PgSnapshot} snapshot The transactional context defining what the current
+ * revision could "see" in the database.
+ * @property {boolean} isWrite Whether this revision modified the field.
+ */
+
+/**
+ * Version metadata sent by the server alongside insert data. Used to determine if
+ * incoming insert values should override stored ones.
+ * @typedef {{snapshot: IPgSnapshot, written_fields_by_record: WrittenFieldsByRecord}} StoreVersion
+ */
+
+/**
+ * VISUAL REPRESENTATION OF THE SNAPSHOT.
+ * Legend: √ committed, ~ pending, × future.
+ *
+ *                                +-------------------------+
+ *                                |     PENDING COUNT (4)   |
+ *                     +--------> +-------------------------+ <------+------+
+ *          XMIN 5     |                        ^                    |      |     XMAX 12
+ *               v     |                        |                    |      |     v
+ *               +--------+--------+--------+--------+--------+---------+---------+
+ *    √ √ √ √    | TX_5 ~ | TX_6 √ | TX_7 √ | TX_8 ~ | TX_9 √ | TX_10 ~ | TX_11 ~ |    × × × ×
+ *  <--------->  +--------+--------+--------+--------+--------+---------+---------+  <--------->
+ *       |                     |        |                |
+ *       |                     |        |                |
+ *       |                     v        v                v
+ *       +----------------> +-------------------------------------------------+
+ *                          |                  FINISHED COUNT                 |
+ *                          |                                                 |
+ *                          |    xmax - 1 - len(xip) = 12 - 1 - 4 = 7         |
+ *                          | OR xmin - 1 + len(not_in_xip) =  5 - 1 + 3 = 7  |
+ *                          +-------------------------------------------------+
+ */
+export class PgSnapshot {
+    /** @param {IPgSnapshot} */
+    constructor(params) {
+        this.current_xact_id = params.current_xact_id
+            ? BigInt(params.current_xact_id)
+            : params.current_xact_id;
+        this.xmin = BigInt(params.xmin);
+        this.xmax = BigInt(params.xmax);
+        const bitmapBinaryStr = atob(params.xip_bitmap);
+        // Bitmap [xmin, xmax) showing which xact_ids are in progress of the time of the snapshot.
+        this.xip_bitmap = new Uint8Array(bitmapBinaryStr.length).map((_, idx) =>
+            bitmapBinaryStr.charCodeAt(idx)
+        );
+        let pendingCount = 0;
+        for (let byte of this.xip_bitmap) {
+            while (byte > 0) {
+                byte &= byte - 1;
+                pendingCount++;
+            }
+        }
+        this.finishedCount = this.xmax - 1n - BigInt(pendingCount);
+    }
+
+    /**
+     * Determine whether the given transaction was visibile by this snapshot.
+     *
+     * @param {BigInt} txid
+     */
+    knowsTransaction(txid) {
+        // tx < xmin are completed. tx between xmin and xmax are completed if not in xip.
+        if (txid >= this.xmin && txid < this.xmax) {
+            const offset = Number(txid - this.xmin);
+            const byteIndex = Math.floor(offset / 8);
+            const bitIndex = offset % 8;
+            return !(this.xip_bitmap[byteIndex] & (1 << bitIndex));
+        }
+        return txid < this.xmin;
+    }
+
+    /**
+     * Determine whether the given revision comes from a newer snapshot than the current
+     * one (i.e. if the given revision knows more committed transactions than the current
+     * one).
+     *
+     * @param {PgSnapshot} other
+     */
+    isAfter(other) {
+        return this.finishedCount > other.finishedCount;
+    }
+
+    /**
+     * Checks whether this snapshot and another snapshot saw the same state of the database.
+     *
+     * @param {PgSnapshot} other
+     */
+    sawSameState(other) {
+        return this.finishedCount === other.finishedCount;
+    }
+}
+
+/**
+ * Determines whether a candidate field revision should replace the current one.
+ *
+ * @param {FieldRevision} candidate
+ * @param {FieldRevision} other
+ * @returns {Boolean} Whether the candidate revision can replace the other one.
+ */
+function shouldReplace(candidate, other) {
+    if (candidate.snapshot.sawSameState(other.snapshot)) {
+        return true;
+    }
+    // candidate is a read:
+    // - vs write: can replace if the candidate revision knows about the transaction the
+    //   write originates from.
+    // - vs read: can replace if the candidate revision comes from a newer snapshot (i.e.
+    //   this revision knows more committed transactions).
+    if (!candidate.isWrite) {
+        return other.isWrite
+            ? candidate.snapshot.knowsTransaction(other.snapshot.current_xact_id)
+            : candidate.snapshot.isAfter(other.snapshot);
+    }
+    // Candidate is a write: we can replace any revision that didn't know
+    // about this transaction.
+    return !other.snapshot.knowsTransaction(candidate.snapshot.current_xact_id);
+}
+
+export const SKIP_REVISION = Symbol("SKIP");
+
+/**
+ * Track a single value field's latest revision and allow to determine if a new value can
+ * be applied based on snapshot visibility.
+ */
+export class SingleFieldVersion {
+    lastRevision = {
+        snapshot: new PgSnapshot({ xmin: 0, xmax: 0, xip_bitmap: "" }),
+        isWrite: false,
+    };
+
+    /**
+     * Determine if the current revision can replace the given one.
+     *
+     * @template T
+     * @param {T} value
+     * @param {FieldRevision} incomingRevision
+     * @returns {typeof SKIP_REVISION|T} The skip symbol, or the value to update the
+     * field.
+     */
+    resolveApply(value, incomingRevision) {
+        if (shouldReplace(incomingRevision, this.lastRevision)) {
+            this.lastRevision = incomingRevision;
+            return value;
+        }
+        return SKIP_REVISION;
+    }
+}
+
+/**
+ * Track a multi value field's command history and determine which commands can be applied
+ * based on revision snapshots.
+ */
+export class ManyFieldVersion {
+    /** @type {import("@mail/model/record").Record} */
+    TargetModel;
+    /**
+     * Tracks the command history for this field, in chronological order. Each entry
+     * represents a single command along with the revision at which it was applied.
+     *
+     * @type {{cmd: [], revision: FieldRevision}[]}
+     */
+    history = [
+        {
+            cmd: ["REPLACE", []],
+            revision: {
+                snapshot: new PgSnapshot({ xmin: 0, xmax: 0, xip_bitmap: "" }),
+                isWrite: false,
+            },
+        },
+    ];
+
+    constructor(TargetModel) {
+        this.TargetModel = TargetModel;
+    }
+
+    /**
+     * Determine what commands should be applied.
+     *
+     * @param {Array[]} commands
+     * @param {FieldRevision} incomingRevision
+     * @returns {Array[]|typeof SKIP_REVISION} The skip symbol, or the commands to apply
+     * to update the field.
+     */
+    resolveApply(commands, incomingRevision) {
+        if (!shouldReplace(incomingRevision, this.history[0].revision)) {
+            return SKIP_REVISION;
+        }
+        const insertionIndex = this._findInsertionIndex(incomingRevision);
+        const insertAtTheEnd = insertionIndex === this.history.length;
+        this.history.splice(
+            insertionIndex,
+            0,
+            ...commands.map((cmd) => ({ cmd, revision: incomingRevision }))
+        );
+        const lastReplaceIndex = this.history.findLastIndex((entry) => entry.cmd[0] === "REPLACE");
+        if (lastReplaceIndex >= insertionIndex) {
+            this.history = this.history.slice(lastReplaceIndex);
+        }
+        if (insertAtTheEnd) {
+            return commands;
+        }
+        return this._generateReplaceFromHistory();
+    }
+
+    /**
+     * Returns the index of the first element strictly greater than the given revision.
+     * This ensures identical revisions are kept in their original arrival order.
+     *
+     * @param {FieldRevision} revision
+     */
+    _findInsertionIndex(revision) {
+        let start = 0;
+        let end = this.history.length;
+        while (start < end) {
+            const mid = Math.floor((start + end) / 2);
+            const midRevision = this.history[mid].revision;
+            if (shouldReplace(revision, midRevision)) {
+                start = mid + 1;
+            } else {
+                end = mid;
+            }
+        }
+        return start;
+    }
+
+    get lastRevision() {
+        return this.history.at(-1).revision;
+    }
+
+    /** Returns a replace command, equivalent to all the commands in history. */
+    _generateReplaceFromHistory() {
+        const positionByLocalId = {};
+        for (let idx = 0; idx < this.history.length; idx++) {
+            const [name, values] = this.history[idx].cmd;
+            for (let subIdx = 0; subIdx < values.length; subIdx++) {
+                const value = values[subIdx];
+                const localId = this.TargetModel.localId(value);
+                if (["REPLACE", "ADD", "ADD.noinv"].includes(name)) {
+                    positionByLocalId[localId] ??= { value, idx, subIdx };
+                } else {
+                    delete positionByLocalId[localId];
+                }
+            }
+        }
+        const sortedValues = Object.values(positionByLocalId)
+            .sort((a, b) => a.idx - b.idx || a.subIdx - b.subIdx)
+            .map((p) => p.value);
+        return [["REPLACE", sortedValues]];
+    }
+}

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -72,6 +72,9 @@ export class RecordInternal {
     /** @type {string} */
     localId;
     gettingField = false;
+    /** @type {Map<string, import("@mail/model/field_version").SingleFieldVersion|import("@mail/model/field_version").ManyFieldVersion>} */
+    fieldsVersion = new Map();
+
     /**
      * For fields that use local storage, this map contains the "ls" object that eases interactions on the related
      * local storage entry. For instance, instead of having to write `browser.localStorage.setItem(EXACT_LOCAL_STORAGE_ENTRY_OF_FIELD, value)`,

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -1,4 +1,5 @@
 import { reactive } from "@web/owl2/utils";
+import { PgSnapshot } from "@mail/model/field_version";
 import { Record } from "./record";
 import { STORE_SYM, modelRegistry } from "./misc";
 import { toRaw } from "@odoo/owl";
@@ -201,36 +202,54 @@ export class Store extends Record {
     }
     /**
      * @template T
-     * @param {T} [dataByModelName={}]
+     * @param {T & {__store_version__?: import("@mail/model/field_version").StoreVersion}} [dataByModelName={}]
      * @param {Object} [options={}]
      * @returns {{ [K in keyof T]: import("models").Models[K][] }}
      */
     insert(dataByModelName = {}, options = {}) {
         const store = this;
-        Record.MAKE_UPDATE(function storeInsert() {
-            const recordsDataToDelete = [];
-            for (const [modelName, data] of Object.entries(dataByModelName)) {
-                if (!store[modelName]) {
-                    console.warn(`store.insert() received data for unknown model “${modelName}”.`);
-                    continue;
-                }
-                const insertData = [];
-                for (const vals of Array.isArray(data) ? data : [data]) {
-                    if (vals._DELETE) {
-                        delete vals._DELETE;
-                        recordsDataToDelete.push([modelName, vals]);
-                    } else {
-                        insertData.push(vals);
+        // Only cleanup if we initiated the insert.
+        const shouldCleanup = !this._.currentInsertVersion;
+        if ("__store_version__" in dataByModelName) {
+            const versionMeta = dataByModelName.__store_version__;
+            delete dataByModelName.__store_version__;
+            this._.currentInsertVersion = {
+                ...versionMeta,
+                snapshot: new PgSnapshot(versionMeta.snapshot),
+            };
+        }
+        try {
+            Record.MAKE_UPDATE(function storeInsert() {
+                const recordsDataToDelete = [];
+                for (const [modelName, data] of Object.entries(dataByModelName)) {
+                    if (!store[modelName]) {
+                        console.warn(
+                            `store.insert() received data for unknown model “${modelName}”.`
+                        );
+                        continue;
                     }
+                    const insertData = [];
+                    for (const vals of Array.isArray(data) ? data : [data]) {
+                        if (vals._DELETE) {
+                            delete vals._DELETE;
+                            recordsDataToDelete.push([modelName, vals]);
+                        } else {
+                            insertData.push(vals);
+                        }
+                    }
+                    store[modelName].insert(insertData, options);
                 }
-                store[modelName].insert(insertData, options);
+                // Delete after all inserts to make sure a relation potentially registered before the
+                // delete doesn't re-add the deleted record by mistake.
+                for (const [modelName, vals] of recordsDataToDelete) {
+                    store[modelName].get(vals)?.delete();
+                }
+            });
+        } finally {
+            if (shouldCleanup) {
+                this._.currentInsertVersion = null;
             }
-            // Delete after all inserts to make sure a relation potentially registered before the
-            // delete doesn't re-add the deleted record by mistake.
-            for (const [modelName, vals] of recordsDataToDelete) {
-                store[modelName].get(vals)?.delete();
-            }
-        });
+        }
     }
     onChange(record, name, cb) {
         return this._onChange(record, name, (observe) => {

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -1,12 +1,15 @@
 /** @typedef {import("./record").Record} Record */
 /** @typedef {import("./record_list").RecordList} RecordList */
 
-import { htmlEscape, markup, toRaw } from "@odoo/owl";
-import { RecordInternal } from "./record_internal";
-import { deserializeDate, deserializeDateTime } from "@web/core/l10n/dates";
-import { IS_DELETED_SYM, isCommandList, isMany, normalizeManyCommands } from "./misc";
-import { browser } from "@web/core/browser/browser";
+import { ManyFieldVersion, SingleFieldVersion, SKIP_REVISION } from "@mail/model/field_version";
+import { IS_DELETED_SYM, isCommandList, isMany, normalizeManyCommands } from "@mail/model/misc";
+import { RecordInternal } from "@mail/model/record_internal";
 import { parseRawValue } from "@mail/utils/common/local_storage";
+
+import { htmlEscape, markup, toRaw } from "@odoo/owl";
+
+import { browser } from "@web/core/browser/browser";
+import { deserializeDate, deserializeDateTime } from "@web/core/l10n/dates";
 
 const Markup = markup().constructor;
 
@@ -32,6 +35,18 @@ export class StoreInternal extends RecordInternal {
     RHD_QUEUE = new Map(); // record-hard-deletes
     ERRORS = [];
     UPDATE = 0;
+    /**
+     * Current version context used in the current store insert operation.
+     *
+     * The version data is provided by the server. If no version is provided,
+     * each field falls back to its last known version.
+     *
+     * @type {{
+     *    written_fields_by_record: import("@mail/model/field_version").WrittenFieldsByRecord,
+     *    snapshot: import("@mail/model/field_version").PgSnapshot
+     * }}
+     */
+    currentInsertVersion = null;
     /**
      * Map of local storage keys of fields synced with local storage to the record and field name.
      *
@@ -243,9 +258,31 @@ export class StoreInternal extends RecordInternal {
             Object.getOwnPropertySymbols(vals).map((sym) => [sym, vals[sym]])
         );
         for (const [fieldName, value] of fieldEntries) {
-            const valueNormalized = isMany(record.Model, fieldName)
-                ? normalizeManyCommands(value)
-                : value;
+            let version = record._.fieldsVersion.get(fieldName);
+            if (!version) {
+                version = isMany(record.Model, fieldName)
+                    ? new ManyFieldVersion(record.Model)
+                    : new SingleFieldVersion();
+                record._.fieldsVersion.set(fieldName, version);
+            }
+            // Always use the server version if provided, the last known version for the
+            // field otherwise.
+            const revision = this.currentInsertVersion
+                ? {
+                      snapshot: this.currentInsertVersion.snapshot,
+                      isWrite:
+                          this.currentInsertVersion.written_fields_by_record?.[
+                              record.Model.getName()
+                          ]?.[record.id]?.includes(fieldName),
+                  }
+                : version.lastRevision;
+            const toApply = version.resolveApply(
+                isMany(record.Model, fieldName) ? normalizeManyCommands(value) : value,
+                revision
+            );
+            if (toApply === SKIP_REVISION) {
+                continue;
+            }
             if (record.Model._.fieldsLocalStorage.has(fieldName)) {
                 // should immediately write in local storage, for immediately correct next compute
                 if (!this.isUpdatingFromStorageEvent) {
@@ -258,9 +295,9 @@ export class StoreInternal extends RecordInternal {
                 }
             }
             if (!record.Model._.fields.get(fieldName) || record.Model._.fieldsAttr.get(fieldName)) {
-                this.updateAttr(record, fieldName, valueNormalized);
+                this.updateAttr(record, fieldName, toApply);
             } else {
-                this.updateRelation(record, fieldName, valueNormalized);
+                this.updateRelation(record, fieldName, toApply);
             }
         }
     }

--- a/addons/mail/static/tests/core/store_versioning.test.js
+++ b/addons/mail/static/tests/core/store_versioning.test.js
@@ -1,0 +1,480 @@
+import { fields, makeStore, Record, Store } from "@mail/model/export";
+import { defineMailModels, start as start2 } from "@mail/../tests/mail_test_helpers";
+
+import { afterEach, beforeEach, expect, test } from "@odoo/hoot";
+
+import { registry } from "@web/core/registry";
+import { mockService } from "@web/../tests/web_test_helpers";
+
+function xipToBitmap(xmin, xmax, xip) {
+    const bitCount = Number(xmax - xmin);
+    if (bitCount <= 0) {
+        return "";
+    }
+    const byteCount = Math.ceil(bitCount / 8);
+    const bytes = new Uint8Array(byteCount);
+    for (const txid of xip) {
+        if (txid >= xmin && txid < xmax) {
+            const offset = Number(txid - xmin);
+            const byteIndex = Math.floor(offset / 8);
+            const bitIndex = offset % 8;
+            bytes[byteIndex] |= 1 << bitIndex;
+        }
+    }
+    return btoa(String.fromCharCode(...bytes));
+}
+
+const localRegistry = registry.category("discuss.model.test");
+
+defineMailModels();
+beforeEach(() => {
+    Record.register(localRegistry);
+    Store.register(localRegistry);
+    mockService("store", (env) => makeStore(env, { localRegistry }));
+});
+afterEach(() => {
+    for (const [modelName] of localRegistry.getEntries()) {
+        localRegistry.remove(modelName);
+    }
+});
+
+async function start() {
+    const env = await start2();
+    return env.services.store;
+}
+
+const SINGLE_FIELD_CASES = [
+    {
+        name: "keep incoming read if it comes from a newer read snapshot",
+        initial: { id: 1, name: "v0" },
+        steps: [
+            {
+                values: { name: "v1" },
+                meta: { snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v1" },
+            },
+            {
+                values: { name: "v3" },
+                meta: { snapshot: { xmin: 40, xmax: 40, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v3" },
+                description: "V3 read's snapshot is newer.",
+            },
+            {
+                values: { name: "v2" },
+                meta: { snapshot: { xmin: 30, xmax: 30, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v3" },
+                description: "V2 read's snapshot is older.",
+            },
+            {
+                values: { name: "v4" },
+                meta: {
+                    snapshot: {
+                        xmin: 65,
+                        xmax: 68,
+                        xip_bitmap: xipToBitmap(65, 68, [65, 66]),
+                        current_xact_id: null,
+                    },
+                },
+                expected: { name: "v4" },
+                description: "V4 read's snapshot is newer.",
+            },
+            {
+                values: { name: "v5" },
+                meta: {
+                    snapshot: {
+                        xmin: 65,
+                        xmax: 68,
+                        xip_bitmap: xipToBitmap(65, 68, [65]),
+                        current_xact_id: null,
+                    },
+                },
+                expected: { name: "v5" },
+                description:
+                    "Same (xmin, xmax) as V4 but one transaction has committed after V4 read but before V5 read.",
+            },
+        ],
+    },
+    {
+        name: "keep incoming write if the current read version couldn't see the write transaction",
+        initial: { id: 1, name: "v0" },
+        steps: [
+            {
+                values: { name: "v3" },
+                meta: {
+                    snapshot: {
+                        xmin: 30,
+                        xmax: 40,
+                        xip_bitmap: xipToBitmap(30, 40, [30, 35]),
+                        current_xact_id: null,
+                    },
+                },
+                expected: { name: "v3" },
+            },
+            {
+                values: { name: "v2" },
+                meta: {
+                    snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: 20 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v3" },
+                description: "Write committed before the V3 read.",
+            },
+            {
+                values: { name: "v4" },
+                meta: {
+                    snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: 35 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v4" },
+                description: "Write started before the V3 read but was committed after (xip).",
+            },
+            {
+                values: { name: "v5" },
+                meta: { snapshot: { xmin: 40, xmax: 40, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v5" },
+                description: "Read after the V4 write committed.",
+            },
+            {
+                values: { name: "v6" },
+                meta: {
+                    snapshot: { xmin: 50, xmax: 50, xip_bitmap: "", current_xact_id: 50 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v6" },
+                description: "Write committed after the V5 read.",
+            },
+            {
+                values: { name: "v7" },
+                meta: { snapshot: { xmin: 60, xmax: 60, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v7" },
+                description: "Read after the V6 write committed.",
+            },
+            {
+                values: { name: "v8" },
+                meta: {
+                    snapshot: { xmin: 60, xmax: 60, xip_bitmap: "", current_xact_id: 60 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v8" },
+                description: "Write committed at xmax boundary: out of V7 read range.",
+            },
+        ],
+    },
+    {
+        name: "keep incoming write if the current write version is newer",
+        initial: { id: 1, name: "v0" },
+        steps: [
+            {
+                values: { name: "v1" },
+                meta: {
+                    snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: 10 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v1" },
+            },
+            {
+                values: { name: "v3" },
+                meta: {
+                    snapshot: { xmin: 30, xmax: 30, xip_bitmap: "", current_xact_id: 30 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v3" },
+                description: "Write committed after the V1 read.",
+            },
+            {
+                values: { name: "v2" },
+                meta: {
+                    snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: 20 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v3" },
+                description: "Write was committed before the V3 write.",
+            },
+        ],
+    },
+    {
+        name: "partial update: newer and older reads in the same payload",
+        initial: { id: 1, name: "v0" },
+        steps: [
+            {
+                values: { name: "v1", description: "desc1" },
+                meta: { snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v1", description: "desc1" },
+            },
+            {
+                values: { name: "v3" },
+                meta: { snapshot: { xmin: 30, xmax: 30, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v3", description: "desc1" },
+            },
+            {
+                values: { name: "v2", description: "desc2" },
+                meta: { snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v3", description: "desc2" },
+                description: "Current version has newer name, but not description.",
+            },
+        ],
+    },
+    {
+        name: "partial update: newer and older writes in the same payload",
+        initial: { id: 1, name: "v0" },
+        steps: [
+            {
+                values: { name: "v1", description: "desc1" },
+                meta: { snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "v1", description: "desc1" },
+            },
+            {
+                values: { name: "v3" },
+                meta: {
+                    snapshot: { xmin: 30, xmax: 30, xip_bitmap: "", current_xact_id: 30 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "v3", description: "desc1" },
+            },
+            {
+                values: { name: "v2", description: "desc2" },
+                meta: {
+                    snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: 20 },
+                    written_fields_by_record: { Thread: { 1: ["name", "description"] } },
+                },
+                expected: { name: "v3", description: "desc2" },
+                description: "Current version has newer name, but not description.",
+            },
+        ],
+    },
+    {
+        name: "read cannot override a newer write",
+        initial: { id: 1, name: "v0" },
+        steps: [
+            {
+                values: { name: "WRITE" },
+                meta: {
+                    snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: 10 },
+                    written_fields_by_record: { Thread: { 1: ["name"] } },
+                },
+                expected: { name: "WRITE" },
+            },
+            {
+                values: { name: "READ" },
+                meta: { snapshot: { xmin: 5, xmax: 5, xip_bitmap: "", current_xact_id: null } },
+                expected: { name: "WRITE" },
+                description: "Read from an older snapshot: do not override the write.",
+            },
+        ],
+    },
+];
+
+for (const testCase of SINGLE_FIELD_CASES) {
+    const testFn = testCase.only ? test.only : test;
+    testFn(`single store versioning - ${testCase.name}`, async () => {
+        (class Thread extends Record {
+            static id = "id";
+            id;
+            name;
+            description;
+        }).register(localRegistry);
+        const store = await start();
+        const thread = store.Thread.insert(testCase.initial);
+        for (const step of testCase.steps) {
+            store.insert({
+                Thread: { id: thread.id, ...step.values },
+                __store_version__: step.meta,
+            });
+            expect(
+                Object.fromEntries(
+                    Object.keys(step.expected).map((fname) => [fname, thread[fname]])
+                )
+            ).toEqual(step.expected, { message: step.description });
+        }
+    });
+}
+
+const MANY_FIELD_CASES = [
+    {
+        name: "keep incoming replace if it comes from a newer replace",
+        initial: { id: 1, messages: [] },
+        steps: [
+            {
+                values: [["REPLACE", [1, 2, 3]]],
+                meta: { snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3],
+            },
+            {
+                values: [["REPLACE", [7, 8, 9]]],
+                meta: { snapshot: { xmin: 30, xmax: 30, xip_bitmap: "", current_xact_id: null } },
+                expected: [7, 8, 9],
+            },
+            {
+                values: [["REPLACE", [4, 5, 6]]],
+                meta: { snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: null } },
+                expected: [7, 8, 9],
+                description: "Replace is outdated thus ignored.",
+            },
+        ],
+    },
+    {
+        name: "keep incoming commands if it comes after the base replace",
+        initial: { id: 1, messages: [] },
+        steps: [
+            {
+                values: [["REPLACE", [1, 2, 3]]],
+                meta: { snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3],
+            },
+            {
+                values: [["ADD", [7, 8]]],
+                meta: { snapshot: { xmin: 30, xmax: 30, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3, 7, 8],
+            },
+            {
+                values: [["DELETE", [7, 8]]],
+                meta: { snapshot: { xmin: 40, xmax: 40, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3],
+            },
+            {
+                values: [["DELETE", [1, 2, 3]]],
+                meta: { snapshot: { xmin: 15, xmax: 15, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3],
+                description:
+                    "Delete command comes from an older snapshot than the base replace: ignored.",
+            },
+        ],
+    },
+    {
+        name: "commands arriving out of order are properly handled",
+        initial: { id: 1, messages: [1, 2, 3] },
+        steps: [
+            {
+                values: [["ADD", [4, 5, 6]]],
+                meta: { snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3, 4, 5, 6],
+            },
+            {
+                values: [["DELETE", [1, 4]]],
+                meta: { snapshot: { xmin: 15, xmax: 15, xip_bitmap: "", current_xact_id: null } },
+                expected: [2, 3, 4, 5, 6],
+                description: "4 was added after the delete command, but 1 wasn't.",
+            },
+        ],
+    },
+    {
+        name: "newer commands arriving before replace are kept",
+        initial: { id: 1, messages: [] },
+        steps: [
+            {
+                values: [["REPLACE", []]],
+                meta: { snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: null } },
+                expected: [],
+            },
+            {
+                values: [["ADD", [4, 5, 6]]],
+                meta: { snapshot: { xmin: 20, xmax: 20, xip_bitmap: "", current_xact_id: null } },
+                expected: [4, 5, 6],
+            },
+            {
+                values: [["REPLACE", [1]]],
+                meta: { snapshot: { xmin: 15, xmax: 15, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 4, 5, 6],
+                description:
+                    "Replace came before the ADD, even if it was received after: add is kept.",
+            },
+        ],
+    },
+    {
+        name: "keep command with equivalent snapshot as the last replace when they come after it",
+        initial: { id: 1, messages: [] },
+        steps: [
+            {
+                values: [["REPLACE", [1, 2, 3]]],
+                meta: { snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3],
+            },
+            {
+                values: [["ADD", [4, 5, 6]]],
+                meta: { snapshot: { xmin: 10, xmax: 10, xip_bitmap: "", current_xact_id: null } },
+                expected: [1, 2, 3, 4, 5, 6],
+            },
+        ],
+    },
+];
+
+for (const testCase of MANY_FIELD_CASES) {
+    const testFn = testCase.only ? test.only : test;
+    testFn(`many store versioning - ${testCase.name}`, async () => {
+        (class Message extends Record {
+            static id = "id";
+            id;
+        }).register(localRegistry);
+        (class Thread extends Record {
+            static id = "id";
+            id;
+            messages = fields.Many("Message");
+        }).register(localRegistry);
+        const store = await start();
+        const thread = store.Thread.insert(testCase.initial);
+        for (const step of testCase.steps) {
+            store.insert({
+                Thread: { id: thread.id, messages: step.values },
+                __store_version__: step.meta,
+            });
+            expect(thread.messages.map(({ id }) => id).sort()).toEqual(step.expected, {
+                message: step.description,
+            });
+        }
+    });
+}
+
+test("Inverse of relations are properly versioned", async () => {
+    (class Message extends Record {
+        static id = "id";
+        thread = fields.One("Thread", { inverse: "messages" });
+    }).register(localRegistry);
+
+    (class Thread extends Record {
+        static id = "id";
+        messages = fields.Many("Message", { inverse: "thread" });
+    }).register(localRegistry);
+
+    const store = await start();
+    store.Thread.insert([1, 2, 3]);
+    store.insert({
+        Thread: { id: 1, messages: [["REPLACE", [1, 2]]] },
+        __store_version__: { snapshot: { xmin: 1, xmax: 1, xip_bitmap: "" } },
+    });
+    expect(store.Thread.get(1).messages.map((m) => m.id)).toEqual([1, 2]);
+    expect(store.Message.get(1).thread.id).toBe(1);
+    store.insert({
+        Thread: { id: 1, messages: [["DELETE", [1]]] },
+        __store_version__: { snapshot: { xmin: 3, xmax: 3, xip_bitmap: "" } },
+    });
+    expect(store.Thread.get(1).messages.map((m) => m.id)).toEqual([2]);
+    expect(store.Message.get(1).thread).toBe(undefined);
+    // Outdated update on the one side, shouldn't update the relation.
+    store.insert({
+        Message: { id: 1, thread: 1 },
+        __store_version__: { snapshot: { xmin: 2, xmax: 2, xip_bitmap: "" } },
+    });
+    expect(store.Message.get(1).thread).toBe(undefined);
+    expect(store.Thread.get(1).messages.map((m) => m.id)).toEqual([2]);
+    store.insert({
+        Message: { id: 1, thread: 1 },
+        __store_version__: { snapshot: { xmin: 4, xmax: 4, xip_bitmap: "" } },
+    });
+    expect(store.Message.get(1).thread.id).toBe(1);
+    expect(
+        store.Thread.get(1)
+            .messages.map((m) => m.id)
+            .sort()
+    ).toEqual([1, 2]);
+    // Outdated delete on the many side, shouldn't impact the relation.
+    store.insert({
+        Thread: { id: 1, messages: [["DELETE", [1]]] },
+        __store_version__: { snapshot: { xmin: 3, xmax: 3, xip_bitmap: "" } },
+    });
+    expect(
+        store.Thread.get(1)
+            .messages.map((m) => m.id)
+            .sort()
+    ).toEqual([1, 2]);
+    expect(store.Message.get(1).thread.id).toBe(1);
+});

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1419,8 +1419,15 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
             self.assertEqual(self._new_msgs, done_msgs, 'Mail: invalid message creation (%s) / expected (%s)' % (len(self._new_msgs), len(done_msgs)))
             self.assertEqual(self._new_notifs, done_notifs, 'Mail: invalid notification creation (%s) / expected (%s)' % (len(self._new_notifs), len(done_notifs)))
 
+    def _pop_store_version(self, data):
+        if not isinstance(data, dict):
+            return
+        data.pop("__store_version__", False)
+        for value in data.values():
+            self._pop_store_version(value)
+
     @contextmanager
-    def assertBus(self, channels=None, message_items=None, get_params=None):
+    def assertBus(self, channels=None, message_items=None, get_params=None, show_store_versioning=False):
         """Check content of bus notifications.
         Params might not be determined in advance (newly created id, create_date, ...), in this case
         the `get_params` function can be given to return the expected values, called after the
@@ -1432,7 +1439,10 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
             return f"{tuple(json.loads(notif.channel))},  # {json.loads(notif.message).get('type')}"
 
         def notif_to_string(notif):
-            return f"{format_notif(notif)}\n{notif.message}"
+            notification_message = json.loads(notif.message)
+            if not show_store_versioning:
+                self._pop_store_version(notification_message)
+            return f"{format_notif(notif)}\n{json.dumps(notification_message)}"
 
         self._reset_bus()
         try:
@@ -1441,7 +1451,11 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
         finally:
             if get_params:
                 channels, message_items = get_params()
-            found_bus_notifs = self.assertBusNotifications(channels, message_items=message_items)
+            found_bus_notifs = self.assertBusNotifications(
+                channels,
+                message_items=message_items,
+                show_store_versioning=show_store_versioning,
+            )
             new_lines = "\n\n"
             self.assertEqual(
                 self._new_bus_notifs,
@@ -1729,7 +1743,7 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
             "payload": Store().add(message, "_store_notification_fields").get_result(),
         }], check_unique=False)
 
-    def assertBusNotifications(self, channels, message_items=None, check_unique=True):
+    def assertBusNotifications(self, channels, message_items=None, check_unique=True, show_store_versioning=False):
         """ Check bus notifications content. Mandatory and basic check is about
         channels being notified. Content check is optional.
 
@@ -1752,7 +1766,10 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
         new_lines = "\n\n"
 
         def notif_to_string(notif):
-            return f"{notif.channel}\n{notif.message}"
+            notification_message = json.loads(notif.message)
+            if not show_store_versioning:
+                self._pop_store_version(notification_message)
+            return f"{notif.channel}\n{json.dumps(notification_message)}"
 
         self.assertEqual(
             bus_notifs.mapped("channel"),
@@ -1762,11 +1779,17 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
         )
         for expected in message_items or []:
             for notification in bus_notifs:
-                if json.loads(json_dump(expected)) == json.loads(notification.message):
+                notification_message = json.loads(notification.message)
+                if not show_store_versioning:
+                    self._pop_store_version(notification_message)
+                if json.loads(json_dump(expected)) == notification_message:
                     break
             else:
                 matching_notifs = [n for n in bus_notifs if json.loads(n.message).get("type") == expected.get("type")]
                 if len(matching_notifs) == 1:
+                    notification_message = json.loads(matching_notifs[0].message)
+                    if not show_store_versioning:
+                        self._pop_store_version(notification_message)
                     self.assertEqual(expected, json.loads(matching_notifs[0].message))
                 if not matching_notifs:
                     matching_notifs = bus_notifs

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -20,6 +20,7 @@ from . import test_discuss_sub_channels
 from . import test_discuss_thread_controller
 from . import test_guest
 from . import test_message_controller
+from . import test_store_versioning
 from . import test_guest_feature
 from . import test_toggle_upload
 from . import test_load_messages

--- a/addons/mail/tests/discuss/test_store_versioning.py
+++ b/addons/mail/tests/discuss/test_store_versioning.py
@@ -1,0 +1,244 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
+import math
+from unittest.mock import patch
+
+from odoo.http import Controller
+from odoo.tests import new_test_user
+
+from odoo.addons.base.tests.common import HttpCase, TransactionCase
+from odoo.addons.mail.models.discuss.discuss_channel import DiscussChannel
+from odoo.addons.mail.tests.common import MailCase
+from odoo.addons.mail.tools.discuss import Store, mail_route, store_version
+
+
+class TestStoreVersioning(HttpCase, MailCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        new_test_user(cls.env, "admin_user", groups="base.group_erp_manager")
+
+        class StoreVersionController(Controller):
+            @mail_route("/store/version/write_fields", type="jsonrpc")
+            def write_fields(self, fields_to_write_by_id):
+                store = Store()
+                for key, values in fields_to_write_by_id.items():
+                    model_name, record_id = key.split(":")
+                    record = self.env[model_name].browse(int(record_id))
+                    record.write(values)
+                    store.add(record, list(values.keys()))
+                return store.get_result()
+
+            @mail_route("/store/version/read_fields", type="jsonrpc")
+            def read_fields(self, fields_to_read_by_id):
+                store = Store()
+                for key, fnames in fields_to_read_by_id.items():
+                    model_name, record_id = key.split(":")
+                    store.add(self.env[model_name].browse(int(record_id)), fnames)
+                return store.get_result()
+
+            @mail_route("/store/version/send_bus_notifications", type="jsonrpc")
+            def send_bus_notifications(self, fields_by_channel):
+                for channel, fields in fields_by_channel.items():
+                    model_name, record_id = channel.split(":")
+                    record = self.env[model_name].browse(int(record_id))
+                    Store(bus_channel=record).add(record, fields).bus_send()
+
+        cls.env.registry.clear_cache("routing")
+        cls.addClassCleanup(cls.env.registry.clear_cache, "routing")
+
+    def test_store_versioning_tracks_updated_fields(self):
+        self.authenticate("admin_user", "admin_user")
+        bob = self.env["res.partner"].create({"name": "bob"})
+        alice = self.env["res.partner"].create({"name": "alice"})
+        general = self.env["discuss.channel"].create({"name": "general"})
+        result = self.make_jsonrpc_request(
+            "/store/version/write_fields",
+            {
+                "fields_to_write_by_id": {
+                    f"res.partner:{bob.id}": {"name": "BobNewName", "email": "bob@test.com"},
+                    f"res.partner:{alice.id}": {"name": "AliceNewName"},
+                    f"discuss.channel:{general.id}": {"description": "General description"},
+                },
+            },
+        )
+        written_fields_by_record = result["__store_version__"]["written_fields_by_record"]
+        self.assertTrue(
+            {
+                "complete_name",
+                "email",
+                "email_normalized",
+                "name",
+                "write_date",
+                "write_uid",
+            }.issubset(written_fields_by_record["res.partner"][str(bob.id)]),
+        )
+        self.assertTrue(
+            {"complete_name", "name", "write_date", "write_uid"}.issubset(
+                written_fields_by_record["res.partner"][str(alice.id)],
+            ),
+        )
+        self.assertTrue(
+            {"description", "write_date", "write_uid"}.issubset(
+                written_fields_by_record["discuss.channel"][str(general.id)]
+            ),
+        )
+        result = self.make_jsonrpc_request(
+            "/store/version/read_fields",
+            {"fields_to_read_by_id": {f"res.partner:{bob.id}": ["name", "email"]}},
+        )
+        self.assertFalse(result["__store_version__"]["written_fields_by_record"])
+
+    def test_store_versioning_sends_snapshot_data(self):
+        self.authenticate("admin_user", "admin_user")
+        bob = self.env["res.partner"].create({"name": "bob"})
+        result = self.make_jsonrpc_request(
+            "/store/version/write_fields",
+            {
+                "fields_to_write_by_id": {
+                    f"res.partner:{bob.id}": {"name": "BobNewName", "email": "bob@test.com"},
+                },
+            },
+        )
+        snapshot = result.pop("__store_version__")["snapshot"]
+        self.assertIn("xmin", snapshot)
+        self.assertIn("xmax", snapshot)
+        self.assertIn("xip_bitmap", snapshot)
+        self.assertIn("current_xact_id", snapshot)
+        result = self.make_jsonrpc_request(
+            "/store/version/read_fields",
+            {
+                "fields_to_read_by_id": {
+                    f"res.partner:{bob.id}": ["name", "email"],
+                },
+            },
+        )
+        snapshot = result["__store_version__"]["snapshot"]
+        self.assertIn("xmin", snapshot)
+        self.assertIn("xmax", snapshot)
+        self.assertIn("xip_bitmap", snapshot)
+
+    def test_store_version_sent_alongside_bus_notifications(self):
+        self.authenticate("admin_user", "admin_user")
+        bob = new_test_user(self.env, login="bob", groups="base.group_user")
+        general = self.env["discuss.channel"].create({"name": "general"})
+        self._reset_bus()
+        self.env.cr.execute("""
+            SELECT pg_current_snapshot(), pg_current_xact_id_if_assigned()
+        """)
+        snapshot, current_xact_id = self.env.cr.fetchone()
+        snapshot_parts = snapshot.split(":")
+        xmin = int(snapshot_parts[0])
+        xmax = int(snapshot_parts[1])
+        xip = {int(xid) for xid in snapshot_parts[2].split(",") if xid}
+        bitmap = bytearray(math.ceil((xmax - xmin) / 8))
+        for x in xip:
+            offset = x - xmin
+            byte_idx = offset // 8
+            bit_idx = offset % 8
+            bitmap[byte_idx] |= 1 << bit_idx
+        expected_snapshot = {
+            "xmin": str(xmin),
+            "xmax": str(xmax),
+            "xip_bitmap": base64.b64encode(bitmap),
+            "current_xact_id": current_xact_id,
+        }
+        with self.assertBus(
+            [bob, general],
+            [
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "res.users": [{"id": bob.id, "name": "bob (base.group_user)"}],
+                        "__store_version__": {
+                            "snapshot": expected_snapshot,
+                            "written_fields_by_record": {},
+                        },
+                    },
+                },
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "discuss.channel": [{"id": general.id, "name": "general"}],
+                        "__store_version__": {
+                            "snapshot": expected_snapshot,
+                            "written_fields_by_record": {},
+                        },
+                    },
+                },
+            ],
+            show_store_versioning=True,
+        ):
+            self.make_jsonrpc_request(
+                "/store/version/send_bus_notifications",
+                {
+                    "fields_by_channel": {
+                        f"res.users:{bob.id}": ["name"],
+                        f"discuss.channel:{general.id}": ["name"],
+                    },
+                },
+            )
+
+
+# This test ensures that an "inner" read-only call captures the correct version, and that
+# later writes in an "outer" call update the version independently, without affecting the
+# previously retrieved inner version.
+#
+# Using a transaction case as any database modification would assign a TX id right away
+# (including `HttpCase.setupClass`).
+class TestStoreVersioningTransactionCase(TransactionCase):
+    def test_store_version_nested_calls(self):
+        @store_version
+        def inner(self, fields_to_read):
+            store = Store(bus_channel=self).add(self, fields_to_read)
+            store.bus_send()
+            return store.get_result()
+
+        @store_version
+        def outer(self, fields_to_write, fields_to_read):
+            inner_store_data = self.inner(fields_to_read)
+            self.write(fields_to_write)
+            store = Store(bus_channel=self).add(self, [*fields_to_write.keys()])
+            store.bus_send()
+            return {
+                "outer_store_data": store.get_result(),
+                "inner_store_data": inner_store_data,
+            }
+
+        with (
+            patch.object(DiscussChannel, "inner", inner, create=True),
+            patch.object(DiscussChannel, "outer", outer, create=True),
+        ):
+            channel = self.env.ref("mail.channel_all_employees")
+            self.env.cr.execute("select pg_current_xact_id_if_assigned()")
+            # No TX id at the beginning as the DB wasn't updated.
+            self.assertIsNone(self.env.cr.fetchone()[0])
+            result = channel.outer(
+                fields_to_write={"name": "written"},
+                fields_to_read=["description"],
+            )
+            self.assertEqual(
+                result["inner_store_data"]["discuss.channel"],
+                [
+                    {
+                        "id": channel.id,
+                        "description": "A place to connect and exchange news with colleagues across the company.",
+                    },
+                ],
+            )
+            inner_version = result["inner_store_data"]["__store_version__"]
+            # Writes occured after `inner` execution, version should not be impacted by the
+            # later writes.
+            self.assertFalse(inner_version["snapshot"]["current_xact_id"])
+            self.assertFalse(inner_version["written_fields_by_record"])
+            self.assertEqual(
+                result["outer_store_data"]["discuss.channel"],
+                [{"id": channel.id, "name": "written"}],
+            )
+            outer_version = result["outer_store_data"]["__store_version__"]
+            # But `outer` wrote on some fields, version should have been updated.
+            self.assertTrue(outer_version["snapshot"]["current_xact_id"])
+            self.assertEqual(
+                outer_version["written_fields_by_record"],
+                {"discuss.channel": {channel.id: ["name", "write_date"]}},
+            )

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -1,17 +1,21 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
+import math
 import os
-from collections import defaultdict, UserList
+from collections import UserList, defaultdict
 from datetime import date, datetime
 from functools import partial, wraps
 from itertools import product
+
 from markupsafe import Markup
 
 import odoo
-from odoo import models
+from odoo import _, models
 from odoo.exceptions import MissingError
-from odoo.http import request
-from odoo.tools import groupby
+from odoo.http import Response, request, route
+from odoo.tools import OrderedSet, groupby
+
 from odoo.addons.bus.websocket import wsrequest
 
 
@@ -20,12 +24,15 @@ def add_guest_to_context(func):
     The guest is then available on the context of the current
     request.
     """
+
     @wraps(func)
-    def wrapper(self, *args, **kwargs):
+    def add_guest_to_context__wrapper(self, *args, **kwargs):
         req = request or wsrequest
-        token = (
-            req.cookies.get(req.env["mail.guest"]._cookie_name, "")
-        )
+        if not req:
+            raise NotImplementedError(
+                self.env._("@add_guest_to_context must be called only within a request context."),
+            )
+        token = req.cookies.get(req.env["mail.guest"]._cookie_name, "")
         guest = req.env["mail.guest"]._get_guest_from_token(token)
         if guest and not guest.timezone and not req.env.cr.readonly:
             timezone = req.env["mail.guest"]._get_timezone_from_request(req)
@@ -36,8 +43,174 @@ def add_guest_to_context(func):
             if isinstance(self, models.BaseModel):
                 self = self.with_context(guest=guest)
         return func(self, *args, **kwargs)
+    return add_guest_to_context__wrapper
 
-    return wrapper
+
+class StoreVersionInternal:
+    """Internal state used by the `@store_version` decorator."""
+    def __init__(self):
+        self._pending_bus_sends = []
+        self._snapshot_data = None
+        # Maps model names to record IDs to the set of updated field names.
+        self._written_fields_by_record = defaultdict(lambda: defaultdict(OrderedSet))
+
+    def enqueue_bus_notification(self, bus_channel, notification_type, payload):
+        """Enqueue a bus notification to be sent when the `@store_version` decorator
+        finishes, ensuring it includes the version metadata.
+        """
+        self._pending_bus_sends.append([bus_channel, notification_type, payload])
+
+    def mark_field_as_written(self, model_name, record_ids, fname):
+        """Mark field as written for the given records. Done automatically when using the
+        ORM, should be done manually otherwise.
+        """
+        for id_ in record_ids:
+            self._written_fields_by_record[model_name][id_].add(fname)
+
+    def _get_formatted_version(self, env):
+        """Get the version metadata, used by the client to determine if an incoming
+        store insert is newer than what it already knows.
+        """
+        if not self._snapshot_data:
+            env.flush_all()  # Ensure TX id is assigned, if the DB was modified, before building the version.
+            env.cr.execute("SELECT pg_current_snapshot(), pg_current_xact_id_if_assigned()")
+            snapshot_str, current_xact_id = env.cr.fetchone()
+            xmin_str, xmax_str, xips_str = snapshot_str.split(":")
+            xmin = int(xmin_str)
+            xmax = int(xmax_str)
+            xips = [int(x) for x in xips_str.split(",") if x]
+            bitmap = bytearray(math.ceil((xmax - xmin) / 8))
+            for x in xips:
+                offset = x - xmin
+                bitmap[offset // 8] |= 1 << (offset % 8)
+            self._snapshot_data = {
+                "xmin": str(xmin),
+                "xmax": str(xmax),
+                "xip_bitmap": base64.b64encode(bitmap).decode(),
+                "current_xact_id": current_xact_id,
+            }
+        elif not self._snapshot_data["current_xact_id"]:
+            env.flush_all()  # Ensure written fields are collected.
+            if self._written_fields_by_record:
+                # Snapshot was already fetched below in the stack, but fields have been
+                # updated since then. The snapshot is frozen at the beginning of the TX,
+                # but the current TX id is only assigned once the DB is modified. Update
+                # it now.
+                env.cr.execute("SELECT pg_current_xact_id_if_assigned()")
+                self._snapshot_data["current_xact_id"] = env.cr.fetchone()[0]
+        return {
+            "snapshot": self._snapshot_data.copy(),
+            "written_fields_by_record": {
+                model: {record_id: list(fnames) for record_id, fnames in recs.items()}
+                for model, recs in self._written_fields_by_record.items()
+            },
+        }
+
+    def _inject_version(self, version, payload):
+        """Add the version to the return value of `Store.get_result()`. Either the
+        payload itself, or one of the values of the payload.
+        """
+        if isinstance(payload, Store.Result) and "__store_version__" not in payload:
+            payload["__store_version__"] = version
+            return True
+        if isinstance(payload, dict):
+            return any(self._inject_version(version, v) for v in payload.values())
+        return False
+
+    def _add_version_to_response(self, version, response):
+        """Inject version metadata into the result returned by `Store.get_result()`,
+        which may be either an HTTP response from a controller or a dict returned by the
+        decorated function.
+        """
+        # Response is the result of `request.render()`, inject metadata inside the qweb context.
+        if isinstance(response, Response) and response.template:
+            self._inject_version(version, response.qcontext)
+        else:
+            self._inject_version(version, response)
+
+    def _send_bus_notifications(self, env, version):
+        """Send the notifications enqueued during the decorator method, alongside store
+        version metadata.
+        """
+        for target, n_type, msg in self._pending_bus_sends:
+            self._inject_version(version, msg)
+            env["bus.bus"].with_context(mail_store=None)._sendone(target, n_type, msg)
+        self._pending_bus_sends.clear()
+
+
+def store_version(func):
+    """Decorator to manage versioned updates in the store.
+
+    Store data is received from RPC and from the bus, and is applied directly to the
+    store. Without versioning, the order of arrival can cause outdated data to overwrite
+    newer data, leading to incorrect store state.
+
+    On the client side, we should be able to determine whether a field represents a newer
+    version of what is already known. This is directly linked to PostgreSQL snapshots and
+    isolation level, in our case, REPEATABLE READ.
+
+    For fields that were read, what matters is what the snapshot could see at the time.
+    For writes, what matters is whether the snapshot of the version we know could see the
+    write transaction. The combination of xmin, xmax, xip and the current transaction id
+    is enough to deduce it.
+
+    This decorator injects version metadata into the return value of `Store.get_result()`,
+    both in the value returned by the decorated function and in any bus notifications
+    emitted during its execution.
+
+    """
+    @wraps(func)
+    def store_version__wrapper(self, *args, **kwargs):
+        manager = self.env.context.get("mail_store")
+        should_cleanup = False
+        if not manager:
+            manager = StoreVersionInternal()
+            if isinstance(self, models.BaseModel):
+                self = self.with_context(mail_store=manager)
+            else:
+                # Clean up only if we inserted the manager in the request context;
+                # otherwise, the original decorator will handle it.
+                should_cleanup = True
+                req = request or wsrequest
+                req.update_context(mail_store=manager)
+        response = func(self, *args, **kwargs)
+        version = manager._get_formatted_version(self.env)
+        manager._add_version_to_response(version, response)
+        manager._send_bus_notifications(self.env, version)
+        if should_cleanup:
+            # Clean context to prevent side effects based on the presence of `mail_store`.
+            req.update_context(mail_store=None)
+        return response
+    return store_version__wrapper
+
+
+def mail_route(*route_args, **route_kwargs):
+    """Thin wrapper around `route` that adds guest context and enables versioning.
+    HTTP route results that return a non-Response object will automatically be converted
+    into a proper HTTP JSON response using `request.make_json_response`.
+
+    This decorator is equivalent to applying, in order:
+        @route(*route_args, **route_kwargs)
+        @store_version
+        @add_guest_to_context
+    """
+    if "type" not in route_kwargs:
+        raise TypeError(_("mail_route() must be called with the `type` keyword argument."))
+
+    def decorator(func):
+        wrapped_func = add_guest_to_context(func)
+        wrapped_func = store_version(wrapped_func)
+
+        @wraps(func)
+        def mail_route__wrapper(*args, **kwargs):
+            result = wrapped_func(*args, **kwargs)
+            if route_kwargs["type"] == "http" and not isinstance(result, Response):
+                return request.make_json_response(result)  # nosemgrep: rules.requests-in-models
+            return result
+
+        return route(*route_args, **route_kwargs)(mail_route__wrapper)
+
+    return decorator
 
 
 def get_twilio_credentials(env) -> tuple[str | None, str | None]:
@@ -221,7 +394,7 @@ class Store:
 
     def get_result(self):
         """Gets resulting data built from adding all data together."""
-        res = {}
+        res = Store.Result()
         for model_name, records in sorted(self.data.items()):
             if not ids_by_model[model_name]:  # singleton
                 res[model_name] = dict(sorted(records.items()))
@@ -374,6 +547,12 @@ class Store:
             )
             self.channel = channel
             self.subchannel = subchannel
+
+    class Result(dict):
+        """Marker class for dictionaries returned by `Store.get_result()`.
+        Used to distinguish store results from arbitrary dicts so version
+        metadata can be added (see `store_version` decorator).
+        """
 
     class Attr:
         """Attribute to be added for each record. The value can be a static value or a function

--- a/addons/rating/models/rating_mixin.py
+++ b/addons/rating/models/rating_mixin.py
@@ -29,7 +29,7 @@ class RatingMixin(models.AbstractModel):
     def _compute_rating_last_value(self):
         # Pure SQL instead of calling read_group to allow ordering array_agg
         self.flush_model(['rating_ids'])
-        self.env['rating.rating'].flush_model(['consumed', 'rating'])
+        self.env['rating.rating'].flush_model(['consumed', 'rating', 'res_id', 'res_model', 'write_date'])
         if not self.ids:
             self.rating_last_value = 0
             return

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -341,6 +341,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     res = fn()
             else:
                 res = fn()
+        res.pop("__store_version__", False)
         self.assertEqual(res, results)
 
     @freeze_time("2025-04-22 21:18:33")


### PR DESCRIPTION
\*: cloud_storage, im_livechat.

In the discuss app, store data is received from both RPC  and bus notifications. Because these updates can arrive out of order (e.g. a long-running RPC returning after a newer bus notification has already been processed), outdated data can overwrite newer data in the store. This leads to inconsistent UI states where messages or channel properties appear to roll back to previous values.

For now, bus notification often arrives ordered, but improving message dispatching would require to fetch notifications from different channels in parallel, which would only guarantee order *per channel*. This change would make this issue even more noticeable.

This commit introduces a decorator, `store_version` which return information about which transactions were visible to the client. With those metadata, store is now able to know whether an update represents a newer version of a field, thus solving the issue.

Another decorator is introduced, `mail_route` which applies `route`, `add_guest_to_context` and the `store_version` decorator, in the correct order.

task-4966085

Perfs, avg on 5 runs. 1k5 channels, 1k5 members:
- RPC
  - Initial page load rpc (`channels_as_member`, `init_messaging`, `failures`, `systray_get_activities`: Before ~3s , After ~3s.
  - Message post: Before ~80ms, After ~80ms.
- Store insert: Before ~9.5s, After ~9s.
Note: 9s is bad but unrelated to the PR, this needs to be fixed with OWL 3 / signals.

enterprise: https://github.com/odoo/enterprise/pull/106986
