### PR TITLE
[FIX] l10n_in: fix tds report negative amount

### DIFF
--- a/addons/l10n_in/data/account_tax_report_tds_data.xml
+++ b/addons/l10n_in/data/account_tax_report_tds_data.xml
@@ -19,7 +19,7 @@
                     <record id="tds_report_line_section_192_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">192</field>
+                        <field name="formula">-192</field>
                     </record>
                 </field>
             </record>
@@ -29,7 +29,7 @@
                     <record id="tds_report_line_section_192a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">192A</field>
+                        <field name="formula">-192A</field>
                     </record>
                 </field>
             </record>
@@ -39,7 +39,7 @@
                     <record id="tds_report_line_section_193_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">193</field>
+                        <field name="formula">-193</field>
                     </record>
                 </field>
             </record>
@@ -49,7 +49,7 @@
                     <record id="tds_report_line_section_194_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194</field>
+                        <field name="formula">-194</field>
                     </record>
                 </field>
             </record>
@@ -59,7 +59,7 @@
                     <record id="tds_report_line_section_194a_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194A</field>
+                        <field name="formula">-194A</field>
                     </record>
                 </field>
             </record>
@@ -69,7 +69,7 @@
                     <record id="tds_report_line_section_194b_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194B</field>
+                        <field name="formula">-194B</field>
                     </record>
                 </field>
             </record>
@@ -79,7 +79,7 @@
                     <record id="tds_report_line_section_194bb_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194BB</field>
+                        <field name="formula">-194BB</field>
                     </record>
                 </field>
             </record>
@@ -89,7 +89,7 @@
                     <record id="tds_report_line_section_194c_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194C</field>
+                        <field name="formula">-194C</field>
                     </record>
                 </field>
             </record>
@@ -99,7 +99,7 @@
                     <record id="tds_report_line_section_194d_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194D</field>
+                        <field name="formula">-194D</field>
                     </record>
                 </field>
             </record>
@@ -109,7 +109,7 @@
                     <record id="tds_report_line_section_194da_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194DA</field>
+                        <field name="formula">-194DA</field>
                     </record>
                 </field>
             </record>
@@ -119,7 +119,7 @@
                     <record id="tds_report_line_section_194e_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194E</field>
+                        <field name="formula">-194E</field>
                     </record>
                 </field>
             </record>
@@ -129,7 +129,7 @@
                     <record id="tds_report_line_section_194ee_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194EE</field>
+                        <field name="formula">-194EE</field>
                     </record>
                 </field>
             </record>
@@ -139,7 +139,7 @@
                     <record id="tds_report_line_section_194f_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194F</field>
+                        <field name="formula">-194F</field>
                     </record>
                 </field>
             </record>
@@ -149,7 +149,7 @@
                     <record id="tds_report_line_section_194g_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194G</field>
+                        <field name="formula">-194G</field>
                     </record>
                 </field>
             </record>
@@ -159,7 +159,7 @@
                     <record id="tds_report_line_section_194h_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194H</field>
+                        <field name="formula">-194H</field>
                     </record>
                 </field>
             </record>
@@ -169,7 +169,7 @@
                     <record id="tds_report_line_section_194i_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194I</field>
+                        <field name="formula">-194I</field>
                     </record>
                 </field>
             </record>
@@ -179,7 +179,7 @@
                     <record id="tds_report_line_section_194ia_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194IA</field>
+                        <field name="formula">-194IA</field>
                     </record>
                 </field>
             </record>
@@ -189,7 +189,7 @@
                     <record id="tds_report_line_section_194ib_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194IB</field>
+                        <field name="formula">-194IB</field>
                     </record>
                 </field>
             </record>
@@ -199,7 +199,7 @@
                     <record id="tds_report_line_section_194ic_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194IC</field>
+                        <field name="formula">-194IC</field>
                     </record>
                 </field>
             </record>
@@ -209,7 +209,7 @@
                     <record id="tds_report_line_section_194j_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194J</field>
+                        <field name="formula">-194J</field>
                     </record>
                 </field>
             </record>
@@ -219,7 +219,7 @@
                     <record id="tds_report_line_section_194k_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194K</field>
+                        <field name="formula">-194K</field>
                     </record>
                 </field>
             </record>
@@ -229,7 +229,7 @@
                     <record id="tds_report_line_section_194la_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194LA</field>
+                        <field name="formula">-194LA</field>
                     </record>
                 </field>
             </record>
@@ -239,7 +239,7 @@
                     <record id="tds_report_line_section_194lba_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194LBA(1)</field>
+                        <field name="formula">-194LBA(1)</field>
                     </record>
                 </field>
             </record>
@@ -249,7 +249,7 @@
                     <record id="tds_report_line_section_194lb_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194LB</field>
+                        <field name="formula">-194LB</field>
                     </record>
                 </field>
             </record>
@@ -259,7 +259,7 @@
                     <record id="tds_report_line_section_194lbb_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194LBB</field>
+                        <field name="formula">-194LBB</field>
                     </record>
                 </field>
             </record>
@@ -269,7 +269,7 @@
                     <record id="tds_report_line_section_194lbc_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194LBC</field>
+                        <field name="formula">-194LBC</field>
                     </record>
                 </field>
             </record>
@@ -279,7 +279,7 @@
                     <record id="tds_report_line_section_194m_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194M</field>
+                        <field name="formula">-194M</field>
                     </record>
                 </field>
             </record>
@@ -289,7 +289,7 @@
                     <record id="tds_report_line_section_194n_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194N</field>
+                        <field name="formula">-194N</field>
                     </record>
                 </field>
             </record>
@@ -299,7 +299,7 @@
                     <record id="tds_report_line_section_194o_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194O</field>
+                        <field name="formula">-194O</field>
                     </record>
                 </field>
             </record>
@@ -309,7 +309,7 @@
                     <record id="tds_report_line_section_194q_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">194Q</field>
+                        <field name="formula">-194Q</field>
                     </record>
                 </field>
             </record>
@@ -319,7 +319,7 @@
                     <record id="tds_report_line_section_195_tag" model="account.report.expression">
                         <field name="label">balance</field>
                         <field name="engine">tax_tags</field>
-                        <field name="formula">195</field>
+                        <field name="formula">-195</field>
                     </record>
                 </field>
             </record>


### PR DESCRIPTION
ref commit-https://github.com/odoo/odoo/commit/17a6117ed88c29b5bc4db0c872bcdbc109a7d98b

The TDS report was incorrectly showing amounts as negative.
This PR, adjusts the sign handling so that the amounts are displayed as positive,
ensuring the report reflects the correct TDS values.

task-5894372
