### PR TITLE
[IMP] l10n_my_edi_pos: enable self-service invoicing in pos for edi

### DIFF
--- a/addons/l10n_my_edi/models/account_move.py
+++ b/addons/l10n_my_edi/models/account_move.py
@@ -158,10 +158,11 @@ class AccountMove(models.Model):
 
         return super().action_invoice_sent()
 
-    def action_l10n_my_edi_send_invoice(self):
+    def action_l10n_my_edi_send_invoice(self, allow_raising=True):
         """
         This action will create the MyInvois Document for this invoice if it does not already exist.
         Once done, it will trigger the sending of said document to the platform.
+        :param allow_raising: whether the process can raise errors.
         """
         invoice_needing_new_document = self.env['account.move']
         myinvois_documents = self.env['myinvois.document']
@@ -180,7 +181,7 @@ class AccountMove(models.Model):
         myinvois_documents |= invoice_needing_new_document._create_myinvois_document()
 
         if myinvois_documents:
-            myinvois_documents.action_submit_to_myinvois()
+            myinvois_documents.action_submit_to_myinvois(allow_raising=allow_raising)
 
     def action_show_myinvois_documents(self):
         return self.l10n_my_edi_document_ids.action_show_myinvois_documents()

--- a/addons/l10n_my_edi/models/myinvois_document.py
+++ b/addons/l10n_my_edi/models/myinvois_document.py
@@ -328,7 +328,7 @@ class MyInvoisDocument(models.Model):
     # Action methods
     # --------------
 
-    def action_submit_to_myinvois(self):
+    def action_submit_to_myinvois(self, allow_raising=True):
         """
         Submit all new documents in self to MyInvois.
         This can also be used on invalid documents to re-submit them after correcting the error.
@@ -339,12 +339,12 @@ class MyInvoisDocument(models.Model):
 
         # Documents linked to an invoice, and whose invoice is cancelled or draft, shouldn't be sent.
         invalid_documents = documents.filtered(lambda d: d.invoice_ids and any(invoice.state in ('draft', 'cancel') for invoice in d.invoice_ids))
-        if invalid_documents:
+        if invalid_documents and allow_raising:
             raise UserError(self.env._('You cannot send this document to MyInvois because the related invoice(s) %s are in draft or canceled state.', ','.join(invalid_documents.mapped('name'))))
 
         # Required for the file, this is the exact date at which the consolidated invoice was sent to MyInvois.
         documents.filtered(lambda d: not d.myinvois_issuance_date).myinvois_issuance_date = fields.Date.context_today(documents)
-        documents._submit_to_myinvois()
+        documents._submit_to_myinvois(allow_raising=allow_raising)
 
     def action_update_submission_status(self):
         """
@@ -356,7 +356,7 @@ class MyInvoisDocument(models.Model):
         else:
             self._myinvois_submission_statuses_update()
 
-    def action_generate_xml_file(self):
+    def action_generate_xml_file(self, allow_raising=True):
         """
         Generate a xml file for each of the MyInvois documents in self.
         If the document already as a file, the previous file's name is updated to include an (old) tag to avoid confusion in the attachment list.
@@ -371,6 +371,15 @@ class MyInvoisDocument(models.Model):
 
             xml_data, errors = document._myinvois_generate_xml_file()
             if errors:
+                # make log on portal in case of public user e.g pos ticket validation
+                if not allow_raising:
+                    document._myinvois_post_message_to_public(
+                        self.env._(
+                            "MyInvois could not validate the details provided. "
+                            "To finalize e-invoice issuance, please contact us directly.",
+                        ),
+                    )
+                    continue
                 raise UserError(document.env._("Error when generating the documents' files:\n\n- %(errors)s", errors='\n- '.join(errors)))
 
             new_documents_data.append({
@@ -474,6 +483,18 @@ class MyInvoisDocument(models.Model):
             raise UserError(self.env._("Please register for the E-Invoicing service in the settings first."))
 
         return proxy_user
+
+    def _myinvois_post_message_to_public(self, message=None):
+        """
+        Small helper to use when posting message for the public users.
+        """
+        if message:
+            for invoice in self.invoice_ids:
+                invoice.message_post(
+                    body=message,
+                    message_type="comment",
+                    subtype_xmlid="mail.mt_comment",
+                )
 
     def _myinvois_log_message(self, message=None, bodies=None):
         """
