### PR TITLE
[FIX] account: fix domain on income/expense account

### DIFF
--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -205,8 +205,8 @@ class ResConfigSettings(models.TransientModel):
 
     # Autopost of bills
     autopost_bills = fields.Boolean(related='company_id.autopost_bills', readonly=False)
-    income_account_id = fields.Many2one(related='company_id.income_account_id', readonly=False)
-    expense_account_id = fields.Many2one(related='company_id.expense_account_id', readonly=False)
+    income_account_id = fields.Many2one(related='company_id.income_account_id', readonly=False, check_company=True)
+    expense_account_id = fields.Many2one(related='company_id.expense_account_id', readonly=False, check_company=True)
 
     @api.depends('country_code')
     def _compute_is_account_peppol_eligible(self):


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting
- Go to "Accounting / Configuration / Settings"
- Edit "Expense Account" property

**Issue:**
It is possible to set a receivable or payable account for the property. If a payable account is set, a constraint will trigger a UserError when trying to create a bill with that account.
The same issue happens for "Income Account".

**Cause:**
The field is a related field.
On the original field, there is a domain to prevent selecting these types of account, but the domain is not applied to the related field.

**Solution:**
Checking the company will retrieve the domain set on the original field.

opw-5492092




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
