### PR TITLE
[FIX] website: use slugified url on "create page" in edit menu dialog

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -529,7 +529,7 @@ export class AddPageDialog extends Component {
                 websiteId: this.props.websiteId,
             });
         }
-        this.props.onAddPage();
+        this.props.onAddPage({ createdUrl: data.url });
         this.props.close();
     }
 

--- a/addons/website/static/src/components/dialog/edit_menu.js
+++ b/addons/website/static/src/components/dialog/edit_menu.js
@@ -405,8 +405,11 @@ export class EditMenuDialog extends Component {
         let url = menu.fields["url"];
         url = url.startsWith("/") ? url : "/" + url;
         this.dialogs.add(AddPageDialog, {
-            onAddPage: () => {
-                this.onClickSave(false, url);
+            onAddPage: ({ createdUrl }) => {
+                if (createdUrl) {
+                    menu.fields["url"] = createdUrl;
+                }
+                this.onClickSave(false, createdUrl ?? url);
             },
             websiteId: this.website.currentWebsite.id,
             forcedURL: url,

--- a/addons/website/static/tests/tours/create_missing_page.js
+++ b/addons/website/static/tests/tours/create_missing_page.js
@@ -39,9 +39,9 @@ registerWebsitePreviewTour(
                 ".modal-dialog .o_website_dialog main div.position-relative:not(.o_page_not_found)",
         },
         {
-            content: "Edit the 'url' input again",
+            content: "Edit the 'url' input again (with a character that will be ignored at creation)",
             trigger: ".modal-dialog .o_website_dialog input:eq(1)",
-            run: "edit zoe-s-diner",
+            run: "edit zoe-s-di,ner",
         },
         {
             content: "Check that the page is not found.",


### PR DESCRIPTION
The "Create Page" button was added in edit menu dialog in commit 990b7c045bf27280c64433510d6e43fba5b3a4b0.

The button creates a page using the link in the menu for the url of the page, but the actual page creation may use a different url (as it slugifies it).

This commit uses the url returned by the server on page creation to update the url of the menu, and correctly redirect to the new page.

Steps to reproduce:
- In edit menu > menu item, create a menu with url `/abc,xyz`
- In edit menu, click "Create Page"
- The page is created with a url that is slugified
- Bug: but the menu does not use the slugified new url, and the url to which we redirect is not that one either

task-5895401