### PR TITLE
[FIX] stock_account,sale_stock: use lot valuation for cogs

### DIFF
--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1386,3 +1386,33 @@ class TestAngloSaxonValuation(TestStockValuationCommon):
                 {'credit': 0, 'debit': 500},
             ]
         )
+
+    def test_cogs_valued_by_lots(self):
+        self.product_avco_auto.product_tmpl_id.categ_id.property_cost_method = 'average'
+        self.product_avco_auto.write({
+            'lot_valuated': True,
+            'tracking': 'lot',
+        })
+        self.lot1, self.lot2 = self.env['stock.lot'].create([
+            {'name': 'lot1', 'product_id': self.product_avco_auto.id},
+            {'name': 'lot2', 'product_id': self.product_avco_auto.id},
+        ])
+        self._make_in_move(self.product_avco_auto, 2, 10, lot_ids=[self.lot1])
+        self._make_in_move(self.product_avco_auto, 2, 16, lot_ids=[self.lot2])
+        self.assertEqual(self.product_avco_auto.standard_price, 13)
+        self.assertEqual(self.lot1.standard_price, 10)
+        self.assertEqual(self.lot2.standard_price, 16)
+        so = self._so_deliver(self.product_avco_auto, 1, 1)
+        invoice = so._create_invoices()
+        invoice.action_post()
+        invoice_cogs_lines = invoice.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        self.assertRecordValues(
+            invoice_cogs_lines,
+            [
+                {'credit': 10, 'debit': 0},
+                {'credit': 0, 'debit': 10},
+            ]
+        )
+        self.assertEqual(self.lot1.standard_price, 10)
+        self.assertEqual(self.lot2.standard_price, 16)
+        self.assertEqual(self.product_avco_auto.standard_price, 14)

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -464,6 +464,9 @@ class ProductProduct(models.Model):
         for product in self:
             if product.cost_method == 'standard':
                 continue
+            if product.lot_valuated:
+                product.sudo().with_context(disable_auto_revaluation=True).standard_price = product.avg_cost
+                continue
             if product.cost_method == 'fifo':
                 qty_available = product._with_valuation_context().qty_available
                 if product.uom_id.compare(qty_available, 0) > 0:

--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -18,7 +18,7 @@ class StockLot(models.Model):
         Used to compute margins on sale orders."""
     )
 
-    @api.depends('product_id.lot_valuated', 'product_id.product_tmpl_id.lot_valuated')
+    @api.depends('product_id.lot_valuated', 'product_id.product_tmpl_id.lot_valuated', 'product_id.stock_move_ids.value')
     @api.depends_context('to_date', 'company', 'warehouse_id')
     def _compute_value(self):
         """Compute totals of multiple svl related values"""


### PR DESCRIPTION
**Problem:**
the cogs do not take into account lot valuation and the standard 
price of the form is not updated after a move out.

**Steps to reproduce:**
- create storable avco perpetual product, tracked and valued by lot
- confirm a purchase order for 2 qty at price 10
- in the receipt add 'lot 1' for the lot
- validate
- confirm a purchase order for 2 qty at price 16
- in the receipt add 'lot 2' for the lot
- validate
- confirm a sale order for a qty of 1, validate the move
- invoice the sale order, and confirm the invoice

**Current behavior:**
1) the cogs line (stock valuation and expenses) have a value of 13
(the avco value)
2) the standard price on the form view is still 13

**Expected behavior:**
1) it should be 10 (the value of lot1)
2) it should have been updated to 14 (weighted average of the lots value)

**Cause of the issue:**
1) get_cogs_price_unit() is taking standard price of the product
if the product is not fifo.
https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/stock_account/models/stock_move.py#L245 
In case of avco lot valuated product, this is not correct, the value should be 
the sum of (the value of each lot * the number of product from this lot in the 
moves) divided by the total quantity. 
this value can be obtained be dividing the total value of the moves by the total 
quantity. 

2) after the move is validated, the standard price should be updated because 
for lot valued product, the avco value can change after a move out. 
Currently it's only updated for fifo products.
https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/stock_account/models/stock_move.py#L172

**fix**
For the diff inside _update_standard_price() for problem 2,
I use avg_cost instead of doing the computation directly in 
_update_standard_price() to not duplicate code logic
 because the computation logic for lot valued products is 
already inside _compute_value()
https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/stock_account/models/product.py#L152-L157

The extra dependency on compute_value on the stock.lot model 
is needed because otherwise total_value of the lot is not 
invalidated in the cache after an out mouve is validated
(in our steps it will stay in cache with a value of 20 even 
after the out move is validated). 
With our steps this does not cause problem because when we use 
the avg_cost value for the product,  \__get__() is called on total_value of the lots, 
but it was not in cache because we didn't compute it before in 
this environment , so it will be recomputed with correct current value . 
But in other cases where the action_done is called on 
the move and there is already a value in cache for total_value 
of the lots (like in the test of this commit for instance), 
this value will become wrong after the move is validated 
and the cache won't be invalidated which will lead to 
incorrect computation of avg_cost because it will use the 
wrong cache value of total_value for the lots.

the test needs to be in sale_stock because the moves used 
for the cogs are being returned via the sale_stock override 
of _get_stock_moves()
https://github.com/odoo/odoo/blob/7ae112acd0c333f09c54e4eabbd22bcef72c32a7/addons/stock_account/models/account_move_line.py#L67

opw-5459082