### PR TITLE
[FIX] pos_restaurant: create new table using current floor max number

### DIFF
--- a/addons/pos_restaurant/static/src/app/services/floor_plan/floor_plan_service.js
+++ b/addons/pos_restaurant/static/src/app/services/floor_plan/floor_plan_service.js
@@ -185,8 +185,8 @@ export class FloorPlanStore extends Reactive {
         if (this.editMode) {
             this.showEditToolbar = true;
             let nextTableNumber = 1;
-            if (this.floors.length) {
-                nextTableNumber = Math.max(...this.floors.map((f) => f.getMaxTableNumber())) + 1;
+            if (this.selectedFloor) {
+                nextTableNumber = this.selectedFloor.getMaxTableNumber() + 1;
             }
             this.editState = {
                 history: new History(),
@@ -613,15 +613,14 @@ export class FloorPlanStore extends Reactive {
     }
 
     selectFloorByUuid(uuid) {
+        this.selectedFloor = uuid instanceof Floor ? uuid : this.getFloorByUuid(uuid);
         if (this.editMode) {
             this.endEditSelectedElement();
             this.selectElementByUuid(null);
+            if (this.selectedFloor) {
+                this.nextTableNumber = this.selectedFloor.getMaxTableNumber() + 1;
+            }
         }
-        if (uuid instanceof Floor) {
-            this.selectedFloor = uuid;
-            return;
-        }
-        this.selectedFloor = this.getFloorByUuid(uuid);
     }
 
     selectFloorById(id) {

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -324,3 +324,17 @@ registry.category("web_tour.tours").add("no_ghost_floor", {
             FloorScreen.hasNotFloor("Ghost Floor"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_add_new_table_number_with_multi_floor", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            Chrome.clickMenuOption("Edit Plan"),
+            FloorScreen.addTable({ close: false }),
+            FloorScreen.hasTable("6"),
+            FloorScreen.selectFloorEditMode("Second Floor"),
+            FloorScreen.addTable({ close: false }),
+            FloorScreen.hasTable("4"),
+        ].flat(),
+});

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -8,7 +8,7 @@ export function table({ name, withClass = "", withoutClass, run = () => {}, numO
         trigger += `:not(${withoutClass})`;
     }
     if (name) {
-        trigger += `:has(.label:contains("${name}"))`;
+        trigger += `:has(.o_fp_table_number:contains("${name}"))`;
     }
     return {
         content: `Check table with attributes: ${JSON.stringify(arguments[0])}`,

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -984,3 +984,7 @@ class TestFrontend(TestFrontendCommon):
         self.assertEqual(present_order.state, 'cancel')
         self.assertEqual(future_order.state, 'draft')
         self.assertEqual(future_order.session_id.id, False)
+
+    def test_add_new_table_number_with_multi_floor(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_add_new_table_number_with_multi_floor', login="pos_admin")


### PR DESCRIPTION
Before this commit:
===================
When multiple floors exist, creating a new table assigns the next table number based on the maximum table number across all floors.

After this commit:
==================
When multiple floors exist, creating a new table assigns the next table number based on the maximum table number of the current floor.

Task: 5888449






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