@@ -1094,35 +1115,57 @@ class MyInvoisDocument(models.Model):
         xml_content = dict_to_xml(document_node, nsmap=nsmap, template=template)
         return etree.tostring(xml_content, xml_declaration=True, encoding='UTF-8'), set(errors)
 
-    def _submit_to_myinvois(self):
+    def _submit_to_myinvois(self, allow_raising=True):
         """
         Submit the documents in self to MyInvois.
         This action will re-generate a new XML file, in order to ensure that we always send an up-to-date version.
         """
         # Make sure that all documents in self have a file ready to be sent.
-        self.action_generate_xml_file()
+        self.action_generate_xml_file(allow_raising=allow_raising)
+
+        valid_docs = self.filtered(lambda d: d.myinvois_file)
+        if not valid_docs:
+            return
 
         # Submit the documents to the API
         errors = self._myinvois_submit_documents({
             document: {
                 'name': document.name,
                 'xml': base64.b64decode(document.myinvois_file).decode('utf-8'),
-            } for document in self
+            } for document in valid_docs
         })
 
         # When sending an individual document, we can raise once we are sure we logged the errors.
         if len(self) == 1 and errors:
             if self._can_commit():
                 self.env.cr.commit()  # Save the error logged in the chatter.
-            raise UserError(errors[self.id]['plain_text_error'])
+            if not allow_raising:
+                self._myinvois_post_message_to_public(
+                        self.env._(
+                            "MyInvois could not validate the details provided. "
+                            "To finalize e-invoice issuance, please contact us directly.",
+                        ),
+                    )
+            else:
+                raise UserError(errors[self.id]['plain_text_error'])
 
         # Try and get the status, up to three time, stopping if all documents have a status already.
         for _i in range(3):
             self._myinvois_submission_statuses_update()
-            if not any(document.myinvois_state == 'in_progress' for document in self):
+            if not any(document.myinvois_state == 'in_progress' for document in valid_docs):
                 break
             if self._can_commit():  # avoid the sleep in tests.
                 time.sleep(1)
+
+        # If status is still in_progress than just make log for public users.
+        if not allow_raising:
+            for doc in (docs for docs in valid_docs if valid_docs.myinvois_state == 'in_progress'):
+                doc._myinvois_post_message_to_public(
+                self.env._(
+                    "Your input has been submitted. "
+                    "Please save this link and refresh later to view the final status.",
+                ),
+            )
 
     def _myinvois_check_can_update_status(self):
         """ The document status can only be updated (for rejection, or cancellation) up to 72h after the validation time.
@@ -1211,6 +1254,16 @@ class MyInvoisDocument(models.Model):
         """
         if message:
             self._myinvois_log_message(message)
+
+        # Case handling for invalid status responses from MyInvois.
+        if self.env.user.is_public:
+            if state in CANCELLED_STATES:
+                self._myinvois_post_message_to_public(
+                    self.env._(
+                        "MyInvois could not validate the details provided. "
+                        "To finalize e-invoice issuance, please contact us directly.",
+                    ),
+                )
 
         self.myinvois_state = state
 

--- a/addons/l10n_my_edi_pos/__init__.py
+++ b/addons/l10n_my_edi_pos/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import controllers
 from . import models
 from . import wizard

--- a/addons/l10n_my_edi_pos/__manifest__.py
+++ b/addons/l10n_my_edi_pos/__manifest__.py
@@ -14,7 +14,15 @@
         "views/pos_order_views.xml",
         "views/product_view.xml",
         "views/res_partner_view.xml",
+        "views/portal_address_templates.xml",
+        "views/ticket_validation_screen.xml",
     ],
+    'assets': {
+        'web.assets_frontend': [
+            'l10n_my_edi_pos/static/src/interactions/address.js',
+        ],
+    },
+
     'auto_install': True,
     'author': 'Odoo S.A.',
     "license": "LGPL-3",

