### PR TITLE
[FIX] html_builder, *: allow inline at root for a, span, ...

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -24,6 +24,14 @@ import { setBuilderCSSVariables } from "@html_builder/utils/utils_css";
 import { withSequence } from "@html_editor/utils/resource";
 import { getHtmlStyle } from "@html_editor/utils/formatting";
 
+// These elements should only have inline content (even if they have a `block`
+// display style, for example if they are in a flex)
+// NOTE: h1, h2, ..., p, pre already prevents wrapping their children into block
+const ONLY_ALLOW_INLINE_TAGS = new Set([
+    ...["a", "em", "strong", "small", "s", "cite", "q", "abbr", "data", "time", "code"],
+    ...["samp", "sub", "sup", "i", "b", "u", "mark", "bdi", "span", "label", "button"],
+]);
+
 /**
  * @typedef {(() => void)[]} on_mobile_preview_clicked
  * @typedef {(() => void)[]} trigger_dom_updated
@@ -156,6 +164,9 @@ export class Builder extends Component {
                     can_display_toolbar: (namespace) => !["image", "icon"].includes(namespace),
 
                     // disable the toolbar for images and icons
+
+                    are_inlines_allowed_at_root_predicates: (el) =>
+                        ONLY_ALLOW_INLINE_TAGS.has(el.tagName.toLowerCase()) || undefined,
                 },
                 localOverlayContainers: {
                     key: this.env.localOverlayContainerKey,

--- a/addons/html_builder/static/tests/editor.test.js
+++ b/addons/html_builder/static/tests/editor.test.js
@@ -240,3 +240,12 @@ describe("toolbar dropdowns", () => {
         expect(emptyStructureEl.childNodes.length).toBe(0);
     });
 });
+
+test("should not insert block element at root editable span", async () => {
+    const { getEditor } = await setupHTMLBuilder("", {
+        headerContent: `<span style="display: block" contenteditable="true" class="test-target">Hello</span>`,
+    });
+    setSelection({ anchorNode: queryOne(":iframe .test-target"), anchorOffset: 1 });
+    pasteHtml(getEditor(), `!`);
+    expect(":iframe .test-target").toHaveInnerHTML("Hello!");
+});

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -75,7 +75,7 @@ function getConnectedParents(nodes) {
  * @typedef {((container: Element, block: Element) => container)[]} before_insert_processors
  * @typedef {((arg: { nodeToInsert: Node, container: HTMLElement }) => nodeToInsert)[]} node_to_insert_processors
  *
- * @typedef {((el: HTMLElement) => Promise<boolean>)[]} are_inlines_allowed_at_root_predicates
+ * @typedef {((el: HTMLElement) => boolean)[]} are_inlines_allowed_at_root_predicates
  *
  * @typedef {string[]} system_attributes
  * @typedef {string[]} system_classes

--- a/addons/website/static/src/builder/plugins/options/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header_option_plugin.js
@@ -99,7 +99,9 @@ export class HeaderOptionPlugin extends Plugin {
         // to avoid wrapping the button in a <p> or <div>, which would remove
         // this button if it's empty
         are_inlines_allowed_at_root_predicates: (node) =>
-            node.matches("#o_main_nav .oe_structure_solo .oe_unremovable [contenteditable='true']"),
+            node.matches(
+                "#o_main_nav .oe_structure_solo .oe_unremovable [contenteditable='true']"
+            ) || undefined,
     };
 }
 


### PR DESCRIPTION
Since [website builder refactor], the editor wraps inline elements at the root of an editable boundary. This is causing issues in website builder when the root element is not supposed to contain `p` or `div` elements (added to wrap the inline elements).

This behavior can be configured globally with `allowInlineAtRoot`. And since 6bc5946796a364634cb5eb217e61a5b882a1b6b2, it can be configured per-element with a "predicate" resource.

This commit adds a predicate to allow inline at root of editable when the root is (according to its tag) not supposed to contain `p` or `div` elements.

Steps to reproduce:
- Open website builder on a product page
- Select text in "Add to cart" button
- Copy
- Paste
- Bug: a `p` element is created

(on master)
- Open website builder
- Select "Company" below footer
- Copy
- Paste
- Bug: a `p` element is created

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-5868460
