### PR TITLE
[IMP] mail: rename 'Invite a User' to 'Invite People'

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
-            <button name="inviteButton" t-on-click="() => this.openInviteDialog()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite a User</span></button>
+            <button name="inviteButton" t-on-click="() => this.openInviteDialog()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite People</span></button>
             <t t-if="props.channel.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="onlineSectionText"/>


### PR DESCRIPTION
For consistency with other "Invite People" actions that result to the same action.

Part of Task-5867464

Before / After
<img width="249" height="259" alt="Screenshot 2026-01-30 at 16 22 13" src="https://github.com/user-attachments/assets/64c6d239-03ce-4bff-aa0f-96fdcd624f0e" /> <img width="252" height="256" alt="Screenshot 2026-01-30 at 16 21 37" src="https://github.com/user-attachments/assets/7d2fda28-af9e-4082-a9af-1f6808a7967c" />
