### PR TITLE
[REF] *: remove synchronous assertions in tours

### DIFF
--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -4,20 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 import { whenReady } from "@odoo/owl";
 
-function openRoot() {
-    return [{
-        content: "return to client root to avoid race condition",
-        trigger: 'body',
-        run() {
-            document.querySelector("body").classList.add("wait");
-            window.location = '/odoo';
-        },
-        expectUnloadPage: true,
-    }, {
-        content: "wait for client reload",
-        trigger: 'body:not(.wait)',
-    }];
-}
 function openUserPreferencesAtSecurityTab() {
     return [{
         content: 'Open user account menu',
@@ -122,8 +108,11 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
 },
 {
     trigger: ".o_notification_content:contains(2-Factor authentication is now enabled)",
+    run() {
+        window.location = '/odoo';
+    },
+    expectUnloadPage: true,
 },
-...openRoot(),
 ...openUserPreferencesAtSecurityTab(),
 ...closePreferencesDialog({
     content: "Check that the button has changed",
@@ -321,8 +310,11 @@ registry.category("web_tour.tours").add('totp_login_device', {
 },
 {
     trigger:".o_notification_content:contains(Two-factor authentication disabled)",
+    run() {
+        window.location = '/odoo';
+    },
+    expectUnloadPage: true,
 },
-...openRoot(),
 ...openUserPreferencesAtSecurityTab(),
 ...closePreferencesDialog({
     content: "Check that the button has changed",

--- a/addons/hr_expense/static/tests/tours/expense_upload_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_upload_tours.js
@@ -16,13 +16,7 @@
         },
         {
             content: "Check Upload Button",
-            trigger: '.o_button_upload_expense',
-            run() {
-                const button = document.querySelector('.o_button_upload_expense');
-                if(!button) {
-                    console.error('Missing Upload button in My Expenses > List View');
-                }
-            }
+            trigger: ".o_button_upload_expense",
         },
         {
             content: "Create a new expense",
@@ -57,12 +51,10 @@
         {
             content: "Check Upload Button",
             trigger: "button.o_switch_view.o_kanban.active",
-            run() {
-                const button = document.querySelector('.o_button_upload_expense');
-                if(!button) {
-                    console.error('Missing Upload button in My Expenses > Kanban View');
-                }
-            }
+        },
+        {
+            content: "Missing Upload button in My Expenses > Kanban View",
+            trigger: ".o_button_upload_expense",
         },
         {
             content: "Go to Reporting",
@@ -82,13 +74,11 @@
         {
             content: "Check Upload Button",
             trigger: "button.o_switch_view.o_list.active",
-            run() {
-                const button = document.querySelector('.o_button_upload_expense');
-                if(!button) {
-                    console.error('Missing Upload button in Expenses Analysis > List View');
-                }
-            }
         },
+        {
+            content: "Missing Upload button in Expenses Analysis > List View",
+            trigger: ".o_button_upload_expense",
+        }
     ]});
 
     registry.category("web_tour.tours").add('hr_expense_access_rights_test_tour', {

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -54,45 +54,24 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Check subject is autofilled",
-            trigger: '[name="subject"] input',
-            run() {
-                const subjectValue = document.querySelector('[name="subject"] input').value;
-                if (subjectValue !== "Jane") {
-                    console.error(
-                        `Full composer should have "Jane" in subject input (actual: ${subjectValue})`
-                    );
-                }
-            },
+            trigger: '[name="subject"] input:value(Jane)',
         },
         {
             content: "Check composer content is kept and contains the user's signature",
-            trigger: '.o_field_html[name="body"]',
-            run() {
-                const bodyContent = document.querySelector(
-                    '.o_field_html[name="body"]'
-                ).textContent;
-                if (!bodyContent.includes("blahblah @Not A Demo User")) {
-                    console.error(
-                        `Full composer should contain text from small composer ("blahblah @Not A Demo User") in body input (actual: ${bodyContent})`
-                    );
-                }
-                const mentionLink = document.querySelector(
-                    '.o_field_html[name="body"] a'
-                ).textContent;
-                if (!mentionLink.includes("@Not A Demo User")) {
-                    console.error(
-                        `Full composer should contain mention link from small composer ("@Not A Demo User") in body input)`
-                    );
-                }
-                /** When opening the full composer for the first time, the system
-                 * should add the user's signature to the end of the message so
-                 * that the user can edit it. After adding the signature to
-                 * the editor, the server shouldn't automatically add the
-                 * signature to the message (see: Python tests). */
-                if ((bodyContent.match(/--\nErnest/g) || []).length !== 1) {
-                    console.error("Full composer should contain the user's signature once.");
-                }
-            },
+            trigger: '.o_field_html[name="body"]:contains(blahblah @Not A Demo User)',
+        },
+        {
+            content: `Full composer should contain mention link from small composer ("@Not A Demo User") in body input)`,
+            trigger: '.o_field_html[name="body"] a:contains(@Not A Demo User)',
+        },
+        /** When opening the full composer for the first time, the system
+         * should add the user's signature to the end of the message so
+         * that the user can edit it. After adding the signature to
+         * the editor, the server shouldn't automatically add the
+         * signature to the message (see: Python tests). */
+        {
+            content: "Full composer should contain the user's signature once.",
+            trigger: '.o_field_html[name="body"] .o-signature-container:contains(-- Ernest)',
         },
         {
             content: "Drop a file on the full composer",
@@ -119,17 +98,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Verify admin template is NOT listed",
-            trigger: ".mail-composer-template-dropdown.popover",
-            run() {
-                const hasAdminTemplate = [...document.querySelectorAll(".o-dropdown-item")].some(
-                    (item) => item.textContent.includes("Test template for admin")
-                );
-                if (hasAdminTemplate) {
-                    console.error(
-                        "Template assigned to the admin is visible to a non-assigned user! This should not happen."
-                    );
-                }
-            },
+            trigger:
+                ".mail-composer-template-dropdown.popover:not(:has(.o-dropdown-item:contains(Test template for admin)))",
         },
         {
             content: "Send message from full composer",
@@ -172,19 +142,11 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             run: "click",
         },
         {
+            /** When opening the full composer, the system should add the
+             * user's signature, as this is a new message and the signature
+             * has not yet been added to it. */
             content: "Check that the composer contains the signature",
-            trigger: '.o_field_html[name="body"]',
-            run() {
-                const bodyContent = document.querySelector(
-                    '.o_field_html[name="body"]'
-                ).textContent;
-                /** When opening the full composer, the system should add the
-                 * user's signature, as this is a new message and the signature
-                 * has not yet been added to it. */
-                if ((bodyContent.match(/--\nErnest/g) || []).length !== 1) {
-                    console.log("Full composer should contain the user's signature once.");
-                }
-            },
+            trigger: '.o_field_html[name="body"] .o-signature-container:contains(-- Ernest)',
         },
         {
             content: "Write something in full composer",
@@ -203,14 +165,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         },
         {
             content: "Check full composer text is kept",
-            trigger: ".o-mail-Composer-input",
-            run() {
-                if (this.anchor.value !== "keep the content") {
-                    console.error(
-                        "Composer in chatter should contain full composer text after discarding."
-                    );
-                }
-            },
+            trigger: ".o-mail-Composer-input:value(keep the content)",
         },
         {
             content: "Open full composer",
@@ -220,18 +175,10 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         {
             content: "Check that the composer doesn't add the user's signature twice",
             trigger: ".note-editable",
-            run() {
-                const bodyContent = document.querySelector(
-                    '.o_field_html[name="body"]'
-                ).textContent;
-                /** When re-opening the full composer, the system shouldn't re-add
-                 * the user's signature to the message. As the user deleted the
-                 * signature in the previous steps (see: `editor keep the content`),
-                 * the editor shouldn't contain any signature. */
-                if ((bodyContent.match(/--\nErnest/g) || []).length !== 0) {
-                    console.error("The composer should not contain the user's signature.");
-                }
-            },
+        },
+        {
+            content: "The composer should not contain the user's signature.",
+            trigger: '.o_field_html[name="body"]:not(:has(.o-signature-container))',
         },
         {
             content: "Close full composer",

--- a/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
@@ -98,16 +98,8 @@ registry.category("web_tour.tours").add("mail_template_dynamic_field_tour", {
         },
         {
             content: "Check if subject value was correctly updated",
-            trigger: 'div[name="subject"] input[type="text"]',
-            run() {
-                const subjectValue = this.anchor.value;
-                const correctValue = "yes_model_id {{object.parent_name|||defValue}}";
-                if (subjectValue !== correctValue) {
-                    console.error(
-                        `Email template should have "${correctValue}" in subject input (actual: ${subjectValue})`
-                    );
-                }
-            },
+            trigger:
+                'div[name="subject"] input[type="text"]:value(yes_model_id {{object.parent_name|||defValue}})',
         },
         {
             content: "Insert text inside editable",

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -8,7 +8,6 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
-import { delay } from "@web/core/utils/concurrency";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("EWalletProgramTour1", {
@@ -44,14 +43,6 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
             }),
             PosLoyalty.orderTotalIs("0.00"),
             ...ProductScreen.clickLine("eWallet"),
-            // Added a small wait because the clickLine function uses a 300ms timeout
-            {
-                content: "Wait 300ms after clicking orderline",
-                trigger: "body",
-                async run() {
-                    await delay(300);
-                },
-            },
             Numpad.isVisible(),
             ...Order.hasLine({
                 withClass: ".selected",
@@ -59,13 +50,6 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
                 productName: "eWallet",
                 quantity: "1.0",
             }),
-            {
-                content: "Wait 300ms after clicking orderline",
-                trigger: "body",
-                async run() {
-                    await delay(300);
-                },
-            },
             negateStep(Numpad.isVisible()),
             {
                 content: "Click Current Balance line in orderline",

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -435,8 +435,20 @@ registry.category("web_tour.tours").add("test_form_view_resequence_actions", {
     ],
 });
 
+function checkMenu({ groups = [], items = [] } = {}) {
+    const build = (arr, type, cls) =>
+        arr.map((text, i) => ({
+            content: `Check menu ${type} ${i} has text "${text}"`,
+            trigger: `.o_select_menu_menu ${cls}:eq(${i}):text("${text}")`,
+        }));
+
+    return [
+        ...build(groups, "group", ".o_select_menu_group"),
+        ...build(items, "item", ".o_select_menu_item"),
+    ];
+}
+
 registry.category("web_tour.tours").add("test_form_view_model_id", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
             trigger: ".o_field_widget[name='model_id'] input",
@@ -450,23 +462,20 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
             trigger: ".o_field_widget[name='trigger'] input",
             run: "click",
         },
-        {
-            trigger: ".o_select_menu_menu",
-            run() {
-                assertEqual(
-                    Array.from(this.anchor.querySelectorAll(".o_select_menu_group"))
-                        .map((el) => el.textContent)
-                        .join(", "),
-                    "Values Updated, Timing Conditions, Custom, External"
-                );
-                assertEqual(
-                    Array.from(this.anchor.querySelectorAll(".o_select_menu_item"))
-                        .map((el) => el.textContent)
-                        .join(", "),
-                    "User is set, Based on date field, After creation, After last update, On create, On create and edit, On deletion, On UI change, On webhook"
-                );
-            }
-        },
+        ...checkMenu({
+            groups: ["Values Updated", "Timing Conditions", "Custom", "External"],
+            items: [
+                "User is set",
+                "Based on date field",
+                "After creation",
+                "After last update",
+                "On create",
+                "On create and edit",
+                "On deletion",
+                "On UI change",
+                "On webhook",
+            ],
+        }),
         {
             trigger: ".o_field_widget[name='model_id'] input",
             run: "edit test_base_automation.project",
@@ -479,23 +488,23 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
             trigger: ".o_field_widget[name='trigger'] input",
             run: "click",
         },
-        {
-            trigger: ".o_select_menu_menu",
-            run() {
-                assertEqual(
-                    Array.from(this.anchor.querySelectorAll(".o_select_menu_group"))
-                        .map((el) => el.textContent)
-                        .join(", "),
-                    "Values Updated, Timing Conditions, Custom, External"
-                );
-                assertEqual(
-                    Array.from(this.anchor.querySelectorAll(".o_select_menu_item"))
-                        .map((el) => el.textContent)
-                        .join(", "),
-                    "Stage is set to, User is set, Tag is added, Priority is set to, Based on date field, After creation, After last update, On create, On create and edit, On deletion, On UI change, On webhook"
-                );
-            }
-        },
+        ...checkMenu({
+            groups: ["Values Updated", "Timing Conditions", "Custom", "External"],
+            items: [
+                "Stage is set to",
+                "User is set",
+                "Tag is added",
+                "Priority is set to",
+                "Based on date field",
+                "After creation",
+                "After last update",
+                "On create",
+                "On create and edit",
+                "On deletion",
+                "On UI change",
+                "On webhook",
+            ],
+        }),
         {
             trigger: ".o_form_button_cancel",
             run: "click",

--- a/addons/test_mail_full/static/tests/tours/portal_composer_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/portal_composer_actions_tour.js
@@ -10,14 +10,9 @@ registry.category("web_tour.tours").add("portal_composer_actions_tour_internal_u
             run: "click",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Composer-input",
-            run() {
-                if (this.anchor.value !== "::") {
-                    console.error(
-                        "Clicking on the canned response button should insert the '::' into the composer."
-                    );
-                }
-            },
+            content:
+                "Clicking on the canned response button should insert the '::' into the composer.",
+            trigger: "#chatterRoot:shadow .o-mail-Composer-input:value(::)",
         },
         {
             trigger:

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -130,15 +130,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "there should only have one notification toaster",
-            trigger: "body",
-            run() {
-                const notificationCount = document.querySelectorAll(".o_notification").length;
-                if (notificationCount !== 1) {
-                    throw new Error(
-                        `There should be one notification toaster opened, and only one, found ${notificationCount}.`
-                    );
-                }
-            },
+            trigger: ".o_notification:count(1)",
         },
         {
             content: "close media dialog",
@@ -173,15 +165,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "there should only have one notification toaster",
-            trigger: ".o_notification",
-            run() {
-                const notificationCount = document.querySelectorAll(".o_notification").length;
-                if (notificationCount !== 1) {
-                    throw new Error(
-                        `There should be one notification toaster opened, and only one, found ${notificationCount}.`
-                    );
-                }
-            },
+            trigger: ".o_notification:count(1)",
         },
         {
             content: "media dialog has closed after the upload",
@@ -228,14 +212,8 @@ registerWebsitePreviewTour(
         },
         {
             content: "there should only have one notification toaster",
-            trigger: ".o_notification",
+            trigger: ".o_notification:count(1)",
             run() {
-                const notificationCount = document.querySelectorAll(".o_notification").length;
-                if (notificationCount !== 1) {
-                    throw new Error(
-                        `There should be one noficiation toaster opened, and only one, found ${notificationCount}.`
-                    );
-                }
                 unpatchMediaDialog();
             },
         },

--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -1,5 +1,4 @@
 import {
-    assertPathName,
     clickOnSave,
     getClientActionUrl,
     registerWebsitePreviewTour,
@@ -255,7 +254,6 @@ function testWebsitePageProperties() {
         },
         ...assertPageCanonicalUrlIs("/"),
         stepUtils.goToUrl(getClientActionUrl("/new-page")),
-        assertPathName("/cool-page", "body"),
         {
             content: "Verify no index",
             trigger: ':iframe head:hidden meta[name="robots"][content="noindex"]',
@@ -301,7 +299,6 @@ function testWebsitePageProperties() {
         },
         ...assertPageCanonicalUrlIs("/new-page"),
         stepUtils.goToUrl(getClientActionUrl("/new-page")),
-        assertPathName("/new-page", "body"),
         {
             content: "Verify is indexed",
             trigger: ':iframe head:hidden:not(:has(meta[name="robots"][content="noindex"]))',

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -32,29 +32,6 @@ export function assertCssVariable(variableName, variableValue, trigger = ":ifram
         },
     };
 }
-export function assertPathName(pathname, trigger) {
-    return {
-        content: `Check if we have been redirected to ${pathname}`,
-        trigger: trigger,
-        async run() {
-            await new Promise((resolve) => {
-                let elapsedTime = 0;
-                const intervalTime = 100;
-                const interval = setInterval(() => {
-                    if (window.location.pathname.startsWith(pathname)) {
-                        clearInterval(interval);
-                        resolve();
-                    }
-                    elapsedTime += intervalTime;
-                    if (elapsedTime >= 5000) {
-                        clearInterval(interval);
-                        console.error(`The pathname ${pathname} has not been found`);
-                    }
-                }, intervalTime);
-            });
-        },
-    };
-}
 
 export function changeBackground(snippet, position = "bottom") {
     return [

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -99,12 +99,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Check that video url has protocol",
-            trigger: "#o_video_text",
-            run() {
-                if (!this.anchor.value.startsWith("https")) {
-                    console.error("Video Url is missing protocol");
-                }
-            },
+            trigger: "#o_video_text:value(/^https/)",
         },
         {
             content: "Close the dialog",

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -117,16 +117,8 @@ registerWebsitePreviewTour(
         ...changeOptionInPopover("Text", "Layout", "[data-action-value='3']"),
         {
             content: "The snippet should have the correct number of columns.",
-            trigger: ":iframe .s_text_block .container > .row .col-lg-4:eq(3)",
-            run() {
-                if (
-                    [...this.anchor.children].filter(
-                        (child) => !child.hasAttribute("data-selection-placeholder")
-                    ).length !== 3
-                ) {
-                    console.error("The snippet does not have the correct number of columns");
-                }
-            },
+            trigger:
+                ":iframe .s_text_block .container > .row:has(.col-lg-4:not([data-selection-placeholder]):count(3))",
         },
         checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         // Test keeping the text selection when removing all columns of a

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -197,20 +197,7 @@ registerWebsitePreviewTour(
         {
             content: "Check that the image src is not the raw data",
             trigger:
-                ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']",
-            run() {
-                const imgEl = document
-                    .querySelector("iframe")
-                    .contentDocument.querySelector(
-                        ".s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']"
-                    );
-                const src = imgEl.getAttribute("src");
-                if (src.startsWith("data:image")) {
-                    throw new Error(
-                        "The image source should not be raw data after the editor save"
-                    );
-                }
-            },
+                ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not([src^='data:image'])",
         },
         ...clickOnEditAndWaitEditMode(),
         ...scrollToSnippet("s_three_columns"),
@@ -241,20 +228,7 @@ registerWebsitePreviewTour(
         {
             content: "Check that the image src is not the raw data",
             trigger:
-                ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']",
-            run() {
-                const imgEl = document
-                    .querySelector("iframe")
-                    .contentDocument.querySelector(
-                        ".s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']"
-                    );
-                const src = imgEl.getAttribute("src");
-                if (src.startsWith("data:image")) {
-                    throw new Error(
-                        "The image source should not be raw data after the editor save"
-                    );
-                }
-            },
+                ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not([src^='data:image'])",
         },
     ]
 );

--- a/addons/website/static/tests/tours/snippet_tabs.js
+++ b/addons/website/static/tests/tours/snippet_tabs.js
@@ -24,12 +24,7 @@ registerWebsitePreviewTour(
         changeOption("Tabs", "button[aria-label='Remove Tab']"),
         {
             content: "Check that only 2 tab panes remain",
-            trigger: ":iframe .s_tabs .s_tabs_content",
-            run() {
-                if (this.anchor.querySelectorAll(".tab-pane").length !== 2) {
-                    console.error("There should be exactly 2 tab panes in the DOM.");
-                }
-            },
+            trigger: ":iframe .s_tabs .s_tabs_content .tab-pane:count(2)",
         },
         {
             content: "Check that the first tab link is active",
@@ -38,12 +33,7 @@ registerWebsitePreviewTour(
         changeOption("Tabs", "button[aria-label='Add Tab']"),
         {
             content: "Check there are 3 tab panes",
-            trigger: ":iframe .s_tabs .s_tabs_content",
-            run() {
-                if (this.anchor.querySelectorAll(".tab-pane").length !== 3) {
-                    console.error("There should be exactly 3 tab panes in the DOM.");
-                }
-            },
+            trigger: ":iframe .s_tabs .s_tabs_content .tab-pane:count(3)",
         },
     ]
 );

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -225,9 +225,9 @@ registerWebsitePreviewTour(
         {
             content: "Apply the first gradient option to the breadcrumb background",
             trigger: ".o_colorpicker_sections button.o_gradient_color_button",
-            run() {
+            async run({ click }) {
                 selectedGradient = this.anchor.dataset.color;
-                this.anchor.click();
+                await click();
             },
         },
         {

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -29,19 +29,10 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
             },
             {
                 trigger: messagesContain("How can I help you?"),
-                // check question_selection message is posted and reactions are not
-                // available since the thread is not yet persisted
-                run() {
-                    if (
-                        this.anchor.querySelector(
-                            ".o-mail-Message-actions [title='Add a Reaction']"
-                        )
-                    ) {
-                        console.error(
-                            "Reactions should not be available before thread is persisted."
-                        );
-                    }
-                },
+            },
+            {
+                content: "Reactions should not be available before thread is persisted.",
+                trigger: `body:not(:has(.o-mail-Message-actions [title='Add a Reaction']))`,
             },
             {
                 trigger: '.o-livechat-root:shadow button:contains("I\'d like to buy the software")',

--- a/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
@@ -22,12 +22,10 @@ registry.category("web_tour.tours").add("test_company_access_error_redirect", {
         },
         {
             trigger: ".o-dropdown--menu",
+        },
+        {
+            trigger: ".o_switch_company_item [role=menuitemcheckbox][aria-checked=true]:count(2)",
             run() {
-                assertEqual(
-                    document.querySelectorAll(".o_switch_company_item [role=menuitemcheckbox][aria-checked=true]")
-                        .length,
-                    2
-                );
                 assertEqual(
                     cookie.get("cids"),
                     [...document.querySelectorAll(".o_switch_company_item[data-company-id]")]


### PR DESCRIPTION
How tours works ?
=================

For each animationFrame, engine searchs the trigger in the DOM until it has been found, then the action (run) is direclty launched.

Why it could be not work properly ?
===================================

Most of time, assertions done in `run` are synchronous. And if the trigger was too generic or clearly present in the DOM (like body, .o_content,...) or was simply the trigger element is already in DOM, then the synchronous assertions can failed... because elements are not present in DOM yet.
Then, either the trigger of this step must be more precise, either you use trigger and HOOT selector to make assertions.
This can cause undeterministic errors.

What we do ?
============

With this commit, we replace synchronous assertions in `run` step function by asynchronous assertions in the `trigger`.
This PR is implemented with the aim of removing the undeterministicTour_doNotCopy key to have tours without delay  between each step.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
