### PR TITLE
[FIX] mail: handle x2many for inherits inverse delete cascade

### DIFF
--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -328,9 +328,16 @@ export class Record {
         return store.MAKE_UPDATE(function recordDelete() {
             // delete records inheriting the current record before deleting the current record
             for (const fieldName of record.Model._.inheritsInverseFields) {
-                const dependentRecordProxy = record._proxyInternal[fieldName];
-                if (dependentRecordProxy) {
-                    store._.ADD_QUEUE("delete", toRaw(dependentRecordProxy)._raw);
+                if (record.Model._.fieldsMany.get(fieldName)) {
+                    const dependentRecordListProxy = record._proxyInternal[fieldName];
+                    for (const dependentRecordProxy of dependentRecordListProxy) {
+                        store._.ADD_QUEUE("delete", toRaw(dependentRecordProxy)._raw);
+                    }
+                } else {
+                    const dependentRecordProxy = record._proxyInternal[fieldName];
+                    if (dependentRecordProxy) {
+                        store._.ADD_QUEUE("delete", toRaw(dependentRecordProxy)._raw);
+                    }
                 }
             }
             store._.ADD_QUEUE("delete", record);


### PR DESCRIPTION
Usually (always?) the "inverse" for an inherited field will be a one2many. Even if in practice it is a one2one.

The cascade deletion of the inverse should thus handle RecordList instead of assuming they're always single records.

related: 478647c4526f42a2455a599555748c844a6f20cf

task-5013894