### PR TITLE
[IMP] account_edi_ubl_cii: Prevent BIS3 without EndpointID to be send

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1531,6 +1531,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         partner = vals['partner']
         commercial_partner = partner.commercial_partner_id
         party_node = {
+            'cbc:EndpointID': {
+                '_text': None,
+                'schemeID': None,
+            },
             'cac:PartyIdentification': {
                 'cbc:ID': {'_text': commercial_partner.ref},
             },

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -645,10 +645,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         commercial_partner = partner.commercial_partner_id
 
         if commercial_partner.peppol_endpoint:
-            party_node['cbc:EndpointID'] = {
-                '_text': commercial_partner.peppol_endpoint,
-                'schemeID': commercial_partner.peppol_eas
-            }
+            party_node['cbc:EndpointID']['_text'] = commercial_partner.peppol_endpoint
+            party_node['cbc:EndpointID']['schemeID'] = commercial_partner.peppol_eas
 
         if commercial_partner.country_code == 'NL' and commercial_partner.peppol_endpoint:
             # [UBL-SR-16] Buyer identifier shall occur maximum once
@@ -908,6 +906,21 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     "The VAT number of the supplier does not seem to be valid. It should be of the form: NO179728982MVA."
                 ) if not mva.is_valid(vat) or len(vat) != 14 or vat[:2] != 'NO' or vat[-3:] != 'MVA' else "",
             })
+
+        # [PEPPOL-EN16931-R010]
+        if not vals['document_node']['cac:AccountingCustomerParty']['cac:Party']['cbc:EndpointID']['_text']:
+            constraints['ubl_peppol_en16931-r010'] = _(
+                "[PEPPOL-EN16931-R010] An electronic address (EAS) must be provided on the customer '%s'.",
+                vals['customer'].display_name,
+            )
+
+        # [PEPPOL-EN16931-R020]
+        if not vals['document_node']['cac:AccountingSupplierParty']['cac:Party']['cbc:EndpointID']['_text']:
+            constraints['ubl_peppol_en16931-r020'] = _(
+                "[PEPPOL-EN16931-R020] An electronic address (EAS) must be provided on the company '%s'.",
+                vals['supplier'].display_name,
+            )
+
         return constraints
 
     # -------------------------------------------------------------------------

--- a/addons/account_edi_ubl_cii/tests/common.py
+++ b/addons/account_edi_ubl_cii/tests/common.py
@@ -20,18 +20,24 @@ class TestUblCiiCommon(AccountTestInvoicingCommon):
         return company
 
     @classmethod
