### PR TITLE
[FIX] resource: fix overtime indicator in multi-company

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -489,7 +489,7 @@ class ResourceCalendar(models.Model):
             ('resource_id', 'in', [False] + [r.id for r in resources_list]),
             ('date_from', '<=', datetime_to_string(end_dt)),
             ('date_to', '>=', datetime_to_string(start_dt)),
-            ('company_id', 'in', [False] + [self.company_id.id]),
+            ('company_id', 'in', [False] + ([r.company_id.id for r in resources_list if r.company_id] or [self.company_id.id])),
         ]
 
         # retrieve leave intervals in (start_dt, end_dt)


### PR DESCRIPTION
Steps to reproduce:
-------------------------
1. Install Timesheets and Time Off.
2. Create an employee and create a Time Off in the past week, then approve it.
3. Open All Timesheets for that employee and observe the overtime indicator.
4. Enable a multi-company environment by creating another company.
5. Remove the `company_id` from the employee’s working schedule (40h/week).

Issue:
----------
The overtime indicator shows an incorrect value.
It displays 40h instead of the expected 32h.

Cause:
----------
Since there is no company defined on the working schedule, `self.company_id.id` becomes False.
The actual leave records are linked with the employee’s company, so the search results
in an empty recordset. As a result, the employee leave is ignored.

Solution:
--------------
Take the resource company into account when building the domain,
before falling back to the calendar company.

opw-5499737




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
