### PR TITLE
[FIX] hr_expense,sale_expense: re-invoiced expense quantity

### DIFF
--- a/addons/sale_expense/models/account_move_line.py
+++ b/addons/sale_expense/models/account_move_line.py
@@ -40,9 +40,12 @@ class AccountMoveLine(models.Model):
             res.update({
                 'name': self.name,
                 'expense_ids': [Command.set(self.expense_id.ids)],
-                'product_uom_qty': self.expense_id.quantity,
                 'analytic_distribution': self.analytic_distribution,
             })
+            if self.expense_id.product_id.expense_policy == 'sales_price' and self.expense_id.product_id.standard_price:
+                res.update({
+                    'product_uom_qty': self.expense_id.quantity,
+                })
         return res
 
     def _sale_create_reinvoice_sale_line(self):


### PR DESCRIPTION
Currently, when re-invoicing an expense paid by company, the line added to the sale order will show a price unit equal to the whole expense amount.

Steps to reproduce:
- Create a new Expense Category with Re-Invoice Costs set to 'At cost'
- Create a new Expense, set the new category, and set Paid By to 'Company'
- Set Quantity to greater than 1, and Customer to Re-Invoice to any Sales Order
- Confirm and Submit Journal Entry on the Expense record

Issue:
- On the linked Sales Order you will see the total of the expense is used as the unit price

This occurs because we don't pass the quantity to the move line creation vals, which then default to 1. In turn, when the sale order line is added, the unit price will be based on the move line vals but the quantity will match the expense.

opw-5883290