### PR TITLE
[FIX] website: TestWebsiteBlogUi.test_blog_access_rights tour

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_manager_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_manager_tour.js
@@ -40,6 +40,9 @@ registerWebsitePreviewTour(
             run: "editor Manager Blog Test Title",
         },
         {
+            trigger: ".o-snippets-menu:has(.o_customize_tab)",
+        },
+        {
             content: "Edit blog content.",
             trigger: ":iframe #o_wblog_post_content p",
             run: "editor Manager Blog Test Content",


### PR DESCRIPTION
With this commit, we fix the tour by adding a step that ensure the menu is well rendered before to destroy it.

runbot-error-id~238489

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
