### PR TITLE
[FIX] stock_account: add test to ensure avco valuation considers correct companies

### DIFF
--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3521,3 +3521,46 @@ class TestStockValuation(TestStockValuationCommon):
         closing = self.branch.with_context(allowed_company_ids=[self.branch.id, self.company.id]).action_close_stock_valuation()
         closing_lines = self.env['account.move'].browse(closing['res_id']).line_ids
         self.assertEqual(closing_lines.move_id.company_id.id, self.branch.id)
+
+    def test_avco_valuation_multicompany(self):
+        """
+        Test that changing values manually for an AVCO product in different companies results
+        in the correct total value when the product is viewed in a single or multi-company context.
+        """
+        product_avco = self.product_avco
+        now = Datetime.now()
+
+        c1 = self.env.company
+        c2 = self.env['res.company'].create({'name': 'Test Company'})
+        c1_stock_loc = self.warehouse.lot_stock_id
+        c2_stock_loc = self.env['stock.warehouse'].search([('company_id', '=', c2.id)], limit=1).lot_stock_id
+        product_company1 = product_avco.with_context(allowed_company_ids=[c1.id])
+        product_company2 = product_avco.with_context(allowed_company_ids=[c2.id])
+
+        # Change cost manually and create stock move for each company
+        with freeze_time(now + timedelta(minutes=1)):
+            product_company1.standard_price = 10
+        with freeze_time(now + timedelta(minutes=2)):
+            self._make_in_move(product_company1, 2.0, company=c1, location_id=self.supplier_location.id, location_dest_id=c1_stock_loc.id)
+        with freeze_time(now + timedelta(minutes=3)):
+            product_company2.standard_price = 50
+        with freeze_time(now + timedelta(minutes=4)):
+            self._make_in_move(product_company2, 1.0, company=c2, location_id=self.supplier_location.id, location_dest_id=c2_stock_loc.id)
+
+        self.assertRecordValues(product_company1, [{
+            'total_value': 20,
+            'qty_available': 2,
+            'avg_cost': 10,
+        }])
+        self.assertRecordValues(product_company2, [{
+            'total_value': 50,
+            'qty_available': 1,
+            'avg_cost': 50,
+        }])
+        product_companies = product_avco.with_context(allowed_company_ids=[c1.id, c2.id])
+        product_companies.invalidate_recordset(fnames=['total_value'])
+        self.assertRecordValues(product_companies, [{
+            'total_value': 70,  # sum of both total_values
+            'qty_available': 3,
+            'avg_cost': 23.33,
+        }])

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3122,3 +3122,45 @@ class TestStockValuation(TestStockValuationCommon):
         recs[-2:]._compute_cumulative_fields()
         self.assertEqual(recs[-1].total_quantity, 3)
         self.assertEqual(recs[-1].total_value, 30)
+
+    def test_avco_valuation_multicompany(self):
+        """
+        Test that changing values manually for an AVCO product in different companies results
+        in the correct total value when the product is viewed in a single or multi-company context.
+        """
+        # _compute_value() uses sudo(False) which doesnt work when the user is the Superuser
+        product_avco = self.product_avco
+        time = Datetime.now()
+
+        c1 = self.env.company
+        c2 = self.env['res.company'].create({
+            'name': 'Test Company',
+        })
+        c1_stock_loc = self.env['stock.warehouse'].search([('company_id', '=', c1.id)], limit=1).lot_stock_id
+        c2_stock_loc = self.env['stock.warehouse'].search([('company_id', '=', c2.id)], limit=1).lot_stock_id
+        c1_product = product_avco.with_context(allowed_company_ids=[c1.id])
+        c2_product = product_avco.with_context(allowed_company_ids=[c2.id])
+
+        # Change cost manually and create stock move for each company
+        # freeze_time is used because avco compares dates of stock moves against dates of new values
+        with freeze_time(time + timedelta(minutes=1)):
+            c1_product.standard_price = 10
+        with freeze_time(time + timedelta(minutes=2)):
+            self._make_in_move(c1_product, 2.0, company=c1, location_id=self.supplier_location.id, location_dest_id=c1_stock_loc.id)
+
+        with freeze_time(time + timedelta(minutes=3)):
+            c2_product.standard_price = 50
+        with freeze_time(time + timedelta(minutes=4)):
+            self._make_in_move(c2_product, 1.0, company=c2, location_id=self.supplier_location.id, location_dest_id=c2_stock_loc.id)
+
+        self.assertEqual(c1_product.total_value, 20)
+        self.assertEqual(c1_product.qty_available, 2)
+        self.assertEqual(c1_product.avg_cost, 10)
+        self.assertEqual(c2_product.total_value, 50)
+        self.assertEqual(c2_product.qty_available, 1)
+        self.assertEqual(c2_product.avg_cost, 50)
+        c3_product = product_avco.with_context(allowed_company_ids=[c1.id, c2.id])
+        c3_product.invalidate_recordset(fnames=['total_value'])
+        self.assertEqual(c3_product.total_value, 70)  # sum of both total_values
+        self.assertEqual(c3_product.qty_available, 3)
+        self.assertEqual(c3_product.avg_cost, 23.33)


### PR DESCRIPTION
Stock value computation did not take companies into account correctly, this issue was fixed with these commits:
https://github.com/odoo/odoo/commit/701729df41a49843e5717675267a26c490050657
https://github.com/odoo/odoo/commit/87385888f4980b6ee827257238d5a6d1e0ce6a04

This commit adds a test to ensure correct behavior
    
 opw-5871009