### PR TITLE
[FIX] hr_attendance : fix wrong reverse link between attendance and o…

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -90,7 +90,7 @@ class HrAttendanceOvertimeLine(models.Model):
 
     def _linked_attendances(self):
         return self.env['hr.attendance'].search([
-            ('date', 'in', self.mapped('date')),
+            ('check_in', 'in', self.mapped('time_start')),
             ('employee_id', 'in', self.employee_id.ids),
         ])
 

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1202,3 +1202,20 @@ class TestHrAttendanceOvertime(HttpCase):
 
         for a, e in zip(actual, expected):
             self.assertAlmostEqual(a, e)
+
+    def test_check_linked_overtime_to_attendance(self):
+        morning_att, afternoon_att = self.env['hr.attendance'].create([{
+            'employee_id': self.employee.id,
+            'check_in': datetime(2023, 1, 4, 7, 0),
+            'check_out': datetime(2023, 1, 4, 11, 0)
+        }, {
+            'employee_id': self.employee.id,
+            'check_in': datetime(2023, 1, 4, 12, 0),
+            'check_out': datetime(2023, 1, 4, 19, 30)
+        }])
+        overtime_lines = (morning_att + afternoon_att).linked_overtime_ids
+        self.assertFalse(morning_att.linked_overtime_ids)
+        # The overtime line is linked to the afternoon attendance
+        self.assertTrue(afternoon_att.linked_overtime_ids)
+        # Should be the same as it's the reverse checking
+        self.assertEqual(overtime_lines._linked_attendances(), afternoon_att)


### PR DESCRIPTION
…vertime

STEP TO REPRODUCE: (hr_Work_entry need to be installed to be tested fromt he frontend) ------------------
1- Create an overtime rule with this configuration :
    quantity rule differs from hours defined in the contract
2- Create two attendances on the same day (should be a worked day and should not be today)
    one from 1AM-2PM
    second from 2PM-undefined
3- Approve the overtime of the first attendance

REASON:
------

If hr_work_entry is installed a traceback will be raised because the link between overtime to attendance is not correctly done Attendance -> overtime (only the first attendance have a link with overtime) overtime, attendance -> the two will be returned

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
