### PR TITLE
[FIX] account_peppol: fix registration regression

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -377,7 +377,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
             if edi_user.proxy_type != 'peppol':
                 continue
             try:
-                proxy_user = edi_user._make_request(f"{self._get_server_url()}/api/peppol/2/participant_status")
+                proxy_user = edi_user._make_request(f"{edi_user._get_server_url()}/api/peppol/2/participant_status")
             except AccountEdiProxyError as e:
                 if e.code == 'client_gone':
                     # reset the connection if it was archived/deleted on IAP side


### PR DESCRIPTION
Fix regression of participant fetch cron introduced in forward port odoo/odoo#245038 Indeed self might be a record set in lots of different cases, which leads to users at least 1 existing edi proxy user in their company, all future registrations will fail