### PR TITLE
[FIX] resource : fix leave duration display

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -523,11 +523,7 @@ class ResourceCalendar(models.Model):
             day_hours[start.date()] += interval_hours
 
         for day, hours in day_hours.items():
-            if len(self) == 1 and self._is_duration_based_on_date(day):
-                hours_per_day = self._get_duration_based_work_hours_on_date(day)
-                day_days[start.date()] += hours / hours_per_day if hours_per_day else 0
-            else:
-                day_days[day] = 0.5 if hours <= self.hours_per_day * 3 / 4 else 1
+            day_days[day] = 0.5 if hours <= self.hours_per_day * 3 / 4 else 1
 
         return {
             # Round the number of days to the closest 16th of a day.


### PR DESCRIPTION
**To reproduce:**
1- Adjust working schedule of an employee to have no work on Wednesday afternoon.
2- Create a time off type that allows half day.
3-Take one week time off, the shown leave duration should be 4.5 days, not 5.

**FIX:**
- Removing unnecessary conditions that leads to wrong calculations.

Task: #5909431