### PR TITLE
[IMP] point_of_sale: use_lna support for IoT requests

### DIFF
--- a/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
+++ b/addons/point_of_sale/static/src/app/hardware_proxy/hardware_proxy_service.js
@@ -147,6 +147,7 @@ export class HardwareProxy extends EventBus {
             const response = await browser
                 .fetch(`${url}/hw_proxy/hello`, {
                     signal: timeoutController.signal,
+                    targetAddressSpace: odoo.use_lna ? "local" : undefined,
                 })
                 .catch(() => ({}));
             if (response.ok) {

--- a/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/navbar/closing_popup/closing_popup.js
@@ -186,6 +186,7 @@ export class ClosePosPopup extends Component {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({ params: { action: "close" } }),
+                targetAddressSpace: odoo.use_lna ? "local" : undefined,
             }).catch(() => {
                 console.log("Failed to send data to customer display");
             });

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -95,6 +95,7 @@ export class Chrome extends Component {
                         data: customerDisplayData,
                     },
                 }),
+                targetAddressSpace: odoo.use_lna ? "local" : undefined,
             }).catch(() => {
                 console.log("Failed to send data to customer display");
             });

--- a/addons/point_of_sale/static/src/customer_display/utils.js
+++ b/addons/point_of_sale/static/src/customer_display/utils.js
@@ -25,6 +25,7 @@ export function openCustomerDisplay(
                 pos_id: configId,
             },
         }),
+        targetAddressSpace: odoo.use_lna ? "local" : undefined,
     })
         .then(() => {
             notificationService?.add(_t("Connection successful"), { type: "success" });

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -21,7 +21,8 @@ export function uuidv4() {
  * @returns {string}
  */
 export function deduceUrl(url) {
-    const { protocol } = window.location;
+    const protocol = odoo.use_lna ? "http:" : window.location.protocol;
+    url = odoo.use_lna ? url.replace(/^(\d+)-(\d+)-(\d+)-(\d+).*/, "$1.$2.$3.$4") : url;
     if (!url.includes("//")) {
         url = `${protocol}//${url}`;
     }


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/106183

This is a backport of odoo/odoo#237147.

Since odoo#235702, there is a `point_of_sale.use_lna` system parameter. When it is set, ePOS requests will use HTTP instead of HTTPS, and the `targetAddressSpace: "local"` option is used in the `fetch` request. This bypasses the need for a HTTPS certificate.

This commit adds the same functionality to all IoT requests from the POS. This should allow the IoT box to function correctly without a HTTPS certificate.

task-5353672

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
