### PR TITLE
[FIX] point_of_sale: use_lna for iot printers

### DIFF
--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -17,7 +17,7 @@
                             <field name="use_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
                             <field name="printer_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
                             <field name="epson_printer_ip" invisible="printer_type != 'epson_epos'" placeholder="10.100.50.87" required="printer_type == 'epson_epos'"/>
-                            <field name="use_lna" invisible="printer_type != 'epson_epos'"/>
+                            <field name="use_lna"/>
                             <field name="product_categories_ids" invisible="use_type != 'preparation'" widget="many2many_tags" required="use_type == 'preparation'"/>
                         </group>
                     </group>


### PR DESCRIPTION
This PR https://github.com/odoo/enterprise/pull/102622 activates lna for the iot box requests if "use_lna" is active in the printer settings. However the field is invisible for the iot printers. This PR makes it visible for all printers, including iot to use lna with iot in saas-19.1

