### PR TITLE
[FIX] mail: show thread display name in notification dialog

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -45,7 +45,7 @@ threadActionsRegistry
         open(component, action) {
             if (action.sidebar) {
                 action.dialogService?.add(ChannelActionDialog, {
-                    title: component.thread.name,
+                    title: component.thread.displayName,
                     contentComponent: NotificationSettings,
                     contentProps: {
                         thread: component.thread,


### PR DESCRIPTION
Before this PR, when a user opened a group chat in Discuss and accessed
the notification settings from the thread actions, the thread name was missing
in the dialog.

This commit fixes the issue by correctly displaying the thread name in
the notification settings dialog.

Part of task-5910210.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
