### PR TITLE
[IMP] test_lint: add some error reporting in overrides lint

### DIFF
--- a/odoo/addons/test_lint/tests/test_override_signatures.py
+++ b/odoo/addons/test_lint/tests/test_override_signatures.py
@@ -183,6 +183,8 @@ class TestLintOverrideSignatures(LintCase):
                     method = getattr(parent_class, method_name, None)
                     if callable(method):
                         break
+                else:
+                    raise LookupError(f"Unable to find callable {method_name!r} in mro of {model_name!r}")
 
                 parent_module = get_odoo_module_name(parent_class.__module__)
                 original_signature = inspect.signature(method)


### PR DESCRIPTION
https://runbot.odoo.com/odoo/error/237983 indicates that there's something somewhere which screws with a model method (possibly a test which patches in a method but does not remove it), but currently this just crashes with "None is not a callable" which is not the most useful, and since it's a side-effect possibly from an other test running this test on its own doesn't do anything.