--- a/addons/l10n_my_edi_pos/controllers/__init__.py
+++ b/addons/l10n_my_edi_pos/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/addons/l10n_my_edi_pos/controllers/portal.py
+++ b/addons/l10n_my_edi_pos/controllers/portal.py
@@ -1,0 +1,116 @@
+from odoo.http import request
+
+from odoo.addons.account.controllers.portal import PortalAccount
+
+
+class L10nMYPortalAccount(PortalAccount):
+
+    def _prepare_address_form_values(self, *args, **kwargs):
+        rendering_values = super()._prepare_address_form_values(*args, **kwargs)
+
+        l10n_my_identification_types = dict(request.env['res.partner']._fields['l10n_my_identification_type'].selection)
+        # BRN applies only to companies. It must not be selectable for individuals, and it's enforced companies.
+        l10n_my_identification_types.pop('BRN')
+        default_classification = request.env.ref(
+            'l10n_my_edi.class_00000', raise_if_not_found=False,
+        )
+        rendering_values.update({
+            'l10n_my_identification_types': l10n_my_identification_types,
+            'l10n_my_edi_industrial_classifications': request.env['l10n_my_edi.industry_classification'].sudo().search([]),
+            'default_industrial_classification_id': default_classification.id if default_classification else False,
+        })
+        return rendering_values
+
+    def _parse_form_data(self, form_data):
+        address_values, extra_form_data = super()._parse_form_data(form_data)
+
+        is_my_user = (
+            request.env['res.country'].browse(address_values.get('country_id'))
+            .exists().code == 'MY'
+        )
+
+        # MyInvois requires VAT, identification number and type; placeholders are used in certain cases which are handled below.
+        if form_data.get('company_type') == 'person':
+            vat_type = 'vat' if is_my_user else 'l10n_my_edi_malaysian_tin'
+            if not address_values.get(vat_type) and address_values.get('l10n_my_identification_number'):
+                address_values[vat_type] = 'EI00000000010'
+
+            if (
+                not address_values.get('l10n_my_identification_number')
+                and address_values.get(vat_type)
+                and is_my_user
+            ):
+                address_values['l10n_my_identification_number'] = '000000000000'
+
+        if form_data.get('company_type') == 'company':
+            address_values['l10n_my_identification_type'] = 'BRN'
+            if not is_my_user and not address_values['l10n_my_identification_number']:
+                address_values['l10n_my_identification_number'] = '000000000000'
+        return address_values, extra_form_data
+
+    def _validate_address_values(self, address_values, partner_sudo, address_type, *args, **kwargs):
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values, partner_sudo, address_type, *args, **kwargs
+        )
+
+        _ = self.env._
+        is_my_user = (
+            request.env['res.country'].browse(address_values.get('country_id'))
+            .exists().code == 'MY'
+        )
+        company_type = request.params.get('company_type')
+        id_number = address_values.get('l10n_my_identification_number')
+        id_type = address_values.get('l10n_my_identification_type')
+
+        def _validate_required_fields(fields, message):
+            missing = [field for field in fields if not address_values.get(field)]
+            if missing:
+                missing_fields.update(missing)
+                error_messages.append(message)
+
+        if id_number and (
+            (id_type in ('NRIC', 'ARMY', 'PASSPORT') and len(id_number) > 12)
+            or (id_type == 'BRN' and len(id_number) > 20)
+        ):
+            missing_fields.add('l10n_my_identification_number')
+            error_messages.append(_("Please add a valid identification number"))
+
+        if company_type == 'person':
+            if is_my_user:
+                if not id_number and not address_values.get('vat'):
+                    _validate_required_fields(
+                        ['l10n_my_identification_number', 'vat'],
+                        _("Please provide at least an Identification Number or a TIN (Income Tax Number) to issue an invoice"),
+                    )
+            else:
+                if (
+                    not id_number
+                    or id_type != 'PASSPORT'
+                ):
+                    error_messages.append(_("Some fields are missing or have wrong values"))
+                    if not id_number:
+                        missing_fields.add('l10n_my_identification_number')
+                    if id_type != 'PASSPORT':
+                        missing_fields.add('l10n_my_identification_type')
+
+        elif company_type == 'company':
+            if is_my_user:
+                _validate_required_fields(
+                    ['l10n_my_identification_number', 'vat'],
+                    _("Please enter your Business Registration Number (BRN) and TIN (Income Tax Number) to proceed."),
+                )
+            else:
+                _validate_required_fields(
+                    ['l10n_my_edi_malaysian_tin'],
+                    _("Malaysian VAT is required to process invoice"),
+                )
+
+        return invalid_fields, missing_fields, error_messages
+
+    def _get_mandatory_address_fields(self, country_sudo):
+        field_names = super()._get_mandatory_address_fields(country_sudo)
+
+        if country_sudo.code == 'MY':
+            field_names.add('state_id')
+
+        return field_names

