### PR TITLE
[IMP] core: colorize PID in logs

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -102,6 +102,7 @@ RESET_SEQ = "\033[0m"
 COLOR_SEQ = "\033[1;%dm"
 BOLD_SEQ = "\033[1m"
 COLOR_PATTERN = f"{COLOR_SEQ}{COLOR_SEQ}%s{RESET_SEQ}"
+TRUE_COLOR_PATTERN = f"\033[38;5;%dm%s{RESET_SEQ}"
 LEVEL_COLOR_MAPPING = {
     logging.DEBUG: (BLUE, DEFAULT),
     logging.INFO: (GREEN, DEFAULT),
@@ -109,6 +110,8 @@ LEVEL_COLOR_MAPPING = {
     logging.ERROR: (RED, DEFAULT),
     logging.CRITICAL: (WHITE, RED),
 }
+# all colors but black, grey and silver; length must be prime.
+PID_COLORS = (1, 2, 3, 4, 5, 6, 9, 10, 11, 12, 13, 14, 15)
 
 class PerfFilter(logging.Filter):
 
@@ -163,6 +166,10 @@ class ColoredFormatter(logging.Formatter):
     def format(self, record):
         fg_color, bg_color = LEVEL_COLOR_MAPPING.get(record.levelno, (GREEN, DEFAULT))
         record.levelname = COLOR_PATTERN % (30 + fg_color, 40 + bg_color, record.levelname)
+        if tools.config['workers']:
+            record.process = TRUE_COLOR_PATTERN % (PID_COLORS[record.process % len(PID_COLORS)], record.process)
+        else:
+            record.process = TRUE_COLOR_PATTERN % (PID_COLORS[record.thread % len(PID_COLORS)], record.process)
         return super().format(record)
 
 


### PR DESCRIPTION
The logs use the following format:

{date} {time} {pid} {level} {database} {module}: {message}

Before the commit, only the `{level}` part of the message, and the request line in case of of a HTTP request, was colored.

In this work we also color the `{pid}` so it is possible at a glance to determine the worker/thread that emitted the log record.

There are two reasons for this change:

1. To be able to follow the logs of a specific server, when multiple servers are emitting logs at a same time.
2. To be able to quickly determine what were the log messages emitted during the processing of a specific HTTP request.

We noted that many many developers think that the HTTP request line is logged *upon receiving the request* but it actually is logged *after* the response is sent. It means that all the logs of a specific request actually appear *before* the logged request line. We hope that this new colored PID adds a welcome cue so that devs read the lines *above* the HTTP request line they care about, and not *bellow*.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
