### PR TITLE
[IMP] survey: show submit confirmation only for certification surveys

### DIFF
--- a/addons/survey/static/src/interactions/survey_form.js
+++ b/addons/survey/static/src/interactions/survey_form.js
@@ -70,6 +70,7 @@ export class SurveyForm extends Interaction {
             scoringType: optionsData.scoringType,
             answerToken: optionsData.answerToken,
             surveyToken: optionsData.surveyToken,
+            isCertification: optionsData.certification,
             usersCanGoBack: !!optionsData.usersCanGoBack,
             sessionInProgress: !!optionsData.sessionInProgress,
             isStartScreen: !!optionsData.isStartScreen,
@@ -409,18 +410,22 @@ export class SurveyForm extends Interaction {
         } else if (targetEl.value === "next_post_submit") {
             this.submitForm({ showNextPostSubmitPage: true });
         } else if (targetEl.value === "finish" && !this.options.sessionInProgress) {
-            // Adding pop-up before the survey is submitted when not in live session
-            this.dialog.add(ConfirmationDialog, {
-                title: _t("Submit survey"),
-                body: _t("Submit your survey? Once it's out, it is like a letter in the mail: it cannot be recalled."),
-                confirmLabel: _t("Yes, submit"),
-                cancelLabel: _t("No, wait a minute"),
-                size: "md",
-                confirm: () => {
-                    this.waitForTimeout(() => this.submitForm({ isFinish: true }), 0);
-                },
-                cancel: () => {},
-            });
+            if (this.options.isCertification) {
+                // Show a confirmation dialog before submitting a certification survey (if not a live session)
+                this.dialog.add(ConfirmationDialog, {
+                    title: _t("Submit survey"),
+                    body: _t("Submit your survey? Once it's out, it is like a letter in the mail: it cannot be recalled."),
+                    confirmLabel: _t("Yes, submit"),
+                    cancelLabel: _t("No, wait a minute"),
+                    size: "md",
+                    confirm: () => {
+                        this.waitForTimeout(() => this.submitForm({ isFinish: true }), 0);
+                    },
+                    cancel: () => {},
+                });
+            } else {
+                this.submitForm({ isFinish: true });
+            }
         } else {
             this.submitForm();
         }

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -69,10 +69,6 @@ const survey_steps = (checkPageTranslation) => [
         content: 'Click Submit and finish the survey',
         trigger: 'button[value="finish"]',
         run: "click",
-    }, {
-        content: "Click on Submit",
-        trigger: ".modal-footer button.btn-primary",
-        run: "click",
     },
     // Final page
     {

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -80,10 +80,6 @@ registry.category("web_tour.tours").add('test_survey_chained_conditional_questio
         content: 'Click Submit and finish the survey',
         trigger: 'button[value="finish"]',
         run: "click",
-    }, {
-        content: "Click on Submit",
-        trigger: 'button.btn-primary:contains("Yes, submit")',
-        run: "click",
     },
     // Final page
     {

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -40,10 +40,6 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
         trigger: 'button.btn:contains("Submit")',
         run: "click",
     }, {
-        content: "Click on Submit",
-        trigger: 'button.btn-primary:contains("Yes, submit")',
-        run: "click",
-    }, {
         content: 'Check if question is Q1',
         trigger: 'div.o_survey_question:contains("Q1")',
     }, {
@@ -93,10 +89,6 @@ registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions
     }, {
         content: 'Click on Submit',
         trigger: 'button.btn:contains("Submit")',
-        run: "click",
-    }, {
-        content: "Click on Submit",
-        trigger: 'button.btn-primary:contains("Yes, submit")',
         run: "click",
     }, {
         content: 'Check if the survey is done',

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -125,6 +125,7 @@
                 t-att-data-scoring-type="survey.scoring_type"
                 t-att-data-answer-token="answer.access_token"
                 t-att-data-survey-token="survey.access_token"
+                t-att-data-certification="survey.certification"
                 t-att-data-users-can-go-back="survey.users_can_go_back and not answer.is_session_answer"
                 t-att-data-session-in-progress="answer.is_session_answer"
                 t-att-data-is-start-screen="answer.state == 'new'"


### PR DESCRIPTION
Previously, a confirmation dialog could appear when finishing a survey
outside of a live session, even when the survey was not a certification.

This commit restricts the submit confirmation dialog to certification
surveys only. For non-certification surveys, the submit button label
is considered explicit enough, and no extra confirmation is required.

Task-5241498
