### PR TITLE
[IMP] data_recycle: allow user to manual refresh

### DIFF
--- a/addons/data_recycle/__manifest__.py
+++ b/addons/data_recycle/__manifest__.py
@@ -18,6 +18,8 @@
     'application': True,
     'assets': {
         'web.assets_backend': [
+            'data_recycle/static/src/cog_menu/data_refresh_cog_menu.js',
+            'data_recycle/static/src/cog_menu/data_refresh_cog_menu.xml',
             'data_recycle/static/src/views/*.js',
             'data_recycle/static/src/views/*.xml',
         ],

--- a/addons/data_recycle/models/data_recycle_model.py
+++ b/addons/data_recycle/models/data_recycle_model.py
@@ -218,3 +218,21 @@ class Data_RecycleModel(models.Model):
         if self.recycle_mode == 'manual':
             return self.open_records()
         return
+
+    def refresh_recycle_records(self):
+        """
+        Refresh recycled records and reopen the Data Recycle view.
+        Preserves the selected search panel filter by passing
+        `recycle_model_id` into the action context.
+        """
+        self.search([])._recycle_records(batch_commits=True)
+        recycle_model_id = self.env.context.get('recycle_model_id')
+        action = self.env["ir.actions.actions"]._for_xml_id("data_recycle.action_data_recycle_record")
+        context = action.get('context', {})
+        if isinstance(context, str):
+            context = ast.literal_eval(context)
+        if recycle_model_id:
+            context['searchpanel_default_recycle_model_id'] = recycle_model_id
+        action['context'] = context
+        action['target'] = 'main'
+        return action

--- a/addons/data_recycle/static/src/cog_menu/data_refresh_cog_menu.js
+++ b/addons/data_recycle/static/src/cog_menu/data_refresh_cog_menu.js
@@ -1,0 +1,47 @@
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+const cogMenuRegistry = registry.category("cogMenu");
+
+export class DataRefreshCogMenu extends Component {
+    static template = "data_recycle.DataRefreshCogMenu";
+    static components = { DropdownItem };
+    static props = {};
+
+    setup() {
+        this.action = useService("action");
+    }
+
+    _getDomainValue(fieldName) {
+        // The searchpanel adds the selected rule to the domain as
+        // ['fieldName', '=', <id>]. We extract that id from the
+        // current domain and pass it in the action context so that,
+        // after refresh, the same rule remains selected in seachpanel.
+        const domain = this.env.searchModel.domain;
+        return domain.find((d) => Array.isArray(d) && d[0] === fieldName && d[1] === "=")?.[2];
+    }
+
+    async refreshData() {
+        const ruleId = this._getDomainValue("recycle_model_id");;
+        return await this.action.doActionButton({
+            type: "object",
+            resModel: "data_recycle.model",
+            name: "refresh_recycle_records",
+            context: {
+                recycle_model_id: ruleId,
+            }
+        });
+    }
+}
+
+export const DataRefreshCogMenuItem = {
+    Component: DataRefreshCogMenu,
+    isDisplayed: ({ searchModel }) => {
+        return searchModel.resModel === "data_recycle.record";
+    },
+    groupNumber: 50,
+};
+
+cogMenuRegistry.add("data_refresh_menu", DataRefreshCogMenuItem, { sequence: 10 });

--- a/addons/data_recycle/static/src/cog_menu/data_refresh_cog_menu.xml
+++ b/addons/data_recycle/static/src/cog_menu/data_refresh_cog_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="data_recycle.DataRefreshCogMenu">
+        <DropdownItem onSelected.bind="refreshData">
+            <i class="fa fa-refresh me-1"/>
+            Refresh
+        </DropdownItem>
+    </t>
+</templates>


### PR DESCRIPTION
Before:
- User was not able to refresh deduplication, recycle, and field cleaning data for all rules at once.
- To refresh data, user had to open each rule and update records manually.

After:
- Added a button in the cog menu to refresh deduplication, recycle, and field cleaning data for all rules at once.

task-5864554

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
