### PR TITLE
[IMP] http: move session methods

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -10,6 +10,7 @@ from odoo import SUPERUSER_ID, _, api
 from odoo.exceptions import AccessDenied
 from odoo.http import Controller, Response, request, route
 from odoo.http.router import db_filter
+from odoo.http.session import authenticate
 from odoo.modules.registry import Registry
 from odoo.tools.misc import clean_context
 
@@ -147,7 +148,7 @@ class OAuthController(Controller):
                 url = '/odoo?menu_id=%s' % menu
 
             credential = {'login': login, 'token': key, 'type': 'oauth_token'}
-            auth_info = request.session.authenticate(request.env, credential)
+            auth_info = authenticate(request.session, request.env, credential)
             resp = request.redirect(_get_login_redirect_url(auth_info['uid'], url), 303)
             resp.autocorrect_location_header = False
 

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -12,6 +12,7 @@ from odoo.addons.base_setup.controllers.main import BaseSetup
 from odoo.exceptions import UserError
 from odoo.tools.translate import LazyTranslate
 from odoo.http import request
+from odoo.http.session import authenticate
 from markupsafe import Markup
 
 _lt = LazyTranslate(__name__)
@@ -179,7 +180,7 @@ class AuthSignupHome(Home):
         login, password = request.env['res.users'].sudo().signup(values, token)
         credential = {'login': login, 'password': password, 'type': 'password'}
         if do_login:
-            request.session.authenticate(request.env, credential)
+            authenticate(request.session, request.env, credential)
 
 class AuthBaseSetup(BaseSetup):
     @http.route()

--- a/addons/base_import_module/controllers/main.py
+++ b/addons/base_import_module/controllers/main.py
@@ -4,6 +4,7 @@ import functools
 from odoo import _
 from odoo.exceptions import AccessError
 from odoo.http import Controller, route, request, Response
+from odoo.http.session import authenticate
 
 
 class ImportModule(Controller):
@@ -15,7 +16,7 @@ class ImportModule(Controller):
             if not request.db:
                 raise Exception(_("Could not select database '%s'", request.db))
             credential = {'login': login, 'password': password, 'type': 'password'}
-            request.session.authenticate(request.env, credential)
+            authenticate(request.session, request.env, credential)
             # request.env.uid is None in case of MFA
             if request.env.uid and request.env.user._is_admin():
                 return request.env['ir.module.module']._import_zipfile(mod_file, force=force == '1')[0]

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -2,6 +2,7 @@
 
 from odoo import models
 from odoo.http import request
+from odoo.http.session import check
 from odoo.tools.misc import OrderedSet
 from ..models.bus import dispatch
 from ..websocket import wsrequest
@@ -74,7 +75,7 @@ class IrWebsocket(models.AbstractModel):
     @classmethod
     def _authenticate(cls):
         if wsrequest.session.uid is not None:
-            wsrequest.session._check(wsrequest)
+            check(wsrequest.session, wsrequest)
         else:
             public_user = wsrequest.env.ref('base.public_user')
             wsrequest.update_env(user=public_user.id)

--- a/addons/bus/session_helpers.py
+++ b/addons/bus/session_helpers.py
@@ -3,7 +3,7 @@ import hmac
 import time
 
 from odoo.api import Environment
-from odoo.http.session import SessionExpiredException
+from odoo.http.session import delete_old_sessions, SessionExpiredException
 from odoo.modules.registry import Registry
 from odoo.sql_db import SQL
 from odoo.tools.lru import LRU
@@ -34,7 +34,7 @@ def _get_session_token_query_params(cr, session):
 
 
 def check_session(cr, session):
-    session._delete_old_sessions()
+    delete_old_sessions(session)
     if 'deletion_time' in session and session['deletion_time'] <= time.time():
         e = "session is too old"
         raise SessionExpiredException(e)

--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -8,6 +8,7 @@ from odoo import _, http
 from odoo.exceptions import UserError
 from odoo.fields import Domain
 from odoo.http import request
