### PR TITLE
[IMP] web,calendar: improve mobile display

### DIFF
--- a/addons/calendar/static/src/scss/calendar_event_views.scss
+++ b/addons/calendar/static/src/scss/calendar_event_views.scss
@@ -22,4 +22,7 @@
     .o_form_nosheet {
         padding-bottom: map-get($spacers, 2);
     }
+    .o_field_many2many_tags[name="partner_ids"] .o_tags_input {
+        width: 100%;
+    }
 }

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -353,30 +353,33 @@
                     keep the last computed duration in the front-end model and send it with "start"
                     when it changes-->
                     <!--field is also used for custom behavior in default_get, check before removing-->
-                    <field name="duration" invisible="1" force_save="1"/>
-                    <field name="start" nolabel="1"
-                        widget="daterange" options="{'end_date_field': 'stop'}"
-                        placeholder="Dates" class="w-100 mb-0"
-                        invisible="allday"
-                    />
-                    <field name="start_date" nolabel="1"
-                        widget="daterange" options="{'end_date_field': 'stop_date'}"
-                        placeholder="Dates" class="w-100 mb-0"
-                        invisible="not allday"
-                    />
-                    <span class="ms-1 w-25">
-                        <!-- This is needed so that show_as can be set as 'free' when creating all day events -->
-                        <field name="show_as" invisible="1"/>
-                        <field name="allday" class="mb-0" title="All Day" nolabel="1"/>
-                        <span>All day</span>
-                    </span>
-                    <field name="stop" invisible="1"/>
+                    <div class="d-flex align-items-center flex-wrap gap-2 w-100">
+                        <field name="duration" invisible="1" force_save="1"/>
+                        <field name="start" nolabel="1"
+                            widget="daterange" options="{'end_date_field': 'stop'}"
+                            placeholder="Dates" class="text-nowrap flex-grow-1 mb-0"
+                            invisible="allday"
+                        />
+                        <field name="start_date" nolabel="1"
+                            widget="daterange" options="{'end_date_field': 'stop_date'}"
+                            placeholder="Dates" class="text-nowrap flex-grow-1 mb-0"
+                            invisible="not allday"
+                        />
+                        <span class="text-nowrap w-auto">
+                            <!-- This is needed so that show_as can be set as 'free' when creating all day events -->
+                            <field name="show_as" invisible="1"/>
+                            <field name="allday" class="mb-0" title="All Day" nolabel="1"/>
+                            <span>All day</span>
+                        </span>
+                        <field name="stop" invisible="1"/>
+                    </div>
                 </div>
                 <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
                     <i class="fa fa-fw flex-shrink-0 fa-user text-600 me-2" title="Participants"/>
                     <field name="partner_ids" nolabel="1"
                         widget="many2many_tags"
                         placeholder="Participants"
+                        class="w-100 mb-0"
                     />
                 </div>
                 <div class="d-flex align-items-center pt-1 pb-2" colspan="2">

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -35,10 +35,8 @@
                         <ViewScaleSelector scales="scales" currentScale="model.scale" isWeekendVisible="state.isWeekendVisible" setScale.bind="setScale" toggleWeekendVisibility.bind="toggleWeekendVisibility" dropdownClass="'d-print-none order-3 order-lg-0'"/>
                         <button
                             class="btn btn-secondary o_calendar_button_today d-print-none order-2 order-lg-0 ms-auto ms-lg-0"
-                            t-att-class="env.isSmall ? 'btn-sm btn-light' : 'btn-secondary'"
-                            t-on-click.stop="() => this.setDate('today')"
-                        >   <span t-if="env.isSmall" class="position-relative pt-1"><t t-out="today"/><i class="fa fa-calendar-o position-absolute top-50 start-50 translate-middle fs-1"></i></span>
-                            <t t-else="">Today</t>
+                            t-on-click.stop="() => this.setDate('today')">
+                            Today
                         </button>
                         <h5 class="d-inline-flex ps-lg-2 ps-print-0 mb-0">
                             <t t-if="model.meta.scale === 'year'">

--- a/addons/web/static/src/views/calendar/calendar_controller_mobile.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller_mobile.scss
@@ -1,13 +1,4 @@
 @include media-breakpoint-down(md) {
-    .o_calendar_header {
-        .o_calendar_button_today {
-            line-height: 1.9em;
-            > span {
-                font-size: .65rem
-            }
-        }
-    }
-
     .o_calendar_container {
         .o_other_calendar_panel {
             grid-area: 2 / 1 / 2 / 4;

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -571,6 +571,12 @@
                     width: 21rem;
                     margin: auto;
 
+                    // On mobile year view, make months take the full screen width.
+                    // Using "vw" instead of "%" to keep each month weekday columns aligned.
+                    @include media-breakpoint-down(md) {
+                        width: calc(100vw - #{map-get($spacers, 5)});
+                    }
+
                     > .fc-toolbar.fc-header-toolbar {
                         margin-bottom: 4px;
                         cursor: default;


### PR DESCRIPTION
Improve the calendar mobile view:

- replace the "today" button from a calendar icon with the day to a simple "Today" button to be more explicit.
- in year view, make sure the months are taking the full width of the screen so that they are easier to interact with.
- in the quick create form, make sure the partner_ids field is taking the full modal width like the other fields. Also prevent the "all day" field from being squeezed on the right, instead if there's not enough space display it on a new line.

Task-5717052


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
