### PR TITLE
[IMP] mrp: display and track end date on done MO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1024,7 +1024,17 @@ class MrpProduction(models.Model):
         if vals.get('state') == 'progress' and 'date_start' not in vals:
             vals['date_start'] = fields.Datetime.now()
 
+        initial_date_finished_mo_values = {}
+        if 'date_finished' in vals and 'state' not in vals:
+            date_finished_field_definition = self.fields_get(['date_finished'])
+            for production in self.filtered(lambda p: p.state == 'done'):
+                initial_date_finished_mo_values[production] = {'date_finished': production.date_finished}
+
         res = super(MrpProduction, self).write(vals)
+
+        for production, initial_value in initial_date_finished_mo_values.items():
+            if tracking_values := production._mail_track(date_finished_field_definition, initial_value)[1]:
+                production._message_log(tracking_value_ids=tracking_values)
 
         for production in self:
             if 'date_start' in vals and not self.env.context.get('force_date', False):

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -245,7 +245,6 @@
                 </header>
                 <sheet>
                     <field name="reservation_state" invisible="1"/>
-                    <field name="date_finished" invisible="1"/>
                     <field name="is_locked" invisible="1"/>
                     <field name="qty_produced" invisible="1"/>
                     <field name="unreserve_visible" invisible="1"/>
@@ -390,6 +389,7 @@
                                 <field name="delay_alert_date" invisible="1"/>
                                 <field nolabel="1" name="json_popover" widget="stock_rescheduling_popover" invisible="not json_popover"/>
                             </div>
+                            <field name="date_finished" string="End Date" readonly="is_locked" invisible="state != 'done'" help="Date at which you finished production."/>
                             <field name="components_availability_state" invisible="1"/>
                             <field name="components_availability" invisible="state not in ['confirmed', 'progress']"
                                 decoration-success="reservation_state == 'assigned' or components_availability_state == 'available'"


### PR DESCRIPTION
For traceability purposes, users need to know when a specific manufacturing
order was completed. In addition, exposing the manufacturing order end date can
support inventory backdating use cases, where the effective completion date of a
production order matters, helping users better understand and rely on the
recorded completion timestamp during operational reviews.

This change displays the manufacturing order end date on the production form
once the order is completed, while keeping it hidden during earlier stages. Any
modification to the end date after the MO is marked as done is logged in the
chatter to maintain a complete audit trail.

Task - 5490220