### PR TITLE
[FIX] point_of_sale: fix error while loading module

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -35,11 +35,11 @@
             <field name="is_pos_groupable">True</field>
         </record>
 
-        <record id="uom.product_uom_pack_6" model="uom.uom">
+        <record id="uom.product_uom_pack_6" model="uom.uom" forcecreate="0">
             <field name="is_pos_groupable">True</field>
         </record>
 
-        <record id="uom.product_uom_dozen" model="uom.uom">
+        <record id="uom.product_uom_dozen" model="uom.uom" forcecreate="0">
             <field name="is_pos_groupable">True</field>
         </record>
 


### PR DESCRIPTION
Currently, an error is produced when loading the pos module when a referenced UoM record (e.g., Pack of 6) has been deleted by the user.

**Steps to Reproduce:**
- Install Sales Module.
- Enable **"Units of Measure & Packaging"**.
- Delete the **"Pack of 6"** Units.
- Install POS.

**Error:**
```
ParseError:
while parsing /home/odoo/src/odoo/saas-19.1/addons/point_of_sale/data/point_of_sale_data.xml:38, somewhere inside <record id="uom.product_uom_pack_6" model="uom.uom">
            <field name="is_pos_groupable">True</field>
        </record>

Exception:
Cannot update missing record 'uom.product_uom_pack_6'
```
The POS module overrides `uom.product_uom_*` records. If the original UoM record has been deleted, the override fails because the record no longer exists.

sentry-7237815280