### PR TITLE
[IMP] payment_custom: make pending message computation generic

### DIFF
--- a/addons/account_payment/models/payment_provider.py
+++ b/addons/account_payment/models/payment_provider.py
@@ -16,6 +16,17 @@ REPORT_REASONS_MAPPING = {
 class PaymentProvider(models.Model):
     _inherit = 'payment.provider'
 
+    bank_account_id = fields.Many2one(
+        string="Bank Account",
+        comodel_name='res.partner.bank',
+        domain='[("partner_id", "=", company_partner_id)]',
+        compute='_compute_bank_account_id',
+        store=True,
+        readonly=False,
+        copy=False,
+        check_company=True,
+    )
+    company_partner_id = fields.Many2one(comodel_name='res.partner', related='company_id.partner_id')
     journal_id = fields.Many2one(
         string="Payment Journal",
         help="The journal in which the successful transactions are posted.",
@@ -33,6 +44,11 @@ class PaymentProvider(models.Model):
     )
 
     #=== COMPUTE METHODS ===#
+
+    @api.depends('company_id')
+    def _compute_bank_account_id(self):
+        for provider in self:
+            provider.bank_account_id = provider.company_id.partner_id.bank_ids[:1]
 
     def _ensure_payment_method_line(self, allow_create=True):
         self.ensure_one()

--- a/addons/account_payment/views/payment_provider_views.xml
+++ b/addons/account_payment/views/payment_provider_views.xml
@@ -17,6 +17,15 @@
                     required="state != 'disabled' and code not in ['none', 'custom']"/>
                 <field name="support_refund" groups="base.group_no_one"/>
             </group>
+            <group name="payment_followup_bank_details" position="inside">
+                <field
+                    name="bank_account_id"
+                    context="{
+                        'default_company_id': company_id,
+                        'default_partner_id': company_partner_id,
+                    }"
+                />
+            </group>
             <field name="available_country_ids" position="after">
                 <field
                     name="available_pricelist_ids"

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -713,6 +713,7 @@ class PaymentProvider(models.Model):
         :return: The pending message.
         :rtype: str
         """
+        self.ensure_one()
         return self.pending_msg
 
     def _is_tokenization_required(self, **_kwargs):

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -707,6 +707,14 @@ class PaymentProvider(models.Model):
 
         return providers
 
+    def _get_pending_msg(self, **_kwargs):
+        """Return the message when the payment is pending after processing.
+
+        :return: The pending message.
+        :rtype: str
+        """
+        return self.pending_msg
+
     def _is_tokenization_required(self, **_kwargs):
         """Return whether tokenizing the transaction is required given its context.
 

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -99,6 +99,11 @@
                                            options="{'no_create': True}"/>
                                 </group>
                                 <group string="Payment Followup" name="payment_followup" invisible="1"/>
+                                <group
+                                    string="Payment Followup"
+                                    name="payment_followup_bank_details"
+                                    invisible="1"
+                                />
                             </group>
                         </page>
                         <page string="Messages"

--- a/addons/payment_custom/data/payment_provider_data.xml
+++ b/addons/payment_custom/data/payment_provider_data.xml
@@ -4,18 +4,15 @@
     <record id="payment.payment_provider_transfer" model="payment.provider">
         <field name="code">custom</field>
         <field name="redirect_form_view_id" ref="payment.generic_redirect_form"/>
-        <!-- Clear the default value before recomputing the pending_msg -->
-        <field name="pending_msg" eval="False"/>
         <field name="custom_mode">wire_transfer</field>
         <field name="payment_method_ids"
                eval="[Command.set([
                          ref('payment_custom.payment_method_wire_transfer'),
                      ])]"
         />
+        <field name="pending_msg" type="html">
+            <p>Please find the payment details below.</p>
+        </field>
     </record>
-
-    <function model="payment.provider"
-              name="_transfer_ensure_pending_msg_is_set"
-              eval="[[ref('payment.payment_provider_transfer')]]"/>
 
 </odoo>

--- a/addons/payment_custom/data/payment_provider_data.xml
+++ b/addons/payment_custom/data/payment_provider_data.xml
@@ -17,12 +17,9 @@
         <field name="custom_mode">wire_transfer</field>
         <field name="is_live">True</field>
         <field name="redirect_form_view_id" ref="payment.generic_redirect_form"/>
-        <!-- Clear the default value before recomputing the pending_msg -->
-        <field name="pending_msg" eval="False"/>
+        <field name="pending_msg" type="html">
+            <p>Please find the payment details below.</p>
+        </field>
     </record>
-
-    <function model="payment.provider"
-              name="_transfer_ensure_pending_msg_is_set"
-              eval="[[ref('payment.payment_provider_transfer')]]"/>
 
 </odoo>

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -25,14 +25,28 @@ class PaymentProvider(models.Model):
     qr_code = fields.Boolean(
         string="Enable QR Codes", help="Enable the use of QR-codes when paying by wire transfer."
     )
+    company_partner_id = fields.Many2one(
+        comodel_name="res.partner", related="company_id.partner_id"
+    )
+    partner_bank_id = fields.Many2one(
+        string="Bank Account",
+        comodel_name="res.partner.bank",
+        domain='[("partner_id", "=", company_partner_id)]',
+        compute="_compute_partner_bank_id",
+        store=True,
+        readonly=False,
+        copy=False,
+        check_company=True,
+    )
+
+    # === COMPUTE METHODS === #
+
+    @api.depends("company_id")
+    def _compute_partner_bank_id(self):
+        for provider in self:
+            provider.partner_bank_id = provider.company_id.partner_id.bank_ids[:1]
 
     # === CRUD METHODS ===#
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        providers = super().create(vals_list)
-        providers.filtered(lambda p: p.custom_mode == "wire_transfer").pending_msg = None
-        return providers
 
     def copy_data(self, default=None):
         vals_list = super().copy_data(default=default)
