### PR TITLE
[FIX] website: add missing aria-label to modals

### DIFF
--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.xml
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.xml
@@ -3,7 +3,7 @@
 
     <t t-name="website.s_floating_blocks.alert.empty">
         <div class="container">
-            <div role="dialog" class="s_floating_blocks_alert_empty alert alert-info mx-auto text-center" style="width: var(--breakpoint-sm)">
+            <div role="dialog" class="s_floating_blocks_alert_empty alert alert-info mx-auto text-center" style="width: var(--breakpoint-sm)" aria-label="Floating blocks alert">
                 <i class="fa fa-plus-circle"/>
                 <span class="o_add_images"> Add Cards</span><br />
                 <small><strong>TIP:</strong> You need at least two cards to perform the effect</small>

--- a/addons/website/static/src/xml/website.xml
+++ b/addons/website/static/src/xml/website.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="website.prompt">
-        <div role="dialog" class="modal o_technical_modal" tabindex="-1">
+        <div role="dialog" class="modal o_technical_modal" tabindex="-1" aria-label="Prompt Dialog">
                 <div class="modal-dialog">
                 <div class="modal-content">
                     <header class="modal-header" t-if="window_title">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2566,7 +2566,8 @@
                  data-bs-backdrop="false"
                  data-bs-keyboard="false"
                  tabindex="-1"
-                 role="dialog">
+                 role="dialog"
+                 aria-label="Cookie bar">
                 <div class="modal-dialog d-flex s_popup_size_full">
                     <div class="modal-content oe_structure">
                         <!-- Keep this section equivalent to the rendering of the `website.cookies_bar.discrete` client template -->
@@ -2990,7 +2991,7 @@
         </t>
     </xpath>
     <xpath expr="//div[@id='wrapwrap']" position="before">
-        <div t-if="view" role="dialog" id="reset_template_confirmation" class="modal" tabindex="-1" t-ignore="true">
+        <div t-if="view" role="dialog" id="reset_template_confirmation" class="modal" tabindex="-1" t-ignore="true" aria-label="Reset template confirmation">
             <div class="modal-dialog">
                 <form role="form">
                     <div class="modal-content">


### PR DESCRIPTION
This PR adds missing aria-label attribute to several modals with `role="dialog"` in the website module to improve accessibility for screen reader users.

task-5172714