### PR TITLE
[FIX] select_menu: check choices length before updating input value

### DIFF
--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -357,7 +357,7 @@ export class SelectMenu extends Component {
             }
         } else if (!this.selectedChoice || this.selectedChoice.value !== value) {
             this.props.onSelect(value);
-            if (this.inputRef.el) {
+            if (this.inputRef.el && this.state.choices && this.state.choices.length) {
                 this.inputRef.el.value = this.state.choices.find((c) => c.value === value).label;
             }
         }


### PR DESCRIPTION
In `onItemSelected`, added truthiness and length checks on `state.choices` to safely handle cases where choices might be undefined or empty during the selection event.

runbot-error-id~234645

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