@@ -50,40 +64,17 @@ class PaymentProvider(models.Model):
             return super()._get_default_payment_method_codes()
         return const.DEFAULT_PAYMENT_METHOD_CODES
 
-    # === ACTION METHODS ===#
+    # === BUSINESS METHODS === #
 
-    def action_recompute_pending_msg(self):
-        """Recompute the pending message to include the existing bank accounts."""
-        account_payment_module = self.env["ir.module.module"]._get("account_payment")
-        if account_payment_module.state == "installed":
-            for provider in self.filtered(lambda p: p.custom_mode == "wire_transfer"):
-                company_id = provider.company_id.id
-                accounts = (
-                    self
-                    .env["account.journal"]
-                    .search([
-                        *self.env["account.journal"]._check_company_domain(company_id),
-                        ("type", "=", "bank"),
-                    ])
-                    .bank_account_id
-                )
-                account_names = "".join(
-                    f"<li><pre>{account.display_name}</pre></li>" for account in accounts
-                )
-                bank_account_label = (
-                    provider.env._("Bank Account")
-                    if len(accounts) == 1
-                    else provider.env._("Bank Accounts")
-                )
-                provider.pending_msg = (
-                    f"<div>"
-                    f"<h5>{provider.env._('Please use the following transfer details')}</h5>"
-                    f"<p><br></p>"
-                    f"<h6>{bank_account_label}</h6>"
-                    f"<ul>{account_names}</ul>"
-                    f"<p><br></p>"
-                    f"</div>"
-                )
+    def _get_custom_bank_account(self):
+        """Return the bank account to display in the pending payment instructions template.
+
+        :return: The bank account of the provider.
+        :rtype: res.partner.bank
+        """
+        if self.custom_mode == "wire_transfer":
+            return self.partner_bank_id
+        return self.env["res.partner.bank"]
 
     # === SETUP METHODS === #
 
@@ -100,10 +91,3 @@ class PaymentProvider(models.Model):
         res = super()._get_removal_values()
         res["custom_mode"] = None
         return res
-
-    def _transfer_ensure_pending_msg_is_set(self):
-        transfer_providers_without_msg = self.filtered(
-            lambda p: p.custom_mode == "wire_transfer" and not p.pending_msg
-        )
-        if transfer_providers_without_msg:
-            transfer_providers_without_msg.action_recompute_pending_msg()

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.fields import Domain
 
 from odoo.addons.payment_custom import const
@@ -28,11 +29,22 @@ class PaymentProvider(models.Model):
 
     # === CRUD METHODS ===#
 
-    @api.model_create_multi
-    def create(self, vals_list):
-        providers = super().create(vals_list)
-        providers.filtered(lambda p: p.custom_mode == "wire_transfer").pending_msg = None
-        return providers
+    def _check_required_if_provider(self):
+        """Check that `bank_account_id` have been filled for wire transfer provider."""
+        if "bank_account_id" not in self._fields:
+            return super()._check_required_if_provider()
+
+        wire_transfer_without_bank = self.filtered(
+            lambda provider: (
+                provider.custom_mode == "wire_transfer"
+                and provider.state != "disabled"
+                and not provider.bank_account_id
+            )
+        )
+        if wire_transfer_without_bank:
+            raise ValidationError(self.env._("Bank account must be filled for Wire Transfer."))
+
+        super()._check_required_if_provider()
 
     def _get_default_payment_method_codes(self):
         """Override of `payment` to return the default payment method codes."""
@@ -41,35 +53,23 @@ class PaymentProvider(models.Model):
             return super()._get_default_payment_method_codes()
         return const.DEFAULT_PAYMENT_METHOD_CODES
 
-    # === ACTION METHODS ===#
+    # === BUSINESS METHODS === #
 
-    def action_recompute_pending_msg(self):
-        """Recompute the pending message to include the existing bank accounts."""
-        account_payment_module = self.env["ir.module.module"]._get("account_payment")
-        if account_payment_module.state == "installed":
-            for provider in self.filtered(lambda p: p.custom_mode == "wire_transfer"):
-                company_id = provider.company_id.id
-                accounts = (
-                    self
-                    .env["account.journal"]
-                    .search([
-                        *self.env["account.journal"]._check_company_domain(company_id),
-                        ("type", "=", "bank"),
-                    ])
-                    .bank_account_id
-                )
-                account_names = "".join(
-                    f"<li><pre>{account.display_name}</pre></li>" for account in accounts
-                )
-                provider.pending_msg = (
-                    f"<div>"
-                    f"<h5>{_('Please use the following transfer details')}</h5>"
-                    f"<p><br></p>"
-                    f"<h6>{_('Bank Account') if len(accounts) == 1 else _('Bank Accounts')}</h6>"
-                    f"<ul>{account_names}</ul>"
-                    f"<p><br></p>"
-                    f"</div>"
-                )
+    def _get_custom_provider_bank_details(self):
+        """Return bank details configured on the provider.
+
+        :return: A dictionary containing the beneficiary name and bank account number.
+        :rtype: dict
+        """
+        if self.custom_mode != "wire_transfer" or "bank_account_id" not in self._fields:
+            return {}
+
+        bank_account = self.bank_account_id
+        return {"beneficiary": bank_account.holder_name, "bank_account": bank_account.display_name}
+
+    def _get_custom_bank_related_modes(self):
+        """Return custom modes that rely on bank details for pending payment instructions."""
+        return ["wire_transfer"]
 
     # === SETUP METHODS === #
 
