### PR TITLE
[FIX] website: test cover image fail intermittently

### DIFF
--- a/addons/website/static/tests/builder/website_builder/cover_properties_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/cover_properties_option.test.js
@@ -1,6 +1,6 @@
 import { Builder } from "@html_builder/builder";
 import { expect, test } from "@odoo/hoot";
-import { animationFrame, click, waitFor } from "@odoo/hoot-dom";
+import { click } from "@odoo/hoot-dom";
 import {
     contains,
     dataURItoBlob,
@@ -69,7 +69,7 @@ test("Add image as cover", async () => {
 
     const blogPostTitle = "Title of Test Post";
 
-    await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="o_record_cover_container" data-res-model="blog.post" data-res-id="3">
             <div class="o_record_cover_image"/>
             <h1 data-oe-model="blog.post" data-oe-id="3" data-oe-field="name">${blogPostTitle}</h1>
@@ -82,8 +82,7 @@ test("Add image as cover", async () => {
     // We use "click" instead of contains.click because contains wait for the image to be visible.
     // In this test we don't want to wait ~800ms for the image to be visible but we can still click on it
     await click("img.o_we_attachment_highlight");
-    await animationFrame();
-    await waitFor(":iframe .o_record_cover_container.o_record_has_cover .o_record_cover_image");
+    await waitSidebarUpdated();
     expect(":iframe .o_record_cover_image").toHaveStyle({
         "background-image": /url\("data:image\/webp;base64,(.*)"\)/,
     });


### PR DESCRIPTION
The test "Add image as cover" was failing intermittently due to image loading depending on an RPC with
an unpredictable duration. This could exceed the 200ms timeout used in waitFor.

Use `waitSidebarUpdated`` to wait for the ongoing action to finish and ensure the sidebar is fully updated.

error-Add image as cover

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
