### PR TITLE
[FIX] pos_loyalty: show next-order coupons on receipt after refresh

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1391,6 +1391,9 @@ class PosOrder(models.Model):
         totalCount = self.search_count(real_domain)
         return {'ordersInfo': list(orders_info.items())[::-1], 'totalCount': totalCount}
 
+    def get_ticket_screen_order_data(self):
+        return self.read_pos_data([], self.config_id[:1].id)
+
     def _send_order(self):
         # This function is made to be overriden by pos_self_order_preparation_display
         pass

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -735,7 +735,9 @@ export class TicketScreen extends Component {
             .map((info) => info[0]);
 
         if (idsNotInCacheOrOutdated.length > 0) {
-            await this.pos.data.read("pos.order", Array.from(new Set(idsNotInCacheOrOutdated)));
+            await this.pos.data.callRelated("pos.order", "get_ticket_screen_order_data", [
+                Array.from(new Set(idsNotInCacheOrOutdated)),
+            ]);
         }
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -735,8 +735,11 @@ export class TicketScreen extends Component {
             .map((info) => info[0]);
 
         if (idsNotInCacheOrOutdated.length > 0) {
-            await this.pos.data.read("pos.order", Array.from(new Set(idsNotInCacheOrOutdated)));
+            await this._fetchNotInCachedOrOutdatedOrders(idsNotInCacheOrOutdated);
         }
+    }
+    async _fetchNotInCachedOrOutdatedOrders(idsNotInCacheOrOutdated) {
+        return await this.pos.data.read("pos.order", Array.from(new Set(idsNotInCacheOrOutdated)));
     }
 }
 

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -199,6 +199,29 @@ class PosOrder(models.Model):
             'coupon_report': coupon_per_report,
         }
 
+    def get_ticket_screen_order_data(self):
+        data = super().get_ticket_screen_order_data()
+
+        histories = self.env['loyalty.history'].search([
+            ('order_model', '=', 'pos.order'),
+            ('card_id.source_pos_order_id', 'in', self.ids),
+            ('card_id.program_id.program_type', '=', 'next_order_coupons'),
+        ])
+        if not histories:
+            return data
+
+        coupon_data = defaultdict(list)
+        for history in histories:
+            coupon_data[history.card_id.source_pos_order_id.id].append({
+                'program_name': history.card_id.program_id.name,
+                'expiration_date': history.card_id.expiration_date,
+                'code': history.card_id.code,
+            })
+        for order in data["pos.order"]:
+            order["new_coupon_info"] = coupon_data.get(order["id"], [])
+
+        return data
+
     def _check_existing_loyalty_cards(self, coupon_data):
         coupon_key_to_modify = []
         for coupon_id, coupon_vals in coupon_data.items():

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -199,6 +199,22 @@ class PosOrder(models.Model):
             'coupon_report': coupon_per_report,
         }
 
+    def get_next_order_coupon_data(self):
+        result = defaultdict(list)
+        histories = self.env['loyalty.history'].search([
+            ('order_model', '=', 'pos.order'),
+            ('card_id.source_pos_order_id', 'in', self.ids),
+            ('card_id.program_id.program_type', '=', 'next_order_coupons'),
+        ])
+        for history in histories:
+            result[history.card_id.source_pos_order_id.id].append({
+                'program_name': history.card_id.program_id.name,
+                'expiration_date': history.card_id.expiration_date,
+                'code': history.card_id.code,
+            })
+
+        return result
+
     def _check_existing_loyalty_cards(self, coupon_data):
         coupon_key_to_modify = []
         for coupon_id, coupon_vals in coupon_data.items():

--- a/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -57,4 +57,14 @@ patch(TicketScreen.prototype, {
             this.pos.updateRewards();
         }
     },
+    async _fetchNotInCachedOrOutdatedOrders(idsNotInCacheOrOutdated) {
+        const orders = await super._fetchNotInCachedOrOutdatedOrders(...arguments);
+        const couponData = await this.pos.data.call("pos.order", "get_next_order_coupon_data", [
+            orders.map(({ id }) => id),
+        ]);
+        for (const order of orders) {
+            order.new_coupon_info = couponData[order.id] ?? [];
+        }
+        return orders;
+    },
 });

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -157,7 +157,7 @@ patch(PosOrder.prototype, {
             result.loyaltyStats = this.getLoyaltyPoints();
             result.partner = this.get_partner();
         }
-        result.new_coupon_info = this.new_coupon_info;
+        result.new_coupon_info = this.new_coupon_info ?? this.raw.new_coupon_info;
         return result;
     },
     //@override

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -10,7 +10,7 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as Notification from "@point_of_sale/../tests/tours/utils/generic_components/notification_util";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import { registry } from "@web/core/registry";
-import { scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
+import { refresh, scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("PosLoyaltyTour1", {
     steps: () =>
@@ -328,6 +328,21 @@ registry.category("web_tour.tours").add("PosLoyaltyTour11.1", {
             ProductScreen.totalAmountIs("150.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.finalizeOrder("Cash", "150"),
+            refresh(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectFilter("Paid"),
+            Chrome.waitRequest(),
+            {
+                trigger: "body",
+                run: () => {
+                    const order = posmodel.data.models["pos.order"]
+                        .getAll()
+                        .filter((o) => o.state === "paid")[0];
+                    if (!order.new_coupon_info && !order.raw.new_coupon_info) {
+                        throw Error("Next order coupon is missing");
+                    }
+                },
+            },
         ].flat(),
 });
 

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -9,7 +9,7 @@ import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import * as Notification from "@point_of_sale/../tests/tours/utils/generic_components/notification_util";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import { registry } from "@web/core/registry";
-import { scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
+import { refresh, scan_barcode } from "@point_of_sale/../tests/tours/utils/common";
 
 registry.category("web_tour.tours").add("PosLoyaltyTour1", {
     steps: () =>
@@ -327,6 +327,21 @@ registry.category("web_tour.tours").add("PosLoyaltyTour11.1", {
             ProductScreen.totalAmountIs("150.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
             PosLoyalty.finalizeOrder("Cash", "150"),
+            refresh(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectFilter("Paid"),
+            Chrome.waitRequest(),
+            {
+                trigger: "body",
+                run: () => {
+                    const order = posmodel.data.models["pos.order"]
+                        .getAll()
+                        .filter((o) => o.state === "paid")[0];
+                    if (!order.new_coupon_info) {
+                        throw Error("Next order coupen is missing");
+                    }
+                },
+            },
         ].flat(),
 });
 


### PR DESCRIPTION
Step to reproduce:
=
- Complete order with Next order coupon 
- Open Order and print receipt (This time coupon is visible)
- Refresh  page Or Reload Data 
- Same order > Print receipt

Issue:
=
- Next time on-wards next order coupon will not shown on the receipt.

Reason:
=
- Loyalty program data is stored in the uistate which destroyed on refresh page OR reload data.

Fix:
=
- Fetched data from the server when uistate doent have any loyalty program data for that order while receipt printing only.


task-5890998
related pr: https://github.com/odoo/enterprise/pull/128730