### PR TITLE
[18.0][FIX] purchase: Avoid singleton error on account.move~purchase_order_name

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -131,7 +131,7 @@ class AccountMove(models.Model):
     def _compute_purchase_order_name(self):
         for move in self:
             if move.purchase_order_count == 1:
-                move.purchase_order_name = move.invoice_line_ids.purchase_order_id.display_name
+                move.purchase_order_name = move.line_ids.purchase_line_id.order_id.display_name
             else:
                 move.purchase_order_name = False
 


### PR DESCRIPTION
Steps to reproduce the problem:

- Have 2 POs of the same vendor to bill.
- Create a bill for that vendor.
- Add the first PO with the autocomplete dropdown.
- When adding the second PO with the autocomplete, you get this traceback:

  ```
  Traceback (most recent call last):
  ...
  File "...addons/account/models/account_move.py", line 3557, in onchange
    return super().onchange(values, field_names, fields_spec)
  File "...addons/web/models/models.py", line 1012, in onchange
    todo = [
  ...
  File "...odoo/odoo/fields.py", line 110, in determine
    return needle(*args)
  File "...addons/purchase/models/account_invoice.py", line 134, in _compute_purchase_order_name
    move.purchase_order_name = move.invoice_line_ids.purchase_order_id.display_name
  File "...odoo/odoo/fields.py", line 1240, in __get__
    record.ensure_one()
  File "...odoo/odoo/models.py", line 6272, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
  ValueError: Expected singleton: purchase.order(87854, 87217)
  ```

This is not directly reproducible in runboat, as the module stack doesn't really uncover the problem, that comes due to the duality line_ids/invoice_line_ids existing in account.move, and the hackish nature of them.

It's also not congruent to use one field (`line_ids`) to compute the field `purchase_order_count`, and another (`invoice_line_ids`) for computing `purchase_order_name`, so let's unify it and laterally avoid this bogus problem.

@Tecnativa TT60634