### PR TITLE
[FIX] sale: allow sale user create product.attribute.custom.value

### DIFF
--- a/addons/sale/security/ir.model.access.csv
+++ b/addons/sale/security/ir.model.access.csv
@@ -20,6 +20,7 @@ access_mail_activity_type_sale_manager,mail.activity.type.sale.manager,mail.mode
 access_product_pricelist_sale_user,product.pricelist.sale.user,product.model_product_pricelist,sales_team.group_sale_salesman,1,0,0,0
 access_product_pricelist_sale_manager,product.pricelist salemanager,product.model_product_pricelist,sales_team.group_sale_manager,1,1,1,1
 access_product_pricelist_item_sale_manager,product.pricelist.item salemanager,product.model_product_pricelist_item,sales_team.group_sale_manager,1,1,1,1
+access_product_product_attribute_custom_value_sale_user,product.attribute.custom value salesman,product.model_product_attribute_custom_value,sales_team.group_sale_salesman,1,1,1,1
 access_product_document_sale_manager,access_product_document_sale_manager,product.model_product_document,sales_team.group_sale_manager,1,1,1,1
 
 access_uom_uom_user,uom.uom.user,uom.model_uom_uom,sales_team.group_sale_salesman,1,0,0,0


### PR DESCRIPTION
### Issue:
Due to this issue, sale group cannot create a sale order with a product with custom value attribute.

#### Steps to reproduce:
1- Create a product using admin with a custom value attribute.
2- Using demo user with sale access group, create a so.
3- Add the created product, adn fill the custom value.

The sale order cannot be saved due to access error.

### Cause:
This is due to #197286. However that shouldn't have been applied to `product.attribute.custom` as that shouldn't be only accessed by people who can manage product like the rest of deleted accesses, but also it's needed by sale groups creating SOs.

opw-5498719

