### PR TITLE
[FIX] point_of_sale: adapt price unit for fiscal position tax mapping

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -396,10 +396,17 @@ export class PosOrderline extends Base {
             ...customValues,
         };
         if (order.fiscal_position_id) {
+            const originalTaxes = values.tax_ids;
             values.tax_ids = getTaxesAfterFiscalPosition(
-                values.tax_ids,
+                originalTaxes,
                 order.fiscal_position_id,
                 order.models
+            );
+            values.price_unit = accountTaxHelpers.adapt_price_unit_to_another_taxes(
+                values.price_unit,
+                product,
+                originalTaxes,
+                values.tax_ids
             );
         }
         return values;


### PR DESCRIPTION
When a fiscal position maps a tax-included tax to a tax-excluded tax (or
vice versa), the price unit must be adjusted to keep the base amount
consistent. This adjustment was missing in the POS frontend after the
tax computation refactoring in v18+.

Background:
In v17, the computePriceAfterFp method handled this price adaptation:
https://github.com/odoo/odoo/blob/36688ce4dad4b3d508b4fd3d778a06a5a7036408/addons/point_of_sale/static/src/app/store/pos_store.js#L1102-L1133

This method was removed in:
https://github.com/odoo/odoo/commit/ab0bdf019212

The refactoring introduced:
https://github.com/odoo/odoo/blob/0d7e3d4c0ea976e37871ca44a10a442cce7caa85/addons/account/static/src/helpers/account_tax.js#L472-L481

However, the POS module was not updated to call this helper when
preparing base lines for tax computation.

Steps to reproduce: 
1. Create a tax configured as "Included in Price" (21)
2. Create a tax configured as "Excluded from Price" (21)
4. Create a fiscal position that maps the included to the excluded tax
4. Add the fiscal position to a contact
5. Create a product with the included tax, priced at 100
6. In POS, add the contact as the client and add the product
7. Total incorrectly shows 121 (or 100 + tax) instead of 100

Ticket [link](https://www.odoo.com/odoo/project.task/5877918)
opw-5877918

------------------------------------------------------------------------

I confirm I have signed the CLA and read the PR guidelines at
www.odoo.com/submit-pr
