### PR TITLE
[FIX] website,website_forum: forum search performance

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/search_bar.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar.js
@@ -41,12 +41,12 @@ export class SearchBar extends Interaction {
         }
         const dataset = this.inputEl.dataset;
         this.options = {
-            displayImage: dataset.displayImage,
-            displayDescription: dataset.displayDescription,
-            displayExtraLink: dataset.displayExtraLink,
-            displayDetail: dataset.displayDetail,
+            displayImage: dataset.displayImage && JSON.parse(dataset.displayImage),
+            displayDescription: dataset.displayDescription && JSON.parse(dataset.displayDescription),
+            displayExtraLink: dataset.displayExtraLink && JSON.parse(dataset.displayExtraLink),
+            displayDetail: dataset.displayDetail && JSON.parse(dataset.displayDetail),
             // Make it easy for customization to disable fuzzy matching on specific searchboxes
-            allowFuzzy: !dataset.noFuzzy,
+            allowFuzzy: !(dataset.noFuzzy && JSON.parse(dataset.noFuzzy)),
         };
         for (const fieldEl of form.querySelectorAll("input[type='hidden']")) {
             this.options[fieldEl.name] = fieldEl.value;
@@ -76,7 +76,7 @@ export class SearchBar extends Interaction {
     }
 
     start() {
-        if (this.inputEl.dataset.noFuzzy) {
+        if (this.inputEl.dataset.noFuzzy && JSON.parse(this.inputEl.dataset.noFuzzy)) {
             const noFuzzyEl = document.createElement("input");
             noFuzzyEl.setAttribute("type", "hidden");
             noFuzzyEl.setAttribute("name", "noFuzzy");

--- a/addons/website/static/tests/interactions/snippets/search_bar.test.js
+++ b/addons/website/static/tests/interactions/snippets/search_bar.test.js
@@ -37,10 +37,10 @@ function supportAutocomplete() {
         expect(json.params.term).toBe("xyz");
         expect(json.params.order).toBe("test desc");
         expect(json.params.limit).toBe(3);
-        expect(json.params.options.displayImage).toBe("false");
-        expect(json.params.options.displayDescription).toBe("false");
-        expect(json.params.options.displayExtraLink).toBe("true");
-        expect(json.params.options.displayDetail).toBe("false");
+        expect(json.params.options.displayImage).toBe(false);
+        expect(json.params.options.displayDescription).toBe(false);
+        expect(json.params.options.displayExtraLink).toBe(true);
+        expect(json.params.options.displayDetail).toBe(false);
         return {
             results: [
                 {

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -171,7 +171,7 @@
                         <t t-set="search_type" t-value="'forums'"/>
                         <t t-set="action" t-value="'/forum/%s' % (_forum_slug)"/>
                     </t>
-                    <t t-set="display_description" t-valuef="true"/>
+                    <t t-set="display_description" t-valuef="false"/>
                     <t t-set="display_detail" t-valuef="true"/>
                     <t t-set="_form_classes" t-valuef="flex-grow-1"/>
                     <t t-set="_input_classes" t-valuef="border-0 bg-light"/>

--- a/addons/website_forum/views/website_profile_templates.xml
+++ b/addons/website_forum/views/website_profile_templates.xml
@@ -181,7 +181,7 @@
                                 <t t-set="_form_classes" t-valuef="d-flex flex-row align-items-center flex-wrap float-end"/>
                                 <t t-set="search_type" t-valuef="forums"/>
                                 <t t-set="action" t-value="'/forum/%s%s' % (forum_id or 'all', '/tag/%s/questions' % slug(tag) if tag else '')"/>
-                                <t t-set="display_description" t-value="true"/>
+                                <t t-set="display_description" t-valuef="false"/>
                                 <t t-set="display_detail" t-valuef="false"/>
                                 <t t-set="placeholder" t-valuef="Search Posts..."/>
                                 <input type="hidden" name="my" value="upvoted"/>


### PR DESCRIPTION
Improve the performance of the website forum search.

Issue:

There is a significant performance issue with a large number of forum posts impacting odoo.com.
This is due to the use of the `<%` operator on the content field of forum posts. It occurs when using the javascript search which autocompletes results in a dropdown on the search bar.

To deactivate the search on the `content` column, displayDescription needs to be set to false. but this was not possible due to the data attribute which contains text. setting it to 'false' was still truthy and therefore enabled the fuzzy search in the content column.

Fix:

- fix a js bug to properly cast the value to a boolean - this was done for other data attributes at the same time.
- set the display_description value to false to disable search on the content field. This is aligned with the python post search settings defined in: https://github.com/odoo/odoo/blob/7abd7ba2f38fdb1953c39fd3693f012c2ad1b497/addons/website_forum/controllers/website_forum.py#L95

