### PR TITLE
[FIX] website: ensure vertical and menu sale 3 headers align navbar correctly

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -833,7 +833,7 @@
                         <t t-call="website.placeholder_header_call_to_action"/>
                     </ul>
                 </div>
-                <t t-call="website.navbar_nav_wrapper" _wrapper_class.f="justify-content-start">
+                <t t-call="website.navbar_nav_wrapper" _wrapper_class.f="justify-content-center">
                     <!-- Navbar -->
                     <t t-call="website.navbar_nav"
                         _nav_class.f="pb-0">
@@ -1180,7 +1180,7 @@
                                 _dropdown_menu_class.f="dropdown-menu-end"/>
                         </ul>
                         <!-- Navbar -->
-                        <t t-call="website.navbar_nav" _nav_class.f="justify-content-start">
+                        <t t-call="website.navbar_nav" _nav_class.f="justify-content-end">
                             <!-- Menu -->
                             <t t-foreach="website.menu_id.child_id" t-as="submenu">
                                 <t t-call="website.submenu"


### PR DESCRIPTION
Steps to produce:
---
- Install website module.
- Go to Website > Edit.
- Select the header and choose Vertical or Menu Sale 3 template.

Issue:
---
- In both Vertical and Menu Sale 3 templates, the navbar is aligned to the `start`.
- This happens because `justify-content-start` is applied to the navbar container.

Solution:
---
- For **Vertical** template, it should be `justify-content-center`.
- For **Menu sale** 3 template, it should be `justify-content-end`.

Before:
---
- `Vertical`        
<img width="1349" height="114" alt="image" src="https://github.com/user-attachments/assets/d82a4393-a7d2-4eca-9d57-3a779465cab1" />

- `Menu sale - 3`
<img width="1416" height="115" alt="image" src="https://github.com/user-attachments/assets/133a07ea-85a9-4843-92b2-bf639782983f" />

After:
---
- `Vertical`
<img width="1389" height="116" alt="image" src="https://github.com/user-attachments/assets/08116ac3-8a85-44ae-89c2-78b2d0623cbc" />

- `Menu sale - 3`
<img width="1386" height="124" alt="image" src="https://github.com/user-attachments/assets/4c939b6d-35fd-4ea6-be80-ba2b7e11aa9d" />


Note:
---
- As this is a small and simple case, the tour has not been added to avoid unnecessary overhead.

opw-5908224
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
