### PR TITLE
[ADD] core: checker for methods being set on models during tests

### DIFF
--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -9,6 +9,9 @@ import odoo.tests
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestAutomation(TransactionCaseWithUserDemo):
+    def tearDown(self):
+        self.env['base.automation']._unregister_hook()
+        super().tearDown()
 
     def test_01_on_create_or_write(self):
         """ Simple on_create with admin user """

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -937,6 +937,10 @@ class TestCompute(common.TransactionCase):
             'email': 'mitchell.admin@example.com',
         })
 
+    def tearDown(self):
+        self.env['base.automation']._unregister_hook()
+        super().tearDown()
+
     def test_automation_form_view(self):
         automation_form = Form(self.env['base.automation'], view='base_automation.view_base_automation_form')
 

--- a/addons/test_base_automation/tests/test_tour.py
+++ b/addons/test_base_automation/tests/test_tour.py
@@ -13,6 +13,10 @@ def _urlencode_kwargs(**kwargs):
 
 @tagged("post_install_l10n", "post_install", "-at_install")
 class BaseAutomationTestUi(HttpCase):
+    def tearDown(self):
+        self.env['base.automation']._unregister_hook()
+        super().tearDown()
+
     def _neutralize_preexisting_automations(self, neutralize_action=True):
         self.env["base.automation"].with_context(active_test=False).search([]).write({"active": False})
         if neutralize_action:

--- a/addons/test_mass_mailing/tests/test_blacklist_mixin.py
+++ b/addons/test_mass_mailing/tests/test_blacklist_mixin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from unittest.mock import patch
 
 from odoo.addons.test_mass_mailing.models.mailing_models import MailingBLacklist
 from odoo.addons.test_mass_mailing.tests import common
@@ -23,16 +24,16 @@ class TestBLMixin(common.TestMassMailCommon):
 
     @users('employee')
     def test_bl_mixin_primary_field_consistency(self):
-        MailingBLacklist._primary_email = 'not_a_field'
-        with self.assertRaises(UserError):
+        with patch.object(MailingBLacklist, '_primary_email', 'not_a_field'), \
+             self.assertRaises(UserError):
             self.env['mailing.test.blacklist'].search([('is_blacklisted', '=', False)])
 
-        MailingBLacklist._primary_email = ['not_a_str']
-        with self.assertRaises(UserError):
+        with patch.object(MailingBLacklist, '_primary_email', ['not_a_str']), \
+             self.assertRaises(UserError):
             self.env['mailing.test.blacklist'].search([('is_blacklisted', '=', False)])
 
-        MailingBLacklist._primary_email = 'email_from'
-        self.env['mailing.test.blacklist'].search([('is_blacklisted', '=', False)])
+        with patch.object(MailingBLacklist, '_primary_email', 'email_from'):
+            self.env['mailing.test.blacklist'].search([('is_blacklisted', '=', False)])
 
     @users('employee')
     def test_bl_mixin_is_blacklisted(self):

--- a/addons/website_sale_comparison/tests/test_website_sale_comparison.py
+++ b/addons/website_sale_comparison/tests/test_website_sale_comparison.py
@@ -52,6 +52,11 @@ class TestWebsiteSaleComparison(TransactionCase):
         # because it would commit the test transaction)
         website_sale_comparison = self.env['ir.module.module'].search([('name', '=', 'website_sale_comparison')])
         website_sale_comparison.module_uninstall()
+        # module_uninstall triggers the injection of a bunch of temporary dupe of fields added by the module into
+        # the leaf model to "unshare" them, but because the uninstall is not committed the dupes remain set
+        del self.registry['product.attribute'].category_id
+        for attr in ('create_uid', 'write_uid', 'create_date', 'write_date', 'name', 'sequence'):
+            delattr(self.registry['product.attribute.category'], attr)
 
         # Check that the generic view is correctly removed
         self.assertFalse(Website0.viewref('website_sale_comparison.product_attributes_body', raise_if_not_found=False))

--- a/odoo/addons/test_apikeys/tests/test_flow.py
+++ b/odoo/addons/test_apikeys/tests/test_flow.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import patch
 
 from odoo import api
 from odoo.tests import tagged, get_db_name, HttpCase
@@ -18,10 +19,7 @@ class TestAPIKeys(TestTOTPMixin, HttpCase):
         @api.model
         def log(inst, *args, **kwargs):
             self.messages.append((inst, args, kwargs))
-        self.registry['ir.logging'].send_key = log
-        @self.addCleanup
-        def remove_callback():
-            del self.registry['ir.logging'].send_key
+        self.startPatcher(patch.object(self.registry['ir.logging'], 'send_key', log, create=True))
 
     def test_addremove(self):
         db = get_db_name()

--- a/odoo/addons/test_new_api/tests/test_new_fields.py
+++ b/odoo/addons/test_new_api/tests/test_new_fields.py
@@ -4462,7 +4462,7 @@ class TestSelectionOndeleteAdvanced(TransactionCase):
         # necessary cleanup for resetting changes in the registry
         for model_name in (self.MODEL_BASE, self.MODEL_REQUIRED):
             Model = self.registry[model_name]
-            self.addCleanup(setattr, Model, '_BaseModel__base_classes', Model._BaseModel__base_classes)
+            self.patch(Model, '_BaseModel__base_classes', Model._BaseModel__base_classes)
 
     def test_ondelete_unexisting_policy(self):
         class Foo(models.Model):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -649,10 +649,15 @@ class BaseModel(metaclass=MetaModel):
     """
 
     # default values for _transient_vacuum()
-    _transient_max_count = lazy_classproperty(lambda _: config.get('osv_memory_count_limit'))
-    "maximum number of transient records, unlimited if ``0``"
-    _transient_max_hours = lazy_classproperty(lambda _: config.get('transient_age_limit'))
-    "maximum idle lifetime (in hours), unlimited if ``0``"
+    @lazy_classproperty
+    def _transient_max_count(cls):
+        """maximum number of transient records, unlimited if ``0``"""
+        return config.get('osv_memory_count_limit')
+
+    @lazy_classproperty
+    def _transient_max_hours(cls):
+        """maximum idle lifetime (in hours), unlimited if ``0``"""
+        return config.get('transient_age_limit')
 
     def _valid_field_parameter(self, field, name):
         """ Return whether the given parameter name is valid for the field. """


### PR DESCRIPTION
Setting methods on models during tests and not removing them afterwards can cause misbehaviour of other tests. Setting mock or test-specific methods is not an issue but it should be done via patchers.

https://runbot.odoo.com/odoo/error/237983
