### PR TITLE
[FIX] account_payment: duplicata of SEPA Direct Debit

### DIFF
--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -70,6 +70,8 @@ class PaymentProvider(models.Model):
             )
             if pay_method_line_same_code:
                 create_values['payment_account_id'] = pay_method_line_same_code.payment_account_id.id
+            if self._get_code() == 'sepa_direct_debit':
+                create_values['name'] = "Online SEPA"
             self.env['account.payment.method.line'].create(create_values)
 
     def _get_payment_method_outstanding_account_id(self, payment_method_id):


### PR DESCRIPTION
When activating SEPA Payment Provider and checking SEPA in your settings,
the name of the two (different) method was the same. Rename the method line
associated with the method that comes from the provider by 'Online SEPA' to
avoid confusion.

task-5875979

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
