### PR TITLE
[FIX] html_builder: use correct CSS variable for color picker preview

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -182,7 +182,7 @@ export class BuilderColorPicker extends Component {
             if (style.backgroundImage !== "none") {
                 return `background-image: ${style.backgroundImage}`;
             } else {
-                return `background-color: var(--${colorCombination}-bg)`;
+                return `background-color: var(--hb-cp-${colorCombination}-bg); background-image: var(--hb-cp-${colorCombination}-bg-gradient);`;
             }
         }
         return "";

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -260,3 +260,29 @@ test("should open the last used tab", async () => {
     await contains(".we-bg-options-container .o_we_color_preview").click();
     expect(".theme-tab.active").toHaveCount(1);
 });
+
+test("should use correct color variables on preview when using color combination", async () => {
+    addBuilderAction({
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue() {
+                return "";
+            }
+        },
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderColorPicker action="'customAction'" defaultColor="''"/>`;
+        }
+    );
+
+    const { getEditor } = await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+    const editor = getEditor();
+    editor.shared.color.getColorCombination = () => "1";
+    await contains(":iframe .test-options-target").click();
+    expect(".we-bg-options-container .o_we_color_preview").toHaveAttribute(
+        "style",
+        "background-color: var(--hb-cp-1-bg); background-image: var(--hb-cp-1-bg-gradient);"
+    );
+});


### PR DESCRIPTION
Issue
-----
When a colour preset that includes a gradient is applied to the header, the color picker preview shows a white background instead of the preset's gradient.

Steps to reproduce
------------------
1. Select any gradient for the given theme.
2. Apply the given theme to the header without selecting a custom colour or gradient.
3. The colour picker preview incorrectly displays a white background.

Fix
---
Use the correct CSS variable for the colour picker preview background so the applied colour combination gradient is displayed properly.