### PR TITLE
[FIX] Compute amount of loyalty using line currency

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -253,6 +253,7 @@ class SaleOrder(models.Model):
                 quantity=line.product_uom_qty,
                 product=line.product_id,
                 partner=line.order_partner_id,
+                currency=line.currency_id,
             )
             # To compute the discountable amount we get the subtotal and add
             # non-fixed tax totals. This way fixed taxes will not be discounted

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -1211,3 +1211,65 @@ class TestLoyalty(TestSaleCouponCommon):
         sale_order._update_programs_and_rewards()
         claimable_rewards = sale_order._get_claimable_rewards()
         self.assertFalse(claimable_rewards.get(self.ewallet))
+
+    def test_program_with_small_amount_in_different_currency(self):
+        company_currency = self.env['res.currency'].create({
+            'name': 'HRC',
+            'symbol': '$',
+            'rounding': 1.0,
+            'position': 'after',
+        })
+        test_company = self.env['res.company'].create({
+            'name': 'Test Company',
+            'currency_id': company_currency.id,
+        })
+        other_currency = self.env['res.currency'].create({
+            'name': 'TST',
+            'symbol': 'T',
+            'rounding': 0.01,
+            'position': 'after',
+        })
+        self.env['res.currency.rate'].create({
+            'name': '2026-01-01',
+            'rate': 1.0,
+            'currency_id': other_currency.id,
+            'company_id': test_company.id,
+        })
+        pricelist = self.env['product.pricelist'].create({
+            'name': 'Test Pricelist',
+            'currency_id': other_currency.id,
+            'company_id': test_company.id,
+        })
+        program = self.env['loyalty.program'].create({
+            'name': 'Test Promotion',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'company_id': test_company.id,
+            'rule_ids': [Command.create({
+                'minimum_amount': 0,
+                'minimum_amount_tax_mode': 'excl',
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+            })],
+        })
+        order = self.env['sale.order'].with_company(test_company).create({
+            'partner_id': self.partner.id,
+            'pricelist_id': pricelist.id,
+        })
+        order.write({'order_line': [
+            (0, False, {
+                'product_id': self.product_A.id,
+                'name': 'Product A',
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1.0,
+                'price_unit': 0.34,
+            })
+        ]})
+        order._update_programs_and_rewards()
+        self._claim_reward(order, program)
+        self.assertEqual(len(order.order_line.ids), 2)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When using the loyalty module with Chilean localization and a sale in UF or Dollars, an error occurs when calculating the promotion amount.

When the system evaluates whether a promotion is applicable, it appears to be taking the value of the sale line after applying the company currency rounding instead of the sale order currency rounding. In the case of Chile with the peso currency, where rounding is applied to the unit, if the value of a line is less than 0.50 UF, the system rounds it to 0. By interpreting the line value as zero, the promotion engine does not recognize the existence of valid products and the "Promotions/Reward" button does not display any available options, even though the program conditions are met.

The root cause of the problem is that the `compute_all` method of taxes is being called without specifying the currency, which causes it to use the company currency instead of the sale order currency.

Current behavior before PR:
- Create a Promotions program (Discount & Loyalty) that applies, for example, a 10% discount without complex minimum restrictions.
- Create a Sales Order and add a product line whose unit price is less than 0.50 (e.g. 0.34 UF).
- Click on the "reward" button. Result: No available promotions are shown or it does not apply if there is only one active promotion.

Desired behavior after PR is merged:
- Create a Promotions program (Discount & Loyalty) that applies, for example, a 10% discount without complex minimum restrictions.
- Create a Sales Order and add a product line whose unit price is less than 0.50 (e.g. 0.34 UF).
- Click on the "reward" button. Result: The button now detects the promotion and allows it to be applied.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
