### PR TITLE
[FIX] website: kept animation intensity visible on mode change

### DIFF
--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -27,7 +27,12 @@ import { EmphasizeAnimatedText } from "./emphasize_animated_text";
 export class AnimateOptionPlugin extends Plugin {
     static id = "animateOption";
     static dependencies = ["history", "selection", "split"];
-    static shared = ["forceAnimation", "getDirectionsItems", "getEffectsItems"];
+    static shared = [
+        "forceAnimation",
+        "getDirectionsItems",
+        "getEffectsItems",
+        "hasAnimationEffect",
+    ];
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [withSequence(ANIMATE, AnimateOption)],
@@ -106,6 +111,20 @@ export class AnimateOptionPlugin extends Plugin {
             { className: "o_anim_from_bottom_left", label: "From bottom left", check: isRotate },
         ];
     }
+
+    /**
+     * Checks whether the given element contains any animation class from the
+     * list returned by getEffectsItems().
+     *
+     * @param {HTMLElement} editingElement- The element to check
+     * @returns {boolean} True if at least one animation class is present
+     */
+    hasAnimationEffect(editingElement) {
+        return this.getEffectsItems().some(({ className }) =>
+            editingElement.classList.contains(className)
+        );
+    }
+
     async forceAnimation(editingElement) {
         editingElement.style.animationName = "dummy";
         if (editingElement.classList.contains("o_animate_on_scroll")) {
@@ -392,7 +411,9 @@ export class SetAnimationModeAction extends BuilderAction {
     }
 
     async apply({ editingElement, value: effectName, params: { forceAnimation } }) {
-        if (this.animationWithFadein.includes(effectName)) {
+        const { hasAnimationEffect } = this.dependencies.animateOption;
+        // Prevent adding fade-in when another animation class is already present.
+        if (this.animationWithFadein.includes(effectName) && !hasAnimationEffect(editingElement)) {
             editingElement.classList.add("o_anim_fade_in");
         }
         if (effectName === "onScroll") {

--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -125,6 +125,10 @@ describe("onAppearance", () => {
         expect(".options-container [data-label='Scroll Zone']").not.toHaveCount();
         expect(".options-container [data-label='Start After'] input").toHaveValue("0");
         expect(".options-container [data-label='Duration'] input").toHaveValue("1");
+        await contains(".options-container [data-label='Animation'] .dropdown-toggle").click();
+        await contains(".o-dropdown--menu [data-action-value='onScroll']").click();
+        await waitSidebarUpdated();
+        expect(".options-container [data-label='Intensity']").toHaveCount(1);
     });
     test("visibility of animation animation=onAppearance effect=flash", async () => {
         const { waitSidebarUpdated } = await setupWebsiteBuilder(


### PR DESCRIPTION
Steps to reproduce:
1. Go to the website and enter edit mode.
2. Click any text in the footer.
3. Change the animation mode from _none_ to _on appearance._
4. Select the _zoom out_ effect; the intensity slider is visible.
5. Change the animation mode to _on scroll_.

Issue:
The animation intensity slider is no longer visible. It only reappears after reselecting the same effect.

Reason:
The `apply` method of `SetAnimationModeAction` always adds the "**o_anim_fade_in**" class, even when an animation effect is already selected. When switching the animation mode, this additional class prevents the intensity slider from being displayed.

task-5896549