### PR TITLE
[FIX] html_editor: replace empty or fully selected links on paste

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -198,8 +198,9 @@ export class ClipboardPlugin extends Plugin {
         }
         ev.preventDefault();
 
-        this.dispatchTo("before_paste_handlers", selection);
         this.dependencies.history.stageSelection();
+
+        this.dispatchTo("before_paste_handlers", selection);
         // refresh selection after potential changes from `before_paste` handlers
         selection = this.dependencies.selection.getEditableSelection();
 

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -415,6 +415,10 @@ export class LinkPlugin extends Plugin {
             description: _t("Create an URL."),
             icon: "fa-link",
             run: () => {
+                this.dispatchTo(
+                    "before_paste_handlers",
+                    this.dependencies.selection.getEditableSelection()
+                );
                 this.dependencies.dom.insert(this.createLink(url, text));
                 this.dependencies.history.addStep();
             },

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -363,6 +363,10 @@ export class ImagePlugin extends Plugin {
                 description: _t("Embed the image in the document."),
                 icon: "fa-image",
                 run: () => {
+                    this.dispatchTo(
+                        "before_paste_handlers",
+                        this.dependencies.selection.getEditableSelection()
+                    );
                     const img = document.createElement("IMG");
                     img.setAttribute("src", url);
                     this.dependencies.dom.insert(img);


### PR DESCRIPTION
Problem:
When pasting text or a image URL inside an empty link, or when the link is fully selected, the link is not removed and replaced by the pasted content. Instead, the text or URL is inserted inside the link, which is not the intended behavior.

Cause:
When pasting text or a image URL, and a command is triggered from the powerbox via `openPowerboxOnUrlPaste`, we call `addStep` after the content insertion. This step not only inserts the content but also removes the link if it was fully selected (via `before_paste_handlers`).

However, `onApplyCommand` then restores the state to before the content insertion and link removal. The command (e.g. “Embed Image”) is executed on that restored state, where the selection is collapsed inside the link. As a result, the inserted content ends up inside the link instead of replacing it.

Solution:
In this situation, fully select the link before inserting the content. This allows the `insert` logic to correctly replace the link with the pasted text or URL.

task-5386862

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
