### PR TITLE
[FIX] website: adapt the selector for livechat composer text

### DIFF
--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -229,7 +229,7 @@ registry.category("web_tour.tours").add("website_form_contactus_submit", {
         // the email
         {
             isActive: ["body:has(.o-livechat-root)"],
-            trigger: ":shadow span:contains(select an option above)",
+            trigger: ":shadow textarea[placeholder='Say something...']",
         },
         {
             content: "Fill in the subject",


### PR DESCRIPTION
Purpose of this commit,
To update the selector for asserting the presence of the livechat
chat window in open state.

runbot error -  https://runbot.odoo.com/odoo/error/232912