### PR TITLE
[FIX] point_of_sale: prevent combo price from being doubled

### DIFF
--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_line_accounting.js
@@ -123,13 +123,13 @@ export class PosOrderlineAccounting extends Base {
     }
 
     get comboTotalPrice() {
-        const allLines = this.getAllLinesInCombo();
-        return allLines.reduce((total, line) => total + line.displayPrice, 0);
+        const childLines = this.getAllLinesInCombo().filter((line) => !line.combo_line_ids.length);
+        return childLines.reduce((total, line) => total + line.displayPrice, 0);
     }
 
     get comboTotalPriceWithoutTax() {
-        const allLines = this.getAllLinesInCombo();
-        return allLines.reduce((total, line) => total + line.displayPriceUnitExcl, 0);
+        const childLines = this.getAllLinesInCombo().filter((line) => !line.combo_line_ids.length);
+        return childLines.reduce((total, line) => total + line.displayPriceUnitExcl, 0);
     }
 
     get comboTotalBasePrice() {

--- a/addons/point_of_sale/static/tests/unit/accounting/price.test.js
+++ b/addons/point_of_sale/static/tests/unit/accounting/price.test.js
@@ -54,3 +54,29 @@ test("Prices excludes", async () => {
     expectFormattedPrice(order.lines[1].currencyDisplayPrice, "$ 100.00");
     expectFormattedPrice(order.lines[1].currencyDisplayPriceUnit, "$ 100.00");
 });
+
+test("Combo prices incl and excl", async () => {
+    const store = await setupPosEnv();
+    const order = store.addNewOrder();
+
+    const template = store.models["product.template"].get(7);
+    const comboProduct = store.models["product.combo.item"].get(1);
+
+    await store.addLineToOrder(
+        {
+            product_tmpl_id: template,
+            payload: [[{ combo_item_id: comboProduct, qty: 1 }]],
+            qty: 1,
+        },
+        order
+    );
+    order.setOrderPrices();
+
+    const [comboParentLine, comboChildLine] = order.lines;
+
+    expect(comboParentLine.comboTotalPrice).toBe(3.75);
+    expect(comboParentLine.comboTotalPriceWithoutTax).toBe(3);
+
+    expect(comboChildLine.comboTotalPrice).toBe(3.75);
+    expect(comboChildLine.comboTotalPriceWithoutTax).toBe(3);
+});


### PR DESCRIPTION
Combo product prices were doubled in the `comboTotalPrice` and
`comboTotalPriceWithoutTax` getters, as we were summing the
`displayPrice` of all the combo lines, including the parent line, which
already had its `displayPrice` as the sum of its children. So now, we
filter out the parent line in those getters before summing.