### PR TITLE
[FIX] tools, test_orm: handle bytearray in magic mimetype detection

### DIFF
--- a/odoo/addons/test_orm/tests/test_guess_mimetypes.py
+++ b/odoo/addons/test_orm/tests/test_guess_mimetypes.py
@@ -152,6 +152,12 @@ class MimeGuessingCases:
             'application/octet-stream',
         )
 
+    def test_bytearray(self):
+        self.assertEqual(
+            self.guess_mimetype(bytearray((TEST_FOLDER / 'file.png').read_bytes())),
+            'image/png',
+        )
+
 
 @tagged('at_install', '-post_install')
 class TestMimeGuessingOdoo(BaseCase, MimeGuessingCases):

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -42,7 +42,8 @@ def _odoo_guess_mimetype(bin_data, default='application/octet-stream'):
 
 
 def _magic_guess_mimetype(bin_data):
-    mimetype = magic.from_buffer(bin_data, mime=True)
+    magic_data = bytes(bin_data[:MIMETYPE_HEAD_SIZE]) if isinstance(bin_data, bytearray) else bin_data
+    mimetype = magic.from_buffer(magic_data, mime=True)
 
     # magic.from_buffer() doesn't properly detect DOC, XLS, and PPT documents.
     if mimetype in _olecf_mimetypes:


### PR DESCRIPTION
The recent mimetype refactor reintroduced a crash where `python-magic` fails on `bytearray` inputs with a `TypeError` (ctypes buffer mismatch).

Steps to reproduce:
- Have python-magic library installed
- Products > Import records
- Upload a file containing an URL as image_1920
- Test upload

The upload fails with error: `Could not retrieve URL: <img-url>
[image_1920: L1]: argument 2: TypeError: wrong type`

This restores the fix from 7f36e380c0b175d0046a19f49e572944a5b307d9 by ensuring `bytearray` inputs are converted to `bytes` before detection.

opw-5893097