### PR TITLE
[FIX] account: access error auto post with only account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3783,7 +3783,7 @@ class AccountMove(models.Model):
         if self.env.su:
             return
         is_user_able_to_supervise = self.env.user.has_group('account.group_account_manager')
-        is_user_able_to_review = self.env.user.has_group('account.group_account_user')
+        is_user_able_to_review = self.env.user.has_group('account.group_account_user') or is_user_able_to_supervise
         for vals in vals_list:
             if (
                 ((vals.get('review_state') == 'reviewed' or not vals.get('review_state', True)) and not is_user_able_to_review)


### PR DESCRIPTION
When a user with `group_account_manager` only tries to confirm an
invoice with auto post set, he gets an Access Error

Steps:

- Install only account
- Create an invoice, set auto post to 'monthly' for example
- Confirm
-> AccessError

Fix:

In the `_check_user_access` method, we align with what we do in the
`write` method to set the `is_user_able_to_review` variable

opw-5886542