@@ -86,10 +86,3 @@ class PaymentProvider(models.Model):
         res = super()._get_removal_values()
         res["custom_mode"] = None
         return res
-
-    def _transfer_ensure_pending_msg_is_set(self):
-        transfer_providers_without_msg = self.filtered(
-            lambda p: p.custom_mode == "wire_transfer" and not p.pending_msg
-        )
-        if transfer_providers_without_msg:
-            transfer_providers_without_msg.action_recompute_pending_msg()

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -61,11 +61,24 @@ class PaymentProvider(models.Model):
         :return: A dictionary containing the beneficiary name and bank account number.
         :rtype: dict
         """
-        if self.custom_mode != "wire_transfer" or "bank_account_id" not in self._fields:
-            return {}
+        if bank_account := self._get_custom_bank_account():
+            return {
+                "beneficiary": bank_account.holder_name,
+                "bank_account": bank_account.display_name,
+            }
+        return {}
 
-        bank_account = self.bank_account_id
-        return {"beneficiary": bank_account.holder_name, "bank_account": bank_account.display_name}
+    def _get_custom_bank_account(self):
+        """Return the bank account configured on the custom provider.
+
+        :return: The bank account of the provider.
+        :rtype: record of `res.partner.bank` or None
+        """
+        if (
+            self.custom_mode in self._get_custom_bank_related_modes()
+            and "bank_account_id" in self._fields
+        ):
+            return self.bank_account_id
 
     @api.model
     def _get_custom_bank_related_modes(self):

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -67,8 +67,9 @@ class PaymentProvider(models.Model):
         bank_account = self.bank_account_id
         return {"beneficiary": bank_account.holder_name, "bank_account": bank_account.display_name}
 
+    @api.model
     def _get_custom_bank_related_modes(self):
-        """Return custom modes that rely on bank details for pending payment instructions."""
+        """Return custom modes that rely on bank details."""
         return ["wire_transfer"]
 
     # === SETUP METHODS === #

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -69,7 +69,11 @@ class PaymentProvider(models.Model):
 
     @api.model
     def _get_custom_bank_related_modes(self):
-        """Return custom modes that rely on bank details."""
+        """Return custom modes that rely on bank details.
+
+        :return: The list of custom modes.
+        :rtype: list
+        """
         return ["wire_transfer"]
 
     # === SETUP METHODS === #

--- a/addons/payment_custom/models/payment_transaction.py
+++ b/addons/payment_custom/models/payment_transaction.py
@@ -108,3 +108,17 @@ class PaymentTransaction(models.Model):
         elif hasattr(self, "sale_order_ids") and self.sale_order_ids:
             communication = self.sale_order_ids[0].reference
         return communication or self.reference
+
+    def _get_custom_qr_code(self):
+        """Return the QR code to scan to pay the custom provider's bank account, if any.
+
+        :return: The base64 QR code.
+        :rtype: str
+        """
+        self.ensure_one()
+        provider = self.provider_id
+        if provider.qr_code and (bank_account := provider._get_custom_bank_account()):
+            return bank_account.build_qr_code_base64(
+                self.amount, self._get_communication(), None, self.currency_id, self.partner_id
+            )
+        return ""

--- a/addons/payment_custom/tests/test_payment_transaction.py
+++ b/addons/payment_custom/tests/test_payment_transaction.py
@@ -16,8 +16,15 @@ class TestPaymentTransaction(PaymentCustomCommon):
         if "product.product" not in cls.env:
             msg = "requires product"
             raise unittest.SkipTest(msg)
-
-        cls.provider = cls._prepare_provider(code="custom", custom_mode="wire_transfer")
+        cls.bank_account = cls.env["res.partner.bank"].create({
+            "account_number": "BANK123456789",
+            "partner_id": cls.company.partner_id.id,
+        })
+        cls.provider = cls._prepare_provider(
+            code="custom",
+            custom_mode="wire_transfer",
+            update_values={"bank_account_id": cls.bank_account.id},
+        )
         cls.product = cls.env["product.product"].create({
             "name": "test product",
             "list_price": cls.amount,

--- a/addons/payment_custom/views/payment_custom_templates.xml
+++ b/addons/payment_custom/views/payment_custom_templates.xml
@@ -14,27 +14,6 @@
     </template>
 
     <template id="custom_state_header" inherit_id="payment.state_header">
-        <xpath expr="//div[@name='o_payment_status_alert']" position="inside">
-            <t t-set="qr_code"
-               t-value="tx.provider_id.sudo().qr_code and tx.company_id.sudo().partner_id.bank_ids[:1].build_qr_code_base64(tx.amount, tx._get_communication(), None, tx.currency_id, tx.partner_id)"
-            />
-            <t t-if="tx._requires_payment_instructions() and qr_code">
-                <div class="position-relative order-2 d-flex flex-md-column justify-content-center align-items-center align-items-md-stretch w-100 w-md-auto">
-                    <hr class="d-inline d-md-none w-100"/>
-                    <div class="vr d-none d-md-block h-100 mx-auto"/>
-                    <h6 class="my-1 my-md-3 px-3 px-md-0 text-muted">OR</h6>
-                    <hr class="d-inline d-md-none w-100"/>
-                    <div class="vr d-none d-md-block h-100 mx-auto"/>
-                </div>
-                <div class="o_qr_code_card card order-1 order-md-3 bg-info flex-shrink-0">
-                    <div class="card-body d-flex flex-column align-items-center justify-content-center pb-3">
-                        <img class="mb-2 border border-dark rounded" t-att-src="qr_code"/>
-                        <small class="text-center text-wrap lh-sm">Scan me in your banking app</small>
-                    </div>
-                </div>
-            </t>
-        </xpath>
-
         <xpath expr="//t[@t-set='o_payment_status_alert_class']" position="replace">
             <t t-if="tx._requires_payment_instructions()">
                <t t-set="o_payment_status_alert_class"
@@ -49,22 +28,67 @@
         </xpath>
 
         <xpath expr="//div[@id='o_payment_status_message']" position="replace">
-            <div t-if="tx._requires_payment_instructions()"
-                 id="o_payment_status_message"
-                 class="order-3 order-md-1 flex-grow-1"
+            <div
+                t-if="tx._requires_payment_instructions()"
+                id="o_payment_status_message"
+                class="w-100"
             >
-                <div class="card flex-grow-1">
-                    <div id="o_payment_status_message_details" class="card-body">
-                        <t>$0</t>
-                        <hr class="w-100"/>
-                        <strong class="mt-auto">Communication: </strong>
-                        <span t-out="tx._get_communication()"/>
-                    </div>
-                </div>
+                <t t-call="payment_custom.custom_payment_transfer_details" tx_sudo="tx"/>
             </div>
             <t t-else="">$0</t>
         </xpath>
 
+    </template>
+
+    <template id="custom_payment_transfer_details">
+        <t
+            t-set="bank_account"
+            t-value="tx_sudo.provider_id._get_custom_bank_account()"
+        />
+        <t t-set="communication" t-value="tx_sudo._get_communication()"/>
+        <t t-set="qr_code" t-value="tx_sudo._get_custom_qr_code()"/>
+        <div
+            t-attf-class="d-flex flex-column align-items-stretch gap-2 pt-1 #{'flex-md-row gap-md-3' if qr_code else ''}"
+        >
+            <div class="card flex-grow-1 order-3 order-md-1 bg-info">
+                <div class="card-body d-flex flex-column gap-1">
+                    <t t-if="status_message" t-out="status_message"/>
+                    <t t-if="bank_account">
+                        <div class="d-flex align-items-center gap-2">
+                            <b>Beneficiary:</b>
+                            <pre t-out="bank_account.holder_name" class="user-select-all mb-0"/>
+                        </div>
+                        <div class="d-flex align-items-center gap-2">
+                            <b>Bank Account:</b>
+                            <pre t-out="bank_account.display_name" class="user-select-all mb-0"/>
+                        </div>
+                    </t>
+                    <div class="d-flex align-items-center gap-2">
+                        <b>Amount:</b>
+                        <pre class="user-select-all mb-0" t-field="tx_sudo.amount"/>
+                    </div>
+                    <t t-if="communication">
+                        <div class="d-flex align-items-center gap-2">
+                            <b>Communication:</b>
+                            <pre t-out="communication" class="user-select-all mb-0"/>
+                        </div>
+                    </t>
+                </div>
+            </div>
+            <t t-if="qr_code">
+                <div class="position-relative order-2 d-flex flex-md-column justify-content-center align-items-center align-items-md-stretch w-100 w-md-auto">
+                    <h6 class="my-1 my-md-3 px-3 px-md-0 text-muted">OR</h6>
+                </div>
+                <div class="o_qr_code_card card order-1 order-md-3 flex-shrink-0">
+                    <div class="card-body d-flex flex-column align-items-center justify-content-center pb-3">
+                        <img class="mb-2 border border-dark rounded" t-att-src="qr_code"/>
+                        <small class="text-center text-wrap lh-sm">
+                            Scan me in your banking app
+                        </small>
+                    </div>
+                </div>
+            </t>
+        </div>
     </template>
 
 </odoo>

--- a/addons/payment_custom/views/payment_custom_templates.xml
+++ b/addons/payment_custom/views/payment_custom_templates.xml
@@ -83,15 +83,15 @@
                 <div>
                     <b>Beneficiary: </b>
                     <pre
-                        class="user-select-all d-inline"
                         t-out="bank_details['beneficiary']"
+                        class="user-select-all d-inline"
                     />
                 </div>
                 <div>
                     <b>Bank Account: </b>
                     <pre
-                        class="user-select-all d-inline"
                         t-out="bank_details['bank_account']"
+                        class="user-select-all d-inline"
                     />
                 </div>
             </t>
@@ -103,7 +103,7 @@
             <t t-if="communication">
                 <div>
                     <b>Communication: </b>
-                    <pre class="user-select-all d-inline" t-out="communication"/>
+                    <pre t-out="communication" class="user-select-all d-inline"/>
                 </div>
             </t>
         </div>

--- a/addons/payment_custom/views/payment_custom_templates.xml
+++ b/addons/payment_custom/views/payment_custom_templates.xml
@@ -64,17 +64,49 @@
                 <div class="card flex-grow-1">
                     <div id="o_payment_status_message_details" class="card-body">
                         <t>$0</t>
-                        <t t-if="tx._get_communication()">
-                            <hr class="w-100"/>
-                            <strong class="mt-auto">Communication: </strong>
-                            <span t-out="tx._get_communication()"/>
-                        </t>
+                        <t t-call="payment_custom.custom_payment_transfer_details"/>
                     </div>
                 </div>
             </div>
             <t t-else="">$0</t>
         </xpath>
 
+    </template>
+
+    <template id="custom_payment_transfer_details">
+        <div class="d-flex flex-column gap-3 pt-2 pb-3">
+            <t
+                t-set="bank_details"
+                t-value="tx.provider_id.sudo()._get_custom_provider_bank_details()"
+            />
+            <t t-if="bank_details">
+                <div>
+                    <b>Beneficiary: </b>
+                    <pre
+                        class="user-select-all d-inline"
+                        t-out="bank_details['beneficiary']"
+                    />
+                </div>
+                <div>
+                    <b>Bank Account: </b>
+                    <pre
+                        class="user-select-all d-inline"
+                        t-out="bank_details['bank_account']"
+                    />
+                </div>
+            </t>
+            <div>
+                <b>Amount: </b>
+                <pre class="user-select-all d-inline" t-field="tx.amount"/>
+            </div>
+            <t t-set="communication" t-value="tx._get_communication()"/>
+            <t t-if="communication">
+                <div>
+                    <b>Communication: </b>
+                    <pre class="user-select-all d-inline" t-out="communication"/>
+                </div>
+            </t>
+        </div>
     </template>
 
 </odoo>

--- a/addons/payment_custom/views/payment_provider_views.xml
+++ b/addons/payment_custom/views/payment_provider_views.xml
@@ -26,19 +26,15 @@
             <group name="payment_followup" position="attributes">
                 <attribute name="invisible">code == 'custom'</attribute>
             </group>
+            <group name="payment_followup_bank_details" position="attributes">
+                <attribute
+                    name="invisible"
+                    separator="and"
+                    add="not (code == 'custom' and custom_mode == 'wire_transfer')"
+                />
+            </group>
             <field name="pre_msg" position="attributes">
                 <attribute name="invisible" separator="or" add="code == 'custom'"/>
-            </field>
-            <field name="pending_msg" position="after">
-                <div class="o_row" colspan="2"
-                     invisible="custom_mode != 'wire_transfer'">
-                    <button string=" Reload Pending Message"
-                            type="object"
-                            name="action_recompute_pending_msg"
-                            class="oe_link ms-0 ps-0"
-                            icon="fa-refresh"
-                            />
-              </div>
             </field>
             <field name="done_msg" position="attributes">
                 <attribute name="invisible" separator="or" add="code == 'custom'"/>

--- a/addons/payment_custom/views/payment_provider_views.xml
+++ b/addons/payment_custom/views/payment_provider_views.xml
@@ -33,22 +33,27 @@
             <group name="provider_config_others" position="attributes">
                 <attribute name="invisible" separator="or" add="code == 'custom'"/>
             </group>
+            <group name="provider_config_others" position="after">
+                <group
+                    string="Others"
+                    name="provider_config_bank"
+                    invisible="not (code == 'custom' and custom_mode == 'wire_transfer')"
+                >
+                    <field
+                        name="partner_bank_id"
+                        required="custom_mode == 'wire_transfer'"
+                        context="{
+                            'default_company_id': company_id,
+                            'default_partner_id': company_partner_id,
+                        }"
+                    />
+                </group>
+            </group>
             <page name="messages" position="attributes">
                 <attribute name="invisible" separator="or" add="custom_mode == 'pay_on_invoice'"/>
             </page>
             <field name="pre_msg" position="attributes">
                 <attribute name="invisible" separator="or" add="code == 'custom'"/>
-            </field>
-            <field name="pending_msg" position="after">
-                <div class="o_row" colspan="2"
-                     invisible="custom_mode != 'wire_transfer'">
-                    <button string=" Reload Pending Message"
-                            type="object"
-                            name="action_recompute_pending_msg"
-                            class="oe_link ms-0 ps-0"
-                            icon="refresh"
-                            />
-                </div>
             </field>
             <field name="done_msg" position="attributes">
                 <attribute name="invisible" separator="or" add="code == 'custom'"/>

--- a/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
+++ b/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
@@ -19,7 +19,6 @@ class TestWEventBoothExhibitorCommon(HttpCaseWithUserDemo, HttpCaseWithUserPorta
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.env.ref('base.user_admin').write({
             'name': 'Mitchell Admin',

--- a/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
+++ b/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
@@ -19,7 +19,6 @@ class TestWEventBoothExhibitorCommon(HttpCaseWithUserDemo, HttpCaseWithUserPorta
             'is_live': True,
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.env.ref('base.user_admin').write({
             'name': 'Mitchell Admin',

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -89,7 +89,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'is_live': True,
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.start_tour("/event", 'event_buy_tickets', login="admin")
 
@@ -100,7 +99,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'is_live': True,
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         #  Ensure the use of USD (company currency)
         self.env['product.pricelist'].create({'name': "Public Pricelist"})
@@ -113,7 +111,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'is_live': True,
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.start_tour("/event", 'event_buy_last_ticket')
 

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -24,10 +24,10 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
         cls.env.ref('payment.payment_provider_transfer').write({
             'state': 'enabled',
             'is_published': True,
+            'bank_account_id': cls.bank_account.id,
         })
 
         cls.env['event.event.ticket'].create({
@@ -87,7 +87,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.start_tour("/event", 'event_buy_tickets', login="admin")
 
@@ -98,7 +97,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         #  Ensure the use of USD (company currency)
         self.env['product.pricelist'].create({'name': "Public Pricelist"})
@@ -111,7 +109,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.start_tour("/event", 'event_buy_last_ticket')
 

--- a/addons/website_sale/models/__init__.py
+++ b/addons/website_sale/models/__init__.py
@@ -7,6 +7,7 @@ from . import (
     digest,
     ir_http,
     ir_module_module,
+    payment_provider,
     payment_token,
     payment_transaction,
     product_attribute,

--- a/addons/website_sale/models/payment_provider.py
+++ b/addons/website_sale/models/payment_provider.py
@@ -8,13 +8,9 @@ class PaymentProvider(models.Model):
 
     # === BUSINESS METHODS === #
 
-    def _get_pending_msg(self, **kwargs):
+    def _get_pending_msg(self, *, from_website=False, **kwargs):
         """Override to return a specific pending message for website orders."""
-        if (
-            kwargs.get("from_website")
-            and self.code == "custom"
-            and self.custom_mode in self._get_custom_bank_related_modes()
-        ):
+        if from_website and self.custom_mode in self._get_custom_bank_related_modes():
             return self.env._("Your order will be confirmed after payment is received.")
 
-        return super()._get_pending_msg(**kwargs)
+        return super()._get_pending_msg(from_website=from_website, **kwargs)

--- a/addons/website_sale/models/payment_provider.py
+++ b/addons/website_sale/models/payment_provider.py
@@ -8,9 +8,8 @@ class PaymentProvider(models.Model):
 
     # === BUSINESS METHODS === #
 
-    def _get_pending_msg(self, *, from_website=False, **kwargs):
+    def _get_pending_msg(self, *, order=None, **kwargs):
         """Override to return a specific pending message for website orders."""
-        if from_website and self.custom_mode in self._get_custom_bank_related_modes():
+        if order.website_id and self.custom_mode in self._get_custom_bank_related_modes():
             return self.env._("Your order will be confirmed after payment is received.")
-
-        return super()._get_pending_msg(from_website=from_website, **kwargs)
+        return super()._get_pending_msg(order=order, **kwargs)

--- a/addons/website_sale/models/payment_provider.py
+++ b/addons/website_sale/models/payment_provider.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class PaymentProvider(models.Model):
+    _inherit = "payment.provider"
+
+    # === BUSINESS METHODS === #
+
+    def _get_pending_msg(self, **kwargs):
+        """Override to return a specific pending message for website orders."""
+        if (
+            kwargs.get("from_website")
+            and self.code == "custom"
+            and self.custom_mode in self._get_custom_bank_related_modes()
+        ):
+            return self.env._("Your order will be confirmed after payment is received.")
+
+        return super()._get_pending_msg(**kwargs)

--- a/addons/website_sale/models/payment_transaction.py
+++ b/addons/website_sale/models/payment_transaction.py
@@ -20,20 +20,19 @@ class PaymentTransaction(models.Model):
             self.landing_route = f"/shop/payment?{urlencode(params)}"
 
     def _get_status_message(self, *, order=None, **kwargs):
-        """Override of `payment` to add a custom message when the cart amount is different after
-        payment in `website_sale`.
+        """Override of `payment` to add custom messages for website orders.
 
         :param sale.order order: The current cart linked to the transaction.
         """
