### PR TITLE
[IMP] l10n_hr_edi: Improvements to XML generation, test coverage, API

### DIFF
--- a/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
+++ b/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
@@ -168,27 +168,45 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
             })
 
     def _add_hr_extension_node(self, document_node):
-        tax_subtotals = document_node['cac:TaxTotal'][0]['cac:TaxSubtotal']
-        hr_tax_subtotals = []
+        """
+        This function constructs hrextac node from existing data within the document.
+        The structure mostly follows that of 'cac:TaxTotal' node of a UBL 2.1/BIS 3 document,
+        but requires additional data compared to the totals/subtotals nodes in UBL HR format.
+        To avoid making additional queries and possible desyncs, we calculate all the data
+        we need while assembling normal subtotals, then trim out the extra bits.
+        """
         cash_basis_line = False
-        for i in range(len(tax_subtotals)):
-            # Removing the HR-specific node from the normal subtotal where we calculate it
-            hr_tax_name = tax_subtotals[i]['cac:TaxCategory'][0].pop('cbc:Name')
-            cash_basis_flag = tax_subtotals[i]['cac:TaxCategory'][0].pop('hrextac:HRObracunPDVPoNaplati')  # Ensure pop() always runs
-            cash_basis_line = cash_basis_line or cash_basis_flag
-            new_item = {
-                'cbc:TaxableAmount': tax_subtotals[i]['cbc:TaxableAmount'],
-                'cbc:TaxAmount': tax_subtotals[i]['cbc:TaxAmount'],
-                'hrextac:HRTaxCategory': {
-                    'cbc:ID': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:ID'],
-                    'cbc:Name': hr_tax_name,
-                    'cbc:Percent': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:Percent'],
-                    'cbc:TaxExemptionReasonCode': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:TaxExemptionReasonCode'],
-                    'cbc:TaxExemptionReason': tax_subtotals[i]['cac:TaxCategory'][0]['cbc:TaxExemptionReason'],
-                    'hrextac:HRTaxScheme': tax_subtotals[i]['cac:TaxCategory'][0]['cac:TaxScheme'] if hr_tax_name['_text'] != "HR:POVNAK" else {'_text': "OTH"},
-                }
-            }
-            hr_tax_subtotals.append(new_item)
+        tax_totals = document_node['cac:TaxTotal']
+        hr_tax_totals = []
+        for total in tax_totals:
+            tax_subtotals = total['cac:TaxSubtotal']
+            hr_tax_subtotals = []
+            for subtotal in tax_subtotals:
+                tax_categories = subtotal['cac:TaxCategory']
+                hr_tax_categories = []
+                for category in tax_categories:
+                    # Cash basis is document-wide, so we do not need to keep it for each category
+                    cash_basis_flag = category.pop('hrextac:HRObracunPDVPoNaplati')  # Ensure pop() always runs
+                    cash_basis_line = cash_basis_line or cash_basis_flag
+                    # Removing the HR-specific node from the normal subtotal where we calculate it
+                    hr_tax_name = category.pop('cbc:Name')
+                    hr_tax_categories.append({
+                        'cbc:ID': category['cbc:ID'],
+                        'cbc:Name': hr_tax_name,
+                        'cbc:Percent': category['cbc:Percent'],
+                        'cbc:TaxExemptionReasonCode': category['cbc:TaxExemptionReasonCode'],
+                        'cbc:TaxExemptionReason': category['cbc:TaxExemptionReason'],
+                        'hrextac:HRTaxScheme': category['cac:TaxScheme'] if hr_tax_name['_text'] != "HR:POVNAK" else {'_text': "OTH"},
+                    })
+                hr_tax_subtotals.append({
+                    'cbc:TaxableAmount': subtotal['cbc:TaxableAmount'],
+                    'cbc:TaxAmount': subtotal['cbc:TaxAmount'],
+                    'hrextac:HRTaxCategory': hr_tax_categories.copy(),
+                })
+            hr_tax_totals.append({
+                'cbc:TaxAmount': total['cbc:TaxAmount'],
+                'hrextac:HRTaxSubtotal': hr_tax_subtotals.copy(),
+            })
         out_of_scope_node = {
             'currencyID': document_node['cac:LegalMonetaryTotal']['cbc:TaxExclusiveAmount'].get('currencyID'),
             '_text': '0.00'     # Currently unsupported, a HR-specific workaround can potentially be made
@@ -199,10 +217,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
                     'ext:ExtensionContent': {
                         'hrextac:HRFISK20Data': {
                             'hrextac:HRObracunPDVPoNaplati': cash_basis_line,
-                            'hrextac:HRTaxTotal': {
-                                'cbc:TaxAmount': document_node['cac:TaxTotal'][0]['cbc:TaxAmount'],
-                                'hrextac:HRTaxSubtotal': hr_tax_subtotals,
-                            },
+                            'hrextac:HRTaxTotal': hr_tax_totals,
                             'hrextac:HRLegalMonetaryTotal': {
                                 'cbc:TaxExclusiveAmount': document_node['cac:LegalMonetaryTotal']['cbc:TaxExclusiveAmount'],
                                 'hrextac:OutOfScopeOfVATAmount': out_of_scope_node,
@@ -215,9 +230,9 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
 
     def _add_invoice_line_item_nodes(self, line_node, vals):
         super()._add_invoice_line_item_nodes(line_node, vals)
-        line = vals['base_line']['record']
         # HR-BR-25: Each item MUST have an item classification identifier from the Classification of Products
         # by Activities scheme: KPD (CPA) - listID "CG", except in the case of advance payment invoices.
+        line = vals['base_line']['record']
         line_node['cac:Item'].update({
             'cac:CommodityClassification': {
                 'cbc:ItemClassificationCode': {
@@ -228,6 +243,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
         })
 
     def _get_party_node(self, vals):
+        # To be updated for new GLN handling
         party_node = super()._get_party_node(vals)
         commercial_partner = vals['partner'].commercial_partner_id
         if commercial_partner.l10n_hr_personal_oib:
@@ -247,19 +263,19 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
 
     def _add_invoice_accounting_supplier_party_nodes(self, document_node, vals):
         super()._add_invoice_accounting_supplier_party_nodes(document_node, vals)
-        invoice = vals['invoice']
         # HR-BR-37: Invoice must contain HR-BT-4: Operator code in accordance with the Fiscalization Act.
         # HR-BR-9: Invoice must contain HR-BT-5: Operator OIB in accordance with the Fiscalization Act.
+        invoice = vals['invoice']
         document_node['cac:AccountingSupplierParty'].update({
-                'cac:SellerContact': {
-                    'cbc:ID': {
-                        '_text': invoice.l10n_hr_operator_oib
-                    },
-                    'cbc:Name': {
-                        '_text': invoice.l10n_hr_operator_name
-                    }
+            'cac:SellerContact': {
+                'cbc:ID': {
+                    '_text': invoice.l10n_hr_operator_oib
+                },
+                'cbc:Name': {
+                    '_text': invoice.l10n_hr_operator_name
                 }
-            })
+            }
+        })
 
     def _ubl_default_tax_category_grouping_key(self, base_line, tax_data, vals, currency):
         # EXTENDS account.edi.xml.ubl_bis3
@@ -268,6 +284,7 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
             return
 
         tax = tax_data['tax']
+        hr_category = tax.l10n_hr_tax_category_id if tax else None
 
         # HR-BR-11: Each document-level expense (BG-21) that is not subject to VAT or is exempt from VAT must have
         # a document-level expense VAT category code (HR-BT-6) from table HR-TB-2 HR VAT category codes
@@ -279,9 +296,12 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
             and not tax.amount
         ):
             grouping_key.update({
-                'tax_category_code': tax.l10n_hr_tax_category_id.code_untdid,
-                'tax_exemption_reason': tax.l10n_hr_tax_category_id.description,
+                'tax_category_code': tax.l10n_hr_tax_category_id.code_untdid
             })
+            # If account_edi_ubl_cii_tax_extension is installed and a value is specified, use that data, if not, override with HR data
+            tax_extension = 'ubl_cii_tax_exemption_reason_code' in tax._fields and tax.ubl_cii_tax_exemption_reason_code
+            if not tax_extension:
+                grouping_key.update({'tax_exemption_reason': hr_category.description})
 
         if tax.tax_exigibility == 'on_payment':
             invoice_legal_notes_str = html2plaintext(tax.invoice_legal_notes or '') or "Obračun po naplaćenoj naknadi"

--- a/addons/l10n_hr_edi/models/account_move.py
+++ b/addons/l10n_hr_edi/models/account_move.py
@@ -206,21 +206,29 @@ class AccountMove(models.Model):
         self.ensure_one()
         if self.is_sale_document():
             response_mer = _mer_api_query_document_process_status_outbox(self.company_id, electronic_id=self.l10n_hr_mer_document_eid)[0]
-            response_fisc = _mer_api_check_fiscalization_status_outbox(self.company_id, electronic_id=self.l10n_hr_mer_document_eid)[0]
+            response_fisc = _mer_api_check_fiscalization_status_outbox(self.company_id, electronic_id=self.l10n_hr_mer_document_eid)
+            if isinstance(response_fisc, list):
+                response_fisc = {} if len(response_fisc) == 0 else response_fisc[0]
         elif self.is_purchase_document():
             response_mer = _mer_api_query_document_process_status_inbox(self.company_id, electronic_id=self.l10n_hr_mer_document_eid)[0]
-            response_fisc = _mer_api_check_fiscalization_status_inbox(self.company_id, electronic_id=self.l10n_hr_mer_document_eid)[0]
+            response_fisc = _mer_api_check_fiscalization_status_inbox(self.company_id, electronic_id=self.l10n_hr_mer_document_eid)
+            if isinstance(response_fisc, list):
+                response_fisc = {} if len(response_fisc) == 0 else response_fisc[0]
         else:
             return
-        self.l10n_hr_edi_addendum_id.write({
+        write_dict = {
             'mer_document_status': str(response_mer.get('StatusId')),
             'business_document_status': str(response_mer.get('DocumentProcessStatusId')),
-            'fiscalization_status': str(response_fisc['messages'][-1].get('status')),
-            'fiscalization_error': str(response_fisc['messages'][-1].get('errorCode') + ' - ' + response_fisc['messages'][-1].get('errorCodeDescription')),
-            'fiscalization_request': str(response_fisc['messages'][-1].get('fiscalizationRequestId')),
-            'business_status_reason': str(response_fisc['messages'][-1].get('businessStatusReason')),
-            'fiscalization_channel_type': str(response_fisc.get('channelType')),
-        })
+        }
+        if response_fisc:
+            write_dict.update({
+                'fiscalization_status': str(response_fisc['messages'][-1].get('status')),
+                'fiscalization_error': str(response_fisc['messages'][-1].get('errorCode') + ' - ' + response_fisc['messages'][-1].get('errorCodeDescription')),
+                'fiscalization_request': str(response_fisc['messages'][-1].get('fiscalizationRequestId')),
+                'business_status_reason': str(response_fisc['messages'][-1].get('businessStatusReason')),
+                'fiscalization_channel_type': str(response_fisc.get('channelType')),
+            })
+        self.l10n_hr_edi_addendum_id.write(write_dict)
 
     def l10n_hr_edi_mer_action_report_paid(self):
         batch = len(self) != 1

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_multiple.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_multiple.xml
@@ -1,20 +1,43 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:hrextac="urn:mfin.gov.hr:schema:xsd:HRExtensionAggregateComponents-1">
-  <ext:UBLExtensions>
+    <ext:UBLExtensions>
     <ext:UBLExtension>
       <ext:ExtensionContent>
         <hrextac:HRFISK20Data>
           <hrextac:HRTaxTotal>
-            <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+            <cbc:TaxAmount currencyID="EUR">51.00</cbc:TaxAmount>
             <hrextac:HRTaxSubtotal>
               <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+              <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+              <hrextac:HRTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Name>HR:PDV25</cbc:Name>
+                <cbc:Percent>25.0</cbc:Percent>
+                <hrextac:HRTaxScheme>
+                  <cbc:ID>VAT</cbc:ID>
+                </hrextac:HRTaxScheme>
+              </hrextac:HRTaxCategory>
+            </hrextac:HRTaxSubtotal>
+            <hrextac:HRTaxSubtotal>
+              <cbc:TaxableAmount currencyID="EUR">200.00</cbc:TaxableAmount>
+              <cbc:TaxAmount currencyID="EUR">26.00</cbc:TaxAmount>
+              <hrextac:HRTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Name>HR:PDV13</cbc:Name>
+                <cbc:Percent>13.0</cbc:Percent>
+                <hrextac:HRTaxScheme>
+                  <cbc:ID>VAT</cbc:ID>
+                </hrextac:HRTaxScheme>
+              </hrextac:HRTaxCategory>
+            </hrextac:HRTaxSubtotal>
+            <hrextac:HRTaxSubtotal>
+              <cbc:TaxableAmount currencyID="EUR">300.00</cbc:TaxableAmount>
               <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
               <hrextac:HRTaxCategory>
-                <cbc:ID>E</cbc:ID>
-                <cbc:Name>HR:E</cbc:Name>
+                <cbc:ID>K</cbc:ID>
+                <cbc:Name>HR:K</cbc:Name>
                 <cbc:Percent>0.0</cbc:Percent>
-                <cbc:TaxExemptionReasonCode>VATEX-EU-143</cbc:TaxExemptionReasonCode>
-                <cbc:TaxExemptionReason>Exempt based on article 143 of Council Directive 2006/112/EC</cbc:TaxExemptionReason>
+                <cbc:TaxExemptionReason>Exempt from VAT due to delivery within the EU</cbc:TaxExemptionReason>
                 <hrextac:HRTaxScheme>
                   <cbc:ID>VAT</cbc:ID>
                 </hrextac:HRTaxScheme>
@@ -22,7 +45,7 @@
             </hrextac:HRTaxSubtotal>
           </hrextac:HRTaxTotal>
           <hrextac:HRLegalMonetaryTotal>
-            <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
+            <cbc:TaxExclusiveAmount currencyID="EUR">600.00</cbc:TaxExclusiveAmount>
             <hrextac:OutOfScopeOfVATAmount currencyID="EUR">0.00</hrextac:OutOfScopeOfVATAmount>
           </hrextac:HRLegalMonetaryTotal>
         </hrextac:HRFISK20Data>
@@ -30,7 +53,7 @@
     </ext:UBLExtension>
   </ext:UBLExtensions>  
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:mfin.gov.hr:cius-2025:1.0#conformant#urn:mfin.gov.hr:ext-2025:1.0</cbc:CustomizationID>
-  <cbc:ProfileID>P1</cbc:ProfileID>
+  <cbc:ProfileID>P99:Test custom process type</cbc:ProfileID>
   <cbc:ID>1/1/1</cbc:ID>
   <cbc:CopyIndicator>false</cbc:CopyIndicator>
   <cbc:IssueDate>2025-01-02</cbc:IssueDate>
@@ -139,15 +162,36 @@
     <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
   </cac:PaymentTerms>
   <cac:TaxTotal>
-    <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+    <cbc:TaxAmount currencyID="EUR">51.00</cbc:TaxAmount>
     <cac:TaxSubtotal>
       <cbc:TaxableAmount currencyID="EUR">100.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">25.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>25.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">200.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">26.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>13.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">300.00</cbc:TaxableAmount>
       <cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
       <cac:TaxCategory>
-        <cbc:ID>E</cbc:ID>
+        <cbc:ID>K</cbc:ID>
         <cbc:Percent>0.0</cbc:Percent>
-        <cbc:TaxExemptionReasonCode>VATEX-EU-143</cbc:TaxExemptionReasonCode>
-        <cbc:TaxExemptionReason>Exempt based on article 143 of Council Directive 2006/112/EC</cbc:TaxExemptionReason>
+        <cbc:TaxExemptionReason>Exempt from VAT due to delivery within the EU</cbc:TaxExemptionReason>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
@@ -155,11 +199,11 @@
     </cac:TaxSubtotal>
   </cac:TaxTotal>
   <cac:LegalMonetaryTotal>
-    <cbc:LineExtensionAmount currencyID="EUR">100.00</cbc:LineExtensionAmount>
-    <cbc:TaxExclusiveAmount currencyID="EUR">100.00</cbc:TaxExclusiveAmount>
-    <cbc:TaxInclusiveAmount currencyID="EUR">100.00</cbc:TaxInclusiveAmount>
+    <cbc:LineExtensionAmount currencyID="EUR">600.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">600.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">651.00</cbc:TaxInclusiveAmount>
     <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-    <cbc:PayableAmount currencyID="EUR">100.00</cbc:PayableAmount>
+    <cbc:PayableAmount currencyID="EUR">651.00</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>
@@ -172,11 +216,9 @@
         <cbc:ItemClassificationCode listID="CG">01.11.11</cbc:ItemClassificationCode>
       </cac:CommodityClassification>
       <cac:ClassifiedTaxCategory>
-        <cbc:ID>E</cbc:ID>
-        <cbc:Name>HR:E</cbc:Name>
-        <cbc:Percent>0.0</cbc:Percent>
-        <cbc:TaxExemptionReasonCode>VATEX-EU-143</cbc:TaxExemptionReasonCode>
-        <cbc:TaxExemptionReason>Exempt based on article 143 of Council Directive 2006/112/EC</cbc:TaxExemptionReason>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Name>HR:PDV25</cbc:Name>
+        <cbc:Percent>25.0</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
@@ -184,6 +226,53 @@
     </cac:Item>
     <cac:Price>
       <cbc:PriceAmount currencyID="EUR">100.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">200.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CG">01.11.11</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Name>HR:PDV13</cbc:Name>
+        <cbc:Percent>13.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">200.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>3</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">300.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CG">01.11.11</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>K</cbc:ID>
+        <cbc:Name>HR:K</cbc:Name>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt from VAT due to delivery within the EU</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">300.0</cbc:PriceAmount>
     </cac:Price>
   </cac:InvoiceLine>
 </Invoice>

--- a/addons/l10n_hr_edi/tests/test_ubl_hr.py
+++ b/addons/l10n_hr_edi/tests/test_ubl_hr.py
@@ -50,6 +50,55 @@ class TestL10nHrEdiXml(TestL10nHrEdiCommon, AccountTestInvoicingCommon):
             self.get_xml_tree_from_string(expected_content),
         )
 
+    def test_export_invoice_with_multiple_taxes(self):
+        """
+        Test content of a generated invoice with multiple taxes in Croation UBL format.
+        """
+        self.setup_partner_as_hr(self.env.company.partner_id)
+        self.setup_partner_as_hr_alt(self.partner_a)
+        tax_1 = self.env['account.chart.template'].ref('VAT_S_IN_ROC_25')
+        tax_2 = self.env['account.chart.template'].ref('VAT_S_IN_ROC_13')
+        tax_3 = self.env['account.chart.template'].ref('VAT_S_EU_G')
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2025-01-01',
+            'l10n_hr_process_type': 'P99',
+            'l10n_hr_customer_defined_process_name': 'Test custom process type',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 100.0,
+                    'tax_ids': [Command.set(tax_1.ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 200.0,
+                    'tax_ids': [Command.set(tax_2.ids)],
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 300.0,
+                    'tax_ids': [Command.set(tax_3.ids)],
+                }),
+            ],
+        })
+        invoice.action_post()
+        # Manually create the addendum which normally happens during sending
+        invoice.l10n_hr_edi_addendum_id = self.env['l10n_hr_edi.addendum'].create({
+            'move_id': invoice.id,
+            'invoice_sending_time': '2025-01-02',
+            'fiscalization_number': self.env['account.move']._get_l10n_hr_fiscalization_number(invoice.name),
+        })
+        actual_content, _dummy = self.env['account.edi.xml.ubl_hr'].with_context(lang='en_US')._export_invoice(invoice)
+        with misc.file_open(f'addons/{self.test_module}/tests/test_files/test_invoice_multiple.xml', 'rb') as file:
+            expected_content = file.read()
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(actual_content),
+            self.get_xml_tree_from_string(expected_content),
+        )
+
     def test_export_invoice_with_cash_basis(self):
         """
         Test content of a generated invoice with an 'on_payment' exigibility tax in Croation UBL format.
@@ -123,11 +172,19 @@ class TestL10nHrEdiXml(TestL10nHrEdiCommon, AccountTestInvoicingCommon):
 
     def test_export_invoice_with_exemption_e(self):
         """
