### PR TITLE
[FIX] purchase : fix POL Vendor Code/Name in desc

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -325,6 +325,30 @@ class PurchaseOrderLine(models.Model):
             if seller or not line.date_planned:
                 line.date_planned = line._get_date_planned(seller).strftime(DEFAULT_SERVER_DATETIME_FORMAT)
 
+            # record product names to avoid resetting custom descriptions
+            default_names = []
+            display_names = []
+            vendors = line.product_id._prepare_sellers(params=params)
+            product_ctx = {'seller_id': None, 'partner_id': None, 'lang': get_lang(line.env, line.partner_id.lang).code}
+            line_without_seller = line.product_id.with_context(product_ctx)
+            default_names.append(line._get_product_purchase_description(line_without_seller))
+            for vendor in vendors:
+                product_ctx = {'seller_id': vendor.id, 'lang': get_lang(line.env, line.partner_id.lang).code}
+                default_names.append(line._get_product_purchase_description(line.product_id.with_context(product_ctx)))
+                display_names.append(line.product_id.with_context(product_ctx).display_name)
+            if not line.name or line.name in default_names:
+                product_ctx = {'seller_id': seller.id, 'lang': get_lang(line.env, line.partner_id.lang).code}
+                line.name = line._get_product_purchase_description(line.product_id.with_context(product_ctx))
+            else:
+                # Checks that the product vendor and vendor name are correct
+                for vendor, display_name in zip(vendors, display_names):
+                    if line.name.startswith(display_name):
+                        if not seller:
+                            line.name = line_without_seller.display_name + line.name[len(display_name):]
+                        elif vendor.id != seller.id:
+                            line.name = display_names[vendors.ids.index(seller.id)] + line.name[len(display_name):]
+                        break
+
             # If not seller, use the standard price. It needs a proper currency conversion.
             if not seller:
                 line.discount = 0
@@ -356,18 +380,6 @@ class PurchaseOrderLine(models.Model):
                 price_unit = float_round(price_unit, precision_digits=max(line.currency_id.decimal_places, self.env['decimal.precision'].precision_get('Product Price')))
                 line.price_unit = seller.product_uom._compute_price(price_unit, line.product_uom)
                 line.discount = seller.discount or 0.0
-
-            # record product names to avoid resetting custom descriptions
-            default_names = []
-            vendors = line.product_id._prepare_sellers(params=params)
-            product_ctx = {'seller_id': None, 'partner_id': None, 'lang': get_lang(line.env, line.partner_id.lang).code}
-            default_names.append(line._get_product_purchase_description(line.product_id.with_context(product_ctx)))
-            for vendor in vendors:
-                product_ctx = {'seller_id': vendor.id, 'lang': get_lang(line.env, line.partner_id.lang).code}
-                default_names.append(line._get_product_purchase_description(line.product_id.with_context(product_ctx)))
-            if not line.name or line.name in default_names:
-                product_ctx = {'seller_id': seller.id, 'lang': get_lang(line.env, line.partner_id.lang).code}
-                line.name = line._get_product_purchase_description(line.product_id.with_context(product_ctx))
 
     @api.depends('product_id', 'product_qty', 'product_uom')
     def _compute_product_packaging_id(self):

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -1177,3 +1177,73 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertRecordValues(purchase_order.order_line, [
             {'price_unit': 100, 'discount': 10, 'price_unit_discounted': 90},
         ])
+
+    def test_orderline_description_change_on_partner_change(self):
+        """Test that The Vendor Code and/or Vendor Name does change correctly in the product description when changing the partner"""
+        supplierinfo_vals = {
+            'min_qty': 1,
+            'product_id': self.product_a.id,
+            'product_tmpl_id': self.product_a.product_tmpl_id.id,
+        }
+
+        self.env["product.supplierinfo"].create([
+            {
+                **supplierinfo_vals,
+                'price': 10,
+                'product_name': 'Name 1',
+                'product_code': 'Code 1',
+                'partner_id': self.partner_a.id,
+            },
+            {
+                **supplierinfo_vals,
+                'price': 20,
+                'product_name': 'Name 2',
+                'product_code': 'Code 2',
+                'partner_id': self.partner_b.id,
+            },
+            {
+                **supplierinfo_vals,
+                'price': 15,
+                'partner_id': self.partner.id,
+            }
+        ])
+
+        partner_c = self.env['res.partner'].create({'name': 'Partner not in sellers'})
+
+        custom_desc = "This is a custom description that should not be touched"
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                    'product_id': self.product_a.id,
+                    'product_qty': 1,
+                    'name': "[Code 1] Name 1\nSome Variant: Some Value: Some Text"
+                }), Command.create({
+                    'product_id': self.product_a.id,
+                    'product_qty': 1,
+                }), Command.create({
+                    'product_id': self.product_a.id,
+                    'product_qty': 1,
+                    'name': custom_desc
+                })
+            ],
+        })
+
+        self.assertEqual(po.order_line[0].name, "[Code 1] Name 1\nSome Variant: Some Value: Some Text")
+        self.assertEqual(po.order_line[1].name, "[Code 1] Name 1")
+        self.assertEqual(po.order_line[2].name, custom_desc)
+        po.partner_id = self.partner.id
+        self.assertEqual(po.order_line[0].name, "product_a\nSome Variant: Some Value: Some Text")
+        self.assertEqual(po.order_line[1].name, "product_a")
+        self.assertEqual(po.order_line[2].name, custom_desc)
+        po.partner_id = self.partner_b.id
+        self.assertEqual(po.order_line[0].name, "[Code 2] Name 2\nSome Variant: Some Value: Some Text")
+        self.assertEqual(po.order_line[1].name, "[Code 2] Name 2")
+        self.assertEqual(po.order_line[2].name, custom_desc)
+        po.partner_id = partner_c.id
+        self.assertEqual(po.order_line[0].name, "product_a\nSome Variant: Some Value: Some Text")
+        self.assertEqual(po.order_line[1].name, "product_a")
+        self.assertEqual(po.order_line[2].name, custom_desc)
+        po.partner_id = self.partner_a.id
+        self.assertEqual(po.order_line[0].name, "[Code 1] Name 1\nSome Variant: Some Value: Some Text")
+        self.assertEqual(po.order_line[1].name, "[Code 1] Name 1")
+        self.assertEqual(po.order_line[2].name, custom_desc)


### PR DESCRIPTION
How to reproduce :
- Create a product
- Create an attribute with a value set to "free text"
- Add 2 different vendors to the purchase tab of the product with different Vendor Code and/or Vendor Name
- Put Dropship as the route for the product to create a PO on a SO confirmation
- Create a SO with that product
- Confirm the SO and go to the PO
- Change the vendor in the SO

The problem :
The Vendor Code and/or Vendor Name does not change correctly in the product description

Why :
The way the description generation for a change in a purchase order line works as follows : Create a collection of default descriptions based on the product and the different vendors. If the collection contains the current description, it means the description was not changed by the user and it can be modified. This is done to prevent resetting a custom description made by an user.

This logic is pretty broken because the code that generate the description when going from a PO to a SO and the code that generate the description when changing the PO partner are different. This makes it so the current description is almost never found in the list of default descriptions.

It looks tempting to try to "resynchronize" those part of the code so the description generation is the same in both cases. This would be done by overriding the _get_product_purchase_description method in the purchase_stock module and using the product_description_variants field. Sadly, this does not work because it conflicts with the purchase_product_matrix module and its own override of that method.

The fix that I implemented checks that the Vendor Code and Name are the right one every time the description is computed following a change.

opw-5888233

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
