### PR TITLE
[FIX] web : fix formating in datetime widget

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -74,6 +74,7 @@ export const datetimePickerService = {
                             restoreTargetMargin();
                             restoreTargetMargin = null;
                         }
+                        hookParams?.onClose();
                     },
                 });
                 // Hook methods
@@ -90,6 +91,7 @@ export const datetimePickerService = {
 
                     inputsChanged = ensureArray(pickerProps.value).map(() => false);
 
+                    debugger;
                     await hookParams.onApply?.(pickerProps.value);
                     lastInitialProps.value = valueCopy;
                 };

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -1,4 +1,4 @@
-import { Component, onWillRender, useState } from "@odoo/owl";
+import { Component, onWillRender, useState, useRef, useEffect } from "@odoo/owl";
 import { useDateTimePicker } from "@web/core/datetime/datetime_hook";
 import { areDatesEqual, deserializeDate, deserializeDateTime, today } from "@web/core/l10n/dates";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
@@ -132,6 +132,9 @@ export class DateTimeField extends Component {
             onChange: () => {
                 this.state.range = this.isRange(this.state.value);
             },
+            onClose: () => {
+                this.picker.activeInput = "";
+            },
             onApply: async () => {
                 const toUpdate = {};
                 if (Array.isArray(this.state.value)) {
@@ -155,7 +158,11 @@ export class DateTimeField extends Component {
         });
         // Subscribes to changes made on the picker state
         this.state = useState(dateTimePicker.state);
+        this.picker = useState({ activeInput: "" });
         this.openPicker = dateTimePicker.open;
+
+        this.startDate = useRef("start-date");
+        this.endDate = useRef("end-date");
 
         onWillRender(() => this.triggerIsDirty());
     }
@@ -280,6 +287,18 @@ export class DateTimeField extends Component {
 
     onInput() {
         this.triggerIsDirty(true);
+    }
+
+    onFocus(field, isStart) {
+        this.picker.activeInput = field;
+        if(isStart) {
+            this.startDate.el?.focus();
+            this.openPicker(0);
+        }
+        else {
+            this.endDate.el?.focus();
+            this.openPicker(0);
+        }
     }
 }
 

--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -17,16 +17,29 @@
                 </button>
             </t>
             <t t-elif="props.required or props.alwaysRange or !isEmpty(startDateField) or startDateField === props.name">
-                <input
-                    t-ref="start-date"
-                    type="text"
-                    t-att-id="showSeparator ? props.endDateField and props.id : props.id"
-                    class="o_input cursor-pointer"
-                    autocomplete="off"
-                    t-att-placeholder="props.placeholder"
-                    t-att-data-field="startDateField"
-                    t-on-input="onInput"
-                />
+                <t t-if="picker.activeInput !== startDateField and values[0]">
+                    <button 
+                        
+                        t-att-id="showSeparator ? props.endDateField and props.id : props.id"
+                        t-on-focus="() => this.onFocus(startDateField, true)"
+                        t-att-data-field="startDateField"
+                        class="o_input cursor-pointer w-100 text-start">
+                        <t t-esc="getFormattedValue(0)" />
+                    </button>
+                </t>
+                <t t-else="">
+                    <input
+                        t-ref="start-date"
+                        type="text"
+                        t-att-id="showSeparator ? props.endDateField and props.id : props.id"
+                        class="o_input cursor-pointer"
+                        autocomplete="off"
+                        t-att-placeholder="props.placeholder"
+                        t-att-data-field="startDateField"
+                        t-on-input="onInput"
+                        t-on-focus="() => this.onFocus(startDateField, true)"
+                    />
+                </t>
                 <span
                     t-if="props.warnFuture and isDateInTheFuture(0)"
                     class="fa fa-exclamation-triangle text-danger"
@@ -54,16 +67,28 @@
                     </button>
                 </t>
                 <t t-elif="props.required or props.alwaysRange or !isEmpty(endDateField) or endDateField === props.name">
-                    <input
-                        t-ref="end-date"
-                        type="text"
-                        t-att-id="props.startDateField and props.id"
-                        class="o_input cursor-pointer"
-                        autocomplete="off"
-                        t-att-placeholder="props.placeholder"
-                        t-att-data-field="endDateField"
-                        t-on-input="onInput"
-                    />
+                    <t t-if="picker.activeInput !== endDateField and values[1]">
+                        <button 
+                            t-on-focus="() => this.onFocus(endDateField, true)"
+                            t-att-id="props.startDateField and props.id"
+                            t-att-data-field="endDateField"
+                            class="o_input cursor-pointer w-100 text-start">
+                            <t t-esc="getFormattedValue(1)" />
+                        </button>
+                    </t>
+                    <t t-else="">
+                        <input
+                            t-ref="end-date"
+                            type="text"
+                            t-att-id="props.startDateField and props.id"
+                            class="o_input cursor-pointer"
+                            autocomplete="off"
+                            t-att-placeholder="props.placeholder"
+                            t-att-data-field="endDateField"
+                            t-on-input="onInput"
+                            t-on-focus="() => this.onFocus(endDateField, true)"
+                        />
+                    </t>
                     <span
                         t-if="props.warnFuture and isDateInTheFuture(1)"
                         class="fa fa-exclamation-triangle text-danger"

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -552,6 +552,8 @@ test("edit a datetime field in form view with show_seconds option", async () => 
     });
 });
 
+//Test if manage to make it work
+
 test("datetime field (with widget) in kanban with show_time option", async () => {
     mockTimeZone(+2);
 


### PR DESCRIPTION
How to reproduce :
- Pick any field in any model with the datetime type (Creating a new one in studio also works)
- The field must not be set to readonly
- Go to the form view
- Go into Studio
- Uncheck the checkbox for "Show time"
- Close Studio

The problem :
The time is still shown

Why:
The service that manages the formatting for the datetime input does not take the "Show time" attribute into account. This commit (https://github.com/odoo/odoo/commit/08934cd399e95459234cb569a80876ca1fbc69e8) mentions the fact that to correctly handle the showTime option, the formatDate and formatDateTime must be imported from "@web/views/fields/formatters".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
