### PR TITLE
[IMP] point_of_sale: prevent zero value for coins/bills

### DIFF
--- a/addons/point_of_sale/views/pos_bill_view.xml
+++ b/addons/point_of_sale/views/pos_bill_view.xml
@@ -7,7 +7,7 @@
             <form string="Bills">
                 <sheet>
                     <group>
-                        <field name="name" />
+                        <field name="name" required="1"/>
                         <field name="value" />
                         <field name="pos_config_ids" widget="many2many_tags" />
                     </group>
@@ -21,7 +21,7 @@
         <field name="model">pos.bill</field>
         <field name="arch" type="xml">
             <list string="Bills" create="1" delete="1" editable="bottom">
-                <field name="name" />
+                <field name="name" required="1"/>
                 <field name="value" />
                 <field name="pos_config_ids" widget="many2many_tags_placeholder_list_view" placeholder="For all point of sale."/>
             </list>


### PR DESCRIPTION
- Add @api.constrains to block saving a pos.bill with value = 0
- Add decoration-danger in list view to highlight zero values in red

task-id: 5901790

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
