### PR TITLE
[FIX] website_forum: fix post comment button click

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -423,14 +423,13 @@
                         <t t-if="can_interact_with_post" t-call="website_forum.post_dropdown"/>
                     </div>
                 </div>
-                <t t-call="website_forum.post_comment" object="post_id">
-                    <t t-if="post_id == answer">
-                        <t t-set="_collapse_uid" t-value="_answer_comment_collapse_uid"/>
-                    </t>
-                    <t t-if="post_id == question">
-                        <t t-set="_collapse_uid" t-value="_question_comment_collapse_uid"/>
-                   </t>
-                </t>
+                <t t-call="website_forum.post_comment"
+                    object="post_id"
+                    _collapse_uid="(
+                        _answer_comment_collapse_uid if post_id == answer else
+                        _question_comment_collapse_uid if post_id == question else
+                        False
+                    )"/>
             </div>
         </div>
 </template>


### PR DESCRIPTION
Purpose
=======
Fix the comment button which doesn't react to clicks on post questions and post answers.

Specification
=============
Following odoo/odoo#232539 a script has been executed to convert every t-call to their new syntax.
Instead of being set inside the t-call with t-set, the variables are now passed as attributes directly on the t-call element.

This script has missed the post comment "_collapse_uid" variable as it was defined inside a <t t-if...> element.
Correctly rewriting the variable as a t-call attribute.

Task-5886055

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
