### PR TITLE
[IMP] website_payment: make payment methods description more generic 

### DIFF
--- a/addons/website_payment/views/res_config_settings_views.xml
+++ b/addons/website_payment/views/res_config_settings_views.xml
@@ -78,7 +78,7 @@
                     <setting
                         string="Configure Payment Methods"
                         id="website_payment_setting"
-                        help="Visa, Mastercard, Maestro, Google Pay, Apple Pay, etc. as well as recurring charges."
+                        help="Visa, Mastercard, Maestro, UPI, Netbanking, PayNow, Klarna, etc., as well as recurring charges."
                         documentation="/applications/finance/payment_providers.html"
                     >
                         <div class="content-group">


### PR DESCRIPTION
Before the commit:
The website Payment Method description listed Google Pay and Apple Pay,
which are only available with Stripe in Express Checkout.

After the commit:
Updated the website Payment Methods description to use a more generic list,
including UPI, Netbanking, PayNow, and Klarna.

task-5896040