### PR TITLE
[FIX] html_editor: table navigation when using Arrow keys in powerbox

### DIFF
--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -138,7 +138,9 @@ export class PowerboxPlugin extends Plugin {
             applyCommand: this.applyCommand.bind(this),
         };
         this.powerboxCommands = this.makePowerboxCommands();
-        this.addDomListener(this.editable.ownerDocument, "keydown", this.onKeyDown);
+        this.addDomListener(this.editable.ownerDocument, "keydown", this.onKeyDown, {
+            capture: true,
+        });
     }
 
     /**
@@ -237,11 +239,13 @@ export class PowerboxPlugin extends Plugin {
                 break;
             case "ArrowUp": {
                 ev.preventDefault();
+                ev.stopImmediatePropagation();
                 this.state.currentIndex = rotate(this.state.currentIndex, this.state.commands, -1);
                 break;
             }
             case "ArrowDown": {
                 ev.preventDefault();
+                ev.stopImmediatePropagation();
                 this.state.currentIndex = rotate(this.state.currentIndex, this.state.commands, 1);
                 break;
             }

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -6,6 +6,7 @@ import { insertText } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 import { press, waitFor, queryOne } from "@odoo/hoot-dom";
 import { expectElementCount } from "../_helpers/ui_expectations";
+import { findInSelection } from "@html_editor/utils/selection";
 
 function expectContentToBe(el, html) {
     expect(getContent(el)).toBe(unformat(html));
@@ -344,6 +345,75 @@ test("should not navigate table cells when table picker is open", async () => {
                             </table>
                             <p><br></p>
                         </td>
+                    </tr>
+                </tbody>
+            </table>
+        `
+    );
+});
+
+test.tags("desktop");
+test("should not navigate table cells when powerbox is open", async () => {
+    const { el, editor } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td><p><br></p></td>
+                    </tr>
+                    <tr>
+                        <td><p>test[]</p></td>
+                    </tr>
+                    <tr>
+                        <td><p><br></p></td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+
+    // Open powerbox
+    await insertText(editor, "/");
+    await waitFor(".o-we-powerbox");
+
+    // Cursor is in second td.
+    const secondTd = el.querySelectorAll("td")[1];
+
+    // Selection starts in first cell
+    let selectedTd = findInSelection(editor.shared.selection.getEditableSelection(), "td");
+    expect(selectedTd).toBe(secondTd);
+
+    // ArrowUp should not navigate table cells
+    press("ArrowUp");
+    await animationFrame();
+
+    selectedTd = findInSelection(editor.shared.selection.getEditableSelection(), "td");
+    expect(selectedTd).toBe(secondTd);
+
+    // ArrowDown should not navigate table cells
+    press("ArrowDown");
+    await animationFrame();
+
+    selectedTd = findInSelection(editor.shared.selection.getEditableSelection(), "td");
+    expect(selectedTd).toBe(secondTd);
+
+    // Enter applies the powerbox command in the same cell
+    press("Enter");
+    await animationFrame();
+
+    expectContentToBe(
+        el,
+        `
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td><p><br></p></td>
+                        </tr>
+                    <tr>
+                        <td><h1>test[]</h1></td>
+                    </tr>
+                    <tr>
+                        <td><p><br></p></td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
### Steps to Reproduce:

- Go to To-Do & create a table (e.g.: /table).
- Place the cursor in the last cell of the table.
- Press / to open the command dialog (focus is on Heading 1).
- Press Arrow Down.
- Notice that cursor comes out of table and focus is as at Heading 2.

### Description of the issue/feature this PR addresses:

- ArrowDown first triggers table cell navigation & cursor moves out of table.
- Powerbox keydown handler runs afterward & focus moves to the next item.

### Desired behavior after PR is merged:

- Powerbox keydown listener runs before table navigation (capture phase) stopImmediatePropagation() prevents table navigate cell. Cursor stays inside table cell & powerbox focus moves to the next item.

task - 5895390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
