### PR TITLE
[FIX] stock: Ensure picking_code is set for MRP moves and move lines

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -172,7 +172,7 @@ class StockMove(models.Model):
         'Quantity', compute='_compute_quantity', digits='Product Unit', inverse='_set_quantity', store=True)
     # TODO: delete this field `show_operations`
     show_operations = fields.Boolean(related='picking_id.picking_type_id.show_operations')
-    picking_code = fields.Selection(related='picking_id.picking_type_id.code', readonly=True)
+    picking_code = fields.Selection(related='picking_type_id.code', readonly=True)
     show_details_visible = fields.Boolean('Details Visible', compute='_compute_show_details_visible')
     is_storable = fields.Boolean(related='product_id.is_storable')
     additional = fields.Boolean("Whether the move was added after the picking's confirmation", default=False)

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6452,8 +6452,8 @@ class TestStockMove(TestStockCommon):
             'picking_type_id': self.picking_type_in.id,
         })
         self.assertFalse(move1.show_lots_text)
-        self.assertFalse(move1.show_lots_m2o)
-        self.assertTrue(move1.show_quant)
+        self.assertTrue(move1.show_lots_m2o)
+        self.assertFalse(move1.show_quant)
 
     def test_recompute_stock_reference(self):
         receipt = self.env['stock.picking'].create({


### PR DESCRIPTION
Issue before this commit:
=========================

Currently, the `picking_code` is not set properly as the `mrp_operation` for 
mrp related `move's`, it's set as false.

Steps to Reproduce:
=========================
- Install the `mrp` module.
- Create a Manufacturing Order (MO) with one component.
- Check the data for all moves of the MO; the `picking_code is set to False`.

Cause of the issue:
=========================
The picking_code is related to `picking_id.picking_type_id.code`. 
If the MO does not have any picking (in one-step MRP), the picking_id is not set.
Which results in `picking_code being False`.

With This Commit:
=========================
Ensure that `picking_code` is set correctly for all moves related to 
MO operations by relating the field directly to `picking_type_id.code`.
