### PR TITLE
[FIX] base_import: field must work with base64 data

### DIFF
--- a/addons/base_import/controllers/main.py
+++ b/addons/base_import/controllers/main.py
@@ -1,22 +1,20 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
 import json
 
 from odoo import http
 from odoo.http import request
-from odoo.tools import misc
 
 
 class ImportController(http.Controller):
 
     @http.route('/base_import/set_file', methods=['POST'])
     # pylint: disable=redefined-builtin
-    def set_file(self, id):
-        file = request.httprequest.files.getlist('ufile')[0]
-
+    def set_file(self, id, ufile, model=None):
+        file = ufile
         written = request.env['base_import.import'].browse(int(id)).write({
-            'file': file.read(),
+            'file': base64.b64encode(file.read()),
             'file_name': file.filename,
             'file_type': file.content_type,
         })

--- a/addons/product/tests/test_import_files.py
+++ b/addons/product/tests/test_import_files.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import base64
 import unittest
 
 from odoo.tests import TransactionCase, can_import, loaded_demo_data, tagged
@@ -13,7 +14,7 @@ class TestImportFiles(TransactionCase):
     def import_product_xls(self, model, filepath=None):
         if filepath is None:
             filepath = f"product/static/xls/{model.replace(".", "_")}.xls"
-        file_content = file_open(filepath, "rb").read()
+        file_content = base64.b64encode(file_open(filepath, "rb").read())
         import_wizard = self.env["base_import.import"].create(
             {
                 "res_model": model,

--- a/addons/project/tests/test_import_files.py
+++ b/addons/project/tests/test_import_files.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 
 from odoo.tests import TransactionCase, can_import, loaded_demo_data, tagged
@@ -16,7 +17,7 @@ class TestImportFiles(TransactionCase):
         model = "project.task"
         filename = "tasks_import_template.xlsx"
 
-        file_content = file_open(f"project/static/xls/{filename}", "rb").read()
+        file_content = base64.b64encode(file_open(f"project/static/xls/{filename}", "rb").read())
         import_wizard = self.env["base_import.import"].create(
             {
                 "res_model": model,

--- a/addons/purchase/tests/test_import_files.py
+++ b/addons/purchase/tests/test_import_files.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 
 from odoo.tests import TransactionCase, can_import, loaded_demo_data, tagged
@@ -16,7 +17,7 @@ class TestImportFiles(TransactionCase):
         model = "purchase.order"
         filename = "requests_for_quotation_import_template.xlsx"
 
-        file_content = file_open(f"purchase/static/xls/{filename}", "rb").read()
+        file_content = base64.b64encode(file_open(f"purchase/static/xls/{filename}", "rb").read())
         import_wizard = self.env["base_import.import"].create(
             {
                 "res_model": model,

--- a/addons/sale/tests/test_import_files.py
+++ b/addons/sale/tests/test_import_files.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 
 from odoo.tests import TransactionCase, can_import, loaded_demo_data, tagged
@@ -16,7 +17,7 @@ class TestImportFiles(TransactionCase):
         model = "sale.order"
         filename = "quotations_import_template.xlsx"
 
-        file_content = file_open(f"sale/static/xls/{filename}", "rb").read()
+        file_content = base64.b64encode(file_open(f"sale/static/xls/{filename}", "rb").read())
         import_wizard = self.env["base_import.import"].create(
             {
                 "res_model": model,

--- a/addons/test_import_export/tests/test_import_csv_magic.py
+++ b/addons/test_import_export/tests/test_import_csv_magic.py
@@ -1,18 +1,19 @@
 """
 Tests for various autodetection magics for CSV imports
 """
+import base64
 import codecs
 
 from odoo.tests import tagged, common
 
 
 class ImportCase(common.TransactionCase):
-    def _make_import(self, contents):
+    def _make_import(self, contents: bytes):
         return self.env['base_import.import'].create({
             'res_model': 'import.complex',
             'file_name': 'f',
             'file_type': 'text/csv',
-            'file': contents,
+            'file': base64.b64encode(contents),
         })
 
 
@@ -76,7 +77,7 @@ class TestFileSeparator(ImportCase):
     def setUp(self):
         super().setUp()
         self.imp = self._make_import(
-"""c|f
+b"""c|f
 a|1
 b|2
 c|3
@@ -122,7 +123,7 @@ d|4
         """ If the guesser has no idea what the separator is, it defaults to
         "," but should not set that value
         """
-        imp = self._make_import('c\na\nb\nc\nd')
+        imp = self._make_import(b'c\na\nb\nc\nd')
         r = imp.parse_preview({
             'separator': '',
             'has_headers': True,

--- a/addons/test_import_export/tests/test_properties.py
+++ b/addons/test_import_export/tests/test_properties.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 from odoo.tests import new_test_user
@@ -352,7 +353,7 @@ class TestPropertiesExportImport(HttpCase):
 
         import_wizard = self.env['base_import.import'].create({
             'res_model': self.ModelProperty._name,
-            'file': '\n'.join([';'.join(values) for values in values_list]),
+            'file': base64.b64encode('\n'.join([';'.join(values) for values in values_list]).encode()),
             'file_type': 'text/csv',
         })
         opts = {'quoting': '"', 'separator': ';', 'has_headers': True}
@@ -436,7 +437,7 @@ class TestPropertiesExportImport(HttpCase):
 
         import_wizard = self.env['base_import.import'].create({
             'res_model': self.ModelProperty._name,
-            'file': '\n'.join([';'.join(values) for values in values_list]),
+            'file': base64.b64encode('\n'.join([';'.join(values) for values in values_list]).encode()),
             'file_type': 'text/csv',
         })
         opts = {'quoting': '"', 'separator': ';', 'has_headers': True}
@@ -504,7 +505,7 @@ class TestPropertiesExportImport(HttpCase):
 
         import_wizard = Import.create({
             'res_model': self.ModelProperty._name,
-            'file': '\n'.join([';'.join(values) for values in values_list]),
+            'file': base64.b64encode('\n'.join([';'.join(values) for values in values_list]).encode()),
             'file_type': 'text/csv',
         })
         opts = {'quoting': '"', 'separator': ';', 'has_headers': True}
@@ -535,7 +536,7 @@ class TestPropertiesExportImport(HttpCase):
 
         import_wizard = Import.create({
             'res_model': self.ModelProperty._name,
-            'file': '\n'.join([';'.join(values) for values in values_list]),
+            'file': base64.b64encode('\n'.join([';'.join(values) for values in values_list]).encode()),
             'file_type': 'text/csv',
         })
         opts = {'quoting': '"', 'separator': ';', 'has_headers': True}

--- a/addons/website/tests/test_import_files.py
+++ b/addons/website/tests/test_import_files.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 
 from odoo.tests import TransactionCase, can_import, loaded_demo_data, tagged
@@ -16,7 +17,7 @@ class TestImportFiles(TransactionCase):
         model = "website.rewrite"
         filename = "redirects_import_template.xlsx"
 
-        file_content = file_open(f"website/static/xls/{filename}", "rb").read()
+        file_content = base64.b64encode(file_open(f"website/static/xls/{filename}", "rb").read())
         import_wizard = self.env["base_import.import"].create(
             {
                 "res_model": model,

--- a/odoo/addons/base/tests/test_import_files.py
+++ b/odoo/addons/base/tests/test_import_files.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 
 from odoo.tests import TransactionCase, can_import, loaded_demo_data, tagged
@@ -16,7 +17,7 @@ class TestImportFiles(TransactionCase):
         model = "res.partner"
         filename = "contacts_import_template.xlsx"
 
-        file_content = file_open(f"base/static/xls/{filename}", "rb").read()
+        file_content = base64.b64encode(file_open(f"base/static/xls/{filename}", "rb").read())
         import_wizard = self.env["base_import.import"].create(
             {
                 "res_model": model,


### PR DESCRIPTION
Since #238513, all Binary fields work the same way. The data is stored in base64 format in cache (no exceptions). Here aligning `file` field of that module did not work this way.

Current behavior before PR:
`file = fields.Binary(...)` expected to store raw bytes.

Desired behavior after PR is merged:
This is not supported as all Binary fields work the same now (base64).




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
