### PR TITLE
[FIX] l10n_it_pos: it fiscal printer traceback

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
@@ -45,12 +45,7 @@ export class FeedbackScreen extends Component {
                             await this.props.waitFor;
                         }
                     } finally {
-                        this.state.loading = false;
-                        if (this.isAutoSkip && !this.ignoreTimeout) {
-                            this.state.timeout = setTimeout(() => {
-                                this.pos.orderDone(this.currentOrder);
-                            }, this.pos.feedbackScreenAutoSkipDelay);
-                        }
+                        await this._afterWaitFinished();
                     }
                 };
 
@@ -62,6 +57,16 @@ export class FeedbackScreen extends Component {
         onWillUnmount(() => {
             clearTimeout(this.state.timeout);
         });
+    }
+
+    async _afterWaitFinished() {
+        this.state.loading = false;
+
+        if (this.isAutoSkip && !this.ignoreTimeout) {
+            this.state.timeout = setTimeout(() => {
+                this.pos.orderDone(this.currentOrder);
+            }, this.pos.feedbackScreenAutoSkipDelay);
+        }
     }
 
     get isAutoSkip() {


### PR DESCRIPTION
Issue:
When printing with the italian fiscal printer since the sync_from_ui was not awaited before printing,
the generation of the ticket was trying to access
the currency from the order that wasn't set.

Fix:
Print the ticket after the order is synced.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
