### PR TITLE
[FIX] delivery: fix the default group by provider

### DIFF
--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -25,7 +25,7 @@
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                 <group expand="1" string="Group By">
-                    <filter string="Provider" name="provider" context="{'group_by':'delivery_type', 'residual_visible':True}"/>
+                    <filter string="Provider" name="group_by_provider" context="{'group_by':'delivery_type', 'residual_visible':True}"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
**Steps to Reproduce:**
- Got to the Shipping Methods.
- No default group by is applied even when the provider is set to default.

**Issue:**
The default group by was not applied in Shipping Methods despite the provider being set as default, due to a mismatch between the filter name and the default group by name.

**Fix:**
Aligned the filter name with the default group by name so the grouping is applied correctly by default.

**Affected Version:** 17.0~master