### PR TITLE
[IMP] tools: add protected accessor for callable

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -147,7 +147,7 @@ class OAuthController(Controller):
                 url = '/odoo?menu_id=%s' % menu
 
             credential = {'login': login, 'token': key, 'type': 'oauth_token'}
-            auth_info = request.session.authenticate(request.env, credential)
+            auth_info = request.session.__.authenticate(request.env, credential)
             resp = request.redirect(_get_login_redirect_url(auth_info['uid'], url), 303)
             resp.autocorrect_location_header = False
 

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -179,7 +179,7 @@ class AuthSignupHome(Home):
         login, password = request.env['res.users'].sudo().signup(values, token)
         credential = {'login': login, 'password': password, 'type': 'password'}
         if do_login:
-            request.session.authenticate(request.env, credential)
+            request.session.__.authenticate(request.env, credential)
 
 class AuthBaseSetup(BaseSetup):
     @http.route()

--- a/addons/auth_totp/controllers/home.py
+++ b/addons/auth_totp/controllers/home.py
@@ -35,7 +35,7 @@ class Home(web_home.Home):
                 user_match = request.env['auth_totp.device']._check_credentials_for_uid(
                     scope="browser", key=key, uid=user.id)
                 if user_match:
-                    request.session.finalize(request.env)
+                    request.session.__.finalize(request.env)
                     request.update_env(user=request.session.uid)
                     request.update_context(**request.session.context)
                     return request.redirect(self._login_redirect(request.session.uid, redirect=redirect))
@@ -53,7 +53,7 @@ class Home(web_home.Home):
             except ValueError:
                 error = _("Invalid authentication code format.")
             else:
-                request.session.finalize(request.env)
+                request.session.__.finalize(request.env)
                 request.update_env(user=request.session.uid)
                 request.update_context(**request.session.context)
                 response = request.redirect(self._login_redirect(request.session.uid, redirect=redirect))

--- a/addons/base_import_module/controllers/main.py
+++ b/addons/base_import_module/controllers/main.py
@@ -15,7 +15,7 @@ class ImportModule(Controller):
             if not request.db:
                 raise Exception(_("Could not select database '%s'", request.db))
             credential = {'login': login, 'password': password, 'type': 'password'}
-            request.session.authenticate(request.env, credential)
+            request.session.__.authenticate(request.env, credential)
             # request.env.uid is None in case of MFA
             if request.env.uid and request.env.user._is_admin():
                 return request.env['ir.module.module']._import_zipfile(mod_file, force=force == '1')[0]

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -74,7 +74,7 @@ class IrWebsocket(models.AbstractModel):
     @classmethod
     def _authenticate(cls):
         if wsrequest.session.uid is not None:
-            wsrequest.session._check(wsrequest)
+            wsrequest.session.__.check(wsrequest)
         else:
             public_user = wsrequest.env.ref('base.public_user')
             wsrequest.update_env(user=public_user.id)

--- a/addons/bus/session_helpers.py
+++ b/addons/bus/session_helpers.py
@@ -34,7 +34,7 @@ def _get_session_token_query_params(cr, session):
 
 
 def check_session(cr, session):
-    session._delete_old_sessions()
+    session.__.delete_old_sessions()
     if 'deletion_time' in session and session['deletion_time'] <= time.time():
         e = "session is too old"
         raise SessionExpiredException(e)

--- a/addons/web/controllers/database.py
+++ b/addons/web/controllers/database.py
@@ -173,7 +173,7 @@ class Database(Controller):
             credential = {'login': post['login'], 'password': password, 'type': 'password'}
             with odoo.modules.registry.Registry(name).cursor() as cr:
                 env = odoo.api.Environment(cr, None, {})
-                request.session.authenticate(env, credential)
+                request.session.__.authenticate(env, credential)
                 request._save_session(env)
                 request.session.db = name
             return request.redirect('/odoo')

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -51,7 +51,7 @@ class Home(Controller):
             return request.redirect_query('/web/login', query={'redirect': request.httprequest.full_path}, code=303)
         if kw.get('redirect'):
             return request.redirect(kw.get('redirect'), 303)
