### PR TITLE
[FIX] iap: make `account_token` editable

### DIFF
--- a/addons/iap/views/iap_views.xml
+++ b/addons/iap/views/iap_views.xml
@@ -30,7 +30,7 @@
                             <field name="service_id" readonly="service_locked" options="{'no_open': True, 'no_create': True}"/>
                             <field name="description"/>
                             <field name="company_ids" widget="many2many_tags" domain="[('id', 'in', allowed_company_ids)]" />
-                            <field name="account_token" groups="base.group_no_one" readonly="1"/>
+                            <field name="account_token" groups="base.group_no_one"/>
                         </group>
                         <group name="external" string="Email Alert">
                             <field name="warning_threshold"/>


### PR DESCRIPTION
Currently the IAP token (`account_token`) is readonly in the IAP account form view.
It was made readonly in this commit
https://github.com/odoo/odoo/commit/8a96f0fc3f18bd1ccfa96e654ef6f74b21593288#diff-f05503a4bccde75e6ef0c6ab5cd0dbd9fa0e32a30da505bdfcab8c7ed3a4a24cR33

Support needs to edit it when moving a DB from test to production though.

After this commit it is editable (again; like in lower versions).

task-None
