### PR TITLE
[FIX] point_of_sale: fix runbot error #234810

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1405,6 +1405,7 @@ class TestPointOfSaleFlow(CommonPosTest):
                 'name': fields.Datetime.now(),
                 'payment_method_id': self.cash_payment_method.id
             }]],
+            'is_refund': True,
         }]
         self.env['pos.order'].sync_from_ui(refund_values)
         refunded_order_line = self.env['pos.order.line'].search([('product_id', '=', product.id), ('qty', '=', -2)])


### PR DESCRIPTION
TASK: [#5897377](https://www.odoo.com/odoo/project/1737/tasks/5897377)

---

The test `point_of_sale:TestPointOfSaleFlow.test_pos_order_refund_ship_delay_totalcost` was failing with the following error:

> You cannot use a credit_note document type with an invoice.

This issue occurred because the refund order was not marked as a refund. As a result, the `account.move` `move_type` was set to `out_invoice` instead of `out_refund`.

Since 19.0, following the change introduced in [odoo/229683](https://github.com/odoo/odoo/pull/229683/files#diff-29cbaebb5b63b539ab173d9340b2aec87b9ad63cd322eec2347879c5412bd50bR850), the `move_type` is no longer determined based on the `pos.order` `amount_total`, but on its `is_refund` field. This field was missing in the test, causing the incorrect behavior.