### PR TITLE
[FIX] website: accept absolute website_meta_og_img


### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
+import urllib.parse
 
 from odoo import api, fields, models, _
 from odoo.fields import Domain
@@ -79,7 +80,10 @@ class WebsiteSeoMetadata(models.AbstractModel):
             opengraph_meta['og:title'] = self.website_meta_title
         if self.website_meta_description:
             opengraph_meta['og:description'] = self.website_meta_description
-        opengraph_meta['og:image'] = url_join(root_url, self.env['ir.http']._url_for(self.website_meta_og_img or opengraph_meta['og:image']))
+        og_image = self.website_meta_og_img and urllib.parse.urlunsplit(
+            ["", "", *urllib.parse.urlsplit(self.website_meta_og_img)[2:]]
+        )
+        opengraph_meta['og:image'] = url_join(root_url, self.env['ir.http']._url_for(og_image or opengraph_meta['og:image']))
         return {
             'opengraph_meta': opengraph_meta,
             'twitter_meta': twitter_meta,

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -989,6 +989,7 @@ export class OptimizeSEODialog extends Component {
 
             seoContext.metaImage =
                 this.data.website_meta_og_img || this.getMeta({ property: "og:image" });
+            this.previousMetaImage = seoContext.metaImage;
 
             this.pageImages = this.getImages();
             this.socialPreviewDescription = _t(
@@ -1062,7 +1063,9 @@ export class OptimizeSEODialog extends Component {
                 data.seo_name = seoContext.seoName;
             }
         }
-        data.website_meta_og_img = seoContext.metaImage;
+        if (seoContext.metaImage !== this.previousMetaImage) {
+            data.website_meta_og_img = seoContext.metaImage;
+        }
         await this.orm.write(this.object.model, [this.object.id], data, {
             context: {
                 lang: this.website.currentWebsite.metadata.lang,

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -301,6 +301,19 @@ class WithContext(HttpCase):
         canonical_url = root_html.xpath('//link[@rel="canonical"]')[0].attrib['href']
         self.assertIn(canonical_url, [f"{website.domain}/", f"{website.domain}/page_1"])
 
+    def test_opengraph_image_with_absolute_url(self):
+        base_url = self.base_url()
+        with MockRequest(self.env, website=self.env['website'].browse(1)):
+            self.page.website_meta_og_img = 'http://wrong.example.com/favicon.ico'
+            r = self.url_open(self.page.url)
+            self.assertEqual(r.status_code, 200)
+            self.assertIn(f'"og:image" content="{base_url}/favicon.ico"', r.text)
+
+            self.page.website_meta_og_img = '/logo'
+            r = self.url_open(self.page.url)
+            self.assertEqual(r.status_code, 200)
+            self.assertIn(f'"og:image" content="{base_url}/logo"', r.text)
+
     def test_website_homepage_url_change(self):
         website = self.env['website'].browse([1])
         self.assertFalse(website.homepage_url)


### PR DESCRIPTION
In 17.0 up to master, website_meta_og_img for newly added cover image
should be a relative URL instead of an absolute URL since 27th september
2025 commit 4c5d9861e389534f9ca684b9faa1ce6289df5639.

In combination with:

- [1] python fix in 19.0: accept absolute URL in website_meta_og_img
- [2] upgrade script in saas-19.1: removes absolute URL that existed in
  19.0 when upgrading to saas-19.1

We wanted to removed the error that happened in 19.0 when configuring a
cover image (in Optimize SEO) and also using a custom domain

These fixes worked up to 19.0, but there is still a possible issue in
saas-19.1:

- open "Optimize SEO" wizard of a page
- click on save without changing the image
- set a domain on the website
- go to the page with the cover image

=> result an absolute URL is saved and we get a traceback error when
visiting on wrong domain.

Cause:

The 4c5d9861e389534f9ca684b9faa1ce6289df5639 was only getting relative
URL when an image was selected. This didn't work if we open and saved
the modal when there was no website_meta_og_img and the image was gotten
from the META og:image element.

In 19.0, since there was a python fix for existing errors [1] this case
was hidden and didn't cause an issue.

Fix:

Forward-port cdffe8ab905068a3947ea62562c7209d216b2b8d in upper versions.

A fix should also be done after to ensure we don't save absolute URL:
for example if the image we save matches the og:image in DOM, don't save
it.

[1]: cdffe8ab905068a3947ea62562c7209d216b2b8d
[2]: odoo/upgrade@5408746b110d660901645b9c7b9aa9cee7aaf235

opw-5867113
opw-5874045
opw-5874931
opw-5875254
opw-5884536
opw-5885941
opw-5887081
opw-5888627
opw-5889050
opw-5891942
opw-5897982
opw-5898621
opw-5898731
opw-5899722
opw-5900450
opw-5906008