### PR TITLE
[FIX] mail: no composer local storage save on empty

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -942,14 +942,20 @@ export class Composer extends Component {
             emailAddSignature,
             replyToMessageId,
         }) => {
-            browser.localStorage.setItem(
-                composer.localId,
-                JSON.stringify({
-                    emailAddSignature,
-                    replyToMessageId,
-                    composerHtml: isMarkup(composerHtml) ? ["markup", composerHtml] : composerHtml,
-                })
-            );
+            if (isHtmlEmpty(composerHtml) && emailAddSignature && !replyToMessageId) {
+                browser.localStorage.removeItem(composer.localId);
+            } else {
+                browser.localStorage.setItem(
+                    composer.localId,
+                    JSON.stringify({
+                        emailAddSignature,
+                        replyToMessageId,
+                        composerHtml: isMarkup(composerHtml)
+                            ? ["markup", composerHtml]
+                            : composerHtml,
+                    })
+                );
+            }
         };
         if (this.state.isFullComposerOpen) {
             this.fullComposerBus.trigger("SAVE_CONTENT", {


### PR DESCRIPTION
Before this commit, composer content was saved in local storage even when the content is empty.

This happens because while there's code to clear local storage entry on message post, the content was necessarily saved from debounced or when triggering an action that unmounts the composer of thread, like a change of active thread in discuss.

This commit fixes the issue by checking that composer has some content, to determine whether the content must be saved in local storage or explicitly removed.

Task-5905834