### PR TITLE
Master mrp workorder revamp ajf

### DIFF
--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -634,7 +634,8 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertEqual(production.reserve_visible, True)
         backorder = produce_one(production)
         self.assertEqual(backorder.state, 'confirmed')
-        self.assertEqual(backorder.reserve_visible, True)
+        # The backorder is re reserved as the date_start is now 'now'
+        self.assertEqual(backorder.reserve_visible, False)
 
         # within scheduled date + reservation days before => auto-assign
         production = create_mo()

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3528,39 +3528,6 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo_backorder.workorder_ids[1].date_start, datetime(2023, 3, 1, 12, 0))
         self.assertEqual(mo_backorder.workorder_ids[2].date_start, datetime(2023, 3, 1, 12, 45))
 
-    @freeze_time('2023-03-01 12:00')
-    def test_all_workorders_planned(self):
-        """
-            Test, when writing to a confirmed MO, that all workorders that are expected to be planned are planned.
-        """
-        self.env.user.group_ids += self.env.ref('mrp.group_mrp_routings')
-
-        mo_form = Form(self.env['mrp.production'])
-        mo_form.product_id = self.product_8
-        mo = mo_form.save()
-        with mo_form.workorder_ids.new() as workorder:
-            workorder.name = "OP1"
-            workorder.workcenter_id = self.workcenter_2
-        with mo_form.workorder_ids.new() as workorder:
-            workorder.name = "OP2"
-            workorder.workcenter_id = self.workcenter_2
-        mo = mo_form.save()
-        mo.action_confirm()
-
-        mo.workorder_ids[1].button_start()
-        mo.workorder_ids[1].button_finish()
-
-        self.assertTrue(mo.workorder_ids[1].date_start)
-
-        with Form(mo) as mo_form:
-            with mo_form.workorder_ids.new() as workorder:
-                workorder.name = "OP3"
-                workorder.workcenter_id = self.workcenter_2
-            mo = mo_form.save()
-
-        self.assertTrue(mo.workorder_ids[0].date_start)
-        self.assertTrue(mo.workorder_ids[2].date_start)
-
     def test_compute_product_id(self):
         """
             Tests the creation of a production order automatically sets the product when the bom is provided,

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -646,6 +646,7 @@
                     <filter string="Cancelled" name="filter_cancel" domain="[('state', '=', 'cancel')]"/>
                     <separator/>
                     <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>
+                    <filter string="To Plan" name="filter_to_plan" domain="[('state', '=', 'confirmed'), ('is_planned', '=', False)]"/>
                     <separator/>
                     <filter string="Draft" name="filter_draft" domain="[('state', '=', 'draft')]"/>
                     <filter string="Confirmed" name="filter_confirmed" domain="[('state', '=', 'confirmed')]"/>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -133,7 +133,7 @@
             <field name="model">mrp.workcenter</field>
             <field name="arch" type="xml">
                 <kanban highlight_color="color" class="o_workcenter_kanban" create="0" can_open="0" sample="0">
-                    <field name="workorder_count"/>
+                    <field name="workorder_blocked_count"/>
                     <field name="working_state"/>
                     <field name="oee_target"/>
                     <templates>
@@ -160,9 +160,6 @@
                                                 Performance
                                             </a>
                                         </div>
-                                        <div role="menuitem">
-                                            <a name="action_work_order" type="object" context="{'search_default_waiting': 1}">Waiting Availability</a>
-                                        </div>
                                     </div>
                                 </div>
 
@@ -171,7 +168,7 @@
                                         <field name="color" widget="kanban_color_picker"/>
                                     </div>
                                     <div role="menuitem" class="col-4">
-                                        <a type="open">Settings</a>
+                                        <a type="open">Configuration</a>
                                     </div>
                                 </div>
                             </div>
@@ -197,11 +194,11 @@
                             <div class="row mt-3 pb-3">
                                 <div class="col-6">
                                     <div class="btn-group p-1" name="o_wo">
-                                        <button t-if="record.workorder_count.raw_value &gt; 0" class="btn btn-primary" name="action_work_order" type="object" context="{'search_default_ready': 1, 'search_default_progress': 1, 'desktop_list_view': 1, 'search_default_workcenter_id': id}">
+                                        <button t-if="record.workorder_ready_count.raw_value + record.workorder_progress_count.raw_value + record.workorder_blocked_count.raw_value == 0" class="btn btn-secondary" name="action_work_order" type="object" context="{'search_default_ready': 1, 'search_default_progress': 1, 'search_default_blocked': 1, 'desktop_list_view': 1, 'search_default_workcenter_id': id}">
                                             <span>WORK ORDERS</span>
                                         </button>
-                                        <button t-if="record.workorder_count.raw_value &lt;= 0" class="btn btn-warning" name="action_work_order_alternatives" type="object">
-                                            <span>PLAN ORDERS</span>
+                                        <button t-else="" class="btn btn-primary" name="action_work_order" type="object" context="{'search_default_ready': 1, 'search_default_progress': 1, 'search_default_blocked': 1, 'desktop_list_view': 1, 'search_default_workcenter_id': id}">
+                                            <span>WORK ORDERS</span>
                                         </button>
                                     </div>
                                 </div>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -128,6 +128,20 @@
         </record>
 
         <!-- Workcenter Kanban view-->
+
+        <record id="mrp_workcenter_workorders_kanban" model="ir.actions.act_window">
+            <field name="name">Work Orders</field>
+            <field name="res_model">mrp.workorder</field>
+            <field name="domain">[('state', 'not in', ('draft', 'done', 'cancel'))]</field>
+            <field name="views" eval="[(False, 'list')]"/>
+            <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
+            <field name="context">{'search_default_workcenter_id': active_id
+                                   'search_default_ready': True,
+                                   'search_default_blocked': True,
+                                   'search_default_filter_to_plan': True,
+                                   'workcenter_to_plan_on': active_id}</field>
+        </record>
+
         <record model="ir.ui.view" id="mrp_workcenter_kanban">
             <field name="name">mrp.workcenter.kanban</field>
             <field name="model">mrp.workcenter</field>
@@ -145,7 +159,10 @@
                                             <span>Actions</span>
                                         </h5>
                                         <div role="menuitem" name="plan_order">
-                                            <a name="action_work_order" type="object">Plan Orders</a>
+                                            <a name="%(mrp_workcenter_workorders_kanban)d" type="action">Plan Orders</a>
+                                        </div>
+                                        <div role="menuitem" name="planning">
+                                            <a name="action_work_order" type="object" context="{'search_default_ready': 1, 'search_default_progress': 1, 'search_default_blocked': 1, 'desktop_list_view': 1, 'search_default_workcenter_id': id, 'view_mode':'gantt'}">Planning</a>
                                         </div>
                                     </div>
                                     <div class="col-6">

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -495,4 +495,23 @@
         <field name="state">code</field>
         <field name="code">action = records.button_pending()</field>
     </record>
+
+    <record id="action_plan_workorders" model="ir.actions.server">
+        <field name="name">Plan</field>
+        <field name="model_id" ref="mrp.model_mrp_workorder"/>
+        <field name="binding_model_id" ref="mrp.model_mrp_workorder"/>
+        <field name="binding_view_types">list,kanban</field>
+        <field name="state">code</field>
+        <field name="code">records.action_plan()</field>
+    </record>
+
+    <record id="action_unplan_workorders" model="ir.actions.server">
+        <field name="name">Unplan</field>
+        <field name="model_id" ref="mrp.model_mrp_workorder"/>
+        <field name="binding_model_id" ref="mrp.model_mrp_workorder"/>
+        <field name="binding_view_types">list,kanban</field>
+        <field name="state">code</field>
+        <field name="code">records.action_unplan()</field>
+    </record>
+
 </odoo>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -269,11 +269,15 @@
                 <field name="product_id"/>
                 <field name="product_variant_attributes"/>
                 <field name="move_raw_ids" string="Component" filter_domain="[('move_raw_ids.product_id', 'ilike', self)]"/>
-                <filter string="In Progress" name="progress" domain="[('state', '=', 'progress')]"/>
                 <filter string="To Do" name="ready" domain="[('state', '=', 'ready')]"/>
                 <filter string="Blocked" name="blocked" domain="[('state', '=', 'blocked')]"/>
-                <filter string="Finished" name="finish" domain="[('state', '=', 'done')]"/>
+                <filter string="In Progress" name="progress" domain="[('state', '=', 'progress')]"/>
+                <filter string="Done" name="finish" domain="[('state', '=', 'done')]"/>
                 <filter string="Cancelled" name="cancel" domain="[('state', '=', 'cancel')]"/>
+                <separator/>
+                <filter string="Planned" name="filter_planned" domain="[('production_state', 'not in', ('done', 'cancel')), ('date_start', '!=', False)]"/>
+                <filter string="To Plan" name="filter_to_plan" domain="[('production_state', '=', 'confirmed'), ('date_start', '=', False)]"/>
+                <separator/>
                 <separator/>
                 <filter string="Late" name="late" domain="['&amp;', ('date_start', '&lt;', 'now'), ('state', '=', 'ready')]"
                     help="Production started late"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -410,6 +410,23 @@
         </field>
     </record>
 
+    <record model="ir.actions.act_window" id="action_mrp_workorder_employee">
+        <field name="name">Work Orders Planning</field>
+        <field name="res_model">mrp.workorder</field>
+        <field name="path">employee-planning</field>
+        <field name="view_mode">list,form,calendar,pivot,graph</field>
+        <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
+        <field name="context">{'search_default_ready': True, 'search_default_blocked': True, 'search_default_progress': True}</field>
+        <field name="help" type="html">
+          <p class="o_view_nocontent_smiling_face">
+            No work orders to do!
+          </p><p>
+            Work orders are operations to do as part of a manufacturing order.
+            Operations are defined in the bill of materials or added in the manufacturing order directly.
+          </p>
+        </field>
+    </record>
+
     <record model="ir.actions.act_window" id="mrp_workorder_mrp_production_form">
         <field name="name">Work Orders</field>
         <field name="res_model">mrp.workorder</field>


### PR DESCRIPTION
1) Adapt planning related views
2) Allow to plan a single workorder
3) Add Planning per Employee

Note that now a production is considered as planned when all of its workorders are planned.

task: 5259535

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
