### PR TITLE
[ADD] l10n_tr_nilvera_einvoice: support commercial invoices and bills

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/addons/l10n_tr_nilvera_einvoice/__manifest__.py
+++ b/addons/l10n_tr_nilvera_einvoice/__manifest__.py
@@ -27,6 +27,7 @@ Features include:
         'views/account_tax_views.xml',
         'views/product_views.xml',
         'views/res_config_settings_views.xml',
+        'wizards/l10n_tr_nilvera_einvoice_ticarifatura_response_wizard_views.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_tr_nilvera_einvoice/data/cron.xml
+++ b/addons/l10n_tr_nilvera_einvoice/data/cron.xml
@@ -49,4 +49,20 @@
         <field name="interval_type">hours</field>
         <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
     </record>
+
+    <record id="ir_cron_nilvera_sync_ticarifatura_response" model="ir.cron">
+        <field name="name">Nilvera: Sync Commercial Invoice customer response</field>
+        <field name="model_id" ref="model_account_move"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Sync Nilvera TICARIFATURA customer responses.
+# Optional: pass limit (default 20) to control how many invoices are processed per run.
+# Example: model._cron_l10n_tr_nilvera_sync_ticarifatura_response(limit=30)
+model._cron_l10n_tr_nilvera_sync_ticarifatura_response()
+]]>
+        </field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">hours</field>
+        <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
 </odoo>

--- a/addons/l10n_tr_nilvera_einvoice/data/cron.xml
+++ b/addons/l10n_tr_nilvera_einvoice/data/cron.xml
@@ -49,4 +49,20 @@
         <field name="interval_type">hours</field>
         <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
     </record>
+
+    <record id="ir_cron_nilvera_sync_ticarifatura_response" model="ir.cron">
+        <field name="name">Nilvera: Sync Commercial Invoice customer response</field>
+        <field name="model_id" ref="model_account_move"/>
+        <field name="state">code</field>
+        <field name="code"><![CDATA[
+# Sync Nilvera TICARIFATURA customer responses.
+# Optional: pass batch_size (default 20) to control how many invoices are processed per run.
+# Example: model._l10n_tr_nilvera_company_sync_ticarifatura_response(batch_size=30)
+model._l10n_tr_nilvera_company_sync_ticarifatura_response()
+]]>
+        </field>
+        <field name="interval_number">12</field>
+        <field name="interval_type">hours</field>
+        <field name="nextcall" eval="(DateTime.now() + timedelta(hours=12)).strftime('%Y-%m-%d %H:%M:%S')"/>
+    </record>
 </odoo>

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -997,8 +997,24 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_20
         logs = super()._import_fill_invoice(invoice, tree, qty_factor)
 
-        # ==== Nilvera UUID ====
-        if uuid_node := tree.findtext('./{*}UUID'):
-            invoice.l10n_tr_nilvera_uuid = uuid_node
+        scenario = self._find_value(".//cbc:ProfileID", tree)
+        if scenario not in {key for key, _ in self.env['account.move']._fields['l10n_tr_gib_invoice_scenario'].selection}:
+            scenario = False
+        invoice_type = self._find_value(".//cbc:InvoiceTypeCode", tree)
+        if invoice_type not in {key for key, _ in self.env['account.move']._fields['l10n_tr_gib_invoice_type'].selection}:
+            invoice_type = False
+
+        invoice.write({
+            'l10n_tr_nilvera_uuid': self._find_value('./cbc:UUID', tree),
+            'l10n_tr_gib_invoice_scenario': scenario,
+            'l10n_tr_gib_invoice_type': invoice_type,
+        })
+
+        if scenario == 'TICARIFATURA' and invoice.move_type in {'in_invoice', 'out_invoice'}:
+            try:
+                # Don't want to block the import in case status retrieval fails
+                invoice.l10n_tr_action_fetch_ticarifatura_response()
+            except UserError as e:
+                logs.append(self.env._("Failed to fetch TICARIFATURA response: %s", str(e)))
 
         return logs

