### PR TITLE
[FIX] point_of_sale:  print combo choice items to preparation printers

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -39,6 +39,13 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
     let changesCount = 0;
     let changeAbsCount = 0;
 
+    const hasPreparationCategory = (product) => {
+        if (!product) {
+            return false;
+        }
+        return product.parentPosCategIds.some((id) => prepaCategoryIds.has(id));
+    };
+
     // Compares the orderlines of the order with the last ones sent.
     // When one of them has changed, we add the change.
     for (const orderline of order.getOrderlines()) {
@@ -46,14 +53,14 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
         const note = orderline.getNote();
         const customerNote = orderline.getCustomerNote();
         const lineKey = orderline.uuid;
-        const baseProduct = orderline.combo_parent_id
-            ? orderline.combo_parent_id.product_id
-            : product;
-        const productCategoryIds = baseProduct.parentPosCategIds.filter((id) =>
-            prepaCategoryIds.has(id)
-        );
 
-        if (productCategoryIds.length > 0) {
+        const hasPrepaCategory =
+            hasPreparationCategory(product) ||
+            hasPreparationCategory(orderline.combo_parent_id?.product_id) ||
+            orderline.combo_line_ids?.some((line) => hasPreparationCategory(line.getProduct())) ||
+            false;
+
+        if (hasPrepaCategory) {
             const key = Object.keys(order.last_order_preparation_change.lines).find((k) =>
                 k.startsWith(orderline.uuid)
             ); // find old data but note changed

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1526,6 +1526,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.printer.write({
             'product_categories_ids': [Command.set(self.env['pos.category'].search([('name', '=', 'Category 2')]).ids)],
         })
+        self.office_combo.write({
+            'pos_categ_ids': [Command.set(self.env['pos.category'].search([('name', '=', 'Category 1')]).ids)],
+        })
         self.main_pos_config.write({
             'is_order_printer': True,
             'printer_ids': [Command.set(self.printer.ids)],


### PR DESCRIPTION
Previously, combo choice items with categories assigned to a preparation printer were skipped when their category differed from the combo parent product’s category. This commit ensures that both the combo parent product’s category and the item product’s category are taken into account to correctly print items to the preparation printer.

Task: 5902389



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
