### PR TITLE
[FIX] mass_mailing: preserve centered images in sent emails

### DIFF
--- a/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/image_tool_option.xml
@@ -3,7 +3,7 @@
         <BuilderRow label.translate="Alignment">
             <BuilderSelect>
                 <BuilderSelectItem classAction="'float-start'">Left</BuilderSelectItem>
-                <BuilderSelectItem classAction="'mx-auto'">Center</BuilderSelectItem>
+                <BuilderSelectItem classAction="'mx-auto d-block'">Center</BuilderSelectItem>
                 <BuilderSelectItem classAction="'float-end'">Right</BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>


### PR DESCRIPTION
Problem:
The center alignment of images is not preserved in sent emails.

Cause:
Images using the `mx-auto` utility require `display: block` to be properly centered. Without it, the centering is lost during email rendering.

Solution:
Add the `d-block` class to images in the affected snippets so that `mx-auto` works correctly and images remain centered in the sent email.

Steps to reproduce:
- Add an image/text block.
- Change the number of columns to 1.
- Center the image.
- Send the email.
- Observe that the image is not centered in the received email.

opw-5504001

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
