### PR TITLE
[IMP] mail: explicitly define singleton records

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/upgrade_19_2.js
+++ b/addons/im_livechat/static/src/core/public_web/upgrade_19_2.js
@@ -1,0 +1,6 @@
+import { upgrade_19_2 } from "@mail/core/common/upgrade/upgrade_19_2";
+
+upgrade_19_2.add("DiscussApp,undefined:isLivechatInfoPanelOpenByDefault", ({ value }) => ({
+    key: "DiscussApp:isLivechatInfoPanelOpenByDefault",
+    value: upgrade_19_2.parseRawValue(value).value,
+}));

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -15,6 +15,8 @@ const CHAT_HUB_COMPACT_LS = "mail.user_setting.chathub_compact";
  */
 
 export class ChatHub extends Record {
+    static singleton = true;
+
     BUBBLE = 56; // same value as $o-mail-ChatHub-bubblesWidth
     recomputeBubbleStart = 0;
     BUBBLE_START = fields.Attr(CHAT_HUB_DEFAULT_BUBBLE_START, {

--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -5,7 +5,7 @@ import { fields, Record } from "@mail/model/export";
 import { rpc } from "@web/core/network/rpc";
 
 export class Settings extends Record {
-    static id = undefined; // as to not be affected by res.users.settings's id`
+    static singleton = true;
 
     id;
 

--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_2.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_2.js
@@ -5,16 +5,49 @@ import { addUpgrade } from "@mail/core/common/upgrade/upgrade_helpers";
 
 export const upgrade_19_2 = {
     /**
-     * @param {string} key
+     * @param {string|(key: string) => string} key
      * @param {((param: UpgradeFnParam) => UpgradeFnReturn)|UpgradeFnReturn} upgrade
      * @returns {UpgradeFnReturn}
      */
     add(key, upgrade) {
         return addUpgrade({ key, version: "19.2", upgrade });
     },
+    /**
+     * Copy from parseRawValue at the time.
+     * Dedicate function so that it never change in the future for these 19.2 scripts.
+     *
+     * @param {string} rawValue
+     */
+    parseRawValue(rawValue) {
+        try {
+            return JSON.parse(rawValue);
+        } catch {
+            return undefined;
+        }
+    },
 };
 
 upgrade_19_2.add("mail.user_setting.push_notification_dismissed", {
-    key: "Store,undefined:isNotificationPermissionDismissed",
+    key: "Store:isNotificationPermissionDismissed",
     value: true,
 });
+
+const settingsFields = [
+    "messageSound",
+    "useCallAutoFocus",
+    "useBlur",
+    "audioInputDeviceId",
+    "audioOutputDeviceId",
+    "cameraInputDeviceId",
+    "backgroundBlurAmount",
+    "edgeBlurAmount",
+    "showOnlyVideo",
+    "voiceActivationThreshold",
+];
+
+for (const fieldName of settingsFields) {
+    upgrade_19_2.add(`Settings,undefined:${fieldName}`, ({ value }) => ({
+        key: `Settings:${fieldName}`,
+        value: upgrade_19_2.parseRawValue(value).value,
+    }));
+}

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app_model.js
@@ -1,6 +1,8 @@
 import { fields, Record } from "@mail/model/export";
 
 export class DiscussApp extends Record {
+    static singleton = true;
+
     INSPECTOR_WIDTH = 300;
     COMPACT_SIDEBAR_WIDTH = 60;
     /** @type {'notification'|'channel'|'chat'|'livechat'|'inbox'} */

--- a/addons/mail/static/src/core/public_web/discuss_app/upgrade_19_2.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/upgrade_19_2.js
@@ -1,20 +1,14 @@
-import { addUpgrade } from "@mail/core/common/upgrade/upgrade_helpers";
-
-/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnParam} UpgradeFnParam */
-/** @typedef {import("@mail/core/common/upgrade/upgrade_helpers").UpgradeFnReturn} UpgradeFnReturn */
-
-export const upgrade_19_2 = {
-    /**
-     * @param {string|(key: string) => string} key
-     * @param {((param: UpgradeFnParam) => UpgradeFnReturn)|UpgradeFnReturn} upgrade
-     * @returns {UpgradeFnReturn}
-     */
-    add(key, upgrade) {
-        return addUpgrade({ key, version: "19.2", upgrade });
-    },
-};
+import { upgrade_19_2 } from "@mail/core/common/upgrade/upgrade_19_2";
 
 upgrade_19_2.add(/^mail\.sidebar_category_(.*)_hidden$/, ({ matchOfKey }) => ({
     key: `DiscussAppCategory,${matchOfKey[1]}:hidden`,
     value: true,
 }));
+
+const discussAppFields = ["isMemberPanelOpenByDefault", "isSidebarCompact", "lastActiveId"];
+for (const fieldName of discussAppFields) {
+    upgrade_19_2.add(`DiscussApp,undefined:${fieldName}`, ({ value }) => ({
+        key: `DiscussApp:${fieldName}`,
+        value: upgrade_19_2.parseRawValue(value).value,
+    }));
+}

--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -273,6 +273,8 @@ export class Network {
  */
 
 export class Rtc extends Record {
+    static singleton = true;
+
     /** @type {typeof CONNECTION_TYPES[keyof typeof CONNECTION_TYPES]} */
     connectionType;
     /** @type {ReturnType<debounce>} */

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -5,6 +5,7 @@ import { reactive, toRaw } from "@odoo/owl";
 /** @typedef {import("./record_list").RecordList} RecordList */
 
 export class Store extends Record {
+    static singleton = true;
     /** @type {import("./store_internal").StoreInternal} */
     _;
     [STORE_SYM] = true;

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -124,11 +124,15 @@ test("local storage for call settings", async () => {
     localStorage.setItem(showOnlyVideoKey, toRawValue(true));
     const useBlurLocalStorageKey = makeRecordFieldLocalId(Settings.localId(), "useBlur");
     localStorage.setItem(useBlurLocalStorageKey, toRawValue(true));
+    const voiceActivationThresholdKey = makeRecordFieldLocalId(
+        Settings.localId(),
+        "voiceActivationThreshold"
+    );
     const callSettingsKeys = [
-        "Settings,undefined:backgroundBlurAmount",
-        "Settings,undefined:edgeBlurAmount",
-        "Settings,undefined:showOnlyVideo",
-        "Settings,undefined:voiceActivationThreshold",
+        backgroundBlurAmountKey,
+        edgeBlurAmountKey,
+        showOnlyVideoKey,
+        voiceActivationThresholdKey,
     ];
     patchWithCleanup(localStorage, {
         setItem(key, value) {
@@ -159,9 +163,9 @@ test("local storage for call settings", async () => {
 
     // testing save to local storage
     await click("input[title='Show video participants only']");
-    await expect.waitForSteps(["Settings,undefined:showOnlyVideo: removed"]);
+    await expect.waitForSteps([`${showOnlyVideoKey}: removed`]);
     await click("input[title='Blur video background']");
     expect(localStorage.getItem(useBlurLocalStorageKey)).toBe(null);
     await editInput(document.body, ".o-Discuss-CallSettings-thresholdInput", 0.3);
-    await expect.waitForSteps(["Settings,undefined:voiceActivationThreshold: 0.3"]);
+    await expect.waitForSteps([`${voiceActivationThresholdKey}: 0.3`]);
 });


### PR DESCRIPTION
Before this commit, singleton records were implicit:
- Before [1] they relied on no definition of `static id`
- After [1] they either don't use default "id" field or had to hack their way to force not using `static id = "id"`

This commit improves definition of singleton through explicit definition `static singleton = true`. When this is set, the model enforces singleton, so all `.insert()` either creates record if none of this model exists or necessarily updates it.

Singleton records also have their local id format cleaned, with removal of ",undefined", which leaked the technical details of no `static id` means `undefined` is the id field, and singleton works thanks to no code attempting to insert data on this "fake" field.

Task-5893196

[1]: https://github.com/odoo/odoo/pull/246122