### PR TITLE
[FIX] hr_expense: prevent layout distortion in empty state

### DIFF
--- a/addons/hr_expense/static/src/scss/hr_expense.scss
+++ b/addons/hr_expense/static/src/scss/hr_expense.scss
@@ -1,6 +1,6 @@
 .hr_expense {
     @include media-breakpoint-up(md) {
-        &.o_list_view, &.o_kanban_view .o_kanban_renderer {
+        &.o_list_renderer, &.o_kanban_renderer {
             min-height: 100% !important;
         }
     }


### PR DESCRIPTION
Steps to reproduce:
1. Open the Expenses app and navigate to 'Expenses to Process'.
2. Ensure no expenses are present so that the 'Upload or Drop Your Receipt' helper appears.
3. Remove filters.
4. The layout becomes 'disturbed'—the upload overlay misaligns and  overlaps the dashboard.

Issue:
The issue occurred because the SCSS selector was incorrectly targeting the combination of .hr_expense and .o_list_view. In the Odoo DOM structure, the hr_expense class is added to the Renderer via XML, while o_list_view is assigned to the main Controller. Because the selector never matched an actual element, the min-height: 100% rule remained inactive.

Without a stable minimum height, the Renderer container collapses when empty. This prevents the 'Pink Overlay' from having a stable anchor point, leading to layout shifts and visual interference with the Search Panel and Dashboard headers.

Solution:
Update the SCSS selector to target &.o_list_renderer and &.o_kanban_renderer. This ensures the rule correctly matches the element carrying the hr_expense class. By forcing a min-height: 100% !important on the renderer itself, the container remains stable regardless of the data count. This provides a consistent workspace for the 'No Content' helper to render without disrupting the surrounding flexbox layout.

opw-5452618