### PR TITLE
[FIX] website_project: Avoid duplicated description in project form

### DIFF
--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -27,7 +27,9 @@ class WebsiteForm(form.WebsiteForm):
         custom_label = nl2br_enclose(_("Other Information"), 'h4')  # Title for custom fields
         default_field = model.website_form_default_field_id
         default_field_data = values.get(default_field.name, '')
-        default_field_content = nl2br_enclose(default_field.name.capitalize(), 'h4') + nl2br_enclose(html2plaintext(default_field_data), 'p')
+        default_field_content = nl2br_enclose(html2plaintext(default_field_data), 'p')
+        if default_field.name and default_field.name != 'description':
+            default_field_content = nl2br_enclose(default_field.name.capitalize(), 'h4') + default_field_content
         custom_content = (default_field_content if default_field_data else '') \
                         + (custom_label + custom if custom else '') \
                         + (self._meta_label + meta if meta else '')


### PR DESCRIPTION
Steps to reproduce:
===================
1. Go to website > contact us page
2. Submit a new task with description.
3. View the Description in the project app.

-> The description field is already shown in the form by default. You will find another time it is repeated.

Cause:
======
The default field content is always appended to the form content.

Solution:
=========
Avoid adding description to the description field content.

opw-5868382

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
