### PR TITLE
[FIX] api_doc: list parameter are not parsed fully

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -478,6 +478,8 @@ def stringify_annotation(annotation) -> str | None:
         return None
     if isinstance(annotation, str):
         return annotation
+    if hasattr(annotation, '__origin__'):
+        return str(annotation)
     if isinstance(annotation, type):
         return annotation.__name__
     return str(annotation)

--- a/addons/api_doc/tests/dummy_methods.py
+++ b/addons/api_doc/tests/dummy_methods.py
@@ -25,12 +25,13 @@ class DummyMethods:
         </div>""",
     }
 
-    def multiple_args_and_error(self, a: int, b: list[int]) -> int:
+    def multiple_args_and_error(self, a: int, b: list[int], c: dict[str, list[str]]) -> int:
         """
         Another dummy function.
 
         :param int a: an int.
         :param list[int] b: a list of int.
+        :param dict[str, list[str]] c: a dict of lists.
         :raises ValueError: raise an error if ``a`` is greater than ``len(b)``.
         :returns: returns the element of ``b`` at index ``a``.
         :rtype: int
@@ -38,10 +39,11 @@ class DummyMethods:
         return a
 
     multiple_args_and_error.expected = {
-        "signature": "(a, b) -> int",
+        "signature": "(a, b, c) -> int",
         "parameters": {
             "a": {"annotation": "int", "doc": "<p>an int.</p>"},
             "b": {"annotation": "list[int]", "doc": "<p>a list of int.</p>"},
+            "c": {"annotation": "dict[str, list[str]]", "doc": "<p>a dict of lists.</p>"},
         },
         'raise': {'ValueError': '<p>raise an error if <tt class="docutils literal">a</tt> is greater than <tt class="docutils literal">len(b)</tt>.</p>'},
         "return": {"annotation": "int", "doc": '<p>returns the element of <tt class="docutils literal">b</tt> at index <tt class="docutils literal">a</tt>.</p>'},


### PR DESCRIPTION
In python 3.10;
When the type of a method parameter is a container (eg: `list[T]`), `stringify_signature` was not getting the full type but only the origin of it (eg: `list` instead of `list[int]`).

This commit fixes the issue by stringifiying the container types separately.

runbot-237782
