### PR TITLE
[REM] l10n_hr_edi: duplicate method

### DIFF
--- a/addons/l10n_hr_edi/models/account_move.py
+++ b/addons/l10n_hr_edi/models/account_move.py
@@ -167,11 +167,6 @@ class AccountMove(models.Model):
         else:
             return super()._get_invoice_reference_odoo_invoice()
 
-    def _get_l10n_hr_fiscal_user_id_domain(self):
-        internal_users = self.env.ref('base.group_user')
-        domain = [('user_ids', 'in', internal_users.users.ids)]
-        return domain
-
     def _post(self, soft=True):
         for move in self:
             if move.country_code == 'HR' and move.is_sale_document():


### PR DESCRIPTION
The duplicate method was introduced in #230757, it apparently was removed while forward porting as it is missing from #241691 but nobody went back to remove it from the original, and after updating pylint on the nightly distro builds they now complain.

https://runbot.odoo.com/odoo/runbot.build.error/237791
