### PR TITLE
[FIX] l10n_de,stock_account: prevent accesserror when confirming the order on eccomerce

### DIFF
--- a/addons/l10n_de/models/datev.py
+++ b/addons/l10n_de/models/datev.py
@@ -17,7 +17,7 @@ class ProductTemplate(models.Model):
         company = self.env.company
         if company.account_fiscal_country_id.code == "DE":
             if not self.property_account_income_id:
-                taxes = self.sudo(False).taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
+                taxes = self.taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
                 if not result['income'] or (result['income'].tax_ids and taxes and taxes[0] not in result['income'].tax_ids):
                     result_income = self.env['account.account'].with_company(company).search([
                         *self.env['account.account']._check_company_domain(company),
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
                     ], limit=1)
                     result['income'] = result_income or result['income']
             if not self.property_account_expense_id:
-                supplier_taxes = self.sudo(False).supplier_taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
+                supplier_taxes = self.supplier_taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(company))
                 if not result['expense'] or (result['expense'].tax_ids and supplier_taxes and supplier_taxes[0] not in result['expense'].tax_ids):
                     result_expense = self.env['account.account'].with_company(company).search([
                         *self.env['account.account']._check_company_domain(company),

--- a/addons/l10n_de/tests/test_account_move.py
+++ b/addons/l10n_de/tests/test_account_move.py
@@ -53,3 +53,19 @@ class TestAccountMoveDE(AccountTestInvoicingCommon):
         self.assertRecordValues(move.line_ids, expected_lines_vals)
         move.action_post()
         self.assertRecordValues(move.line_ids, expected_lines_vals)
+
+    def test_public_user_invoice_creation_with_product_record_rule(self):
+        public_user = self.env['res.users'].create({'name': 'Public User test', 'login': 'blablabla', 'is_public': True})
+        self.product_a.write({'property_account_income_id': False, 'property_account_expense_id': False})
+        model = self.env['ir.model']._get('product.template')
+        self.env['ir.rule'].create({
+            'name': "Only The Lone Wanderer allowed",
+            'model_id': model.id,
+            'domain_force': [('name', '=', 'coucou')],
+        })
+        move = self.env['account.move'].with_user(public_user).create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id})],
+        })
+        self.assertTrue(move)

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -347,7 +347,7 @@ will update the cost of every lot/serial number in stock."),
             }
             svl_vals_list.append(svl_vals)
         stock_valuation_layers = self.env['stock.valuation.layer'].sudo().create(svl_vals_list)
-        stock_valuation_layers._change_standart_price_accounting_entries(new_price)
+        stock_valuation_layers.sudo(False)._change_standart_price_accounting_entries(new_price)
 
     def _get_fifo_candidates_domain(self, company, lot=False):
         return [

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -5,6 +5,7 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 from odoo.tests import Form, tagged
 from odoo import fields, Command
+from unittest.mock import patch
 
 class TestAccountMoveStockCommon(AccountTestInvoicingCommon):
     @classmethod
@@ -442,3 +443,34 @@ class TestAccountMove(TestAccountMoveStockCommon):
         self.assertFalse(move.invoice_line_ids.name)
         # ensure the invoice is posted successfully
         self.assertEqual(move.state, 'posted')
+
+    def test_product_standard_price_multicompany_with_taxes(self):
+        """Test updating standard price on storable product with taxes from multiple companies."""
+        def _mock_get_product_accounts(p_self):
+            tax_income = p_self.taxes_id.filtered_domain(p_self.env['account.tax']._check_company_domain(p_self.env.company))
+            tax_expense = p_self.supplier_taxes_id.filtered_domain(p_self.env['account.tax']._check_company_domain(p_self.env.company))
+            return {
+                'income': p_self.env['account.account'].search([
+                    ('internal_group', '=', 'income'),
+                    ('tax_ids', 'in', tax_income.ids),
+                ], limit=1),
+                'expense': p_self.env['account.account'].search([
+                    ('internal_group', '=', 'expense'),
+                    ('tax_ids', 'in', tax_expense.ids),
+                ], limit=1),
+            }
+        product = self.env['product.product'].create({
+            'name': 'Test Product',
+            'type': 'consu',
+            'is_storable': True,
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'taxes_id': [Command.set(self.company_data['default_tax_sale'].ids)],
+        })
+        with patch('odoo.addons.account.models.product.ProductTemplate._get_product_accounts', _mock_get_product_accounts):
+            product.quantity_svl = 10.0
+            product.standard_price = 100
+            specification = {
+                'standard_price': {},
+                'taxes_id': {'fields': {'name': {}}},
+            }
+            product.web_read(specification)


### PR DESCRIPTION
**Steps to reproduce:**
- Install `l10n_de, website_sale and appointment` modules.
- Create a website for the `DE company` and make it default.
 (simply place it first in the sequence.)
- From settings enable `Automatic Invoice` and `Discounts, Loyalty & Gift Card`.
- Go to the appointment module and create a new appointment for the DE company.
- In the options tab, enable `Up-front payment` and publish it.
- Create a new gift card program and generate a gift card to test (should cover the entire cost of the appointment booking).
- Now go to an Incognito tab, go to the appointment, and book the currently created appointment. When confirming the order, use the gift card and then confirm the order.

**Issue:**
- When you confirm the order, an access error occurs.

**Root cause:**
- Since automatic invoicing is enabled, at [1] the method
  `get_product_accounts` is called for the DE company.
  Inside this method at [2], self.sudo(False) is used, which removes the
  elevated access rights. As a result, the `Public product template` record
  rule is triggered, and because the public user cannot access the product,
  an AccessError is raised.
- In this [commit], we can see that `sudo(False)` was added when coming from
  the stock flow because the stock valuation layer was being created as sudo.

**Solution:**
- Instead of adding `sudo(False)` in **l10n_de**, we can apply `sudo(False)`
  at the point where the **stock valuation layer** is created using `sudo()`.

[1]https://github.com/odoo/odoo/blob/9d5d5c08f950d32bf61c2186181e8eddad9036da/addons/account/models/account_move_line.py#L603-L604
[2]https://github.com/odoo/odoo/blob/9d5d5c08f950d32bf61c2186181e8eddad9036da/addons/l10n_de/models/datev.py#L20

[commit]: https://github.com/odoo/odoo/pull/236931/changes/0919774791bb998954b870798c88843f999f2de4

opw-5483472
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
