### PR TITLE
[FIX] stock: prevent invisible serial number when assigning generic stock

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -597,7 +597,7 @@ Please change the quantity done or the rounding precision of your unit of measur
                         mls_without_lots -= move_line
                     else:  # No line without serial number, creates a new one.
                         reserved_quants = self.env['stock.quant']._get_reserve_quantity(move.product_id, move.location_id, 1.0, lot_id=lot)
-                        if reserved_quants:
+                        if reserved_quants and reserved_quants[0][0].lot_id:
                             move_line_vals = self._prepare_move_line_vals(quantity=0, reserved_quant=reserved_quants[0][0])
                         else:
                             move_line_vals = self._prepare_move_line_vals(quantity=0)

--- a/addons/stock/tests/test_move_lines.py
+++ b/addons/stock/tests/test_move_lines.py
@@ -4,6 +4,7 @@
 import datetime
 from freezegun import freeze_time
 
+from odoo import Command
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.tests import Form
 from odoo.exceptions import UserError
@@ -236,3 +237,37 @@ class StockMoveLine(TestStockCommon):
             })
             # 36 units > 24 units
             self.assertTrue(ml.date > update_date_3, "Quantity change check for date should take into account UoM conversion")
+
+    def test_lot_creation_from_move_line_with_generic_stock(self):
+        """
+        Test that if the product already have quantities and after that tracking is set to serial,
+        we can create a lot and assign it to the move.
+        """
+        self.productA.tracking = "none"
+
+        self.env["stock.quant"]._update_available_quantity(self.productA, self.env["stock.location"].browse(self.stock_location), 100)
+
+        self.productA.tracking = "serial"
+
+        serial_lot = self.env["stock.lot"].create(
+            {
+                "name": "SN001",
+                "product_id": self.productA.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Repair Move",
+                "product_id": self.productA.id,
+                "product_uom": self.productA.uom_id.id,
+                "product_uom_qty": 1.0,
+                "location_id": self.stock_location,
+                "location_dest_id": self.customer_location,
+                "lot_ids": [Command.link(serial_lot.id)],
+            }
+        )
+
+        line = move.move_line_ids[0]
+        self.assertEqual(line.lot_id, serial_lot)


### PR DESCRIPTION
Steps to reproduce:
1. Create a storable product with tracking set to 'By Quantity'.
2. Update the Quantity on Hand (e.g., 100 units).
3. Change the product tracking to 'By Serial Number'.
4. Create a Repair Order for this product.
5. Add a line, select a specific Serial Number, and click Save.
6. Observe that the serial number disappears.

Cause:
When reserving stock that was originally created as 'Generic' (no serial), the `_prepare_move_line_vals` method returns `lot_id=False`. The repair view uses `_compute_lot_ids` to display selected lots, which filters out any move lines where `lot_id` is False. This causes the new line to be effectively invisible to the UI immediately after creation.

Solution:
In the `_set_lot_ids` inverse method, explicitly force the `lot_id` into the create values dictionary (`move_line_vals`). This ensures that even if Odoo reserves generic stock, the resulting move line is born with the correct Serial Number identity, keeping it visible and valid.

opw-5156267