+    def _create_partner_default_values(cls):
+        return {
+            'invoice_sending_method': 'manual',
+            'property_account_receivable_id': cls.company_data['default_account_receivable'].id,
+            'property_account_payable_id': cls.company_data['default_account_payable'].id,
+            'company_id': cls.company_data['company'].id,
+        }
+
+    @classmethod
     def _create_partner_be(cls, **kwargs):
         return cls.env['res.partner'].create({
+            **cls._create_partner_default_values(),
             'name': 'partner_be',
             'street': "Rue des Bourlottes 9",
             'zip': "1367",
             'city': "Ramillies",
             'vat': 'BE0477472701',
             'company_registry': '0477472701',
-            'invoice_sending_method': 'manual',
-            'property_account_receivable_id': cls.company_data['default_account_receivable'].id,
-            'property_account_payable_id': cls.company_data['default_account_payable'].id,
-            'company_id': cls.company_data['company'].id,
             'bank_ids': [Command.create({'acc_number': 'BE90735788866632'})],
             'country_id': cls.env.ref('base.be').id,
             **kwargs,
@@ -40,15 +46,12 @@ class TestUblCiiCommon(AccountTestInvoicingCommon):
     @classmethod
     def _create_partner_lu_dig(cls, **kwargs):
         return cls.env['res.partner'].create({
+            **cls._create_partner_default_values(),
             'name': "Division informatique et gestion",
             'street': "bd de la Foire",
             'zip': "L-1528",
             'city': "Luxembourg",
             'vat': None,
-            'invoice_sending_method': 'manual',
-            'property_account_receivable_id': cls.company_data['default_account_receivable'].id,
-            'property_account_payable_id': cls.company_data['default_account_payable'].id,
-            'company_id': cls.company_data['company'].id,
             'country_id': cls.env.ref('base.lu').id,
             'peppol_eas': '9938',
             'peppol_endpoint': '00005000041',
@@ -58,15 +61,12 @@ class TestUblCiiCommon(AccountTestInvoicingCommon):
     @classmethod
     def _create_partner_au(cls, **kwargs):
         return cls.env['res.partner'].create({
+            **cls._create_partner_default_values(),
             'name': "partner_au",
             'street': "Parliament Dr",
             'zip': "2600",
             'city': "Canberra",
             'vat': '53 930 548 027',
-            'invoice_sending_method': 'manual',
-            'property_account_receivable_id': cls.company_data['default_account_receivable'].id,
-            'property_account_payable_id': cls.company_data['default_account_payable'].id,
-            'company_id': cls.company_data['company'].id,
             'country_id': cls.env.ref('base.au').id,
             'bank_ids': [Command.create({'acc_number': '93999574162167'})],
             **kwargs,
@@ -160,14 +160,10 @@ class TestUblCiiBECommon(TestUblCiiCommon):
 class TestUblBis3Common(TestUblCiiCommon):
 
     @classmethod
-    def _create_partner_be(cls, **kwargs):
-        kwargs.setdefault('invoice_edi_format', 'ubl_bis3')
-        return super()._create_partner_be(**kwargs)
-
-    @classmethod
-    def _create_partner_lu_dig(cls, **kwargs):
-        kwargs.setdefault('invoice_edi_format', 'ubl_bis3')
-        return super()._create_partner_lu_dig(**kwargs)
+    def _create_partner_default_values(cls):
+        values = super()._create_partner_default_values()
+        values['invoice_edi_format'] = 'ubl_bis3'
+        return values
 
     # -------------------------------------------------------------------------
     # EXPORT HELPERS

--- a/addons/account_edi_ubl_cii/tests/test_download_docs.py
+++ b/addons/account_edi_ubl_cii/tests/test_download_docs.py
@@ -3,20 +3,19 @@ from zipfile import ZipFile
 
 from odoo.fields import Command
 from odoo.tests.common import tagged
+from odoo.addons.account_edi_ubl_cii.tests.common import TestUblBis3Common, TestUblCiiBECommon
 from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
 
 
 @tagged('post_install', '-at_install')
-class TestDownloadDocs(AccountTestInvoicingHttpCommon):
+class TestDownloadDocs(TestUblBis3Common, TestUblCiiBECommon, AccountTestInvoicingHttpCommon):
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.partner_a.country_id = cls.env.ref('base.be')
-        cls.partner_a.invoice_edi_format = 'ubl_bis3'
         invoice_1 = cls.env['account.move'].create({
             'move_type': 'out_invoice',
-            'partner_id': cls.partner_a.id,
+            'partner_id': cls.partner_be.id,
             'invoice_line_ids': [
                 Command.create({
                     'price_unit': 100,
@@ -27,7 +26,7 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
         })
         invoice_2 = cls.env['account.move'].create({
             'move_type': 'out_invoice',
-            'partner_id': cls.partner_a.id,
+            'partner_id': cls.partner_be.id,
             'invoice_line_ids': [
                 Command.create({
                     'price_unit': 20,
@@ -38,7 +37,7 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
         })
         invoice_3 = cls.env['account.move'].create({
             'move_type': 'out_invoice',
-            'partner_id': cls.partner_a.id,
+            'partner_id': cls.partner_be.id,
             'invoice_line_ids': [
                 Command.create({
                     'price_unit': 300,
@@ -49,7 +48,7 @@ class TestDownloadDocs(AccountTestInvoicingHttpCommon):
         })
         cls.invoices = invoice_1 + invoice_2
         cls.invoices.action_post()
-        cls.invoices._generate_and_send(sending_methods=['manual'])
+        cls._generate_invoice_ubl_file(cls.invoices)
         cls.invoices += invoice_3
         assert invoice_1.invoice_pdf_report_id and invoice_2.invoice_pdf_report_id and not invoice_3.invoice_pdf_report_id
         assert invoice_1.ubl_cii_xml_id and invoice_2.ubl_cii_xml_id and not invoice_3.ubl_cii_xml_id

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -1,5 +1,6 @@
 from odoo import Command
 from odoo.addons.account_edi_ubl_cii.tests.common import TestUblBis3Common, TestUblCiiBECommon
+from odoo.exceptions import UserError
 try:
     from odoo.addons.test_mimetypes.tests.test_guess_mimetypes import contents
 except ImportError:
@@ -623,3 +624,35 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
 
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_product_commodity_code_cpv')
+
+    def test_invoice_PEPPOL_EN16931_R010_R020_ensure_customer_supplier_endpoint_id(self):
+        """
+        [PEPPOL-EN16931-R010] Buyer electronic address MUST be provided.
+        [PEPPOL-EN16931-R020] Seller electronic address MUST be provided.
+        """
+        partner = self.env['res.partner'].create({
+            **self._create_partner_default_values(),
+            'name': "partner",
+            'country_id': self.env.ref('base.be').id,
+        })
+        tax_21 = self.percent_tax(21.0)
+        product = self._create_product(lst_price=10.0, taxes_id=tax_21)
+        invoice = self._create_invoice_one_line(
+            product_id=product,
+            partner_id=partner,
+            post=True,
+        )
+
+        # Check customer's endpoint.
+        with self.assertRaisesRegex(UserError, r".*\[PEPPOL\-EN16931\-R010\].*"):
+            self._generate_invoice_ubl_file(invoice)
+
+        # Check supplier's endpoint.
+        partner.peppol_eas = '0208'
+        partner.peppol_endpoint = '0477472701'
+        self.env.company.partner_id.vat = None
+        self.env.company.partner_id.company_registry = None
+        self.env.company.partner_id.peppol_eas = None
+        self.env.company.partner_id.peppol_endpoint = None
+        with self.assertRaisesRegex(UserError, r".*\[PEPPOL\-EN16931\-R020\].*"):
+            self._generate_invoice_ubl_file(invoice)

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_invoice.xml
@@ -20,6 +20,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0195">197401143C</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_1</cbc:ID>
       </cac:PartyIdentification>
@@ -53,6 +54,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0195">S16FC0121D</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_2</cbc:ID>
       </cac:PartyIdentification>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/sg_out_refund.xml
@@ -19,6 +19,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0195">197401143C</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_1</cbc:ID>
       </cac:PartyIdentification>
@@ -52,6 +53,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0195">S16FC0121D</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_2</cbc:ID>
       </cac:PartyIdentification>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_sg.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_sg.py
@@ -23,6 +23,8 @@ class TestUBLSG(TestUBLCommon):
             'bank_ids': [(0, 0, {'acc_number': '000099998B57'})],
             'ref': 'ref_partner_1',
             'invoice_edi_format': 'ubl_sg',
+            'peppol_eas': '0195',
+            'peppol_endpoint': '197401143C',
         })
 
         cls.partner_2 = cls.env['res.partner'].create({
@@ -36,6 +38,8 @@ class TestUBLSG(TestUBLCommon):
             'bank_ids': [(0, 0, {'acc_number': '93999574162167'})],
             'ref': 'ref_partner_2',
             'invoice_edi_format': 'ubl_sg',
+            'peppol_eas': '0195',
+            'peppol_endpoint': 'S16FC0121D',
         })
 
     ####################################################

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes.xml
@@ -12,6 +12,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0230">C2584563200</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -47,6 +48,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0230">C2584563201</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>partner_a</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes_new.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes_new.xml
@@ -12,6 +12,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0230">C2584563200</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -47,6 +48,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0230">C2584563201</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>partner_a</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_with_sst.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_with_sst.xml
@@ -13,6 +13,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0230">C2584563200</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -48,6 +49,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0230">C2584563201</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>partner_a</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_my_ubl_pint/tests/test_my_ubl_pint.py
+++ b/addons/l10n_my_ubl_pint/tests/test_my_ubl_pint.py
@@ -20,12 +20,14 @@ class TestMyUBLPint(AccountTestInvoicingCommon):
         cls.other_currency = cls.setup_other_currency('EUR')
 
         # TIN number is required
-        cls.company_data['company'].write({
+        cls.company_data['company'].partner_id.write({
             'vat': 'C2584563200',
             'state_id': cls.env.ref('base.state_my_jhr').id,
             'street': 'that one street, 5',
             'city': 'Main city',
             'phone': '+60123456789',
+            'peppol_eas': '0230',
+            'peppol_endpoint': 'C2584563200',
         })
         cls.partner_a.write({
             'vat': 'C2584563201',
@@ -34,6 +36,8 @@ class TestMyUBLPint(AccountTestInvoicingCommon):
             'street': 'that other street, 3',
             'city': 'Main city',
             'phone': '+60123456786',
+            'peppol_eas': '0230',
+            'peppol_endpoint': 'C2584563201',
         })
 
         cls.fakenow = datetime(2024, 7, 15, 10, 00, 00)

--- a/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
@@ -54,6 +54,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="0195">301131415A</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>partner_a</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
+++ b/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
@@ -29,6 +29,7 @@ class TestSgUBLPint(AccountTestInvoicingCommon):
         })
         cls.partner_a.write({
             'vat': 'S16FC0121D',
+            'l10n_sg_unique_entity_number': '301131415A',
             'country_id': cls.env.ref('base.sg').id,
             'street': 'that other street, 3',
             'zip': '248050',


### PR DESCRIPTION
If EndpointID is not set, the generated file is invalid due to the 2 following rules:
[PEPPOL-EN16931-R010] Buyer electronic address MUST be provided. [PEPPOL-EN16931-R020] Seller electronic address MUST be provided.

Since this is a configuration issue, there is no point of sending such files to be rejected right away. Instead, let's add those 2 contraints ODOO-side.

task-5890887

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
