### PR TITLE
[FIX] Normalize limit=False in _search (Fixes #228555)

### DIFF
--- a/doc/cla/individual/rafageist.md
+++ b/doc/cla/individual/rafageist.md
@@ -1,0 +1,11 @@
+Suriname, 2026-02-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Rafa Rodriguez rafageist@hotmail.com https://github.com/rafageist

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -5381,7 +5381,10 @@ class BaseModel(metaclass=MetaModel):
         # add order and limits
         if order:
             query.order = self._order_to_sql(order, query)
-        if limit is not None:
+
+        # In RPC, None is not available; False is used instead to mean "no limit"
+        # Note: True is kept for backward-compatibility (treated as 1)
+        if limit is not None and limit is not False:
             query.limit = limit
         if offset is not None:
             query.offset = offset


### PR DESCRIPTION
Some callers use `limit=False` to mean "no limit" (e.g. from RPC, where `None` is not available).  
Since `bool` is a subclass of `int`, `False` was treated as `0` and ended up applying `LIMIT 0`, returning an empty result set.

This PR updates `_search` to treat `limit=False` as "no limit" while preserving the valid semantics of `limit=0`.

Note: `limit=True` is left unchanged for backward compatibility and continues to behave as `LIMIT 1`.

Fixes #228555  
merge=merge

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)
