### PR TITLE
[FIX] point_of_sale: fix close session argument length for multiple orders

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -621,7 +621,7 @@ export class PosStore extends WithLazyGetterTrap {
     async deleteOrders(orders, serverIds = [], ignoreChange = false) {
         const ordersToDelete = [];
         const actionPosOrderCancelCall = async (orderIds) => {
-            await this.data.call("pos.order", "cancel_order_from_pos", orderIds, {
+            await this.data.call("pos.order", "cancel_order_from_pos", [orderIds], {
                 context: {
                     device_identifier: this.device.identifier,
                 },


### PR DESCRIPTION
In 3f95dd4413d3e72637ef92a1b02bddc1d9c6d165, we can call `cancel_order_from_pos` with either one or more orders; In the case of calling it with multiple orders, we were passing as argument an array of order ids as params for the python method, but since the method only expects a single argumetn, `self`, it will crash if we passed an array.

The fix is to pass `[[1, 2, 3]]` instead of `[1, 2, 3]` for multiple orders.

This still works for a single order too as both `[1]` and `[[1]]` works.