### PR TITLE
[FIX] api_doc: stringify lists types alias signatures

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -367,8 +367,12 @@ def parse_signature(method) -> Signature:
         break
 
     # replace BaseModel and such by list[int], see /json/2
-    if isign.return_annotation in (Self, 'Self', models.BaseModel, models.Model):
-        isign = isign.replace(return_annotation=list[int])
+    if isign.return_annotation in (
+        Self, 'Self',
+        models.BaseModel, 'models.BaseModel',
+        models.Model, 'models.Model'
+    ):
+        isign = isign.replace(return_annotation='list[int]')
 
     # parse the signature
     parameters = {


### PR DESCRIPTION
In python 3.10, `parse_signature` causes some issues with some of the newer type annotations (eg: `list[int]`).
This broke several test cases in api_doc where signatures were stringified except when converted from `Self`, `models.BaseModel` and `models.Model`.

This commit forces those type aliases to be replaced by the string `'list[int]'`.

runbot-237792
