### PR TITLE
[FIX] html_editor: image resize sets 100% width inside links

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -26,6 +26,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 import { Component, onMounted, useExternalListener, useRef } from "@odoo/owl";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { usePositionHook } from "@html_editor/position_hook";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 const rad = Math.PI / 180;
 const MIN_IMAGE_SIZE = 20;
@@ -210,8 +211,12 @@ export class ImageTransformation extends Component {
 
     convertPixelWidthToPercentage() {
         const currentPixelWidth = this.image.offsetWidth;
-        const widthPercent = (currentPixelWidth / this.image.parentElement.offsetWidth) * 100;
-        this.image.style.width = widthPercent.toFixed(2) + "%";
+        const container = closestElement(
+            this.image.parentElement,
+            (node) => node.offsetWidth > currentPixelWidth
+        );
+        const widthPercent = (currentPixelWidth / container.offsetWidth) * 100;
+        this.image.style.width = Math.min(100, widthPercent).toFixed(2) + "%";
     }
 
     mouseUp() {


### PR DESCRIPTION
Problem:
Resizing an image inside a link causes it to snap to 100% width on mouseup.

Cause:
The percentage calculation uses the parent element's width as reference. When the parent is inline (like `<a>`) or has fit-content width, its width equals the image width, resulting in 100% every time.

Solution:
Find the first ancestor with content width larger than the image and use it as reference for the percentage calculation.

Steps to reproduce:
- Add an image inside a link
- Resize the image
- Observe the image snaps to 100% width on release

opw-xxxx

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
