### PR TITLE
[FIX] html_builder: prevent `loadFields` on destroyed `ModelMany2Many`

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/model_many2many.js
+++ b/addons/html_builder/static/src/core/building_blocks/model_many2many.js
@@ -1,4 +1,4 @@
-import { Component, useState, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { Component, useState, onWillStart, onWillUpdateProps, status } from "@odoo/owl";
 import { uniqueId } from "@web/core/utils/functions";
 import { useService } from "@web/core/utils/hooks";
 import { useDomState } from "@html_builder/core/utils";
@@ -57,6 +57,11 @@ export class ModelMany2Many extends Component {
             [props.recordId],
             [props.m2oField]
         );
+
+        if (status(this) === "destroyed") {
+            return;
+        }
+
         const selectedRecordIds = record[props.m2oField];
         // TODO: handle no record
         const modelData = await this.fields.loadFields(props.baseModel, {


### PR DESCRIPTION
### Before this commit

If the `ModelMany2Many` was destroyed before the call to `this.fields.loadFields`, a `Component is destroyed` error would occur.

The tour `TestWebsiteBlogUi.test_blog_access_rights` would regularly fail because it instantly closed the website builder before the `onWillStart` method finished, revealing this issue.

### Fix

Add a safety check to ensure the component still exists before calling `loadFields`.

runbot-238489