### PR TITLE
[FIX] web, calendar: calendar popover: use "text-wrap" for the description field

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -354,7 +354,7 @@
                 <field name="is_highlighted" invisible="1"/>
                 <field name="is_organizer_alone" invisible="1"/>
                 <field name="display_description" invisible="1"/>
-                <field name="description" invisible="not display_description" options="{'icon': 'fa fa-bars'}"/>
+                <field name="description" class="text-wrap" invisible="not display_description" options="{'icon': 'fa fa-bars'}"/>
                 <field name="privacy" invisible="1"/>
                 <field name="res_model_name" invisible="not res_model_name"
                        options="{'icon': 'fa fa-link', 'shouldOpenRecord': true}"/>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -57,7 +57,7 @@
                                 </t>
                             </span>
                             <div class="flex-grow-1 o_cw_popover_field overflow-hidden">
-                                <Field name="fieldInfo.name" record="slot.record" fieldInfo="fieldInfo" type="fieldInfo.widget" />
+                                <Field name="fieldInfo.name" record="slot.record" class="fieldInfo.attrs.class" fieldInfo="fieldInfo" type="fieldInfo.widget" />
                             </div>
                         </li>
                     </t>

--- a/addons/web/static/tests/views/calendar/calendar_common_popover.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_common_popover.test.js
@@ -17,6 +17,7 @@ const FAKE_RECORD = {
     isTimeHidden: false,
     rawRecord: {
         name: "Meeting",
+        description: "<p>Test description</p>",
     },
 };
 
@@ -41,6 +42,7 @@ test(`mount a CalendarCommonPopover`, async () => {
     expect(`.popover-header`).toHaveText("Meeting");
     expect(`.list-group`).toHaveCount(2);
     expect(`.list-group.o_cw_popover_fields_secondary`).toHaveCount(1);
+    expect(`.list-group.o_cw_popover_fields_secondary div[name="description"]`).toHaveClass("text-wrap");
     expect(`.card-footer .o_cw_popover_edit`).toHaveCount(1);
     expect(`.card-footer .o_cw_popover_delete`).toHaveCount(1);
 });

--- a/addons/web/static/tests/views/calendar/calendar_test_helpers.js
+++ b/addons/web/static/tests/views/calendar/calendar_test_helpers.js
@@ -154,6 +154,7 @@ export const FAKE_FIELDS = {
         default: 1,
     },
     name: { string: "Name", type: "char" },
+    description: { string: "Description", type: "html" },
     start_date: { string: "Start Date", type: "date" },
     stop_date: { string: "Stop Date", type: "date" },
     start: { string: "Start Datetime", type: "datetime" },
@@ -200,9 +201,22 @@ export const FAKE_MODEL = {
             "event",
             "calendar"
         ),
+        description: Field.parseFieldNode(
+            createElement("field", { name: "description" , class: "text-wrap"}),
+            { event: { fields: FAKE_FIELDS } },
+            "event",
+            "calendar"
+        ),
     },
     activeFields: {
         name: {
+            context: "{}",
+            invisible: false,
+            readonly: false,
+            required: false,
+            onChange: false,
+        },
+        description: {
             context: "{}",
             invisible: false,
             readonly: false,


### PR DESCRIPTION
Changes done:
- [x] `calendar`: Add `class="text-wrap"` in the description field of the calendar view to use it in the popover
- [x] `web`: Define the appropriate class in the calendar popover field

**Before**
<img width="548" height="428" alt="antes" src="https://github.com/user-attachments/assets/77060ee6-30a1-47ed-8ba4-d5c2baa33fe3" />

**After**
<img width="559" height="627" alt="despues" src="https://github.com/user-attachments/assets/cc9dfb47-3f98-4b5b-80c2-c3e5c15df0b0" />

@Tecnativa TT60670

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
