### PR TITLE
[PERF] website_sale: Batch has_published field on category

### DIFF
--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -87,10 +87,15 @@ class ProductPublicCategory(models.Model):
 
     @api.depends('product_tmpl_ids.is_published', 'child_id.has_published_products')
     def _compute_has_published_products(self):
+        grouped_product_templates = self.env['product.template']._read_group(
+            domain=[('public_categ_ids', 'in', self.ids), ('is_published', '=', True)],
+            groupby=['public_categ_ids']
+        )
+        published_category_ids = {group[0].id for group in grouped_product_templates}
         for category in self:
+            has_published = category.id in published_category_ids
             category.has_published_products = (
-                any(category.mapped('product_tmpl_ids.is_published'))
-                or any(category.mapped('child_id.has_published_products'))
+                has_published or any(c.has_published_products for c in category.child_id)
             )
 
     # === CONSTRAINT METHODS === #


### PR DESCRIPTION
Previously the function was fetching all the product template ids and looping over them for each product template. This triggered the prefetch_ids and prefetch fields for these products which would cause memory issues due to the bloat of the cache from the prefetcher.

The current way is a read_group over the categories and check if category id exists or not.

Backport of odoo/odoo#239499



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
