### PR TITLE
[FIX] mail: fix insertion of mixed up many commands

### DIFF
--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1589,3 +1589,22 @@ test("Record exists is reactive", async () => {
     thread.delete();
     await expect.waitForSteps(["thread does not exist"]);
 });
+
+test("Can insert mixed up many commands", async () => {
+    (class Message extends Record {
+        static id = "id";
+        id;
+    }).register(localRegistry);
+    (class Thread extends Record {
+        static id = "name";
+        name;
+        messages = fields.Many("Message");
+    }).register(localRegistry);
+    const store = await start();
+    const thread = store.Thread.insert("General");
+    store.Thread.insert({
+        name: "General",
+        messages: [{ id: 1 }, { id: 2 }, ["ADD", [{ id: 3 }, { id: 4 }]], ["DELETE", [{ id: 4 }]]],
+    });
+    expect(thread.messages.map((msg) => msg.id).sort()).toEqual([1, 2, 3]);
+});


### PR DESCRIPTION
Many fields can be updated in the discuss store in different modes: `ADD`, `DELETE`, `REPLACE`.

The `REPLACE` case is the most frequent one, so the server doesn't bother sending it wrapped up as a command but instead return the array that should replace the current field value.

However, the client doesn't handle well replace being mixed up with other commands.

This commit ensures many commands are normalized on the client side. This also allows to simplify the `updateRelationMany` function since we only have one command format.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
