### PR TITLE
[FIX] web, portal: allow `confirmatioDialog` size change

### DIFF
--- a/addons/portal/static/src/interactions/portal_security.js
+++ b/addons/portal/static/src/interactions/portal_security.js
@@ -72,6 +72,7 @@ export class PortalSecurity extends Interaction {
                 duration_selection: duration.selection.filter((option) => option[0] !== "-1"),
             }),
             confirmLabel: _t("Confirm"),
+            size: 'md',
             confirm: async ({ inputEl }) => {
                 const formData = Object.fromEntries(new FormData(inputEl.closest("form")));
                 const wizardId = await this.services.orm.create("res.users.apikeys.description", [{
@@ -168,6 +169,7 @@ export async function handleCheckIdentity(wrapped, ormService, dialogService) {
                 title: _t("Security Control"),
                 body: renderToMarkup("portal.identitycheck"),
                 confirmLabel: _t("Confirm Password"),
+                size: 'md',
                 confirm: async ({ inputEl }) => {
                     if (!inputEl.reportValidity()) {
                         inputEl.classList.add("is-invalid");

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -24,6 +24,7 @@ export class ConfirmationDialog extends Component {
             },
             optional: true,
         },
+        size: { type: String, optional: true },
         body: { type: String, optional: true },
         confirm: { type: Function, optional: true },
         confirmLabel: { type: String, optional: true },
@@ -37,6 +38,7 @@ export class ConfirmationDialog extends Component {
         cancelLabel: _t("Discard"),
         confirmClass: "btn-primary",
         title: _t("Confirmation"),
+        size: "sm",
     };
 
     setup() {

--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.ConfirmationDialog">
-    <Dialog size="'sm'" title="props.title" modalRef="modalRef">
+    <Dialog size="props.size" title="props.title" modalRef="modalRef">
       <p t-out="props.body" class="text-prewrap mb-0"/>
       <t t-set-slot="footer">
         <button class="btn" t-att-class="props.confirmClass" t-on-click="_confirm" t-esc="props.confirmLabel" data-hotkey="q"/>


### PR DESCRIPTION
### Context:

A confirmation dialog must be small and minimal for several reasons:

- Users are being interrupted mid-task. A wall of text forces them to context-switch and parse information when they just need to make a quick decision
- The goal is a binary choice (confirm/discard). Too much content complicates what should be a simple yes/no moment
- ...

In the backend, our dialogs `SM` size is set to a **forgiving** `460px`. This value allows dialogs to be relatively small, while still providing enough tolerance to showcase more content if necessary.

In the frontend, instead, the default value in use is BS default, thus `300px`. A website default font-size is also much bigger, `16px` against `13px` in the backend.

As a result, the dialog may be too small when used in scenarios that are not "confirmation dialogs" strictly speaking.

### The issue:

In some cases, enforcing SM size to any confirmation dialog gives bad results in the frontend.

| backend | fronted |
|--------|--------|
| <img width="644" height="370" alt="image" src="https://github.com/user-attachments/assets/ab40312a-06df-4203-8b3d-3b2074341986" /> | <img width="667" height="416" alt="image" src="https://github.com/user-attachments/assets/c0770de4-e3c0-4a15-b2a5-6a498c94fb20" /> | 

Enforcing a higher `SM` value for the frontend (eg. `500px`) is not a solution because the default BS value is technically correct and users can customize it anyway by overriding this setting.

### The solution:

Allow the ConfirmationDialog component to use sizes different from `SM`. This commit sets some portal dialogs to MD size.

| saas-19.1 | this pr |
|--------|--------|
| <img width="667" height="416" alt="image" src="https://github.com/user-attachments/assets/c0770de4-e3c0-4a15-b2a5-6a498c94fb20" /> | <img width="953" height="605" alt="image" src="https://github.com/user-attachments/assets/07eab456-97c3-4e9d-8ce2-dd79ac5b82d4" /> | 

task-5906425

note: Several design improvements are necessary and will be handled in forward-port targeting master 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
