### PR TITLE
[FIX] res.partner write() issues caused by custom mixin inheritance order

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -904,7 +904,7 @@ class ResPartner(models.Model):
         for partner, pre_values in zip(self, pre_values_list, strict=True):
             if internal_users := partner.user_ids.filtered(lambda u: u._is_internal() and u != self.env.user):
                 internal_users.check_access('write')
-            updated = {fname: fvalue for fname, fvalue in vals.items() if partner[fname] != pre_values[fname]}
+            updated = {fname: fvalue for fname, fvalue in vals.items() if not pre_values.get(fname) or partner[fname] != pre_values[fname]}
             if updated:
                 partner._fields_sync(updated)
         return result


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When res.partner is inherited together with a custom mixin that adds additional values to vals inside the write() method, the behavior depends on the inheritance order. If the mixin is inherited after res.partner, the values added by the mixin are not included in the data collected by res.partner.write() for later synchronization, which can lead to runtime errors.

Current behavior before PR:

If the inheritance order is:

```python
_inherit = ['res.partner', 'custom.mixin']
```

the custom mixin’s write() method is executed after res.partner.write().
As a result, any values added by the mixin are missing from pre_values_list, which is built by res.partner.write() and later accessed by _fields_sync(), causing failures when those fields are expected to be present.

This issue does not occur when the inheritance order is:

```python
_inherit = ['custom.mixin', 'res.partner']
```

because the mixin modifies vals before res.partner.write() is executed.


Desired behavior after PR is merged:

Values added to vals by a custom mixin during write() are consistently available to res.partner internal synchronization logic, regardless of the inheritance order.
res.partner.write() and _fields_sync() should behave correctly even when mixins extend vals and are inherited after res.partner.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