+from odoo.http.session import logout, touch
 from odoo.http.stream import content_disposition
 from odoo.tools import SQL, float_round, py_to_js_locale
 from odoo.tools.image import image_data_uri
@@ -83,7 +84,7 @@ class HrAttendance(http.Controller):
             # before leaving the kiosk mode open to the public. This is a prevention security
             # measure.
             if self.has_password():
-                request.session.logout(keep_db=True)
+                logout(request.session, keep_db=True)
             return request.redirect(request.env['res.company'].browse(company_id).attendance_kiosk_url)
         else:
             return request.not_found()
@@ -155,7 +156,7 @@ class HrAttendance(http.Controller):
 
     @http.route('/hr_attendance/kiosk_keepalive', auth='user', type='jsonrpc')
     def kiosk_keepalive(self):
-        request.session.touch()
+        touch(request.session)
         return {}
 
     @http.route(["/hr_attendance/<token>"], type='http', auth='public', website=True, sitemap=True)
@@ -176,7 +177,7 @@ class HrAttendance(http.Controller):
             ]
             has_password = self.has_password()
             if not from_trial_mode and has_password:
-                request.session.logout(keep_db=True)
+                logout(request.session, keep_db=True)
             if (from_trial_mode or (not has_password and not request.env.user.is_public)):
                 kiosk_mode = "settings"
             else:

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -16,6 +16,7 @@ from odoo.exceptions import (
     ValidationError,
 )
 from odoo.http import Controller, request, route
+from odoo.http.session import logout
 from odoo.http.stream import content_disposition
 from odoo.tools import clean_context, consteq, single_email_re, str2bool
 from odoo.tools.translate import LazyTranslate
@@ -933,7 +934,7 @@ class CustomerPortal(Controller):
             try:
                 request.env['res.users']._check_credentials(credential, {'interactive': True})
                 request.env.user.sudo()._deactivate_portal_user(**post)
-                request.session.logout()
+                logout(request.session)
                 return request.redirect('/web/login?message=%s' % urls.url_quote(_('Account deleted!')))
             except AccessDenied:
                 values['errors'] = {'deactivate': 'password'}

--- a/addons/web/controllers/database.py
+++ b/addons/web/controllers/database.py
@@ -19,6 +19,7 @@ import odoo.modules.registry
 from odoo import release
 from odoo.http import Controller, Response, request, route
 from odoo.http.router import db_list
+from odoo.http.session import authenticate, logout
 from odoo.sql_db import db_connect
 from odoo.tools.misc import file_open, str2bool
 from odoo.tools.translate import _
@@ -173,7 +174,7 @@ class Database(Controller):
             credential = {'login': post['login'], 'password': password, 'type': 'password'}
             with odoo.modules.registry.Registry(name).cursor() as cr:
                 env = odoo.api.Environment(cr, None, {})
-                request.session.authenticate(env, credential)
+                authenticate(request.session, env, credential)
                 request._save_session(env)
                 request.session.db = name
             return request.redirect('/odoo')
@@ -207,7 +208,7 @@ class Database(Controller):
             verify_access(master_pwd)
             odoo.modules.db.drop(name)
             if request.session.db == name:
-                request.session.logout()
+                logout(request.session)
             return request.redirect('/web/database/manager')
         except Exception as e:
             e.error_response = _render_exception(e)

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -10,6 +10,7 @@ from odoo import http, tools, models
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.fields import Domain
 from odoo.http import request
+from odoo.http.session import touch
 from odoo.tools import html2plaintext
 from odoo.tools.misc import get_lang
 from odoo.tools import sql
@@ -337,5 +338,5 @@ class WebsiteBlog(http.Controller):
                 if not request.session.get('posts_viewed'):
                     request.session['posts_viewed'] = []
                 request.session['posts_viewed'].append(blog_post.id)
-                request.session.touch()
+                touch(request.session)
         return response

