### PR TITLE
[IMP] l10n_tr_nilvera_einvoice: add new field for Nilvera PDFs

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move_send.py
@@ -29,8 +29,8 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         # Add the Nilvera PDF to the mail attachments.
         attachments = super()._get_invoice_extra_attachments(move)
-        if move.l10n_tr_nilvera_send_status == 'succeed' and move.message_main_attachment_id.id != move.invoice_pdf_report_id.id:
-            attachments += move.message_main_attachment_id
+        if move.l10n_tr_nilvera_send_status == 'succeed' and move.l10n_tr_nilvera_pdf_id:
+            attachments += move.l10n_tr_nilvera_pdf_id
         return attachments
 
     # -------------------------------------------------------------------------

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
@@ -279,4 +279,5 @@ class TestTRNilveraMockedRequests(TestUBLTRCommon):
 
             invoice = self.env['account.move'].search([('l10n_tr_nilvera_uuid', '=', 'invoice_uuid')])
             self.assertEqual(len(invoice), 1)
-            self.assertListEqual(sorted(invoice.attachment_ids.mapped('mimetype')), ['application/pdf', 'application/xml'])
+            self.assertListEqual(sorted(invoice.attachment_ids.mapped('mimetype')), ['application/xml'])
+            self.assertTrue(invoice.l10n_tr_nilvera_pdf_id)


### PR DESCRIPTION
Before this commit, the PDF generated by Nilvera was stored as a generic attachment (message_main_attachment_id) on the invoice because a dedicated field could not be added in the stable version.

To find out which invoices still needed to download their Nilvera generatedPDF, a workaround was used in stable to avoid adding a field.

This commit adds a new dedicated field for the Nilvera PDF to replace that workaround.

Upgrade PR: https://github.com/odoo/upgrade/pull/9408

task-5904554