### PR TITLE
[IMP] project: move project stages menu to debug mode

### DIFF
--- a/addons/project/models/ir_ui_menu.py
+++ b/addons/project/models/ir_ui_menu.py
@@ -14,4 +14,9 @@ class IrUiMenu(models.Model):
         if self.env.user.has_group('project.group_project_stages'):
             res.append(self.env.ref('project.menu_projects').id)
             res.append(self.env.ref('project.menu_projects_config').id)
+        if not (
+            self.env.user.has_group('project.group_project_stages') and
+            self.env.user.has_group('base.group_no_one')
+        ):
+            res.append(self.env.ref('project.menu_project_config_project_stage').id)
         return res

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -87,7 +87,6 @@
                 name="Project Stages"
                 id="menu_project_config_project_stage"
                 action="project_project_stage_configure"
-                groups="project.group_project_stages"
                 sequence="9"
             />
             <menuitem

--- a/addons/project/views/res_config_settings_views.xml
+++ b/addons/project/views/res_config_settings_views.xml
@@ -11,11 +11,6 @@
                         <block title="Tasks Management" id="tasks_management">
                             <setting id="project_stages" help="Track the progress of your projects">
                                 <field name="group_project_stages"/>
-                                <div class="content-group" invisible="not group_project_stages">
-                                    <div class="mt8">
-                                        <button name="%(project.project_project_stage_configure)d" icon="oi-arrow-right" type="action" string="Configure Stages" class="btn-link"/>
-                                    </div>
-                                </div>
                             </setting>
                         </block>
                         <block title="Time Management" name="project_time">

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -56,8 +56,8 @@ class TestPerfSessionInfo(common.HttpCase):
         self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 14
-        # - All modules 62
-        with self.assertQueryCount(62):
+        # - All modules 64
+        with self.assertQueryCount(64):
             self.env['ir.ui.menu'].load_web_menus(False)
 
         # cold fields cache:
@@ -72,8 +72,8 @@ class TestPerfSessionInfo(common.HttpCase):
         self.env.invalidate_all()
         # cold orm/fields cache:
         # - Web only: 14
-        # - All modules 62
-        with self.assertQueryCount(62):
+        # - All modules 64
+        with self.assertQueryCount(64):
             self.env['ir.ui.menu'].load_menus(False)
 
         # cold fields cache:


### PR DESCRIPTION
This commit moves the 'Project Stages' configuration menu to debug mode. Additionally, it removes the 'Configure Stages' link from the settings.

The reason behind is that it is easier to configure stages from the kanban view of projects directly and to be consistent with the 'task stages' menu that is in debug mode already.

task-5272899