### PR TITLE
[FIX] mail: weird overflow of active action in dropdown

### DIFF
--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -79,7 +79,7 @@
     })"/>
     <t t-set="attrs" t-value="{ 'aria-label': action.name, 'disabled': action.disabledCondition, 'name': action.id, 'data-sequence': action.sequence, 'data-sequence-group': action.sequenceGroup, 'data-sequence-quick': action.sequenceQuick }"/>
     <t t-if="action.component and action.componentCondition" t-component="action.component" t-props="action.componentProps"/>
-    <DropdownItem t-elif="props.dropdown" class="btnClass + ' d-flex align-items-center ' + (ui.isSmall ? 'gap-2' : 'gap-1')" tag="'button'" onSelected="(ev) => this.onSelected(action, ev)" attrs="attrs">
+    <DropdownItem t-elif="props.dropdown" class="btnClass + ' d-flex align-items-center dropdown-item_active_noarrow ' + (ui.isSmall ? 'gap-2' : 'gap-1')" tag="'button'" onSelected="(ev) => this.onSelected(action, ev)" attrs="attrs">
         <t t-call="mail.Action.content"/>
     </DropdownItem>
     <button t-else="" t-att-class="btnClass" t-att="Object.assign(attrs, { 'title': action.name })" t-on-click="(ev) => this.onSelected(action, ev)" t-att-data-hotkey="action.hotkey" t-att-style="props.style">


### PR DESCRIPTION
Webclient style has style to apply checkbox next to active dropdown item when it doesn't have the `.dropdown-item_active_noarrow`, through adding some content in `.dropdown-item:before`.

This checkbox is problematic because it overflows with `Dropdown`, and items in a discuss action list dropdown already have enough to show when they are active or not.

This commit cancels the webclient style of adding the checkbox by adding `dropdown-item_active_noarrow` on ActionList's dropdown items.

Part of Task-5867464

Before / After (see barely checkbox overflows on "Unmute" item):
<img width="254" height="268" alt="Screenshot 2026-01-30 at 18 06 27" src="https://github.com/user-attachments/assets/196ec808-c22c-41f0-9ab3-c8f9b9a52535" />
<img width="254" height="264" alt="Screenshot 2026-01-30 at 18 17 42" src="https://github.com/user-attachments/assets/77a918db-fd55-4a09-8c47-ec615bd4f280" />
