### PR TITLE
[FIX] account: Clear message_main_attachment_id field at unattaching

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -379,6 +379,10 @@ class AccountDocumentImportMixin(models.AbstractModel):
     # Helpers to consistently attach/unattach attachments to records
     # --------------------------------------------------------------
 
+    def _attachment_fields_to_clear(self):
+        """ Return a list of fields that should be cleared when an attachment is unattached from the record. """
+        return []
+
     def _fix_attachments_on_record(self, attachments):
         """ Ensure that only attachments of certain types appear in `self`'s attachments.
 
@@ -396,6 +400,8 @@ class AccountDocumentImportMixin(models.AbstractModel):
             })
         attachments_to_unattach = (attachments - attachments_to_attach).filtered(lambda a: a.res_model == self._name and not a.res_field)
         if attachments_to_unattach:
+            for fname in self._attachment_fields_to_clear():
+                self[fname] -= attachments_to_unattach
             attachments_to_unattach.write({
                 'res_model': False,
                 'res_id': 0,

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6897,6 +6897,9 @@ class AccountMove(models.Model):
 
         return move
 
+    def _attachment_fields_to_clear(self):
+        return super()._attachment_fields_to_clear() + ['message_main_attachment_id']
+
     def _message_post_after_hook(self, new_message, message_values):
         """ This method processes the attachments of a new mail.message. It handles the 3 following situations:
             (1) receiving an e-mail from a mail alias. In that case, we potentially want to split the attachments into several invoices.

--- a/addons/account/tests/test_account_incoming_supplier_invoice.py
+++ b/addons/account/tests/test_account_incoming_supplier_invoice.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from odoo import Command
 from odoo.exceptions import ValidationError
 from odoo.tests import tagged, RecordCapturer
