### PR TITLE
[FIX] website_slides: wait for portal chatter in tours

### DIFF
--- a/addons/website_slides/static/tests/tours/slide_portal_chatter_bundle.js
+++ b/addons/website_slides/static/tests/tours/slide_portal_chatter_bundle.js
@@ -13,16 +13,7 @@ registry.category("web_tour.tours").add("portal_chatter_bundle", {
         {
             content: "Wait for the whole page to load",
             trigger: "#chatterRoot:shadow .o-mail-Chatter",
-            run: () => {
-                odoo.portalChatterReady.then(() => {
-                    const errors = odoo.loader.findErrors();
-                    if (Object.keys(errors).length) {
-                        console.error("Couldn't load all JS modules.", errors);
-                    } else {
-                        console.log("test successful");
-                    }
-                });
-            },
+            run: () => odoo.portalChatterReady,
         },
     ],
 });

--- a/addons/website_slides/static/tests/tours/slides_text_highlights.js
+++ b/addons/website_slides/static/tests/tours/slides_text_highlights.js
@@ -4,29 +4,30 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     registerWebsitePreviewTour,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
-const selectText = (selector) => {
-    return {
-        content: "Select some text content",
-        trigger: "iframe",
-        run() {
-            const iframeWindow = this.anchor.contentWindow;
-            const iframeDocument = iframeWindow.document;
-            const p = iframeDocument.querySelector(selector);
-            p.click();
-            const selection = iframeWindow.getSelection();
-            const range = iframeDocument.createRange();
-            range.selectNodeContents(p);
-            selection.removeAllRanges();
-            selection.addRange(range);
-        },
-    };
-};
+const selectText = (selector) => ({
+    content: "Select some text content",
+    trigger: "iframe",
+    run() {
+        const iframeWindow = this.anchor.contentWindow;
+        const iframeDocument = iframeWindow.document;
+        const p = iframeDocument.querySelector(selector);
+        p.click();
+        const selection = iframeWindow.getSelection();
+        const range = iframeDocument.createRange();
+        range.selectNodeContents(p);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    },
+});
 
-registerWebsitePreviewTour('fullscreen_slide_text_highlights', {
-    url: "/slides",
-}, () => [
+registerWebsitePreviewTour(
+    "fullscreen_slide_text_highlights",
+    {
+        url: "/slides",
+    },
+    () => [
         {
             trigger: ':iframe a:contains("Basics of Gardening - Test")',
             run: "click",
@@ -34,6 +35,11 @@ registerWebsitePreviewTour('fullscreen_slide_text_highlights', {
         {
             trigger: ':iframe a:contains("Article test")',
             run: "click",
+        },
+        {
+            content: "Wait for the review tab chatter to be ready",
+            trigger: ":iframe #chatterRoot:not(:visible)",
+            run: () => odoo.portalChatterReady,
         },
         ...clickOnEditAndWaitEditMode(),
         selectText(".s_text_block > p"),
@@ -44,12 +50,12 @@ registerWebsitePreviewTour('fullscreen_slide_text_highlights', {
         },
         {
             content: "Click on the 'Highlight Effects' button to show the listing",
-            trigger: 'button.o-select-highlight',
+            trigger: "button.o-select-highlight",
             run: "click",
         },
         {
             content: "Click on the first highlight effect proposed to activate it",
-            trigger: 'span.o_text_highlight',
+            trigger: "span.o_text_highlight",
             run: "click",
         },
         {
@@ -58,19 +64,23 @@ registerWebsitePreviewTour('fullscreen_slide_text_highlights', {
         },
         {
             content: "Check that the highlight was applied",
-            trigger: ":iframe .o_wslides_lesson_content_type p span.o_text_highlight > svg.o_text_highlight_svg",
+            trigger:
+                ":iframe .o_wslides_lesson_content_type p span.o_text_highlight > svg.o_text_highlight_svg",
         },
         ...clickOnSave(),
         {
             content: "Click on the fullscreen button",
             trigger: ':iframe #wrapwrap a[aria-label="Fullscreen"]',
             run: "click",
-        }, {
+        },
+        {
             content: "Wait for fullscreen",
             trigger: ':iframe #wrapwrap a[title="Exit Fullscreen"]',
-        }, {
-            content: "Check that the highlight was applied in fullscreen",
-            trigger: ":iframe .o_wslides_fs_content p span.o_text_highlight > svg.o_text_highlight_svg",
         },
-    ],
+        {
+            content: "Check that the highlight was applied in fullscreen",
+            trigger:
+                ":iframe .o_wslides_fs_content p span.o_text_highlight > svg.o_text_highlight_svg",
+        },
+    ]
 );


### PR DESCRIPTION
### Before commit
Some tours did not wait for the portal chatter to load when needed:
- `portal_chatter_bundle`: the `run` function creates a promise but the tour finishes before it resolves.
- `fullscreen_slide_text_highlights`: `PortalChatterService` adds an element in the DOM while the selection is updated in the `selectText` tour step. This caused the following warning to show:
```
should not have any "characterData", "remove" or "add" mutations in
current step when you update the selection
```

### Fix
Properly wait for `portalChatterReady` to resolve before proceeding with the rest of the tour steps.

(Also fixed the typo in the filename `slide_portal_chatter_bundle.js`)

runbot-229803