### PR TITLE
[FIX] l10n_ro_efactura: Allow reset to draft for e-bills

### DIFF
--- a/addons/l10n_ro_efactura/models/account_move.py
+++ b/addons/l10n_ro_efactura/models/account_move.py
@@ -44,7 +44,7 @@ class AccountMove(models.Model):
         # EXTENDS 'account'
         super()._compute_show_reset_to_draft_button()
         for move in self:
-            if move.l10n_ro_edi_state in ('invoice_sending', 'invoice_sent'):
+            if move.move_type in ('out_invoice', 'out_refund') and move.l10n_ro_edi_state in ('invoice_sending', 'invoice_sent'):
                 move.show_reset_to_draft_button = False
 
     ################################################################################


### PR DESCRIPTION
Adjusting the visibility check for "Reset to draft" button to allow Vendor Bills received from ANAF to be reset even when they have a EDI state.
Will require to be shifted to `l10n_ro_edi` in 18.0+ as the efactura module is merged into it.
task-5892651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
