### PR TITLE
[FIX] html_builder, *: disable image filters when WebGL missing

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -22,6 +22,7 @@ export class BuilderRow extends Component {
         extraLabelClass: { type: String, optional: true },
         observeCollapseContent: { type: Boolean, optional: true },
         fullRowToggler: { type: Boolean, optional: true },
+        disabled: { type: Boolean, optional: true },
     };
     static defaultProps = { expand: false, observeCollapseContent: false, fullRowToggler: false };
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -38,6 +38,13 @@
     align-items: center;
     color: var(--o-hb-row-color, #{$o-we-fg-dark});
 
+    &[data-disabled] {
+        .hb-row-label {
+            opacity: 0.5;
+        }
+        cursor: not-allowed;
+    }
+
     .hb-container-subtitle {
         padding: $o-hb-row-spacing 0 $o-hb-row-spacing $o-hb-row-padding-left;
     }

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.xml
@@ -8,6 +8,8 @@
             t-att-class="this.getLevelClass()"
             t-ref="root"
             t-att-data-label="props.label"
+            t-att-data-disabled="props.disabled"
+            t-att-aria-disabled="props.disabled ? 'true' : undefined"
             >
 
             <button

--- a/addons/html_builder/static/src/core/building_blocks/builder_select.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.js
@@ -29,6 +29,7 @@ export class BuilderSelect extends Component {
         ...basicContainerBuilderComponentProps,
         className: { type: String, optional: true },
         dropdownContainerClass: { type: String, optional: true },
+        disabled: { type: Boolean, optional: true },
         slots: {
             type: Object,
             shape: {

--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -8,7 +8,13 @@
         <div t-ref="root" class="o-hb-select-wrapper">
             <div inert="" class="h-0 w-0 overflow-hidden" t-att-class="props.className" t-ref="content"><WithIgnoreItem><t t-slot="default" /></WithIgnoreItem></div>
             <Dropdown state="this.dropdown" menuClass="'o-hb-select-dropdown'">
-                <button class="o-hb-select-toggle o-hb-btn btn btn-secondary text-start o-dropdown-caret" t-ref="button" t-att-id="props.id">
+                <button 
+                    class="o-hb-select-toggle o-hb-btn btn btn-secondary text-start o-dropdown-caret"
+                    t-ref="button"
+                    t-att-id="props.id"
+                    t-att-disabled="props.disabled ? 'disabled' : undefined"
+                    t-att-aria-disabled="props.disabled ? 'true' : undefined"
+                    >
                     <t t-slot="fixedButton"/>
                 </button>
                 <t t-set-slot="content">

--- a/addons/html_builder/static/src/plugins/image/image_filter_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_filter_option.js
@@ -1,6 +1,7 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { shouldPreventGifTransformation } from "@html_editor/main/media/image_post_process_plugin";
-import { loadImageInfo } from "@html_editor/utils/image_processing";
+import { loadImageInfo, isWebGLEnabled } from "@html_editor/utils/image_processing";
+import { _t } from "@web/core/l10n/translation";
 
 export class ImageFilterOption extends BaseOptionComponent {
     static template = "html_builder.ImageFilterOption";
@@ -17,9 +18,12 @@ export class ImageFilterOption extends BaseOptionComponent {
                 ...editingElement.dataset,
                 ...data,
             }));
+            const canUseGlFilter = isWebGLEnabled();
             return {
                 isCustomFilter: editingElement.dataset.glFilter === "custom",
                 showFilter: data.mimetypeBeforeConversion && !shouldPreventGifTransformation(data),
+                disableFilter: !canUseGlFilter,
+                tooltip: !canUseGlFilter ? _t("WebGL is not enabled on your browser.") : undefined,
             };
         });
     }

--- a/addons/html_builder/static/src/plugins/image/image_filter_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_filter_option.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.ImageFilterOption">
-    <BuilderRow label.translate="Filter" level="this.props.level" t-if="state.showFilter">
-        <BuilderSelect>
+    <BuilderRow label.translate="Filter" level="this.props.level" t-if="state.showFilter" disabled="state.disableFilter" tooltip="state.tooltip">
+        <BuilderSelect disabled="state.disableFilter">
             <BuilderSelectItem action="'glFilter'" actionParam="''">None</BuilderSelectItem>
             <BuilderSelectItem action="'glFilter'" actionParam="'blur'">Blur</BuilderSelectItem>
             <BuilderSelectItem action="'glFilter'" actionParam="'1977'">1977</BuilderSelectItem>

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -4,6 +4,7 @@ import {
     getDataURLBinarySize,
     getImageSizeFromCache,
     isGif,
+    isWebGLEnabled,
     loadImage,
     loadImageDataURL,
     loadImageInfo,
@@ -208,7 +209,8 @@ export class ImagePostProcessPlugin extends Plugin {
         }
 
         // GL filter
-        if (glFilter) {
+        const canUseWebGL = glFilter && isWebGLEnabled() && window.WebGLImageFilter;
+        if (canUseWebGL) {
             const glf = new window.WebGLImageFilter();
             const cv = document.createElement("canvas");
             cv.width = canvas.width;

--- a/addons/html_editor/static/src/utils/image_processing.js
+++ b/addons/html_editor/static/src/utils/image_processing.js
@@ -8,6 +8,27 @@ import { getImageSrc } from "./image";
 export const cropperDataFields = ["x", "y", "width", "height", "rotate", "scaleX", "scaleY"];
 export const cropperDataFieldsWithAspectRatio = [...cropperDataFields, "aspectRatio"];
 export const isGif = (mimetype) => mimetype === "image/gif";
+
+let _isWebGLEnabled;
+/**
+ * Cacheable check telling whether the current browser can allocate a WebGL context.
+ */
+export function isWebGLEnabled() {
+    if (_isWebGLEnabled !== undefined) {
+        return _isWebGLEnabled;
+    }
+    try {
+        const canvas = document.createElement("canvas");
+        _isWebGLEnabled = !!(
+            window.WebGLRenderingContext &&
+            (canvas.getContext("webgl") || canvas.getContext("experimental-webgl"))
+        );
+    } catch {
+        _isWebGLEnabled = false;
+    }
+    return _isWebGLEnabled;
+}
+
 const modifierFields = [
     "filter",
     "quality",


### PR DESCRIPTION
*: html_editor

This commit backports [3817cdd], which was properly adapted in 19.0. In 18.4 ([c943a88]), it was kept by mistake as in previous versions, prior to the html_builder refactoring. As a result, the fix didn't work in this specific version.

Original explanation:
On recent versions of Chrome for Linux (v140+), the old SwiftShader software fallback for WebGL has been removed. As a result, new window.WebGLImageFilter() now throws if no GPU context is available, typically when WebGL is disabled or unsupported.

Since the application cannot enable WebGL from JavaScript, this commit improves the user experience by detecting the absence of a WebGL context early and disabling image filters in edit mode. Instead of raising a traceback, the editor now skips the filter feature and can optionally display a friendly message explaining that WebGL is required to use image filters.

This avoids runtime errors and ensures a more robust behavior on platforms where WebGL is unavailable.

[3817cdd]: https://github.com/odoo/odoo/commit/3817cdd3bc096e62dbd017a85356a8032d5217bd
[c943a88]: https://github.com/odoo/odoo/commit/c943a882624900743f02719560b70a0a683f095a

task-5117584