### PR TITLE
[FIX] l10n_it_edi: propagate l10n_it on create_company

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -202,3 +202,10 @@ class ResPartner(models.Model):
     def _peppol_eas_endpoint_depends(self):
         # extends account_edi_ubl_cii
         return super()._peppol_eas_endpoint_depends() + ['l10n_it_codice_fiscale']
+
+    def create_company(self):
+        res = super().create_company()
+        if res:
+            it_values = self._update_fields_values(('l10n_it_codice_fiscale', 'l10n_it_pa_index'))
+            self.parent_id.update(it_values)
+        return res

--- a/addons/l10n_it_edi/tests/test_res_partner.py
+++ b/addons/l10n_it_edi/tests/test_res_partner.py
@@ -176,3 +176,18 @@ class TestResPartner(TransactionCase):
                 'normalized_vat': False,
             },
         ])
+
+    def test_create_company(self):
+        """Test that when creating a company from an individual, l10n_it values are propagated"""
+        individual_partner = self.env['res.partner'].create({
+            'company_name': 'Mario Bros. Plumbing',
+            'name': 'Mario',
+            'l10n_it_codice_fiscale': '12345670546',
+            'l10n_it_pa_index': '1231231',
+        })
+        individual_partner.create_company()
+        self.assertRecordValues(individual_partner.parent_id, [{
+            'name': 'Mario Bros. Plumbing',
+            'l10n_it_codice_fiscale': '12345670546',
+            'l10n_it_pa_index': '1231231',
+        }])


### PR DESCRIPTION
**STEP TO REPRODUCE**

1. Create a ecommerce order on a shop page of a italian company.
2. Goes to the checkout page, enter info (company_name, l10n_it_codice_fiscale, l10n_it_pa_index).
3. On the contact created, click on create company.
4. Notice l10n_it fields are not propagated to the company.

opw-5477372
