### PR TITLE
[IMP] l10n_be_hr_payroll:  Car BIK

### DIFF
--- a/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
+++ b/addons/hr_fleet/models/fleet_vehicle_assignation_log.py
@@ -8,8 +8,10 @@ class FleetVehicleAssignationLog(models.Model):
 
     driver_employee_id = fields.Many2one('hr.employee', string='Driver (Employee)', compute='_compute_driver_employee_id', store=True, readonly=False)
     attachment_number = fields.Integer('Number of Attachments', compute='_compute_attachment_number')
+    driver_employee_date_start = fields.Date(string="Drier Employee Start Date", compute='_compute_driver_employee_id', store=True)
+    driver_employee_date_end = fields.Date(string="Driver Employee End Date", compute='_compute_driver_employee_id', store=True)
 
-    @api.depends('driver_id')
+    @api.depends('driver_id', 'date_start', 'date_end')
     def _compute_driver_employee_id(self):
         employees_by_partner_id_and_company_id = self.env['hr.employee']._read_group(
             domain=[('work_contact_id', 'in', self.driver_id.ids)],
@@ -22,6 +24,8 @@ class FleetVehicleAssignationLog(models.Model):
         for log in self:
             employees = employees_by_partner_id_and_company_id.get((log.driver_id, log.vehicle_id.company_id))
             log.driver_employee_id = employees[0] if employees else False
+            log.driver_employee_date_start = log.date_start
+            log.driver_employee_date_end = log.date_end
 
     def _compute_attachment_number(self):
         attachment_data = self.env['ir.attachment']._read_group([

--- a/addons/hr_fleet/views/fleet_vehicle_views.xml
+++ b/addons/hr_fleet/views/fleet_vehicle_views.xml
@@ -42,6 +42,8 @@
             <field name="date_end" position="after">
                 <field name="driver_id" string="Current Driver" optional="hide"/>
                 <field name="attachment_number" optional="show" />
+                <field name="driver_employee_date_start"/>
+                <field name="driver_employee_date_end"/>
                 <button name="action_get_attachment_view" string="Attachments" type="object" icon="fa-paperclip" />
             </field>
         </field>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
. Update CO₂ fee computation
. Update minimum CO₂ fee computation
. Update BIK (ATN) computation

**Current behavior before PR:**
. Health index parameters are incomplete and missing values for multiple years
. Minimum CO₂ fee parameters have many missing values and rely on outdated indexed values
. Greening factor is not applied
. Yearly ATN value is divided by 12 without proper proration
. No proration is applied when a vehicle is used for only part of a month
. No keeping track the employee–driver usage period of a vehicle, only the driver period
. When changing the driver of a vehicle, the previous driver’s end_date is not updated

**Desired behavior after PR is merged:**
. Add missing health index parameter values
. Convert indexed parameters to non-indexed values for better adaptability to health index changes
. Add greening parameter values
. Update CO₂ fee calculations to apply the greening factor for vehicles ordered after July 2023
. Update minimum CO₂ fee calculations
. Add employee_driver_date_start and employee_driver_date_end to track the employee’s vehicle usage period
. Update ATN (BIK) car calculations
. Compute yearly ATN based on used calendar days / total days in the year (365 or 366)
. Prorate monthly ATN based on the actual vehicle usage period within the month
. Rename Car ATN to BIK


**Calculations**
```
. co2_fee_min = 'co2_fee_min_coff' * (health_indice / health_indice_reference)
. co2_fee = (((co2 * 9.0) - fuel_coefficient.get(fuel_type)) / 12.0) * (health_indice / health_indice_reference) * greening_factor
. co2_fee = max(co2_fee, co2_fee_min)
```

```
. min_car_bik = 'min_car_bik_coff',
. yearly_bik = car_value * age_coefficient * co2_percentage * 6 / 7
. monthly_bik = max(min_car_bik, bik) * occupied_days / days_in_year
```

task-5473706

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
