### PR TITLE
[FIX] project: incorrect view change after deleting task stage

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
@@ -22,17 +22,7 @@ export class ProjectTaskKanbanHeader extends KanbanHeader {
     }
 
     async deleteGroup() {
-        if (this.group.groupByField.name === 'stage_id') {
-            const action = await this.group.model.orm.call(
-                this.group.groupByField.relation,
-                'unlink_wizard',
-                [this.group.value],
-                { context: this.group.context },
-            );
-            this.action.doAction(action);
-            return;
-        }
-        super.deleteGroup();
+        return this.props.deleteGroup(this.group);
     }
 
     canEditGroup(group) {

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
@@ -6,6 +6,23 @@ export class ProjectTaskKanbanDynamicGroupList extends RelationalModel.DynamicGr
     get isGroupedByStage() {
         return !!this.groupByField && this.groupByField.name === "stage_id";
     }
+
+    async _unlinkGroups(groups) {
+        if (this.groupByField.name === "stage_id") {
+            const action = await this.model.orm.call(
+                this.groupByField.relation,
+                'unlink_wizard',
+                groups.map((g) => g.value),
+                { context: this.context },
+            );
+            return new Promise((resolve) => {
+                this.model.action.doAction(action, {
+                    onClose: ({ success }) => resolve(!!success),
+                });
+            });
+        }
+        return super._unlinkGroups();
+    }
 }
 
 export class ProjectTaskKanbanModel extends RelationalModel {

--- a/addons/project/static/tests/project_task_kanban_renderer_tests.js
+++ b/addons/project/static/tests/project_task_kanban_renderer_tests.js
@@ -6,11 +6,12 @@ import { start } from "@mail/../tests/helpers/test_utils";
 
 import { registry } from "@web/core/registry";
 import { makeFakeUserService } from "@web/../tests/helpers/mock_services";
-import { getFixture, nextTick } from "@web/../tests/helpers/utils";
+import { click, editInput, getFixture, nextTick } from "@web/../tests/helpers/utils";
 import { setupViewRegistries } from "@web/../tests/views/helpers";
 
 let target;
 let serverData;
+let mockRPC;
 
 const serviceRegistry = registry.category("services");
 
@@ -40,6 +41,15 @@ QUnit.module("project", (hooks) => {
             },
             records: [],
         };
+        pyEnv.mockServer.models["project.task.type.delete.wizard"] = {
+            fields: {
+                tasks_count: { string: "Number of Tasks", type: "integer" },
+                stages_active: { string: "Stages Active", type: "boolean" },
+                project_ids: { string: "Projects", type: "many2many", relation: "project.project" },
+                stage_ids: { string: "Stages To Delete", type: "many2many", relation: "project.task.type" },
+            },
+            records: [],
+        };
         serverData = {
             views: {
                 "project.task,false,kanban": `
@@ -54,17 +64,46 @@ QUnit.module("project", (hooks) => {
                         </templates>
                     </kanban>
                 `,
+                "project.task.type.delete.wizard,false,form": `
+                    <form string="Delete Stage">
+                        <footer>
+                            <button string="Delete" type="object" name="action_unlink" class="btn btn-primary"/>
+                            <button string="Discard" special="cancel"/>
+                        </footer>
+                    </form>
+                `,
             },
+        };
+        mockRPC = async (route, args) => {
+            if (args.method === "unlink_wizard") {
+                return {
+                    type: "ir.actions.act_window",
+                    name: "Delete Stage",
+                    res_model: "project.task.type.delete.wizard",
+                    view_mode: "form",
+                    views: [[false, "form"]],
+                    target: "new",
+                    res_id: 1,
+                };
+            }
+            if (args.method === "action_unlink") {
+                return {
+                    type: "ir.actions.act_window_close",
+                    infos: {
+                        success: true,
+                    },
+                }
+            }
         };
         target = getFixture();
         setupViewRegistries();
-    });
-    QUnit.test("delete a column in grouped on m2o", async function (assert) {
         serviceRegistry.add(
             "user",
             makeFakeUserService((group) => group === "project.group_project_manager"),
             { force: true }
         );
+    });
+    QUnit.test("delete a column in grouped on m2o", async function (assert) {
         const { openView } = await start({ serverData });
 
         await openView({
@@ -86,5 +125,62 @@ QUnit.module("project", (hooks) => {
             1,
             "ghost column visible"
         );
+    });
+    QUnit.test("delete just created stage", async function (assert) {
+        const { openView } = await start({ serverData, mockRPC });
+
+        await openView({
+            res_model: "project.task",
+            views: [[false, "kanban"]],
+            context: {
+                active_model: "project.project",
+                default_project_id: 1,
+            },
+        });
+
+        await editInput(target.querySelector(".o_column_quick_create input"), null, "Stage 1");
+        await click(target, ".o_kanban_add");
+
+        await click(target, ".o_kanban_group:first-child .o_kanban_config.dropdown .dropdown-toggle");
+        await click(target, ".dropdown-item.o_column_delete");
+        await click(target, "button[special=cancel]");
+        assert.containsOnce(target, ".o_column_title", "The stage should not have been deleted.");
+
+        await click(target, ".o_kanban_group:first-child .o_kanban_config.dropdown .dropdown-toggle");
+        await click(target, ".dropdown-item.o_column_delete");
+        await click(target, "button[name=action_unlink]");
+        assert.containsNone(target, ".o_column_title", "The stage should have been deleted.");
+    });
+    QUnit.test("delete existing stage", async function (assert) {
+        const originalMockRPC = mockRPC;
+        mockRPC = async (route, args) => {
+            if (args.method === "web_read_group") {
+                return {
+                    groups: [{ stage_id: [1, "Stage 1"] }],
+                    length: 1,
+                };
+            }
+            return originalMockRPC(route, args);
+        };
+        const { openView } = await start({ serverData, mockRPC });
+
+        await openView({
+            res_model: "project.task",
+            views: [[false, "kanban"]],
+            context: {
+                active_model: "project.project",
+                default_project_id: 1,
+            },
+        });
+
+        await click(target, ".o_kanban_group:first-child .o_kanban_config.dropdown .dropdown-toggle");
+        await click(target, ".dropdown-item.o_column_delete");
+        await click(target, "button[special=cancel]");
+        assert.containsOnce(target, ".o_column_title", "The stage should not have been deleted.");
+
+        await click(target, ".o_kanban_group:first-child .o_kanban_config.dropdown .dropdown-toggle");
+        await click(target, ".dropdown-item.o_column_delete");
+        await click(target, "button[name=action_unlink]");
+        assert.containsNone(target, ".o_column_title", "The stage should have been deleted.");
     });
 });

--- a/addons/project/wizard/project_task_type_delete.py
+++ b/addons/project/wizard/project_task_type_delete.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from ast import literal_eval
 
 
 class ProjectTaskTypeDelete(models.TransientModel):
@@ -55,23 +54,9 @@ class ProjectTaskTypeDelete(models.TransientModel):
         return self._get_action()
 
     def _get_action(self):
-        project_id = self.env.context.get('default_project_id')
-
-        if project_id:
-            action = self.env["ir.actions.actions"]._for_xml_id("project.action_view_task")
-            action['domain'] = [('project_id', '=', project_id), ('display_in_project', '=', 'True')]
-            action['context'] = str({
-                'pivot_row_groupby': ['user_ids'],
-                'default_project_id': project_id,
-            })
-        elif self.env.context.get('stage_view'):
-            action = self.env["ir.actions.actions"]._for_xml_id("project.open_task_type_form")
-        else:
-            action = self.env["ir.actions.actions"]._for_xml_id("project.action_view_my_task")
-
-        context = action.get('context', '{}')
-        context = context.replace('uid', str(self.env.uid))
-        context = dict(literal_eval(context), active_test=True)
-        action['context'] = context
-        action['target'] = 'main'
-        return action
+        return {
+            'type': 'ir.actions.act_window_close',
+            'infos': {
+                'success': True,
+            },
+        }

--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -264,7 +264,10 @@ export class DynamicGroupList extends DynamicList {
 
     async _deleteGroups(groups) {
         const shouldReload = groups.some((g) => g.count > 0);
-        await this._unlinkGroups(groups);
+        const succeeded = await this._unlinkGroups(groups);
+        if (succeeded === false) {
+            return;
+        }
         const configGroups = { ...this.config.groups };
         for (const group of groups) {
             delete configGroups[group.value];


### PR DESCRIPTION
# Steps to reproduce
1. Create a project
2. Create a stage
4. Remove the stage

# Current behavior
Instead of remaining in the project tasks view, it switches to the tasks view filtered with the current project. Additionally, it displays archived tasks because no filter is selected, thereby discarding original ones.

This also applies to stage deletion in other views (e.g., My Tasks), where the search filters are completely discarded.

# Expected behavior
The dialog should be closed, the stage should be deleted, and the original view should remain active. This is done through a soft-reload of the page, ensuring the original view is kept, together with original breadcrumbs, and the stage is visually disappearing.

task-5498274