### PR TITLE
[CLN] html_editor: remove unused plugin resource `clean_handlers`

### DIFF
--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -32,7 +32,6 @@ export class SeparatorPlugin extends Plugin {
         normalize_handlers: this.normalize.bind(this),
         selectionchange_handlers: this.handleSelectionInHr.bind(this),
         deselect_custom_selected_nodes_handlers: this.deselectHR.bind(this),
-        clean_handlers: this.deselectHR.bind(this),
         clean_for_save_handlers: ({ root }) => {
             for (const el of root.querySelectorAll("hr[contenteditable]")) {
                 el.removeAttribute("contenteditable");


### PR DESCRIPTION
The resource named `clean_handlers` should have been removed since [1], but a single
occurrence has been forgotten and survived in `SeparatorPlugin`. This commit removes it.

[1]: https://github.com/odoo/odoo/commit/3cd28b1972e704c54e5b40226bfbe4e0895481d8

task-5363816