### PR TITLE
[FIX] mrp{,_subcontracting}: use interpolated prefix/suffix for generating serial batch

### DIFF
--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -695,6 +695,36 @@ class TestTraceability(TestMrpCommon):
         third_serials_wizard = Form.from_action(self.env, third_mo.action_generate_serial())
         self.assertEqual(third_serials_wizard.lot_name, 'TEST0000006')
 
+    @freeze_time('2024-02-03')
+    def test_interpolation_in_batch_serials(self):
+        """
+        Test that prefixes are correctly interpolated when
+        generating multiple serial numbers in one MO
+        """
+        mo, _bom, final_product, _comp_1, _comp_2 = self.generate_mo(
+            tracking_final='serial',
+            qty_base_1=1,
+            qty_base_2=1,
+            qty_final=2,
+        )
+        final_product.lot_sequence_id.prefix = '%(day)s-%(month)s-'
+        final_product.lot_sequence_id.number_next_actual = 1
+        serials_wizard = Form.from_action(self.env, mo.action_generate_serial())
+        self.assertEqual(serials_wizard.lot_name, '03-02-0000001')
+        serials_wizard.save().action_generate_serial_numbers()
+        serials_wizard.save().action_apply()
+        self.assertRecordValues(mo.lot_producing_ids.sorted('name'), [
+            {'name': '03-02-0000001'},
+            {'name': '03-02-0000002'},
+        ])
+        mo.button_mark_done()
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(final_product, self.stock_location), 2)
+        self.assertRecordValues(self.env['stock.lot'].search([('product_id', '=', final_product.id)]).sorted('name'), [
+            {'name': '03-02-0000001'},
+            {'name': '03-02-0000002'},
+        ])
+        self.assertEqual(final_product.next_serial, '0000003')
+
     def test_assign_stock_move_date_on_mark_done(self):
         product_final = self.env['product.product'].create({
             'name': 'Finished Product',

--- a/addons/mrp/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.py
@@ -19,12 +19,14 @@ class MrpProductionSerials(models.TransientModel):
     @api.depends('production_id')
     def _compute_lot_name(self):
         for wizard in self:
-            wizard.serial_numbers = '\n'.join(self.production_id.lot_producing_ids.mapped('name'))
+            wizard.serial_numbers = '\n'.join(wizard.production_id.lot_producing_ids.mapped('name'))
             if wizard.lot_name:
                 continue
-            wizard.lot_name = self.production_id.lot_producing_ids[:1].name
+            wizard.lot_name = wizard.production_id.lot_producing_ids[:1].name
             if not wizard.lot_name:
-                wizard.lot_name = self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial
+                sequence = wizard.production_id.product_id.lot_sequence_id
+                wizard.lot_name = sequence.get_next_char(sequence.number_next_actual) if sequence \
+                                 else wizard.production_id.product_id.serial_prefix_format + wizard.production_id.product_id.next_serial
 
     @api.depends('production_id')
     def _compute_lot_quantity(self):
@@ -56,13 +58,12 @@ class MrpProductionSerials(models.TransientModel):
         ])
         existing_lot_names = existing_lots.mapped('name')
         new_lots = []
+        sequence = self.production_id.product_id.lot_sequence_id
         for lot_name in sorted(lots):
             if lot_name in existing_lot_names:
                 continue
-
-            if lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
-                if self.production_id.product_id.lot_sequence_id:
-                    self.production_id.product_id.lot_sequence_id.number_next_actual += 1
+            if sequence and lot_name == sequence.get_next_char(sequence.number_next_actual):
+                sequence.number_next_actual += 1
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id

--- a/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
@@ -20,12 +20,12 @@ class MrpProductionSerials(models.TransientModel):
         ])
         existing_lot_names = existing_lots.mapped('name')
         new_lots = []
+        sequence = self.production_id.product_id.lot_sequence_id
         for lot_name in sorted(lots):
             if lot_name in existing_lot_names:
                 continue
