### PR TITLE
[FIX] website: add flag to snippets_all_drag_and_drop

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -32,6 +32,8 @@ if (searchParams) {
 }
 
 registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
+    // should not have any "characterData", "remove" or "add" mutations in current step when you update the selection
+    undeterministicTour_doNotCopy: true,
     steps: () => {
         let steps = [];
         let n = 0;


### PR DESCRIPTION
With this commit, we add a flag to tour snippets_all_drag_and_drop to allow delay between steps and not get warning.
Must be fixed ASAP to remove this undeterministicTour flag.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