-        if (
-            order
-            and order.website_id
-            and self.state == "done"
-            and order.amount_total != self.amount
-        ):
-            return Markup("<p>%s</p>") % self.env._(
-                "Unfortunately your order can not be confirmed as the amount of your payment"
-                " does not match the amount of your cart. Please contact the responsible of"
-                " the shop for more information."
-            )
+        if order and order.website_id:
+            if self.state == "done" and order.amount_total != self.amount:
+                return Markup("<p>%s</p>") % self.env._(
+                    "Unfortunately your order can not be confirmed as the amount of your payment"
+                    " does not match the amount of your cart. Please contact the responsible of"
+                    " the shop for more information."
+                )
+            if self.state == "pending" and self._requires_payment_instructions():
+                return Markup("<p>%s</p>") % self.env._(
+                    "Your order will be confirmed after payment is received."
+                )
         return super()._get_status_message(order=order, **kwargs)

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -326,7 +326,7 @@ export function payWithTransfer({
             {
                 content: "Last step",
                 trigger:
-                    '[name="order_confirmation"]:contains("Please use the following transfer details")',
+                    '[name="order_confirmation"]:contains("Your order will be confirmed after payment is received.")',
                 timeout: 30000,
             },
         ];
@@ -337,7 +337,7 @@ export function payWithTransfer({
             {
                 content: "Last step",
                 trigger:
-                    '[name="order_confirmation"]:contains("Please use the following transfer details")',
+                    '[name="order_confirmation"]:contains("Your order will be confirmed after payment is received.")',
                 timeout: 30000,
                 run() {
                     window.location.href = '/contactus'; // Redirect in JS to avoid the RPC loop (20x1sec)

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -319,7 +319,7 @@ export function payWithTransfer({
             {
                 content: "Last step",
                 trigger:
-                    '[name="order_confirmation"]:contains("Please use the following transfer details")',
+                    '[name="order_confirmation"]:contains("Your order will be confirmed after payment is received.")',
                 timeout: 30000,
             },
         ];
@@ -330,7 +330,7 @@ export function payWithTransfer({
             {
                 content: "Last step",
                 trigger:
-                    '[name="order_confirmation"]:contains("Please use the following transfer details")',
+                    '[name="order_confirmation"]:contains("Your order will be confirmed after payment is received.")',
                 timeout: 30000,
                 run() {
                     window.location.href = '/contactus'; // Redirect in JS to avoid the RPC loop (20x1sec)

--- a/addons/website_sale/templates/checkout/confirmation_templates.xml
+++ b/addons/website_sale/templates/checkout/confirmation_templates.xml
@@ -124,21 +124,17 @@
             <div
                 id="order_confirmation_banner"
                 t-if="tx_sudo"
-                t-attf-class="alert #{alert_class}"
+                t-attf-class="#{'' if tx_sudo._requires_payment_instructions() else 'alert ' + alert_class}"
                 role="alert"
             >
-                <t t-out="tx_sudo._get_status_message(order=order)"/>
+                <t t-set="status_message" t-value="tx_sudo._get_status_message(order=order)"/>
                 <t t-if="tx_sudo._requires_payment_instructions()">
-                    <div id="order_reference" t-if="order.reference" class="mt-2 mb-3">
-                        <b>Communication: </b><span t-out='order.reference'/>
+                    <div id="o_custom_payment_details">
+                        <t t-call="payment_custom.custom_payment_transfer_details"/>
                     </div>
-                    <div t-if="tx_sudo.provider_id.sudo().qr_code">
-                        <t t-set="qr_code" t-value="tx_sudo.company_id.partner_id.bank_ids[:1].build_qr_code_base64(order.amount_total,tx_sudo.reference, None, tx_sudo.currency_id, tx_sudo.partner_id)"/>
-                        <div class="mt-2" t-if="qr_code">
-                            <h3>Or scan me with your banking app.</h3>
-                            <img class="border border-dark rounded" t-att-src="qr_code"/>
-                        </div>
-                    </div>
+                </t>
+                <t t-else="">
+                    <t t-out="status_message"/>
                 </t>
             </div>
         </div>

--- a/addons/website_sale/templates/checkout/confirmation_templates.xml
+++ b/addons/website_sale/templates/checkout/confirmation_templates.xml
@@ -129,7 +129,7 @@
             >
                 <div>
                     <t t-if="tx_sudo.state == 'pending'">
-                        <t t-out="tx_sudo.provider_id.sudo()._get_pending_msg(from_website=True)"/>
+                        <t t-out="tx_sudo.provider_id.sudo()._get_pending_msg(order=order)"/>
                     </t>
                     <t t-if="tx_sudo.state == 'done'">
                         <span t-if='tx_sudo.provider_id.sudo().done_msg' t-out="tx_sudo.provider_id.sudo().done_msg"/>

--- a/addons/website_sale/templates/checkout/confirmation_templates.xml
+++ b/addons/website_sale/templates/checkout/confirmation_templates.xml
@@ -127,20 +127,9 @@
                 t-attf-class="alert px-3 pb-0 pt-3 #{alert_class}"
                 role="alert"
             >
-                <a
-                    title="Edit"
-                    class="btn btn-sm btn-link text-dark float-end"
-                    role="button"
-                    groups="base.group_system"
-                    target="_blank"
-                    aria-label="Edit"
-                    t-attf-href="/odoo/action-payment.action_payment_provider/{{tx_sudo.provider_id.id}}"
-                >
-                    <i class="fa fa-pencil"/>
-                </a>
                 <div>
                     <t t-if="tx_sudo.state == 'pending'">
-                        <t t-out="tx_sudo.provider_id.sudo().pending_msg"/>
+                        <t t-out="tx_sudo.provider_id.sudo()._get_pending_msg(from_website=True)"/>
                     </t>
                     <t t-if="tx_sudo.state == 'done'">
                         <span t-if='tx_sudo.provider_id.sudo().done_msg' t-out="tx_sudo.provider_id.sudo().done_msg"/>
@@ -161,8 +150,8 @@
                     </t>
                 </div>
                 <t t-if="tx_sudo.provider_code == 'custom'">
-                    <div id="order_reference" t-if="order.reference" class="mt-2">
-                        <b>Communication: </b><span t-out='order.reference'/>
+                    <div id="o_custom_payment_details">
+                        <t t-call="payment_custom.custom_payment_transfer_details" tx="tx_sudo"/>
                     </div>
                     <div t-if="tx_sudo.provider_id.sudo().qr_code">
                         <t t-set="qr_code" t-value="tx_sudo.company_id.partner_id.bank_ids[:1].build_qr_code_base64(order.amount_total,tx_sudo.reference, None, tx_sudo.currency_id, tx_sudo.partner_id)"/>

--- a/addons/website_sale/tests/common.py
+++ b/addons/website_sale/tests/common.py
@@ -87,6 +87,10 @@ class WebsiteSaleCommon(DeliveryCommon):
             "phone": "+1 555-555-5555",
             "email": "admin@yourcompany.example.com",
         }
+        cls.bank_account = cls.env["res.partner.bank"].create({
+            "account_number": "BANK123456789",
+            "partner_id": cls.env.company.partner_id.id,
+        })
 
     @classmethod
     def _create_pricelist(cls, **create_vals):

--- a/addons/website_sale/tests/test_delivery_ui.py
+++ b/addons/website_sale/tests/test_delivery_ui.py
@@ -10,10 +10,16 @@ class TestUi(HttpCase):
         if self.env["ir.module.module"]._get("payment_custom").state != "installed":
             self.skipTest("Transfer provider is not installed")
 
+        self.bank_account = self.env["res.partner.bank"].create({
+            "account_number": "BANK123456789",
+            "partner_id": self.env.company.partner_id.id,
+        })
         transfer_provider = self.env.ref("payment.payment_provider_transfer")
-        transfer_provider.write({"state": "enabled", "is_published": True})
-        transfer_provider._transfer_ensure_pending_msg_is_set()
-
+        transfer_provider.write({
+            "state": "enabled",
+            "is_published": True,
+            "bank_account_id": self.bank_account.id,
+        })
         if "enforce_cities" in self.env["res.country"]._fields:
             self.env.company.country_id.enforce_cities = False
 

--- a/addons/website_sale/tests/test_delivery_ui.py
+++ b/addons/website_sale/tests/test_delivery_ui.py
@@ -12,7 +12,6 @@ class TestUi(HttpCase):
 
         transfer_provider = self.env.ref("payment.payment_provider_transfer")
         transfer_provider.is_published = True
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         if "enforce_cities" in self.env["res.country"]._fields:
             self.env.company.country_id.enforce_cities = False

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -68,8 +68,11 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
 
         if cls.env["ir.module.module"]._get("payment_custom").state == "installed":
             transfer_provider = cls.env.ref("payment.payment_provider_transfer")
-            transfer_provider.write({"state": "enabled", "is_published": True})
-            transfer_provider._transfer_ensure_pending_msg_is_set()
+            transfer_provider.write({
+                "state": "enabled",
+                "is_published": True,
+                "bank_account_id": cls.bank_account.id,
+            })
 
     def test_01_admin_shop_tour(self):
         self.start_tour(

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -71,7 +71,6 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
         if cls.env["ir.module.module"]._get("payment_custom").state == "installed":
             transfer_provider = cls.env.ref("payment.payment_provider_transfer")
             transfer_provider.is_published = True
-            transfer_provider._transfer_ensure_pending_msg_is_set()
 
     def test_01_admin_shop_tour(self):
         self.start_tour(

--- a/addons/website_sale_collect/models/payment_provider.py
+++ b/addons/website_sale_collect/models/payment_provider.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
+from odoo.tools import format_date
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.website_sale_collect import const
@@ -63,3 +64,13 @@ class PaymentProvider(models.Model):
             )
 
         return compatible_providers
+
+    def _get_pending_msg(self, *, order=None, **kwargs):
+        """Override to return a specific pending message for on-site orders."""
+        if order.website_id and self.custom_mode == "on_site":
+            if order.commitment_date and order.commitment_date.date() != order.date_order.date():
+                return self.env._(
+                    "Your order will be ready on %s.", format_date(self.env, order.commitment_date)
+                )
+            return self.env._("Your order will be ready soon.")
+        return super()._get_pending_msg(order=order, **kwargs)

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -12,7 +12,7 @@
                 t-value="'alert-success'"
             />
         </t>
-        <div id="order_reference" position="replace">
+        <div id="o_custom_payment_details" position="replace">
             <t t-if="tx_sudo.provider_id.custom_mode == 'on_site'">
                 <div class="mt-2 mb-3">
                     <div class="o_body_carrier_message">

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -25,7 +25,7 @@
                 <t>$0</t> <!-- Replaced by old content. -->
             </t>
         </t>
-        <div id="order_reference" position="replace">
+        <div id="o_custom_payment_details" position="replace">
             <t t-if="tx_sudo.provider_id.custom_mode == 'on_site'">
                 <div class="mt-2 mb-3">
                     <div class="o_body_carrier_message">

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -12,19 +12,6 @@
                 t-value="'alert-success'"
             />
         </t>
-        <t t-out="tx_sudo.provider_id.sudo().pending_msg" position="replace" >
-            <t t-if="tx_sudo.provider_id.custom_mode == 'on_site'">
-                <t t-if="order.commitment_date and order.commitment_date.date() != order.date_order.date()">
-                    Your order will be ready on <span t-field="order.commitment_date" t-options='{"widget": "date"}'/>.
-                </t>
-                <t t-else="">
-                    Your order will be ready soon.
-                </t>
-            </t>
-            <t t-else="">
-                <t>$0</t> <!-- Replaced by old content. -->
-            </t>
-        </t>
         <div id="o_custom_payment_details" position="replace">
             <t t-if="tx_sudo.provider_id.custom_mode == 'on_site'">
                 <div class="mt-2 mb-3">

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -38,13 +38,16 @@ class WebsiteSaleLoyaltyTestUi(TestSaleCommon, HttpCase):
         if self.env["ir.module.module"]._get("payment_custom").state != "installed":
             self.skipTest("Transfer provider is not installed")
 
+        self.env["res.partner.bank"].create({
+            "account_number": "BANK123456789",
+            "partner_id": self.env.company.partner_id.id,
+        })
         transfer_provider = self.env.ref("payment.payment_provider_transfer")
         transfer_provider.sudo().write({
             "state": "enabled",
             "is_published": True,
             "company_id": self.env.company.id,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         large_cabinet = self.env["product.product"].create({
             "name": "Small Cabinet",

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -52,7 +52,6 @@ class WebsiteSaleLoyaltyTestUi(TestSaleCommon, HttpCase):
             "is_published": True,
             "company_id": self.env.company.id,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         large_cabinet = self.env["product.product"].create({
             "name": "Small Cabinet",


### PR DESCRIPTION
Change the way pending payment instructions works for `wire_transfer`.

- Introduce generic template for instructions to be displayed after the
  payment completion(status and confirmation pages)
- Choose a specific bank account to show payment instructions.
- Allow easy extension for other custom modes (e.g. SEPA)

task-4975272