### PR TITLE
[FIX] calendar: preserve duration when editing quick-created events

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -305,6 +305,11 @@
                         <h1 class="w-100"><field name="name" nolabel="1" placeholder="Add title" colspan="2"/></h1>
                     </div>
                     <group>
+                        <!--when "stop" is set manually, "duration" is computed. When "start" is changed
+                        "stop" is computed based on the previously-computed "duration". Hence we need to
+                        keep the last computed duration in the front-end model and send it with "start"
+                        when it changes-->
+                        <field name="duration" invisible="1" force_save="1"/>
                         <field name="start_date" widget="daterange" options="{'end_date_field': 'stop_date'}" invisible="not allday" required="allday"/>
                         <field name="start" widget="daterange" options="{'end_date_field': 'stop'}" invisible="allday" required="not allday"/>
                         <field name="stop_date" invisible="1" />


### PR DESCRIPTION
Currently, an incorrect duration is displayed when the start or end time 
is `manually changed` during event creation.

**Steps to reproduce:**
- Install the `Calendar` module and open the app.
- Drag on the calendar to create a `2-hour` time slot (quick-create popup opens).
- Manually adjust the start or end time to make the event `3 hours` long.
- Click `Save & Close`.
- Click on the event: it correctly displays (3 hours).
- Click `Edit` and observe the `Duration` value.

**Observation:**
The duration field shows 2 hours instead of 3 hours.

**Root cause:**
- The `duration` field is not available (and therefore not stored) in the 
 `quick-create view` at [1].
- When the `stop` time is set manually, the `duration` is computed at [2].
- When the `start` time is changed, the `stop` time is computed based on the 
  previously computed `duration` at [3].

**Fix:**
This commit adds the `duration` field to the `quick-create` view as `invisible` 
(preventing it from being recomputed on each onchange) and `force_save`. 
This aligns the behavior with `19.0` by preserving the last computed 
duration in the front-end model, as implemented in PR [4].

[1]:
https://github.com/odoo/odoo/blob/84571c03ff38ee768ed135bef3afa98511e3ab7b/addons/calendar/views/calendar_views.xml#L294-L339

[2]:
https://github.com/odoo/odoo/blob/84571c03ff38ee768ed135bef3afa98511e3ab7b/addons/calendar/models/calendar_event.py#L353-L356

[3]:
https://github.com/odoo/odoo/blob/84571c03ff38ee768ed135bef3afa98511e3ab7b/addons/calendar/models/calendar_event.py#L358-L374

[4]:
https://github.com/odoo/odoo/pull/226909

opw-5867946