### PR TITLE
[FIX] pos_hr: prevent loading all employees

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -53,7 +53,7 @@ class PosConfig(models.Model):
 
     def _employee_domain(self, user_id):
         domain = self._check_company_domain(self.company_id)
-        if len(self.basic_employee_ids) > 0:
+        if len(self.basic_employee_ids + self.advanced_employee_ids + self.minimal_employee_ids) > 0:
             domain = AND([
                 domain,
                 ['|', ('user_id', '=', user_id), ('id', 'in', self.basic_employee_ids.ids + self.advanced_employee_ids.ids + self.minimal_employee_ids.ids)]


### PR DESCRIPTION
Before this commit, when some employee was assigned to advanced or minimal employee, all of the employees were loaded in the POS session, because there was no basic employee assigned to the POS config.

opw-5898068

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