+from odoo.tools import file_open
 from odoo.tools.misc import mute_logger
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -967,3 +968,44 @@ class TestAccountIncomingSupplierInvoice(AccountTestInvoicingCommon, TestAccount
             move_id = self.journal.create_document_from_attachment(attachment.ids).get('res_id')
 
         self.assertEqual(self.env['account.move'].browse(move_id).attachment_ids, attachment)
+
+    def test_import_xml_with_embedded_pdf(self):
+        with file_open("account/tests/test_files/xml_with_embedded_pdf.xml", 'rb') as file:
+            xml_vals = {'name': 'invoice.xml', 'raw': file.read(), 'mimetype': 'application/xml'}
+
+        self.assert_attachment_import(
+            origin='journal',
+            attachments_vals=[xml_vals],
+            expected_invoices={
+                1: {
+                    'invoice.xml': {
+                        'on_invoice': True,
+                        'on_message': True,
+                        'is_decoded': True,
+                        'is_new': True,
+                    },
+                    'test_pdf.pdf': {
+                        'on_invoice': True,
+                        'on_message': True,
+                    },
+                },
+            },
+        )
+
+        self.assert_attachment_import(
+            origin='mail_alias',
+            attachments_vals=[xml_vals],
+            expected_invoices={
+                1: {
+                    'invoice.xml': {
+                        'on_message': True,
+                        'is_decoded': True,
+                        'is_new': True,
+                    },
+                    'test_pdf.pdf': {
+                        'on_invoice': True,
+                        'on_message': True,
+                    },
+                },
+            },
+        )

--- a/addons/account/tests/test_files/xml_with_embedded_pdf.xml
+++ b/addons/account/tests/test_files/xml_with_embedded_pdf.xml
@@ -1,0 +1,146 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>F26/0045</cbc:ID>
+	<cbc:IssueDate>2026-02-28</cbc:IssueDate>
+	<cbc:DueDate>2026-02-01</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:Note>Test Invoice Note</cbc:Note>
+	<cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+	<cac:OrderReference>
+		<cbc:ID>F26/0045</cbc:ID>
+	</cac:OrderReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>test_pdf.pdf</cbc:ID>
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="test_pdf.pdf">
+				JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PAovVHlwZSAvQ2F0YWxvZwovUGFnZXMgMiAwIFIKPj4KZW5kb2JqCjIgMCBvYmoKPDwKL1R5cGUgL1BhZ2VzCi9Db3VudCAxCi9LaWRzIFszIDAgUl0KPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovTWVkaWFCb3ggWzAgMCAzMDAgMTQ0XQovQ29udGVudHMgNCAwIFIKL1Jlc291cmNlcyA8PAovRm9udCA8PAovRjEgNSAwIFIKPj4KPj4KPj4KZW5kb2JqCjQgMCBvYmoKPDwKL0xlbmd0aCA0NAo+PgpzdHJlYW0KQlQgL0YxIDEyIFRmIDUwIDcwIFRkIChIZWxsbyBQREYpIFRqIEVUCmVuZHN0cmVhbQplbmRvYmoKNSAwIG9iago8PAovVHlwZSAvRm9udAovU3VidHlwZSAvVHlwZTEKL05hbWUgL0YxCi9CYXNlRm9udCAvSGVsdmV0aWNhCj4+CmVuZG9iagp4cmVmCjAgNgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMTAgMDAwMDAgbiAKMDAwMDAwMDA2MSAwMDAwMCBuIAowMDAwMDAwMTE2IDAwMDAwIG4gCjAwMDAwMDAyMjAgMDAwMDAgbiAKMDAwMDAwMDMxNSAwMDAwMCBuIAp0cmFpbGVyCjw8Ci9TaXplIDYKL1Jvb3QgMSAwIFIKPj4Kc3RhcnR4cmVmCjM5MAolJUVPRgo=
+			</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0239843188</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>Testing company</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Street</cbc:StreetName>
+				<cbc:CityName>City</cbc:CityName>
+				<cbc:PostalZone>5000</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0239843188</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>Testing company</cbc:RegistrationName>
+				<cbc:CompanyID>BE0239843188</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Testing company</cbc:Name>
+				<cbc:Telephone>+32 123 12 12 12</cbc:Telephone>
+				<cbc:ElectronicMail>info@testingcompany.be</cbc:ElectronicMail>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="0208">0239843189</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>Odoo</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Street</cbc:StreetName>
+				<cbc:CityName>City</cbc:CityName>
+				<cbc:PostalZone>5001</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>BE0239843189</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>Odoo</cbc:RegistrationName>
+				<cbc:CompanyID>BE0239843189</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Odoo</cbc:Name>
+				<cbc:Telephone>+1 123-123-1234</cbc:Telephone>
+				<cbc:ElectronicMail>info@odoo.com</cbc:ElectronicMail>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:Delivery>
+		<cac:DeliveryLocation>
+			<cac:Address>
+				<cbc:StreetName>Street</cbc:StreetName>
+				<cbc:CityName>City</cbc:CityName>
+				<cbc:PostalZone>5001</cbc:PostalZone>
+				<cac:Country>
+					<cbc:IdentificationCode>BE</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:DeliveryLocation>
+	</cac:Delivery>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+		<cbc:PaymentID>F26/0045</cbc:PaymentID>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>BE0239843189</cbc:ID>
+			<cac:FinancialInstitutionBranch>
+				<cbc:ID>REVOBEB2</cbc:ID>
+			</cac:FinancialInstitutionBranch>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="EUR">713.14</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">3395.92</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">713.14</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="EUR">3395.92</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">3395.92</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">4109.06</cbc:TaxInclusiveAmount>
+		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+		<cbc:PayableAmount currencyID="EUR">4109.06</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>1</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">3395.92</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Description>PO1234</cbc:Description>
+			<cbc:Name>Commission</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>21.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">3395.92</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>


### PR DESCRIPTION
Problem:
when a user uploads an XML file containing an embedded PDF to create a bill,
the bill is created correctly and the PDF is set as the main attachment.
However, when the same XML is used to create a bill via email aliases,
the PDF is not set as the bill’s main attachment.

Root cause:
1. When an email is received, it's first posted as a message on the bill chatter
2. Posting the email sets its XML as the main attachment of the bill
3. _fix_attachments_on_record from account.document.import.mixin then removes res_id and res_model fields from the XML
4. The PDF is then attached as the main attachment of the bill
5. In documents_account module, when the PDF is set as the main attachment,
it mistakenly assigns it as an attachment to the XML document because the XML was assigned as the bill main attachment,
resulting in the bill having no attachment actually linked to it.

Solution:
This commit fixes this issue by clearing the field message_main_attachment_id whenever the attachment in it
gets unattached in _fix_attachment_on_record.

task-5900088