### PR TITLE
[FIX] base: Fix 'None' value on unlink_related_attachments

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -363,8 +363,16 @@ class IrModel(models.Model):
 
         # Get files attached solely to the models being deleted (and none other)
         fname_rows = self.env.execute_query(SQL(
-            "SELECT DISTINCT store_fname FROM ir_attachment WHERE res_model IN %s",
-            models,
+            """
+            SELECT DISTINCT store_fname
+            FROM ir_attachment
+            WHERE res_model IN %s AND store_fname IS NOT NULL
+            EXCEPT
+            SELECT store_fname
+            FROM ir_attachment
+            WHERE res_model NOT IN %s
+            """,
+            models, models,
         ))
 
         self.env.execute_query(SQL(


### PR DESCRIPTION
There is an issue when for some models the store_fname in ir.attachment would return null, and we don't verify for that before trying to delete the files. So this would cause an error on the console, but for the end user it would be silent.
```
Traceback (most recent call last):
  File "/home/admac/projects/odoo/odoo/odoo/addons/base/models/ir_model.py", line 2564, in delete
    records.unlink()
  File "/home/admac/projects/odoo/odoo/odoo/addons/base/models/ir_model.py", line 398, in unlink
    res = super().unlink()
          ^^^^^^^^^^^^^^^^
  File "/home/admac/projects/odoo/odoo/addons/mail/models/models.py", line 46, in unlink
    result = super().unlink()
             ^^^^^^^^^^^^^^^^
  File "/home/admac/projects/odoo/odoo/odoo/orm/models.py", line 3507, in unlink
    func(self)
  File "/home/admac/projects/odoo/odoo/odoo/addons/base/models/ir_model.py", line 376, in _unlink_related_attachments
    self.env['ir.attachment']._file_delete(fname)
  File "/home/admac/projects/odoo/odoo/odoo/addons/base/models/ir_attachment.py", line 177, in _file_delete
    self._mark_for_gc(fname)
  File "/home/admac/projects/odoo/odoo/odoo/addons/base/models/ir_attachment.py", line 182, in _mark_for_gc
    fname = re.sub('[.:]', '', fname).strip('/\\')
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 186, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```
This would stop the unlinking and leave random models hanging on the db. So when we would try to reinstall a module, those models would cause a TB.

The fix checks that there's an actual file name before executing the `_file_delete`

Concrete example:
Using demo data with `pos_self_order` would create a `pos_config` with some images that are stored inside the static files of the module. If we uninstall the `point_of_sale` module, it would try to remove all `pos_config` but because of the attachments the config would linger. Afterwards when trying to install the `point_of_sale` module again, it would throw a TB because of the lingering data.

Task-[5906095](https://www.odoo.com/odoo/project/1737/tasks/5906095)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
