### PR TITLE
[IMP] web: D&co apply decoration-muted to m2o avatar

### DIFF
--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.scss
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.scss
@@ -3,6 +3,12 @@
         cursor: context-menu;
         outline: $border-width solid $o-action;
     }
+    &.text-muted {
+        img {
+            filter: grayscale(1);
+            opacity: 0.5;
+        }
+    }
 }
 
 .o_kanban_record  {

--- a/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
@@ -431,3 +431,21 @@ test("widget many2one_avatar in kanban view without access rights", async () => 
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > .o_quick_assign"
     ).toHaveCount(0);
 });
+
+test(`decoration-muted works on avatars`, async () => {
+    Partner._records.forEach((rec) => (rec.int_field = 9));
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="int_field"/>
+                <field name="user_id" widget="many2one_avatar" decoration-muted="int_field &lt; 5"/>
+                <field name="user_id" widget="many2one_avatar" decoration-muted="int_field &gt; 5"/>
+            </form>
+        `,
+        resId: 2,
+    });
+    expect(`.o_avatar:eq(0) img`).not.toHaveStyle({ opacity: 0.5, filter: "grayscale(1)" });
+    expect(`.o_avatar:eq(1) img`).toHaveStyle({ opacity: 0.5, filter: "grayscale(1)" });
+});


### PR DESCRIPTION
This commit adds a grayscale filter on the m2o avatar when the field has
the `decoration-muted` attribute.

task-5469063