### PR TITLE
[IMP] orm: determine faster which fields are groupable

### DIFF
--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -1221,6 +1221,7 @@ class TestPrivateReadGroup(common.TransactionCase):
             GROUP BY "test_read_group_related_inherits__base_id__foo_id"."name"
             ORDER BY "test_read_group_related_inherits__base_id__foo_id"."name" ASC
         """
+        RelatedInherits._read_group([], ['foo_id_name'], ['__count'])  # warmup
         with self.assertQueries([expected_query, expected_query]):
             self.assertEqual(
                 RelatedInherits._read_group([], ['foo_id_name'], ['__count']),

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -964,6 +964,10 @@ class Field[T]:
         if self.inherited_field and self.inherited_field._description_groupable(env):
             # avoid compuation for inherited field
             return True
+        from .models import BaseModel  # noqa: PLC0415
+        if self.type != 'many2many' and env.registry[self.model_name]._read_group_groupby is BaseModel._read_group_groupby:
+            # the default implementation has an edge case for many2many
+            return False
 
         model = env[self.model_name]
         groupby = self.name if self.type not in ('date', 'datetime') else f"{self.name}:month"
@@ -979,6 +983,10 @@ class Field[T]:
         if self.inherited_field and self.inherited_field._description_aggregator(env):
             # avoid compuation for inherited field
             return self.inherited_field.aggregator
+        from .models import BaseModel  # noqa: PLC0415
+        if env.registry[self.model_name]._read_group_select is BaseModel._read_group_select:
+            # the default implementation does not handle additional fields
+            return False
 
         model = env[self.model_name]
         query = model._as_query(ordered=False)


### PR DESCRIPTION
The default implementations have a a defined scope, they don't handle a lot of edge cases. If we have no overwrite, shortcut.

```
# master
In [2]: %timeit self.fields_get(attributes=['groupable'])
2.02 ms ± 122 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
In [3]: %timeit self.fields_get()
8.86 ms ± 141 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# this PR
In [4]: %timeit self.fields_get(attributes=['groupable'])
515 μs ± 5.33 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
In [5]: %timeit self.fields_get()
6.76 ms ± 67.6 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
