### PR TITLE
[FIX] hr_holidays: error when deleting employee leave report record

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_report_views.xml
+++ b/addons/hr_holidays/report/hr_leave_employee_report_views.xml
@@ -15,7 +15,7 @@
     <record id="hr_leave_employee_report_view_graph" model="ir.ui.view">
         <field name="model">hr.leave.employee.report</field>
         <field name="arch" type="xml">
-            <graph>
+            <graph disable_linking="True">
                 <field name="color" invisible="1"/>
                 <field name="employee_id"/>
                 <field name="number_of_days" string="Number of Days" type='measure'/>


### PR DESCRIPTION
When the user tries to perform delete operation on the ``hr.leave.employee.report`` model, a traceback appears.

Steps to reproduce the error:
- Install ``hr_holidays`` module with demo data
- Go to > Time Off > Reporting > by Employee > Switch to Graph View
- Click on any record > Select any record > Actions > Delete

Traceback:
```py
UndefinedTable: relation "hr_leave_employee_report" does not exist
```

``hr.leave.employee.report`` model is ``_auto=False``,
meaning that no database table is created for this model.
When the user attempts to delete a record of that model,
It will lead to the above traceback.

sentry-7202115608

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