-        request.session._check(request)
+        request.session.__.check(request)
         if not is_user_internal(request.session.uid):
             return request.redirect('/web/login_successful', 303)
 
@@ -136,7 +136,7 @@ class Home(Controller):
                 credential.setdefault('type', 'password')
                 if request.env['res.users']._should_captcha_login(credential):
                     request.env['ir.http']._verify_request_recaptcha_token('login')
-                auth_info = request.session.authenticate(request.env, credential)
+                auth_info = request.session.__.authenticate(request.env, credential)
                 request.params['login_success'] = True
                 return request.redirect(self._login_redirect(auth_info['uid'], redirect=redirect))
             except odoo.exceptions.AccessDenied as e:
@@ -173,7 +173,7 @@ class Home(Controller):
             uid = request.session.uid = odoo.SUPERUSER_ID
             # invalidate session token cache as we've changed the uid
             request.env.registry.clear_cache()
-            request.session._update_session_token(request.env)
+            request.session.__.update_session_token(request.env)
 
         return request.redirect(self._login_redirect(uid))
 

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -39,7 +39,7 @@ class Session(Controller):
                 env = request.env
 
             credential = {'login': login, 'password': password, 'type': 'password'}
-            auth_info = request.session.authenticate(env, credential)
+            auth_info = request.session.__.authenticate(env, credential)
             if auth_info['uid'] != request.session.uid:
                 # Crapy workaround for unupdatable Odoo Mobile App iOS (Thanks Apple :@) and Android
                 # Correct behavior should be to raise AccessError("Renewing an expired session for user that has multi-factor-authentication is not supported. Please use /web/login instead.")

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -566,7 +566,7 @@ class IrActionsReport(models.Model):
                     '_trace_disable': True,
                 })
                 if temp_session.uid:
-                    temp_session._update_session_token(self.env)
+                    temp_session.__.update_session_token(self.env)
                 root.session_store.save(temp_session)
                 stack.callback(root.session_store.delete, temp_session)
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -289,7 +289,7 @@ class IrHttp(models.AbstractModel):
         try:
             if request.session.uid is not None:
                 try:
-                    request.session._check(request)
+                    request.session.__.check(request)
                 except SessionExpiredException as exc:
                     session_expired_exc = exc  # save the traceback
                     request.env = api.Environment(request.env.cr, None, request.session.context)

--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -52,7 +52,7 @@ class ResDeviceLog(models.Model):
 
             :param request: Request or WebsocketRequest object
         """
-        device = request.session.update_device(request)
+        device = request.session.__.update_device(request)
         if not device:
             return
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2406,7 +2406,7 @@ class HttpCase(TransactionCase):
             session['login'] = user
             session['session_token'] = None
             if uid:
-                session._update_session_token(env)
+                session.__.update_session_token(env)
             session['context'] = dict(env['res.users'].context_get())
 
         root.session_store.save(session)

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -7,7 +7,7 @@ from .parse_version import parse_version
 from .cache import ormcache
 from .config import config
 from .float_utils import float_compare, float_is_zero, float_repr, float_round, float_split, float_split_str
-from .func import classproperty, conditional, lazy, lazy_classproperty, reset_cached_properties
+from .func import classproperty, conditional, lazy, lazy_classproperty, protected, reset_cached_properties
 from .i18n import format_list, py_to_js_locale
 from .json import json_default
 from .mail import *


### PR DESCRIPTION
In Odoo, we define the concept of `protected` for attributes whose name contains a double underscore (`__`).
Protected attributes are not accepted in the `safe_eval` evaluation context.

Unfortunately, the use of double underscores in Odoo is applied in such a way as to avoid ambiguities with Python itself, but also to avoid name mangling. This results in attributes such as `_<attr_name>__`. Developers are not necessarily aware of the importance of double underscores within the framework.

The purpose of this commit is to add a tool that allows attributes to be protected using the `protected` decorator.

It is simple to use, we just need to go through the `__` attribute to access the protected attributes.

```py
class C:

    @protected
    def func(self): ...

c = C()
c.__.func()
c.func()  # `AttributeError`
```

Note:
This only applies to the callable attribute.

Task-5901436