### PR TITLE
[FIX] web: repair syntax error in pwa service selector

### DIFF
--- a/addons/web/static/src/core/pwa/pwa_service.js
+++ b/addons/web/static/src/core/pwa/pwa_service.js
@@ -125,7 +125,7 @@ const pwaService = {
         async function getManifest() {
             if (!_manifest) {
                 const manifest = await get(
-                    document.querySelector("link[rel=manifest")?.getAttribute("href"),
+                    document.querySelector("link[rel=manifest]")?.getAttribute("href"),
                     "text"
                 );
                 _manifest = JSON.parse(manifest);


### PR DESCRIPTION
This commit fixes a syntax error in the CSS selector used in pwa_service.js. The closing bracket ']' was missing in document.querySelector('link[rel=manifest]'), which prevented the manifest URL from being correctly retrieved. This ensures the PWA service can accurately fetch the manifest.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
