### PR TITLE
[FIX] point_of_sale: fix combo last line price assignment

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -27,8 +27,11 @@ export const computeComboItems = (
         let priceUnit = ProductPrice.round((combo.base_price * parentLstPrice) / originalTotal);
         remainingTotal -= priceUnit * conf.qty;
 
-        if (comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id) {
-            priceUnit += remainingTotal;
+        if (
+            remainingTotal &&
+            comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id
+        ) {
+            priceUnit += ProductPrice.round(remainingTotal / conf.qty);
         }
         const attribute_value_ids = conf.configuration?.attribute_value_ids?.map(
             (id) => productTemplateAttributeValueById[id]

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -211,6 +211,22 @@ registry.category("web_tour.tours").add("ProductComboMaxFreeQtyTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_combo_remaining_amount_applied_to_last_line", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Combo"),
+            combo.checkTotal("40.00"),
+            combo.select("Combo Item A"),
+            combo.clickQtyBtnAdd("Combo Item A"),
+            Dialog.confirm(),
+            inLeftSide([...ProductScreen.selectedOrderlineHasDirect("Test Combo", "1", "46.00")]),
+            ProductScreen.totalAmountIs("46.00"),
+            ProductScreen.clickPayButton(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("ProductComboChangePricelist", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1197,6 +1197,41 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('ProductComboMaxFreeQtyTour')
 
+    def test_combo_remaining_amount_applied_to_last_line(self):
+        """Test remaining combo amount is correctly applied to the last combo line"""
+        combo_items = self.env["product.product"].create([
+            {
+                "name": "Combo Item A",
+                "is_storable": True,
+                "available_in_pos": True,
+                "list_price": 0.0,
+            },
+            {
+                "name": "Combo Item B",
+                "is_storable": True,
+                "available_in_pos": True,
+                "list_price": 0.0,
+            },
+        ])
+        combo = self.env["product.combo"].create({
+            "name": "combo",
+            "qty_free": 2,
+            "qty_max": 2,
+            "combo_item_ids": [
+                Command.create({"product_id": combo_items[0].id}),
+                Command.create({"product_id": combo_items[1].id}),
+            ],
+        })
+        self.env["product.product"].create({
+            "name": "Test Combo",
+            "type": "combo",
+            "available_in_pos": True,
+            "list_price": 40,
+            "combo_ids": [(6, 0, [combo.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("test_combo_remaining_amount_applied_to_last_line")
+
     def test_line_configurators(self):
         setup_product_combo_items(self)
         self.env['product.combo.item'].create({


### PR DESCRIPTION
Step to reproduce:
- create two products with 0 price, A and B
- create combo choice 'combo' with A and B, with max 2 items , free 2 items
- create a combo product "test combo" with this combo choice, set price=40
- start pos and select this product
- in combo product selector dialog, select same product 2 time and confirm

Observation:
- the total price is 80 (double then expected) in product screen

Cause:
- Remaining combo amount is assigned to the last line unit price.
- For zero-price items, remaining amount equals combo price.
- as `Total = qty × unit price`, as qty =2 it duplicates the combo price.

Fix:
- Since we assign unit price, divide remaining amount by combo qty.

opw-5868831



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
