### PR TITLE
[FIX] project: fix portal task Search in Assignees (user_ids) does not work

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -353,7 +353,7 @@ class ProjectCustomerPortal(CustomerPortal):
                 left=Markup('<span class="nolabel">'),
                 right=Markup('</span>'),
             ), 'sequence': 10},
-            'users': {'input': 'user_ids', 'label': _('Search in Assignees'), 'sequence': 20},
+            'user_ids': {'input': 'user_ids', 'label': _('Search in Assignees'), 'sequence': 20},
             'stage_id': {'input': 'stage_id', 'label': _('Search in Stages'), 'sequence': 30},
             'status': {'input': 'status', 'label': _('Search in Status'), 'sequence': 40},
             'priority': {'input': 'priority', 'label': _('Search in Priority'), 'sequence': 60},
@@ -369,7 +369,7 @@ class ProjectCustomerPortal(CustomerPortal):
     def _task_get_search_domain(self, search_in, search, milestones_allowed, project):
         if not search_in or search_in == 'name':
             return ['|', ('name', 'ilike', search), ('id', 'ilike', search)]
-        elif search_in == 'users':
+        elif search_in == 'user_ids':
             user_ids = request.env['res.users'].sudo().search([('name', 'ilike', search)])
             return [('user_ids', 'in', user_ids.ids)]
         elif search_in == 'priority':


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- On the portal task, "Search In Assignees" always returns no tasks.

<img width="1482" height="979" alt="Screenshot 2026-02-04 at 23 02 53" src="https://github.com/user-attachments/assets/263429b4-0c32-4323-bf88-2dfaf2115181" />

<img width="1430" height="943" alt="image" src="https://github.com/user-attachments/assets/3c196cc1-f12d-4064-838d-8e29914e5fab" />



Current behavior before PR:

- Cannot search for tasks in the portal by assignee.

Desired behavior after PR is merged:

- Can search for tasks in the portal by assignee.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
