### PR TITLE
[FIX] base: uid should not be set during MFA

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1203,8 +1203,6 @@ class Session(collections.abc.MutableMapping):
         self['pre_login'] = credential['login']
         self['pre_uid'] = pre_uid
 
-        env = env(user=pre_uid)
-
         # if 2FA is disabled we finalize immediately
         user = env['res.users'].browse(pre_uid)
         if auth_info.get('mfa') == 'skip' or not user._mfa_url():


### PR DESCRIPTION
Before this fix the uid was set in the environment even when the MFA was not yet complete. The uid is set in finalize function and was accidentally set before due to a refactor of DLE. This was indeed a bug since the code expects the uid to be set to None.

Task-5910537