### PR TITLE
[IMP] pos_sale: mention down payment details in invoice

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 from odoo import api, fields, models, _
 
 
@@ -148,10 +149,13 @@ class PosOrder(models.Model):
 
     def _get_invoice_lines_values(self, line_values, pos_line, move_type):
         inv_line_vals = super()._get_invoice_lines_values(line_values, pos_line, move_type)
-
         if pos_line.sale_order_origin_id:
+            inv_line_vals["name"] = pos_line.display_name
+            if inv_line_vals['extra_tax_data'].get('computation_key') == 'down_payment' and pos_line.down_payment_details:
+                downpayment_details = ast.literal_eval(pos_line.down_payment_details)
+                if downpayment_details and downpayment_details[0].get('percentage_value'):
+                    inv_line_vals["name"] += " of " + str(downpayment_details[0].get('percentage_value')) + "%"
             origin_line = pos_line.sale_order_line_id
-            inv_line_vals["name"] = origin_line.name
             origin_line._set_analytic_distribution(inv_line_vals)
 
         return inv_line_vals

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -326,6 +326,10 @@ patch(PosStore.prototype, {
         }
     },
     addDownPaymentProductOrderlineToOrder(saleOrder, amount, isPercentage) {
+        let percentage_value = 0;
+        if (isPercentage) {
+            percentage_value = amount;
+        }
         this.loadDownPaymentProduct();
         const saleOrderLines = saleOrder.order_line.filter((soLine) => !soLine.display_type);
         const baseLines = [];
@@ -398,6 +402,7 @@ patch(PosStore.prototype, {
                     product_uom_qty: saleOrderLine.product_uom_qty,
                     price_unit: saleOrderLine.price_unit,
                     total: saleOrderLine.price_total,
+                    percentage_value: isPercentage ? percentage_value : 0,
                 })),
                 tax_ids: [["link", ...baseLine.tax_ids]],
                 extra_tax_data: accountTaxHelpers.export_base_line_extra_tax_data(baseLine),

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -702,9 +702,7 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         legal_documents = self.env['pos.order'].search([]).account_move._get_invoice_legal_documents('pdf', allow_fallback=True)
         self.assertEqual(len(legal_documents), 1)
         invoice_pdf_content = str(legal_documents[0]['content'])
-        self.assertEqual(invoice_pdf_content.count('Product A'), 1)
-        self.assertEqual(invoice_pdf_content.count('Product B'), 1)
-        self.assertEqual(invoice_pdf_content.count('Product C'), 1)
+        self.assertEqual(invoice_pdf_content.count('Down Payment of 20%'), 3)
 
         for order_line in sale_order.order_line.filtered(lambda l: l.product_id == self.downpayment_product):
             order_line = order_line.with_context(lang=partner_test.lang)

--- a/addons/pos_sale/views/point_of_sale_report.xml
+++ b/addons/pos_sale/views/point_of_sale_report.xml
@@ -9,18 +9,7 @@
                     <t t-if="line.product_id == down_payment_product">
                         <t t-set="sale_orders" t-value="pos_orders[0].lines.filtered(lambda l: l.product_id == down_payment_product and l.price_subtotal_incl == line.price_total).mapped('sale_order_origin_id')"/>
                         <t t-if="sale_orders">
-                            <t t-set="sale_order" t-value="sale_orders[0]"/>
-                            <t t-foreach="sale_order.order_line" t-as="sale_order_line">
-                                <t t-if="sale_order_line.product_id != down_payment_product and sale_order_line.tax_ids == line.tax_ids">
-                                    <div>
-                                        <span style="margin-right: 5px;"><t t-out="int(sale_order_line.product_uom_qty)"/>x</span>
-                                        <span t-out="sale_order_line.name" />
-                                        <span style="margin: 0px 5px;">:</span>
-                                        <t t-out="sale_order_line.price_total" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                                    </div>
-                                </t>
-                            </t>
-                            <div style="font-weight: bold">From <t t-out="sale_order.name"/> </div>
+                            <div style="font-weight: bold"><i class="fa fa-shopping-basket me-1"/> <t t-out="sale_orders[0].name"/> </div>
                         </t>
                     </t>
                 </div>


### PR DESCRIPTION
Following this commit:
=====
- Down payment details are been mentioned in invoice, if down payment is done on percentage basis then % value is displayed other Down Payment (POS) is mentioned.

task-5896695
