### PR TITLE
[FIX] account: Fix and Improve payment move syncronization

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from itertools import zip_longest
 from odoo import models, fields, api, _, Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.misc import format_date, formatLang
@@ -261,6 +262,7 @@ class AccountPayment(models.Model):
         return lines
 
     def _get_valid_liquidity_accounts(self):
+        self.ensure_one()
         return (
             self.journal_id.default_account_id |
             self.payment_method_line_id.payment_account_id |
@@ -292,28 +294,72 @@ class AccountPayment(models.Model):
             ('label', label),
         ]
 
-    def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
-        ''' Prepare the dictionary to create the default account.move.lines for the current payment.
-        :param write_off_line_vals: Optional list of dictionaries to create a write-off account.move.line easily containing:
-            * amount:       The amount to be added to the counterpart amount.
-            * name:         The label to set on the line.
-            * account_id:   The account on which create the write-off.
-        :param force_balance: Optional balance.
-        :return: A list of python dictionary to be passed to the account.move.line's 'create' method.
+    def _prepare_move_withholding_lines(self, default_values):
+        self.ensure_one()
+        return []
+
+    def _prepare_move_liquidity_lines(self, default_values):
+        self.ensure_one()
+        return [{
+            'name': default_values['name'],
+            'date_maturity': self.date,
+            'partner_id': self.partner_id.id,
+            'account_id': self.outstanding_account_id.id,
+            'currency_id': self.currency_id.id,
+            'balance': default_values['balance'],
+            'amount_currency': default_values['amount_currency'],
+        }]
+
+    def _prepare_move_counterpart_lines(self, default_values):
+        self.ensure_one()
+        return [{
+            'name': default_values['name'],
+            'date_maturity': self.date,
+            'partner_id': self.partner_id.id,
+            'account_id': self.destination_account_id.id,
+            'currency_id': self.currency_id.id,
+            'balance': default_values['balance'],
+            'amount_currency': default_values['amount_currency'],
+        }]
+
+    def _prepare_move_lines_per_type(self, write_off_line_vals=None, force_balance=None):
+        ''' Prepare the dictionary containing default vals for account.move.lines for the current payment.
+        returns a dictionary of list of python dictionary containing liquidity, counterpart and writeoff lines.
+            E.g.
+            {
+                'liquidity_lines': [...],
+                'counterpart_lines': [...],
+                'writeoff_lines': [...],
+            }
         '''
         self.ensure_one()
-        write_off_line_vals = write_off_line_vals or []
 
         if not self.outstanding_account_id:
             raise UserError(_(
                 "You can't create a new payment without an outstanding payments/receipts account set either on the company or the %(payment_method)s payment method in the %(journal)s journal.",
                 payment_method=self.payment_method_line_id.name, journal=self.journal_id.display_name))
 
-        # Compute amounts.
-        write_off_line_vals_list = write_off_line_vals or []
-        write_off_amount_currency = sum(x['amount_currency'] for x in write_off_line_vals_list)
-        write_off_balance = sum(x['balance'] for x in write_off_line_vals_list)
+        # Compute a default label to set on the journal items.
+        line_name = ''.join(x[1] for x in self._get_aml_default_display_name_list() if x[1])
 
+        # Prepare write-off lines.
+        write_off_lines = write_off_line_vals or []
+        write_off_amount_currency = sum(x['amount_currency'] for x in write_off_lines)
+        write_off_balance = sum(x['balance'] for x in write_off_lines)
+
+        # Prepare withholding lines.
+        withholding_lines = self._prepare_move_withholding_lines({})
+        withholding_amount_currency = sum(x['amount_currency'] for x in withholding_lines)
+        withholding_balance = sum(x['balance'] for x in withholding_lines)
+
+        # We don't support to combine 'write_off_lines' and 'withholding_lines' together because the withholding lines are already
+        # passed as parameter as write-off lines in '_synchronize_to_moves'.
+        if withholding_lines and write_off_lines:
+            write_off_lines = []
+            write_off_amount_currency = 0.0
+            write_off_balance = 0.0
+
+        # Prepare liquidity lines.
         if self.payment_type == 'inbound':
             # Receive money.
             liquidity_amount_currency = self.amount
@@ -333,39 +379,47 @@ class AccountPayment(models.Model):
                 self.company_id,
                 self.date,
             )
-        counterpart_amount_currency = -liquidity_amount_currency - write_off_amount_currency
-        counterpart_balance = -liquidity_balance - write_off_balance
-        currency_id = self.currency_id.id
+        liquidity_amount_currency -= withholding_amount_currency
+        liquidity_balance -= withholding_balance
 
-        # Compute a default label to set on the journal items.
-        liquidity_line_name = ''.join(x[1] for x in self._get_aml_default_display_name_list() if x[1])
-        counterpart_line_name = liquidity_line_name
+        liquidity_lines = self._prepare_move_liquidity_lines({
+            'name': line_name,
+            'balance': liquidity_balance,
+            'amount_currency': liquidity_amount_currency,
+        })
 
-        line_vals_list = [
-            # Liquidity line.
-            {
-                'name': liquidity_line_name,
-                'date_maturity': self.date,
-                'amount_currency': liquidity_amount_currency,
-                'currency_id': currency_id,
-                'debit': liquidity_balance if liquidity_balance > 0.0 else 0.0,
-                'credit': -liquidity_balance if liquidity_balance < 0.0 else 0.0,
-                'partner_id': self.partner_id.id,
-                'account_id': self.outstanding_account_id.id,
-            },
-            # Receivable / Payable.
-            {
-                'name': counterpart_line_name,
-                'date_maturity': self.date,
-                'amount_currency': counterpart_amount_currency,
-                'currency_id': currency_id,
-                'debit': counterpart_balance if counterpart_balance > 0.0 else 0.0,
-                'credit': -counterpart_balance if counterpart_balance < 0.0 else 0.0,
-                'partner_id': self.partner_id.id,
-                'account_id': self.destination_account_id.id,
-            },
-        ]
-        return line_vals_list + write_off_line_vals_list
+        # Prepare counterpart lines.
+        counterpart_amount_currency = -liquidity_amount_currency - write_off_amount_currency - withholding_amount_currency
+        counterpart_balance = -liquidity_balance - write_off_balance - withholding_balance
+        counterpart_lines = self._prepare_move_counterpart_lines({
+            'name': line_name,
+            'balance': counterpart_balance,
+            'amount_currency': counterpart_amount_currency,
+        })
+
+        return {
+            'liquidity_lines': liquidity_lines,
+            'counterpart_lines': counterpart_lines,
+            'write_off_lines': write_off_lines,
+            'withholding_lines': withholding_lines,
+        }
+
+    def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
+        ''' Prepare the dictionary to create the default account.move.lines for the current payment.
+        :param write_off_line_vals: Optional list of dictionaries to create a write-off account.move.line easily containing:
+            * amount:       The amount to be added to the counterpart amount.
+            * name:         The label to set on the line.
+            * account_id:   The account on which create the write-off.
+        :param force_balance: Optional balance.
+        :return: A list of python dictionary to be passed to the account.move.line's 'create' method.
+        '''
+        self.ensure_one()
+
+        line_vals_per_type = self._prepare_move_lines_per_type(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
+        line_vals = []
+        for sub_line_vals in line_vals_per_type.values():
+            line_vals += sub_line_vals
+        return line_vals
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
@@ -985,6 +1039,10 @@ class AccountPayment(models.Model):
             if pay.move_id.state == 'posted':
                 continue
             liquidity_lines, counterpart_lines, writeoff_lines = pay._seek_for_lines()
+
+            if 'amount' in changed_fields and len(liquidity_lines) > 1:
+                raise UserError(_("You cannot change the amount of a payment with multiple liquidity lines."))
+
             # Make sure to preserve the write-off amount.
             # This allows to create a new payment with custom 'line_ids'.
             write_off_line_vals = []
@@ -997,14 +1055,28 @@ class AccountPayment(models.Model):
                     'amount_currency': sum(writeoff_lines.mapped('amount_currency')),
                     'balance': sum(writeoff_lines.mapped('balance')),
                 })
-            line_vals_list = pay._prepare_move_line_default_vals(write_off_line_vals=write_off_line_vals)
-            line_ids_commands = [
-                Command.update(liquidity_lines.id, line_vals_list[0]) if liquidity_lines else Command.create(line_vals_list[0]),
-                Command.update(counterpart_lines.id, line_vals_list[1]) if counterpart_lines else Command.create(line_vals_list[1])
-            ]
+            line_vals_per_type = pay._prepare_move_lines_per_type(write_off_line_vals=write_off_line_vals)
+            line_ids_commands = []
+
+            liquidity_lines_vals = line_vals_per_type.get('liquidity_lines', [])
+            for liquidity_line, newline_val in zip_longest(liquidity_lines, liquidity_lines_vals):
+                if liquidity_line and newline_val:
+                    line_ids_commands.append(Command.update(liquidity_line.id, newline_val))
+                elif not liquidity_line and newline_val:
+                    line_ids_commands.append(Command.create(newline_val))
+                elif liquidity_line and not newline_val:
+                    line_ids_commands.append(Command.delete(liquidity_line.id))
+
+            counterpart_lines_vals = line_vals_per_type.get('counterpart_lines', [])
+            line_ids_commands.append(
+                Command.update(counterpart_lines.id, counterpart_lines_vals[0])
+                if counterpart_lines
+                else Command.create(counterpart_lines_vals[0])
+            )
+
             for line in writeoff_lines:
                 line_ids_commands.append((2, line.id))
-            for extra_line_vals in line_vals_list[2:]:
+            for extra_line_vals in line_vals_per_type.get('write_off_lines', []) + line_vals_per_type.get('withholding_lines', []):
                 line_ids_commands.append((0, 0, extra_line_vals))
             # Update the existing journal items.
             # If dealing with multiple write-off lines, they are dropped and a new one is generated.

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -2,6 +2,7 @@
 from contextlib import contextmanager
 
 from odoo import Command, fields
+from odoo.exceptions import UserError
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import Form, tagged
@@ -878,3 +879,31 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
             'amount_signed': -100,
             'amount_company_currency_signed': -50,
         }])
+
+    def test_payment_move_with_multiple_liquidity_lines(self):
+        payment = self.env['account.payment'].create({
+            'amount': 150.0,
+            'payment_type': 'inbound',
+            'partner_type': 'customer',
+            'partner_id': self.partner_a.id,
+            'journal_id': self.company_data['default_journal_bank'].id,
+        })
+        payment.action_post()
+        move = payment.move_id
+        move.button_draft()
+        liquidity_lines = payment._seek_for_lines()[0]
+        move.write({
+            'line_ids': [
+                Command.update(liquidity_lines.id, {'amount_currency': 100}),
+                Command.create({
+                    'account_id': liquidity_lines.account_id.id,
+                    'balance': 50.0,
+                    'amount_currency': 50.0,
+                    'currency_id': payment.currency_id.id,
+                }),
+            ],
+        })
+        move.action_post()
+        payment.action_draft()
+        with self.assertRaises(UserError):
+            payment.amount = 300.0

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -355,8 +355,8 @@ class TestAccountPayment(AccountPaymentCommon):
         # Now try to change the journal, and check if the name is now updated
         payment.move_id.button_draft()
         new_journal = journal.copy()
-        new_payment_method_line = new_journal.inbound_payment_method_line_ids[0]
-        new_payment_method_line.write({'payment_account_id': self.company_data['default_account_receivable'].id})
+        new_payment_method_line = new_journal.outbound_payment_method_line_ids[0]
+        new_payment_method_line.write({'payment_account_id': payment.payment_method_line_id.payment_account_id.id})
         payment.write({
             'journal_id': new_journal.id,
             'payment_method_line_id': new_payment_method_line.id,

--- a/addons/l10n_account_withholding_tax/models/account_payment.py
+++ b/addons/l10n_account_withholding_tax/models/account_payment.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import Command, api, fields, models
+from odoo import api, fields, models
 
 
 class AccountPayment(models.Model):
@@ -96,84 +96,12 @@ class AccountPayment(models.Model):
 
     @api.model
     def _get_trigger_fields_to_synchronize(self):
-        # EXTEND account to add the withholding fields in the list.
+        # EXTEND account
         return super()._get_trigger_fields_to_synchronize() + ('withholding_line_ids', 'should_withhold_tax')
 
-    def _synchronize_to_moves(self, changed_fields):
-        """ Updates the synchronization in order to ensure that the entry takes into account changes in the withholding lines. """
-        # EXTEND account
-        if not any(field_name in changed_fields for field_name in self._get_trigger_fields_to_synchronize()):
-            return
-
-        withholding_payments = self.filtered(lambda payment: payment.withholding_line_ids and payment.should_withhold_tax)
-        for pay in withholding_payments:
-            liquidity_lines, counterpart_lines, write_off_lines = pay._seek_for_lines()
-
-            # Reset/update the liquidity/counterpart lines.
-            line_vals_list = pay._prepare_move_line_default_vals()
-            liquidity_line_values = line_vals_list[0]
-            counterpart_line_values = line_vals_list[1]
-
-            # Generate the new withholding lines.
-            liquidity_line_balance = liquidity_line_values['debit'] - liquidity_line_values['credit']
-            liquidity_line_amount_currency = liquidity_line_values['amount_currency']
-            withholding_line_values_list = pay.withholding_line_ids._prepare_withholding_amls_create_values()
-            write_off_line_ids_commands = []
-            for line_values in withholding_line_values_list:
-                write_off_line_ids_commands.append(Command.create(line_values))
-                liquidity_line_balance -= line_values['balance']
-                liquidity_line_amount_currency -= line_values['amount_currency']
-            if liquidity_line_balance > 0.0:
-                liquidity_line_values['debit'] = liquidity_line_balance
-                liquidity_line_values['credit'] = 0.0
-            else:
-                liquidity_line_values['debit'] = 0.0
-                liquidity_line_values['credit'] = -liquidity_line_balance
-            liquidity_line_values['amount_currency'] = liquidity_line_amount_currency
-
-            line_ids_commands = [
-                Command.update(liquidity_lines.id, liquidity_line_values) if liquidity_lines else Command.create(liquidity_line_values),
-                Command.update(counterpart_lines.id, counterpart_line_values) if counterpart_lines else Command.create(counterpart_line_values),
-            ] + [
-                Command.delete(line.id)
-                for line in write_off_lines
-            ] + write_off_line_ids_commands
-
-            pay.move_id \
-                .with_context(skip_invoice_sync=True) \
-                .write({
-                    'name': '/',  # Set the name to '/' to allow it to be changed
-                    'date': pay.date,
-                    'partner_id': pay.partner_id.id,
-                    'currency_id': pay.currency_id.id,
-                    'partner_bank_id': pay.partner_bank_id.id,
-                    'line_ids': line_ids_commands,
-                    'journal_id': pay.journal_id.id,
-                })
-
-        # All other payments will use the original logic
-        super(AccountPayment, self - withholding_payments)._synchronize_to_moves(changed_fields)
-
-    def _generate_move_vals(self, write_off_line_vals=None, force_balance=None, line_ids=None):
-        """ Ensure that the generated payment entry takes into account the withholding lines. """
-        # EXTEND account
-        move_vals = super()._generate_move_vals(write_off_line_vals=write_off_line_vals, force_balance=force_balance, line_ids=line_ids)
-        if not self.withholding_line_ids or not self.should_withhold_tax:
-            return move_vals
-
-        liquidity_line_values = move_vals['line_ids'][0][2]
-        liquidity_line_balance = liquidity_line_values['debit'] - liquidity_line_values['credit']
-        liquidity_line_amount_currency = liquidity_line_values['amount_currency']
-        withholding_line_values_list = self.withholding_line_ids._prepare_withholding_amls_create_values()
-        for line_values in withholding_line_values_list:
-            move_vals['line_ids'].append(Command.create(line_values))
-            liquidity_line_balance -= line_values['balance']
-            liquidity_line_amount_currency -= line_values['amount_currency']
-        liquidity_line_values['amount_currency'] = liquidity_line_amount_currency
-        if liquidity_line_balance > 0.0:
-            liquidity_line_values['debit'] = liquidity_line_balance
-            liquidity_line_values['credit'] = 0.0
-        else:
-            liquidity_line_values['debit'] = 0.0
-            liquidity_line_values['credit'] = -liquidity_line_balance
-        return move_vals
+    def _prepare_move_withholding_lines(self, default_values):
+        # EXTENDS account
+        withholding_lines = super()._prepare_move_withholding_lines(default_values)
+        if self.should_withhold_tax and self.withholding_line_ids:
+            withholding_lines += self.withholding_line_ids._prepare_withholding_amls_create_values()
+        return withholding_lines

--- a/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
+++ b/addons/l10n_account_withholding_tax/tests/test_account_withholding_flows.py
@@ -821,10 +821,10 @@ class TestL10nAccountWithholdingTaxesFlows(TestTaxCommon, AnalyticCommon):
             # Receivable line:
             {'name': 'Manual Payment: INV/2024/00001',          'balance': -1150.0},
             # withholding line:
-            {'name': 'WH Tax: 0001',                 'balance': 10.0},
+            {'name': 'WH Tax: 0001',                            'balance': 10.0},
             # base lines:
-            {'name': 'WH Base: 0001',                'balance': 1000.0},
-            {'name': 'WH Base Counterpart: 0001',    'balance': -1000.0},
+            {'name': 'WH Base: 0001',                           'balance': 1000.0},
+            {'name': 'WH Base Counterpart: 0001',               'balance': -1000.0},
         ])
 
         payment.action_draft()


### PR DESCRIPTION
This PR improves payment move synchronization and fixes an error that is caused while changing amount of a Payment that has multiple liquidity lines.

Steps to reproduce:
1. Create payment with x amount and validate it.
2. Open the payment journal entry.
3. Reset to draft and update the liquidity line amount from x to (x - y)
4. Create another liquidity line with amount y to balance entry and post it.
5. Draft the payment and try to update the amount.

A traceback will appear. `ValueError: Expected singleton`

Cause:
The lines for payment JE are prepared for the case assuming that there will be only 1 liquidity line, but since we have more than 1, we get a Singleton error.

Description of changes made:
While preparing values for move in `synchronize_to_moves()` check for multiple liquidity lines and append all values to write.
Further, the `_prepare_move_line_default_vals()` is also improved in order to manage different type of move lines individually.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
