### PR TITLE
[IMP] mail: meeting channel revamp

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1227,6 +1227,7 @@ class DiscussChannel(models.Model):
         res.one("discuss_category_id", "_store_category_fields", sudo=True)
         res.attr("channel_type")
         res.attr("create_uid")
+        res.attr("create_date", predicate=lambda channel: channel.default_display_mode == "video_full_screen")
         res.many(
             "channel_member_ids",
             "_store_member_fields",

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MeetingChat">
-        <ActionPanel t-if="channel" title.translate="Chat" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
+        <ActionPanel t-if="channel" title.translate="In call messages" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
             <Thread thread="channel.thread" jumpPresent="state.jumpPresent"/>
             <t t-call="mail.ChatWindow.memberTyping"/>
             <Composer

--- a/addons/mail/static/src/discuss/call/common/message_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/message_model_patch.js
@@ -1,0 +1,19 @@
+import { Message } from "@mail/core/common/message_model";
+
+import { patch } from "@web/core/utils/patch";
+
+/** @type {import("models").Message} */
+const messagePatch = {
+    get notificationHidden() {
+        if (
+            this.store.rtc.channel?.eq(this.channel_id) &&
+            this.channel_id.default_display_mode === "video_full_screen" &&
+            this.store?.meetingViewOpened &&
+            this.notificationType === "call"
+        ) {
+            return true;
+        }
+        return super.notificationHidden;
+    },
+};
+patch(Message.prototype, messagePatch);

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -2,6 +2,7 @@ import { MessageConfirmDialog } from "@mail/core/common/message_confirm_dialog";
 import { fields, Record } from "@mail/model/export";
 
 import { _t } from "@web/core/l10n/translation";
+import { user } from "@web/core/user";
 import { Deferred } from "@web/core/utils/concurrency";
 import { rpc } from "@web/core/network/rpc";
 import {
@@ -202,6 +203,15 @@ export class DiscussChannel extends Record {
         return this.channel_member_ids.filter(({ persona }) => persona?.notEq(this.store.self));
     }
     get displayName() {
+        if (this.default_display_mode === "video_full_screen" && this.create_date && !this.name) {
+            const localizedDatetime = this.store.self?.tz
+                ? this.create_date.setZone(this.store.self?.tz)
+                : this.create_date.toLocal();
+            const formatDate = localizedDatetime.toLocaleString(luxon.DateTime.DATE_MED, {
+                locale: user.lang,
+            });
+            return _t("Meeting - %(date)s", { date: formatDate });
+        }
         if (this.channel_type === "chat" && this.correspondent) {
             return this.correspondent.name;
         }
@@ -218,6 +228,7 @@ export class DiscussChannel extends Record {
         }
         return this.name;
     }
+    create_date = fields.Datetime();
     /** @type {"not_fetched"|"pending"|"fetched"} */
     fetchMembersState = "not_fetched";
     /** @type {"not_fetched"|"fetching"|"fetched"} */

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -258,6 +258,7 @@ export class DiscussChannel extends models.ServerModel {
         return [
             "avatar_cache_key",
             "channel_type",
+            "create_date",
             "create_uid",
             "default_display_mode",
             "description",

--- a/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_meeting_view_tour.js
@@ -28,7 +28,7 @@ function getMeetingViewTourSteps({ inWelcomePage = false } = {}) {
         },
         {
             trigger:
-                ".o-mail-Meeting .o-mail-ActionPanel .o-mail-Thread:contains('john (base.group_user), bob (base.group_user), and Guest')",
+                ".o-mail-Meeting .o-mail-ActionPanel .o-mail-Thread:contains('Meeting - Jan 1, 2026')",
         },
         {
             trigger: ".o-mail-Message[data-persistent]:contains('Hello everyone!')",

--- a/addons/mail/tests/discuss/test_ui.py
+++ b/addons/mail/tests/discuss/test_ui.py
@@ -2,6 +2,7 @@
 
 from odoo import Command
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, new_test_user
+from odoo.addons.mail.tests.common import freeze_all_time
 
 
 class TestUi(HttpCaseWithUserDemo):
@@ -27,13 +28,14 @@ class TestUi(HttpCaseWithUserDemo):
         bob = new_test_user(self.env, "bob", groups="base.group_user", email="bob@test.com")
         john = new_test_user(self.env, "john", groups="base.group_user", email="john@test.com")
         guest = self.env["mail.guest"].create({"name": "Guest"})
-        group_chat = (
-            self.env["discuss.channel"]
-            .with_user(bob)
-            ._create_group(
-                partners_to=john.partner_id.ids, default_display_mode="video_full_screen"
+        with freeze_all_time("2026-01-01"):
+            group_chat = (
+                self.env["discuss.channel"]
+                .with_user(bob)
+                ._create_group(
+                    partners_to=john.partner_id.ids, default_display_mode="video_full_screen"
+                )
             )
-        )
         group_chat._add_members(guests=guest)
         self.authenticate("bob", "bob")
         self.make_jsonrpc_request("/mail/rtc/channel/join_call", {"channel_id": group_chat.id})


### PR DESCRIPTION
Purpose of this commit:

For channels created using the New Meeting Button:
- The channel should have a default name in the format 'Meeting-{date}'

For channels with default_display_mode == 'video_full_screen':
- In the meeting view, the chat panel of the these channels should not contains any 'call' type notification message
- Rename meeting view's chat panel's name from 'Chat' ->  'In Call Messages'

task-5460982