### PR TITLE
[FIX] point_of_sale,account_peppol: Fix concurrent update when sending invoices

### DIFF
--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -1,3 +1,5 @@
+import logging
+
 from base64 import b64encode
 from datetime import timedelta
 
@@ -5,6 +7,8 @@ from odoo import _, api, fields, models
 
 from odoo.addons.account.models.company import PEPPOL_LIST
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMoveSend(models.AbstractModel):
@@ -157,6 +161,7 @@ class AccountMoveSend(models.AbstractModel):
 
         params = {'documents': []}
         invoices_data_peppol = {}
+        to_lock_peppol_invoices = self.env['account.move']
         for invoice, invoice_data in invoices_data.items():
             partner = invoice.partner_id.commercial_partner_id.with_company(invoice.company_id)
             if 'peppol' in invoice_data['sending_methods']:
@@ -206,11 +211,16 @@ class AccountMoveSend(models.AbstractModel):
                     'ubl': b64encode(xml_file).decode(),
                 })
                 invoices_data_peppol[invoice] = invoice_data
+                to_lock_peppol_invoices |= invoice
 
         if not params['documents']:
             return
 
         edi_user = next(iter(invoices_data)).company_id.account_peppol_edi_user
+
+        if not self.env['res.company']._with_locked_records(to_lock_peppol_invoices, allow_raising=False):
+            _logger.error('Failed to lock invoices for Peppol sending')
+            return
 
         try:
             response = edi_user._call_peppol_proxy(

--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -150,6 +150,9 @@ class PosController(PortalAccount):
         if pos_order.account_move and pos_order.account_move.is_sale_document():
             return request.redirect('/my/invoices/%s?access_token=%s' % (pos_order.account_move.id, pos_order.account_move._portal_ensure_token()))
 
+        if not request.env['res.company']._with_locked_records(pos_order, allow_raising=False):
+            return
+
         # Get the optional extra fields that could be required for a localisation.
         pos_order_country = pos_order.company_id.account_fiscal_country_id
         additional_partner_fields = request.env['res.partner'].get_partner_localisation_fields_required_to_invoice(pos_order_country)


### PR DESCRIPTION
Steps to reproduce:
- Set up a test company with Peppol enabled
- Create a Peppol customer and ensure they can receive invoices
- In the POS settings, enable the “Self-service invoicing” option
- Create a POS order linked to the Peppol customer
- Log in as this customer
- Enter the POS order information to access the invoice download view (from /pos/ticket)
- Repeatedly click the “Request invoice” button
- On the Peppol side, you will notice that the same invoice is sent as many times as the button is clicked

Why ?
This error is not really Peppol related, it can actually happen with all EDI making API call: the transaction is rolled-back when Odoo tries to create multiple invoices with a serialization error but the API call happened so, in this cas, the invoice is sent over Peppol.

opw-5469467
