### PR TITLE
[FIX] pos_self_order: fix qr for pos_self_order

### DIFF
--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -145,17 +145,16 @@ class ResConfigSettings(models.TransientModel):
         """
         Generate the data needed to print the QR codes page
         """
+        name = ""
+        url = url_unquote(self.pos_config_id._get_self_order_url())
         if self.pos_self_ordering_mode == 'mobile' and self.pos_module_pos_restaurant:
             table_ids = self.pos_config_id.floor_ids.table_ids
-
             if not table_ids:
                 raise ValidationError(_("In Self-Order mode, you must have at least one table to generate QR codes"))
 
-            url = url_unquote(self.pos_config_id._get_self_order_url(table_ids[0].id))
-            name = table_ids[0].name
-        else:
-            url = url_unquote(self.pos_config_id._get_self_order_url())
-            name = ""
+            if self.pos_self_ordering_service_mode == 'table':
+                url = url_unquote(self.pos_config_id._get_self_order_url(table_ids[0].id))
+                name = table_ids[0].name
 
         return self.env.ref("pos_self_order.report_self_order_qr_codes_page").report_action(
             [], data={

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -3,6 +3,7 @@
 
 from . import test_frontend
 from . import self_order_common_test
+from . import test_res_config_settings
 from . import test_self_order_mobile
 from . import test_self_order_kiosk
 from . import test_self_order_attribute

--- a/addons/pos_self_order/tests/test_res_config_settings.py
+++ b/addons/pos_self_order/tests/test_res_config_settings.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderSettings(SelfOrderCommonTest):
+    def test_self_order_qr_generation(self):
+
+        def validate_url(url, has_table):
+            self.assertIn("access_token", url)
+            if has_table:
+                self.assertIn("table_identifier", url)
+            else:
+                self.assertNotIn("table_identifier", url)
+
+        def validate_qr_data(qr_data, table_mode):
+            self.assertTrue(all(
+                k in qr_data
+                for k in ("floors", "pos_name", "self_order", "table_example", "table_mode")
+            ))
+            self.assertEqual(qr_data["table_mode"], table_mode)
+
+        settings = self.env['res.config.settings'].create({
+            'pos_config_id': self.pos_config.id,
+            'pos_self_ordering_mode': 'mobile',
+        })
+        for mode, has_table in (('table', True), ('counter', False)):
+            settings.pos_self_ordering_service_mode = mode
+            qr_data = settings.generate_qr_codes_page()['context']['report_action']['data']
+            first_qr_url = qr_data['floors'][0]['table_rows'][0][0]['url']
+            example_url = qr_data['table_example']['decoded_url']
+            validate_url(first_qr_url, has_table)
+            validate_url(example_url, has_table)
+            validate_qr_data(qr_data, has_table)


### PR DESCRIPTION
Step to reproduce:
- setup Restaurant and do the following config
- set "self-ordering" -> "Qr Menu + Ordering"
- set "service At" -> "pickup zone"
- save and print the qr-code ( option is right there below these configs)

Observation:
- in downloaded pdf, we see a wrong url, which includes table_id, which shouldn't be.
- QRs do not have table_id

Cause:
- there is issue in `generate_qr_codes_page` method, which uses table_id even if ordering mode is "pickup zone"

Fix:
- we only use table_id when ordering_mode = 'table'.

**Before:** 
<img width="1002" height="397" alt="image" src="https://github.com/user-attachments/assets/e6dc50e5-6384-45b8-8ee5-817526769dc2" />


**After**
<img width="1021" height="405" alt="image" src="https://github.com/user-attachments/assets/0be9b902-3870-4fc7-a409-e01265b7a1b3" />


opw-5095607


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
