### PR TITLE
[FIX] account_peppol: prevent invoice reset to skipped

### DIFF
--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -300,14 +300,15 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
             checkbox_send_peppol=True,
         )
 
-        wizard.action_send_and_print()
-
-        self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
-        self.assertRecordValues(move, [{
-                'peppol_move_state': 'done',
-                'peppol_message_uuid': FAKE_UUID[0],
-            }],
-        )
+        # Try to send the invoice twice to ensure the second send doesn't mark the state as skipped
+        for _ in range(2):
+            wizard.action_send_and_print()
+            self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
+            self.assertRecordValues(move, [{
+                    'peppol_move_state': 'done',
+                    'peppol_message_uuid': FAKE_UUID[0],
+                }],
+            )
         self.assertTrue(bool(move.ubl_cii_xml_id))
 
     def test_send_peppol_and_email_default_values(self):

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -162,11 +162,11 @@ class AccountMoveSend(models.TransientModel):
         params = {'documents': []}
         invoices_data_peppol = {}
         for invoice, invoice_data in invoices_data.items():
-            if invoice_data.get('send_peppol'):
+            if invoice_data.get('send_peppol') and invoice.peppol_move_state not in ('processing', 'done'):
                 if invoice_data.get('ubl_cii_xml_attachment_values'):
                     xml_file = invoice_data['ubl_cii_xml_attachment_values']['raw']
                     filename = invoice_data['ubl_cii_xml_attachment_values']['name']
-                elif invoice.ubl_cii_xml_id and invoice.peppol_move_state not in ('processing', 'canceled', 'done'):
+                elif invoice.ubl_cii_xml_id and invoice.peppol_move_state != 'canceled':
                     xml_file = invoice.ubl_cii_xml_id.raw
                     filename = invoice.ubl_cii_xml_id.name
                 else:


### PR DESCRIPTION
This fix addresses two issues related to resending invoices via Peppol.

It prevents users from accidentally resending an invoice and having its status incorrectly set to “skipped”. It also prevents from resending an invoice via Peppol when it is already in a “processing”, then "skipped" state.

Steps to reproduce:
- Create and send a customer invoice to Peppol
- Try to send it again, Odoo sets the status to “skipped”
- Try to send it again, Odoo resends the invoice via Peppol

This fix is a light adaptation of the `_is_applicable_to_move` method introduced in version 18.

After the fix:
Trying to resend to Peppol an invoice already in "processing" or "done" state is prevented.

opw-5491341