### PR TITLE
[IMP] l10n_sa{_edi,_pos}: improve partner company/individual detection

### DIFF
--- a/addons/l10n_sa/models/account_move.py
+++ b/addons/l10n_sa/models/account_move.py
@@ -133,7 +133,6 @@ class AccountMove(models.Model):
     def _l10n_sa_is_simplified(self):
         """
             Returns True if the customer is an individual, i.e: The invoice is B2C
-        :return:
         """
         self.ensure_one()
-        return not self.partner_id.vat
+        return not self.commercial_partner_id.is_company

--- a/addons/l10n_sa_edi/models/res_partner.py
+++ b/addons/l10n_sa_edi/models/res_partner.py
@@ -1,5 +1,7 @@
 from odoo import fields, models, api
 
+COMPANY_SCHEMES = {'CRN', 'MOM', 'MLS', '700', 'SAG', 'OTH'}
+
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
@@ -22,6 +24,23 @@ class ResPartner(models.Model):
     ], default="OTH", string="Identification Scheme", help="Additional Identification Scheme for the Seller/Buyer")
 
     l10n_sa_edi_additional_identification_number = fields.Char("Identification Number (SA)", help="Additional Identification Number for the Seller/Buyer")
+
+    @api.depends('l10n_sa_edi_additional_identification_scheme', 'l10n_sa_edi_additional_identification_number')
+    def _compute_is_company(self):
+        """ Determines if a Saudi partner is a company or an individual based on VAT and
+        additional identification fields.
+        """
+        l10n_sa_commercial_partners = self.filtered(
+            lambda p: (
+                p.country_code == 'SA'
+                and p.commercial_partner_id == p
+                and p._is_vat_void(p.vat)
+                and p.l10n_sa_edi_additional_identification_number
+                and p.l10n_sa_edi_additional_identification_scheme in COMPANY_SCHEMES
+            )
+        )
+        l10n_sa_commercial_partners.is_company = True
+        super(ResPartner, self - l10n_sa_commercial_partners)._compute_is_company()
 
     @api.model
     def _commercial_fields(self):

--- a/addons/l10n_sa_edi/tests/common.py
+++ b/addons/l10n_sa_edi/tests/common.py
@@ -117,8 +117,8 @@ class TestSaEdiCommon(AccountEdiTestCommon):
             'country_id': cls.saudi_arabia.id,
             'state_id': cls.riyadh.id,
             # Simplified invoices use different ID schemes
-            'l10n_sa_edi_additional_identification_scheme': 'MOM',  # Momra License
-            'l10n_sa_edi_additional_identification_number': '3123123213131',
+            'l10n_sa_edi_additional_identification_scheme': 'NAT',
+            'l10n_sa_edi_additional_identification_number': '1076543210',
         })
 
     @classmethod

--- a/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/credit.xml
@@ -106,7 +106,7 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="MOM">3123123213131</cbc:ID>
+        <cbc:ID schemeID="NAT">1076543210</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>Mohammed Ali</cbc:Name>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/debit.xml
@@ -106,7 +106,7 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="MOM">3123123213131</cbc:ID>
+        <cbc:ID schemeID="NAT">1076543210</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>Mohammed Ali</cbc:Name>

--- a/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/simplified/invoice.xml
@@ -101,7 +101,7 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cac:PartyIdentification>
-        <cbc:ID schemeID="MOM">3123123213131</cbc:ID>
+        <cbc:ID schemeID="NAT">1076543210</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>Mohammed Ali</cbc:Name>

--- a/addons/l10n_sa_pos/static/src/overrides/models/pos_order.js
+++ b/addons/l10n_sa_pos/static/src/overrides/models/pos_order.js
@@ -31,6 +31,6 @@ patch(PosOrder.prototype, {
         return computeSAQRCode(name, vat, date_isostring, amount_total, amount_tax);
     },
     get isSimplified() {
-        return !this?.partner_id?.vat && this.company_id.country_id?.code === "SA";
+        return !this.commercial_partner_id?.is_company;
     },
 });


### PR DESCRIPTION
Before this commit:
- Partner identification relied only on the VAT field.

After this commit:
- Partner identification in Saudi Arabia also considers Identification Scheme and Identification Number.
- This improves detection of companies vs individuals when VAT is missing.

task-5866942

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
