### PR TITLE
[FIX] account,sale: ensure product column visibility in tour

### DIFF
--- a/addons/account/static/src/js/tours/tour_utils.js
+++ b/addons/account/static/src/js/tours/tour_utils.js
@@ -8,7 +8,7 @@ export function showProductColumn() {
         },
         {
             content: "Show product column",
-            trigger: '.o-dropdown-item input[name="product_id"]',
+            trigger: '.o-dropdown-item input[name="product_id"], .o-dropdown-item input[name="product_template_id"]',
             run: function (actions) {
                 if (!this.anchor.checked) {
                     actions.click();
@@ -69,6 +69,7 @@ export function addSectionFromProductCatalog() {
             trigger: '.o-kanban-button-back',
             run: 'click',
         },
+        ...showProductColumn(),
         {
             content: "Ensure Section is first row",
             trigger: '.o_section_and_note_list_view tr:nth-child(1).o_is_line_section',

--- a/addons/sale/static/tests/tours/sale_catalog.js
+++ b/addons/sale/static/tests/tours/sale_catalog.js
@@ -1,4 +1,4 @@
-import { addSectionFromProductCatalog, showProductColumn } from "@account/js/tours/tour_utils";
+import { addSectionFromProductCatalog } from "@account/js/tours/tour_utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('sale_catalog', {
@@ -93,7 +93,6 @@ registry.category("web_tour.tours").add('test_add_section_from_product_catalog_o
             trigger: '.o_field_res_partner_many2one .dropdown-item:not([id$="_loading"]):first',
             run: 'click',
         },
-        ...showProductColumn(),
         ...addSectionFromProductCatalog(),
     ]
 });


### PR DESCRIPTION
Commit 01848b5 missed a case causing the `test_add_section_from_product_catalog_on_invoice_tour` tour to fail.

To resolve this, `showProductColumn()` is now called automatically within `addSectionFromProductCatalog()`. This ensures the product column is visible before content verification, removing the need for manual calls in other tours.

Additionally, the `showProductColumn()` trigger is updated to support both `product_id` and `product_template_id`, ensuring compatibility with the `purchase_product_matrix` module.

runbot-234872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
