### PR TITLE
[FIX] stock_account: multiple stock moves due to BOM breaks invoice

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -7,8 +7,6 @@ class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     def _get_cogs_value(self):
-        price_unit = super()._get_cogs_value()
-
         so_line = self.sale_line_ids and self.sale_line_ids[-1] or False
         if so_line:
             # We give preference to the bom in the stock moves for the sale order lines
@@ -38,5 +36,5 @@ class AccountMoveLine(models.Model):
                     prod_moves = moves.filtered(lambda m: m.product_id == product)
                     product = product.with_company(self.company_id)
                     average_price_unit += factor * prod_moves._get_price_unit()
-                price_unit = average_price_unit / bom.product_qty or price_unit
-        return price_unit
+                return average_price_unit / bom.product_qty
+        return super()._get_cogs_value()


### PR DESCRIPTION
Current behavior:
--
When an invoice that contains a kit product is created, it crashes at the _get_cogs_price_unit() function

Expected behavior:
---
An invoice should be able to be created even when containing kit products

Steps to reproduce:
---
1. Create a clean database
2. Turn on the locations setting
3. Create a product with a BOM with atleast 2 components and set it to kit
4. Create a product category and set the invoice period to perpetual
5. Create a sales order containing the product and confirm
6. Validate the Delivery
7. Create an invoice and confirm

Cause of the issue:
---
the code self.product_id only works
The code inside _get_cogs_price_unit() single records or a record set with the same product.

Fix:
---
Add an if statement before the _get_cogs_price_unit() call to handle kit products buy checking if the first stock_move is the same as the product used as the main product

opw-5879615
---------------------------------------------------------------

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
