### PR TITLE
[FIX] sale: robustness in _create_invoices sequence handling

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1594,7 +1594,9 @@ class SaleOrder(models.Model):
                     optional_values['extra_tax_data'] = self.env['account.tax']\
                         ._reverse_quantity_base_line_extra_tax_data(line.extra_tax_data)
 
+                sequence = optional_values.pop('sequence')
                 for vals in line._prepare_invoice_lines_vals_list(**optional_values):
+                    vals['sequence'] = sequence
                     invoice_line_vals.append(Command.create(vals))
 
                 invoice_item_sequence += 1


### PR DESCRIPTION
This commit acts as a robustness fix for _create_invoices. It explicitly handles the 'sequence' argument by assigning it to the result dictionary after the _prepare_invoice_line call. This prevents TypeErrors when third-party modules override _prepare_invoice_line without accepting **kwargs, ensuring greater compatibility and stability.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
