### PR TITLE
[FIX] l10n_in: correct column shift section pdf

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -37,6 +37,10 @@
             </td>
         </xpath>
 
+        <xpath expr="//t[@name='account_invoice_line_accountable']/following-sibling::*[1]/td[1]" position="after">
+            <td t-if="o.company_id.account_fiscal_country_id.code == 'IN' and o.company_id.l10n_in_is_gst_registered"></td>
+        </xpath>
+
         <xpath expr="//div[@id='qrcode_info']" position="attributes">
             <attribute name="t-if" add="o.company_id.account_fiscal_country_id.code != 'IN'" separator="and"/>
         </xpath>


### PR DESCRIPTION
How to reproduce :
- With l10n_in company
- Create Invoice
- Add section
- Add product under section
- Confirm invoice
- Print to pdf

The problem :
The value for the total amount of the section is in the wrong column (the one to the left)

Why :
The l10n_in module adds a column in the report for the HSN/SAC of the products. It correctly did for the products and the table title but not for the sections.

opw-5879828

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