--- a/addons/website_sale/controllers/wishlist.py
+++ b/addons/website_sale/controllers/wishlist.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.http import Controller, request, route
+from odoo.http.session import touch
 
 
 class ProductWishlist(Controller):
@@ -50,7 +51,7 @@ class ProductWishlist(Controller):
             wish_ids = request.session.get('wishlist_ids') or []
             if wish_id in wish_ids:
                 request.session['wishlist_ids'].remove(wish_id)
-                request.session.touch()
+                touch(request.session)
                 wish.sudo().unlink()
         else:
             wish.unlink()

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -17,6 +17,7 @@ from odoo.addons.website_profile.controllers.main import WebsiteProfile
 from odoo.exceptions import AccessError, ValidationError, UserError, MissingError
 from odoo.fields import Domain
 from odoo.http import request, Response
+from odoo.http.session import touch
 from odoo.tools import consteq, email_normalize_all
 from odoo.tools.translate import LazyTranslate
 
@@ -86,7 +87,7 @@ class WebsiteSlides(WebsiteProfile):
             if slide_id not in viewed_slides:
                 if tools.sql.increment_fields_skiplock(slide, 'public_views', 'total_views'):
                     viewed_slides[slide_id] = 1
-                    request.session.touch()
+                    touch(request.session)
         else:
             slide.action_set_viewed(quiz_attempts_inc=quiz_attempts_inc)
         return True

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -26,6 +26,7 @@ from odoo.exceptions import AccessError, RedirectWarning, UserError, ValidationE
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.http.router import root
+from odoo.http.session import update_session_token
 from odoo.tools import config, is_html_empty, parse_version, split_every
 from odoo.tools.barcode import (
     check_barcode_encoding,
@@ -566,7 +567,7 @@ class IrActionsReport(models.Model):
                     '_trace_disable': True,
                 })
                 if temp_session.uid:
