### PR TITLE
[FIX] base: ensure an uniform environment between action variables

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -391,7 +391,4 @@ class IrActionsServer(models.Model):
         key set to False in the context. This way all notification emails linked
         to the currently executed action will be set in the queue instead of
         sent directly. This will avoid possible break in transactions. """
-        eval_context = super()._get_eval_context(action=action)
-        env = eval_context['env']
-        eval_context['env'] = env(context={**env.context, 'mail_notify_force_send': False})
-        return eval_context
+        return super(IrActionsServer, self.with_context(mail_notify_force_send=False))._get_eval_context(action=action)


### PR DESCRIPTION
### [FIX] base: ensure an uniform environment between action variables

The aim of this commit is to make the environment and context uniform
across the variables that can be accessed in an action.

Context:
The mail override of `<ir.actions.server>._get_eval_context` that
modifies the `env` wasn't reflected on the other variables which lead to
a difference of context.

Before this commit:
This difference resulted in a concurrent update error caused by a direct
mail send in method like `_cron_try_auto_reconcile_statement_lines`.

After this commit:
The environment and its context are uniform as expected and cron don't
trigger a mail send directly, removing the concurrent error issue.

task-id: None

The issue was brought in the internal channel, temporarily fixed by
adding the context in the server action and seen again in odoo.com logs
through another cron.