### PR TITLE
[FIX] hr: add missing resource parameter in _get_unusual_days

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1931,6 +1931,7 @@ class HrEmployee(models.Model):
                 datetime.combine(fields.Date.from_string(tmp_date_from), time.min, tzinfo=UTC),
                 datetime.combine(fields.Date.from_string(tmp_date_to), time.max, tzinfo=UTC),
                 self.company_id,
+                self.resource_id,
             ))
         return unusual_days
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the "Employees" module.
2. Create an employee with a contract.
3. Make his working hours flexible.
4. Press the Timee Off smart button.
5. You get an error.

**Cause of the issue:**
The flexible resource is not passed as a parameter to the method `_get_unusual_days`.