### PR TITLE
[FIX] website: disable inline icon edition in s_accordion

### DIFF
--- a/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/accordion_option_plugin.js
@@ -103,7 +103,7 @@ export class CustomAccordionIconAction extends BuilderAction {
                     return;
                 }
                 const customIconsClasses =
-                    "position-absolute top-0 end-0 bottom-0 start-0 d-flex align-items-center justify-content-center";
+                    "position-absolute top-0 end-0 bottom-0 start-0 d-flex align-items-center justify-content-center o_not_editable";
                 const customIconActiveEl = document.createElement("span");
                 customIconActiveEl.className = customIconsClasses;
                 customIconActiveEl.classList.add("o_custom_icon_active");


### PR DESCRIPTION
In the accordion snippet option, the user can set the icons as custom to choose them. He can do so in the sidebar with the options "Active / Inactive Icons", or by double clicking on them.

Since clicking on the icon open / close the accordion item, switching from one icon to the other, it is not a practical way to edit them that way. It was decided to remove the possibility to edit the icon inline.

task-5885917