### PR TITLE
[FIX] web: fix two datetime field non deterministic tests

### DIFF
--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -8078,9 +8078,9 @@ test(`list view, editable, without data`, async () => {
         type: "list",
         arch: `
             <list editable="top">
+                <field name="foo"/>
                 <field name="date"/>
                 <field name="m2o"/>
-                <field name="foo"/>
                 <button type="object" icon="fa-plus-square" name="method"/>
             </list>
         `,
@@ -8102,7 +8102,7 @@ test(`list view, editable, without data`, async () => {
     expect(`tbody tr:eq(0)`).toHaveClass("o_selected_row", {
         message: "the date field td should be in edit mode",
     });
-    expect(`tbody tr:eq(0) td:eq(1)`).toHaveText("Feb 10, 2017", {
+    expect(`tbody tr:eq(0) td:eq(2)`).toHaveText("Feb 10, 2017", {
         message: "the date field td should have the default value",
     });
     expect(`tr.o_selected_row .o_list_record_selector input`).toHaveProperty("disabled", true, {
@@ -8254,6 +8254,10 @@ test(`editable list view, should refocus date field`, async () => {
 
     await contains(getPickerCell("15")).click();
     expect(`.o_datetime_picker`).toHaveCount(0);
+
+    // the datetime field is rendered multiple times before `picker.activeInput`
+    // is reset, and so before the field displays a button instead of the input
+    await waitFor(`.o_field_widget[name=date] button`);
     expect(`.o_field_widget[name=date] button`).toHaveValue("02/15/2017");
     expect(`.o_field_widget[name=date] button`).toBeFocused();
 });


### PR DESCRIPTION
This commit fixes two unit tests involving the datetime field which are randomly failing since [1].

In the first one, we add a record in an editable list view. The first field is automatically focused (in `onMounted`). Before this commit, the first field was the datetime. When it is focused, the datetime field re-renders itself (from a `<button>` to an `<input>` with datepicker). The test failed when those two renderings were done within the same animationFrame, which was rare but possible. We fix the test by moving `foo` field before `date`, that way, the date field is never focused, and we can properly assert the default date value.

In the second one, again in an editable list, we select a date in the picker, and we then assert that the field is rendered with a `<button>` whose text is correct. The test sometimes failed because there was no button (the field was still displaying an `<input>`). When the value is selected, an update is done in the model, which triggers a re-rendering. At that moment, the picker still states that there's an `activeInput` ("date"), so the field is rendered with an input. The picker state is only updated afterwards, so there's another rendering, where `picker.activeInput` is "", which leads to the expected `<button>` being rendered. However, that rendering can happen in another animationFrame, thus triggering the issue. This commit fixes it by simply waiting for the button to be displayed.

[1] https://github.com/odoo/odoo/pull/218387

runbot error-238437 (1)
runbot error-238758 (2)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
