### PR TITLE
[FIX] pos_sale: fix payment provider creation in test

### DIFF
--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1864,6 +1864,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         })
         provider = self.env['payment.provider'].create({
             'name': 'Test',
+            'code': 'none',
         })
         transaction = self.env['payment.transaction'].create({
             'provider_id': provider.id,


### PR DESCRIPTION
Depending on the modules installed, the tests sometimes use a different value for creating the `payment.provider` record. The code is sometimes set to custom if the `payment_custom` module is installed. This causes a runbot error.

To avoid this, we force the code `none` in our tests. This will have no impact and will fix the indeterminate error.

RunbotID: 237707


