### PR TITLE
[FIX] base: match server actions visual sort with execution

### DIFF
--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -511,7 +511,7 @@ env['res.partner'].create({'name': partner_name})
             <field name="name">Server Actions</field>
             <field name="model">ir.actions.server</field>
             <field name="arch" type="xml">
-                <kanban>
+                <kanban default_order="sequence, name, id">
                     <control>
                         <create string="Add an action" />
                     </control>


### PR DESCRIPTION
Currently, the server actions Kanban view implicitly sorts records by sequence and then by ID. This behavior is triggered automatically by the web client when a field with the 'handle' widget is present and no default order is specified in the view.

However, the backend execution logic for multi-actions (ir.actions.server) processes actions based on 'sequence' and then 'name' (alphabetical).

This creates a discrepancy when multiple actions share the same sequence number: the user sees them sorted by creation order (ID) in the interface, but they are executed alphabetically. This leads to confusion as the visual hierarchy does not accurately represent the flow of operations.

This commit ensures the view aligns with the backend model's sorting logic, so that the visual order in the frontend matches the actual execution order.

Task-5075610

