### PR TITLE
[IMP] point_of_sale: prevent archiving pos.config with active session

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -712,7 +712,7 @@ class PosConfig(models.Model):
         return new_vals
 
     def _get_forbidden_change_fields(self):
-        return ['module_pos_restaurant', 'payment_method_ids']
+        return ['module_pos_restaurant', 'payment_method_ids', 'active']
 
     def unlink(self):
         # Delete the pos.config records first then delete the sequences linked to them

--- a/addons/point_of_sale/tests/test_point_of_sale.py
+++ b/addons/point_of_sale/tests/test_point_of_sale.py
@@ -2,6 +2,7 @@
 
 from odoo.fields import Command
 from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
 
 
 class TestPointOfSale(TransactionCase):
@@ -144,3 +145,7 @@ class TestPointOfSale(TransactionCase):
         models_to_filter = {'product.template': products_to_display}
         products_to_display = list(set(products_to_display) - set(session.filter_local_data(models_to_filter)['product.template']))
         self.assertEqual(products_to_display, [])
+
+        # Cannot archive config while session is active
+        with self.assertRaises(UserError):
+            config.write({'active': False})


### PR DESCRIPTION
Add 'active' to _get_forbidden_change_fields to block archiving a Point of Sale configuration while a session is still open.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
