### PR TITLE
[FIX] website_sale: show contact us button for zero-priced variants

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
+++ b/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
@@ -7,6 +7,23 @@ registry.category('web_tour.tours').add('website_sale_contact_us_button', {
             trigger: '.js_attribute_value:has([checked]):contains(red)',
         },
         {
+            content: "Product price should be 20",
+            trigger: '.product_price .oe_currency_value:contains(20.00)',
+        },
+        {
+            content: '"Add to Cart" button should be visibile',
+            trigger: '#add_to_cart_wrap',
+        },
+        {
+            content: '"Contact Us" button should be hidden',
+            trigger: '#contact_us_wrapper:not(:visible)',
+        },
+        {
+            content: "Select attribute with price zero value",
+            trigger: '.js_attribute_value:contains(blue) input',
+            run: 'click',
+        },
+        {
             content: "Zero-priced product should be unavailable",
             trigger: '#product_unavailable',
         },
@@ -21,23 +38,6 @@ registry.category('web_tour.tours').add('website_sale_contact_us_button', {
         {
             content: '"Contact Us" button should be visible',
             trigger: '#contact_us_wrapper',
-        },
-        {
-            content: "Select attribute with price extra value",
-            trigger: '.js_attribute_value:contains(blue):contains(20.00) input',
-            run: 'click',
-        },
-        {
-            content: "Product price should be updated",
-            trigger: '.product_price .oe_currency_value:contains(20.00)',
-        },
-        {
-            content: '"Add to Cart" button should now be visibile',
-            trigger: '#add_to_cart_wrap',
-        },
-        {
-            content: '"Contact Us" button should now be hidden',
-            trigger: '#contact_us_wrapper:not(:visible)',
         },
     ],
 });

--- a/addons/website_sale/tests/test_website_sale_product_page.py
+++ b/addons/website_sale/tests/test_website_sale_product_page.py
@@ -25,8 +25,8 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
         self.website.prevent_zero_price_sale = True
 
         self.product_template_sofa.list_price = 0
-        red_sofa, blue_sofa = self.product_template_sofa.product_variant_ids[:2]
-        blue_sofa.product_template_attribute_value_ids.price_extra = 20
+        red_sofa = self.product_template_sofa.product_variant_ids[:1]
+        red_sofa.product_template_attribute_value_ids.price_extra = 20
 
         self.start_tour(red_sofa.website_url, 'website_sale_contact_us_button')
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2145,12 +2145,11 @@
                                     </div>
 
                                     <div
-                                        t-if="combination_info['prevent_zero_price_sale']"
                                         class="o_wsale_product_details_content_section o_wsale_product_details_content_section_contact mb-4"
                                     >
                                         <div
                                             id="contact_us_wrapper"
-                                            t-attf-class="d-flex oe_structure oe_structure_solo #{_div_classes}"
+                                            t-attf-class="d-flex oe_structure oe_structure_solo #{_div_classes} {{'d-flex' if combination_info['prevent_zero_price_sale'] else 'd-none'}}"
                                         >
                                             <section
                                                 class="s_text_block"


### PR DESCRIPTION
### Steps to reproduce:
- Download eCommerce app.
- Create a product priced at zero.
- Add an attribute and make the FIRST value of the attribute priced at more than 0.
- Check Configuration > Settings > Prevent Sale of Zero Priced Product.
- Open the created product on the website, choose the zero-priced variant.

### Issue:
The 'Contact Us' button doesn't appear when you view the zero-priced variant. This happens because when you initially load the product that has a positive price, the contact us component isn't loaded because it has an if condition that checks if the price is above 0.
https://github.com/odoo/odoo/blob/cda011dc8590773f6c3a26f4ae9d5242a3147024/addons/website_sale/views/templates.xml#L2147-L2154
Consequently, when https://github.com/odoo/odoo/blob/7a39185f83d0daca207c8007512f4700537c7e88/addons/website_sale/static/src/js/variant_mixin.js#L302-L315 tries to load the 'Contact Us' button via the query selector, it gets null as a return value.
The test made for this issue loaded the variant that has the zero-price first, so the 'Contact Us' button was loaded normally.

### Note about the test:
Edit the test so that the positive priced variant is loaded first, which will fail in case that the fix isn't applied, as the 'contact-us-wrapper' component won't be loaded at the start of the test.

opw-5491935