### PR TITLE
[IMP] hr_expense: replace 'toutes taxes comprises' with 'ttc'

### DIFF
--- a/addons/hr_expense/i18n/fr.po
+++ b/addons/hr_expense/i18n/fr.po
@@ -101,7 +101,7 @@ msgstr ""
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
 msgid "(incl"
-msgstr "(toutes taxes comprises"
+msgstr "(ttc"
 
 #. module: hr_expense
 #. odoo-python


### PR DESCRIPTION
In French, replace 'toutes taxes comprises' with 'ttc' for better UI alignment.

task-5712223