### PR TITLE
[FIX] project_timesheet_holidays: delete timesheets when time off is deleted

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_leave.py
+++ b/addons/project_timesheet_holidays/models/hr_leave.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 
 import pytz
 
@@ -126,7 +126,15 @@ class HrLeave(models.Model):
         timesheet_ids_to_remove = []
         for leave in self:
             if leave.number_of_days == 0 and leave.sudo().timesheet_ids:
+                timesheet_ids_to_remove.extend(leave.timesheet_ids.ids)
                 leave.sudo().timesheet_ids.holiday_id = False
-                timesheet_ids_to_remove.extend(leave.timesheet_ids)
         self.env['account.analytic.line'].browse(set(timesheet_ids_to_remove)).sudo().unlink()
         return res
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_timesheets(self):
+        """ Remove timesheets when the timeoff is deleted. """
+        timesheets = self.sudo().timesheet_ids
+        timesheets.write({'holiday_id': False})
+        timesheets.unlink()
+        self._check_missing_global_leave_timesheets()

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -88,6 +88,18 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         holiday.with_user(SUPERUSER_ID).action_refuse()
         self.assertEqual(len(holiday.timesheet_ids), 0, 'Number of linked timesheets should be zero, since the leave is refused.')
 
+        # Ensure timesheets generated from a time off are deleted when the leave is removed
+        holiday.with_user(SUPERUSER_ID).action_approve()
+        timesheets = holiday.timesheet_ids
+        self.assertEqual(
+            len(timesheets),
+            holiday.number_of_days,
+            'Number of generated timesheets should be the same as the leave duration'
+        )
+
+        holiday.with_user(SUPERUSER_ID).unlink()
+        self.assertFalse(timesheets.exists(), 'Timesheet should be deleted')
+
         company = self.env['res.company'].create({"name": "new company"})
         self.empl_employee.write({
             "company_id": company.id,
@@ -198,13 +210,14 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         self.assertEqual(len(timesheets.filtered('global_leave_id')), 1, '1 timesheet should be linked to global leave')
 
     def test_delete_timesheet_after_new_holiday_covers_whole_timeoff(self):
-        """ User should be able to delete a timesheet created after a new public holiday is added,
-            covering the *whole* period of a existing time off.
+        """ A timesheet created from a validated time off should be removed
+            when a new public holiday fully covers that time off period.
+
             Test Case:
             =========
             1) Create a Time off, approve and validate it.
             2) Create a new Public Holiday, covering the whole time off created in step 1.
-            3) Delete the new timesheet associated with the public holiday.
+            3) The associated timesheet should be deleted to avoid orphan records.
         """
 
         leave_start_datetime = datetime(2022, 1, 31, 7, 0, 0, 0)    # Monday
@@ -228,18 +241,16 @@ class TestTimesheetHolidays(TestCommonTimesheet):
             'date_to': datetime(2022, 1, 31, 23, 0, 0, 0),
         })
 
-        # The timeoff should have been force_cancelled and its associated timesheet unlinked.
+        # The timeoff should have been force_cancelled and its associated timesheet should be removed.
         self.assertFalse(time_off.timesheet_ids, '0 timesheet should remain for this time off.')
 
-        # (3) Delete the timesheet
+        # (3) Ensure no timesheet exists for that employee and date
         timesheets = self.env['account.analytic.line'].search([
             ('date', '>=', leave_start_datetime),
             ('date', '<=', leave_end_datetime),
             ('employee_id', '=', self.empl_employee.id),
         ])
 
-        # timesheet should be unlinked to the timeoff, and be able to delete it
-        timesheets.with_user(SUPERUSER_ID).unlink()
         self.assertFalse(timesheets.exists(), 'Timesheet should be deleted')
 
     def test_timeoff_task_creation_with_holiday_leave(self):


### PR DESCRIPTION
BUG 1:
-----------

**Steps to reproduce:**
1. Install Time Off and Timesheets with demo data.
2. Create a time off for an employee and approve it.
3. Check the related timesheet entry for that employee.
4. Delete the approved time off.
5. Check the timesheet entries again.

**Issue:**
The timesheet entry remains even after the related time off record is deleted.

**Cause:**
Following commit 944c11e, admins can delete [approved time off ](https://github.com/odoo/odoo/blob/f6cf0d067e5f30e2b22ea513071cd7c5e3d9f44c/addons/hr_holidays/models/hr_leave.py#L956-L959)records. 
The relationship between the leave and the analytic line (timesheet) did not
have a deletion policy defined. When the leave was [unlinked](https://github.com/odoo/odoo/blob/f6cf0d067e5f30e2b22ea513071cd7c5e3d9f44c/addons/hr_holidays/models/hr_leave.py#L961-L964), the analytic
line remained without its parent reference.

**Solution:**
Explicitly remove related timesheet entries before deleting the leave record.


BUG 2:
-----------


Currently, refusing/cancelling a time off record can lead to orphan 
timesheets/duplicated hours (16h instead of 8h) if a public holiday 
exists on the same day.

**Root cause:**
The issue comes from this write method:
https://github.com/odoo/odoo/blob/79ff1d63caed2c1058aa338947b9af90ebb6cd20/addons/project_timesheet_holidays/models/hr_leave.py#L128-L130
The method first unlinks the holiday_id from the timesheets
and then attempts to delete them.

However, once the holiday_id is set to False, the timesheets are
no longer linked to the leave. As a result, leave.timesheet_ids becomes empty,
and nothing is deleted. This leads to orphan timesheet records.

When the leave is later refused or cancelled, a new public holiday timesheet
entry is generated (if applicable), resulting in duplicated timesheet entries
for the same day.

**Steps to reproduce:**
1. Create a time off for one day and validate it (8h timesheet generated).
2. Create a public holiday for the same day.
3. Observe that leave duration becomes 0, but the timesheet remains.
4. Refuse or cancel the time off.
5. Observe two timesheet entries for the same day (16h total).

opw-5384428





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
