### PR TITLE
[FIX] stock_account: prevent standard_price update on empty stock

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -474,7 +474,7 @@ class ProductProduct(models.Model):
                     product.sudo().with_context(disable_auto_revaluation=True).standard_price = last_in._get_price_unit()
                 continue
             new_standard_price = product._run_avco()[0]
-            if new_standard_price:
+            if new_standard_price and product.qty_available > 0:
                 product.with_context(disable_auto_revaluation=True).sudo().standard_price = new_standard_price
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Revaluing an inventory move (e.g., Landed Costs or manual adjustment) for a product that is currently out of stock (quantity <= 0) incorrectly recalculates and updates the product's `standard_price`. This causes "ghost" cost fluctuations for future stock based on past, fully consumed inventory.

Current behavior before PR:
When `qty_available` is 0, `_update_standard_price` still applies a new cost based on the revaluation of old moves.

Desired behavior after PR is merged:
`_update_standard_price` now skips the update if `qty_available <= 0`, treating the revaluation purely as an accounting variance without affecting the current unit cost of the product.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
