### PR TITLE
[FIX] iot_drivers: fix cover open printer stuck

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -55,7 +55,7 @@ class PrinterDriver(PrinterDriverBase):
                         usb_device.serial_number == device['usb_serial_number']
                     )
 
-                self.escpos_device = printer.Usb(usb_args={"custom_match": usb_matcher})
+                self.escpos_device = printer.Usb(usb_args={"custom_match": usb_matcher}, timeout=5)
             elif device.get('ip'):
                 self.escpos_device = printer.Network(device['ip'], timeout=5)
             else:


### PR DESCRIPTION
This PR https://github.com/odoo/odoo/pull/244031 added `self.printer._raw` method usage. Behind the scenes it uses "write" which in its turn uses the timeout defined when instantiating `self.escpos_device = printer.Usb()`

Since we currently provide no timeout in some situations like when the printer cover is open the `_raw` method would block indefenitely and stop all the other printers detection.

This PR fixes it by adding a timeout, ensuring that print jobs which take too long result in a timeout.

