### PR TITLE
[FIX] point_of_sale: use correct quantity when computing amounts for stock accounts

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -967,7 +967,7 @@ class PosSession(models.Model):
                         product_accounts = move.product_id._get_product_accounts()
                         exp_key = product_accounts['expense']
                         stock_key = product_accounts['stock_valuation']
-                        signed_product_qty = move.quantity
+                        signed_product_qty = move._get_valued_qty()
                         if move._is_in():
                             signed_product_qty *= -1
                         amount = signed_product_qty * move._get_price_unit()


### PR DESCRIPTION
Problem:
In `_accumulate_amounts`, when computing the total value of moved quantities on a POS picking, the `quantity` field on `stock.move` is used to inform the total value of the move, used in conjunction with `_get_price_unit`. However, `quantity` will not always represent the correct UoM, and can have unintended consequences.

Solution:
We will instead opt for `_get_valued_qty`, which will always return the quantity of the moved product in its own default UoM.

Steps to replicate (Runbot 19)
- Company has perpetual valuation
- UoM that is 1:500, called "500 Units" here
- Component product tracked in "500 Units", set cost to $1000
- Kit that requires 200 Units of original product
--- The value of each kit should be $1000/500u*200u = $400
- AVCO perpetual for both

1. Sell 1 kit on the POS
2. Close the register
3. Navigate to the journal entry for that session, note the expense and valuation lines @ $200,000
--$1000*200u = $200,000, which is wrong

opw-5893089
