### PR TITLE
[FIX] account_edi_ubl_cii: Avoid importing existing bank belonging to different company

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -745,7 +745,7 @@ class AccountEdiCommon(models.AbstractModel):
         banks_to_create = []
         acc_number_partner_bank_dict = {
             bank.sanitized_account_number: bank
-            for bank in ResPartnerBank.with_context(active_test=False).search(
+            for bank in ResPartnerBank.sudo().with_context(active_test=False).search(
                 [('partner_id', '=', partner.id), ('account_number', 'in', bank_details)]
             )
         }
@@ -754,7 +754,8 @@ class AccountEdiCommon(models.AbstractModel):
             if partner_bank.partner_id == partner:
                 if not partner_bank.active:
                     partner_bank.active = True
-                invoice.partner_bank_id = partner_bank
+                if not partner_bank.company_id or invoice.company_id == partner_bank.company_id:
+                    invoice.partner_bank_id = partner_bank
                 return
             elif not partner_bank and account_number:
                 banks_to_create.append({


### PR DESCRIPTION
Problem:
Assume there is in DB a bank account for partner P with account number A restricted to company C1.
If the user attempts to import a file with a bank account for partner P with account number A but for company C2
the search for the first bank account fails because it's restricted to a different company.
However, the creation of a new bank account also fails because the combination (P, A) already exists.

This was the case already with belgian demo data bank account and unit test files used in purchase_edi_ubl_bis3 module.

Solution:
This commit fixes this issue by:
1. Doing a sudo search for bank accounts to avoid duplicating (partner, account number) combination
2. avoid setting the bank account on the imported invoice if their company_id fields are not compatible.

build_error-237563