### PR TITLE
[FIX] im_livechat: no yellow bg in 'create lead' livechat action

### DIFF
--- a/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
+++ b/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
@@ -4,7 +4,7 @@
         <ActionPanel title="props.title" icon="props.icon" resizable="false">
             <div class="input-group my-2 shadow-sm">
                 <div class="o-livechat-LivechatCommandDialog-form form-control bg-view p-0" aria-autocomplete="list">
-                    <input type="text" class="border-0 h-100 rounded px-2" accesskey="Q" t-att-placeholder="props.placeholderText" t-on-keydown="onKeydown" t-ref="autofocus" t-model="state.inputText"/>
+                    <input type="text" class="border-0 h-100 rounded px-2 form-control" accesskey="Q" t-att-placeholder="props.placeholderText" t-on-keydown="onKeydown" t-ref="autofocus" t-model="state.inputText"/>
                 </div>
                 <button class="btn btn-primary" t-on-click="executeCommand" t-att-disabled="!state.inputText" t-out="props.title"/>
             </div>


### PR DESCRIPTION
Before this commit, when using the "Create Lead" thread action in discuss app on a live chat conversation, the background of input was yellow.

This happens because this is the default color of input of `<input>` in dark theme in a popover. This commit fixes by setting the `.form-control` classname on the `input`, which is intended to be used in almost all inputs to have proper web client style.

Part of Task-5867464

Before / After
<img width="385" height="152" alt="Screenshot 2026-01-30 at 15 15 33" src="https://github.com/user-attachments/assets/d86acf02-169a-43f6-9042-5faa1ccf5c3e" />
<img width="384" height="146" alt="Screenshot 2026-01-30 at 15 14 46" src="https://github.com/user-attachments/assets/ea672c8c-8446-4b2d-be4b-4fbd41dcda1d" />

