### PR TITLE
[FIX] point_of_sale: search partner before clicking in tours

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -1,12 +1,39 @@
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
+export function partnerListTrigger(name = "") {
+    return `.modal .partner-list b:contains(${name})`;
+}
+
 export function clickPartner(name = "", { expectUnloadPage = false } = {}) {
-    return {
-        content: `click partner '${name}' from partner list screen`,
-        trigger: `.modal .partner-list b:contains(${name})`,
-        run: "click",
-        expectUnloadPage,
-    };
+    if (!name) {
+        return [
+            {
+                content: `click partner from partner list screen`,
+                trigger: partnerListTrigger(),
+                run: "click",
+                expectUnloadPage,
+            },
+        ];
+    }
+    return [
+        {
+            isActive: ["mobile"],
+            content: `Click search field`,
+            trigger: `.modal .fa-search.undefined`,
+            run: `click`,
+        },
+        {
+            content: `Search for partner "${name}"`,
+            trigger: `.modal-dialog .input-group input`,
+            run: `edit ${name}`,
+        },
+        {
+            content: `click partner '${name}' from partner list screen`,
+            trigger: partnerListTrigger(name),
+            run: "click",
+            expectUnloadPage,
+        },
+    ];
 }
 export function clickPartnerOptions(name) {
     return {
@@ -121,7 +148,7 @@ export function searchCustomerValue(val, pressEnter = false) {
         {
             isActive: ["mobile"],
             content: `Click search field`,
-            trigger: `.fa-search.undefined`,
+            trigger: `.modal .fa-search.undefined`,
             run: `click`,
         },
         {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -346,13 +346,13 @@ export function clickPartnerButton() {
         },
         {
             content: "partner screen is shown",
-            trigger: `${PartnerList.clickPartner().trigger}`,
+            trigger: PartnerList.partnerListTrigger(),
         },
     ];
 }
 
 export function clickCustomer(name) {
-    return [PartnerList.clickPartner(name)];
+    return [...PartnerList.clickPartner(name)];
 }
 
 export function shippingLaterHighlighted() {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -206,12 +206,12 @@ export function clickPartnerButton() {
         },
         {
             content: "partner screen is shown",
-            trigger: `${PartnerList.clickPartner().trigger}`,
+            trigger: PartnerList.partnerListTrigger(),
         },
     ];
 }
 export function clickCustomer(name) {
-    return [PartnerList.clickPartner(name), { ...back(), isActive: ["mobile"] }];
+    return [...PartnerList.clickPartner(name), { ...back(), isActive: ["mobile"] }];
 }
 export function selectPreset(selectedPreset, presetToSelect) {
     return [


### PR DESCRIPTION
Make clickPartner search for the partner first to handle infinite scroll.

Fixes:
- test_preset_customer_selection
- test_not_create_loyalty_card_expired_program
- test_not_create_loyalty_card_max_usage_programm

task-id: 5897380

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
