### PR TITLE
[FIX] pos_self_order: pay after meal only shows the line changes price

### DIFF
--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -69,7 +69,7 @@ export class OrderWidget extends Component {
                 if (value.qty && value.qty > 0) {
                     const line = this.selfOrder.models["pos.order.line"].getBy("uuid", key);
                     acc.count += value.qty;
-                    acc.price += line.get_display_price();
+                    acc.price += line.getDisplayPriceWithQty(value.qty);
                 }
                 return acc;
             },

--- a/addons/pos_self_order/static/src/app/models/pos_order_line.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order_line.js
@@ -40,4 +40,13 @@ patch(PosOrderline.prototype, {
     isLotTracked() {
         return false;
     },
+    getDisplayPriceWithQty(qty) {
+        const prices = this.get_all_prices(qty);
+
+        if (this.config.iface_tax_included === "total") {
+            return prices.priceWithTax;
+        } else {
+            return prices.priceWithoutTax;
+        }
+    },
 });

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -122,11 +122,13 @@ export class CartPage extends Component {
     getPrice(line) {
         const childLines = line.combo_line_ids;
         if (childLines.length == 0) {
-            return line.get_display_price();
+            const qty = this.getLineChangeQty(line) || line.qty;
+            return line.getDisplayPriceWithQty(qty);
         } else {
             let price = 0;
             for (const child of childLines) {
-                price += child.get_display_price();
+                const qty = this.getLineChangeQty(child) || child.qty;
+                price += child.getDisplayPriceWithQty(qty);
             }
             return price;
         }


### PR DESCRIPTION
Steps to reproduce
------------------
If we set pay after to "meal", order one product A for price 10, then on
the same order, adds again product A and go to cart page, we see
"product A: 1" as expected, but its price set to "20".

-> Mismatch between the shown quantity and the total price of that line.

Why it's happening
------------------
When displaying the line qty, we just display the diff (1), however,
when displaying its price, we take the price of the whole line (having
qty 2).

Fix
---
Backport the line price display amount change made in saas-18.2 in
https://github.com/odoo/odoo/commit/98f0534450520ce037039ffe0be17cf1dc3b91ba.

We also fix "Your Order" to show the price of only the products of the
newly added lines.

opw-5467612