### PR TITLE
[IMP] l10n_latam_check: Add bank field on checks

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -142,6 +142,7 @@ class AccountPayment(models.Model):
         'payment_method_line_id', 'state', 'date', 'amount', 'currency_id', 'company_id',
         'l10n_latam_move_check_ids.issuer_vat', 'l10n_latam_move_check_ids.payment_id.date',
         'l10n_latam_new_check_ids.amount', 'l10n_latam_new_check_ids.name',
+        'l10n_latam_new_check_ids.bank_account_id', 'l10n_latam_move_check_ids.bank_account_id',
     )
     def _compute_l10n_latam_check_warning_msg(self):
         """
@@ -156,11 +157,15 @@ class AccountPayment(models.Model):
             if rec.payment_method_code == 'new_third_party_checks':
                 same_checks = self.env['l10n_latam.check']
                 for check in rec.l10n_latam_new_check_ids.filtered(
-                        lambda x: x.name and x.payment_method_line_id.code == 'new_third_party_checks' and x.issuer_vat):
+                    lambda x: x.name
+                    and x.payment_method_line_id.code == "new_third_party_checks"
+                    and x.issuer_vat
+                ):
                     same_checks += same_checks.search([
                         ('company_id', '=', rec.company_id.id),
                         ('issuer_vat', '=', check.issuer_vat),
                         ('name', '=', check.name),
+                        ('bank_account_id', '=', check.bank_account_id.id),
                         ('payment_id.state', 'not in', ['draft', 'canceled']),
                         ('id', '!=', check._origin.id)], limit=1)
                 if same_checks:

--- a/addons/l10n_latam_check/views/account_payment_view.xml
+++ b/addons/l10n_latam_check/views/account_payment_view.xml
@@ -14,6 +14,7 @@
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="currency_id" column_invisible="True"/>
                                     <field name="name" />
+                                    <field name="bank_account_id" column_invisible="parent.payment_method_code == 'own_checks'" options="{'no_create': True}"/>
                                     <field name="issuer_vat" column_invisible="parent.payment_method_code == 'own_checks'"/>
                                     <field name="payment_date"/>
                                     <field name="amount" />
@@ -30,6 +31,7 @@
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="currency_id" column_invisible="True"/>
                                     <field name="name" />
+                                    <field name="bank_account_id" optional="hide"/>
                                     <field name="issuer_vat" optional="hide"/>
                                     <field name="payment_date" optional="hide"/>
                                     <field name="amount"/>

--- a/addons/l10n_latam_check/views/l10n_latam_check_view.xml
+++ b/addons/l10n_latam_check/views/l10n_latam_check_view.xml
@@ -47,6 +47,7 @@
                     domain="[('current_journal_id.inbound_payment_method_line_ids.payment_method_id.code', '=', 'in_third_party_checks')]"/>
             </filter>
             <field name="original_journal_id" position="before">
+                <field name="bank_account_id"/>
                 <field name="issuer_vat"/>
                 <field name="current_journal_id"/>
             </field>
@@ -133,6 +134,7 @@
                         </group>
                         <group>
                             <field name="amount"/>
+                            <field name="bank_account_id" invisible="issue_state"/>
                             <field name="issuer_vat"  invisible="issue_state"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/addons/l10n_latam_check/views/report_payment_receipt_templates.xml
+++ b/addons/l10n_latam_check/views/report_payment_receipt_templates.xml
@@ -7,6 +7,7 @@
                     <thead>
                         <tr>
                             <th><span>Check Number</span></th>
+                            <th t-if="o.payment_method_code != 'own_checks'"><span>Bank</span></th>
                             <th t-if="o.payment_method_code != 'own_checks'"><span>Issuer VAT</span></th>
                             <th><span>Payment date</span></th>
                             <th class="text-end"><span>Amount</span></th>
@@ -17,6 +18,9 @@
                             <tr>
                                 <td>
                                     <span t-field='check.name'/>
+                                </td>
+                                <td t-if="o.payment_method_code != 'own_checks'">
+                                    <span t-field='check.bank_account_id.display_name'/>
                                 </td>
                                 <td t-if="o.payment_method_code != 'own_checks'">
                                     <span t-field='check.issuer_vat'/>

--- a/addons/l10n_latam_check/wizards/account_payment_register.py
+++ b/addons/l10n_latam_check/wizards/account_payment_register.py
@@ -41,6 +41,7 @@ class AccountPaymentRegister(models.TransientModel):
             vals.update({'l10n_latam_new_check_ids': [Command.create({
                 'name': x.name,
                 'issuer_vat': x.issuer_vat,
+                'bank_account_id': x.bank_account_id.id,
                 'payment_date': x.payment_date,
                 'amount': x.amount}) for x in self.l10n_latam_new_check_ids
             ]})

--- a/addons/l10n_latam_check/wizards/account_payment_register_views.xml
+++ b/addons/l10n_latam_check/wizards/account_payment_register_views.xml
@@ -15,6 +15,7 @@
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="currency_id" column_invisible="True"/>
                                     <field name="name" />
+                                    <field name="bank_account_id" column_invisible="parent.payment_method_code == 'own_checks'" options="{'no_create': True}"/>
                                     <field name="issuer_vat" column_invisible="parent.payment_method_code == 'own_checks'"/>
                                     <field name="payment_date"/>
                                     <field name="amount" />
@@ -30,6 +31,7 @@
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="currency_id" column_invisible="True"/>
                                     <field name="name" />
+                                    <field name="bank_account_id" optional="hide"/>
                                     <field name="issuer_vat" optional="hide"/>
                                     <field name="payment_date" optional="show"/>
                                     <field name="amount"/>


### PR DESCRIPTION
This commit adds partner bank field for Latam Checks.

After a recent improvement in saas~19.2, #234974 the `res.bank` was moved to `res.partner.bank`, resulting in removal of existing `bank_id` field from latam checks.
Hence this commit introduces a new field `bank_account_id` aiming to fullfill the same purpose.

task-5893461

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
