### PR TITLE
[FIX] account: update invoice payment reference with name

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -818,7 +818,8 @@ class AccountMove(models.Model):
         for move in self.filtered(lambda m: (
             m.state == 'posted'
             and m.move_type == 'out_invoice'
-            and not m.payment_reference
+            and not m.inalterable_hash
+            and not (m.is_move_sent or m.is_being_sent)
         )):
             move.payment_reference = move._get_invoice_computed_reference()
         self._inverse_payment_reference()

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2440,6 +2440,25 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             'amount_total': 1430.0,
         })
 
+    def test_out_invoice_name_change(self):
+        ''' Check the invoice.name, payment_term and invoice_line.name.'''
+        # Create an invoice.
+        move = self._create_invoice(invoice_date='2016-01-01', post=True)
+        payment_term_line = move.line_ids.filtered(lambda m: m.display_type == 'payment_term')
+
+        self.assertRecordValues(move, [{'payment_reference': 'INV/2016/00001'}])
+        self.assertRecordValues(payment_term_line, [{'name': 'INV/2016/00001'}])
+
+        move.button_draft()
+        move.name = 'INV/2016/00002'
+        move.action_post()
+
+        self.assertRecordValues(move, [{
+            'name': 'INV/2016/00002',
+            'payment_reference': 'INV/2016/00002'
+        }])
+        self.assertRecordValues(payment_term_line, [{'name': 'INV/2016/00002'}])
+
     def test_out_invoice_switch_out_refund_1(self):
         # Test creating an account_move with an out_invoice_type and switch it in an out_refund.
         move = self.env['account.move'].create({


### PR DESCRIPTION
Issue:
Updating the invoice name should update the payment reference if the invoice isn't already sent.

Step to reproduce:
- Create an invoice,
- Post it,
- Draft it,
- Change name,
- Post it again,

Current behavior:
only the invoice name change

Expected behavior:
- invoice name change
- payment_reference update
- linked account_move_line labeled payment_term are updated

opw-5428471

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
