### PR TITLE
[IMP] l10n_fr:  add SIRET format validation warning on partners

### DIFF
--- a/addons/l10n_fr/models/res_company.py
+++ b/addons/l10n_fr/models/res_company.py
@@ -8,6 +8,7 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     l10n_fr_closing_sequence_id = fields.Many2one('ir.sequence', 'Sequence to use to build sale closings', readonly=True)
+    l10n_fr_siret_warning = fields.Char(related='partner_id.l10n_fr_siret_warning')
     ape = fields.Char(string='APE')
     is_france_country = fields.Boolean(
         compute="_compute_is_france_country",

--- a/addons/l10n_fr/models/res_partner.py
+++ b/addons/l10n_fr/models/res_partner.py
@@ -1,3 +1,6 @@
+from stdnum.exceptions import ValidationError as StdnumValidationError
+from stdnum.fr import siret
+
 from odoo import api, fields, models
 
 
@@ -5,8 +8,29 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     l10n_fr_is_french = fields.Boolean(compute='_compute_l10n_fr_is_french')
+    l10n_fr_siret_warning = fields.Char(compute='_compute_l10n_fr_siret_warning')
 
     @api.depends('country_code')
     def _compute_l10n_fr_is_french(self):
         for partner in self:
             partner.l10n_fr_is_french = partner.country_code in self.env['res.company']._get_france_country_codes()
+
+    @api.depends('company_registry', 'l10n_fr_is_french')
+    def _compute_l10n_fr_siret_warning(self):
+        for partner in self:
+            partner.l10n_fr_siret_warning = False
+            if (not partner.company_registry or not partner.l10n_fr_is_french):
+                continue
+
+            try:
+                siret.validate(partner.company_registry)
+            except StdnumValidationError as e:
+                partner.l10n_fr_siret_warning = self.env._(
+                    "Invalid SIRET: %(error)s",
+                    error=str(e),
+                )
+
+    def _get_company_registry_labels(self):
+        labels = super()._get_company_registry_labels()
+        labels['FR'] = self.env._("SIRET")
+        return labels

--- a/addons/l10n_fr/views/res_company_views.xml
+++ b/addons/l10n_fr/views/res_company_views.xml
@@ -10,6 +10,22 @@
              <xpath expr="//field[@name='company_registry']" position="after">
                  <field name="ape" invisible="not is_france_country"/>
              </xpath>
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning mt-1 mb-1"
+                    role="alert"
+                    invisible="not is_france_country or not l10n_fr_siret_warning">
+                    <field name="l10n_fr_siret_warning"/>
+                </div>
+            </xpath>
+            <xpath expr="//field[@name='company_registry']" position="attributes">
+                <attribute name="invisible" add="is_france_country" separator=" or "/>
+            </xpath>
+            <xpath expr="//field[@name='company_registry']" position="after">
+                <field name="company_registry"
+                       string="SIRET"
+                       options="{'placeholder_field': 'company_registry_placeholder'}"
+                       invisible="not is_france_country"/>
+            </xpath>
         </data>
         </field>
     </record>

--- a/addons/l10n_fr/views/res_partner_views.xml
+++ b/addons/l10n_fr/views/res_partner_views.xml
@@ -6,8 +6,15 @@
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="priority">14</field>
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning mt-1 mb-1"
+                    role="alert"
+                    invisible="not l10n_fr_is_french or not l10n_fr_siret_warning">
+                    <field name="l10n_fr_siret_warning"/>
+                </div>
+            </xpath>
             <field name="company_registry" position="attributes">
-                <attribute name="invisible">parent_id or not is_company or l10n_fr_is_french</attribute>
+                <attribute name="invisible">parent_id or l10n_fr_is_french</attribute>
             </field>
             <field name="vat" position="after">
                 <field name="company_registry" string="Siret" invisible="not l10n_fr_is_french" options="{'placeholder_field': 'company_registry_placeholder'}"/>


### PR DESCRIPTION
- Display a non-blocking warning on the partner form when a French company SIRET is invalid.

- The validation relies on stdnum.fr.siret to check the official SIRET rules (length, format, checksum, La Poste exceptions), and surfaces the library error message with contextual information.

TaskID-5882793
