### PR TITLE
[CLN] website: remove default arrow position option

### DIFF
--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_carousel_option.xml
@@ -6,7 +6,6 @@
         <BuilderRow label.translate="Arrow Position">
             <BuilderSelect>
                 <BuilderSelectItem classAction="''">Default</BuilderSelectItem>
-                <BuilderSelectItem classAction="'o_arrows_inside'">Inside</BuilderSelectItem>
                 <BuilderSelectItem classAction="'o_arrows_bottom o_arrows_bottom_left'">Bottom Left</BuilderSelectItem>
                 <BuilderSelectItem classAction="'o_arrows_bottom o_arrows_bottom_center'">Bottom Center</BuilderSelectItem>
                 <BuilderSelectItem classAction="'o_arrows_bottom o_arrows_bottom_right'">Bottom Right</BuilderSelectItem>

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
@@ -38,16 +38,6 @@
 
     @include media-breakpoint-up(md) {
         &:where(:not([class*="o_arrows_"])){
-            .carousel-control-prev {
-                transform: translateX(-50%);
-            }
-
-            .carousel-control-next {
-                transform: translateX(50%);
-            }
-        }
-
-        &.o_arrows_inside {
             .s_dynamic_snippet_arrows a {
                 margin: 0 map-get($spacers, 3);
             }


### PR DESCRIPTION
This PR remove the "**default**" arrow position option and its related CSS from the dynamic product snippet and renames the "**inside**" option to "**default**". This change is based on the discussion here - https://github.com/odoo/odoo/pull/237876#issuecomment-3777902859