### PR TITLE
[ADD] l10n_latam_sale: Show LATAM identification types in sale reports

### DIFF
--- a/.weblate.json
+++ b/.weblate.json
@@ -2550,6 +2550,12 @@
                 "language_regex": "^(es_419|pt_BR)$"
             },
             {
+                "name": "l10n_latam_sale",
+                "filemask": "addons/l10n_latam_sale/i18n/*.po",
+                "new_base": "addons/l10n_latam_sale/i18n/l10n_latam_sale.pot",
+                "language_regex": "^(es_419|pt_BR)$"
+            },
+            {
                 "name": "l10n_lb_account",
                 "filemask": "addons/l10n_lb_account/i18n/*.po",
                 "new_base": "addons/l10n_lb_account/i18n/l10n_lb_account.pot",

--- a/addons/l10n_latam_sale/__init__.py
+++ b/addons/l10n_latam_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import report

--- a/addons/l10n_latam_sale/__manifest__.py
+++ b/addons/l10n_latam_sale/__manifest__.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'LATAM - Sale Report',
+    'version': '1.0',
+    'description': """LATAM Sale Report""",
+    'category': 'Accounting/Localizations/Sale',
+    'depends': [
+        'l10n_latam_base',
+        'sale',
+    ],
+    'data': [
+        'report/sale_ir_actions_report_templates.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_latam_sale/report/sale_ir_actions_report_templates.xml
+++ b/addons/l10n_latam_sale/report/sale_ir_actions_report_templates.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_saleorder_document" inherit_id="sale.report_saleorder_document">
+        <xpath expr="//t[@t-set='address']//p[@t-if='doc.partner_id.vat']" position="replace">
+            <p t-if="doc.partner_id.vat" class="mb-0">
+                <t t-if="not doc.partner_id.is_vat or 'LATAMID' in doc.partner_id.fiscal_country_group_codes" t-out="doc.partner_id.l10n_latam_identification_type_id.name"/>
+                <t t-elif="doc.company_id.account_fiscal_country_id.vat_label" t-out="doc.company_id.account_fiscal_country_id.vat_label"/>
+                <t t-else="">Tax ID</t>: <span t-field="doc.partner_id.vat"/>
+            </p>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Problem:
Latin American (LATAM) countries have many identification types (Tax ID, Passport, etc.). Each LATAM partners can be identified by any of the types. However, when printing a sales report (a PDF Quote of a sales order), the VAT label of the company is showing instead of the chosen identification type of the customer. For example, CUIT (VAT label for Argentina) would show instead of Passport for a customer who is identified by their passport number.

Cause:
The generic sales reports do not take into consideration that LATAM partners can be identified by types other than their tax ID.

Solution:
Create a new app, specifically for LATAM partners, to override the sales report generated. It overrides the part with the customer's details to show the correct identification type for LATAM partners.

Steps to reproduce:
- Choose (or create) a Latin American Company from your companies.
- Create a new partner with passprt identification type.
- Create a new sales quotation for that customer.
- Confirm the quotation.
- Print a PDF quote of the sales order
- See how the partner is identified by the country's VAT label and not the passport. (Although the number shown is the correct passport number, but the label is incorrect)

opw-5879261