-                    temp_session._update_session_token(self.env)
+                    update_session_token(temp_session, self.env)
                 root.session_store.save(temp_session)
                 stack.callback(root.session_store.delete, temp_session)
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -38,6 +38,7 @@ from odoo.http.requestlib import is_cors_preflight
 from odoo.http.router import root
 from odoo.http.routing_map import ROUTING_KEYS
 from odoo.http.session import (
+    check,
     CheckIdentityException,
     SessionExpiredException,
     get_session_max_inactivity,
@@ -289,7 +290,7 @@ class IrHttp(models.AbstractModel):
         try:
             if request.session.uid is not None:
                 try:
-                    request.session._check(request)
+                    check(request.session, request)
                 except SessionExpiredException as exc:
                     session_expired_exc = exc  # save the traceback
                     request.env = api.Environment(request.env.cr, None, request.session.context)

--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from odoo import api, fields, models, tools
 from odoo.http import request
 from odoo.http.router import root
-from odoo.http.session import STORED_SESSION_BYTES, get_session_max_inactivity
+from odoo.http.session import STORED_SESSION_BYTES, get_session_max_inactivity, logout, update_device
 from odoo.tools import SQL
 from odoo.tools._vendor.useragents import UserAgent
 from odoo.tools.translate import _
@@ -52,7 +52,7 @@ class ResDeviceLog(models.Model):
 
             :param request: Request or WebsocketRequest object
         """
-        device = request.session.update_device(request)
+        device = update_device(request.session, request)
         if not device:
             return
 
@@ -300,4 +300,4 @@ class ResSession(models.Model):
 
         must_logout = bool(self.filtered('is_current'))
         if must_logout:
-            request.session.logout()
+            logout(request.session)

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -9,6 +9,7 @@ from psycopg2.errors import SerializationFailure
 from odoo import http
 from odoo.exceptions import AccessError, ConcurrencyError, UserError
 from odoo.http import request
+from odoo.http.session import touch
 from odoo.tools import replace_exceptions, str2bool
 
 from odoo.addons.web.controllers.utils import ensure_db
@@ -194,12 +195,12 @@ class TestHttp(http.Controller):
 
     @http.route('/test_http/save_session', type='http', auth='none')
     def touch(self):
-        request.session.touch()
+        touch(request.session)
         return ''
 
     @http.route('/test_http/no_save_session', type='http', auth='none', save_session=False)
     def no_touch(self):
-        request.session.touch()
+        touch(request.session)
         return ''
 
     # =====================================================

--- a/odoo/http/dispatcher.py
+++ b/odoo/http/dispatcher.py
@@ -212,7 +212,7 @@ class HttpDispatcher(Dispatcher):
                 })
             session = self.request.session
             was_connected = session.uid is not None
-            session.logout(keep_db=True)
+            logout(session, keep_db=True)
             response = self.request.redirect_query('/web/login', {
                 'redirect': self.request.httprequest.full_path})
             if was_connected:
@@ -400,4 +400,5 @@ from .session import (
     CheckIdentityException,
     SessionExpiredException,
     get_session_max_inactivity,
+    logout,
 )

--- a/odoo/http/requestlib.py
+++ b/odoo/http/requestlib.py
@@ -125,7 +125,7 @@ class Request:
         if session.db != dbname:
             if session.db:
                 _logger.warning("Logged into database %r, but dbfilter rejects it; logging session out.", session.db)
-                session.logout(keep_db=False)
+                logout(session, keep_db=False)
             session.db = dbname
 
         session.is_dirty = False
@@ -678,6 +678,7 @@ from .session import (
     STORED_SESSION_BYTES,
     get_default_session,
     get_session_max_inactivity,
+    logout,
 )
 from .stream import STATIC_CACHE, Stream
 

--- a/odoo/http/router.py
+++ b/odoo/http/router.py
@@ -254,7 +254,7 @@ class Application:
                         _logger.warning("Database or registry unusable, trying without", exc_info=e.__cause__)
                         # TODO: move those bits in a dedicated function
                         request.db = None
-                        request.session.logout()
+                        logout(request.session)
                         if (httprequest.path.startswith('/odoo/')
                             or httprequest.path in (
                                 '/odoo', '/web', '/web/login', '/test_http/ensure_db',
@@ -307,4 +307,4 @@ from .requestlib import (
     request,
 )
 from .routing_map import ROUTING_KEYS, _generate_routing_rules
-from .session import SessionExpiredException, SessionStore
+from .session import SessionExpiredException, SessionStore, logout

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -62,7 +62,7 @@ from odoo.exceptions import AccessError
 from odoo.fields import Command
 from odoo.http.requestlib import Request, _request_stack, request
 from odoo.http.router import root
-from odoo.http.session import DEFAULT_LANG, get_default_session
+from odoo.http.session import DEFAULT_LANG, get_default_session, logout, update_session_token
 from odoo.http.session import Session as OdooHttpSession
 from odoo.modules.registry import Registry
 from odoo.sql_db import Cursor, Savepoint
@@ -2375,7 +2375,7 @@ class HttpCase(TransactionCase):
             odoo.tools.misc.dumpstacks()
 
     def logout(self, keep_db=True):
-        self.session.logout(keep_db=keep_db)
+        logout(self.session, keep_db=keep_db)
         root.session_store.save(self.session)
 
     def authenticate(self, user, password, browser: ChromeBrowser = None):
@@ -2406,7 +2406,7 @@ class HttpCase(TransactionCase):
             session['login'] = user
             session['session_token'] = None
             if uid:
-                session._update_session_token(env)
+                update_session_token(session, env)
             session['context'] = dict(env['res.users'].context_get())
 
         root.session_store.save(session)


### PR DESCRIPTION
The session is a critical object.
The goal of this commit is to limit its exposure.

Developers should use the session as a dictionary (`MutableMapping`).
Developers should (generally) not use internal logic that processes the
session.

To achieve this, this commit moves the methods from the `Session` class
to make them module-level functions.

Task-5882018