### PR TITLE
[IMP] website: clarify default website language behavior

### DIFF
--- a/addons/website/models/res_config_settings.py
+++ b/addons/website/models/res_config_settings.py
@@ -206,6 +206,7 @@ class ResConfigSettings(models.TransientModel):
             self.website_default_lang_id = False
         elif self.website_default_lang_id not in language_ids:
             self.website_default_lang_id = language_ids[0]
+        self.website_language_count = len(language_ids)
 
     def action_website_create_new(self):
         return {

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -50,7 +50,7 @@
                             <field name="language_ids" widget="many2many_tags" options="{'no_create': True, 'no_open': True}" required="website_id"/>
                             <div class="row mt8" invisible="website_language_count &lt; 2">
                                 <label class="col-lg-3" string="Default" for="website_default_lang_id"/>
-                                <field name="website_default_lang_id" options="{'no_open': True, 'no_create': True}" required="website_id"/>
+                                <field name="website_default_lang_id" options="{'no_open': True, 'no_create': True}" required="website_id" domain="[('id', 'in', language_ids)]"/>
                             </div>
                             <div class="mt8">
                                 <button type="action" name="%(base.action_view_base_language_install)d" string="Install new languages" class="btn-link" icon="oi-arrow-right"/>

--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -43,6 +43,10 @@
                         <setting string="Languages"
                                  title="Languages available on your website"
                                  documentation="/applications/websites/website/configuration/translate.html">
+                            <div class="text-muted mt-n3 mb16">
+                                <span invisible="website_language_count &lt; 2">Website visitors see the version matching their browser language, or the default if unavailable.</span>
+                                <span invisible="website_language_count &gt;= 2">Install multiple languages to enable translation across your website.</span>
+                            </div>
                             <field name="language_ids" widget="many2many_tags" options="{'no_create': True, 'no_open': True}" required="website_id"/>
                             <div class="row mt8" invisible="website_language_count &lt; 2">
                                 <label class="col-lg-3" string="Default" for="website_default_lang_id"/>


### PR DESCRIPTION
1. Clarify default website language behavior
    Previously, the purpose of a website's default language was unclear to many users. It was commonly assumed that the website would always open in the selected default language.
    
    In practice, if a visitor's browser language is available on website, it takes precedence over the default language. This PR adds clear help messages to explain the same.

2. Restrict default languages to installed ones
    
    Before this PR, users could select a default language that was not installed on the website.

    Steps to reproduce:
    i. Add new languages in Settings > General.
    ii. Add a language in Settings > Website > Languages.
    iii. Go to Settings > Website > Languages > Default.

    The default language dropdown included languages which are not installed on the website.
    
    After this PR, only languages installed on the website are available for default language selection.

task-5901757

**After this PR**
| If single language is installed | If multiple languages are installed |
|-----------------------------|---------------------------------|
| <img width="394" height="216" alt="image" src="https://github.com/user-attachments/assets/d4c7633c-da57-441e-ad3c-b0105f1913e4" /> | <img width="452" height="216" alt="image" src="https://github.com/user-attachments/assets/cb24dbba-39ef-4ad6-bd65-657aa1c704bd" /> |