--- a/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_edi_xml_ubl_tr.py
@@ -983,8 +983,24 @@ class AccountEdiXmlUblTr(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_20
         logs = super()._import_fill_invoice(invoice, tree, qty_factor)
 
-        # ==== Nilvera UUID ====
-        if uuid_node := tree.findtext('./{*}UUID'):
-            invoice.l10n_tr_nilvera_uuid = uuid_node
+        scenario = self._find_value(".//cbc:ProfileID", tree)
+        if scenario not in {key for key, _ in self.env['account.move']._fields['l10n_tr_gib_invoice_scenario'].selection}:
+            scenario = False
+        invoice_type = self._find_value(".//cbc:InvoiceTypeCode", tree)
+        if invoice_type not in {key for key, _ in self.env['account.move']._fields['l10n_tr_gib_invoice_type'].selection}:
+            invoice_type = False
+
+        invoice.write({
+            'l10n_tr_nilvera_uuid': self._find_value('./cbc:UUID', tree),
+            'l10n_tr_gib_invoice_scenario': scenario,
+            'l10n_tr_gib_invoice_type': invoice_type,
+        })
+
+        if scenario == 'TICARIFATURA' and invoice.move_type in {'in_invoice', 'out_invoice'}:
+            try:
+                # Don't want to block the import in case status retrieval fails
+                invoice.l10n_tr_action_fetch_ticarifatura_response()
+            except UserError as e:
+                logs.append(self.env._("Failed to fetch TICARIFATURA response: %s", str(e)))
 
         return logs

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -1,11 +1,18 @@
 import base64
+import logging
 import uuid
-from markupsafe import Markup
+from datetime import timedelta
+from json import JSONDecodeError
 from urllib.parse import quote, urlencode, urlparse
 
-from odoo import Command, _, api, fields, models
-from odoo.exceptions import UserError
+from markupsafe import Markup
+
+from odoo import _, Command, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
 from odoo.addons.l10n_tr_nilvera.lib.nilvera_client import _get_nilvera_client
+
+_logger = logging.getLogger(__name__)
 
 MOVE_TYPE_CATEGORY_MAP = {
     "out_invoice": {
@@ -22,6 +29,21 @@ CATEGORY_MOVE_TYPE_MAP = {
     "sale": "out_invoice",
     "purchase": "in_invoice",
 }
+
+TICARIFATURA_ANSWER_TO_FIELD_VALUE_MAP = {
+    "approved": "commercial_approved",
+    "rejected": "commercial_rejected",
+    "documentAnsweredAutomatically": "commercial_answered_automatically",
+}
+
+UNSYNCED_COMMERCIAL_MOVE_DOMAIN = [
+    ("move_type", "in", ["out_invoice", "in_invoice"]),
+    ("l10n_tr_gib_invoice_scenario", "=", "TICARIFATURA"),
+    ("l10n_tr_nilvera_send_status", "=", "succeed"),
+    ("partner_id", "!=", False),  # Partner's status is needed to determine endpoint when fetching response
+    ("company_id.country_code", "=", "TR"),
+    ("company_id.l10n_tr_nilvera_api_key", "!=", False),
+]
 
 
 class AccountMove(models.Model):
@@ -44,6 +66,9 @@ class AccountMove(models.Model):
             ('succeed', "Successful"),
             ('waiting', "Waiting"),
             ('unknown', "Unknown"),
+            ('commercial_approved', "Approved (Commercial)"),
+            ('commercial_answered_automatically', "Approved Automatically (Commercial)"),
+            ('commercial_rejected', "Rejected (Commercial)"),
         ],
         string="Nilvera Status",
         readonly=True,
@@ -62,6 +87,7 @@ class AccountMove(models.Model):
         selection=[
             ('TEMELFATURA', "Basic"),
             ('KAMU', "Public Sector"),
+            ('TICARIFATURA', "Commercial"),
         ],
         default='TEMELFATURA',
         string="Invoice Scenario",
@@ -134,6 +160,9 @@ class AccountMove(models.Model):
         string="Partner Nilvera Status",
         related='partner_id.l10n_tr_nilvera_customer_status',
         help="Shows the Nilvera status of the customer. ",
+    )
+    l10n_tr_ticarifatura_last_checked_at = fields.Datetime(
+        string="Commercial Status Check Date", copy=False,
     )
     l10n_tr_nilvera_pdf_file = fields.Binary(
         attachment=True,
@@ -224,11 +253,11 @@ class AccountMove(models.Model):
 
     def button_draft(self):
         # EXTENDS account
-        for move in self.filtered(lambda move: move.l10n_tr_nilvera_uuid and move.move_type == 'out_invoice'):
+        for move in self.filtered(lambda move: move.l10n_tr_nilvera_uuid and move.move_type in {'out_invoice', 'in_invoice'}):
             if move.l10n_tr_nilvera_send_status == 'error':
                 move.message_post(body=_("To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue."))
-            elif move.l10n_tr_nilvera_send_status != 'not_sent':
-                raise UserError(_("You cannot reset to draft an entry that has been sent to Nilvera."))
+            elif move.l10n_tr_nilvera_send_status not in {"not_sent", "commercial_rejected"}:
+                raise UserError(_("You cannot reset to draft an entry that has been sent/received from Nilvera."))
         super().button_draft()
 
     def _l10n_tr_nilvera_einvoice_check_invalid_invoice_reference(self):
@@ -353,7 +382,6 @@ class AccountMove(models.Model):
 
                     nilvera_status = response.get('InvoiceStatus', {}).get('Code') or response.get('StatusCode')
                     if nilvera_status in dict(invoice._fields['l10n_tr_nilvera_send_status'].selection):
-                        invoice.l10n_tr_nilvera_send_status = nilvera_status
                         if nilvera_status == 'error':
                             invoice.message_post(
                                 body=Markup(
@@ -364,6 +392,13 @@ class AccountMove(models.Model):
                                     response.get('InvoiceStatus', {}).get('DetailDescription') or response.get('ReportStatus'),
                                 )
                             )
+                        elif invoice.l10n_tr_gib_invoice_scenario == "TICARIFATURA" and invoice.move_type in {'out_invoice', 'in_invoice'} and nilvera_status == 'succeed':
+                            if response['Answer'] and response['Answer'].get('AnswerCode') in {'approved', 'rejected', 'documentAnsweredAutomatically'}:
+                                invoice.l10n_tr_nilvera_send_status = TICARIFATURA_ANSWER_TO_FIELD_VALUE_MAP[response['Answer']['AnswerCode']]
+                                if response['Answer']['AnswerCode'] == 'rejected':
+                                    invoice._l10n_tr_action_process_rejected_ticarifatura(response['Answer'].get('Description', ''), client)
+                        else:
+                            invoice.l10n_tr_nilvera_send_status = nilvera_status
                     else:
                         invoice.message_post(body=_("The invoice status couldn't be retrieved from Nilvera."))
 
@@ -698,3 +733,196 @@ class AccountMove(models.Model):
             )
 
         return super()._reverse_moves(default_values_list, cancel=cancel)
+
+    def _l10n_tr_handle_409_error_for_send_answer(self, response):
+        self.ensure_one()
+        error_codes_to_handle = {1003, 1007, 1008, 1011}
+        for error in response["Errors"]:
+            # These error means, the move was responded to already
+            # Thus we sync now
+            if error.get("Code") in error_codes_to_handle:
+                self.l10n_tr_action_fetch_ticarifatura_response()
+                return {
+                    "type": "ir.actions.client",
+                    "tag": "display_notification",
+                    "params": {
+                        "message": self.env._(
+                            "Nilvera has already received a response for this invoice."
+                            "\nThe latest response has been fetched and updated on the invoice.",
+                        ),
+                        "type": "warning",
+                        "next": {"type": "ir.actions.client", "tag": "soft_reload"},
+                    },
+                }
+        errors = [f"{error.get('Code')}: {error.get('Description')}" for error in response["Errors"]]
+        raise ValidationError(self.env._("Error sending request:\n%s", "\n".join(errors)))
+
+    def _l10n_tr_action_send_ticarifatura_response(self, answer_code="approved", rejection_note=""):
+        self.ensure_one()
+        if (
+            self.move_type != "in_invoice"
+            or self.l10n_tr_gib_invoice_scenario != "TICARIFATURA"
+        ):
+            raise UserError(
+                self.env._("This action is only available for commercial bills.")
+            )
+        if self.l10n_tr_nilvera_send_status != "succeed":
+            raise UserError(self.env._("The bill must be in 'Successful' status before sending a response."))
+
+        with _get_nilvera_client(self.env._, self.env.company) as client:
+            response = client.request(
+                method="POST",
+                endpoint="/einvoice/Purchase/SendAnswer",
+                json={
+                    "UUID": self.l10n_tr_nilvera_uuid,
+                    "AnswerCode": answer_code,
+                    "RejectNote": rejection_note,
+                },
+                handle_response=False,
+            )
+
+            if response.status_code == 200:
+                self.l10n_tr_nilvera_send_status = TICARIFATURA_ANSWER_TO_FIELD_VALUE_MAP[answer_code]
+                if answer_code == "rejected":
+                    self._l10n_tr_action_process_rejected_ticarifatura(rejection_note, client)
+            elif response.status_code in {401, 403}:
+                raise UserError(self.env._("Oops, seems like you're unauthorised to do this. Try another API key with more rights or contact Nilvera."))
+            elif 403 < response.status_code < 600 and response.status_code != 409:
+                raise UserError(
+                    self.env._(
+                        "Odoo could not perform this action at the moment, try again later.\n"
+                        "%(reason)s - %(status)s",
+                        reason=response.reason,
+                        status=response.status_code,
+                    ),
+                )
+            elif response.status_code == 409:
+                try:
+                    decoded_response = response.json()
+                except JSONDecodeError:
+                    _logger.exception("Invalid JSON response: %s", response.text)
+                    raise UserError(self.env._("An error occurred. Try again later."))
+                return self._l10n_tr_handle_409_error_for_send_answer(decoded_response)
+            return True
+
+    def _l10n_tr_action_process_rejected_ticarifatura(self, rejection_note, client):
+        self.ensure_one()
+        responder = self.partner_id if self.move_type == "out_invoice" else self.company_id
+        self.message_post(
+            body=Markup("""
+                <div class="border-start border-danger border-3 ps-3 py-2 bg-opacity-10 rounded">
+                    <strong class="text-danger">❌ Rejected</strong>
+                    <p class="mb-0 mt-1">
+                        <strong>Responder:</strong> %s <br/>
+                        <strong>Reason:</strong> %s
+                    </p>
+                </div>
+            """)
+            % (
+                responder.name,
+                rejection_note,
+            ),
+            message_type="notification",
+            subtype_xmlid="mail.mt_note",
+        )
+        if self.move_type == 'out_invoice':
+            self._l10n_tr_nilvera_add_pdf_to_invoice(
+                client,
+                self,
+                self.l10n_tr_nilvera_uuid,
+                document_category="Sale",
+                invoice_channel=self.l10n_tr_nilvera_customer_status,
+            )
+        self.filtered(lambda m: m.state == "posted").button_draft()
+        self.button_cancel()
+
+    def l10n_tr_action_fetch_ticarifatura_response(self):
+        self.ensure_one()
+
+        if self.move_type not in {"out_invoice", "in_invoice"} or self.l10n_tr_gib_invoice_scenario != "TICARIFATURA":
+            raise UserError(self.env._("This action is only available for Commercial Invoices/Bills."))
+        if self.l10n_tr_nilvera_send_status in {"commercial_approved", "commercial_answered_automatically", "commercial_rejected"}:
+            raise UserError(self.env._("The response has already been received for this invoice."))
+        if self.l10n_tr_nilvera_send_status != "succeed":
+            raise UserError(self.env._("The invoice is not approved by Nilvera yet."))
+
+        return self._l10n_tr_nilvera_get_submitted_document_status()
+
+    def l10n_tr_action_approve_ticarifatura(self):
+        self.ensure_one()
+        return self.env['l10n_tr.ticarifatura.response.wizard']._get_records_action(
+            name=self.env._('Accept Bill'),
+            target='new',
+            context={
+                **self.env.context,
+                'default_move_id': self.id,
+                'default_response_code': 'approved',
+            },
+        )
+
+    def l10n_tr_action_reject_ticarifatura(self):
+        self.ensure_one()
+        return self.env['l10n_tr.ticarifatura.response.wizard']._get_records_action(
+            name=self.env._('Reject Bill'),
+            target='new',
+            context={
+                **self.env.context,
+                'default_move_id': self.id,
+                'default_response_code': 'rejected',
+            },
+        )
+
+    def _cron_l10n_tr_nilvera_sync_ticarifatura_response(self, *, limit=20):
+        """
+        Commercial invoices require a response from the counterpart within 7 days.
+        After that window, Nilvera automatically accepts the invoice.
+
+        To ensure no invoice is starved across the 7-day window, records are
+        processed least recently checked first, so that every pending invoice
+        gets polled evenly over time.
+
+        :param int limit: Number of invoices to process per run. Default: 20.
+        """
+        _logger.info("Nilvera commercial move response sync started.")
+
+        # This cron is run with commit. So on rerun our processed data still remain in the domain
+        # As current processed data will have l10n_tr_ticarifatura_last_checked_at as now
+        # With timedelta we are avoiding those
+        now_minus_2_hours = fields.Datetime.now() - timedelta(hours=2)
+        domain = UNSYNCED_COMMERCIAL_MOVE_DOMAIN + [
+            "|",
+            ("l10n_tr_ticarifatura_last_checked_at", "=", False),
+            ("l10n_tr_ticarifatura_last_checked_at", "<", now_minus_2_hours),
+        ]
+
+        move_ids_to_process = self.env["account.move"].search(
+            domain,
+            order="l10n_tr_ticarifatura_last_checked_at asc NULLS FIRST",
+            limit=limit,
+        )
+
+        if not move_ids_to_process:
+            _logger.info("No commercial moves found for response sync.")
+            return
+
+        for move in move_ids_to_process:
+            try:
+                # UNSYNCED_COMMERCIAL_MOVE_DOMAIN ensures the moves passed are valid
+                move._l10n_tr_nilvera_get_submitted_document_status()
+            except UserError as e:
+                _logger.warning(
+                    "Failed to fetch commercial move response for move %s: %s",
+                    move.id,
+                    e,
+                )
+
+            # Always update checked date, to avoid checking the same record on the same cron
+            move.write({"l10n_tr_ticarifatura_last_checked_at": fields.Datetime.now()})
+        remaining = (
+            0
+            if len(move_ids_to_process) < limit
+            else self.env["account.move"].search_count(domain)
+        )
+        self.env["ir.cron"]._commit_progress(
+            len(move_ids_to_process), remaining=remaining,
+        )

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -1,11 +1,17 @@
 import base64
+import logging
 import uuid
-from markupsafe import Markup
+from json import JSONDecodeError
 from urllib.parse import quote, urlencode, urlparse
 
-from odoo import Command, _, api, fields, models
-from odoo.exceptions import UserError
+from markupsafe import Markup
+
+from odoo import _, Command, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
 from odoo.addons.l10n_tr_nilvera.lib.nilvera_client import _get_nilvera_client
+
+_logger = logging.getLogger(__name__)
 
 MOVE_TYPE_CATEGORY_MAP = {
     "out_invoice": {
@@ -22,6 +28,19 @@ CATEGORY_MOVE_TYPE_MAP = {
     "sale": "out_invoice",
     "purchase": "in_invoice",
 }
+
+TICARIFATURA_ANSWER_TO_FIELD_VALUE_MAP = {
+    "approved": "commercial_approved",
+    "rejected": "commercial_rejected",
+    "documentAnsweredAutomatically": "commercial_answered_automatically",
+}
+
+UNSYNCED_COMMERCIAL_MOVE_DOMAIN = [
+    ("move_type", "in", ["out_invoice", "in_invoice"]),
+    ("l10n_tr_gib_invoice_scenario", "=", "TICARIFATURA"),
+    ("l10n_tr_nilvera_send_status", "=", "succeed"),
+    ("partner_id", "!=", False),  # Partner's status is needed to determine endpoint when fetching response
+]
 
 
 class AccountMove(models.Model):
@@ -44,6 +63,9 @@ class AccountMove(models.Model):
             ('succeed', "Successful"),
             ('waiting', "Waiting"),
             ('unknown', "Unknown"),
+            ('commercial_approved', "Approved (Commercial)"),
+            ('commercial_answered_automatically', "Approved Automatically (Commercial)"),
+            ('commercial_rejected', "Rejected (Commercial)"),
         ],
         string="Nilvera Status",
         readonly=True,
@@ -62,6 +84,7 @@ class AccountMove(models.Model):
         selection=[
             ('TEMELFATURA', "Basic"),
             ('KAMU', "Public Sector"),
+            ('TICARIFATURA', "Commercial"),
         ],
         default='TEMELFATURA',
         string="Invoice Scenario",
@@ -134,6 +157,10 @@ class AccountMove(models.Model):
         string="Partner Nilvera Status",
         related='partner_id.l10n_tr_nilvera_customer_status',
         help="Shows the Nilvera status of the customer. ",
+    )
+    l10n_tr_ticarifatura_status_check_priority = fields.Integer(
+        string="Commercial Status Check Priority",
+        copy=False,
     )
     l10n_tr_nilvera_pdf_file = fields.Binary(
         attachment=True,
@@ -210,11 +237,11 @@ class AccountMove(models.Model):
 
     def button_draft(self):
         # EXTENDS account
-        for move in self.filtered(lambda move: move.l10n_tr_nilvera_uuid and move.move_type == 'out_invoice'):
+        for move in self.filtered(lambda move: move.l10n_tr_nilvera_uuid and move.move_type in {'out_invoice', 'in_invoice'}):
             if move.l10n_tr_nilvera_send_status == 'error':
                 move.message_post(body=_("To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue."))
-            elif move.l10n_tr_nilvera_send_status != 'not_sent':
-                raise UserError(_("You cannot reset to draft an entry that has been sent to Nilvera."))
+            elif move.l10n_tr_nilvera_send_status not in {"not_sent", "commercial_rejected"}:
+                raise UserError(_("You cannot reset to draft an entry that has been sent/received from Nilvera."))
         super().button_draft()
 
     def _l10n_tr_nilvera_einvoice_check_invalid_invoice_reference(self):
@@ -339,7 +366,6 @@ class AccountMove(models.Model):
 
                     nilvera_status = response.get('InvoiceStatus', {}).get('Code') or response.get('StatusCode')
                     if nilvera_status in dict(invoice._fields['l10n_tr_nilvera_send_status'].selection):
-                        invoice.l10n_tr_nilvera_send_status = nilvera_status
                         if nilvera_status == 'error':
                             invoice.message_post(
                                 body=Markup(
@@ -350,6 +376,13 @@ class AccountMove(models.Model):
                                     response.get('InvoiceStatus', {}).get('DetailDescription') or response.get('ReportStatus'),
                                 )
                             )
+                        elif invoice.l10n_tr_gib_invoice_scenario == "TICARIFATURA" and invoice.move_type in {'out_invoice', 'in_invoice'} and nilvera_status == 'succeed':
+                            if response['Answer'] and response['Answer'].get('AnswerCode') in {'approved', 'rejected', 'documentAnsweredAutomatically'}:
+                                invoice.l10n_tr_nilvera_send_status = TICARIFATURA_ANSWER_TO_FIELD_VALUE_MAP[response['Answer']['AnswerCode']]
+                                if response['Answer']['AnswerCode'] == 'rejected':
+                                    invoice._l10n_tr_action_process_rejected_ticarifatura(response['Answer'].get('Description', ''), client)
+                        else:
+                            invoice.l10n_tr_nilvera_send_status = nilvera_status
                     else:
                         invoice.message_post(body=_("The invoice status couldn't be retrieved from Nilvera."))
 
@@ -684,3 +717,187 @@ class AccountMove(models.Model):
             )
 
         return super()._reverse_moves(default_values_list, cancel=cancel)
+
+    def _l10n_tr_handle_409_error_for_send_answer(self, response):
+        self.ensure_one()
+        error_codes_to_handle = {1003, 1007, 1008, 1011}
+        for error in response["Errors"]:
+            # These error means, the move was responded to already
+            # Thus we sync now
+            if error.get("Code") in error_codes_to_handle:
+                self.l10n_tr_action_fetch_ticarifatura_response()
+                return {
+                    "type": "ir.actions.client",
+                    "tag": "display_notification",
+                    "params": {
+                        "message": self.env._(
+                            "Nilvera has already received a response for this invoice."
+                            "\nThe latest response has been fetched and updated on the invoice.",
+                        ),
+                        "type": "warning",
+                        "next": {"type": "ir.actions.client", "tag": "soft_reload"},
+                    },
+                }
+        errors = [f"{error.get('Code')}: {error.get('Description')}" for error in response["Errors"]]
+        raise ValidationError(self.env._("Error sending request:\n%s", "\n".join(errors)))
+
+    def _l10n_tr_action_send_ticarifatura_response(self, answer_code="approved", rejection_note=""):
+        self.ensure_one()
+        if (self.move_type != "in_invoice" or self.l10n_tr_gib_invoice_scenario != "TICARIFATURA"):
+            raise UserError(self.env._("This action is only available for commercial bills."))
+        if self.l10n_tr_nilvera_send_status != "succeed":
+            raise UserError(self.env._("The bill must be in 'Successful' status before sending a response."))
+
+        with _get_nilvera_client(self.env._, self.env.company) as client:
+            response = client.request(
+                method="POST",
+                endpoint="/einvoice/Purchase/SendAnswer",
+                json={
+                    "UUID": self.l10n_tr_nilvera_uuid,
+                    "AnswerCode": answer_code,
+                    "RejectNote": rejection_note,
+                },
+                handle_response=False,
+            )
+
+            if response.status_code == 200:
+                self.l10n_tr_nilvera_send_status = TICARIFATURA_ANSWER_TO_FIELD_VALUE_MAP[answer_code]
+                if answer_code == "rejected":
+                    self._l10n_tr_action_process_rejected_ticarifatura(rejection_note, client)
+            elif response.status_code in {401, 403}:
+                raise UserError(self.env._("Oops, seems like you're unauthorised to do this. Try another API key with more rights or contact Nilvera."))
+            elif 403 < response.status_code < 600 and response.status_code != 409:
+                raise UserError(
+                    self.env._(
+                        "Odoo could not perform this action at the moment, try again later.\n"
+                        "%(reason)s - %(status)s",
+                        reason=response.reason,
+                        status=response.status_code,
+                    ),
+                )
+            elif response.status_code == 409:
+                try:
+                    decoded_response = response.json()
+                except JSONDecodeError:
+                    _logger.exception("Invalid JSON response: %s", response.text)
+                    raise UserError(self.env._("An error occurred. Try again later."))
+                return self._l10n_tr_handle_409_error_for_send_answer(decoded_response)
+            return True
+
+    def _l10n_tr_action_process_rejected_ticarifatura(self, rejection_note, client):
+        self.ensure_one()
+        responder = self.partner_id if self.move_type == "out_invoice" else self.company_id
+        self.message_post(
+            body=Markup("""
+                <div class="border-start border-danger border-3 ps-3 py-2 bg-opacity-10 rounded">
+                    <strong class="text-danger">❌ Rejected</strong>
+                    <p class="mb-0 mt-1">
+                        <strong>Responder:</strong> %s <br/>
+                        <strong>Reason:</strong> %s
+                    </p>
+                </div>
+            """)
+            % (
+                responder.name,
+                rejection_note,
+            ),
+            message_type="notification",
+            subtype_xmlid="mail.mt_note",
+        )
+        if self.move_type == 'out_invoice':
+            self._l10n_tr_nilvera_add_pdf_to_invoice(
+                client,
+                self,
+                self.l10n_tr_nilvera_uuid,
+                document_category="Sale",
+                invoice_channel=self.l10n_tr_nilvera_customer_status,
+            )
+        self.filtered(lambda m: m.state == "posted").button_draft()
+        self.button_cancel()
+
+    def l10n_tr_action_fetch_ticarifatura_response(self):
+        self.ensure_one()
+
+        if self.move_type not in {"out_invoice", "in_invoice"} or self.l10n_tr_gib_invoice_scenario != "TICARIFATURA":
+            raise UserError(self.env._("This action is only available for Commercial Invoices/Bills."))
+        if self.l10n_tr_nilvera_send_status in {"commercial_approved", "commercial_answered_automatically", "commercial_rejected"}:
+            raise UserError(self.env._("The response has already been received for this invoice."))
+        if self.l10n_tr_nilvera_send_status != "succeed":
+            raise UserError(self.env._("The invoice is not approved by Nilvera yet."))
+
+        return self._l10n_tr_nilvera_get_submitted_document_status()
+
+    def l10n_tr_action_approve_ticarifatura(self):
+        self.ensure_one()
+        return self.env['l10n_tr.ticarifatura.response.wizard']._get_records_action(
+            name=self.env._('Accept Bill'),
+            target='new',
+            context={
+                **self.env.context,
+                'default_move_id': self.id,
+                'default_response_code': 'approved',
+            },
+        )
+
+    def l10n_tr_action_reject_ticarifatura(self):
+        self.ensure_one()
+        return self.env['l10n_tr.ticarifatura.response.wizard']._get_records_action(
+            name=self.env._('Reject Bill'),
+            target='new',
+            context={
+                **self.env.context,
+                'default_move_id': self.id,
+                'default_response_code': 'rejected',
+            },
+        )
+
+    def _l10n_tr_nilvera_company_sync_ticarifatura_response(self, batch_size=20):
+        for company in self.env.companies:
+            if company.country_code != "TR" or not company.l10n_tr_nilvera_api_key:
+                continue
+            self.with_company(company)._cron_l10n_tr_nilvera_sync_ticarifatura_response(batch_size)
+
+    def _cron_l10n_tr_nilvera_sync_ticarifatura_response(self, batch_size=20):
+        """
+        Commercial invoices require a response from the counterpart within 7 days.
+        After that window, Nilvera automatically accepts the invoice.
+
+        To ensure no invoice is starved across the 7-day window, records are
+        processed in ascending order of check count, least recently checked first,
+        so that every pending invoice gets polled evenly over time.
+
+        :param int batch_size: Number of invoices to process per run. Default: 20.
+        """
+        _logger.info("Nilvera commercial move response sync started.")
+
+        # Fetch IDs only upfront to avoid re-fetching updated records mid-run.
+        # Full record data is loaded lazily per batch via browse().
+        pending_move_ids = self.env["account.move"].search(
+            UNSYNCED_COMMERCIAL_MOVE_DOMAIN,
+            order="l10n_tr_ticarifatura_status_check_priority asc NULLS FIRST",
+        ).ids
+
+        if not pending_move_ids:
+            _logger.info("No commercial moves found for response sync.")
+            return
+
+        total = len(pending_move_ids)
+        total_batches = -(-total // batch_size)  # ceiling division
+        _logger.info("Found %d commercial move(s) to process in %d batch(es).", total, total_batches)
+
+        for offset in range(0, total, batch_size):
+            batch_ids = pending_move_ids[offset : offset + batch_size]
+            batch_num = offset // batch_size + 1
+            _logger.info("Processing batch %d/%d — move ids: %s", batch_num, total_batches, batch_ids)
+
+            for move in self.env["account.move"].browse(batch_ids):
+                try:
+                    # UNSYNCED_COMMERCIAL_MOVE_DOMAIN ensures the moves passed are valid
+                    move._l10n_tr_nilvera_get_submitted_document_status()
+                except UserError as e:
+                    _logger.warning("Failed to fetch commercial move response for move %s: %s", move.id, e)
+
+                # Always increment priority, even on failure, to avoid retrying the same failing invoices indefinitely.
+                move.write({"l10n_tr_ticarifatura_status_check_priority": move.l10n_tr_ticarifatura_status_check_priority + 1})
+
+        _logger.info("Nilvera commercial move response sync completed.")

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -31,7 +31,7 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         # Add the Nilvera PDF to the mail attachments.
         attachments = super()._get_invoice_extra_attachments(move)
-        if move.l10n_tr_nilvera_send_status == 'succeed' and move.l10n_tr_nilvera_pdf_id:
+        if move.l10n_tr_nilvera_send_status in {'succeed', 'commercial_approved', 'commercial_rejected', 'commercial_answered_automatically'} and move.l10n_tr_nilvera_pdf_id:
             attachments += move.l10n_tr_nilvera_pdf_id
         return attachments
 

--- a/addons/l10n_tr_nilvera_einvoice/security/ir.model.access.csv
+++ b/addons/l10n_tr_nilvera_einvoice/security/ir.model.access.csv
@@ -6,3 +6,4 @@
 "access_l10n_tr_nilvera_einvoice_tax_office_employee","l10n_tr_nilvera_einvoice_tax_office_group_user","model_l10n_tr_nilvera_einvoice_tax_office","base.group_user","1","0","0","0"
 "access_l10n_tr_nilvera_einvoice_tax_office_group_partner_manager","l10n_tr_nilvera_einvoice_tax_office_group_partner_manager","model_l10n_tr_nilvera_einvoice_tax_office","base.group_partner_manager","1","1","1","1"
 "access_l10n_tr_nilvera_einvoice_tax_office_group_system","l10n_tr_nilvera_einvoice_tax_office_group_system","model_l10n_tr_nilvera_einvoice_tax_office","base.group_system","1","1","1","1"
+"access_l10n_tr_ticarifatura_response_wizard_group_invoicing","l10n_tr_ticarifatura_response_wizard_group_invoicing","model_l10n_tr_ticarifatura_response_wizard","account.group_account_invoice","1","1","1","1"

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -12,6 +12,44 @@
                 <div class="alert alert-info" role="alert" invisible="state != 'draft' or l10n_tr_nilvera_send_status != 'error' or not l10n_tr_nilvera_uuid">
                     To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue.
                 </div>
+                <div invisible="l10n_tr_gib_invoice_scenario != 'TICARIFATURA' or l10n_tr_nilvera_send_status not in ('succeed', 'commercial_approved', 'commercial_answered_automatically', 'commercial_rejected')">
+                    <div class="alert alert-info w-100 d-flex align-items-center gap-1" role="alert" invisible="l10n_tr_nilvera_send_status != 'succeed'">
+                        <span>Pending: Awaiting response from </span>
+                        <field invisible="move_type != 'out_invoice' or not partner_id" name="partner_id" readonly="True"/>
+                        <span invisible="move_type != 'out_invoice' or partner_id">Customer</span>
+                        <field invisible="move_type != 'in_invoice'" name="company_id" readonly="True"/>
+                        <span>.</span>
+                        <div class="ms-auto d-flex gap-2" invisible="move_type != 'in_invoice'">
+                            <button name="l10n_tr_action_approve_ticarifatura" type="object" class="btn btn-link">
+                                <i class="fa fa-check text-success" aria-hidden="true"></i>
+                                <span class="text-success">Accept</span>
+                            </button>
+                            <button name="l10n_tr_action_reject_ticarifatura" type="object" class="btn btn-link">
+                                <i class="fa fa-times text-warning" aria-hidden="true"></i>
+                                <span class="text-warning">Reject</span>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="alert alert-success w-100 d-flex align-items-center gap-1" role="alert"
+                         invisible="l10n_tr_nilvera_send_status != 'commercial_approved'">
+                        <field invisible="move_type != 'out_invoice' or not partner_id" name="partner_id" readonly="True"/>
+                        <span invisible="move_type != 'out_invoice' or partner_id">Customer </span>
+                        <field invisible="move_type != 'in_invoice'" name="company_id" readonly="True"/>
+                        <span>Accepted the commercial invoice</span>
+                    </div>
+                    <div class="alert alert-success w-100 d-flex align-items-center gap-1" role="alert"
+                         invisible="l10n_tr_nilvera_send_status != 'commercial_answered_automatically'">
+                        <span>The commercial invoice has been automatically accepted</span>
+                    </div>
+                    <div class="alert alert-danger w-100 d-flex flex-column align-items-sm-start gap-1" role="alert"
+                         invisible="l10n_tr_nilvera_send_status != 'commercial_rejected'">
+                        <span>
+                            <field invisible="move_type != 'out_invoice' or not partner_id" name="partner_id" readonly="True"/>
+                            <field invisible="move_type != 'in_invoice'" name="company_id" readonly="True"/>
+                            <span> The commercial invoice has been rejected.</span>
+                        </span>
+                    </div>
+                </div>
             </xpath>
             <xpath expr="//button[@name='action_post'][2]" position="attributes">
                 <attribute name="invisible" separator=" or " add="l10n_tr_nilvera_send_status == 'error' and l10n_tr_nilvera_uuid"/>
@@ -30,6 +68,13 @@
                         title="Synchronize with Nilvera"
                         icon="fa-refresh"/>
                     </div>
+                    <button
+                        name="l10n_tr_action_fetch_ticarifatura_response"
+                        type="object"
+                        class="o_icon_button text-primary"
+                        invisible="move_type != 'out_invoice' or l10n_tr_nilvera_send_status != 'succeed' or l10n_tr_gib_invoice_scenario != 'TICARIFATURA'"
+                        title="Synchronize response"
+                        icon="fa-refresh"/>
                 <field name="l10n_tr_is_export_invoice"
                        invisible="l10n_tr_nilvera_customer_status not in ('einvoice', 'earchive')"
                        readonly="state in ['cancel', 'posted']"/>
@@ -132,8 +177,8 @@
                     string="Nilvera Status"
                     widget="badge"
                     decoration-danger="l10n_tr_nilvera_send_status == 'error'"
-                    decoration-warning="l10n_tr_nilvera_send_status in ('sent', 'waiting')"
-                    decoration-success="l10n_tr_nilvera_send_status == 'succeed'"
+                    decoration-warning="l10n_tr_nilvera_send_status in ('sent', 'waiting', 'commercial_rejected')"
+                    decoration-success="l10n_tr_nilvera_send_status in ('succeed', 'commercial_approved', 'commercial_answered_automatically')"
                     optional="hide"/>
             </xpath>
         </field>

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -12,6 +12,44 @@
                 <div class="alert alert-info" role="alert" invisible="state != 'draft' or l10n_tr_nilvera_send_status != 'error' or not l10n_tr_nilvera_uuid">
                     To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue.
                 </div>
+                <div invisible="l10n_tr_gib_invoice_scenario != 'TICARIFATURA' or l10n_tr_nilvera_send_status not in ('succeed', 'commercial_approved', 'commercial_answered_automatically', 'commercial_rejected')">
+                    <div class="alert alert-info w-100 d-flex align-items-center gap-1" role="alert" invisible="l10n_tr_nilvera_send_status != 'succeed'">
+                        <span>Pending: Awaiting response from </span>
+                        <field invisible="move_type != 'out_invoice' or not partner_id" name="partner_id" readonly="True"/>
+                        <span invisible="move_type != 'out_invoice' or partner_id">Customer</span>
+                        <field invisible="move_type != 'in_invoice'" name="company_id" readonly="True"/>
+                        <span>.</span>
+                        <div class="ms-auto d-flex gap-2" invisible="move_type != 'in_invoice'">
+                            <button name="l10n_tr_action_approve_ticarifatura" type="object" class="btn btn-link">
+                                <i class="fa fa-check text-success" aria-hidden="true"></i>
+                                <span class="text-success">Accept</span>
+                            </button>
+                            <button name="l10n_tr_action_reject_ticarifatura" type="object" class="btn btn-link">
+                                <i class="fa fa-times text-warning" aria-hidden="true"></i>
+                                <span class="text-warning">Reject</span>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="alert alert-success w-100 d-flex align-items-center gap-1" role="alert"
+                         invisible="l10n_tr_nilvera_send_status != 'commercial_approved'">
+                        <field invisible="move_type != 'out_invoice' or not partner_id" name="partner_id" readonly="True"/>
+                        <span invisible="move_type != 'out_invoice' or partner_id">Customer </span>
+                        <field invisible="move_type != 'in_invoice'" name="company_id" readonly="True"/>
+                        <span>Accepted the commercial invoice</span>
+                    </div>
+                    <div class="alert alert-success w-100 d-flex align-items-center gap-1" role="alert"
+                         invisible="l10n_tr_nilvera_send_status != 'commercial_answered_automatically'">
+                        <span>The commercial invoice has been automatically accepted</span>
+                    </div>
+                    <div class="alert alert-danger w-100 d-flex flex-column align-items-sm-start gap-1" role="alert"
+                         invisible="l10n_tr_nilvera_send_status != 'commercial_rejected'">
+                        <span>
+                            <field invisible="move_type != 'out_invoice' or not partner_id" name="partner_id" readonly="True"/>
+                            <field invisible="move_type != 'in_invoice'" name="company_id" readonly="True"/>
+                            <span> The commercial invoice has been rejected.</span>
+                        </span>
+                    </div>
+                </div>
             </xpath>
             <xpath expr="//button[@name='action_post'][2]" position="attributes">
                 <attribute name="invisible" separator=" or " add="l10n_tr_nilvera_send_status == 'error' and l10n_tr_nilvera_uuid"/>
@@ -30,6 +68,13 @@
                         title="Synchronize with Nilvera"
                         icon="fa-refresh"/>
                     </div>
+                    <button
+                        name="l10n_tr_action_fetch_ticarifatura_response"
+                        type="object"
+                        class="o_icon_button text-primary"
+                        invisible="move_type != 'out_invoice' or l10n_tr_nilvera_send_status != 'succeed' or l10n_tr_gib_invoice_scenario != 'TICARIFATURA'"
+                        title="Synchronize response"
+                        icon="fa-refresh"/>
                 <field name="l10n_tr_is_export_invoice"
                        invisible="l10n_tr_nilvera_customer_status != 'earchive'"
                        readonly="state in ['cancel', 'posted']"/>
@@ -125,8 +170,8 @@
                     string="Nilvera Status"
                     widget="badge"
                     decoration-danger="l10n_tr_nilvera_send_status == 'error'"
-                    decoration-warning="l10n_tr_nilvera_send_status in ('sent', 'waiting')"
-                    decoration-success="l10n_tr_nilvera_send_status == 'succeed'"
+                    decoration-warning="l10n_tr_nilvera_send_status in ('sent', 'waiting', 'commercial_rejected')"
+                    decoration-success="l10n_tr_nilvera_send_status in ('succeed', 'commercial_approved', 'commercial_answered_automatically')"
                     optional="hide"/>
             </xpath>
         </field>

--- a/addons/l10n_tr_nilvera_einvoice/wizards/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_tr_nilvera_einvoice_ticarifatura_response_wizard

--- a/addons/l10n_tr_nilvera_einvoice/wizards/l10n_tr_nilvera_einvoice_ticarifatura_response_wizard.py
+++ b/addons/l10n_tr_nilvera_einvoice/wizards/l10n_tr_nilvera_einvoice_ticarifatura_response_wizard.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class AccountMoveTicarifaturaResponseWizard(models.TransientModel):
+    _name = 'l10n_tr.ticarifatura.response.wizard'
+    _description = 'Response Wizard for Bills of type Ticarifatura E-Invoice'
+
+    move_id = fields.Many2one('account.move', required=True)
+    response_code = fields.Selection([
+        ('approved', "Approve"),
+        ('rejected', "Reject"),
+    ], string="Response Code", required=True)
+    response_note = fields.Text(string="Response Note")
+
+    def action_proceed(self):
+        self.ensure_one()
+        self.move_id._l10n_tr_action_send_ticarifatura_response(self.response_code, self.response_note or '')
+        return {'type': 'ir.actions.act_window_close'}

--- a/addons/l10n_tr_nilvera_einvoice/wizards/l10n_tr_nilvera_einvoice_ticarifatura_response_wizard_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/wizards/l10n_tr_nilvera_einvoice_ticarifatura_response_wizard_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="l10n_tr_nilvera_einvoice.ticarifatura_response_wizard_form" model="ir.ui.view">
+            <field name="name">l10n_tr_nilvera_einvoice.ticarifatura.response.wizard.form</field>
+            <field name="model">l10n_tr.ticarifatura.response.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <div class="oe_form_box">
+                        <p class="oe_form_warning">
+                            <span>
+                                <span>You are about to </span>
+                                <span invisible="response_code != 'approved'">approve</span>
+                                <span invisible="response_code != 'rejected'">reject</span>
+                                a <strong>Commercial Bill</strong>.
+                            </span>
+                            <span> This action will send a response to Nilvera and cannot be undone.</span>
+                        </p>
+                    </div>
+                    <field name="response_note" nolabel="1" placeholder="Enter reason for rejection..." invisible="response_code != 'rejected'" required="response_code == 'rejected'"/>
+                    <footer>
+                        <button string="Proceed" name="action_proceed" type="object" class="oe_highlight" data-hotkey="q"/>
+                        <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_tr_nilvera_einvoice/wizards/l10n_tr_nilvera_einvoice_ticarifatura_response_wizard_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/wizards/l10n_tr_nilvera_einvoice_ticarifatura_response_wizard_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="l10n_tr_nilvera_einvoice.ticarifatura_response_wizard_form" model="ir.ui.view">
+            <field name="name">l10n_tr_nilvera_einvoice.ticarifatura.response.wizard.form</field>
+            <field name="model">l10n_tr.ticarifatura.response.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <div class="oe_form_box">
+                        <p class="oe_form_warning fst-italic">
+                            <span>
+                                <span>You are about to </span>
+                                <span invisible="response_code != 'approved'">approve</span>
+                                <span invisible="response_code != 'rejected'">reject</span>
+                                a <strong>Commercial Bill</strong>.
+                            </span>
+                            <span> This action will send a response to Nilvera and cannot be undone.</span>
+                        </p>
+                    </div>
+                    <field name="response_note" nolabel="1" placeholder="Enter reason for rejection..." invisible="response_code != 'rejected'" required="response_code == 'rejected'"/>
+                    <footer>
+                        <button string="Proceed" name="action_proceed" type="object" class="oe_highlight" data-hotkey="q"/>
+                        <button string="Cancel" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
# Description of the issue/feature this PR addresses
Odoo's Nilvera integration (l10n_tr_nilvera_einvoice) currently supports only basic e-invoice scenarios.
Commercial invoices and commercial bills (TICARIFATURA), which are widely used in Turkish e-invoicing
workflows, were not supported. This PR adds full support for creating, sending, and responding to
commercial invoices and bills in alignment with Nilvera's API specifications.

# Current behavior before PR
- Only standard e-invoice profiles were supported.
- Commercial invoices and bills (ProfileID: TICARIFATURA) could not be created or processed.
- Incoming responses for commercial invoices were not handled.
- Sending responses for commercial bills was not possible.

# Desired behavior after PR is merged
- Commercial invoices and bills are fully supported via Nilvera.
- Odoo can create and process invoices/bills with:
    - ProfileID: TICARIFATURA
    - Move types: sale and purchase
- Both customer invoices and vendor bills are supported.
- Invoice responses can be retrieved from Nilvera and sent back for commercial bills.
- UI banner on the invoice form shows the current response status:
    - Pending: awaiting response from the counterpart
    - Accepted by the counterpart
    - Automatically accepted by Nilvera
    - Rejected (reason posted to chatter, invoice cancelled, updated PDF fetched)
- Commercial bills can be accepted or rejected directly from Odoo via a confirmation wizard.
- A scheduled job (12-hour interval) periodically syncs response status from Nilvera,
  processing invoices in order of priority to avoid repeatedly retrying failing records.

# Supported scenarios
- Profile ID
    - TICARIFATURA
- Invoice Type Codes
    - SATIS
    - TEVKIFAT
    - ISTISNA
    - IHRACKAYITLI
- Move types
    - Customer invoices
    - Vendor bills

# Behavior notes
- If InvoiceTypeCode is not one of the supported values, it falls back to SATIS to ensure
  bill response handling remains functional.
- Rejected commercial invoices can be reset to draft for correction and resubmission.
- The Nilvera PDF is automatically attached to outgoing emails for all terminal statuses
  (approved, auto-approved, rejected).

# Unsupported scenarios
- Credit notes (out of scope for this PR)

---
task-4741223
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)