### PR TITLE
[FIX] html_editor: keep paragraph usable after removing its only image

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -4,10 +4,12 @@ import { isImageUrl } from "@html_editor/utils/url";
 import { ImageDescription } from "./image_description";
 import { ImagePadding } from "./image_padding";
 import { createFileViewer } from "@web/core/file_viewer/file_viewer_hook";
-import { boundariesOut, childNodeIndex } from "@html_editor/utils/position";
+import { boundariesOut } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { ImageTransformButton } from "./image_transform_button";
-import { isEmpty } from "@html_editor/utils/dom_info";
+import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
+import { closestBlock } from "@html_editor/utils/blocks";
+import { fillEmpty } from "@html_editor/utils/dom";
 
 function hasShape(imagePlugin, shapeName) {
     return () => imagePlugin.isSelectionShaped(shapeName);
@@ -265,20 +267,12 @@ export class ImagePlugin extends Plugin {
             if (this.delegateTo("delete_image_overrides", targetedImg)) {
                 return;
             }
-            const anchorNode = targetedImg.parentElement;
-            let anchorOffset = childNodeIndex(targetedImg);
+            const cursors = this.dependencies.selection.preserveSelection();
+            cursors.update(callbacksForCursorUpdate.remove(targetedImg));
+            const parentEl = closestBlock(targetedImg);
             targetedImg.remove();
-            // When an image is added as the first element of a <p> tag,
-            // the `dom_plugin.insert` method automatically creates a #text node just before the <img>.
-            // After removing the image and setting the selection at the <p> tag (offset 0),
-            // the selection unexpectedly jumps back to the parent node during input.
-            // To address this issue, we handle this specific case separately.
-            if (anchorNode.nodeName === "P" && isEmpty(anchorNode)) {
-                const br = this.document.createElement("br");
-                anchorNode.replaceChildren(br);
-                anchorOffset = 0;
-            }
-            this.dependencies.selection.setSelection({ anchorNode, anchorOffset });
+            cursors.restore();
+            fillEmpty(parentEl);
             this.dependencies.history.addStep();
         }
     }


### PR DESCRIPTION
Problem:
When removing an image that is the only element inside a base paragraph, the paragraph remains empty and it becomes difficult to place the cursor inside it.

Solution:
This issue is already fixed in later versions. The fix consists in filling the parent block when its last remaining element (the image) is removed, so the paragraph stays editable.

Steps to reproduce:
- Add an image inside a paragraph.
- Remove the image.
- Observe that the HTML field collapses and the cursor is hard to place.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
