### PR TITLE
[FIX] website_blog: next_post cover image not shown correctly

### DIFF
--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -356,9 +356,9 @@ list of filtered posts (by date or tag).
                 <div id="o_wblog_next_container" class="d-flex flex-column">
                     <button aria-labelledby="o_wblog_next_title" class="o_wblog_next_button o_button_area btn z-1"/>
                     <t t-call="website.record_cover"
+                        _record="next_post"
                         use_filters="True"
                         additionnal_classes.f="o_wblog_post_page_cover o_wblog_post_page_cover_footer o_record_has_cover">
-                        <t t-set="_record" t-value="next_post"/>
                         <t t-set="_cp" t-value="json.loads(_record.cover_properties)"/>
 
                         <a id="o_wblog_next_post_info" class="d-none"


### PR DESCRIPTION
**Issue:**
The next post's cover image incorrectly displays the current post's
cover image instead of its own cover image.

**Steps to reproduce:**
1. Go to Website -> Create two blog posts.
2. In both blog posts have different cover images
3. Open one of the blog posts.
4. Scroll down to the Next Article section.
5. Observe that the Next Article displays the same cover image as the 
   currently opened post.

**Cause:**
After this [commit] template values are now passed as props instead of 
using `t-set`. However, the `record_cover` template for the next post 
was not updated and still used `t-set` inside the `t-call`. This caused
`_record` to be incorrect, making the template fall back to the previous
record's data, incorrectly displaying the current post's cover image
instead of the next post's.

**Solution:**
Pass `_record` as a proper prop to the `t-call` for the `record_cover` 
template when rendering the next post, ensuring the correct record data 
is available in the template context.

[commit]: https://github.com/odoo/odoo/commit/f926cfae515cee46aa70a9ac34c4bcd368d838c6
task-[5909203](https://www.odoo.com/odoo/project/974/tasks/5909203)