### PR TITLE
[FIX] project: use python_method for burndown chart embedded actions

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -248,7 +248,8 @@
         <field name="sequence">120</field>
         <field name="name">Burndown Chart</field>
         <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
-        <field name="action_id" ref="project.action_project_task_burndown_chart_report"/>
+        <field name="action_id" eval="False"/>
+        <field name="python_method">action_project_task_burndown_chart_report</field>
         <field name="groups_ids" eval="[(4, ref('project.group_project_manager'))]" />
     </record>
 
@@ -257,7 +258,8 @@
         <field name="sequence">120</field>
         <field name="name">Burndown Chart</field>
         <field name="parent_action_id" ref="project.project_update_all_action"/>
-        <field name="action_id" ref="project.action_project_task_burndown_chart_report"/>
+        <field name="action_id" eval="False"/>
+        <field name="python_method">action_project_task_burndown_chart_report</field>
         <field name="groups_ids" eval="[(4, ref('project.group_project_manager'))]" />
     </record>
 


### PR DESCRIPTION
        The burndown chart embedded actions use action_id which bypasses the
        Python method that sets required context (stage_name_and_sequence_per_id).
        Without this context, the JS model makes RPC calls that fail in sample
        mode when no project record is selected.

        This change replaces action_id with python_method, following the same
        pattern used by hr_timesheet for similar embedded actions.

        Steps to reproduce:
        1. Open Project app
        2. Access burndown chart via embedded action without records
        3. Sample mode triggers the crash

        Current behavior: TypeError reading undefined field type
        Expected behavior: Burndown chart loads with proper context

        task-5347524

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
