### PR TITLE
[IMP] mail: redesign message highlight effect for better focus

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -10,11 +10,6 @@
         --border-opacity: .2;
     }
 
-    &.o-highlighted {
-        transform: translateY(-#{map-get($spacers, 3)});
-        z-index: 2;
-    }
-
     &.o-actionMenuMobileOpen {
         background-color: rgba($o-action, .075);
         outline: 1px solid rgba($o-action, .125);
@@ -177,4 +172,15 @@
 
 .o-mail-Message-translated {
     color: $o-enterprise-action-color;
+}
+
+.o-mail-Thread-content {
+    > * {
+        transition: opacity .3s ease-in-out, filter .3s ease-in-out;
+    }
+
+    &:has(.o-highlighted) > *:not(.o-highlighted) {
+        opacity: .4;
+        filter: blur(1px);
+    }
 }

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -516,7 +516,7 @@ export class Thread extends Component {
 
     getMessageClassName(message) {
         return !message.isNotification && this.messageHighlight?.highlightedMessageId === message.id
-            ? "o-highlighted bg-view shadow-lg pb-1"
+            ? "o-highlighted"
             : "";
     }
 

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.Thread">
     <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto o-scrollbar-thin bg-inherit" t-att-class="{ 'pb-5': env.inChatter?.aside, 'o-pb-3_5': !env.inChatter?.aside, 'ps-2 pe-3': env.inDiscussApp and !ui.isSmall, 'o-focused': state.isFocused }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1" t-on-focusin="onFocusin" t-on-focusout="onFocusout">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
-            <div class="d-flex flex-column position-relative flex-grow-1 bg-inherit" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
+            <div class="o-mail-Thread-content d-flex flex-column position-relative flex-grow-1 bg-inherit" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>
                 <t t-set="currentDay" t-value="0"/>
                 <t t-if="props.order === 'asc'">

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -383,7 +383,7 @@ export function useVisible(refName, cb, { ready = true } = {}) {
  * @property {number|null} highlightedMessageId
  * @returns {MessageScrolling}
  */
-export function useMessageScrolling(duration = 2000) {
+export function useMessageScrolling(duration = 1500) {
     let timeout;
     const state = useState({
         clear() {


### PR DESCRIPTION
**Current behavior before PR:**
When a message is highlighted it visually `jumps` due to a vertical translation (`translateY`). This animation creates a layout shift that is distracting and makes the text difficult to read while the transition is occurring.

**Desired behavior after PR is merged:**
The highlighted message now remains static, eliminating the visual jump. Instead, the focus is achieved by dimming and applying a blur effect to all surrounding messages and elements in the thread. This creates a stable `spotlight` effect that improves readability and focus on highlighted message.

Before
![before](https://github.com/user-attachments/assets/ee31c1e2-e902-4222-8f11-a0394fd53a86)

After
![after](https://github.com/user-attachments/assets/45a63230-7385-4767-929c-526197e061b7)


task-[4543530](https://www.odoo.com/odoo/project/1519/tasks/4543530)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
