### PR TITLE
[FIX] l10n_in_pos: remove unnecessary use of `l10n_gcc_dual_language_receipt`

### DIFF
--- a/addons/l10n_in_pos/tests/test_in_pos.py
+++ b/addons/l10n_in_pos/tests/test_in_pos.py
@@ -29,7 +29,6 @@ class TestGenericIN(TestGenericLocalization):
         })
 
     def test_generic_localization(self):
-        self.main_pos_config.l10n_gcc_dual_language_receipt = True
         _, html = super().test_generic_localization()
         self.assertTrue("HSN Code" in html)
         self.assertTrue("Tax Invoice" in html)


### PR DESCRIPTION

This commit removes the use of the field `l10n_gcc_dual_language_receipt` in the following test case `TestGenericIN.test_generic_localization`. This field is part of `l10n_gcc_pos` and is not needed for `l10n_in_pos` tests.

Runbot-237988
Task-5897376





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
