### PR TITLE
[IMP] account: include draft vendor bills in 'Unpaid' filter

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1479,7 +1479,7 @@
                     <filter string="To Check" name="to_check" domain="[('to_check', '=', True)]"/>
                     <separator/>
                     <!-- not_paid & partial -->
-                    <filter name="open" string="Unpaid" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('not_paid', 'partial'))]"/>
+                    <filter name="open" string="Unpaid" domain="[('state', '!=', 'cancel'), ('payment_state', 'in', ('not_paid', 'partial')), ('move_type', '!=', 'entry')]"/>
                     <!-- in_payment & paid -->
                     <filter name="closed" string="Paid" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('in_payment', 'paid'))]"/>
                     <!-- reversed -->


### PR DESCRIPTION
In this commit:
- Updated the `Unpaid` filter to show draft bills in addition to posted bills. The filter now includes all non-cancelled bills with payment status `Not Paid` or `Partially Paid`.
- Backported the logic from 18.0 to ensure journal entries are filtered out by checking that type is not equal to `journal_entry`.

task-5900283