### PR TITLE
[FIX] point_of_sale: Fix discard of combo products in POS

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1100,7 +1100,7 @@ export class PosStore extends WithLazyGetterTrap {
                       });
 
             if (!payload) {
-                return;
+                return false;
             }
 
             // Product template of combo should not have more than 1 variant.


### PR DESCRIPTION
When discarding a combo product in the POS, it was creating an empty orderline with the product with a price of 0.0$.

How to reproduce ?

1. Open a POS
2. Click on a combo product
3. Press ESC or press the cross icon
4. It creates an order line with the parent combo with a quantity of 0 and a price of 0.0 

Fix : It’s because the popup payload returns undefined when the user discards it, but the condition was checking for false instead of undefined.

task: 5868094

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
