### PR TITLE
[FIX] stock_account: remove store from avg_cost in multi-company

### DIFF
--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -7,7 +7,7 @@ class StockLot(models.Model):
     _inherit = 'stock.lot'
 
     lot_valuated = fields.Boolean(related='product_id.lot_valuated', readonly=True, store=False)
-    avg_cost = fields.Monetary(string="Average Cost", compute='_compute_value', compute_sudo=True, readonly=True, currency_field='company_currency_id')
+    avg_cost = fields.Monetary(string="Average Cost", compute='_compute_value', compute_sudo=True, store=False, readonly=True, currency_field='company_currency_id')
     total_value = fields.Monetary(string="Total Value", compute='_compute_value', compute_sudo=True, currency_field='company_currency_id')
     company_currency_id = fields.Many2one('res.currency', 'Valuation Currency', compute='_compute_value', compute_sudo=True)
     standard_price = fields.Float(
@@ -35,20 +35,23 @@ class StockLot(models.Model):
             qty_available = lot.with_context(warehouse_id=False).product_qty
             if valuated_product.uom_id.is_zero(qty_valued):
                 lot.total_value = 0
+                lot.avg_cost = 0.0
             elif valuated_product.cost_method == 'standard' or valuated_product.uom_id.is_zero(qty_available):
                 lot.total_value = lot.standard_price * qty_valued
+                lot.avg_cost = lot.standard_price
             elif valuated_product.cost_method == 'average':
-                lot.total_value = valuated_product.with_context(warehouse_id=False)._run_avco(at_date=at_date, lot=lot.with_context(warehouse_id=False))[1] * qty_valued / qty_available
+                avco_result = valuated_product.with_context(warehouse_id=False)._run_avco(at_date=at_date, lot=lot.with_context(warehouse_id=False))
+                lot.total_value = avco_result[1] * qty_valued / qty_available
+                lot.avg_cost = avco_result[0]
             else:
-                lot.total_value = valuated_product.with_context(warehouse_id=False)._run_fifo(qty_available, at_date=at_date, lot=lot.with_context(warehouse_id=False)) * qty_valued / qty_available
-            lot.avg_cost = lot.total_value / qty_valued if qty_valued else 0.0
+                fifo_value = valuated_product.with_context(warehouse_id=False)._run_fifo(qty_available, at_date=at_date, lot=lot.with_context(warehouse_id=False))
+                lot.total_value = fifo_value * qty_valued / qty_available
+                lot.avg_cost = fifo_value / qty_available if qty_available else 0.0
 
     # TODO: remove avg cost column in master and merge the two compute methods
-    @api.depends('product_id.lot_valuated')
-    @api.depends_context('to_date')
     def _compute_avg_cost(self):
-        """Compute totals of multiple svl related values"""
-        self.avg_cost = 0
+        # DEPRECATED: This method is no longer used.
+        self.avg_cost = 0.0
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/stock_account/tests/__init__.py
+++ b/addons/stock_account/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_anglo_saxon_valuation_reconciliation_common
 from . import test_lot_valuation
 from . import test_stockvaluation
 from . import test_stockvaluationlayer
+from . import test_multicompany_lot_valuation

--- a/addons/stock_account/tests/test_multicompany_lot_valuation.py
+++ b/addons/stock_account/tests/test_multicompany_lot_valuation.py
@@ -1,0 +1,74 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestMultiCompanyLotValuation(TransactionCase):
+    """
+    Test that lot.avg_cost computes correctly per company context in multi-company
+    databases with FIFO costing and lot valuation enabled.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company_b = cls.env['res.company'].create({
+            'name': 'Company B',
+            'currency_id': cls.env.ref('base.EUR').id,
+        })
+
+        cls.stock_account_product_categ = cls.env['product.category'].create({
+            'name': 'Test Stock Category',
+            'property_cost_method': 'fifo',
+            'property_valuation': 'periodic',
+        })
+
+        cls.product_fifo_lot = cls.env['product.product'].create({
+            'name': 'Product FIFO Lot Valuated',
+            'is_storable': True,
+            'categ_id': cls.stock_account_product_categ.id,
+            'tracking': 'serial',
+            'company_id': False,
+            'lot_valuated': True,
+        })
+
+        cls.warehouse_b = cls.env['stock.warehouse'].search([('company_id', '=', cls.company_b.id)])
+        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
+
+    def test_lot_avg_cost_multicompany_fifo(self):
+        """Test that a shared lot's avg_cost is computed correctly per company context."""
+
+        lot_b = self.env['stock.lot'].create({
+            'name': 'LOT-B-001',
+            'product_id': self.product_fifo_lot.id,
+            'company_id': False,
+        })
+
+        lot_b.with_company(self.company_b).standard_price = 100.0
+
+        move_in_b = self.env['stock.move'].with_company(self.company_b).create({
+            'product_id': self.product_fifo_lot.id,
+            'product_uom': self.product_fifo_lot.uom_id.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.warehouse_b.lot_stock_id.id,
+            'product_uom_qty': 1.0,
+            'company_id': self.company_b.id,
+        })
+        move_in_b._action_confirm()
+        move_in_b._action_assign()
+        move_in_b.move_line_ids.lot_id = lot_b
+        move_in_b.move_line_ids.quantity = 1.0
+        move_in_b.picked = True
+        move_in_b._action_done()
+
+        self.assertEqual(
+            lot_b.with_company(self.env.company).avg_cost, 0.0,
+            "avg_cost should be 0 in Company A context"
+        )
+        self.assertEqual(
+            lot_b.with_company(self.company_b).avg_cost, 100.0,
+            "avg_cost should be 100 EUR in Company B context"
+        )


### PR DESCRIPTION
Field avg_cost was set to store=True in 42d3e34, but the compute method _compute_avg_cost() is company-context-dependent (calls _run_fifo which filters by env.company). Storing a single value causes incorrect valuations in multi-company databases with FIFO + lot valuation.

In multi-company setups with shared products (company_id=False), the lot's avg_cost would compute in one company's context and store that value globally, causing all other companies to see the wrong cost.

Fix: Remove store=True to compute dynamically per company context. Cannot use company_dependent=True as it requires JSONB migration.

opw-5446941

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
