### PR TITLE
[FIX] pos_self_order: fix failing tour without demo data

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -335,7 +335,7 @@ registry.category("web_tour.tours").add("test_mobile_self_order_preparation_chan
             CartPage.checkProduct("Fanta", "2.53", "1"),
             CartPage.checkProduct("Coca-Cola", "2.53", "1"),
             Utils.clickBtn("Pay"),
-            CartPage.selectTable("3"),
+            CartPage.selectTable("303"),
             ConfirmationPage.isShown(),
             Utils.clickBtn("Ok"),
         ].flat(),

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -183,6 +183,11 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
             'self_ordering_service_mode': 'table',
             'use_presets': False,
         })
+        self.env['restaurant.table'].create({
+            'table_number': 303,
+            'floor_id': self.pos_main_floor.id,
+            'shape': 'square'
+        })
 
         self.pos_config.with_user(self.pos_user).open_ui()
         self.pos_config.current_session_id.set_opening_control(0, "")


### PR DESCRIPTION
Fixes `test_mobile_self_order_preparation_changes` failing on
non-demo databases by selecting the table created during the test.

Runbot: [232944](https://runbot.odoo.com/odoo/runbot.build.error/232944)
