### PR TITLE
[IMP] point_of_sale: introduce local printer support

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -44,7 +44,7 @@ export class Navbar extends Component {
         this.notification = useService("notification");
         this.hardwareProxy = useService("hardware_proxy");
         this.dialog = useService("dialog");
-        this.isDisplayStandalone = isDisplayStandalone();
+        this.isDisplayStandalone = isDisplayStandalone() || Boolean(window.OdooNativeApp);
         this.isBarcodeScannerSupported = isBarcodeScannerSupported;
         this.timeout = null;
         this.bufferedInput = "";

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -49,6 +49,7 @@ import { EpsonPrinter } from "@point_of_sale/app/utils/printer/epson_printer";
 import OrderPaymentValidation from "../utils/order_payment_validation";
 import { logPosMessage } from "../utils/pretty_console_log";
 import { initLNA } from "../utils/init_lna";
+import { OdooLocalPrinter } from "@point_of_sale/app/utils/printer/local_printer";
 
 const { DateTime } = luxon;
 export const CONSOLE_COLOR = "#F5B427";
@@ -711,6 +712,8 @@ export class PosStore extends WithLazyGetterTrap {
 
         if (this.config.other_devices && this.config.epson_printer_ip) {
             this.hardwareProxy.printer = new EpsonPrinter({ ip: this.config.epson_printer_ip });
+        } else if (window.OdooNativeApp) {
+            this.hardwareProxy.printer = new OdooLocalPrinter();
         }
     }
 

--- a/addons/point_of_sale/static/src/app/utils/printer/local_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/local_printer.js
@@ -1,0 +1,78 @@
+import { _t } from "@web/core/l10n/translation";
+import { BasePrinter } from "@point_of_sale/app/utils/printer/base_printer";
+
+const ERROR_MESSAGES = {
+    PRINTER_NOT_FOUND: {
+        title: _t("Printer Not Found"),
+        body: _t("No printer is detected. Please check the printer connection and try again."),
+    },
+    CONNECTION_FAILED: {
+        title: _t("Connection Failed"),
+        body: _t(
+            "Unable to connect to the printer. Please check the printer connection and try again."
+        ),
+    },
+    PRINT_FAILED: {
+        title: _t("Printing Failed"),
+        body: _t("Failed to print. Please check the printer connection and try again."),
+    },
+};
+
+export class OdooLocalPrinter extends BasePrinter {
+    async setup() {
+        super.setup(...arguments);
+        this.odooNativeApp = window.OdooNativeApp;
+    }
+
+    async openCashbox() {
+        return this._sendPrintingJob("", true);
+    }
+
+    async sendPrintingJob(printData) {
+        return this._sendPrintingJob(printData);
+    }
+
+    async _sendPrintingJob(printData = "", openCashBox) {
+        try {
+            const response = await this.odooNativeApp.printReceipt({
+                receipt: printData,
+                cash_drawer: openCashBox,
+            });
+            if (response.status === true) {
+                return {
+                    result: true,
+                    canRetry: false,
+                };
+            } else {
+                return this._getErrorResult(response.error_code, "PRINT_FAILED");
+            }
+        } catch {
+            return this._getErrorResult();
+        }
+    }
+
+    _getErrorResult(errorCode, defaultCode = "CONNECTION_FAILED") {
+        const message = ERROR_MESSAGES[errorCode] || ERROR_MESSAGES[defaultCode];
+        return {
+            result: false,
+            errorCode,
+            canRetry: true,
+            message: {
+                title: message.title,
+                body: message.body,
+            },
+        };
+    }
+
+    getActionError() {
+        const actionError = super.getResultsError();
+        actionError.message.body = _t(
+            "Please make sure the printer is turned on and properly connected, then try again."
+        );
+        return actionError;
+    }
+
+    getResultsError(printResult) {
+        return printResult || this._getErrorResult();
+    }
+}


### PR DESCRIPTION
### In this commit:
Expand POS printing capabilities so that the user can detect and use a local USB printer (via `window.OdooNativeApp`) without requiring any network printer or IoT Box setup. This allows users to rely solely on a directly connected USB printer for receipt printing.
- Extend `PosStore` to instantiate a new `OdooLocalPrinter` when `window.OdooNativeApp` is available.
- Introduce a `OdooLocalPrinter` class that calls `window.OdooNativeApp.printReceipt` to print receipts using an available local USB printer.

Task:5368831