### PR TITLE
[FIX] mrp: Fix memory error

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -134,7 +134,8 @@ class MrpWorkcenter(models.Model):
     def _get_workcenter_load_per_week(self, week_range, date_start, date_stop):
         load_data = {rec: {} for rec in self}
         # demo data
-        if not self.order_ids:
+        has_workorder = self.env['mrp.workorder'].search_count([('workcenter_id', 'in', self.ids)], limit=1)
+        if not has_workorder:
             for wc in self:
                 load_limit = 40     # default max load per week is 40 hours on a new workcenter
                 load_data[wc] = {week_start: randint(0, int(load_limit * 2)) for week_start in week_range}
@@ -151,9 +152,10 @@ class MrpWorkcenter(models.Model):
 
     def _prepare_graph_data(self, load_data, week_range):
         graph_data = {wid: [] for wid in self._ids}
+        has_workorder = self.env['mrp.workorder'].search_count([('workcenter_id', 'in', self.ids)], limit=1)
         for workcenter in self:
             load_limit = sum(workcenter.resource_calendar_id.attendance_ids.mapped('duration_hours'))
-            wc_data = {'is_sample_data': not self.order_ids, 'labels': list(week_range.values())}
+            wc_data = {'is_sample_data': not has_workorder, 'labels': list(week_range.values())}
             load_bar = []
             excess_bar = []
             for week_start in week_range:


### PR DESCRIPTION
Previously, ``self.order_ids`` fetched all work orders  all work centers, causing issue during fetching when there are multiple workorder per workcentre. Updated the logic to check only the count if order exist or not since that is all required.

opw-5472114
upg-3862178

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
