### PR TITLE
[IMP] point_of_sale,pos_loyalty: ticket backend follow-up

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -15,13 +15,13 @@ _logger = logging.getLogger(__name__)
 
 class PosController(PortalAccount):
 
-    @http.route('/pos/receipt/<order_id>', type='http', auth='user', sitemap=False, website=True)
-    def pos_receipt_download(self, order_id=None):
-        pos_order = request.env['pos.order'].browse(int(order_id))
+    @http.route('/pos/receipt/<order_id>', type='http', auth='user')
+    def pos_receipt_download(self, order_id=None, company_id=None):
+        pos_order = request.env['pos.order'].with_company(company_id).browse(int(order_id))
         if not pos_order.exists():
             return request.not_found()
 
-        image = pos_order.with_company(pos_order.company_id).sudo().order_receipt_generate_image()
+        image = pos_order.order_receipt_generate_image()
         return request.make_response(image, [
             ('Content-Type', 'image/png'),
             ('Content-Length', len(image)),

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -525,7 +525,7 @@ class PosOrder(models.Model):
     def _get_order_tax_totals(self):
         self.ensure_one()
         self.amount_paid = sum(payment.amount for payment in self.payment_ids)
-        self.amount_return = -sum((payment.amount < 0 and payment.amount) or 0 for payment in self.payment_ids)
+        self.amount_return = -sum(payment.amount for payment in self.payment_ids if payment.amount < 0 and not self.is_refund)
         base_lines = self.lines._prepare_tax_base_line_values()
         self.env['account.tax']._add_tax_details_in_base_lines(base_lines, self.company_id)
         self.env['account.tax']._round_base_lines_tax_details(base_lines, self.company_id)

--- a/addons/point_of_sale/receipt/pos_order_receipt.py
+++ b/addons/point_of_sale/receipt/pos_order_receipt.py
@@ -35,21 +35,22 @@ class PosOrderReceipt(models.AbstractModel):
         return self.currency_id.format(amount).replace('\xa0', ' ')  # Wkhtmltoimage does not support non-breaking spaces
 
     def _order_receipt_generate_taxe_data(self):
+        sign = -1 if self.is_refund else 1
         tax_totals = self._get_order_tax_totals()  # Use account helpers to compute tax totals
-        discount_amount = sum(line._get_discount_amount() for line in self.lines)
+        discount_amount = sum(line._get_discount_amount() for line in self.lines.filtered(lambda l: l.discount > 0))
         rounding = tax_totals.get('cash_rounding_base_amount_currency', 0)
 
         return {
             'same_tax_base': tax_totals['same_tax_base'],
             'discount_amount': self._order_receipt_format_currency(-abs(discount_amount)) if discount_amount else False,
-            'rounding_amount': self._order_receipt_format_currency(rounding) if rounding else False,
-            'tax_amount': self._order_receipt_format_currency(tax_totals['tax_amount_currency']),
-            'total_amount': self._order_receipt_format_currency(tax_totals['total_amount_currency']),
-            'subtotal_amount': self._order_receipt_format_currency(tax_totals['base_amount_currency']),
+            'rounding_amount': self._order_receipt_format_currency(sign * rounding) if rounding else False,
+            'tax_amount': self._order_receipt_format_currency(sign * tax_totals['tax_amount_currency']),
+            'total_amount': self._order_receipt_format_currency(sign * tax_totals['total_amount_currency']),
+            'subtotal_amount': self._order_receipt_format_currency(sign * tax_totals['base_amount_currency']),
             'taxes': [{
                 'name': tax['group_name'],
-                'amount': self._order_receipt_format_currency(tax['tax_amount']),
-                'amount_base': self._order_receipt_format_currency(tax['base_amount_currency']),
+                'amount': self._order_receipt_format_currency(sign * tax['tax_amount']),
+                'amount_base': self._order_receipt_format_currency(sign * tax['base_amount_currency']),
             } for tax in tax_totals['subtotals'][0]['tax_groups']] if len(tax_totals['subtotals']) > 0 else [],
         }
 
@@ -78,7 +79,12 @@ class PosOrderReceipt(models.AbstractModel):
 
             data['qty'] = int(line.qty) if float(line.qty).is_integer() else line.qty
             data['product_data'] = product_by_id[data['product_id']]
-            data['lot_names'] = line.pack_lot_ids.mapped('lot_name') if line.pack_lot_ids else False
+
+            data['lot_names'] = False
+            if line.pack_lot_ids:
+                lot_label = _("Lot") if line.product_id.tracking == "lot" else _("SN")
+                data['lot_names'] = ["%s %s" % (lot_label, lot.lot_name) for lot in line.pack_lot_ids]
+
             data['product_uom_name'] = line.product_id.uom_id.name
             data['price_subtotal_incl'] = self._order_receipt_format_currency(data['price_subtotal_incl'])
 

--- a/addons/point_of_sale/receipt/pos_order_receipt.xml
+++ b/addons/point_of_sale/receipt/pos_order_receipt.xml
@@ -18,8 +18,8 @@
                             </table>
                         </div>
                     </div>
-                    <div class="w-100 text-large mb-3" name="prices" t-if="not conditions['basic_receipt']">
-                        <table class="w-100">
+                    <div class="w-100 mb-3" name="prices" t-if="not conditions['basic_receipt']">
+                        <table class="w-100 text-large">
                             <tbody>
                                 <tr>
                                     <td class="text-start w-70" name="subtotal">Subtotal:</td>
@@ -76,7 +76,7 @@
                                         <img class="invoice-qr-code" t-att-src="image['invoice_qr_code']" />
                                     </td>
                                     <td class="text-start top w-75 ps-1" t-if="conditions['display_url']">
-                                        <p class="text-bold text-normal">Need an invoice?</p>
+                                        <div class="text-bold text-normal">Need an invoice?</div>
                                         <div class="text-small" t-out="extra_data['self_invoicing_url']" />
                                         <div class="text-small">Code: <t t-out="order['ticket_code']"/></div>
                                     </td>
@@ -113,7 +113,7 @@
 
         <template id="point_of_sale.pos_order_receipt_header">
             <div class="w-100 text-center mb-3" name="logo">
-                <img t-if="image['logo']" t-att-src="image['logo']" style="max-height: 75px" />
+                <img t-if="image['logo']" t-att-src="image['logo']" class="w-50" />
             </div>
             <div class="w-100 text-center">
                 <div name="ticket_reference">
@@ -170,7 +170,7 @@
 
         <template id="point_of_sale.pos_orderline_receipt_information">
             <div class="name text-large" t-out="line['product_data']['display_name']" />
-            <span class="text-normal price-unit font-monospace" name="standard-unit-price" t-if="not conditions['basic_receipt'] and not len(line['combo_line_ids'])">
+            <span class="text-small price-unit font-monospace" name="standard-unit-price" t-if="not conditions['basic_receipt'] and not len(line['combo_line_ids'])">
                 <t t-out="line['unit_price']" /> / <t t-out="line['product_uom_name']" />
             </span>
             <div t-if="line['customer_note']" class="text-small">
@@ -178,10 +178,9 @@
                 <span class="line-note" t-out="line['customer_note']" />
             </div>
             <div t-if="line['lot_names']" class="text-small">
-                <strong>Lot number: </strong>
-                <span t-foreach="line['lot_names']" t-as="lot_name">
-                    <t t-out="lot_name" />
-                </span>
+                <ul t-foreach="line['lot_names']" t-as="lot_name" style="list-style: none; padding: 0; margin: 0;">
+                    <li t-out="lot_name" />
+                </ul>
             </div>
             <div name="extra-info" />
         </template>
@@ -189,8 +188,8 @@
         <template id="point_of_sale.pos_order_receipt_footer">
             <div class="w-100 text-center mt-3">
                 <div class="w-100 mt-2" name="footer" />
-                <div class="mt-2 mb-2" t-if="extra_data['formated_shipping_date']">
-                    Expected delivery: <span class="shipping-date" t-out="extra_data['formated_shipping_date']" />
+                <div t-if="extra_data['formated_shipping_date']" class="mt-2 mb-2 w-100 text-start text-small">
+                    <span>Expected delivery:</span> <span class="shipping-date" style="float:right;" t-out="extra_data['formated_shipping_date']"/>
                 </div>
                 <t t-call="point_of_sale.company_info_receipt" />
                 <div t-if="config['receipt_footer']" class="w-100 text-center mt-2 mb-2" t-out="config['receipt_footer']" />

--- a/addons/point_of_sale/receipt/pos_receipt_common.xml
+++ b/addons/point_of_sale/receipt/pos_receipt_common.xml
@@ -6,16 +6,16 @@
                 <tbody name="company_info">
                     <tr>
                         <td class="text-start top w-60" >
-                            <div t-out="config['name']"/>
-                            <div t-out="config['receipt_address']"/>
+                            <div t-if="config.get('name')" t-out="config['name']"/>
+                            <div t-if="config.get('receipt_address')" t-out="config['receipt_address']"/>
                         </td>
 
                         <td class="text-end top w-40" >
-                            <div t-if="config['phone']">
+                            <div t-if="config.get('phone')">
                                 <div>Tel: <t t-out="config['phone']"/></div>
                             </div>
-                            <div t-if="config['email']" t-out="config['email']"/>
-                            <div t-if="config['website']" t-out="config['website']"/>
+                            <div t-if="config.get('email')" t-out="config['email']"/>
+                            <div t-if="config.get('website')" t-out="config['website']"/>
                         </td>
                     </tr>
                     <tr>
@@ -66,6 +66,7 @@
                 #pos-receipt .me-3 { margin-left: 16px !important; }
                 #pos-receipt .me-4 { margin-left: 24px !important; }
                 #pos-receipt .me-5 { margin-left: 32px !important; }
+                #pos-receipt .ms-auto { margin-left: auto !important; }
                 #pos-receipt .ms-1 { margin-right: 4px !important; }
                 #pos-receipt .ms-2 { margin-right: 8px !important; }
                 #pos-receipt .ms-3 { margin-right: 16px !important; }
@@ -118,11 +119,12 @@
                 #pos-receipt .text-break{ word-wrap: break-word !important; word-break: break-word !important; }
                 #pos-receipt .font-monospace  { font-variant-numeric: tabular-nums !important; }
                 #pos-receipt .text-center { text-align: center !important; }
+                #pos-receipt .text-top { vertical-align: top !important; }
                 #pos-receipt .text-start { text-align: left !important; }
                 #pos-receipt .text-end { text-align: right !important; }
                 #pos-receipt .text-small { font-size: 18px !important; line-height: 26px !important; }
-                #pos-receipt .text-normal { font-size: 22px !important; line-height: 32px !important; }
-                #pos-receipt .text-large { font-size: 26px !important; line-height: 38px !important; }
+                #pos-receipt .text-normal { font-size: 20px !important; line-height: 28px !important; }
+                #pos-receipt .text-large { font-size: 22px !important; line-height: 30px !important; }
                 #pos-receipt .text-huge { font-size: 34px !important; line-height: 50px !important; }
                 #pos-receipt .text-insane { font-size: 50px !important; line-height: 74px !important; }
                 #pos-receipt .text-bold { font-weight: bold !important; }

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -458,12 +458,8 @@ export class PosOrderline extends PosOrderlineAccounting {
     }
 
     get packLotLines() {
-        return this.pack_lot_ids.map(
-            (l) =>
-                `${l.pos_order_line_id.product_id.tracking == "lot" ? "Lot Number" : "SN"} ${
-                    l.lot_name
-                }`
-        );
+        const label = this.product_id.tracking === "lot" ? _t("Lot") : _t("SN");
+        return this.pack_lot_ids.map((l) => `${label} ${l.lot_name}`);
     }
 
     getDiscount() {

--- a/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
@@ -192,9 +192,7 @@ export class GeneratePrinterData {
                 unit_price: line.currencyDisplayPriceUnit,
                 product_unit_price: line.product_id.displayPriceUnit,
                 price_subtotal_incl: line.currencyDisplayPrice,
-                lot_names: line.pack_lot_ids?.length
-                    ? line.pack_lot_ids.map((l) => l.lot_name)
-                    : false,
+                lot_names: line.packLotLines,
             };
         });
     }

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -421,7 +421,7 @@ registry.category("web_tour.tours").add("test_combo_price_unchanged_with_lot_tra
                 ...ProductScreen.enterLotNumber("1", "lot"),
                 ...ProductScreen.orderLineHas("Product A", "1.0"),
                 {
-                    trigger: ".info-list:contains('Lot Number 1')",
+                    trigger: ".info-list:contains('Lot 1')",
                 },
             ]),
             ProductScreen.totalAmountIs("8.05"),

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1166,7 +1166,7 @@ registry.category("web_tour.tours").add("test_only_existing_lots", {
             ProductScreen.selectNthLotNumber(1),
             ProductScreen.selectedOrderlineHas("Product with existing lots", "1.0"),
             inLeftSide({
-                trigger: ".order-container .orderline .lot-number:contains('Lot Number 1001')",
+                trigger: ".order-container .orderline .lot-number:contains('Lot 1001')",
             }),
             Chrome.endTour(),
         ].flat(),

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -423,7 +423,7 @@ registry.category("web_tour.tours").add("LotTour", {
             // Check auto assign lot number if there is only one available option
             ProductScreen.clickDisplayedProduct("Product B"),
             inLeftSide({
-                trigger: ".info-list:contains('Lot Number 1001')",
+                trigger: ".info-list:contains('Lot 1001')",
             }),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/feedback_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/feedback_screen_util.js
@@ -367,10 +367,10 @@ export function trackingMethodIsLot(lot) {
     return [
         {
             content: `tracking method is Lot`,
-            trigger: `li.lot-number:contains("Lot Number ${lot}")`,
+            trigger: `li.lot-number:contains("Lot ${lot}")`,
             run: function () {
                 if (document.querySelectorAll("li.lot-number").length !== 1) {
-                    throw new Error(`Expected exactly one 'Lot Number ${lot}' element.`);
+                    throw new Error(`Expected exactly one 'Lot ${lot}' element.`);
                 }
             },
         },

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -146,8 +146,8 @@ class PosOrder(models.Model):
             {
                 'order_id': self.id,
                 'card_id': coupon_id,
-                'spent': -coupon_vals['points'] if coupon_vals['points'] < 0 else 0,
-                'won': coupon_vals['points'] if coupon_vals['points'] > 0 else 0,
+                'spent': coupon_vals.get('spent', 0),
+                'won': coupon_vals.get('won', 0),
             }
             for coupon_id, coupon_vals in coupon_data.items()
         ]
@@ -176,7 +176,7 @@ class PosOrder(models.Model):
                 'program_name': coupon.program_id.name,
                 'expiration_date': coupon.expiration_date,
                 'code': coupon.code,
-                'barcode_base64': 'data:image/png;base64,' + base64.b64encode(self.env['ir.actions.report'].barcode('Code128', coupon.code)).decode('utf-8'),
+                'barcode_base64': 'data:image/png;base64,' + base64.b64encode(self.env['ir.actions.report'].barcode('Code128', coupon.code, quiet=False)).decode('utf-8'),
             } for coupon in new_coupons if (
                 coupon.program_id.applies_on == 'future'
                 # Don't send the coupon code for the gift card and ewallet programs.

--- a/addons/pos_loyalty/receipt/pos_order_receipt.py
+++ b/addons/pos_loyalty/receipt/pos_order_receipt.py
@@ -2,6 +2,7 @@
 import base64
 
 from odoo import models, _
+from odoo.tools import float_round
 
 
 class PosOrderReceipt(models.AbstractModel):
@@ -10,23 +11,35 @@ class PosOrderReceipt(models.AbstractModel):
 
     def order_receipt_generate_data(self, basic_receipt=False):
         data = super().order_receipt_generate_data(basic_receipt)
-        histories = self.env['loyalty.history'].search([
-            ('order_id', '=', self.id),
-            ('order_model', '=', 'pos.order'),
-        ])
+        loyalties, new_coupons = [], []
+        histories = self.env['loyalty.history'].search([('order_id', '=', self.id), ('order_model', '=', 'pos.order')])
+        for history in histories:
+            program_type = history.card_id.program_id.program_type
+            if program_type == 'loyalty':
+                for field, label in [('issued', _('Won:')), ('used', _('Spent:'))]:
+                    amount = history[field]
+                    if amount > 0:
+                        loyalties.append({
+                            'name': history.card_id.program_id.portal_point_name,
+                            'type': label,
+                            'points': float_round(amount, 2),
+                        })
 
-        if len(histories) > 0:
-            issued = [{
-                'name': history.card_id.program_id.name,
-                'type': _('Won:') if history.issued > 0 else _('Spent:'),
-                'points': history.issued or history.used,
-            } for history in histories if history.card_id.program_id.program_type == 'loyalty']
-            new_coupon = [{
-                'name': history.card_id.program_id.name,
-                'type': '',
-                'points': history.card_id.code,
-                'barcode_base64': 'data:image/png;base64,' + base64.b64encode(self.env['ir.actions.report'].barcode('Code128', history.card_id.code)).decode('utf-8'),
-            } for history in histories if history.card_id.program_id.program_type == 'next_order_coupons']
-            data['extra_data']['loyalties'] = issued + new_coupon
+                loyalties.append({
+                    'name': history.card_id.program_id.portal_point_name,
+                    'type': _('Balance:'),
+                    'points': float_round(history.card_id.points, 2),
+                })
+
+            elif program_type == 'next_order_coupons':
+                new_coupons.append({
+                    'name': history.card_id.program_id.name,
+                    'code': history.card_id.code,
+                    'expiration_date': history.card_id.expiration_date,
+                    'barcode_base64': 'data:image/png;base64,' + base64.b64encode(self.env['ir.actions.report'].barcode('Code128', history.card_id.code, quiet=False)).decode('utf-8'),
+                })
+
+        data['extra_data']['loyalties'] = loyalties
+        data['extra_data']['new_coupons'] = new_coupons
 
         return data

--- a/addons/pos_loyalty/receipt/pos_order_receipt.xml
+++ b/addons/pos_loyalty/receipt/pos_order_receipt.xml
@@ -4,22 +4,25 @@
         <template id="pos_loyalty.pos_order_receipt" inherit_id="point_of_sale.pos_order_receipt">
             <div name="before-footer" position="before">
                 <table t-if="extra_data.get('loyalties')" class="w-100 mt-2">
-                    <tbody>
-                        <t t-foreach="extra_data['loyalties']" t-as="loyalty">
-                            <tr>
-                                <td class="text-start pb-1" style="width: 40%;">
-                                    <span t-out="loyalty['name']"/>
-                                </td>
-                                <td class="pb-1 text-end" style="width: 60%;">
-                                    <t t-if="loyalty.get('barcode_base64')">
-                                        <img t-att-src="loyalty['barcode_base64']" class="img-fluid" style="transform: translateX(13%);"/>
-                                    </t>
-                                    <div>
-                                        <t t-out="loyalty['type']"/> <t t-out="loyalty['points']"/>
-                                    </div>
-                                </td>
-                            </tr>
-                        </t>
+                    <tbody t-foreach="extra_data['loyalties']" t-as="loyalty">
+                        <tr>
+                            <td class="text-start" t-out="loyalty['name'] + ' ' + loyalty['type']"/>
+                            <td class="text-end w-50"  t-out="loyalty['points']"/>
+                        </tr>
+                    </tbody>
+                </table>
+                <table t-if="extra_data.get('new_coupons')" class="w-100 mt-2">
+                    <tbody t-foreach="extra_data['new_coupons']" t-as="coupon">
+                        <tr>
+                            <td class="text-start text-top pt-3">
+                                <div class="pb-1" t-out="coupon['name']"/>
+                                <div class="pb-1"> Until: <t t-if="coupon.get('expiration_date')" t-out="coupon['expiration_date']"/><t t-else="">no expiration</t></div>
+                            </td>
+                            <td class="text-end pt-3">
+                                <div><img t-att-src="coupon['barcode_base64']" style="width:300px;height:70px"/></div>
+                                <div class="text-end pb-1" t-out="coupon['code']"/>
+                            </td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -757,8 +757,12 @@ patch(PosStore.prototype, {
         const rewardLines = order._get_reward_lines();
         const partner = order.getPartner();
         let couponData = Object.values(order.uiState.couponPointChanges).reduce((agg, pe) => {
+            const netPoints =
+                pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id));
             agg[pe.coupon_id] = Object.assign({}, pe, {
-                points: pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id)),
+                points: netPoints,
+                won: netPoints,
+                spent: 0,
             });
             const program = ProgramModel.get(pe.program_id);
             if (
@@ -778,6 +782,8 @@ patch(PosStore.prototype, {
             if (!couponData[couponId]) {
                 couponData[couponId] = {
                     points: 0,
+                    spent: 0,
+                    won: 0,
                     program_id: reward.program_id.id,
                     coupon_id: couponId,
                     barcode: false,
@@ -793,6 +799,7 @@ patch(PosStore.prototype, {
                 !couponData[couponId].line_codes.push(line.reward_identifier_code);
             }
             couponData[couponId].points -= line.points_cost;
+            couponData[couponId].spent += line.points_cost;
         }
         // We actually do not care about coupons for 'current' programs that did not claim any reward, they will be lost if not validated
         couponData = Object.fromEntries(

--- a/addons/pos_loyalty/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/pos_loyalty/static/src/app/utils/printer/generate_printer_data.js
@@ -12,28 +12,24 @@ patch(GeneratePrinterData.prototype, {
         data.extra_data.loyalties = [];
 
         for (const coupon of points) {
-            data.extra_data.loyalties.push({
-                name: coupon.program.name,
-                type: coupon.points.won >= 0 ? _t("Won:") : _t("Spent:"),
-                points: coupon.points.won || coupon.points.spent,
-            });
-            data.extra_data.loyalties.push({
-                name: coupon.program.name,
-                type: _t("Balance:"),
-                points: coupon.points.balance,
-            });
-        }
-
-        if (this.order.new_coupon_info) {
-            for (const coupon of this.order.new_coupon_info) {
-                data.extra_data.loyalties.push({
-                    name: coupon.program_name,
-                    type: "",
-                    points: coupon.code,
-                    barcode_base64: coupon.barcode_base64,
-                });
+            for (const label of ["Won", "Spent", "Balance"]) {
+                const key = label.toLowerCase();
+                if (coupon.points[key]) {
+                    data.extra_data.loyalties.push({
+                        name: coupon.program.portal_point_name,
+                        type: _t(label + ":"),
+                        points: coupon.points[key],
+                    });
+                }
             }
         }
+
+        data.extra_data.new_coupons = (this.order.new_coupon_info || []).map((coupon) => ({
+            name: coupon.program_name,
+            code: coupon.code,
+            expiration_date: coupon.expiration_date,
+            barcode_base64: coupon.barcode_base64,
+        }));
 
         return data;
     },

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -337,6 +337,9 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.assertEqual(loyalty_program.pos_order_count, 1)
         self.assertAlmostEqual(aaa_loyalty_card.points, 4)
+        histories = aaa_loyalty_card.history_ids.sorted("order_id")
+        self.assertEqual(histories.mapped("issued"), [2.0, 2.0, 4.0])
+        self.assertEqual(histories.mapped("used"), [0.0, 4.0, 0.0])
 
         # Part 2
         self.start_pos_tour("PosLoyaltyLoyaltyProgram2")

--- a/addons/pos_loyalty/tests/test_loyalty_history.py
+++ b/addons/pos_loyalty/tests/test_loyalty_history.py
@@ -74,6 +74,7 @@ class TestPOSLoyaltyHistory(TestPointOfSaleHttpCommon):
         coupon_data = {
             -1: {
                 'points': 50,
+                'won': 50,
                 'program_id': ewallet_program.id,
                 'coupon_id': -1,
                 'barcode': '',
@@ -106,6 +107,7 @@ class TestPOSLoyaltyHistory(TestPointOfSaleHttpCommon):
         coupon_data = {
             loyalty_card.id: {
                 'points': -10,
+                'spent': 10,
                 'program_id': ewallet_program.id,
                 'coupon_id': loyalty_card.id,
                 'barcode': '',


### PR DESCRIPTION
In this commit:
=
- `Next Order Coupon` code below bardcode is displayed.
- Displayed correct string for won and balance points.
- Logo size increased.
- Company details not shown if not available while printing from terminal.
- Next order coupon Barcode alignment fixed.
- Fixed Lot and Serial number alignment.
- Prevented traceback for l10n-specific company (e.g. CL, SE).
- Removed extra padding from around "Need an invoice ?" text


task-5499545

