### PR TITLE
[IMP] website: parent page breadcrumb followup

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -315,6 +315,16 @@ body {
                 > * {
                     margin-bottom: $spacer * 2;
                 }
+                // When breadcrumb exists, remove margin from header and apply
+                // it to breadcrumb instead
+                &:has(div.o_page_breadcrumb) {
+                    > header {
+                        margin-bottom: 0;
+                    }
+                    div.o_page_breadcrumb {
+                        margin-bottom: $spacer * 2;
+                    }
+                }
                 > header {
                     &, &.o_header_affix {
                         .navbar {

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -3,6 +3,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
+    goToTheme,
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
@@ -171,6 +172,31 @@ registerWebsitePreviewTour(
             trigger:
                 ":iframe nav[aria-label='breadcrumb'] ol.breadcrumb li:first-child a:contains(Home)",
         },
+        ...clickOnEditAndWaitEditMode(),
+        ...goToTheme(),
+        {
+            content: "Open the Page Layout dropdown",
+            trigger: ".hb-row[data-label='Page Layout'] .o-dropdown",
+            run: "click",
+        },
+        {
+            content: "Select the Postcard layout",
+            trigger: ".o-hb-select-dropdown-item[data-action-value='postcard']",
+            run: "click",
+        },
+        {
+            content: "Verify Breadcrumb has bottom spacing in postcard layout",
+            trigger: ":iframe .o_page_breadcrumb",
+            run() {
+                const marginBottom = getComputedStyle(this.anchor).marginBottom;
+                if (marginBottom === "0px") {
+                    throw new Error(
+                        `Expected breadcrumb to have bottom margin in Postcard layout, but got "${marginBottom}".`
+                    );
+                }
+            },
+        },
+        ...clickOnSave(),
         ...clickOnEditAndWaitEditMode(),
         ...clickOnSnippet(breadcrumb),
         ...openBackgroundColorPicker("Background Color", "Theme"),


### PR DESCRIPTION
Step to reproduce:
1. Open the contactus page and add a breadcrumb.
3. Enter edit mode -> Theme.
4. Set the Page Layout to Postcard.

Issue:
In the Postcard layout, a `margin-bottom` is appliead to all direct
children of `#wrapwrap`. When a breadcrumb is present, both the header
and the breadcrumb receive spacing, creating unintended empty space
between them.

Fix:
When breadcrumb exist remove the bottom margin from the header and apply
the spacing to the breadcrumb instead.

task-5884633