-            if lot_name == self.production_id.product_id.serial_prefix_format + self.production_id.product_id.next_serial:
-                if self.production_id.product_id.lot_sequence_id:
-                    self.production_id.product_id.lot_sequence_id.number_next_actual += 1
+            if sequence and lot_name == sequence.get_next_char(sequence.number_next_actual):
+                sequence.number_next_actual += 1
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id


### PR DESCRIPTION
## Issue
When generating multiple serial numbers in a single manufacturing order, interpolations are not replaced. For example, if the sequence prefix is `%(month)s`, the placeholder is not be replaced by the current month, and the generated serial numbers contain `%(month)s` literally.

This issue also impacts the `mrp_subcontracting` serial numbers generation by causing a similar issue as the second bug described by https://github.com/odoo/odoo/commit/20158a1. When creating a duplicate of a subcontracted manufacturing order, the *First SN* field (`lot_name`) is initiated to `1` again, instead of starting from the last SN of the previous MO. This issue was supposedly fixed by https://github.com/odoo/odoo/commit/9cd0c4a, but the issue still occurs when using interpolated prefix.

## Steps to reproduce
1. Install *Manufacturing* (`mrp`)
2. In Settings, enable *Lots & Serial Numbers*
3. In Settings > Technical > Sequences, give a prefix using interpolation to the `stock.lot.serial` sequence. An example of such prefix could be `%(year)s-%(month)s-%(day)s-`
3. Create a product P
    - Tracked *By Unique Serial Number*
    - Create a BoM for the product P
4. Create and confirm a Manufacturing Order for product P
    - Quantity >= 2
5. Click *Generate Serial*
6. **The _First SN_ field uses the interpolation without replacing the placeholders. When clicking _Generate_, more serials are generated where the placeholders are not replaced. If we proceed, the produced serial numbers still contain the placeholders.**

If we generate a MO with a quantity of one, the serial number is correctly generated (the placeholders are replaced as expected). 

## Cause

The method responsible for replacing the interpolation placeholder is `IrSequence._get_prefix_suffix` which is called by `IrSequence.get_next_char`:

https://github.com/odoo/odoo/blob/bf7dee8069f203095c44381708153865d3e8f19e/odoo/addons/base/models/ir_sequence.py#L240-L242

Generating a single serial numbers work as expected because it calls `MrpProduction.action_generate_serial`, which uses `IrSequence.get_next_char` further down the call stack.

When generating **multiple** serial numbers in a single MO, the [`mrp.production.serials` wizard](https://github.com/odoo/odoo/blob/19.0/addons/mrp/wizard/mrp_production_serial_numbers.py) is used. In this flow, `get_next_char` is never called, because the serial number logic is reimplemented using fields (`serial_prefix_format` and `next_serial`) from the `product.product` model.

## Fix
Serial numbers are generated from the *First SN* (`lot_name`) field. Correctly applying the interpolation to that field ensures that all subsequently generated serial numbers also use the interpolated values. Because `mrp_subcontracting` inherits the behavior from `mrp` to generate the lot_name, fixing this issue in `mrp` also solves it in `mrp_subcontracting`.

When initiating the `lot_name` field, we need to take in account cases where the product does not have a `lot_sequence_id`. This can happen if the sequence of the product was deleted. The same check is not required when updating the `number_next_actual`, as if there's no `lot_sequence_id`, there's no `number_next_actual` to update.

The logic updating the `number_next_actual` has also been adjusted to ensure the field is incremented correctly. This was an issue corrected by https://github.com/odoo/odoo/commit/20158a115ef3dfb9fe2dd5103d3bed7e87e37940 and https://github.com/odoo/odoo/commit/3ff0f2e3ef4fbcbf0b0b0ae6db8ff6f52bfdf67a, but without taking interpolated prefixes into account.

opw-5882578