### PR TITLE
[FIX] mail: muted color for looking for help live chat description

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
@@ -8,12 +8,12 @@
             </t>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-itemName')]" position="inside">
-            <div t-if="channel.livechat_status === 'need_help' and channel.description" t-att-title="channel.description" class="text-warning text-truncate smaller" t-esc="channel.description"/>
+            <div t-if="channel.livechat_status === 'need_help' and channel.description" t-att-title="channel.description" class="text-muted text-truncate smaller" t-esc="channel.description"/>
         </xpath>
     </t>
     <t t-inherit="mail.DiscussSidebarChannel" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-floatingName')]" position="after">
-            <div t-if="channel.livechat_status === 'need_help' and channel.description" t-att-title="channel.description" class="text-warning text-truncate smaller px-2 pb-2" t-esc="channel.description"/>
+            <div t-if="channel.livechat_status === 'need_help' and channel.description" t-att-title="channel.description" class="text-muted text-truncate smaller px-2 pb-2" t-esc="channel.description"/>
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/core/web/discuss_content_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_content_patch.js
@@ -13,7 +13,7 @@ patch(DiscussContent.prototype, {
     get threadDescriptionAttClass() {
         return {
             ...super.threadDescriptionAttClass,
-            "text-warning":
+            "text-muted":
                 this.thread.channel?.livechat_status === "need_help" && this.thread.description,
         };
     },


### PR DESCRIPTION
Text was using `.text-warning`, which is too distracting.

Part of Task-5867464

Before / After
<img width="960" height="387" alt="Screenshot 2026-01-30 at 16 27 00" src="https://github.com/user-attachments/assets/9cc1129c-5169-4ef0-a84e-dfbb866ddcea" />
<img width="961" height="384" alt="Screenshot 2026-01-30 at 16 26 31" src="https://github.com/user-attachments/assets/e858cc16-14cd-4149-98bd-cbbb44ee5cb1" />
