### PR TITLE
[FIX] website_sale: prevent error when opening shop when variants are deleted

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -454,9 +454,12 @@ class WebsiteSale(payment_portal.PaymentPortal):
         products.fetch()
 
         # map each product to its variant, and prefetch the variants
-        variants = request.env['product.product'].sudo().browse(product._get_first_possible_variant_id() for product in products)
+        Product = request.env['product.product']
+        product_variant_ids = [product._get_first_possible_variant_id() for product in products]
+        variants = Product.sudo().browse(vid for vid in product_variant_ids if vid)
         variants.fetch()
-        product_variants = dict(zip(products, variants))
+        variant_by_id = {v.id: v for v in variants}
+        product_variants = dict(zip(products, (variant_by_id.get(vid, Product) for vid in product_variant_ids)))
 
         ProductAttribute = request.env['product.attribute']
         if products:

--- a/addons/website_sale/tests/test_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_product_attribute_value_config.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.fields import Command
-from odoo.tests import tagged
+from odoo.tests import HttpCase, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.product.tests.test_product_attribute_value_config import (
@@ -11,7 +11,7 @@ from odoo.addons.website_sale.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install', 'product_attribute')
-class TestWebsiteSaleProductAttributeValueConfig(AccountTestInvoicingCommon, TestProductAttributeValueCommon):
+class TestWebsiteSaleProductAttributeValueConfig(AccountTestInvoicingCommon, HttpCase, TestProductAttributeValueCommon):
 
     @classmethod
     def setUpClass(cls):
@@ -175,3 +175,5 @@ class TestWebsiteSaleProductAttributeValueConfig(AccountTestInvoicingCommon, Tes
         product_template.product_variant_ids.unlink()
         previewed_attribute_values = product_template._get_previewed_attribute_values()
         self.assertFalse(previewed_attribute_values)
+        response = self.url_open('/shop')
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
When all variants of a product template are deleted, opening the Shop page on the website raises a traceback.

Steps to reproduce the error:
- Install ``website_sale`` module
- Go to settings > Enable variants
- Create a product template > In Attributes & Variants Tab > add one attribute with two values > Save
- Click on the variants smart button > select all > delete
- Go to Website > Shop

Traceback:
```py
AssertionError: Invalid falsy real id
```

https://github.com/odoo/odoo/blob/b6598c11a3580cfc6ff1ffeb67b0d388c55383d1/addons/website_sale/controllers/main.py#L456 After [commit](https://github.com/odoo/odoo/commit/4290724a4c8c57fba4f4d3d688d38f65dadcc38f), falsy IDs are no longer allowed in ``browse()``.
When all variants of a product template are deleted, ``product._get_first_possible_variant_id()`` returns False.
This falsy value is later passed to ``browse()``,
which triggers the above traceback.

[1]: https://github.com/odoo/odoo/commit/4290724a4c8c57fba4f4d3d688d38f65dadcc38f

sentry-7201563878

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
