### PR TITLE
[FIX] calendar: preserve values when opening more options

### DIFF
--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
@@ -12,8 +12,10 @@ export const QUICK_CREATE_CALENDAR_EVENT_FIELDS = {
     stop: { type: "datetime" },
     allday: { type: "boolean" },
     partner_ids: { type: "many2many" },
+    privacy: { type: "selection" },
+    location: { type: "string" },
     videocall_location: { type: "string" },
-    description: { type: "string" }
+    notes: { type: "string" }
 };
 
 function getDefaultValuesFromRecord(data) {


### PR DESCRIPTION
Steps to produce:
---
- Install `calendar` module.
- Go to `Calendar and create a new event using quick create`.
- Set Location and Notes and other values.
- Click `More options`.

Issue:
---
- When the full form view opens, the `Location, Notes and Privacy`
  fields are empty, even though they were filled in the
  quick-create dialog.

Root cause:
---
- At [1], [2] & [3], `Location, Notes and Privacy` values are
  correctly stored in the location, notes and privacy
  fields respectively.
- When opening the full form, default values are built via
  `getDefaultValuesFromRecord`.
- And here at [4], location,notes and privacy are missing from the
  `QUICK_CREATE_CALENDAR_EVENT_FIELDS`.
- As a result, these fields are skipped and not passed through the
  context, causing data loss.

Solution:
---
- Add the location and privacy fields to the
  `QUICK_CREATE_CALENDAR_EVENT_FIELDS` dictionary so they
  are included when generating default values for the
  full form view.
- And replace `description` with `notes`.

Note:
---
- As this is a small and simple case, the test has not been added to avoid unnecessary overhead.

[1]: https://github.com/odoo/odoo/blob/7abd7ba2f38fdb1953c39fd3693f012c2ad1b497/addons/calendar/views/calendar_views.xml#L378-L381
[2]: https://github.com/odoo/odoo/blob/7abd7ba2f38fdb1953c39fd3693f012c2ad1b497/addons/calendar/views/calendar_views.xml#L404-L407
[3]: https://github.com/odoo/odoo/blob/7abd7ba2f38fdb1953c39fd3693f012c2ad1b497/addons/calendar/views/calendar_views.xml#L400-L403
[4]: https://github.com/odoo/odoo/blob/7abd7ba2f38fdb1953c39fd3693f012c2ad1b497/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js#L7-L17

opw-5504553
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