-        Test the content of a generated invoice with HR:E exemption in Croation UBL format.
+        Test the content of a generated invoice with HR:E exemption,
+        filled from 'account_edi_ubl_cii_tax_extension' fields, in Croation UBL format.
         """
-        self.setup_partner_as_hr(self.env.company.partner_id)
+        tax_extension_module = self.env['ir.module.module']._get('account_edi_ubl_cii_tax_extension')
+        if tax_extension_module.state != 'installed':
+            self.skipTest("This test will fail if account_edi_ubl_cii_tax_extension is not installed")
+
+        self.setup_partner_as_hr(self.company_data['company'].partner_id)
         self.setup_partner_as_hr_alt(self.partner_a)
-        tax = self.env['account.chart.template'].ref('VAT_S_other_exempt_O')
+        company_id = self.company_data['company'].id
+        tax = self.env.ref(f'account.{company_id}_VAT_S_other_exempt_O')
+        tax.ubl_cii_tax_category_code = 'E'
+        tax.ubl_cii_tax_exemption_reason_code = 'VATEX-EU-143'
 
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_hr_edi/views/account_move_views.xml
+++ b/addons/l10n_hr_edi/views/account_move_views.xml
@@ -35,9 +35,6 @@
                     <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="move_type not in ('in_invoice', 'in_refund') or not l10n_hr_mer_document_eid or l10n_hr_fiscalization_status == '0' or invoice_date &gt;= '2026-01-01 00:00:00'"  role="alert">
                         <span>This document is dated before 01.01.2026 and is not fiscalized by MojEracun</span>
                     </div>
-                    <div class="alert alert-danger w-100 d-flex align-items-center gap-1" invisible="move_type not in ('in_invoice', 'in_refund') or not l10n_hr_mer_document_eid or l10n_hr_fiscalization_status == '0' or invoice_date &lt; '2026-01-01 00:00:00'"  role="alert">
-                        <span>This document is not successfully fiscalized by MojEracun</span>
-                    </div>
                     <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="not l10n_hr_mer_document_eid or l10n_hr_fiscalization_channel_type != '1'"  role="alert">
                         <span>Warning: this document was not successfully delivered to the recepient via EDI and needs to be sent manually (ex. via e-mail)</span>
                     </div>


### PR DESCRIPTION
- Improving the ubl_hr method chain to include less overrides in favor of extensions
- Adding proper handling of multiple tax total and tax category nodes for hrextac
- Refining docstrings and comments for ubl_hr
- Adding a test with multiple tax types
- Adding a test for account_edi_ubl_cii_tax_extension integration
- Adjusting MER methods to correspond to API changes: fiscalization queries are now only available for own documents
task-none

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
