### PR TITLE
[IMP] fleet: add multi-company support to vehicle models

### DIFF
--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -30,6 +30,7 @@ class FleetVehicleModel(models.Model):
         return [(str(i), i) for i in range(1970, current_year + 1)]
 
     name = fields.Char('Model name', required=True, tracking=True)
+    company_id = fields.Many2one('res.company', string='Company')
     brand_id = fields.Many2one('fleet.vehicle.model.brand', 'Manufacturer', required=True, tracking=True, index='btree_not_null')
     category_id = fields.Many2one('fleet.vehicle.model.category', 'Category', tracking=True)
     vendors = fields.Many2many('res.partner', 'fleet_vehicle_model_vendors', 'model_id', 'partner_id', string='Vendors')

--- a/addons/fleet/security/fleet_security.xml
+++ b/addons/fleet/security/fleet_security.xml
@@ -67,5 +67,11 @@
             <field name="global" eval="True"/>
             <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
         </record>
+        <record id="ir_rule_fleet_vehicle_model" model="ir.rule">
+            <field name="name">Fleet vehicle model: Multi Company</field>
+            <field name="model_id" ref="model_fleet_vehicle_model"/>
+            <field name="global" eval="True"/>
+            <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        </record>
     </data>
 </odoo>

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -35,6 +35,7 @@
                             <field name="active" invisible="1"/>
                             <field name="vehicle_type"/>
                             <field name="category_id" options="{'no_create_edit': True}"/>
+                            <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
Add a company_id field to fleet.vehicle.model to allow restricting vehicle models to specific companies. When empty, the model is available to all companies (default for existing records).

Changes:
- Add company_id field to fleet.vehicle.model
- Add multi-company record rule
- Update form, list, and search views with company field

Task id: 5906191
