### PR TITLE
[IMP] account: add helper to prepare journal entry lines in tests

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -673,6 +673,18 @@ class AccountTestInvoicingCommon(ProductCommon):
         return Command.create(invoice_line_args)
 
     @classmethod
+    def _prepare_entry_line(cls, account_id=None, debit=0.0, credit=0.0, **line_args):
+        assert account_id, "`account_id` must be provided for an entry line."
+        entry_line_args = {
+            'account_id': account_id,
+            'debit': debit,
+            'credit': credit,
+            **line_args,
+        }
+        cls._prepare_record_kwargs('account.move.line', entry_line_args)
+        return Command.create(entry_line_args)
+
+    @classmethod
     def _prepare_order_line(cls, price_unit=None, product_id=None, product_uom_qty=1.0, tax_ids=None, **line_args):
         assert price_unit is not None or product_id is not None, "Either `price_unit` or `product_id` must be filled!"
         cls.ensure_installed('sale')

--- a/odoo/addons/base/tests/test_ir_ui_view.py
+++ b/odoo/addons/base/tests/test_ir_ui_view.py
@@ -5039,7 +5039,6 @@ class TestInvisibleField(TransactionCaseWithUserDemo):
             'l10n_mx_edi_stock',
             'l10n_mx_hr_payroll',
             'l10n_mx_reports',
-            'l10n_mx_xml_polizas',
             'l10n_my_edi',
             'l10n_my_edi_pos',
             'l10n_nl_reports',


### PR DESCRIPTION
- Introduce `_prepare_journal_entry_line` test helper function to build `account.move.line` records for `move_type='entry'` moves.

- This mirrors existing `_prepare_invoice_line` and `_prepare_order_line` helpers, but avoids invoice-specific constraints (price_unit/product_id), making journal entry tests clearer and less error-prone.

Related PR-https://github.com/odoo/enterprise/pull/103445

TaskID-5431997