### PR TITLE
[FIX] html_editor: revert image transformation icon

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_transform_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_transform_option.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="website.ImageTransformOption">
         <div class="btn-group o-hb-button-group">
-            <BuilderButton title.translate="Transform the picture" id="'transform_image'" action="'transformImage'" actionParam="{ isImageTransformationOpen: transform.isImageTransformationOpen, closeImageTransformation: closeImageTransformation.bind(this) }" icon="'fa-repeat'" />
+            <BuilderButton title.translate="Transform the picture" id="'transform_image'" action="'transformImage'" actionParam="{ isImageTransformationOpen: transform.isImageTransformationOpen, closeImageTransformation: closeImageTransformation.bind(this) }" icon="'fa-object-ungroup'" />
             <BuilderButton title.translate="Reset transformation" action="'resetTransformImage'" t-if="isActiveItem('transform_image')" actionParam="closeImageTransformation.bind(this)" icon="'oi-close'" className="'btn-danger-color-hover rounded-start-0 m-0 py-0 flex-grow-0'" />
         </div>
     </t>

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -393,7 +393,7 @@ export class ImagePlugin extends Plugin {
     getImageTransformProps() {
         return {
             id: "image_transform",
-            icon: "fa-repeat",
+            icon: "fa-object-ungroup",
             title: _t("Transform the picture (click twice to reset transformation)"),
             getTargetedImage: this.getTargetedImage.bind(this),
             resetImageTransformation: this.resetImageTransformation.bind(this),


### PR DESCRIPTION
In commit [1], image transformation icon was changed from `fa-object-ungroup` to `fa-repeat`. This commit reverts that change and restores the original `fa-object-ungroup` icon.

[1]: https://github.com/odoo/odoo/commit/633267efef54bc6f88d2d6b5517e2dd56ec135f0






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
