### PR TITLE
[REM] website: remove unused website.assets_all_wysiwyg bundle

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -404,9 +404,6 @@
             'website/static/src/xml/website_form_editor.xml',
             'website/static/src/xml/website.cookies_bar.xml',
         ],
-        'website.assets_all_wysiwyg': [
-            ('include', 'website.assets_wysiwyg'),
-        ],
         'html_editor.assets_media_dialog': [
             'website/static/src/components/media_dialog/*',
         ],

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -207,10 +207,3 @@ class IrQweb(models.AbstractModel):
         if isinstance(atts.get('style'), str) and 'background-image' in atts['style']:
             atts['style'] = re_background_image.sub(lambda m: '%s%s' % (m[1], url_adapter(m[2])), atts['style'])
         return atts
-
-    def _get_bundles_to_pregenarate(self):
-        js_assets, css_assets = super()._get_bundles_to_pregenarate()
-        assets = {
-            'website.assets_all_wysiwyg',
-        }
-        return (js_assets | assets, css_assets | assets)


### PR DESCRIPTION
Since the commit [^1] where we stop loading the legacy web_editor, the
bundle `website.assets_all_wysiwyg` isn't used anymore.

[^1]: https://github.com/odoo/odoo/commit/213c32be89b46511d8c2aac19fd654ae91dd8103