### PR TITLE
[FIX] spreadsheet: comparable keys for period/year granularities

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_time_adapters.js
@@ -6,7 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 
 const { pivotTimeAdapterRegistry } = registries;
-const { toNumber, toJsDate, toString } = helpers;
+const { toNumber, toJsDate, toString, periodYearToComparable } = helpers;
 const { DEFAULT_LOCALE } = constants;
 
 const { DateTime } = luxon;
@@ -114,6 +114,9 @@ const odooWeekAdapter = {
         const nextWeek = date.plus({ weeks: step });
         return `${nextWeek.weekNumber}/${nextWeek.weekYear}`;
     },
+    toComparableValue(normalizedValue) {
+        return periodYearToComparable(normalizedValue);
+    },
 };
 
 /**
@@ -130,6 +133,9 @@ const odooMonthAdapter = {
         return DateTime.fromFormat(normalizedValue, "MM/yyyy", { numberingSystem: "latn" })
             .plus({ months: step })
             .toFormat("MM/yyyy");
+    },
+    toComparableValue(normalizedValue) {
+        return periodYearToComparable(normalizedValue);
     },
 };
 
@@ -169,6 +175,9 @@ const odooQuarterAdapter = {
         const date = DateTime.fromObject({ year: Number(year), month: Number(quarter) * 3 });
         const nextQuarter = date.plus({ quarters: step });
         return `${nextQuarter.quarter}/${nextQuarter.year}`;
+    },
+    toComparableValue(normalizedValue) {
+        return periodYearToComparable(normalizedValue);
     },
 };
 
@@ -257,6 +266,12 @@ function falseHandlerDecorator(adapter) {
                 return "FALSE";
             }
             return adapter.toFunctionValue(value);
+        },
+        toComparableValue(value) {
+            if (value === false) {
+                return undefined;
+            }
+            return adapter.toComparableValue?.(value);
         },
     };
 }

--- a/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_helpers.test.js
@@ -259,6 +259,12 @@ describe("pivot time adapters formatted value", () => {
         expect(adapter.toValueAndFormat("3/1998", DEFAULT_LOCALE)).toEqual({ value: "Q3 1998" });
     });
 
+    test("Week/Month/Quarter comparable values", () => {
+        expect(pivotTimeAdapter("week").toComparableValue("5/2024")).toBe(202405);
+        expect(pivotTimeAdapter("month").toComparableValue("02/2024")).toBe(202402);
+        expect(pivotTimeAdapter("quarter").toComparableValue("2/2025")).toBe(202502);
+    });
+
     test("Year adapter", () => {
         const adapter = pivotTimeAdapter("year");
         expect(adapter.toValueAndFormat("2020", DEFAULT_LOCALE)).toEqual({


### PR DESCRIPTION
Odoo week/quarter/month granularities normalize to "period/year" strings
(e.g. "47/2025"), which broke running-total comparisons because values were
not directly comparable.

This adds a shared period/year comparable helper from o-spreadsheet, wires
it into Odoo’s week/quarter/month adapters, and adds tests for comparable
values and running-total carry-forward on month granularity.

Task: [5420999](https://www.odoo.com/odoo/project/2328/tasks/5420999)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
