### PR TITLE
[FIX] mail: prevent horizontal scrollbar in messaging menu

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -38,7 +38,7 @@
                     <div class="flex-grow-1"/>
                     <div class="d-flex align-items-start position-relative">
                         <span class="position-absolute" t-if="props.hasMarkAsReadButton">
-                            <span t-if="rootHover.isHover" class="ms-1 bg-view">
+                            <span t-if="rootHover.isHover" class="bg-view" t-att-class="{ 'ms-1': !props.muted }">
                                 <span class="o-mail-NotificationItem-badge o-discuss-badgeShape d-flex align-items-center justify-content-center mx-1 my-0 rounded fw-bold o-mail-NotificationItem-markAsRead text-600 cursor-pointer shadow-sm position-absolute top-0 end-0 z-1" title="Mark As Read" t-ref="markAsRead"><i class="fa fa-check text-success"/></span>
                             </span>
                         </span>


### PR DESCRIPTION
**Purpose of this PR:**

Hovering over a muted notification in the messaging menu caused a horizontal scrollbar because the `'Mark as Read'` button retained a margin that overflowed the container when the unread counter was hidden.

This commit makes the margin conditional on the counter's presence, preventing the layout overflow.

task-[5904526](https://www.odoo.com/odoo/project.task/5904526)

**Before/After:**
![Before](https://github.com/user-attachments/assets/f87f1392-d0ea-4723-b6a4-eb121db2c701)

![After](https://github.com/user-attachments/assets/14d0a9a8-559b-44df-be8d-ebe6692c6e30)