### PR TITLE
[IMP] website: lower sequence ir_actions_todo

### DIFF
--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -435,6 +435,7 @@
         <record id="website_configurator_todo" model="ir.actions.todo">
             <field name="name">Start Website Configurator</field>
             <field name="action_id" ref="action_open_website_configurator"/>
+            <field name="sequence">8</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
The reason we lower the sequence of the ir_actions_todo is because only one can be executed after a module installation. That means that if another module has auto-install with website and also a todo, it will take precedence and skip the openning of the website_configurator.

In order to prevent this from happining (again), we lower the sequence to 8 so that it takes priority over the default which is 10. That way any new auto-install with a todo will not silently beak the flow from website.

Linked to: https://github.com/odoo/enterprise/pull/105919

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
