### PR TITLE
[FIX] hr,hr_attendance: company-specific attendance setting and reliable module installation

### DIFF
--- a/addons/hr/models/res_company.py
+++ b/addons/hr/models/res_company.py
@@ -12,6 +12,10 @@ class ResCompany(models.Model):
     hr_presence_control_login = fields.Boolean(string="Based on user status in system", default=True)
     hr_presence_control_email = fields.Boolean(string="Based on number of emails sent")
     hr_presence_control_ip = fields.Boolean(string="Based on IP Address")
-    hr_presence_control_attendance = fields.Boolean(string="Based on attendances")
+    hr_presence_control_attendance = fields.Boolean(string="Based on attendances", default=lambda self: self._default_hr_presence_control_attendance())
     contract_expiration_notice_period = fields.Integer("Contract Expiry Notice Period", default=7)
     work_permit_expiration_notice_period = fields.Integer("Work Permit Expiry Notice Period", default=60)
+
+    def _default_hr_presence_control_attendance(self):
+        module = self.env['ir.module.module'].sudo().search([('name', '=', 'hr_attendance'), ('state', '=', 'installed')], limit=1)
+        return bool(module)

--- a/addons/hr/models/res_config_settings.py
+++ b/addons/hr/models/res_config_settings.py
@@ -13,8 +13,15 @@ class ResConfigSettings(models.TransientModel):
     hr_presence_control_login = fields.Boolean(related='company_id.hr_presence_control_login', readonly=False)
     hr_presence_control_email = fields.Boolean(related='company_id.hr_presence_control_email', readonly=False)
     hr_presence_control_ip = fields.Boolean(related='company_id.hr_presence_control_ip', readonly=False)
-    module_hr_attendance = fields.Boolean(related='company_id.hr_presence_control_attendance', readonly=False)
+    hr_presence_control_attendance = fields.Boolean(related='company_id.hr_presence_control_attendance', readonly=False)
     hr_presence_control_email_amount = fields.Integer(related="company_id.hr_presence_control_email_amount", readonly=False)
     hr_presence_control_ip_list = fields.Char(related="company_id.hr_presence_control_ip_list", readonly=False)
     contract_expiration_notice_period = fields.Integer(string="Contract Expiry Notice Period", related='company_id.contract_expiration_notice_period', readonly=False)
     work_permit_expiration_notice_period = fields.Integer(string="Work Permit Expiry Notice Period", related='company_id.work_permit_expiration_notice_period', readonly=False)
+
+    def set_values(self):
+        super().set_values()
+        if self.hr_presence_control_attendance:
+            attendance_module = self.env['ir.module.module'].sudo().search([('name', '=', 'hr_attendance'), ('state', '!=', 'installed')], limit=1)
+            if attendance_module:
+                attendance_module.button_immediate_install()

--- a/addons/hr/views/res_config_settings_views.xml
+++ b/addons/hr/views/res_config_settings_views.xml
@@ -12,8 +12,8 @@
                         <setting id="presence_control_setting" title="Presence of employees" string="Presence Display">
                             <div class="content-group" name="hr_presence_options">
                                 <div class="d-flex">
-                                    <field name="module_hr_attendance" class="ml16"/>
-                                    <label for="module_hr_attendance" class="o_light_label"/>
+                                    <field name="hr_presence_control_attendance" class="ml16"/>
+                                    <label for="hr_presence_control_attendance" class="o_light_label"/>
                                 </div>
                                 <div class="d-flex">
                                     <field name="hr_presence_control_login" class="ml16"/>

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -101,6 +101,7 @@ class ResCompany(models.Model):
                 company.hr_presence_control_attendance = True
             if not at_install and company.hr_presence_control_attendance:
                 company.hr_presence_control_login = True
+                company.hr_presence_control_attendance = False
 
     def _action_open_kiosk_mode(self):
         return {


### PR DESCRIPTION

 Steps to reproduce
1. Install hr_attendance and create employees in a company (e.g., US). The attendance pill appears as expected.Go to Employees > Configuration > Settings: 'Employees' and you will find 'Based on attendance' checked
2. Install l10n_be_hr_payroll, switch to the Belgian company, and create employees. The attendance pill is missing, even if 'Based on attendance' is checked in settings.

 Bug cause
- The field `module_hr_attendance` was used to control the attendance setting, but it only indicates if the hr_attendance module is installed, not the per-company setting.
- `hr_presence_control_attendance` is company-dependent, but `module_hr_attendance` is global. This caused the UI to show the setting as enabled in all companies if the module was installed, regardless of the actual per-company setting.
- The previous workaround set `hr_presence_control_attendance` to True for all companies at module install, but this fails if localizations (and thus new companies) are added after hr_attendance is installed.
 
 Solution
- The settings UI now displays and controls `hr_presence_control_attendance`, which is company-specific, instead of `module_hr_attendance`.
- In the uninstall hook, when hr_attendance is uninstalled, `hr_presence_control_attendance` is set to False for all companies.
- Override the write method in setting to check if `hr_presence_control_attendance` checked then install attendance module if doesn't installed

This ensures the attendance pill and settings are correctly shown per company, regardless of when localizations or companies are added.

Task Id: 5125126
