### PR TITLE
[IMP] mrp, *: correct typo "Theorical" to "Theoretical"

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -57,11 +57,11 @@ class MrpRoutingWorkcenter(models.Model):
     cycle_number = fields.Integer("Repetitions", compute="_compute_time_cycle")
     time_total = fields.Float('Total Duration', compute="_compute_time_cycle")
     show_time_total = fields.Boolean('Show Total Duration?', compute="_compute_time_cycle")
-    cost_mode = fields.Selection([('actual', 'Actual time'), ('estimated', 'Theorical time')],
+    cost_mode = fields.Selection([('actual', 'Actual time'), ('estimated', 'Theoretical time')],
                                  string='Cost based on', default='actual', tracking=True,
                                  help="Determines the way Odoo calculates the cost of the operation:\n"
                                  "- Based on Actual time: the cost will be calculated based on tracked time and real employee costs.\n"
-                                 "- Based on Estimated time: the cost will be calculated based on estimated time and costs.")
+                                 "- Based on Theoretical time: the cost will be calculated based on estimated time and costs.")
     cost = fields.Float('Cost', compute="_compute_cost")
 
     @api.depends('time_mode', 'time_mode_batch')

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -922,7 +922,7 @@ class MrpWorkorder(models.Model):
     def _compute_current_operation_cost(self):
         return (self.get_duration() / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
 
-    def _get_current_theorical_operation_cost(self, without_employee_cost=False):
+    def _get_current_theoretical_operation_cost(self, without_employee_cost=False):
         return (self.get_duration() / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
 
     def _set_cost_mode(self):

--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -301,7 +301,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
             real_cost_decorator = False
             mo_cost_decorator = False
             if self._is_production_started(production):
-                mo_cost = mo_cost if workorder.duration_expected else workorder._get_current_theorical_operation_cost()
+                mo_cost = mo_cost if workorder.duration_expected else workorder._get_current_theoretical_operation_cost()
                 real_cost_decorator = self._get_comparison_decorator(mo_cost, real_cost, 0.01)
             elif production.state == "confirmed":
                 if workorder.operation_id not in production.bom_id.operation_ids:
@@ -385,7 +385,7 @@ class ReportMrpReport_Mo_Overview(models.AbstractModel):
             duration = (workorder.duration_expected if estimate_cost else workorder.get_duration()) / 60
             operation_cost = duration * hourly_cost
             mo_cost = workorder._compute_expected_operation_cost(without_employee_cost=True) if workorder.duration_expected\
-                        else workorder._get_current_theorical_operation_cost(without_employee_cost=True)
+                        else workorder._get_current_theoretical_operation_cost(without_employee_cost=True)
             bom_cost = self._get_bom_operation_cost(workorder, production)
             total_duration += duration
             total_duration_expected += workorder.duration_expected

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -371,7 +371,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             self.component_g: 21
         }
 
-        # Check that the computed quantities are matching the theorical ones.
+        # Check that the computed quantities are matching the theoretical ones.
         # Since component_e was totally processed, this componenent shouldn't be
         # present in backorder_2
         self.assertEqual(len(backorder_2.move_ids), 6)

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -882,7 +882,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
             self.component_g: 21
         }
 
-        # Check that the computed quantities are matching the theorical ones.
+        # Check that the computed quantities are matching the theoretical ones.
         # Since component_e was totally processed, this componenent shouldn't be
         # present in backorder_2
         self.assertEqual(len(backorder_2.move_ids), 6)


### PR DESCRIPTION
_* = purchase_mrp, sale_mrp

- Fix the misspelling `Theorical time` to `Theoretical time` in the Operation
  Cost Mode selection field to avoid unnecessary confusion.
- Update the tooltip from `Based on Estimated time` to `Based on Theoretical
  time`,
  as the user-facing label refers to theoretical time rather than estimated time.
- Rename the related occurrences in the codebase to maintain consistent terminology
  and help prevent similar issues in the future.

task-5137717