### PR TITLE
[FIX] account: translate product names on invoice reprint

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -140,7 +140,22 @@
 
                                     <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                                         <t t-if="line.display_type == 'product'" name="account_invoice_line_accountable">
-                                            <td name="account_invoice_line_name"><span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span></td>
+                                            <td name="account_invoice_line_name">
+                                                <t t-if="line.product_id">
+                                                    <span t-field="line.product_id.display_name">Product Name</span>
+                                                    <t t-if="line.product_id.description_sale and line.journal_id.type == 'sale'">
+                                                        <br/>
+                                                        <span t-field="line.product_id.description_sale"/>
+                                                    </t>
+                                                    <t t-if="line.product_id.description_purchase and line.journal_id.type == 'purchase'">
+                                                        <br/>
+                                                        <span t-field="line.product_id.description_purchase"/>
+                                                    </t>
+                                                </t>
+                                                <span t-else="" t-if="line.name" t-field="line.name"
+                                                      t-options="{'widget': 'text'}">Bacon Burger
+                                                </span>
+                                            </td>
                                             <td name="td_quantity" class="text-end">
                                                 <span t-field="line.quantity">3.00</span>
                                                 <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>


### PR DESCRIPTION
**Problem:**
When a customer's language is changed and an invoice is reprinted, all invoice fields translate correctly except for product names and descriptions, which remain in the original language.

**Steps to reproduce:**
1. Create an invoice for a customer with English language
2. Post the invoice (product names appear in English)
3. Change the customer's language to French
4. Reprint/download the invoice PDF
5. Observe that product names still appear in English instead of French

**Current behavior:**
Product names remain in the original language when reprinting invoices after changing the customer's language.

**Expected behavior:**
Product names and descriptions should dynamically translate based on the customer's current language setting when the invoice is reprinted.

**Cause of the issue:**
The invoice report template uses `line.name`, which is a stored text field frozen at invoice creation time. This field contains the product name in whatever language was active when the line was created and does not update when the partner's language changes. When rendering the PDF, this frozen text is displayed regardless of the current language context.

**Fix:**
Use `product_id.display_name` instead of `line.name` for product-linked invoice lines. The `display_name` field is computed dynamically and respects the current language context during PDF generation. For lines without a product (manual entries, notes, sections), fall back to `line.name` to preserve existing behavior. This allows product names to translate on reprint while maintaining compatibility with non-product lines.

opw-5887170