### PR TITLE
[REF] spreadsheet: reuse default operator and adapt editor filter values

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -38,6 +38,7 @@ export class FilterValue extends Component {
         globalFilterValue: { optional: true },
         showTitle: { type: Boolean, optional: true },
         showClear: { type: Boolean, optional: true },
+        rangesOfAllowedValues: { type: Array, optional: true },
     };
 
     setup() {
@@ -79,6 +80,9 @@ export class FilterValue extends Component {
     }
 
     get textAllowedValues() {
+        if (this.props.rangesOfAllowedValues) {
+            return this.getters.getTextFilterOptionsFromRanges(this.props.rangesOfAllowedValues);
+        }
         return this.getters.getTextFilterOptions(this.filter.id);
     }
 

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -27,18 +27,18 @@
                  t-att-class="filterValue?.operator === 'between' ? 'justify-content-between' : ''">
                 <t t-if="filterValue?.operator === 'between'">
                     <NumericFilterValue
-                        value="filterValue.minimumValue"
+                        value="filterValue?.minimumValue"
                         onValueChanged="(value) => this.onMinimumValueNumericInput(filter.id, value)"
                     />
                     <i class="fa fa-long-arrow-right mx-2"/>
                     <NumericFilterValue
-                        value="filterValue.maximumValue"
+                        value="filterValue?.maximumValue"
                         onValueChanged="(value) => this.onMaximumValueNumericInput(filter.id, value)"
                     />
                 </t>
                 <t t-else="">
                     <NumericFilterValue
-                        value="filterValue.targetValue"
+                        value="filterValue?.targetValue"
                         onValueChanged="(value) => this.onTargetValueNumericInput(filter.id, value)"
                     />
                 </t>

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -975,11 +975,15 @@ export function isSetOperator(operator) {
     return SET_OPERATORS_BEHAVIORS.operators.includes(operator);
 }
 
+export function getDefaultOperator(type) {
+    return FILTERS_BEHAVIORS[type][0].operators[0];
+}
+
 export function getDefaultValue(type) {
     if (type === "date" || type === "boolean") {
         return undefined;
     }
-    const defaultOperator = FILTERS_BEHAVIORS[type][0].operators[0];
+    const defaultOperator = getDefaultOperator(type);
     return {
         operator: defaultOperator,
         ...getEmptyFilterValue({ type }, defaultOperator),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Current behavior before PR:
- Default operator logic was embedded in getDefaultValue().
- Text filter allowed values were always computed from the global filter id.

Desired behavior after PR is merged:
- Extracted default operator logic into getDefaultOperator() for reuse.
- Editor panel now computes text filter allowed values directly from ranges.

Task: [5850422](https://www.odoo.com/odoo/project/2328/tasks/5850422)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
