### PR TITLE
[FIX] website: test inde "Save image"

### DIFF
--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -310,5 +310,5 @@ test("Save image with correct parameter", async () => {
             >
         </div>`);
     await contains(".o-snippets-top-actions button:contains(Save)").click();
-    expect.verifySteps(["modify_image"]);
+    await expect.waitForSteps(["modify_image"]);
 });


### PR DESCRIPTION
The purpose of this commit is to fix the non-deterministic test “Save image with correct parameter.” There is no guarantee that ‘modify_image’ will be executed during the next animationFrame.

Solution:
Use “expect.waitForSteps” to wait for “modify_image” to be executed.

error-238377

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
