### PR TITLE
[REM] website: remove unnecessary clean of highlight in snippet preview

### DIFF
--- a/addons/website/static/src/builder/snippet_model.js
+++ b/addons/website/static/src/builder/snippet_model.js
@@ -1,20 +1,8 @@
-import { applyTextHighlight } from "@website/js/highlight_utils";
 import { registry } from "@web/core/registry";
 import { _t } from "@web/core/l10n/translation";
 import { SnippetModel } from "@html_builder/snippets/snippet_service";
 
 export class WebsiteSnippetModel extends SnippetModel {
-    /**
-     * @override
-     */
-    updateSnippetContent(snippetEl) {
-        super.updateSnippetContent(...arguments);
-        // Build the highlighted text content for new added snippets.
-        for (const textEl of snippetEl?.querySelectorAll(".o_text_highlight") || []) {
-            applyTextHighlight(textEl);
-        }
-    }
-
     /**
      * @override
      */


### PR DESCRIPTION
Commit 21044308329e415621ef63e49709ebed22fe4723 added a cleanup of the highlight of the snippet preview.

This clean up is not necessary because the highlights are cleaned by the interaction on snippet drop.

This commit removes the extra cleanup.