### PR TITLE
[IMP] hr_holidays: allow negative allocations with configurable limits

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -126,10 +126,6 @@ class HrLeaveAllocation(models.Model):
     virtual_remaining_leaves = fields.Float(compute='_compute_leaves', string='Available Time Off')
     expiring_carryover_days = fields.Float("The number of carried over days that will expire on carried_over_days_expiration_date")
     carried_over_days_expiration_date = fields.Date("Carried over days expiration date")
-    _duration_check = models.Constraint(
-        "CHECK( ( number_of_days > 0 AND allocation_type='regular') or (allocation_type != 'regular'))",
-        'The duration must be greater than 0.',
-    )
 
     @api.constrains('date_from', 'date_to')
     def _check_date_from_date_to(self):
@@ -273,6 +269,21 @@ class HrLeaveAllocation(models.Model):
                 allocation.number_of_days = allocation.number_of_days_display
             elif allocation_unit == 'hour' and allocation.employee_id:
                 allocation.number_of_days = allocation.number_of_hours_display / allocation.employee_id._get_hours_per_day(allocation.date_from)
+
+    @api.constrains('number_of_days', 'work_entry_type_id', 'employee_id')
+    def _check_negative_allocation(self):
+        for allocation in self:
+            if allocation.number_of_days >= 0:
+                continue
+            if not allocation.work_entry_type_id.allows_negative:
+                raise ValidationError(self.env._("Negative allocations are not allowed for this time off type."))
+            allocation_unit = allocation.type_request_unit
+            if allocation_unit != 'hour' and abs(allocation.number_of_days_display) > allocation.work_entry_type_id.max_allowed_negative:
+                raise ValidationError(self.env._("The negative allocation cannot exceed the maximum allowed negative value of %(max)s day(s).",
+                      max=allocation.work_entry_type_id.max_allowed_negative))
+            if allocation_unit == 'hour' and abs(allocation.number_of_hours_display) > allocation.work_entry_type_id.max_allowed_negative:
+                raise ValidationError(self.env._("The negative allocation cannot exceed the maximum allowed negative value of %(max)s hour(s).",
+                      max=allocation.work_entry_type_id.max_allowed_negative))
 
     @api.depends('allocation_type')
     def _compute_accrual_plan_id(self):

--- a/addons/hr_holidays/tests/test_negative.py
+++ b/addons/hr_holidays/tests/test_negative.py
@@ -90,3 +90,46 @@ class TestNegative(TestHrHolidaysCommon):
                 one_day_leave.with_user(self.user_hrmanager_id).write({
                     'date_to': datetime(2023, 10, 24),
                 })
+
+    def test_negative_allocation_not_allowed(self):
+        """Negative allocation should fail when leave type doesn't allow it."""
+        work_entry_type_no_negative = self.env['hr.work.entry.type'].create({
+            'name': 'No Negative Allowed',
+            'code': 'No Negative Allowed',
+            'requires_allocation': True,
+            'allows_negative': False,
+        })
+        with self.assertRaises(ValidationError):
+            self.env['hr.leave.allocation'].create({
+                'employee_id': self.employee_emp_id,
+                'work_entry_type_id': work_entry_type_no_negative.id,
+                'number_of_days': -3,
+            })
+
+    def test_negative_allocation_exceeds_limit_days(self):
+        """Negative allocation exceeding limit should fail."""
+        with self.assertRaises(ValidationError):
+            self.env['hr.leave.allocation'].create({
+                'employee_id': self.employee_emp_id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': -6,  # exceeds max_allowed_negative of 5
+            })
+
+    def test_negative_allocation_exceeds_limit_hours(self):
+        """Negative allocation exceeding limit should fail (hours)."""
+        work_entry_type_hours = self.env['hr.work.entry.type'].create({
+            'name': 'Negative Hours',
+            'code': 'Negative Hours',
+            'requires_allocation': True,
+            'allows_negative': True,
+            'max_allowed_negative': 10,
+            'request_unit': 'hour',
+            'unit_of_measure': 'hour',
+        })
+        # hours_per_day is 8, so -2 days = -16 hours (exceeds limit of 10)
+        with self.assertRaises(ValidationError):
+            self.env['hr.leave.allocation'].create({
+                'employee_id': self.employee_emp_id,
+                'work_entry_type_id': work_entry_type_hours.id,
+                'number_of_days': -2,
+            })


### PR DESCRIPTION
Replace the SQL constraint that blocked all negative allocations with Python validation that allows negative allocations when the time off type permits it.

The new validation checks:
- Whether the time off type allows negative allocations
- Whether the negative value exceeds the maximum allowed negative hours

Task Id: 5438492