### PR TITLE
[FIX] spreadsheet: remove zoom slicer for scatter plot

### DIFF
--- a/addons/spreadsheet/static/src/chart/index.js
+++ b/addons/spreadsheet/static/src/chart/index.js
@@ -17,7 +17,7 @@ chartComponentRegistry.add("odoo_sunburst", ChartJsComponent);
 chartComponentRegistry.add("odoo_treemap", ChartJsComponent);
 chartComponentRegistry.add("odoo_waterfall", ZoomableChartJsComponent);
 chartComponentRegistry.add("odoo_pyramid", ChartJsComponent);
-chartComponentRegistry.add("odoo_scatter", ZoomableChartJsComponent);
+chartComponentRegistry.add("odoo_scatter", ChartJsComponent);
 chartComponentRegistry.add("odoo_combo", ZoomableChartJsComponent);
 chartComponentRegistry.add("odoo_geo", ChartJsComponent);
 chartComponentRegistry.add("odoo_funnel", ChartJsComponent);

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_scatter_chart.js
@@ -22,7 +22,6 @@ export class OdooScatterChart extends OdooChart {
         super(definition, sheetId, getters);
         this.verticalAxisPosition = definition.verticalAxisPosition;
         this.axesDesign = definition.axesDesign;
-        this.zoomable = definition.zoomable;
     }
 
     getDefinition() {
@@ -30,7 +29,6 @@ export class OdooScatterChart extends OdooChart {
             ...super.getDefinition(),
             verticalAxisPosition: this.verticalAxisPosition,
             axesDesign: this.axesDesign,
-            zoomable: this.zoomable,
         };
     }
 }


### PR DESCRIPTION
## Task Description

This PR aims to remove the zoomable feature for the scatter plot, as it's kind of non-sense to be able to zoom on an axis and not on the other for this type of chart. Moreover, we will soon be able to manually set the min/max of each axis manually (in master).

## Related Task/PR

- Task: 5388389
- [https://github.com/odoo/enterprise/pull/106189](https://github.com/odoo/enterprise/pull/106189)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
