### PR TITLE
[FIX] web: avoid non-deterministic error in `barcode_dialog` test

### DIFF
--- a/addons/web/static/tests/webclient/barcode/barcode_scanner.test.js
+++ b/addons/web/static/tests/webclient/barcode/barcode_scanner.test.js
@@ -75,6 +75,7 @@ test("Barcode scanner crop overlay", async () => {
 
     const firstBarcodeFound = scanBarcode(env);
     await videoReady;
+    await animationFrame();
     await contains(".o_crop_icon").dragAndDrop(".o_crop_container", {
         relative: true,
         position: {
@@ -95,6 +96,7 @@ test("Barcode scanner crop overlay", async () => {
 
     const secondBarcodeFound = scanBarcode(env);
     await videoReady;
+    await animationFrame();
     const secondValueScanned = await secondBarcodeFound;
     expect(secondValueScanned).toBe(secondBarcodeValue, {
         message: `The detected barcode (${secondValueScanned}) should be the same as generated (${secondBarcodeValue})`,


### PR DESCRIPTION
This commit ensure to await the view to be correctly re-rendered.

runbot-error-233551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
