### PR TITLE
[FIX] pos_restaurant: wait for requests correctly in tours

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -13,12 +13,7 @@ import * as ProductScreenPos from "@point_of_sale/../tests/tours/utils/product_s
 import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
-import {
-    inLeftSide,
-    negateStep,
-    waitForLoading,
-    refresh,
-} from "@point_of_sale/../tests/tours/utils/common";
+import { inLeftSide, negateStep, refresh } from "@point_of_sale/../tests/tours/utils/common";
 import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/tours/utils/numpad_util";
 import { delay } from "@odoo/hoot-dom";
@@ -747,13 +742,12 @@ registry.category("web_tour.tours").add("test_book_and_release_table", {
             FloorScreen.clickTable("5"),
             ProductScreen.bookOrReleaseTable(),
             FloorScreen.isShown(),
-            waitForLoading(),
+            Chrome.waitRequest(),
             {
                 content: "Check if order has a server ID",
                 trigger: "body",
                 run: () => {
                     const order = posmodel.models["pos.order"].getFirst();
-
                     if (typeof order.id !== "number") {
                         throw new Error("Order does not have a valid server ID");
                     }
@@ -761,7 +755,7 @@ registry.category("web_tour.tours").add("test_book_and_release_table", {
             },
             FloorScreen.clickTable("5"),
             ProductScreen.bookOrReleaseTable(),
-            waitForLoading(),
+            Chrome.waitRequest(),
         ].flat(),
 });
 


### PR DESCRIPTION
Fix failing tour `test_book_and_release_table` by replacing `waitForLoading`, which is intended for POS loading, with `waitRequest` to properly wait for RPC requests.

Error-227652
Task-5897383
