### PR TITLE
[FIX] mail: link attachments to record in mass mail

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1099,7 +1099,10 @@ class MailComposer(models.TransientModel):
                 mail_values['attachment_ids'] = process_record._process_attachments_for_post(
                     decoded_attachments,
                     attachment_ids,
-                    {'model': 'mail.message', 'res_id': 0}
+                    {'model': 'mail.message', 'res_id': 0} if (
+                        not hasattr(record, "_process_attachments_for_post")
+                        or (self.auto_delete and not self.auto_delete_keep_log)
+                    ) else {}  # link to record if kept in chatter, this ensures users can download it
                 )['attachment_ids']
             # comment mode: prepare attachments as a list of IDs, to be processed by MailThread
             else:

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -2684,6 +2684,9 @@ class TestComposerResultsMass(TestMailComposer):
                                   default_template_id=self.template.id)
         ))
         composer = composer_form.save()
+        composer.attachment_ids = self.env['ir.attachment'].sudo().create(
+            self._generate_attachments_data(1, res_model=composer._name, res_id=composer.id)
+        )
         self.assertFalse(composer.reply_to_force_new, 'Mail: thread-enabled models should use auto thread by default')
         with self.mock_mail_gateway(mail_unlink_sent=True):
             composer._action_send_mail()
@@ -2708,6 +2711,11 @@ class TestComposerResultsMass(TestMailComposer):
             self.assertEqual(message.subject, 'TemplateSubject %s' % record.name)
             self.assertEqual(message.body, '<p>TemplateBody %s</p>' % record.name)
             self.assertEqual(message.author_id, self.user_employee.partner_id)
+            self.assertEqual(len(message.attachment_ids), 1)
+            self.assertEqual(message.attachment_ids.res_model, record._name)
+            self.assertEqual(message.attachment_ids.res_id, record.id)
+            self.assertEqual(composer.attachment_ids.name, message.attachment_ids.name)
+            self.assertEqual(composer.attachment_ids.datas, message.attachment_ids.datas)
             # post-related fields are void
             self.assertFalse(message.subtype_id)
             self.assertFalse(message.partner_ids)


### PR DESCRIPTION
**Steps to reproduce:**
- Install Event app
- Log as a user with Events/Administrator rights
- Ensure its Administration rights are not set to Settings
- Go to an open Event
- Add a new attendee with mail
- Ticket is automatically sent, and logged in chatter
- User doesn't have the rights to download the file from the chatter

**Issue:**
User has no 'read' access to `ir.attachment` due to a missing related record (res_model
and res_id are set to "mail.message" and 0 instead of the `event.registration` record).

It can be bypassed when the user also has system rights (or is the sender) and
it works properly when sending manually the mail.

**Fix:**
Reapply the fix used in 19.0+.
(We could also hide the attachment in chatter when it is not linked properly)

related: https://github.com/odoo/odoo/commit/19c78b2585cec9473ad2d2ab9101235c45a03314

opw-5349820
