### PR TITLE
[FIX] account_peppol: prevent invoice reset to skipped

### DIFF
--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -345,14 +345,15 @@ class TestPeppolMessage(AccountTestInvoicingCommon):
             'peppol_warning': False,
         }])
 
-        wizard.send_and_print_action()
-
-        self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
-        self.assertRecordValues(move, [{
-                'peppol_move_state': 'done',
-                'peppol_message_uuid': FAKE_UUID[0],
-            }],
-        )
+        # Try to send the invoice twice to ensure the second send doesn't mark the state as skipped
+        for _ in range(2):
+            wizard.send_and_print_action()
+            self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
+            self.assertRecordValues(move, [{
+                    'peppol_move_state': 'done',
+                    'peppol_message_uuid': FAKE_UUID[0],
+                }],
+            )
 
     def test_send_peppol_requires_peppol_document(self):
         """Without peppol document the Peppol option in the wizard is shown but readonly."""

--- a/addons/account_peppol/wizard/account_invoice_send.py
+++ b/addons/account_peppol/wizard/account_invoice_send.py
@@ -150,6 +150,8 @@ class AccountInvoiceSend(models.TransientModel):
 
         documents = []
         for invoice, invoice_data in invoices_data.items():
+            if invoice.peppol_move_state in ('processing', 'done'):
+                continue
             partner = invoice.partner_id.commercial_partner_id
             if not partner.peppol_eas or not partner.peppol_endpoint:
                 invoice.peppol_move_state = 'error'


### PR DESCRIPTION
This fix addresses two issues related to resending invoices via Peppol.

It prevents users from accidentally resending an invoice and having its status incorrectly set to “skipped”. It also prevents from resending an invoice via Peppol when it is already in a “processing”, then "skipped" state.

Steps to reproduce:
- Create and send a customer invoice to Peppol
- Try to send it again, Odoo sets the status to “skipped”
- Try to send it again, Odoo resends the invoice via Peppol

This fix is a light adaptation of the `_is_applicable_to_move` method introduced in version 18.

After the fix:
Trying to resend to Peppol an invoice already in "processing" or "done" state is prevented.

opw-5491341