### PR TITLE
[PERF] stock: optimize purchase order computation on lots

### DIFF
--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+from collections import defaultdict
 from odoo import api, fields, models, _
 from odoo.osv.expression import AND
 
@@ -225,14 +225,18 @@ class StockLot(models.Model):
 
     @api.depends('name')
     def _compute_purchase_order_ids(self):
+        purchase_order_ids_map = defaultdict(set)
+        move_lines = self.env['stock.move.line'].search([
+            ('lot_id', 'in', self.ids),
+            ('state', '=', 'done'),
+            ('move_id.picking_id.location_id.usage', '=', 'supplier'),
+            ('move_id.purchase_line_id.order_id', '!=', False)
+        ])
+        for move_line in move_lines:
+            purchase_order_ids_map[move_line.lot_id.id].add(move_line.move_id.purchase_line_id.order_id.id)
         for lot in self:
-            stock_moves = self.env['stock.move.line'].search([
-                ('lot_id', '=', lot.id),
-                ('state', '=', 'done')
-            ]).mapped('move_id')
-            stock_moves = stock_moves.search([('id', 'in', stock_moves.ids)]).filtered(
-                lambda move: move.picking_id.location_id.usage == 'supplier' and move.state == 'done')
-            lot.purchase_order_ids = stock_moves.mapped('purchase_line_id.order_id')
+            po_ids = purchase_order_ids_map.get(lot.id, [])
+            lot.purchase_order_ids = self.env['purchase.order'].browse(po_ids)
             lot.purchase_order_count = len(lot.purchase_order_ids)
 
     def action_view_po(self):


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

We optimize the retrieval of stock move lines by resolving a classic N+1 query bottleneck. In the previous implementation, the system performed a database search for every individual lot in the recordset. This refactor backports the batch processing pattern to fetch all necessary data in a single query, significantly improving performance for large data batches. 

This PR goes beyond just backporting the V18/19 logic by using python set logic instead of recordsets to ensure that that grouping logic remains O(n)

### Current behavior before PR:

The system uses a nested search pattern within a loop. A separate database request is triggered for every lot in the recordset. Performance degrades linearly as the number of lots increases, leading to slow processing times for large batches. 

### Desired behavior after PR is merged:

Logic is refactored into a single batch search on stock.move.line. Database overhead is reduced to a constant number of queries regardless of the recordset size. A defaultdict of python sets is utilized to map findings back to their respective lots. 

### Benchmarks

Profiling creation of purchase orders. Database has ~4200 stock.lot records.

| Before | After |
|---|---|
| 27sec | 7sec |  

### References

opw-5453842

Backported from: 99b39b72c7e65e85af6f06dcb6b02867623f3f69

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
