### PR TITLE
[FIX] web, project, payment: Fix extractProps and update props in CopyClipboardField

### DIFF
--- a/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
+++ b/addons/payment/static/src/js/payment_wizard_copy_clipboard_field.js
@@ -22,10 +22,6 @@ class PaymentWizardCopyClipboardButtonField extends CopyClipboardButtonField {
 const paymentWizardCopyClipboardButtonField = {
     ...copyClipboardButtonField,
     component: PaymentWizardCopyClipboardButtonField,
-    extractProps: (fieldInfo, dynamicInfo) => ({
-        ...copyClipboardButtonField.extractProps(fieldInfo, dynamicInfo),
-        string: fieldInfo.string,
-    }),
 };
 
 registry

--- a/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
+++ b/addons/payment/static/tests/payment_wizard_copy_clipboard_field_tests.js
@@ -16,6 +16,11 @@ QUnit.module("Payment", {
                     fields: {
                         amount: { string: "Amount", type: "float" },
                         link: { string: "Payment Link", type: "char" },
+                        link_copy_text: {
+                            string: "Custom Link Copy",
+                            type: "char",
+                            default: "Generate and Copy Payment Link",
+                        },
                     },
                     onchanges: {
                         amount(record) {
@@ -31,7 +36,7 @@ QUnit.module("Payment", {
     },
 });
 
-QUnit.test("copy link immediatly after entering the amount", async (assert) => {
+QUnit.test("copy link immediately after entering the amount", async (assert) => {
     assert.expect(3);
 
     await makeView({
@@ -42,11 +47,10 @@ QUnit.test("copy link immediatly after entering the amount", async (assert) => {
             <group>
                 <group>
                     <field name="amount"/>
-                     <field
-                        string="Generate and Copy Payment Link"
-                        name="link"
-                        widget="PaymentWizardCopyClipboardButtonField"
-                    />
+                    <field name="link_copy_text" invisible="1"/>
+                    <field name="link"
+                           widget="PaymentWizardCopyClipboardButtonField"
+                           options="{'copy_text_field': 'link_copy_text'}"/>
                 </group>
             </group>
         </form>`,

--- a/addons/payment/wizards/payment_link_wizard.py
+++ b/addons/payment/wizards/payment_link_wizard.py
@@ -32,6 +32,7 @@ class PaymentLinkWizard(models.TransientModel):
     partner_id = fields.Many2one('res.partner')
     partner_email = fields.Char(related='partner_id.email')
     link = fields.Char(string="Payment Link", compute='_compute_link')
+    link_copy_text = fields.Char(default=lambda self: _("Generate and Copy Payment Link"), readonly=True, store=False)
     company_id = fields.Many2one('res.company', compute='_compute_company_id')
     warning_message = fields.Char(compute='_compute_warning_message')
 

--- a/addons/payment/wizards/payment_link_wizard_views.xml
+++ b/addons/payment/wizards/payment_link_wizard_views.xml
@@ -31,11 +31,12 @@
                     <field name="warning_message"/>
                 </div>
                 <footer>
+                    <field name="link_copy_text" invisible="True"/>
                     <field name="link"
-                           string="Generate and Copy Payment Link"
                            readonly="1"
                            disabled="bool(warning_message)"
                            widget="PaymentWizardCopyClipboardButtonField"
+                           options="{'copy_text_field': 'link_copy_text'}"
                            data-hotkey="q"/>
                     <button string="Close"
                             class="btn btn-secondary rounded-2"

--- a/addons/project/wizard/project_share_wizard.py
+++ b/addons/project/wizard/project_share_wizard.py
@@ -34,6 +34,7 @@ class ProjectShareWizard(models.TransientModel):
 
     access_mode = fields.Selection([('read', 'Readonly'), ('edit', 'Edit')])
     display_access_mode = fields.Boolean()
+    share_link_copy_text = fields.Char(default=lambda self: _("Copy Link"), readonly=True, store=False)
 
     @api.depends('res_model', 'res_id')
     def _compute_resource_ref(self):

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -20,7 +20,13 @@
                 <p class="alert alert-warning" invisible="access_warning == ''" role="alert"><field name="access_warning"/></p>
                 <group>
                     <field options="{'horizontal': true}" name="access_mode" widget="radio" invisible="not display_access_mode" class="mb-4"/>
-                    <field name="share_link" widget="CopyClipboardChar" options="{'string': 'Copy Link'}" invisible="access_mode == 'edit'" string="Link" class="mb-4"/>
+                    <field name="share_link_copy_text" invisible="True"/>
+                    <field name="share_link" 
+                           string="Link" 
+                           widget="CopyClipboardChar" 
+                           options="{'copy_text_field': 'share_link_copy_text'}" 
+                           invisible="access_mode == 'edit'" 
+                           class="mb-4"/>
                     <div class="o_td_label mb-4">
                         <label for="partner_ids" string="Invite People" invisible="access_mode == 'read'"/>
                         <label for="partner_ids" invisible="access_mode == 'edit'"/>

--- a/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_clipboard_field.js
@@ -17,20 +17,21 @@ class CopyClipboardField extends Component {
     static template = "web.CopyClipboardField";
     static props = {
         ...standardFieldProps,
-        string: { type: String, optional: true },
+        copyTextField: { type: String, optional: true },
+        successTextField: { type: String, optional: true },
         disabledExpr: { type: String, optional: true },
     };
 
     setup() {
-        this.copyText = this.props.string || _t("Copy");
-        this.successText = _t("Copied");
+        this.copyText = this.props?.record?.evalContextWithVirtualIds?.[this.props.copyTextField] || _t("Copy");
+        this.successText = this.props?.record?.evalContextWithVirtualIds?.[this.props.successTextField] || _t("Copied");
     }
 
     get copyButtonClassName() {
         return `o_btn_${this.type}_copy btn-sm`;
     }
     get fieldProps() {
-        return omit(this.props, "string", "disabledExpr");
+        return omit(this.props, "copyTextField", "successTextField", "disabledExpr");
     }
     get type() {
         return this.props.record.fields[this.props.name].type;
@@ -68,9 +69,10 @@ export class CopyClipboardURLField extends CopyClipboardField {
 
 // ----------------------------------------------------------------------------
 
-function extractProps({ attrs }) {
+function extractProps({ attrs, options }) {
     return {
-        string: attrs.string,
+        copyTextField: options.copy_text_field,
+        successTextField: options.success_text_field,
         disabledExpr: attrs.disabled,
     };
 }

--- a/doc/cla/individual/Mazen-Ghaleb.md
+++ b/doc/cla/individual/Mazen-Ghaleb.md
@@ -1,0 +1,11 @@
+Egypt, 2026-01-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mazen Ghaleb mazenghaleb@outlook.com https://github.com/Mazen-Ghaleb


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**  
The `CopyClipboardField` widget previously relied on the `string` attribute inside `attributes` to determine the text of copy button. In Odoo 17+, the `string` attribute is no longer inside `attributes` but defined outside, causing the widget to break. 

Additionally, using `string`for the copy text introduced ambiguity between the field label and the actual text to copy. The intended approach is to define the copy text through widget options (as shown in the project share link), but directly using `copyText`, in options previously caused translation issues, as discussed in PR #245826.

This PR resolves the translation issue by passing the copy text through a dedicated char field, similar to how color is passed in  fields and currency is passed in monetary fields. The widget handles if this field is not stored too by using virtual records.

In the Payment Wizard button, the widget was inherited and `extractProps` was overridden to handle the `string` attribute manually, which is no longer necessary with the new approach.

**Current behavior before PR:**  
- `CopyClipboardField` reads the removed `string` attribute from `attributes`.  
- Copy text is ambiguous and can be confused with the field label.
- Project share link usage fails to read the copy text correctly.
- `PaymentWizardCopyClipboardButtonField` overrides `extractProps` unnecessarily to fix copy text handling.

**Desired behavior after PR is merged:**  
- `CopyClipboardField` reads text from field in  `copy_text_field` defined in widget options.
- Copy text is clearly separated from field labels.  
- Project share link works correctly using widget options. 
- `PaymentWizardCopyClipboardButtonField` no longer needs to override `extractProps` and copy text is set directly via field options.
- Submit/copy text can be customized through field options.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
