### PR TITLE
[IMP] sale: rename Salesperson to Contact on SO PDF

### DIFF
--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -81,7 +81,7 @@
                     </div>
                 </div>
                 <div t-if="doc.user_id.name" class="col">
-                    <strong>Salesperson</strong>
+                    <strong>Contact</strong>
                     <div t-field="doc.user_id">Mitchell Admin</div>
                 </div>
             </div>


### PR DESCRIPTION
Avoid using the term Salesperson directly on end customer documents as it can be connoted.

task-5887854

See Also:
Enterprise PR:https://github.com/odoo/enterprise/pull/106866

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
