### PR TITLE
[FIX] calendar: use proper icon syntax for mobile view

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -311,9 +311,9 @@
                                             <field name="email" widget="email"/>
                                             <span>Status: <field name="state" /></span>
                                             <footer class="justify-content-end">
-                                                <button name="do_tentative" invisible="state not in ('needsAction', 'declined', 'accepted')" string="Uncertain" type="object" class="btn fa fa-asterisk"/>
-                                                <button name="do_accept" invisible="state not in ('needsAction', 'tentative', 'declined')" string="Accept" type="object" class="btn fa fa-check text-success"/>
-                                                <button name="do_decline" invisible="state not in ('needsAction', 'tentative', 'accepted')" string="Decline" type="object" class="btn fa fa-times-circle text-danger"/>
+                                                <button name="do_tentative" invisible="state not in ('needsAction', 'declined', 'accepted')" string="Uncertain" type="object" icon="fa-asterisk"/>
+                                                <button name="do_accept" invisible="state not in ('needsAction', 'tentative', 'declined')" string="Accept" type="object" class="text-success" icon="fa-check"/>
+                                                <button name="do_decline" invisible="state not in ('needsAction', 'tentative', 'accepted')" string="Decline" type="object" class="text-danger" icon="fa-times-circle"/>
                                             </footer>
                                         </t>
                                     </templates>


### PR DESCRIPTION
The proper syntax for buttons with icons is to use the icon="" keyword instead of manually defining the font within a class attribute. When it is implemented via the class attribute any string attribute on the button appears in some random sarif font instead of the standard odoo text font.

Before / After
<img width="418" height="345" alt="image" src="https://github.com/user-attachments/assets/07f3a5dc-23fe-44df-a97e-9bcdb2df9d07" /> <img width="412" height="354" alt="image" src="https://github.com/user-attachments/assets/5086a85c-e548-4eed-9c22-5cd31dc8d96d" />

