### PR TITLE
[FIX] pos_restaurant: wait for synchronisation

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -746,6 +746,7 @@ registry.category("web_tour.tours").add("test_book_and_release_table", {
             Dialog.confirm("Open Register"),
             FloorScreen.clickTable("5"),
             ProductScreen.bookOrReleaseTable(),
+            FloorScreen.isShown(),
             waitForLoading(),
             {
                 content: "Check if order has a server ID",


### PR DESCRIPTION
When booking the table we now wait to be back on the floor screen before checking that the loader is gone and that the order has a server ID. If we don't do that we might check that the loader is not there before it appears, and then checking the server ID before it is set.

runbot-227652