### PR TITLE
[FIX] html_builder: use label of original snippet for custom snippets

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -183,6 +183,7 @@ export class SnippetModel extends Reactive {
                     imagePreviewSrc: snippetEl.dataset.oImagePreview,
                     isCustom: false,
                     label: this.getSnippetLabel(snippetEl),
+                    originalLabel: snippetEl.dataset.oLabel,
                     isDisabled: false,
                     forbidSanitize: false,
                 };
@@ -238,6 +239,16 @@ export class SnippetModel extends Reactive {
             }
         }
         this.snippetsByCategory["snippet_custom_content"] = customInnerContent;
+
+        // Apply to custom snippets the labels from their original snippets
+        for (const snippet of this.snippetsByCategory.snippet_custom) {
+            if (!snippet.label && snippet.name) {
+                const originalSnippet = this.getOriginalSnippet(snippet.name);
+                if (originalSnippet && originalSnippet.originalLabel) {
+                    snippet.label = originalSnippet.originalLabel;
+                }
+            }
+        }
     }
 
     async deleteCustomSnippet(snippet) {

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -358,13 +358,14 @@ export function clickOnText(snippet, element, position = "bottom") {
  * dialog.
  * @param {*} position Where the purple arrow will show up
  */
-export function insertSnippet(snippet, { position = "bottom", ignoreLoading = false } = {}) {
+export function insertSnippet(snippet, { position = "bottom", ignoreLoading = false, label } = {}) {
     const blockEl = snippet.groupName || snippet.name;
     const insertSnippetSteps = [{
         trigger: ".o_builder_sidebar_open",
         noPrepend: true,
     }];
     const snippetIDSelector = snippet.id ? `[data-snippet-id="${snippet.id}"]` : `[data-snippet-id^="${snippet.customID}_"]`;
+    const labelSelector = label ? `[data-label="${label}"]` : ``;
     if (snippet.groupName) {
         insertSnippetSteps.push({
             content: markup(_t("Click on the <b>%s</b> category.", blockEl)),
@@ -376,7 +377,7 @@ export function insertSnippet(snippet, { position = "bottom", ignoreLoading = fa
             content: markup(_t("Click on the <b>%s</b> building block.", snippet.name)),
             // FIXME `:not(.d-none)` should obviously not be needed but it seems
             // currently needed when using a tour in user/interactive mode.
-            trigger: `.modal .show:iframe .o_snippet_preview_wrap${snippetIDSelector}:not(.d-none)`,
+            trigger: `.modal .show:iframe .o_snippet_preview_wrap${snippetIDSelector}${labelSelector}:not(.d-none)`,
             noPrepend: true,
             tooltipPosition: "top",
             run: "click",

--- a/addons/website/static/tests/tours/custom_popup_snippet.js
+++ b/addons/website/static/tests/tours/custom_popup_snippet.js
@@ -17,7 +17,7 @@ registerWebsitePreviewTour(
         edition: true,
     },
     () => [
-        ...insertSnippet(snippets[0]),
+        ...insertSnippet(snippets[0], { label: "Popup" }),
         ...clickOnSnippet(snippets[1]),
         {
             content: "save this snippet to save later",
@@ -34,7 +34,7 @@ registerWebsitePreviewTour(
             trigger: ".o_we_invisible_entry i",
             run: "click",
         },
-        ...insertSnippet(snippets[2]),
+        ...insertSnippet(snippets[2], { label: "Popup" }),
         {
             content: "check whether new custom popup is visible or not.",
             trigger: ":iframe section[data-snippet='s_banner']",


### PR DESCRIPTION
The label was never set for the custom snippets.

This commit adds a pass in `computeSnippetTemplates` to copy the labels to custom snippets from their corresponding original snippet.

Steps to reproduce:
- Open website builder
- Drop a snippet with the label "Carousel"
- Save this snippet as a custom snippet
- Click on "Custom" category
- Bug: the custom carousel does not have the "Carousel" label

task-5902478