### PR TITLE
[FIX] mass_mailing: handle reviews wall crash

### DIFF
--- a/addons/mass_mailing/static/src/builder/plugins/reviews_wall_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/reviews_wall_option_plugin.js
@@ -1,4 +1,5 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
 import { LayoutColumnOption } from "@html_builder/plugins/layout_column_option";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
@@ -6,6 +7,7 @@ import { registry } from "@web/core/registry";
 export class CustomerTestimonialsBlockquote extends BaseOptionComponent {
     static template = "mass_mailing.CustomerTestimonialsBlockquote";
     static selector = ".s_reviews_wall .s_mail_blockquote";
+    static components = { BorderConfigurator };
 }
 
 export class MassMailingLayoutColumnOption extends LayoutColumnOption {


### PR DESCRIPTION
This commit fixes an issue with the s_reviews_wall snippet which makes the builder crash if it selected.

The issue was that the BorderConfigurator used on the option's template wasn't specified in the option's components. Leading to a crash that renders the builder inoperable.

task-5380467

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
