### PR TITLE
[FIX] hr: use action_archive in departure wizard

### DIFF
--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -28,7 +28,7 @@ class HrDepartureWizard(models.TransientModel):
     def action_register_departure(self):
         employee = self.employee_id
         if self.env.context.get('toggle_active', False) and employee.active:
-            employee.with_context(no_wizard=True).toggle_active()
+            employee.with_context(no_wizard=True).action_archive()
         employee.departure_reason_id = self.departure_reason_id
         employee.departure_description = self.departure_description
         employee.departure_date = self.departure_date


### PR DESCRIPTION
When archiving an employee from the departure wizard, use the action_archive method instead of toggle_active.

Related to odoo/enterprise#100437

task: 5354002