### PR TITLE
[IMP] mail: support action inline text only

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -425,6 +425,19 @@ export class Action {
         );
     }
 
+    /** @param {Action} action @returns {boolean} */
+    _inlineIcon(action) {}
+    /** When action is used in inline, determines whether the icon should be displayed or not. */
+    get inlineIcon() {
+        return (
+            this._inlineIcon(this.params) ??
+            (typeof this.definition.inlineIcon === "function"
+                ? this.definition.inlineIcon.call(this, this.params)
+                : this.definition.inlineIcon) ??
+            true
+        );
+    }
+
     /** @param {Action} action @returns {string|undefined} */
     _inlineName(action) {}
     /** If set, when action is used in inline, shows action name in addition to icon. */

--- a/addons/mail/static/src/core/common/action_list.js
+++ b/addons/mail/static/src/core/common/action_list.js
@@ -58,7 +58,8 @@ class Action extends Component {
         return (
             this.props.odooControlPanelSwitchStyle ||
             this.props.hasBtnBg ||
-            this.props.action.hasBtnBg
+            this.props.action.hasBtnBg ||
+            (this.props.inline && !this.action.inlineIcon && this.action.inlineName)
         );
     }
 

--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -27,7 +27,11 @@
         &.o-inline {
             &:where(:has(i:first-child:last-child)) {
                 opacity: var(--o-mail-ActionList-Button-opacity);
-
+            }
+            &:where(:has(span:first-child:last-child)) {
+                opacity: var(--o-mail-ActionList-Button-opacityInlineName);
+            }
+            &:where(:has(i:first-child:last-child)), &:where(:has(span:first-child:last-child)) {
                 &:where(.rounded-circle) {
                     aspect-ratio: 1;
                 }

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -129,7 +129,7 @@
     <t t-if="this.action.icon?.template" t-call="{{ this.action.icon.template }}">
         <t t-set="templateParams" t-value="this.action.icon.params"/>
     </t>
-    <i t-elif="this.action.icon" t-attf-class="{{ this.action.icon }}" t-att-class="{ 'o-fs-small': this.props.dropdown, 'fa-fw': this.props.fw, 'fa-lg': inMeetingViewCallButtonsFullscreen }"/>
+    <i t-elif="this.action.icon and !(this.props.inline and !this.action.inlineIcon and this.action.inlineName)" t-attf-class="{{ this.action.icon }}" t-att-class="{ 'o-fs-small': this.props.dropdown, 'fa-fw': this.props.fw, 'fa-lg': inMeetingViewCallButtonsFullscreen }"/>
     <i t-elif="this.props.dropdown" class="fa-question fa-fw opacity-0" t-att-class="this.props.fw ? 'fa-fw' : ''"/>
     <span t-if="this.action.name and (this.props.dropdown or (this.props.inline and (!this.action.icon or this.action.inlineName)))" class="o-mail-ActionList-actionLabel" t-attf-class="{{ this.action.nameClass }}" t-att-class="{ 'mx-1': this.props.dropdown }" t-out="(this.props.inline and this.action.inlineName) or this.action.name"/>
     <t t-if="this.props.dropdown and this.action.badge" t-call="mail.Action.badge"/>

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -135,6 +135,7 @@
 
 .o-mail-Message-actions {
     --o-mail-ActionList-Button-opacity: .35;
+    --o-mail-ActionList-Button-opacityInlineName: .5;
     --o-mail-ActionList-Button-opacity--hover: 1;
     --o-mail-ActionList-Button-color--hover: var(--mail-Message-actionIconHoveredColor, black);
 


### PR DESCRIPTION
This commit adds a new property `inlineIcon` on actions, which determines whether to display icon or not in inline mode. This is `true` by default.

This is useful when paired with `inlineName`, so that we can have an inline action displayed as just text.

Example:

"Copy Text" looks like this, without `inlineIcon` and `inlineName`:
<img width="322" height="102" alt="Screenshot 2026-02-06 at 18 16 53" src="https://github.com/user-attachments/assets/c2393789-7cdd-419c-aa54-a23d9e275f25" />
<img width="160" height="253" alt="Screenshot 2026-02-06 at 18 16 06" src="https://github.com/user-attachments/assets/bf86c6e8-31d5-4e0c-be92-b4b145384c2f" />

If we want to have it look like a button with just text:

<img width="466" height="168" alt="Screenshot 2026-02-02 at 11 29 10" src="https://github.com/user-attachments/assets/9dd988b3-3151-4b68-9453-843fbf27c553" />

This looks like this:
<img width="323" height="109" alt="Screenshot 2026-02-06 at 18 30 05" src="https://github.com/user-attachments/assets/2bf0d57c-d9f3-4504-b829-43007d3eec5f" />
<img width="327" height="115" alt="Screenshot 2026-02-06 at 18 15 57" src="https://github.com/user-attachments/assets/e6339d82-74a3-4172-924f-fe14f9b8ca95" />


While preserving its look of icon + text in dropdown.