### PR TITLE
[FIX] analytic: support any operator in analytic distribution search

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -67,6 +67,14 @@ class AnalyticMixin(models.AbstractModel):
             rec.distribution_analytic_account_ids = self.env['account.analytic.account'].browse(ids)
 
     def _search_distribution_analytic_account_ids(self, operator, value):
+        if operator in ('any', 'not any', 'any!', 'not any!'):
+            if isinstance(value, Domain):
+                value = self.env['account.analytic.account'].search(value).ids
+            elif isinstance(value, Query):
+                value = value.get_result_ids()
+            else:
+                return NotImplemented
+            operator = 'in' if operator in ('any', 'any!') else 'not in'
         return [('analytic_distribution', operator, value)]
 
     def _compute_analytic_distribution(self):


### PR DESCRIPTION
`distribution_analytic_account_ids` is a virtual relational field backed by the `JSON` field `analytic_distribution`. Its custom search method did not handle the `any` / `not any` operators, causing domains like:
```py
('distribution_analytic_account_ids', 'any', <analytic.account domain>)
```
to fail during domain optimization with errors such as:
```py
ValueError: Cannot use 'any' with non-relational fields in condition ('analytic_distribution', 'any', [('plan_id', 'in', [2])])
```

This commit adds support for relational semantics in `_search_distribution_analytic_account_ids` by resolving the RHS domain on `account.analytic.account` into ids and converting:
- `any` → `in`
- `not any` → `not in`

This aligns the behavior with relational field expectations while keeping the logic at the field search level instead of modifying domain internals.

**Steps to reproduce:**
- Created a `v19` db and install Accounting app
- Navigate to `journal items` menu
- Add the custom filter: `[("distribution_analytic_account_ids.plan_id", "in", [2])]`
- In logs you will see:
```py
ValueError: Cannot use 'any' with non-relational fields in condition ('analytic_distribution', 'any', [('plan_id', 'in', [2])])
```
- In UI it will pop up domain is invalid.

opw-5875337
upg-3855669


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
