### PR TITLE
[IMP] website: relocate popups after insertion

### DIFF
--- a/addons/website/static/src/@types/plugins.d.ts
+++ b/addons/website/static/src/@types/plugins.d.ts
@@ -25,6 +25,8 @@ declare module "plugins" {
     import { NavTabsStyleOptionShared } from "@website/builder/plugins/options/navtabs_style_option_plugin";
     import { WebsiteParallaxShared } from "@website/builder/plugins/options/parallax_option_plugin";
     import { searchbar_option_order_by_items } from "@website/builder/plugins/options/searchbar_option_plugin";
+    import { popup_container_selectors } from "@website/builder/plugins/options/popup_option_plugin";
+    import { searchbar_option_display_items, searchbar_option_order_by_items } from "@website/builder/plugins/options/searchbar_option_plugin";
     import { SocialMediaOptionShared } from "@website/builder/plugins/options/social_media_option_plugin";
     import { on_visibility_toggled_handlers, visibility_selector_parameters } from "@website/builder/plugins/options/visibility_option_plugin";
     import { WebsitePageConfigOptionShared } from "@website/builder/plugins/options/website_page_config_option_plugin";
@@ -94,6 +96,8 @@ declare module "plugins" {
         header_templates_providers: header_templates_providers;
 
         // Data
+        popup_container_selectors: popup_container_selectors;
+        searchbar_option_display_items: searchbar_option_display_items;
         searchbar_option_order_by_items: searchbar_option_order_by_items;
         theme_options: theme_options;
         visibility_selector_parameters: visibility_selector_parameters;

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -1,6 +1,17 @@
-import { Plugin } from "@html_editor/plugin";
-import { registry } from "@web/core/registry";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { Plugin } from "@html_editor/plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { registry } from "@web/core/registry";
+
+function getPopupContainerFromSelectors(editable, selectors) {
+    for (const selector of selectors) {
+        const containerEl = editable.querySelector(selector);
+        if (containerEl) {
+            return containerEl;
+        }
+    }
+    return null;
+}
 
 export class PopupOptionPlugin extends Plugin {
     static id = "PopupOption";
@@ -31,9 +42,12 @@ export class PopupOptionPlugin extends Plugin {
             return popupModalChildrenEls.every((child) => child.matches(".s_popup_close"));
         },
         on_cloned_handlers: this.onCloned.bind(this),
-        on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        on_snippet_dropped_handlers: withSequence(0, this.onSnippetDropped.bind(this)),
+        // TODO remove when popup dragging from the page is disabled.
+        on_element_dropped_handlers: withSequence(0, this.onElementDropped.bind(this)),
         on_will_remove_handlers: this.onWillRemove.bind(this),
         no_parent_containers: ".s_popup",
+        popup_container_selectors: withSequence(10, "main .oe_structure.o_savable"),
     };
 
     onCloned({ cloneEl }) {
@@ -44,6 +58,7 @@ export class PopupOptionPlugin extends Plugin {
 
     onSnippetDropped({ snippetEl }) {
         if (snippetEl.matches(".s_popup")) {
+            this.relocatePopup(snippetEl);
             this.assignUniqueID(snippetEl);
             this.dependencies.history.addCustomMutation({
                 apply: () => {
@@ -71,6 +86,26 @@ export class PopupOptionPlugin extends Plugin {
     assignUniqueID(editingElement) {
         editingElement.closest(".s_popup").id = `sPopup${Date.now()}`;
     }
+
+    onElementDropped({ droppedEl }) {
+        if (droppedEl.matches(".s_popup")) {
+            this.relocatePopup(droppedEl);
+        }
+    }
+
+    relocatePopup(editingElement) {
+        const popupEl = editingElement.closest(".s_popup");
+        if (popupEl.closest("#o_shared_blocks")) {
+            return;
+        }
+        const containerEl = getPopupContainerFromSelectors(
+            this.editable,
+            this.getResource("popup_container_selectors")
+        );
+        if (containerEl) {
+            containerEl.insertAdjacentElement("afterbegin", popupEl);
+        }
+    }
 }
 
 // Moves the snippet in #o_shared_blocks to be common to all pages
@@ -84,10 +119,17 @@ export class MoveBlockAction extends BuilderAction {
             : value === "currentPage";
     }
     apply({ editingElement, value }) {
-        const selector = value === "allPages" ? "#o_shared_blocks" : "main .oe_structure.o_savable";
-        const whereEl = this.editable.querySelector(selector);
         const popupEl = editingElement.closest(".s_popup");
-        whereEl.insertAdjacentElement("afterbegin", popupEl);
+        const whereEl =
+            value === "allPages"
+                ? this.editable.querySelector("#o_shared_blocks")
+                : getPopupContainerFromSelectors(
+                      this.editable,
+                      this.getResource("popup_container_selectors")
+                  );
+        if (whereEl) {
+            whereEl.insertAdjacentElement("afterbegin", popupEl);
+        }
     }
 }
 export class SetBackdropAction extends BuilderAction {

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -53,6 +53,48 @@ function checkEyesIconAfterSave(footerIsHidden = true) {
     }
     return eyeIconChecks;
 }
+
+function checkInvisiblePanelOrder(expectedNames) {
+    const firstExpected = expectedNames[0];
+    return {
+        content: "Check the order in the Invisible Elements panel",
+        trigger: `.o_we_invisible_el_panel .o_we_invisible_entry:contains("${firstExpected}")`,
+        run: () => {
+            const directPanelEntries = [
+                ...document.querySelectorAll(
+                    ".o_we_invisible_el_panel > .o_we_invisible_entry .o_title"
+                ),
+            ].map((entry) => entry.textContent.trim());
+
+            let lastIndex = -1;
+            const missing = [];
+
+            for (const expectedName of expectedNames) {
+                const index = directPanelEntries.indexOf(expectedName);
+                if (index < 0) {
+                    missing.push(expectedName);
+                    continue;
+                }
+                if (index <= lastIndex) {
+                    console.error(
+                        `error Unexpected Invisible Elements order. Expected: ${expectedNames.join(
+                            " < "
+                        )}`
+                    );
+                    return;
+                }
+                lastIndex = index;
+            }
+
+            if (missing.length) {
+                console.error(
+                    `error Missing entries in Invisible Elements panel: ${missing.join(", ")}`
+                );
+            }
+        },
+    };
+}
+
 registerWebsitePreviewTour(
     "conditional_visibility_1",
     {
@@ -185,10 +227,9 @@ registerWebsitePreviewTour(
             run: "click",
         },
         ...checkEyesIconAfterSave(),
-        {
-            content: "Check the order on the 'Invisible Elements' panel",
-            trigger: ".o_we_invisible_el_panel div:nth-child(3):contains('Banner')",
-        },
+        // Popups are relocated to the beginning of the page savable, so they
+        // appear before other snippets in the panel.
+        checkInvisiblePanelOrder(["Popup", "Banner", "Text - Image"]),
         {
             content: "Toggle the visibility of the Footer",
             trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Footer')",
@@ -206,10 +247,7 @@ registerWebsitePreviewTour(
             run: "drag_and_drop :iframe #wrapwrap footer",
         },
         ...checkEyesIconAfterSave(false),
-        {
-            content: "Check the order on the 'Invisible Elements' panel",
-            trigger: ".o_we_invisible_el_panel div:nth-child(3):contains('Text - Image')",
-        },
+        checkInvisiblePanelOrder(["Popup", "Text - Image", "Banner"]),
     ]
 );
 

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -107,13 +107,13 @@ registerWebsitePreviewTour(
         toggleBackdrop("Popup"), // show Popup backdrop
         {
             content: "Close the Popup that has now backdrop.",
-            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:first",
+            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Popup')",
             run: "click",
         },
         checkScrollbar(true),
         {
             content: "Open the Cookies Bar.",
-            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:last",
+            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Cookies Bar')",
             run: "click",
         },
         checkScrollbar(true),
@@ -122,7 +122,7 @@ registerWebsitePreviewTour(
         checkScrollbar(true),
         {
             content: "Open the Popup that has backdrop.",
-            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:first",
+            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Popup')",
             run: "click",
         },
         goBackToBlocks(),
@@ -147,13 +147,13 @@ registerWebsitePreviewTour(
         },
         {
             content: "Remove the s_popup snippet",
-            trigger: ".overlay .o_overlay_options .oe_snippet_remove",
+            trigger: ".o_customize_tab [data-container-title='Popup'] button.oe_snippet_remove",
             run: "click",
         },
         checkScrollbar(true),
         {
             content: "Open the Cookie Bar.",
-            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry",
+            trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Cookies Bar')",
             run: "click",
         },
         goBackToBlocks(),

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -6,6 +6,7 @@ import { isImageCorsProtected } from "@html_editor/utils/image";
 import { TABS } from "@html_editor/main/media/media_dialog/media_dialog_utils";
 import { WebsiteConfigAction, PreviewableWebsiteConfigAction } from "@website/builder/plugins/customize_website_plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { withSequence } from "@html_editor/utils/resource";
 import wSaleUtils from "@website_sale/js/website_sale_utils";
 
 export class ProductPageOptionPlugin extends Plugin {
@@ -69,7 +70,8 @@ export class ProductPageOptionPlugin extends Plugin {
         },
         builder_options_render_context: {
             productPageOptionSelector: PRODUCT_PAGE_OPTION_SELECTOR,
-        }
+        },
+        popup_container_selectors: withSequence(5, "#product_full_description"),
     };
 
     setup() {


### PR DESCRIPTION
Before this, popups were being inserted/moved inside other snippets, which caused confusion and styling/logic issues along with accidental deletion when the parent snippet was removed. Also, it could leak popup headings into structures like table of contents.

Now, on drop, page-specific popups are always relocated to a stable top-level savable container so we can avoid the previous issues.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
