### PR TITLE
[FIX] l10n_pl_edi: create column for binary field

### DIFF
--- a/addons/l10n_pl_edi/data/neutralize.sql
+++ b/addons/l10n_pl_edi/data/neutralize.sql
@@ -1,13 +1,25 @@
 -- disable_l10n_pl_edi_integration
 
+-- Delete customer's certificates
+DELETE FROM certificate_certificate
+      WHERE id IN (
+                SELECT l10n_pl_edi_certificate
+                  FROM res_company
+               )
+;
+
 -- clear KSeF Credentials
 UPDATE res_company
    SET l10n_pl_edi_certificate = NULL,
        l10n_pl_edi_access_token = NULL,
        l10n_pl_edi_refresh_token = NULL,
-       l10n_pl_edi_session_id = NULL,
-       l10n_pl_edi_session_key = NULL,
-       l10n_pl_edi_session_iv = NULL
+       l10n_pl_edi_session_id = NULL
+;
+
+-- Remove the attached binary data
+DELETE FROM ir_attachment
+      WHERE res_model = 'res.company'
+        AND res_field IN ('l10n_pl_edi_session_key', 'l10n_pl_edi_session_iv')
 ;
 
 -- set test environment parameter


### PR DESCRIPTION
### Issue:

Due to recent [commit]
(https://github.com/odoo/odoo/commit/06ff5d42e66b800a7e09a52e9abd51b7fb759cc3) , neutralization of the database is hampered and following error is encountered.

Traceback on neutralizing:
```py
odoo.sql_db: bad query: b"-- disable_l10n_pl_edi_integration\n\n-- clear KSeF Credentials\nUPDATE res_company\n   SET l10n_pl_edi_certificate = NULL,\n       l10n_pl_edi_access_token = NULL,\n       l10n_pl_edi_refresh_token = NULL,\n       l10n_pl_edi_session_id = NULL,\n       l10n_pl_edi_session_key = NULL,\n       l10n_pl_edi_session_iv = NULL\n;\n\n-- set test environment parameter\n     INSERT INTO ir_config_parameter (key, value, create_date, write_date)\n          VALUES ('l10n_pl_edi_ksef.mode', 'test', NOW(), NOW())\n     ON CONFLICT (key)\n   DO UPDATE SET value = 'test',\n                 write_date = NOW()\n;"
ERROR: column "l10n_pl_edi_session_key" of relation "res_company" does not exist
LINE 9:        l10n_pl_edi_session_key = NULL,

```

Before this commit:
```sql
test_18_pl=> SELECT column_name
FROM information_schema.columns
WHERE table_name = 'res_company'
  AND column_name LIKE 'l10n_pl_edi%';
        column_name
---------------------------
 l10n_pl_edi_certificate
 l10n_pl_edi_access_token
 l10n_pl_edi_refresh_token
 l10n_pl_edi_session_id
(4 rows)
```

After this commit:
```sql
test_18_pl=> SELECT column_name
FROM information_schema.columns
WHERE table_name = 'res_company'
  AND column_name LIKE 'l10n_pl_edi%';
        column_name
---------------------------
 l10n_pl_edi_certificate
 l10n_pl_edi_session_iv
 l10n_pl_edi_session_key
 l10n_pl_edi_access_token
 l10n_pl_edi_refresh_token
 l10n_pl_edi_session_id
(6 rows)
```

### Solution:

Set attachment=False for the fields `l10n_pl_edi_session_key` and `l10n_pl_edi_session_iv`, ensuring that their columns are created directly on the  res.company model instead of being stored as attachments. Eventually, during [neutralizing]
(https://github.com/odoo/odoo/blob/18.0/addons/l10n_pl_edi/data/neutralize.sql#L4-#L10) there won't be any column missing error.

Ticket [link](https://www.odoo.com/odoo/project.task/5751411)
opw-5751411