### PR TITLE
[FIX] mail: don't show timezone when same as self user in avatar card

### DIFF
--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -38,18 +38,21 @@ export class AvatarCardPopover extends Component {
             model: this.props.model,
         });
         useDynamicInterval(
-            (partnerTz, currentUserTz) => {
-                this.state.partnerLocalDateTimeFormatted = formatLocalDateTime(
-                    partnerTz,
-                    currentUserTz
-                );
-                if (!this.state.partnerLocalDateTimeFormatted) {
-                    return;
-                }
-                return 60000 - (Date.now() % 60000);
-            },
+            (...args) => this.onChangeTz(...args),
             () => [this.partner?.tz, this.store.self?.tz]
         );
+    }
+
+    /**
+     * @param {string} partnerTz
+     * @param {string} currentUserTz
+     */
+    onChangeTz(partnerTz, currentUserTz) {
+        this.state.partnerLocalDateTimeFormatted = formatLocalDateTime(partnerTz, currentUserTz);
+        if (!this.state.partnerLocalDateTimeFormatted) {
+            return;
+        }
+        return 60000 - (Date.now() % 60000);
     }
 
     get openChatModel() {

--- a/addons/mail/static/src/utils/common/dates.js
+++ b/addons/mail/static/src/utils/common/dates.js
@@ -28,7 +28,8 @@ export function formatLocalDateTime(partnerTz, currentUserTz) {
     if (
         !resolvedPartnerTz ||
         !resolvedCurrentUserTz ||
-        [resolvedPartnerTz, resolvedCurrentUserTz].includes("local")
+        [resolvedPartnerTz, resolvedCurrentUserTz].includes("local") ||
+        resolvedPartnerTz === resolvedCurrentUserTz
     ) {
         return null;
     }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1094,7 +1094,6 @@ test("open author avatar card", async () => {
         partner_id: partnerId,
         name: "Demo",
     });
-    window.pyEnv = pyEnv;
     const [channelId_1] = pyEnv["discuss.channel"].create([
         { name: "General" },
         {


### PR DESCRIPTION
Before this commit, the local time zone was shown on avatar card even when this is the same as current user.

The intent of showing of local timezone is to see when it differs. When this is the same, this just adds noise to the card.

This commit hides the showing of local timezone when this is the same as current user.

Part of Task-5867464

Before / After
<img width="310" height="206" alt="Screenshot 2026-01-30 at 17 24 04" src="https://github.com/user-attachments/assets/c47f885d-fb98-48f8-91fb-24d6a33e4c9a" /> <img width="311" height="193" alt="Screenshot 2026-01-30 at 17 23 50" src="https://github.com/user-attachments/assets/26fe6cf8-f2b1-40a3-b478-065ea88e01af" />

