### PR TITLE
[IMP] account: include all attachments in email notifications

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -288,9 +288,6 @@ class AccountJournal(models.Model):
     incoming_einvoice_notification_email = fields.Char(  # no longer incoming-specific, rename in master
         string="Send Copy To",
         help="Email addresses that will receive copy for sent and received invoices. Separate entries with ';'.",
-        compute='_compute_incoming_einvoice_notification_email',
-        store=True,
-        readonly=False,
     )
 
     _code_company_uniq = models.Constraint(
@@ -536,16 +533,6 @@ class AccountJournal(models.Model):
         for journal in self:
             temp_move = self.env['account.move'].new({'journal_id': journal.id})
             journal.accounting_date = temp_move._get_accounting_date(move_date, has_tax)
-
-    @api.depends('company_id', 'type')
-    def _compute_incoming_einvoice_notification_email(self):
-        for journal in self:
-            if (
-                journal.type == 'purchase'
-                and not journal.incoming_einvoice_notification_email
-                and journal.company_id.email
-            ):
-                journal.incoming_einvoice_notification_email = journal.company_id.email
 
     @api.depends('type')
     def _compute_show_fetch_in_einvoices_button(self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4802,7 +4802,7 @@ class AccountMove(models.Model):
 
         if new and res:
             try:
-                attachments = self._from_files_data(files_data + self._unwrap_attachments(files_data))
+                attachments = set(self.attachment_ids + self._from_files_data(files_data + self._unwrap_attachments(files_data)))
                 self.journal_id._notify_invoice_subscribers(
                     invoice=self,
                     mail_params={


### PR DESCRIPTION
Before this PR, when importing an invoice or vendor bill, the email notification only included the first imported attachment. As a result, embedded files (e.g. a PDF inside an XML) were missing from the email.

This commit ensures that all imported attachments are included in the notification email, improving document visibility for users.

Additionally, the field "Send Copy To" will no longer be computed, It'll be manually filled by the user.

task-5895328

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
