### PR TITLE
[FIX] l10n_hr_edi: method already defined in account_move

### DIFF
--- a/addons/l10n_hr_edi/models/account_move.py
+++ b/addons/l10n_hr_edi/models/account_move.py
@@ -167,11 +167,6 @@ class AccountMove(models.Model):
         else:
             return super()._get_invoice_reference_odoo_invoice()
 
-    def _get_l10n_hr_fiscal_user_id_domain(self):
-        internal_users = self.env.ref('base.group_user')
-        domain = [('user_ids', 'in', internal_users.users.ids)]
-        return domain
-
     def _post(self, soft=True):
         for move in self:
             if move.country_code == 'HR' and move.is_sale_document():


### PR DESCRIPTION
This commit removes the duplicated method definition for `_get_l10n_hr_fiscal_user_id_domain()` in the account_move model.

Reported by pylint 4.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
