### PR TITLE
[IMP] mail: improve notification settings thread action

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -280,7 +280,12 @@ export class Action {
     _dropdown(action) {}
     /** Determines whether this action opens a dropdown on selection. */
     get dropdown() {
-        return this._dropdown(this.params) ?? this.definition.dropdown;
+        return (
+            this._dropdown(this.params) ??
+            (typeof this.definition.dropdown === "function"
+                ? this.definition.dropdown.call(this, this.params)
+                : this.definition.dropdown)
+        );
     }
 
     /** @param {Action} action @returns {Component|undefined} */

--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -15,8 +15,13 @@
             background-color: inherit;
         }
     
-        &.o-simulateDarkTheme.o-hasBtnBg:hover {
-            filter: brightness(1.3);
+        &.o-simulateDarkTheme {
+            &.o-hasBtnBg:hover {
+                filter: brightness(1.3);
+            }
+            &.o-dropdown-item:hover {
+                backdrop-filter: brightness(1.3);
+            }
         }
 
         &.o-inline {

--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -6,6 +6,10 @@ a.o_mail_redirect, a.o_channel_redirect, a.o_message_redirect_transformed {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .2), rgba(lighten($o-action, 5%), .3), lighten($o-action, 10%));
 }
 
+.o-discuss-dropdownMenu {
+    --discuss-dropdownMenuBg: #{$gray-100};
+}
+
 a.o-discuss-mention {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%));
 }

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -90,6 +90,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
         }
     }
 
