### PR TITLE
[FIX] loyalty: remove duplicated gift card

### DIFF
--- a/addons/loyalty/data/loyalty_data.xml
+++ b/addons/loyalty/data/loyalty_data.xml
@@ -42,6 +42,7 @@
         <field name="discount_applicability">order</field>
         <field name="required_points">1</field>
         <field name="program_id" ref="loyalty.gift_card_program"/>
+        <field name="discount_line_product_id" ref="gift_card_product_50"/>
     </record>
     <record id="gift_card_program_rule" model="loyalty.rule">
         <field name="reward_point_amount">1</field>


### PR DESCRIPTION
Current behavior before PR: When creating a database, two gift card products appear in eCommerce>Products. This happens because the link between the reward record and a product was missing, which caused Odoo to auto-generate a duplicate, visible product for the reward.

In this commit, we explicitly linked the gift card reward to the gift card product, preventing the creation of an unwanted "ghost" product in the shop.

task-5865210