### PR TITLE
[FIX] account_reports: Account Status Badge traceback

### DIFF
--- a/addons/account/static/src/components/account_review_state_selection/account_review_state_selection_badge.js
+++ b/addons/account/static/src/components/account_review_state_selection/account_review_state_selection_badge.js
@@ -93,7 +93,7 @@ export class AccountReviewStateSelectionBadge extends Component {
 
     get additionalClassName() {
         const addClasses = [];
-        if (this.props.size === 'small' || this.env.config.viewType === 'list') {
+        if (this.props.size === 'small' || this.env.config?.viewType === 'list') {
             addClasses.push('o_account_review_state_selection_badge_button_small');
         }
         if (this.props.class) {


### PR DESCRIPTION
If this.env is not present, the config will be undefined and when accessing the viewType it will raise a traceback.

task-5417418

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
