### PR TITLE
[IMP] website: add arrow styling option for dynamic snippet

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
@@ -12,6 +12,20 @@
                 <BuilderSelectItem classAction="'o_arrows_bottom o_arrows_bottom_right'">Bottom Right</BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>
+        <BuilderRow label.translate="Style" level="1">
+            <BuilderSelect>
+                <BuilderSelectItem classAction="'o_default_arrows'">Default</BuilderSelectItem>
+                <BuilderSelectItem classAction="'o_boxed_arrows'">Boxed</BuilderSelectItem>
+                <BuilderSelectItem classAction="''">Rounded</BuilderSelectItem>
+                <BuilderSelectItem classAction="'o_hidden_arrows'">Hidden</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+        <BuilderRow label.translate="Color" level="1">
+            <BuilderSelect>
+                <BuilderSelectItem classAction="'o_light_arrows'">Regular</BuilderSelectItem>
+                <BuilderSelectItem classAction="''">Inverted colors</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
 	    <BuilderRow label.translate="Slider Speed" t-if="numberOfRecords > 1">
 	        <BuilderNumberInput action="'setCarouselSliderSpeed'" default="1" unit="'s'" saveUnit="''" step="0.1" min="0" preview="false" id="'speed_opt'"/>
 	    </BuilderRow>

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
@@ -24,6 +24,37 @@
         width: auto;
     }
 
+    // Rounded arrows (default selected)
+    .o_carousel_arrow {
+        border-radius: $border-radius-pill;
+        background-color: $carousel-dark-indicator-active-bg;
+        color: $carousel-control-color;
+    }
+
+    &.o_light_arrows, &.o_default_arrows {
+        .o_carousel_arrow {
+            filter: $carousel-dark-control-icon-filter;
+        }
+    }
+
+    &.o_default_arrows {
+        .o_carousel_arrow {
+            background: none;
+        }
+
+        &.o_light_arrows .o_carousel_arrow {
+            filter: none;
+        }
+    }
+
+    &.o_boxed_arrows .o_carousel_arrow {
+        border-radius: $border-radius;
+    }
+
+    &.o_hidden_arrows .o_carousel_arrow {
+        display: none;
+    }
+
     &:where(:not(.o_carousel_multi_items)) > :where(:not(.container-fluid)) {
         .s_dynamic_snippet_title_aside + .s_dynamic_snippet_content {
             .s_dynamic_snippet_arrows {
@@ -37,13 +68,21 @@
     }
 
     @include media-breakpoint-up(md) {
-        &:where(:not([class*="o_arrows_"])){
+        --o-DynamicCarousel__arrowPrev-offset: -50% /* rtl: 50% */;
+        --o-DynamicCarousel__arrowNext-offset: 50% /* rtl: -50% */;
+
+        &.o_default_arrows {
+            --o-DynamicCarousel__arrowPrev-offset: -100% /* rtl: 100% */;
+            --o-DynamicCarousel__arrowNext-offset: 100% /* rtl: -100% */;
+        }
+
+        &:where(:not([class*="o_arrows_"])) {
             .carousel-control-prev {
-                transform: translateX(-50%);
+                transform: translateX(var(--o-DynamicCarousel__arrowPrev-offset));
             }
 
             .carousel-control-next {
-                transform: translateX(50%);
+                transform: translateX(var(--o-DynamicCarousel__arrowNext-offset));
             }
         }
 

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
@@ -3,13 +3,13 @@
     <t t-name="website.s_dynamic_snippet.carousel.arrows">
         <div class="o_carousel_arrow_wrap align-items-center pe-none">
             <a t-attf-href="##{unique_id}" class="carousel-control-prev position-relative pe-auto" data-bs-slide="prev" role="button" aria-label="Previous" title="Previous">
-                <span class="oi oi-chevron-left rounded-pill p-3 bg-700"/>
+                <span class="o_carousel_arrow oi oi-chevron-left p-3"/>
                 <span class="visually-hidden">Previous</span>
             </a>
         </div>
         <div class="o_carousel_arrow_wrap align-items-center justify-content-end pe-none">
             <a t-attf-href="##{unique_id}" class="carousel-control-next position-relative pe-auto" data-bs-slide="next" role="button" aria-label="Next" title="Next">
-                <span class="oi oi-chevron-right rounded-pill p-3 bg-700"/>
+                <span class="o_carousel_arrow oi oi-chevron-right p-3"/>
                 <span class="visually-hidden">Next</span>
             </a>
         </div>


### PR DESCRIPTION
This PR adds new option for arrow styling on the dynamic snippet carousel, including "**default**", "**boxed**", "**rounded**", and "**hidden**" states. Additionally, it adds a new option to **invert** the arrow colors.

task-5179779