--- a/addons/l10n_my_edi_pos/models/__init__.py
+++ b/addons/l10n_my_edi_pos/models/__init__.py
@@ -2,3 +2,4 @@
 from . import account_edi_xml_ubl_my
 from . import myinvois_document_pos
 from . import pos_order
+from . import res_partner

--- a/addons/l10n_my_edi_pos/models/pos_order.py
+++ b/addons/l10n_my_edi_pos/models/pos_order.py
@@ -88,7 +88,9 @@ class PosOrder(models.Model):
 
             # At this point we don't want to raise anymore, if there are issues it'll be logged on the invoice, and we will
             # move on.
-            self.account_move.action_l10n_my_edi_send_invoice()
+            # Do not raise for public (portal / POS) users: errors are logged on the invoice
+            # to avoid breaking the HTTP flow. Internal users still get raised errors.
+            self.account_move.action_l10n_my_edi_send_invoice(allow_raising=not self.env.user.is_public)
 
             if self.env.context.get('generate_pdf', True):
                 self.account_move.with_context(skip_invoice_sync=True)._generate_and_send()

--- a/addons/l10n_my_edi_pos/models/res_partner.py
+++ b/addons/l10n_my_edi_pos/models/res_partner.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    def _get_frontend_writable_fields(self):
+        frontend_writable_fields = super()._get_frontend_writable_fields()
+        frontend_writable_fields.update({'l10n_my_edi_malaysian_tin'})
+
+        return frontend_writable_fields

--- a/addons/l10n_my_edi_pos/static/src/interactions/address.js
+++ b/addons/l10n_my_edi_pos/static/src/interactions/address.js
@@ -1,0 +1,100 @@
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+import { patchDynamicContent } from "@web/public/utils";
+import { CustomerAddress } from "@portal/interactions/address";
+
+patch(CustomerAddress.prototype, {
+    setup() {
+        super.setup();
+
+        patchDynamicContent(this.dynamicContent, {
+            'input[name="company_type"]': {
+                "t-on-change": this.onChangeType.bind(this),
+            },
+        });
+    },
+
+    start() {
+        super.start();
+        if (!this.el.querySelector('input[name="company_type"]:checked')) {
+            return;
+        }
+
+        this._hideInput("parent_name");
+        const applyValidation = (field_name, pattern, title) => {
+            const field = this.el.querySelector(`input[name="${field_name}"]`);
+
+            if (field) {
+                field.pattern = pattern;
+                field.title = _t(title);
+            }
+        };
+        applyValidation("zip", "[0-9]+", "Zip code must contain only numbers");
+        applyValidation(
+            "phone",
+            "\\+[1-9][0-9]{6,14}",
+            "Phone Number must be in E.164 format (e.g. +60123456789)"
+        );
+        this.onChangeType();
+    },
+
+    onChangeType(ev = null) {
+        const radio = this.el.querySelector('input[name="company_type"]:checked');
+
+        if (!radio) {
+            return;
+        }
+
+        const setLabel = (forAttr, companyText, individualText) => {
+            const label = this.el.querySelector(`label[for="${forAttr}"]`);
+            if (label) {
+                label.textContent =
+                    radio.value === "company" ? _t(companyText) : _t(individualText);
+            }
+        };
+
+        setLabel("o_name", "Company Name", "Your Name");
+        setLabel(
+            "l10n_my_identification_number",
+            "Business Registration Number",
+            "Identification Number"
+        );
+
+        if (ev) {
+            const nameInput = this.el.querySelector('input[name="name"]');
+            if (nameInput) {
+                nameInput.value = "";
+            }
+
+            const errorBlock = this.el.querySelector(".o_portal_address_error");
+            if (errorBlock) {
+                errorBlock.style.display = "none";
+            }
+        }
+
+        if (radio.value === "person") {
+            this._hideInput("l10n_my_edi_industrial_classification");
+            this._showInput("l10n_my_identification_type");
+        } else {
+            this._hideInput("l10n_my_identification_type");
+            this._showInput("l10n_my_edi_industrial_classification");
+        }
+    },
+
+    async _onChangeCountry(init = false) {
+        await super._onChangeCountry(init);
+        const radio = this.el.querySelector('input[name="company_type"]:checked');
+
+        if (!radio || !this.el.querySelector('input[name="l10n_my_edi_malaysian_tin"]')) {
+            return;
+        }
+
+        if (this._getSelectedCountryCode() === "MY") {
+            this._hideInput("l10n_my_edi_malaysian_tin");
+            this._showInput("vat");
+        } else {
+            this._showInput("l10n_my_edi_malaysian_tin");
+            this._hideInput("vat");
+        }
+    },
+});

