### PR TITLE
[FIX] hr_holidays: correct timezone for time off calendar event

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1050,13 +1050,18 @@ Versions:
                 "%(employee)s on Time Off : %(duration)s",
                 employee=holiday.employee_id.name or holiday.category_id.name,
                 duration=holiday.duration_display)
-            allday_value = not holiday.request_unit_half
+            allday_value = not holiday.request_unit_half or holiday.request_date_from_period == 'am' and holiday.request_date_to_period == 'pm'
             if holiday.leave_type_request_unit == 'hour':
                 allday_value = float_compare(holiday.number_of_days, 1.0, 1) >= 0
 
-            leave_tz = pytz.timezone(holiday.tz) if holiday.tz else pytz.UTC
-            start_value = pytz.UTC.localize(holiday.date_from).astimezone(leave_tz).replace(tzinfo=None)
-            stop_value = pytz.UTC.localize(holiday.date_to).astimezone(leave_tz).replace(tzinfo=None)
+            if allday_value:
+                # `start` and `stop` are not in UTC for allday events
+                leave_tz = pytz.timezone(holiday.tz) if holiday.tz else pytz.UTC
+                start_value = pytz.UTC.localize(holiday.date_from).astimezone(leave_tz).replace(tzinfo=None)
+                stop_value = pytz.UTC.localize(holiday.date_to).astimezone(leave_tz).replace(tzinfo=None)
+            else:
+                start_value = holiday.date_from
+                stop_value = holiday.date_to
 
             meeting_values = {
                 'name': meeting_name,


### PR DESCRIPTION
Forward port of https://github.com/odoo/odoo/pull/238941
which was not included by mistake here: https://github.com/odoo/odoo/pull/234703

Additionally, fix an issue where a full day leave was not displayed as a fullday event in the calendar if the leave type unit was half days.