### PR TITLE
[FIX] html_builder: transfer builder range props to builder number input

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_range.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.xml
@@ -38,7 +38,11 @@
             preview="preview"
             clampValue.bind="clampValue"
             onKeydown.bind="onKeydownNumber"
-            selectTextOnFocus="true">
+            selectTextOnFocus="true"
+            min="min"
+            max="max"
+            step="props.step"
+        >
             <span class="o-hb-input-field-unit" t-out="props.unit"/>
         </BuilderNumberInputBase>
     </BuilderComponent>

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
@@ -245,6 +245,54 @@ test("should syncronize previews", async () => {
     await expect(".options-container input[type='number']").toHaveProperty("value", 10);
 });
 
+test("number input should have the same min, max and step as the range input", async () => {
+    addBuilderAction({
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue({ editingElement }) {
+                return editingElement.textContent;
+            }
+            apply({ editingElement, value }) {
+                expect.step(`customAction ${value}`);
+                editingElement.textContent = value;
+            }
+        },
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderRange action="'customAction'" withNumberInput="true" min="0" max="5" step="2"/>`;
+        }
+    );
+    await setupHTMLBuilder(`
+        <div class="test-options-target">2</div>
+    `);
+
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container input[type='number']").keyDown("ArrowUp");
+
+    // Check that step=2
+    expect(".options-container input[type='number']").toHaveProperty("value", 4);
+    expect(":iframe .test-options-target").toHaveInnerHTML("4");
+    expect.verifySteps(["customAction 4"]);
+
+    await contains(".options-container input[type='number']").keyDown("ArrowUp");
+
+    // Check that max=5
+    expect(".options-container input[type='number']").toHaveProperty("value", 5);
+    expect(":iframe .test-options-target").toHaveInnerHTML("5");
+    expect.verifySteps(["customAction 5"]);
+
+    await contains(".options-container input[type='number']").keyDown("ArrowDown");
+    await contains(".options-container input[type='number']").keyDown("ArrowDown");
+    await contains(".options-container input[type='number']").keyDown("ArrowDown");
+
+    // Check that min=0
+    expect(".options-container input[type='number']").toHaveProperty("value", 0);
+    expect(":iframe .test-options-target").toHaveInnerHTML("0");
+    expect.verifySteps(["customAction 3", "customAction 1", "customAction 0"]);
+});
+
 describe("unit & saveUnit", () => {
     test("should handle unit", async () => {
         addBuilderAction({


### PR DESCRIPTION
The props "withNumberInput" for builder range added a number input next to the slider, to fine tune the value. However, the min / max / step props were not given. Therefore if the user pressed arrow up in the number input, the value would increase by 1, instead of the value of step given to the builder range input.

This commit fixes the issue by giving the correct props to the builder number input.