--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -3,11 +3,11 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 from freezegun import freeze_time
-from lxml import etree
+from lxml import etree, html
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import tagged
+from odoo.tests import HttpCase, tagged
 from odoo.tools import file_open, mute_logger
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -18,7 +18,7 @@ CONTACT_PROXY_METHOD = 'odoo.addons.l10n_my_edi.models.account_edi_proxy_user.Ac
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class TestMyInvoisPoS(TestPoSCommon):
+class TestMyInvoisPoS(TestPoSCommon, HttpCase):
 
     @classmethod
     @AccountTestInvoicingCommon.setup_country('my')
@@ -860,6 +860,58 @@ class TestMyInvoisPoS(TestPoSCommon):
             with file_open('l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_refund.xml', 'rb') as f:
                 expected_xml = etree.fromstring(f.read())
             self.assertXmlTreeEqual(root, expected_xml)
+
+    @mute_logger('odoo.addons.point_of_sale.models.pos_order')
+    def test_portal_invoice_request_flow(self):
+        """ Test the flow from the portal ticket validation to EDI submission. """
+        with self.with_pos_session():
+            order = self._create_order({
+                "pos_order_lines_ui_args": [(self.product_one, 1.0)],
+            })
+
+        self.assertFalse(order.account_move)
+
+        url = f"/pos/ticket/validate?access_token={order.access_token}"
+        response = self.url_open(url)  # GET request to get csrf token
+        self.assertEqual(response.status_code, 200)
+
+        token_elements = html.fromstring(response.content).xpath(
+            '//input[@name="csrf_token"]/@value',
+        )
+        self.assertTrue(token_elements, "CSRF token not found in the HTML tree")
+        csrf_token = token_elements[0]
+
+        requested_invoice_data = {
+            'access_token': order.access_token,
+            'name': 'Test Name',
+            'vat': 'C2584563200',
+            'l10n_my_identification_type': 'BRN',
+            'l10n_my_identification_number': '202001234567',
+            'country_id': self.env.ref('base.my').id,
+            'state_id': self.env.ref('base.state_my_kul').id,
+            'zip': '50300',
+            'street': '1 Wisma Dato Dagang',
+            'city': 'Kuala Lumpur',
+            'phone': '+60123456789',
+            'email': 'test@example.com',
+            'csrf_token': csrf_token,
+        }
+
+        with patch(CONTACT_PROXY_METHOD, new=self._mock_successful_submission):
+            self.url_open(url=url, data=requested_invoice_data)
+
+        self.assertTrue(order.account_move, "Invoice is not created")
+
+        myinvois_document = order.account_move._get_active_myinvois_document()
+        self.assertTrue(
+            myinvois_document,
+            "MyInvois document was not created",
+        )
+        self.assertIn(
+            myinvois_document.myinvois_state,
+            ("in_progress", "submitted", "valid"),
+            f"Unexpected MyInvois state: {myinvois_document.myinvois_state}",
+        )
 
     #################
     # Patched methods

--- a/addons/l10n_my_edi_pos/views/portal_address_templates.xml
+++ b/addons/l10n_my_edi_pos/views/portal_address_templates.xml
@@ -1,0 +1,28 @@
+<odoo>
+
+    <template id="portal_address_form_fields_my" inherit_id="portal.address_form_fields">
+
+        <xpath expr="//div[@id='div_vat']/label" position="replace">
+            <label for="o_vat" class="col-form-label fw-normal label-optional">
+                Tax Identification Number
+            </label>
+        </xpath>
+
+        <xpath expr="//div[@id='div_vat']" position="after">
+            <div id="div_my_tin" class="col-lg-6 mb-2"
+                t-if="pos_order and pos_order.company_id.account_fiscal_country_id.code == 'MY'">
+                <label class="col-form-label fw-normal label-optional">
+                    Tax Identification Number
+                </label>
+                <input
+                    type="text"
+                    name="l10n_my_edi_malaysian_tin"
+                    class="form-control"
+                    t-att-value="partner.l10n_my_edi_malaysian_tin"
+                />
+            </div>
+        </xpath>
+
+    </template>
+
+</odoo>

