### PR TITLE
[FIX] point_of_sale: adjust review button width on ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -140,7 +140,7 @@
                             t-on-click="() => this.setOrder(_selectedSyncedOrder)">
                             <span class="d-block">Load Order</span>
                         </button>
-                        <button class="btn-switchpane btn btn-lg lh-lg w-50 py-3 secondary review-button" t-att-class="{'btn-primary': isOrderSynced, 'btn-light': !isOrderSynced}" t-on-click="switchPane">
+                        <button class="btn-switchpane btn btn-lg lh-lg py-3 secondary review-button" t-att-class="isOrderSynced ? 'w-100 btn-primary' : 'w-50 btn-light'" t-on-click="switchPane">
                             <span class="d-block">Review</span>
                         </button>
                     </div>


### PR DESCRIPTION
Before this commit:
---
- On the ticket screen in small UI, two btns are shown: Review and Load Order.
- The Load Order button is only visible when the selected order is not paid.
- When the order is paid, only the Review btn is shown, but it takes 50% width.

After this commit:
---
- When the order is paid, the Review button expands to take 100% width.

task-5892189

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
