### PR TITLE
[IMP] sale, _*: show promised delivery and delivery status sheet header of SO

### DIFF
--- a/addons/delivery/views/sale_order_views.xml
+++ b/addons/delivery/views/sale_order_views.xml
@@ -4,6 +4,7 @@
     <record id="view_order_form_with_carrier" model="ir.ui.view">
         <field name="name">delivery.sale.order.form.view.with_carrier</field>
         <field name="model">sale.order</field>
+        <field name="priority">30</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <header position="inside">
@@ -33,9 +34,9 @@
             <xpath expr="//field[@name='order_line']/list" position="attributes">
                 <attribute name="decoration-warning" add="(recompute_delivery_price and is_delivery)" separator="or"/>
             </xpath>
-            <label for="commitment_date" position="before">
+            <field name="incoterm_location" position="after">
                 <field name="shipping_weight" readonly="True"/>
-            </label>
+            </field>
         </field>
     </record>
 

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -562,7 +562,20 @@
                             name="payment_term_id"
                             placeholder="Immediate"
                             options="{'no_open': True, 'no_create': True}"/>
-                    </group>
+                        <label for="commitment_date" invisible="state == 'draft'"/>
+                        <label for="commitment_date" string="Delivery Date" invisible="state != 'draft'"/>
+                        <div name="commitment_date_div" class="o_row align-items-center">
+                            <field name="commitment_date" readonly="state == 'cancel' or locked"/>
+                            <field
+                                name="delivery_status"
+                                widget="badge"
+                                decoration-success="delivery_status == 'full'"
+                                decoration-warning="delivery_status == 'partial'"
+                                decoration-info="delivery_status in ['pending', 'started']"
+                                invisible="state != 'sale'"
+                            />
+                        </div>
+                   </group>
                 </group>
                 <notebook>
                     <page string="Order Lines" name="order_lines">
@@ -971,12 +984,6 @@
                             <group name="sale_shipping" string="Shipping">
                                 <field name="incoterm" options="{'no_open': True, 'no_create': True}"/>
                                 <field name="incoterm_location"/>
-                                <label for="commitment_date" string="Delivery Date" invisible="state != 'draft'"/>
-                                <label for="commitment_date" string="Promised Delivery" invisible="state =='draft'"/>
-                                <div name="commitment_date_div" class="o_row">
-                                    <field name="commitment_date" readonly="state == 'cancel' or locked"/>
-                                </div>
-                                <field name="delivery_status" invisible="state != 'sale'"/>
                             </group>
                             <group name="sale_reporting" string="Tracking">
                                 <field name="origin"/>

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -5,6 +5,7 @@
         <field name="name">sale.order.form.sale.stock</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="priority">20</field>
         <field name="arch" type="xml">
             <button name="action_view_invoice" position="before">
                 <button
@@ -22,28 +23,19 @@
                 <attribute name="groups"></attribute><!-- Remove the res.group on the group and set it on the field directly-->
                 <attribute name="string">Delivery</attribute>
             </group>
-            <label for="commitment_date" position="before">
+            <field name="incoterm_location" position="after">
                 <field name="warehouse_id" options="{'no_create': True}" force_save="1" readonly="state == 'sale'"/>
                 <field name="picking_policy" required="True" readonly="state not in ['draft', 'sent']"/>
-            </label>
-            <div name="commitment_date_div" position="replace">
-                <div class="o_row">
-                    <field name="expected_date" invisible="1"/>  <!-- Needed for the placeholder widget -->
-                    <field name="commitment_date" options="{'placeholder_field': 'expected_date'}"/>
-                    <field
-                        name="delivery_status"
-                        class="oe_inline"
-                        invisible="state != 'sale'"
-                        decoration-success="delivery_status == 'full'"
-                        decoration-warning="delivery_status == 'partial'"
-                        decoration-info="delivery_status in ['pending', 'started']"
-                        widget="badge"/>
-                </div>
+            </field>
+            <div name="commitment_date_div" position="after">
                 <field name="effective_date" invisible="not effective_date"/>
             </div>
-            <xpath expr="//page[@name='other_information']//field[@name='commitment_date']" position="after">
+            <field name="commitment_date" position="attributes">
+                <attribute name="options">{'placeholder_field': 'expected_date'}</attribute>
+            </field>
+            <field name="commitment_date" position="after">
                 <field string=" " name="json_popover" widget="stock_rescheduling_popover" invisible="not show_json_popover"/>
-            </xpath>
+            </field>
             <xpath expr="//field[@name='order_line']//form//field[@name='analytic_distribution']" position="before">
                 <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}"/>
             </xpath>


### PR DESCRIPTION
_*= sale_stock, delivery

Before the commit:
Promised delivery date and delivery status were displayed separately
and buried in the Delivery section of the Sales Order, making them
easy to miss.

After the commit:
Moved promised delivery to the top of the Sales Order
Combined delivery status with promised delivery
Displayed delivery status as a badge next to the date

task-5892894

See also:

- https://github.com/odoo/enterprise/pull/107470