### PR TITLE
[18.0][FIX] calendar: Display the description of an event using full width (similar to 16.0)

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -211,7 +211,6 @@
                                         <field name="privacy" readonly="not user_can_edit" nolabel="1" placeholder="Default"/>
                                     </div>
                                     <field name="user_id" widget="many2one_avatar_user" readonly="not user_can_edit"/>
-                                    <field name="description" options="{'height': 100}" placeholder="Add description" readonly="not user_can_edit"/>
                         </group>
                         <group>
                             <field name="should_show_status" invisible="1"/>
@@ -241,6 +240,9 @@
                                     readonly="not user_can_edit"
                                 />
                             </div>
+                        </group>
+                        <group colspan="2">
+                            <field name="description" options="{'height': 100}" placeholder="Add description" readonly="not user_can_edit"/>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Display the description of an event using full width (similar to 16.0 https://github.com/odoo/odoo/blob/1d4e5e796372190d9e8ee9030cd8f8d610c3437e/addons/calendar/views/calendar_views.xml#L181)

Same behavior as in v16.

**Before**
<img width="1598" height="696" alt="antes" src="https://github.com/user-attachments/assets/65e4df21-7e93-4dc1-8825-7519d4c8ce70" />

**After**
<img width="1582" height="686" alt="despues" src="https://github.com/user-attachments/assets/2c2a5f05-8046-42b3-b147-0f3b7df862fd" />

@Tecnativa TT60670

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
