### PR TITLE
[FIX] web: properly handle null element passed to scrollTo

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -489,7 +489,10 @@ export class AutoComplete extends Component {
             return;
         }
         if (isScrollableY(this.listRef.el)) {
-            scrollTo(this.listRef.el.querySelector(`#${this.activeSourceOptionId}`));
+            const element = this.listRef.el.querySelector(`#${this.activeSourceOptionId}`);
+            if (element) {
+                scrollTo(element);
+            }
         }
     }
 }


### PR DESCRIPTION
Steps to reproduce:
1. Ensure you have a good amount of contacts set up in your database
2. Ensure that you have an IAP Account setup for the service "Partner Autocomplete"
3. Zoom in on your browser to at least 150% AND/OR make your browser window incredibly short
4. Go to the CRM app
5. Go into the form view of an opportunity
6. Type 3 characters or more into the 'Contact' field
7. Observe the error

An Unhandled Promise error could occur if, after typing more than 3 characters in an autocomplete field, the dropdown is scrollable, and Partner Autocomplete finishes loading before the normal autocomplete does. In this scenario, normal autocomplete is still loading and has not rendered it's options. This causes a `null` element to be passed [`scrollTo()`](https://github.com/odoo/odoo/blob/555df96ac87a51405767c32f0396f762d458fd29/addons/web/static/src/core/utils/scrolling.js#L80), which causes an error when it tries to access `element.parentElement`. This change ensures that this scenario is properly handled and does not cause the database to crash.

opw-5491270