### PR TITLE
[FIX] l10n_ar: Correct condition to assign 'FA Exterior' document type

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -206,8 +206,8 @@ class AccountMove(models.Model):
             x.company_id.account_fiscal_country_id.code == "AR"
             and x.state == 'draft'
             and x.move_type in ['in_invoice', 'in_refund']
-            and x.l10n_latam_document_type_id
-            and x.partner_id.l10n_ar_afip_responsibility_type_id.code == '8'))
+            and (x.l10n_latam_document_type_id or x.l10n_latam_use_documents)
+            and x.partner_id.l10n_ar_afip_responsibility_type_id.code in ['8', '9']))
         doctype_fa_exterior = self.env.ref('l10n_ar.fa_exterior', raise_if_not_found=False)
         if doctype_fa_exterior:
             foreign_vendor_bills.l10n_latam_document_type_id = doctype_fa_exterior


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**: This PR addresses an issue in the Argentine localization where Debit Notes generated from foreign vendor bills are not being assigned a document type. The system fails to map or allow the selection of any types when creating a Debit Note from an existing foreign invoice.

**Current behavior before PR**: When a user creates a Debit Note from a vendor bill issued by a foreign supplier, the Document Type field remains empty. Furthermore, the dropdown list is empty, preventing the user from manually selecting the appropriate "dummy" document type required for foreign operations.

**Desired behavior after PR is merged**: When a Debit Note is generated from a foreign vendor bill, it should automatically inherit the same document type logic as the original invoice. Specifically, it should be assigned the corresponding "dummy" document type (or allow its selection) to ensure consistency with the parent document and compliance with local tax requirements.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
