### PR TITLE
[FIX] base: fix Model Overview crash on unknown field types

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -356,7 +356,7 @@ class IrQwebFieldSelection(models.AbstractModel):
     def value_to_html(self, value, options):
         if not value:
             return ''
-        return escape(options['selection'][value] or '')
+        return escape(options['selection'].get(value, value) or '')
 
     @api.model
     def record_to_html(self, record, field_name, options):


### PR DESCRIPTION
This PR fixes a crash in the 'Model Overview' report (KeyError: 'vector') when models contain field types not recognized by the ir.qweb.field.selection widget (e.g. ector from the i module).

The rendering logic in IrQwebFieldSelection.value_to_html assumed that alue would always be present in the selection map. This change adds a .get() fallback to display the raw value instead of crashing.

Steps to reproduce:
1. Have a model with a field of type 'vector' (or any type missing from logical widget map).
2. Print Model Overview.
3. Observe KeyError.

Closes #247281