### PR TITLE
[FIX] l10n_my: fix aggregation_formula of expressions in SST-02

### DIFF
--- a/addons/l10n_my/data/account_tax_report_data.xml
+++ b/addons/l10n_my/data/account_tax_report_data.xml
@@ -167,6 +167,7 @@
                         <field name="name">12) Total Value of Tax Payable</field>
                         <field name="name@ms_MY">12) Jumlah Nilai Cukai Yang Kena Dibayar</field>
                         <field name="code">SST02_PTV</field>
+                        <field name="aggregation_formula" eval="False"/>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
                             <record id="l10n_my_sst_tax_payable_total_value_agg_d" model="account.report.expression">
@@ -252,6 +253,7 @@
                         <field name="name">14) Total Tax Payable Before Penalty Imposed</field>
                         <field name="name@ms_MY">14) Jumlah Cukai Yang Kena Dibayar Seblum Penalti Dikenakan</field>
                         <field name="code">SST02_PTBP</field>
+                        <field name="aggregation_formula" eval="False"/>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
                             <record id="l10n_my_sst_tax_payable_total_before_penalty_agg_d" model="account.report.expression">
@@ -278,6 +280,7 @@
                     <record id="l10n_my_sst_total_including_penalty" model="account.report.line">
                         <field name="name">16) Total of Tax Payable Inclusive Penalty</field>
                         <field name="name@ms_MY">16) Jumlah Cukai Kena Dibayar Termasuk Penalti</field>
+                        <field name="aggregation_formula" eval="False"/>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
                             <record id="l10n_my_sst_total_including_penalty_agg_d" model="account.report.expression">


### PR DESCRIPTION
Steps To Reproduce:
-
- Create a database in version 18.4 or earlier.
- Install the `l10n_my` module.
- Migrate the database to version 19.
- Open the Tax Report  `SST-02 (B2, C, D, E)`. You will get an Invalid Operation error.

Issue
-
- In this [commit](https://github.com/odoo/odoo/commit/965e4b1ff56e998a8824d133f268810eb6d775f3) `aggregation_formula` was removed and new introduced `expression_ids`
- After migration, the old data still exists in the database. Due to this old `aggregation_formula`, the error occurs.

Solution
-
- To resolve this issue Set `aggregation_formula` to False

**Before fix:**
```sql
suba_17_18.0=> select id,report_line_id,label,engine,formula from account_report_expression where report_line_id in (6,12,14);
 id | report_line_id |  label  |   engine    |                                        formula                                         
----+----------------+---------+-------------+----------------------------------------------------------------------------------------
  5 |              6 | balance | aggregation | SST_5.balance + SST_10.balance + SST_6.balance + SST_H.balance
 10 |             12 | balance | aggregation | SST_PTV.balance - SST_CN.balance + SST_SAD.balance + SST_SED.balance + SST_TDA.balance
 12 |             14 | balance | aggregation | SST_PTBP.balance + SST_P.balance
(3 rows)

suba_17_18.0_19.0=> select id,report_line_id,label,engine,formula from account_report_expression where report_line_id in (6,12,14);
 id  | report_line_id |   label   |   engine    |                                                           formula                                                           
-----+----------------+-----------+-------------+-----------------------------------------------------------------------------------------------------------------------------
   5 |              6 | balance   | aggregation | SST_5.balance + SST_10.balance + SST_6.balance + SST_H.balance
 196 |              6 | balance_d | aggregation | SST02_5.balance_d + SST02_10.balance_d + SST02_6.balance_d + SST02_8.balance_d + SST02_H_8.balance_d + SST02_H_25.balance_d
  10 |             12 | balance   | aggregation | SST_PTV.balance - SST_CN.balance + SST_SAD.balance + SST_SED.balance + SST_TDA.balance
 203 |             12 | balance_d | aggregation | SST02_PTV.balance_d - SST02_CN.balance_d - SST02_SAD.balance_d - SST02_SED.balance_d - SST02_TDA.balance_d
  12 |             14 | balance   | aggregation | SST_PTBP.balance + SST_P.balance
 205 |             14 | balance_d | aggregation | SST02_PTBP.balance_d + SST02_P.balance_d
(6 rows)


```

**After fix:**
```sql
suba_17_18.0_19.0=> select id,report_line_id,label,engine,formula from account_report_expression where report_line_id in (6,12,14);
 id  | report_line_id |   label   |   engine    |                                                           formula                                                           
-----+----------------+-----------+-------------+-----------------------------------------------------------------------------------------------------------------------------
 196 |              6 | balance_d | aggregation | SST02_5.balance_d + SST02_10.balance_d + SST02_6.balance_d + SST02_8.balance_d + SST02_H_8.balance_d + SST02_H_25.balance_d
 203 |             12 | balance_d | aggregation | SST02_PTV.balance_d - SST02_CN.balance_d - SST02_SAD.balance_d - SST02_SED.balance_d - SST02_TDA.balance_d
 205 |             14 | balance_d | aggregation | SST02_PTBP.balance_d + SST02_P.balance_d
(3 rows)

```

OPW - [5489736](https://www.odoo.com/odoo/project/70/tasks/5489736)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
