### PR TITLE
[IMP] website: display deleted url in referencing pages

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1356,8 +1356,12 @@ class Website(models.CachedModel):
                     'record_name': page.name,
                     'link': page.url,
                     'model_name': page_model_name,
+                    'url': _choose_url(page.arch_db),
                 } for page in page_views.page_ids]
             return views
+
+        def _choose_url(field_value):
+            return next((url for url, _domain in search_criteria if url in field_value), '')
 
         # Prepare what's needed to later generate the URL search domain for the
         # given records
@@ -1376,7 +1380,7 @@ class Website(models.CachedModel):
             domains = []
             for url, website_domain in search_criteria:
                 domains.append(Domain.AND([
-                    [(field_name, 'ilike', url)],
+                    [(field_name, 'ilike', f'href=%{url}')],
                     website_domain if hasattr(Model, 'website_id') else [],
                 ]))
 
@@ -1393,6 +1397,7 @@ class Website(models.CachedModel):
                     'record_name': rec.display_name,
                     'link': 'website_url' in rec and rec.website_url or f'/odoo/{model_name}/{rec.id}',
                     'model_name': model_display_name,
+                    'url': _choose_url(rec[field_name]),
                 } for rec in dependency_records]
 
         return dependencies

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -38,9 +38,9 @@
                 <div t-attf-id="collapseDependencies{{ dependency_index }}" class="collapse" aria-expanded="false">
                     <ul>
                         <li t-foreach="dependency_value" t-as="item" t-key="item_index">
-                            <t t-set="link_text">This URL is contained in the “%(field)s” of the following “%(model)s”</t>
+                            <t t-set="link_text">The URL “%(url)s“ is contained in the “%(field)s” of the following “%(model)s”</t>
                             <a t-att-href="item.link" target="_blank">
-                                <t t-out="this.sprintf(link_text, { field: item.field_name, model: item.model_name })"/>: <b t-out="item.record_name"/>
+                                <t t-out="this.sprintf(link_text, { url: item.url, field: item.field_name, model: item.model_name })"/>: <b t-out="item.record_name"/>
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
When deleting a website page, a search is carried out to find records that may be referencing that deleted url.
When deleting multiple pages at the same time, we are unable to tell which page is being referenced.
To improve the UX, we now display the delete URL.

Before:
This URL is contained in the "[Field]" of the following "[Model]".

After:
The URL "/[deleted_page]" is contained in the "[Field]" of the following "[Model]"

Furthermore, we also enhance the domain for the view search to ensure that it has both `href` and the deleted page url.
This might reduce false positives (but won't eliminate them)

Task-5960826