### PR TITLE
[FIX] pos_restaurant: prevent double-click on release table button

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -33,8 +33,14 @@ patch(OrderSummary.prototype, {
         return result;
     },
     async unbookTable() {
-        const order = this.pos.getOrder();
-        await this.pos.deleteOrders([order]);
+        this.env.services.ui.block();
+        try {
+            const order = this.pos.getOrder();
+            await this.pos.deleteOrders([order]);
+            this.pos.showDefault();
+        } finally {
+            this.env.services.ui.unblock();
+        }
     },
     showUnbookButton() {
         if (this.pos.selectedTable) {


### PR DESCRIPTION
When unbooking a table, the UI was not blocked, allowing the user to
potentially spam the button or perform other actions while the order
was being deleted. It also lacked a proper redirection.

task-id: 5859460

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