+    &:not(.o-simulateDarkTheme) {
+        background-color: var(--discuss-dropdownMenuBg, $o-view-background-color);
+    }
+
     .o_bottom_sheet_sheet:has(&) {
         background-color: $gray-100;
         box-shadow: unset !important;

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -116,7 +116,6 @@ export class Store extends BaseStore {
         return attClassObjectToString({
             "o-discuss-dropdownMenu d-flex flex-column border-secondary": true,
             "o-simulateDarkTheme": simulateDarkTheme,
-            "bg-view": !simulateDarkTheme,
         });
     }
 

--- a/addons/mail/static/src/discuss/core/common/notification_settings.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.dark.scss
@@ -1,3 +1,3 @@
 .o-discuss-NotificationSettings {
-    --mail-NotificationSettings-btnHoverBg: #{$gray-300};
+    --mail-NotificationSettings-btnHoverBg: #{$gray-200};
 }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -6,6 +6,8 @@ import { useService } from "@web/core/utils/hooks";
 import { DiscussNotificationSettingsClientAction } from "./discuss_notification_settings_client_action";
 import { Dialog } from "@web/core/dialog/dialog";
 import { DROPDOWN_NESTING } from "@web/core/dropdown/_behaviours/dropdown_nesting";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
+import { useHover } from "@mail/utils/common/hooks";
 
 class NotificationDialog extends Component {
     static props = ["close?"];
@@ -27,6 +29,11 @@ export class NotificationSettings extends Component {
         this.dialog = useService("dialog");
         this.ui = useService("ui");
         this.DROPDOWN_NESTING = DROPDOWN_NESTING;
+        this.muteConversationDropdownState = useDropdownState();
+        this.muteConversationHover = useHover(["mute-button", "mute-menu"], {
+            onHover: () => (this.muteConversationDropdownState.isOpen = true),
+            onAway: () => (this.muteConversationDropdownState.isOpen = false),
+        });
     }
 
     setMute(minutes) {

--- a/addons/mail/static/src/discuss/core/common/notification_settings.js
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.js
@@ -5,6 +5,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useService } from "@web/core/utils/hooks";
 import { DiscussNotificationSettingsClientAction } from "./discuss_notification_settings_client_action";
 import { Dialog } from "@web/core/dialog/dialog";
+import { DROPDOWN_NESTING } from "@web/core/dropdown/_behaviours/dropdown_nesting";
 
 class NotificationDialog extends Component {
     static props = ["close?"];
@@ -25,6 +26,7 @@ export class NotificationSettings extends Component {
         this.store = useService("mail.store");
         this.dialog = useService("dialog");
         this.ui = useService("ui");
+        this.DROPDOWN_NESTING = DROPDOWN_NESTING;
     }
 
     setMute(minutes) {

--- a/addons/mail/static/src/discuss/core/common/notification_settings.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.scss
@@ -7,9 +7,9 @@
         min-width: 20px;
     }
 
-    button {
+    .btn {
         &:hover, &.show {
-            background-color: var(--mail-NotificationSettings-btnHoverBg, $gray-200);
+            background-color: var(--mail-NotificationSettings-btnHoverBg, mix($gray-100, $gray-200));
         }
     }
 }

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.NotificationSettings">
-        <ActionPanel t-if="ui.isSmall" title.translate="Notification Settings" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-bell'">
+        <ActionPanel t-if="!env[DROPDOWN_NESTING] and env.inChatWindow" title.translate="Notification Settings" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-bell'">
             <t t-call="discuss.NotificationSettings.content"/>
         </ActionPanel>
         <t t-else="" t-call="discuss.NotificationSettings.content"/>
@@ -12,58 +12,60 @@
         <div class="o-discuss-NotificationSettings">
             <t t-if="props.channel.channel_type === 'channel'">
                 <t t-call="discuss.NotificationSettings.unMuteSttings" />
-                <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" menuClass="'o-mail-NotificationSettings-submenu my-0 ' + store.discussDropdownMenuClass(this)">
-                    <button class="btn w-100 d-flex opacity-75 border-0">
-                        <div class="d-flex flex-grow-1 align-items-center px-0 py-1 w-100 rounded">
-                            <span class="text-wrap text-start text-break">Mute Conversation</span>
-                            <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                            <i t-if="!env[DROPDOWN_NESTING]" class="fa fa-caret-right fa-lg mx-2"/>
-                        </div>
+                <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" state="muteConversationDropdownState" menuClass="'o-mail-NotificationSettings-submenu my-0 py-0 ' + store.discussDropdownMenuClass(this)" manual="true">
+                    <button class="btn w-100 d-flex border-0 py-2 opacity-100-hover" t-att-class="{
+                        'o-px-2_5': env[DROPDOWN_NESTING],
+                        'o-ps-2_5 o-pe-1_5': !env[DROPDOWN_NESTING],
+                        'opacity-100': muteConversationDropdownState.isOpen,
+                        'opacity-75': !muteConversationDropdownState.isOpen,
+                    }" t-ref="mute-button">
+                        <span class="text-wrap text-start text-break">Mute Conversation</span>
+                        <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
+                        <i t-if="!env[DROPDOWN_NESTING]" class="fa fa-caret-right fa-lg mx-2"/>
                     </button>
                     <t t-set-slot="content">
                         <t t-call="discuss.NotificationSettings.muteSttings"/>
                     </t>
                 </Dropdown>
-                <hr class="solid mx-1 my-2"/>
-                <button class="btn d-flex w-100 p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(false, props.channel)">
-                    <div class="d-flex flex-grow-1 align-items-center px-2 rounded">
-                        <div class="d-flex flex-column align-items-start">
-                            <span class="fs-6 text-wrap text-start text-break">Use Default</span>
-                            <span class="o-fw-600 o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
-                        </div>
-                        <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                        <input class="form-check-input shadow-sm" type="radio" t-att-checked="!props.channel.self_member_id?.custom_notifications"/>
+                <hr class="solid o-mx-2_5 mt-1 mb-2"/>
+                <button class="btn d-flex w-100 o-ps-2_5 o-pe-1_5 py-1 border-0 opacity-75 opacity-100-hover" t-on-click="() => store.settings.setCustomNotifications(false, props.channel)">
+                    <div class="d-flex flex-column align-items-start">
+                        <span class="fs-6 text-wrap text-start text-break">Use Default</span>
+                        <span class="o-fw-600 o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
                     </div>
+                    <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
+                    <input class="form-check-input shadow-sm me-1" type="radio" t-att-checked="!props.channel.self_member_id?.custom_notifications"/>
                 </button>
                 <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
-                    <button class="btn w-100 d-flex p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.channel)">
-                        <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
-                            <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
-                            <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                            <input class="form-check-input ms-2 shadow-sm" type="radio" t-att-checked="props.channel.self_member_id?.custom_notifications === notif.label"/>
-                        </div>
+                    <button class="btn w-100 d-flex o-ps-2_5 o-pe-1_5 py-1 border-0 opacity-75 opacity-100-hover" t-att-class="{ 'mb-1': notif_last and !env[DROPDOWN_NESTING] }" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.channel)">
+                        <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
+                        <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
+                        <input class="form-check-input ms-2 shadow-sm me-1" type="radio" t-att-checked="props.channel.self_member_id?.custom_notifications === notif.label"/>
                     </button>
                 </t>
             </t>
-            <t t-else="" t-call="discuss.NotificationSettings.muteSttings"/>
+            <t t-else="">
+                <span t-if="!env[DROPDOWN_NESTING]" class="p-2 pb-0 d-flex smaller fw-bold text-muted">Mute Conversation</span>
+                <t t-call="discuss.NotificationSettings.muteSttings"/>
+            </t>
         </div>
     </t>
 
     <t t-name="discuss.NotificationSettings.muteSttings">
-        <div class="d-flex flex-column" >
+        <div class="d-flex flex-column" t-attf-class="{{ store.discussDropdownMenuClass(this) }}" t-ref="mute-menu">
             <t t-if="props.channel.channel_type !== 'channel'" t-call="discuss.NotificationSettings.unMuteSttings" />
             <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
-                <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="()=>this.setMute(mute.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="mute.name"/></DropdownItem>
+                <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn btn-secondary rounded-0 d-flex align-items-center px-3 o-py-1_5 m-0'" onSelected="()=>this.setMute(mute.value)"><t t-out="mute.name"/></DropdownItem>
             </t>
         </div>
     </t>
 
     <t t-name="discuss.NotificationSettings.unMuteSttings">
         <t t-if="props.channel.self_member_id?.mute_until_dt">
-            <button class="btn w-100 d-flex p-1 opacity-75 border-0" t-on-click="()=>this.setMute(false)">
-                <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
+            <button class="btn w-100 d-flex o-px-2_5 py-1 opacity-75 border-0 opacity-75 opacity-100-hover" t-on-click="()=>this.setMute(false)">
+                <div class="d-flex flex-column flex-grow-1 w-100 rounded">
                     <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Conversation</span>
-                    <span class="fw-normal smaller text-start" t-out="store.settings.getMuteUntilText(props.channel.self_member_id?.mute_until_dt)"/>
+                    <span class="fw-normal smaller text-start text-muted" t-out="store.settings.getMuteUntilText(props.channel.self_member_id?.mute_until_dt)"/>
                 </div>
             </button>
         </t>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -2,56 +2,71 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.NotificationSettings">
-        <ActionPanel title.translate="Notification Settings" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-bell'">
-            <div class="o-discuss-NotificationSettings">
-                <t t-if="props.channel.self_member_id?.mute_until_dt">
-                    <button class="btn w-100 d-flex p-1 opacity-75 border-0" t-on-click="()=>this.setMute(false)">
-                        <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
-                            <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Conversation</span>
-                            <span class="fw-normal smaller text-start" t-out="store.settings.getMuteUntilText(props.channel.self_member_id?.mute_until_dt)"/>
-                        </div>
-                    </button>
-                </t>
-                <div class="d-flex">
-                    <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" menuClass="'o-mail-NotificationSettings-submenu my-0 ' + store.discussDropdownMenuClass(this)">
-                        <button class="btn w-100 d-flex p-1 opacity-75 border-0">
-                            <div class="d-flex flex-grow-1 align-items-center px-0 py-1 w-100 rounded">
-                                <span class="text-wrap text-start text-break">Mute Conversation</span>
-                                <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                                <i class="oi oi-arrow-right ms-2 me-1"/>
-                            </div>
-                        </button>
-                        <t t-set-slot="content">
-                            <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
-                                <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="()=>this.setMute(mute.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="mute.name"/></DropdownItem>
-                            </t>
-                        </t>
-                    </Dropdown>
-                </div>
-                <t t-if="props.channel.channel_type === 'channel'">
-                    <hr class="solid mx-1 my-2"/>
-                    <button class="btn d-flex w-100 p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(false, props.channel)">
-                        <div class="d-flex flex-grow-1 align-items-center px-2 rounded">
-                            <div class="d-flex flex-column align-items-start">
-                                <span class="fs-6 text-wrap text-start text-break">Use Default</span>
-                                <span class="fw-bolder o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
-                            </div>
-                            <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                            <input class="form-check-input shadow-sm" type="radio" t-att-checked="!props.channel.self_member_id?.custom_notifications"/>
-                        </div>
-                    </button>
-                    <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
-                        <button class="btn w-100 d-flex p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.channel)">
-                            <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
-                                <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
-                                <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                                <input class="form-check-input ms-2 shadow-sm" type="radio" t-att-checked="props.channel.self_member_id?.custom_notifications === notif.label"/>
-                            </div>
-                        </button>
-                    </t>
-                </t>
-            </div>
+        <ActionPanel t-if="ui.isSmall" title.translate="Notification Settings" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-bell'">
+            <t t-call="discuss.NotificationSettings.content"/>
         </ActionPanel>
+        <t t-else="" t-call="discuss.NotificationSettings.content"/>
+    </t>
+
+    <t t-name="discuss.NotificationSettings.content">
+        <div class="o-discuss-NotificationSettings">
+            <t t-if="props.channel.channel_type === 'channel'">
+                <t t-call="discuss.NotificationSettings.unMuteSttings" />
+                <Dropdown position="ui.isSmall ? 'bottom-end' : 'right-start'" menuClass="'o-mail-NotificationSettings-submenu my-0 ' + store.discussDropdownMenuClass(this)">
+                    <button class="btn w-100 d-flex opacity-75 border-0">
+                        <div class="d-flex flex-grow-1 align-items-center px-0 py-1 w-100 rounded">
+                            <span class="text-wrap text-start text-break">Mute Conversation</span>
+                            <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
+                            <i t-if="!env[DROPDOWN_NESTING]" class="fa fa-caret-right fa-lg mx-2"/>
+                        </div>
+                    </button>
+                    <t t-set-slot="content">
+                        <t t-call="discuss.NotificationSettings.muteSttings"/>
+                    </t>
+                </Dropdown>
+                <hr class="solid mx-1 my-2"/>
+                <button class="btn d-flex w-100 p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(false, props.channel)">
+                    <div class="d-flex flex-grow-1 align-items-center px-2 rounded">
+                        <div class="d-flex flex-column align-items-start">
+                            <span class="fs-6 text-wrap text-start text-break">Use Default</span>
+                            <span class="o-fw-600 o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
+                        </div>
+                        <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
+                        <input class="form-check-input shadow-sm" type="radio" t-att-checked="!props.channel.self_member_id?.custom_notifications"/>
+                    </div>
+                </button>
+                <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
+                    <button class="btn w-100 d-flex p-0 border-0" t-on-click="() => store.settings.setCustomNotifications(notif.label, props.channel)">
+                        <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
+                            <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
+                            <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
+                            <input class="form-check-input ms-2 shadow-sm" type="radio" t-att-checked="props.channel.self_member_id?.custom_notifications === notif.label"/>
+                        </div>
+                    </button>
+                </t>
+            </t>
+            <t t-else="" t-call="discuss.NotificationSettings.muteSttings"/>
+        </div>
+    </t>
+
+    <t t-name="discuss.NotificationSettings.muteSttings">
+        <div class="d-flex flex-column" >
+            <t t-if="props.channel.channel_type !== 'channel'" t-call="discuss.NotificationSettings.unMuteSttings" />
+            <t t-foreach="store.settings.MUTES" t-as="mute" t-key="mute.label">
+                <DropdownItem class="'o-mail-NotificationSettings-muteDuration btn rounded-0 d-flex align-items-center px-2 py-2 m-0'" onSelected="()=>this.setMute(mute.value)"><button class="btn p-0 mx-2 text-wrap text-start text-break" t-out="mute.name"/></DropdownItem>
+            </t>
+        </div>
+    </t>
+
+    <t t-name="discuss.NotificationSettings.unMuteSttings">
+        <t t-if="props.channel.self_member_id?.mute_until_dt">
+            <button class="btn w-100 d-flex p-1 opacity-75 border-0" t-on-click="()=>this.setMute(false)">
+                <div class="d-flex flex-column flex-grow-1 px-2 py-1 w-100 rounded">
+                    <span class="fs-6 fw-bold text-wrap text-start text-break">Unmute Conversation</span>
+                    <span class="fw-normal smaller text-start" t-out="store.settings.getMuteUntilText(props.channel.self_member_id?.mute_until_dt)"/>
+                </div>
+            </button>
+        </t>
     </t>
 
 </templates>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -109,13 +109,7 @@ registerThreadAction("notification-settings", {
     actionPanelComponent: NotificationSettings,
     actionPanelComponentProps: ({ channel }) => ({ channel }),
     actionPanelOpen({ channel, owner, store }) {
-        if (owner.isDiscussSidebarChannelActions || owner.env.inMeetingView) {
-            store.env.services.dialog?.add(ChannelActionDialog, {
-                title: channel.displayName,
-                contentComponent: NotificationSettings,
-                contentProps: { channel },
-            });
-        } else {
+        if (owner.isDiscussContent) {
             this.popover?.open(owner.root.el.querySelector(`[name="${this.id}"]`), {
                 hasSizeConstraints: true,
                 channel,
@@ -123,6 +117,9 @@ registerThreadAction("notification-settings", {
         }
     },
     actionPanelOuterClass: "bg-100 border border-secondary",
+    dropdown: ({ owner }) => !owner.isDiscussContent,
+    dropdownComponent: NotificationSettings,
+    dropdownComponentProps: ({ channel }) => ({ channel }),
     condition: ({ channel, owner, store }) =>
         channel && store.self_user && (!owner.props.chatWindow || owner.props.chatWindow.isOpen),
     setup({ owner }) {
@@ -136,10 +133,11 @@ registerThreadAction("notification-settings", {
         }
     },
     icon: ({ channel }) =>
-        channel.self_member_id?.mute_until_dt
+        channel?.self_member_id?.mute_until_dt
             ? "fa fa-fw text-danger fa-bell-slash"
             : "fa fa-fw fa-bell",
-    name: _t("Notification Settings"),
+    name: ({ channel }) =>
+        channel.channel_type == "channel" ? _t("Notification Settings") : _t("Mute Conversation"),
     sequence: 10,
     sequenceGroup: 30,
 });

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -116,7 +116,7 @@ registerThreadAction("notification-settings", {
             });
         }
     },
-    actionPanelOuterClass: "bg-100 border border-secondary",
+    actionPanelOuterClass: ({ owner, store }) => store.discussDropdownMenuClass(owner),
     dropdown: ({ owner }) => !owner.isDiscussContent,
     dropdownComponent: NotificationSettings,
     dropdownComponentProps: ({ channel }) => ({ channel }),
@@ -178,10 +178,10 @@ registerThreadAction("invite-people", {
             });
         }
     },
-    actionPanelOuterClass: ({ owner }) =>
+    actionPanelOuterClass: ({ owner, store }) =>
         `o-discuss-ChannelInvitation ${
             owner.props.chatWindow ? "bg-inherit" : ""
-        } bg-100 border border-secondary`,
+        } border border-secondary ` + store.discussDropdownMenuClass(owner),
     condition: ({ channel, owner }) =>
         channel &&
         !owner.env.pipWindow &&

--- a/addons/mail/static/src/discuss/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_actions.js
@@ -16,7 +16,7 @@ registerThreadAction("show-threads", {
             channel: channel.parent_channel_id || channel,
         });
     },
-    actionPanelOuterClass: "bg-100 border border-secondary",
+    actionPanelOuterClass: ({ owner, store }) => store.discussDropdownMenuClass(owner),
     condition: ({ channel, owner }) =>
         (channel?.hasSubChannelFeature || channel?.parent_channel_id?.hasSubChannelFeature) &&
         !owner.isDiscussSidebarChannelActions,

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -5,6 +5,7 @@ import {
     contains,
     defineMailModels,
     focus,
+    hover,
     inputFiles,
     insertText,
     isInViewportOf,
@@ -881,13 +882,13 @@ test("Notification settings rendering in chatwindow", async () => {
     await contains("button:has(:text('Nothing'))");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("button:has(:text('Mute Conversation'))");
-    await click("button:has(:text('Mute Conversation'))");
-    await contains("button:text('For 15 minutes')");
-    await contains("button:text('For 1 hour')");
-    await contains("button:text('For 3 hours')");
-    await contains("button:text('For 8 hours')");
-    await contains("button:text('For 24 hours')");
-    await contains("button:text('Until I turn it back on')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await contains(".o-dropdown-item:text('For 15 minutes')");
+    await contains(".o-dropdown-item:text('For 1 hour')");
+    await contains(".o-dropdown-item:text('For 3 hours')");
+    await contains(".o-dropdown-item:text('For 8 hours')");
+    await contains(".o-dropdown-item:text('For 24 hours')");
+    await contains(".o-dropdown-item:text('Until I turn it back on')");
 });
 
 test("open channel in chat window from push notification", async () => {

--- a/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/sub_channels.test.js
@@ -2,6 +2,7 @@ import {
     click,
     contains,
     defineMailModels,
+    hover,
     insertText,
     onRpcAfter,
     openDiscuss,
@@ -271,8 +272,8 @@ test("sub-thread is visually muted when mute is active", async () => {
     await contains(".opacity-50.o-mail-DiscussSidebar-item:contains('New Thread')", { count: 0 });
     await click(".o-mail-DiscussSidebar-item:contains('New Thread')");
     await click("button[title='Notification Settings']");
-    await click("button:contains('Mute Conversation')");
-    await click("button:contains('Until I turn it back on')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await click(".o-dropdown-item:contains('Until I turn it back on')");
     await contains(".opacity-50.o-mail-DiscussSidebar-item:contains('New Thread')");
 });
 
@@ -295,8 +296,8 @@ test("muted channel hides sub-thread unless channel is selected or thread has un
     await openDiscuss(channelId);
     await click(".o-mail-DiscussSidebar-item:contains('General')");
     await click("button[title='Notification Settings']");
-    await click("button:contains('Mute Conversation')");
-    await click("button:contains('Until I turn it back on')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await click(".o-dropdown-item:contains('Until I turn it back on')");
     await click(".o-mail-DiscussSidebar-item:contains('Other')");
     await contains(".o-mail-DiscussSidebar-item:contains('New Thread')", { count: 0 });
     await click(".o-mail-DiscussSidebar-item:contains('General')");

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -2410,13 +2410,13 @@ test("Notification settings: basic rendering", async () => {
     await contains("button:text('Nothing')");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("button:text('Mute Conversation')");
-    await click("button:text('Mute Conversation')");
-    await contains("button:text('For 15 minutes')");
-    await contains("button:text('For 1 hour')");
-    await contains("button:text('For 3 hours')");
-    await contains("button:text('For 8 hours')");
-    await contains("button:text('For 24 hours')");
-    await contains("button:text('Until I turn it back on')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await contains(".o-dropdown-item:text('For 15 minutes')");
+    await contains(".o-dropdown-item:text('For 1 hour')");
+    await contains(".o-dropdown-item:text('For 3 hours')");
+    await contains(".o-dropdown-item:text('For 8 hours')");
+    await contains(".o-dropdown-item:text('For 24 hours')");
+    await contains(".o-dropdown-item:text('Until I turn it back on')");
 });
 
 test("Notification settings: mute conversation will change the style of sidebar", async () => {
@@ -2434,8 +2434,8 @@ test("Notification settings: mute conversation will change the style of sidebar"
     await click("[title='Notification Settings']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("button:text('Mute Conversation')");
-    await click("button:text('Mute Conversation')");
-    await click("button:text('For 15 minutes')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await click(".o-dropdown-item:text('For 15 minutes')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Mario Party')");
     await contains(".o-mail-DiscussSidebar-item[class*='opacity-50']:text('Mario Party')");
 });
@@ -2455,15 +2455,15 @@ test("Notification settings: change the mute duration of the conversation", asyn
     await click("[title='Notification Settings']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("button:text('Mute Conversation')");
-    await click("button:text('Mute Conversation')");
-    await click("button:text('For 15 minutes')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await click(".o-dropdown-item:text('For 15 minutes')");
     await click("[title='Notification Settings']");
     await click(".o-discuss-NotificationSettings span:text('Unmute Conversation')");
     await click("[title='Notification Settings']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("button:text('Mute Conversation')");
-    await click("button:text('Mute Conversation')");
-    await click("button:text('For 1 hour')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await click(".o-dropdown-item:text('For 1 hour')");
 });
 
 test("Notification settings: mute/unmute conversation works correctly", async () => {
@@ -2478,8 +2478,8 @@ test("Notification settings: mute/unmute conversation works correctly", async ()
     await click("[title='Notification Settings']");
     // dropdown requires an extra delay before click (because handler is registered in useEffect)
     await contains("button:text('Mute Conversation')");
-    await click("button:text('Mute Conversation')");
-    await click("button:text('For 15 minutes')");
+    await hover("button:has(:text('Mute Conversation'))");
+    await click(".o-dropdown-item:text('For 15 minutes')");
     await click("[title='Notification Settings']");
     await contains("button:has(:text('Unmute Conversation'))");
     await click("button:has(:text('Unmute Conversation'))");

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -312,7 +312,7 @@ test("sidebar: basic chat rendering", async () => {
     await waitFor(`${group[1]} .o-dropdown-item:eq(0):text('Invite People')`);
     await waitFor(`${group[1]} .o-dropdown-item:eq(1):text('Add to Favorites')`);
     await waitFor(`${group[2]} .o-dropdown-item:count(2)`);
-    await waitFor(`${group[2]} .o-dropdown-item:eq(0):text('Notification Settings')`);
+    await waitFor(`${group[2]} .o-dropdown-item:eq(0):text('Mute Conversation')`);
     await waitFor(`${group[2]} .o-dropdown-item:eq(1):text('Advanced Settings')`);
     await waitFor(`${group[3]} .o-dropdown-item:count(1)`);
     await waitFor(`${group[3]} .o-dropdown-item:text('Hide Until New Message')`);


### PR DESCRIPTION
Before this PR, opening the notification settings from the thread action (In Discuss App) displayed them in a dialog, which made the UI less consistent with other thread actions.

After this commit, opening the notification settings from the thread action displays them in a dropdown instead of a dialog, providing a more consistent and streamlined user experience.

Task-5936685


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
