### PR TITLE
[FIX] point_of_sale: update serial numbers requirements

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -331,10 +331,6 @@ export class PosOrderline extends Base {
     }
 
     hasValidProductLot() {
-        if (this.pack_lot_ids.length > 0) {
-            return true;
-        }
-
         const valid_product_lot = this.getValidLots();
         const lotsRequired = this.product_id.tracking == "serial" ? Math.abs(this.qty) : 1;
         return lotsRequired === valid_product_lot.length;


### PR DESCRIPTION
## Issue
In the Point of Sale, when selling a product tracked by unique serial number with a quantity greater than one, no warning are displayed to the displayed as long as one serial number is given.

## Steps to reproduce
1. Install Point of Sale (`point_of_sale`)
2. In Settings, enable *Lots & Serial Numbers*
3. Create a PoS product P
    - Tracked *By Unique Serial Number*
    - Update its quantity and create a few serial numbers
4. In the Point of Sale, select product P and set a serial number, then update the quantity to 2.
5. **The _Valid product lot_ icon next to the product is still green. We can also go to the payment screen without any warning, even though only one serial number was selected for two products.**

## Cause
The color and name of the icon displayed next to the serial tracked product is decided here:

https://github.com/odoo/odoo/blob/3d787e1b7c2ab471694849a04bdf2d3a5ff7e515/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml#L9-L14

The `PosOrderLine.hasValidProductLot` is defined here:

https://github.com/odoo/odoo/blob/3d787e1b7c2ab471694849a04bdf2d3a5ff7e515/addons/point_of_sale/static/src/app/models/pos_order_line.js#L333-L341

The very first condition of this method makes the icon green as long as one serial number is selected.

opw-5486210