### PR TITLE
[FIX] html_builder, *: fix pill shape

### DIFF
--- a/addons/html_builder/static/image_shapes/geometric_round/geo_round_pill.svg
+++ b/addons/html_builder/static/image_shapes/geometric_round/geo_round_pill.svg
@@ -1,9 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="600" data-aspect-ratio-crop="true">
     <defs>
         <clipPath id="clip-path" clipPathUnits="objectBoundingBox">
             <use xlink:href="#filterPath" fill="none"/>
         </clipPath>
-        <path id="filterPath" d="M 0.5 0 A 0.25 0.25 90 0 0 0.25 0.25 L 0.25 0.75 A 0.25 0.25 90 0 0 0.5 1 L 0.5 1 A 0.25 0.25 90 0 0 0.75 0.75 L 0.75 0.25 A 0.25 0.25 90 0 0 0.5 0 Z">
+        <path id="filterPath" d="M 0.5 0 A 0.5 0.25 0 0 0 0 0.25 L 0 0.75 A 0.5 0.25 0 0 0 0.5 1 L 0.5 1 A 0.5 0.25 0 0 0 1 0.75 L 1 0.25 A 0.5 0.25 0 0 0 0.5 0 Z">
         </path>
     </defs>
     <svg viewBox="0 0 1 1" id="preview" preserveAspectRatio="none">

--- a/addons/html_builder/static/src/plugins/image/image_shapes_definition.js
+++ b/addons/html_builder/static/src/plugins/image/image_shapes_definition.js
@@ -187,6 +187,7 @@ export const imageShapeDefinitions = {
                     "html_builder/geometric_round/geo_round_pill": {
                         selectLabel: _t("Pill (R)"),
                         togglableRatio: true,
+                        aspectRatio: "1/2",
                     },
                     "html_builder/geometric_round/geo_round_gem": {
                         selectLabel: _t("Gem (R)"),

--- a/addons/website/static/tests/builder/image_test_helpers.js
+++ b/addons/website/static/tests/builder/image_test_helpers.js
@@ -2,7 +2,7 @@ import { before, globals } from "@odoo/hoot";
 import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { ImagePositionOverlay } from "@html_builder/plugins/image/image_position_overlay";
 
-function onRpcReal(route) {
+export function onRpcReal(route) {
     onRpc(route, () => globals.fetch.call(window, route));
 }
 

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -162,3 +162,13 @@ class TestSnippets(HttpCase):
 
     def test_shape_image_snippet(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_shape_image', login='admin')
+
+    def test_snippet_pill_shape(self):
+        res = self.url_open('/html_editor/image_shape/website.s_intro_pill_default_image/html_builder/geometric_round/geo_round_pill.svg')
+        svg = html.fromstring(res.text)
+        self.assertEqual(float(svg.attrib['width']), 439, "SVG should have the width of the original image")
+        self.assertEqual(float(svg.attrib['height']), 878, "SVG height should be double the width because the pill shape has a default aspect ratio of 1/2")
+        image_elem = svg.find('.//image')
+        self.assertEqual(image_elem.attrib['width'], '100%')
+        self.assertEqual(image_elem.attrib['height'], '100%')
+        self.assertEqual(image_elem.attrib['preserveaspectratio'], 'xMidYMid slice')

--- a/addons/website/views/snippets/s_intro_pill.xml
+++ b/addons/website/views/snippets/s_intro_pill.xml
@@ -5,9 +5,9 @@
     <section class="s_intro_pill pt40 pb40">
         <div class="container-fluid">
             <div class="row o_grid_mode" data-row-count="11">
-                <div class="o_grid_item oe_img_bg o_grid_item_image g-col-lg-5 g-height-9 col-lg-5 order-lg-0" style="order: 2; z-index: 1; grid-area: 1 / 1 / 10 / 6; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                <div class="o_grid_item oe_img_bg o_grid_item_image g-col-lg-3 g-height-9 col-lg-3 order-lg-0" style="order: 2; z-index: 1; grid-area: 1 / 2 / 10 / 5; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
                     <img class="img-fluid mx-auto" data-shape="html_builder/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image.jpg"
-                    data-format-mimetype="image/jpeg" src="/html_editor/image_shape/website.s_intro_pill_default_image/html_builder/geometric_round/geo_round_pill.svg" alt=""/>
+                    data-format-mimetype="image/jpeg" data-aspect-ratio="1/2" src="/html_editor/image_shape/website.s_intro_pill_default_image/html_builder/geometric_round/geo_round_pill.svg" alt=""/>
                 </div>
                 <div class="o_grid_item g-height-11 g-col-lg-4 col-lg-4 order-lg-0" data-name="Box" style="order: 1; z-index: 3; grid-area: 1 / 5 / 12 / 9; --grid-item-padding-y: 120px;">
                     <h1 class="display-3" style="text-align: center;">Discover our<br/>services</h1>
@@ -18,8 +18,8 @@
                         <a t-att-href="cta_btn_href" class="btn btn-lg btn-primary o_translate_inline">Get Started</a>
                     </p>
                 </div>
-                <div class="o_grid_item o_grid_item_image g-col-lg-5 g-height-10 d-none d-lg-block col-lg-5 order-lg-0" style="order: 3; z-index: 2; grid-area: 2 / 8 / 12 / 13; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
-                    <img class="img-fluid mx-auto" data-shape="html_builder/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image_2.webp" data-format-mimetype="image/webp" src="/html_editor/image_shape/website.s_intro_pill_default_image_2/html_builder/geometric_round/geo_round_pill.svg" alt=""/>
+                <div class="o_grid_item o_grid_item_image g-col-lg-3 g-height-10 d-none d-lg-block col-lg-3 order-lg-0" style="order: 3; z-index: 2; grid-area: 2 / 9 / 12 / 12; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px;">
+                    <img class="img-fluid mx-auto" data-shape="html_builder/geometric_round/geo_round_pill" data-file-name="s_intro_pill_default_image_2.webp" data-format-mimetype="image/webp" data-aspect-ratio="1/2" src="/html_editor/image_shape/website.s_intro_pill_default_image_2/html_builder/geometric_round/geo_round_pill.svg" alt=""/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
*: website, html_editor

__Before this commit__
The pill shape is the only stretchable shape that does not fit a square.
This means it behaves differently from other shapes, resulting in
unexpected behavior when resizing an image using the builder overlay.

__Steps to reproduce__
- Open the website builder.
- Drop an `s_intro_pill` snippet.
- Click on an image; the overlay displays excessive, unnecessary margins
  that overlap the center text.
- Attempt to resize the image width; the pill resizes prematurely
  because of its internal horizontal margins.

__Fix__
- Remove the margins from the pill shape.
- Add some attributes to the image element of the svg for the default
  snippet shaped images. This way the image is cropped directly inside
  the svg created in the `/html_editor/image_shape/...` controller.
- Add `aspectRatio` key to the pill shape definition to keep its aspect
  ratio when not stretched.
- Ensure the shape default aspect ratio is not kept when changing shape.

task-5914518