### PR TITLE
[IMP][FIX] mrp_workorder: better employee cost calculation

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -607,6 +607,17 @@ class MrpWorkcenterProductivity(models.Model):
                 raise UserError(_("You need to define at least one unactive productivity loss in the category 'Performance'. Create one from the Manufacturing app, menu: Configuration / Productivity Losses."))
             underperformance_timers.write({'loss_id': underperformance_type.id})
 
+    # In the Enterprise function, this should be the code used.
+    # Since it should also check that the employee should have a hourly cost and not just set it without checking it.
+    # Causing the employee cost to be 0 instead of the workcenter price, please fix in Enterprise.
+    @api.depends("employee_id.hourly_cost")
+    def _compute_employee_cost(self):
+        for time in self:
+            time.employee_cost = (
+                time.employee_id.hourly_cost
+                if time.employee_id and time.employee_id.hourly_cost > 0
+                else time.workcenter_id.employee_costs_hour
+            )
 
 class MrpWorkcenterCapacity(models.Model):
     _name = 'mrp.workcenter.capacity'

--- a/doc/cla/individual/darkel61.md
+++ b/doc/cla/individual/darkel61.md
@@ -1,0 +1,11 @@
+Venezuela, 03/02/2026
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Henry Yu ddhenry809@gmail.com https://github.com/darkel61


### PR DESCRIPTION

**Please don't merge this, this needs to be fixed in enterprise, not in community. Thanks.**


Description of the issue/feature this PR addresses:
In the enterprise modules, the function _compute_employee_cost doesn't take the employee_costs_hour of workcenter if a employee is assigned, this should be a check too to make sure the hourly_cost of the employee is different or higher than 0.
Current behavior before PR:
If employee is assigned and doesnt have a hourly_cost, just set a 0, this should not be the case, it should take the employee cost of the workcenter.

Desired behavior after PR is merged:
Use the workcenter employee cost if the employee doesnt have a hourly cost.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
