### PR TITLE
[FIX] mail: fix insertion of mixed up many commands

### DIFF
--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -2,7 +2,7 @@ import { markup, toRaw } from "@odoo/owl";
 import {
     IS_DELETED_SYM,
     OR_SYM,
-    isCommand,
+    isCommandList,
     isMany,
     isOne,
     isRecord,
@@ -86,7 +86,7 @@ export class Record {
                 if (!isRelation(Model, expr)) {
                     return data[expr];
                 }
-                if (isCommand(data[expr])) {
+                if (isCommandList(data[expr])) {
                     // Note: only fields.One is supported
                     const [cmd, data2] = data[expr].at(-1);
                     if (cmd === "DELETE") {
@@ -122,7 +122,7 @@ export class Record {
         }
         function _deepRetrieve(expr2) {
             if (typeof expr2 === "string") {
-                if (isCommand(data[expr2])) {
+                if (isCommandList(data[expr2])) {
                     // Note: only fields.One() is supported
                     const [cmd, data2] = data[expr2].at(-1);
                     return Object.assign(res, {
@@ -154,7 +154,7 @@ export class Record {
             if (typeof data !== "object" || data === null) {
                 return { [Model.id]: data }; // non-object data => single id
             }
-            if (isCommand(data[Model.id])) {
+            if (isCommandList(data[Model.id])) {
                 // Note: only fields.One is supported
                 const [cmd, data2] = data[Model.id].at(-1);
                 return Object.assign(res, {
@@ -262,7 +262,7 @@ export class Record {
                 if (
                     ids[name] &&
                     !isRecord(ids[name]) &&
-                    !isCommand(ids[name]) &&
+                    !isCommandList(ids[name]) &&
                     isRelation(Model, name)
                 ) {
                     // preinsert that record in relational field,

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -528,9 +528,12 @@ class Store:
             super()._add_to_store(store, target, key)
             if not self.only_data and (self.records or self.mode == "REPLACE"):
                 rel_val = self._get_id()
-                target[key] = (
-                    target[key] + rel_val if key in target and self.mode != "REPLACE" else rel_val
-                )
+                if self.mode == "REPLACE" or key not in target:
+                    target[key] = rel_val
+                    return
+                if target[key] and not isinstance(target[key][0], tuple):
+                    target[key] = [("REPLACE", target[key])]
+                target[key] += rel_val
 
         def _get_id(self):
             """Return the ids that can be used to insert the current relation in the store."""


### PR DESCRIPTION
Many fields can be updated in the discuss store in different
modes: `ADD`, `DELETE`, `REPLACE`.

`REPLACE` commands are returned as a value list as it is the
default mode. However, when other commands are added, the
resulting value doesn't make sense as commands and raw values
are mixed up.

This commit fixes the `_add_to_store` method to properly format
the command list:
- When there is only a replace, the return value is kept as is
(i.e. a list of values).
- When there are other commands, the `REPLACE` command is wrapped
into a command.
- As a bonus, when a `REPLACE` command comes after other commands,
the list is cleared. It doesn't make sense to keep other commands
as they will be cleared by the `REPLACE` anyway.

This PR also normalize commands on the client side to ease their
processing: we don't need to guess the shape of the command anymore.