### PR TITLE
[FIX] pos_self_order: catch error when loading self order

### DIFF
--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -58,6 +58,8 @@
             'web_editor/static/src/js/editor/odoo-editor/src/base_style.scss',
             'web_editor/static/src/scss/web_editor.common.scss',
             "point_of_sale/static/src/app/components/numpad/*",
+            "point_of_sale/static/src/app/components/loader/*",
+            "point_of_sale/static/src/app/components/loader/critical_pos_error/*",
             "point_of_sale/static/src/app/components/product_card/*",
             "point_of_sale/static/src/app/components/order_display/*",
             "point_of_sale/static/src/app/components/orderline/*",

--- a/addons/pos_self_order/static/src/app/self_order_index.js
+++ b/addons/pos_self_order/static/src/app/self_order_index.js
@@ -1,4 +1,4 @@
-import { Component, whenReady } from "@odoo/owl";
+import { mount, Component, reactive, whenReady } from "@odoo/owl";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { useSelfOrder } from "@pos_self_order/app/services/self_order_service";
 import { Router } from "@pos_self_order/app/router";
@@ -15,6 +15,8 @@ import { OrdersHistoryPage } from "@pos_self_order/app/pages/order_history_page/
 import { LoadingOverlay } from "@pos_self_order/app/components/loading_overlay/loading_overlay";
 import { mountComponent } from "@web/env";
 import { hasTouch } from "@web/core/browser/feature_detection";
+import { Loader } from "@point_of_sale/app/components/loader/loader";
+import { getTemplate } from "@web/core/templates";
 
 export class selfOrderIndex extends Component {
     static template = "pos_self_order.selfOrderIndex";
@@ -33,6 +35,7 @@ export class selfOrderIndex extends Component {
         LandingPage,
         LoadingOverlay,
         MainComponentsContainer,
+        Loader,
     };
 
     setup() {
@@ -48,4 +51,18 @@ export class selfOrderIndex extends Component {
         return this.selfOrder.models["product.product"].length > 0;
     }
 }
-whenReady(() => mountComponent(selfOrderIndex, document.body));
+whenReady(async () => {
+    try {
+        await mountComponent(selfOrderIndex, document.body);
+    } catch (err) {
+        const loader = reactive({ isShown: true, error: err });
+        mount(Loader, document.body, {
+            getTemplate,
+            props: { loader },
+            translatableAttributes: ["data-tooltip"],
+            translateFn: (s) => s,
+        });
+
+        console.log(err);
+    }
+});


### PR DESCRIPTION
Inconsistent data in the localDB or local storage can cause the pos_self_rder to fail before it can get initialized. When this happens the page just stays white.

Now when an error happens while initializing an error message will show up and give the user the option to clear all local data and refresh the page. This should be especially useful for users on mobile where it's a pain to refresh the local data manually.

Task-[5420544](https://www.odoo.com/odoo/project/1737/tasks/5420544)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
