### PR TITLE
[FIX] website: correctly wait for loading in `insertSnippet` tour util

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -392,7 +392,7 @@ export function insertSnippet(snippet, { position = "bottom", ignoreLoading = fa
 
     if (!ignoreLoading) {
         insertSnippetSteps.push({
-            trigger: ":iframe:not(:has(.o_loading_screen))",
+            trigger: ".o_website_preview :iframe:not(:has(.o_loading_screen))",
         });
     }
 


### PR DESCRIPTION
`insertSnippet` has a step to wait for `o_loading_screen` to disappear, but it is querying the iframe inside the dialog instead of the main iframe.

This issue causes the following undeterministic warning error:
```
should not have any "characterData", "remove" or "add" mutations in
current step when you update the selection
```

Ensure we are waiting for the loading screen of the correct iframe.

runbot-229803

Backport-Of: https://github.com/odoo/odoo/pull/246750