### PR TITLE
[FIX] html_editor: fix image size getting reduced

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_transform_option_plugin.js
@@ -26,7 +26,6 @@ class TransformImageAction extends BuilderAction {
         params: { isImageTransformationOpen, closeImageTransformation },
     }) {
         if (!isImageTransformationOpen()) {
-            let changed = false;
             const deferredTillMounted = new Deferred();
             registry.category("main_components").add("ImageTransformation", {
                 Component: ImageTransformation,
@@ -35,14 +34,8 @@ class TransformImageAction extends BuilderAction {
                     document: this.document,
                     editable: this.editable,
                     destroy: () => closeImageTransformation(),
-                    onChange: () => {
-                        changed = true;
-                    },
                     onApply: () => {
-                        if (changed) {
-                            changed = false;
-                            this.dependencies.history.addStep();
-                        }
+                        this.dependencies.history.addStep();
                     },
                     onComponentMounted: () => {
                         deferredTillMounted.resolve();

--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -38,7 +38,7 @@ export class ImageTransformation extends Component {
         editable: { validate: (p) => p.nodeType === Node.ELEMENT_NODE },
         image: { validate: (p) => p.tagName === "IMG" },
         destroy: { type: Function },
-        onChange: { type: Function },
+        onChange: { type: Function, optional: true },
         onApply: { type: Function, optional: true },
         onComponentMounted: { type: Function, optional: true },
     };
@@ -239,7 +239,7 @@ export class ImageTransformation extends Component {
         }
         this.transfo.active = null;
         this.props.onApply?.();
-        this.props.onChange();
+        this.props.onChange?.();
     }
 
     mouseDown(ev) {

--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -215,14 +215,29 @@ export class ImageTransformation extends Component {
             this.image.parentElement,
             (node) => node.offsetWidth > currentPixelWidth
         );
-        const widthPercent = (currentPixelWidth / container.offsetWidth) * 100;
+        const containerStyles = window.getComputedStyle(container);
+        const widthPercent =
+            (currentPixelWidth /
+                (container.offsetWidth -
+                    parseFloat(containerStyles.paddingLeft) -
+                    parseFloat(containerStyles.paddingRight) -
+                    parseFloat(containerStyles.borderLeftWidth) -
+                    parseFloat(containerStyles.borderRightWidth))) *
+            100;
         this.image.style.width = Math.min(100, widthPercent).toFixed(2) + "%";
     }
 
     mouseUp() {
+        if (!this.transfo.active) {
+            return;
+        }
         this.isCurrentlyTransforming = false;
+        // Width should be converted to percentage only
+        // when image dimension is changed. See `mouseMove`.
+        if (this.transfo.active.type.length === 2) {
+            this.convertPixelWidthToPercentage();
+        }
         this.transfo.active = null;
-        this.convertPixelWidthToPercentage();
         this.props.onApply?.();
         this.props.onChange();
     }


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- In website, drag and drop a `text - image` snippet.
- Click on image, click on Transform button.
- Try to rotate the image.
- You will notice that the size of the image is reduced a bit.

This issue happens because in `image_transformation.js`, `convertPixelWidthToPercentage` converts image width from `px` to percentage. In this case image's parentElement has padding, causing reduction in image's size.

**Desired behavior after PR is merged:**

This PR ensures that `paddingLeft` and `paddingRight` of image's parentElement is ignored from calculation so that image size doesn't get changed.

task-5884679



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
