### PR TITLE
[FIX] l10n_ar_website_sale: handle missing l10n fields on checkout

### DIFF
--- a/addons/l10n_ar_website_sale/controllers/main.py
+++ b/addons/l10n_ar_website_sale/controllers/main.py
@@ -41,18 +41,21 @@ class L10nARWebsiteSale(WebsiteSale):
             fnames.add('l10n_latam_identification_type_id')
         return fnames
 
-    def _validate_address_values(self, address_values, partner_sudo, address_type, *args, **kwargs):
+    def _validate_address_values(self, address_values, partner_sudo, address_type, use_delivery_as_billing=None, *args, **kwargs):
         """ We extend the method to add a new validation. If AFIP Resposibility is:
 
         * Final Consumer or Foreign Customer: then it can select any identification type.
         * Any other (Monotributista, RI, etc): should select always "CUIT" identification type
         """
         invalid_fields, missing_fields, error_messages = super()._validate_address_values(
-            address_values, partner_sudo, address_type, *args, **kwargs
+            address_values, partner_sudo, address_type, use_delivery_as_billing, *args, **kwargs
         )
 
         # Identification type and AFIP Responsibility Combination
-        if address_type == 'billing' and request.website.sudo().company_id.country_id.code == 'AR':
+        if (
+            (address_type == 'billing' or use_delivery_as_billing) and
+            request.website.sudo().company_id.country_id.code == 'AR'
+        ):
             fnames = {'l10n_latam_identification_type_id', 'l10n_ar_afip_responsibility_type_id'}
             for fname in fnames:
                 if fname in address_values:

--- a/addons/l10n_ar_website_sale/controllers/portal.py
+++ b/addons/l10n_ar_website_sale/controllers/portal.py
@@ -26,8 +26,13 @@ class L10nARCustomerPortal(CustomerPortal):
 
         if self._is_argentine_company():
             partner = request.env.user.partner_id
+            is_vat_info_missing = (
+                not partner.l10n_ar_afip_responsibility_type_id or
+                not partner.l10n_latam_identification_type_id or
+                not partner.vat
+            )
             portal_layout_values.update({
-                'can_edit_vat': partner.can_edit_vat(),
+                'can_edit_vat': partner.can_edit_vat() or is_vat_info_missing,
                 'responsibility': partner.l10n_ar_afip_responsibility_type_id,
                 'identification': partner.l10n_latam_identification_type_id,
                 'partner_sudo': partner,

--- a/addons/l10n_ar_website_sale/models/__init__.py
+++ b/addons/l10n_ar_website_sale/models/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import website
+from . import res_partner
 from . import sale_order

--- a/addons/l10n_ar_website_sale/models/res_partner.py
+++ b/addons/l10n_ar_website_sale/models/res_partner.py
@@ -1,0 +1,13 @@
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _name = 'res.partner'
+    _inherit = 'res.partner'
+
+    def can_edit_vat(self):
+        res = super().can_edit_vat()
+        if self.env.company.country_code == 'AR':
+            return res or not self.vat
+        return res


### PR DESCRIPTION
### Issue:

Cannot get passed the address form in `ar` localization.

#### Steps to reproduce:
1- Set up a company with Argentinian localization.
2- Set the portal user to this company.
3- Add an address and set country to `Argentina`.
4- Assign website to Argentinian company;
5- As the portal user, add something to cart.
6- go to checkout, and save the address.

You will get the error that some fields are missing.

### Cause:

This issue is partially fixed in https://github.com/odoo/odoo/pull/239998. However, there are three issues left:

1. That fix doesn't show the error regarding 'Identification and AFIP Resposibility Types' when we have `use_delivery_as_billing`. As a result a generic error `some fields are missing` is shown.

2. `can_edit_vat` is used in:
https://github.com/odoo/odoo/blob/5b39cdceb84758f767b83b741be927c1a7cfac7a/addons/l10n_ar_website_sale/views/templates.xml#L7-L9
https://github.com/odoo/odoo/blob/5b39cdceb84758f767b83b741be927c1a7cfac7a/addons/l10n_ar_website_sale/views/templates.xml#L32-L35
This needs to also consider `l10n_ar_afip_responsibility_type_id` and `l10n_latam_identification_type_id` being set.

3. Also we need to make sure `Identification Number` which is `vat` is set if we want to prevent it from being modified.

opw-5376149