--- a/addons/l10n_my_edi_pos/views/ticket_validation_screen.xml
+++ b/addons/l10n_my_edi_pos/views/ticket_validation_screen.xml
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+
+    <template id="ticket_validation_screen" inherit_id="point_of_sale.ticket_validation_screen">
+
+        <xpath expr="//div[@id='get_info_div']/parent::div" position="after">
+            <t t-if="pos_order.company_id.account_fiscal_country_id.code == 'MY'">
+                <div class="form-check form-check-inline">
+                    <input type="radio" class="form-check-input"
+                        name="company_type" value="person" id="company_type_person" checked="checked" />
+                    <label class="form-check-label" for="company_type_person">Individual</label>
+                </div>
+
+                <div class="form-check form-check-inline">
+                    <input type="radio" class="form-check-input"
+                        name="company_type" value="company" id="company_type_company" />
+                    <label class="form-check-label" for="company_type_company">Company</label>
+                </div>
+
+                <t t-if="invalid_field and messages">
+                    <div class="fs-5 text-danger o_portal_address_error">
+                        <t t-foreach="messages" t-as="err">
+                            <t t-out="err" />
+                        </t>
+                    </div>
+                </t>
+            </t>
+        </xpath>
+
+        <xpath expr="//t[@t-call='portal.address_form_fields']" position="after">
+            <t t-if="pos_order.company_id.account_fiscal_country_id.code == 'MY'">
+                <t t-if="len(l10n_my_identification_types) > 1">
+                    <div class="mb-3 col-xl-6">
+                        <label class="col-form-label" for="l10n_my_identification_type">Identification
+                            Type</label>
+                        <select name="l10n_my_identification_type" class="form-select">
+                            <option
+                                t-foreach="l10n_my_identification_types"
+                                t-as="type"
+                                t-att-value="type"
+                                t-att-selected="l10n_my_identification_type == type"
+                                t-out="type_value"
+                            />
+                        </select>
+                    </div>
+                </t>
+                <div t-attf-class="mb-3 col-xl-6">
+                    <label class="col-form-label label-optional o_identification_label" for="l10n_my_identification_number">Identification
+                        Number</label>
+                    <input type="text" name="l10n_my_identification_number" t-attf-class="form-control"
+                        t-att-value="l10n_my_identification_number or partner_sudo.l10n_my_identification_number" />
+                </div>
+                <div t-attf-class="mb-3 col-xl-6">
+                    <label class="col-form-label label-optional"
+                        for="l10n_my_edi_industrial_classification">MSIC code</label>
+                    <select name="l10n_my_edi_industrial_classification" t-attf-class="form-select">
+                        <option
+                            t-foreach="l10n_my_edi_industrial_classifications"
+                            t-as="industrial_classification"
+                            t-att-value="industrial_classification.id"
+                            t-att-selected="industrial_classification.id == int(l10n_my_edi_industrial_classification) if l10n_my_edi_industrial_classification else industrial_classification.id == default_industrial_classification_id"
+                            t-out="industrial_classification.display_name"
+                        />
+                    </select>
+                </div>
+            </t>
+        </xpath>
+
+    </template>
+
+</odoo>


### PR DESCRIPTION
### PURPOSE
 - For Malaysian e-invoicing, if a buyer requests an e-invoice for the order
   that was previously not e- invoiced, they can request a vendor for can
   e-invoice later, as long as it has not been consolidated yet.
 - Currently validation form of the ticket does not have the EDI fields, so it
   can't process the invoice.
 - The invoice processing is different for both 'Individual' and 'Company' types
   partner.

### SPECIFICATION
 - Allow buyers to request a Malaysian e-Invoice for a previously non–e-invoiced
   order, as long as the invoice has not been consolidated.
 - Extend the invoice validation form (/pos/ticket/validation) to include
   mandatory Malaysian EDI fields required for e-Invoice processing.
 - Validate invoice eligibility before processing (not already e-Invoiced, not
   consolidated, Malaysian buyer).
 - Handle e-Invoice processing differently based on buyer type
   (Individual and Company).

task-5216103

