### PR TITLE
[FIX] stock: include product in package for shipping weight

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -893,18 +893,14 @@ class StockPicking(models.Model):
     def _compute_shipping_weight(self):
         for picking in self:
             # if shipping weight is not assigned => default to calculated product weight
-            packages_weight = picking.move_line_ids.result_package_id.sudo()._get_weight(picking.id)
-
             shipping_weight = picking.weight_bulk
             relevant_packages = picking.move_line_ids.result_package_id.outermost_package_id
-            children_packages_by_pack = relevant_packages._get_all_children_package_dest_ids()[0]
+            packages_weight = relevant_packages.sudo()._get_weight(picking.id)
             for package in relevant_packages:
                 if package.shipping_weight:
                     shipping_weight += package.shipping_weight
                 else:
-                    shipping_weight += package.package_type_id.base_weight
-                    shipping_weight += sum(packages_weight.get(pack, 0) for pack in self.env['stock.package'].browse(children_packages_by_pack.get(package)))
-
+                    shipping_weight += packages_weight.get(package, 0)
             picking.shipping_weight = shipping_weight
 
     def _compute_shipping_volume(self):


### PR DESCRIPTION
On delivery slip, the total weight of a package doesn't include the weight of the product in the outermost package.

Steps to reproduce:
-------------------
* Create a Package "Pa" with a package type that has a weight
* Create a product "Po" tracked by quantity
* Add two units of the product Po to the package Pa
* Create Delivery with two units of Po.
* Confirm the Delivery and print the delivery slip -> The total weight is the weight of the package type without including the products inside.

Observation:
-------------
When computing the shipping_weight for the delivery, it will fallback on the package_weight to calculate it weight, https://github.com/odoo/odoo/blob/ca14f1aa21a75398919c1453be19011522bb3b5c/addons/stock/models/stock_picking.py#L893-L906 
It retrieve the weight calculated by _get_weight
https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/stock/models/stock_package.py#L435
Except for the outermost package,  where it incorrectly considers only the package type weight and does not include the products weight

opw-5499770