### PR TITLE
[FIX] mail: show thread name in invite dialog

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -49,7 +49,7 @@ export class ChannelMemberList extends Component {
                 channel: this.props.channel,
                 close: () => this.store.env.services.dialog.closeAll(),
             },
-            title: "",
+            title: this.props.channel.displayName,
         });
     }
 }

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -96,7 +96,7 @@ registerThreadAction("notification-settings", {
     actionPanelOpen({ channel, owner, store }) {
         if (owner.isDiscussSidebarChannelActions || owner.env.inMeetingView) {
             store.env.services.dialog?.add(ChannelActionDialog, {
-                title: channel.name,
+                title: channel.displayName,
                 contentComponent: NotificationSettings,
                 contentProps: { channel },
             });


### PR DESCRIPTION
Before this PR, when a user opened any Discuss channel and invited people
from the member list, the channel name was missing in the invitation dialog.

This commit fixes the issue by correctly displaying the thread name
in the invitation dialog.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
