### PR TITLE
[IMP] l10n_in: remove restriction for accessing tax returns

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -1138,6 +1138,7 @@ class ResCompany(models.Model):
             self.env['ir.default'].set('product.category', 'property_account_expense_categ_id', company.expense_account_id.id, company_id=company.id)
             self.env['ir.default'].set('product.category', 'property_account_income_categ_id', company.income_account_id.id, company_id=company.id)
 
+    # Deprecated, removed in master.
     def _check_tax_return_configuration(self):
         """
         To override in localizations to check if the company is properly configured for tax returns.

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -1,8 +1,4 @@
-import pytz
-from stdnum.in_ import pan, gstin
-
-from odoo import Command, _, api, fields, models
-from odoo.exceptions import RedirectWarning
+from odoo import Command, api, fields, models
 
 
 class ResCompany(models.Model):
@@ -178,18 +174,3 @@ class ResCompany(models.Model):
     def action_update_state_as_per_gstin(self):
         self.ensure_one()
         self.partner_id.action_update_state_as_per_gstin()
-
-    def _check_tax_return_configuration(self):
-        """
-        Check if the company is properly configured for tax returns.
-        :raises RedirectWarning: if something is wrong configured.
-        """
-
-        if self.country_code != 'IN':
-            return super()._check_tax_return_configuration()
-
-        is_l10n_in_reports_installed = 'l10n_in_reports' in self.env['ir.module.module']._installed()
-        if not is_l10n_in_reports_installed:
-            msg = _("First enable GST e-Filing feature from configuration for company %s.", (self.name))
-            action = self.env.ref("account.action_account_config")
-            raise RedirectWarning(msg, action.id, _('Go to configuration'))


### PR DESCRIPTION
BEFORE:
- Before this commit, when we disable the gst e-filing feature from the configuration and try to access the tax return view, we are getting blocked by the redirect warning, which suggests enabling the gst e-filing feature from the configuration.
- Which is not desirable, as there might be some returns that are not related to gst e-filing, which should be accessible by the user.

AFTER:
- After this commit, removed the RedirectWarning when accessing the tax return view with gst e-filing feature disabled. So now the user can access tax returns without enabling gst e-filing feature.
- At the time of setting the fiscal year(generating/refreshing returns automatically), the GSTR returns will not be created.
- And at the time of manual GSTR return creation, we are raising UserError to instruct the user about enabling the gst e-filing feature.

Related Ent PR: https://github.com/odoo/enterprise/pull/105983

Task-5486586