### PR TITLE
[FIX] point_of_sale: Allow to identify uniquely product with GS1

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -307,7 +307,7 @@ export class ProductScreen extends Component {
             vals.qty = (vals.qty || 1) * packaging[productBarcode.code].qty;
         }
 
-        await this.pos.addLineToCurrentOrder(vals, { code: lotBarcode });
+        await this.pos.addLineToCurrentOrder(vals, { code: lotBarcode }, product.needToConfigure());
         this.numberBuffer.reset();
     }
     displayAllControlPopup() {


### PR DESCRIPTION
In GS1 barcode action when scanning a GS1 composed of (01) product identification followed by product barcode as GTIN representation only, check if product is configurable or not (as we possibly identify a variant) as in ean barcode check.

This will avoid the variant configuration popup that is useless in this case.

Description of the issue/feature this PR addresses:

Avoid useless user interaction with the variant configurator in POS when scanning a product GS1 with
only the GTIN representation of the product (no lot, no package, ...).

Current behavior before PR:

When scanning a GS1 barcode that represent with certitude a variant, the variant configuration
popup is launched.

Desired behavior after PR is merged:

When scanning a GS1 barcode that represent with certitude a variant, the variant configuration
popup is not launched and the scanned variant is added to the order line.


opw-5912669

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
