### PR TITLE
[FIX] account: UserError in linking of bills at import

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4396,7 +4396,10 @@ class AccountMove(models.Model):
                         if success or file_data['type'] == 'pdf' or file_data['attachment'].mimetype in ALLOWED_MIMETYPES:
                             (invoice.invoice_line_ids - existing_lines).is_imported = True
                             if not extend_with_existing_lines:
-                                invoice.with_context(default_move_type=invoice.move_type)._link_bill_origin_to_purchase_orders(timeout=4)
+                                try:
+                                    invoice.with_context(default_move_type=invoice.move_type)._link_bill_origin_to_purchase_orders(timeout=4)
+                                except (UserError, ValueError):
+                                    _logger.exception("Failed to link bill to purchase order")
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -141,16 +141,19 @@ class AccountEdiProxyClientUser(models.Model):
         })
         if 'is_in_extractable_state' in move._fields:
             move.is_in_extractable_state = False
+        try:
+            move._extend_with_attachments(attachment, new=True)
+            move._message_log(
+                body=_(
+                    "Peppol document (UUID: %(uuid)s) has been received successfully",
+                    uuid=uuid,
+                ),
+                attachment_ids=attachment.ids,
+            )
+            move._autopost_bill()
+        except Exception:
+            _logger.exception("Unexpected error occurred during the import of bill with id %s", move.id)
 
-        move._extend_with_attachments(attachment, new=True)
-        move._message_log(
-            body=_(
-                "Peppol document (UUID: %(uuid)s) has been received successfully",
-                uuid=uuid,
-            ),
-            attachment_ids=attachment.ids,
-        )
-        move._autopost_bill()
         attachment.write({'res_model': 'account.move', 'res_id': move.id})
         return True
 


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/commit/71de6902d73bec32f93e3be8f4de4ec89e9dc987

A UserError there can cause duplicates in peppol fetching. It should never block an ack.
We can leave them unlinked
We also do the same for any unexpected error that occurs after we've created the move.

opw-5492092





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
