### PR TITLE
[FIX] website_event_sale: ensure address form redirection for public user payment

### DIFF
--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -56,6 +56,17 @@ registry.category("web_tour.tours").add('event_buy_last_ticket', {
         run: "click",
         expectUnloadPage: true,
     },
+    ...wsTourUtils.fillAdressForm(
+        {
+            name: "John Doe",
+            phone: "123456789",
+            email: "johndoe@gmail.com",
+            street: "1 rue de la paix",
+            city: "Paris",
+            zip: "75000",
+        },
+        true,
+    ),
     ...wsTourUtils.payWithTransfer(true),
     ],
 });

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -258,10 +258,11 @@ class SaleOrder(models.Model):
     def _needs_customer_address(self):
         """Return whether we need the address details of the customer (country, street, ...).
 
-        If an order only has services, unless the customer wants an invoice, their checkout can
-        be sped up by allowing them to only provide their name, email and phone numbers.
+        Make it true by default as it's required before payment for taxes based on fiscal position.
         """
-        return not self.only_services
+        # TODO: should probably be removed in master, as we cannot skip the address form
+        # when the taxes applied on product/service depend on the fiscal position.
+        return True
 
     def _update_address(self, partner_id, fnames=None):
         if not fnames:


### PR DESCRIPTION
**Steps to reproduce:**
- Install Website/Event/Sales apps
- Create a new event and set a ticket price
- Create a fiscal position (with specific tax) for a country with `auto_apply` enabled
- Publish the event
- Register to the event as a anonymous user
- The process bypasses the address form and goes directly to payment
- The resulting sale order will have no fiscal position
- Prices won't be impacted by taxes related to the user billing address

**Issue:**
Address form is skipped before payment for event registration of a public user as `_needs_customer_address` is not overwritten properly in some module. This is probably due to a refactoring that changed how the required information is evaluated in the payment flow (see related commit).

**Fix:**
Set `_needs_customer_address` to `True` by default to avoid such issues in
dependant modules. Might need to remove this feature in master as the workarounds are
not that clean (geo_ip, check on fiscal position enabled, overwrite everywhere, others ?).

Similar fix is done for appointments with payment enabled.

related: https://github.com/odoo/odoo/commit/d43f0423667835512e16c3fd3474328da63a948d
original-task: https://www.odoo.com/odoo/project/49/tasks/4307281

opw-5143124
