### PR TITLE
[IMP] point_of_sale: pre-fill partner form with search query

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -220,6 +220,7 @@
             ('remove', 'web/static/src/webclient/actions/reports/report_layouts.scss'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'google_address_autocomplete/static/src/**/*',
+            'point_of_sale/static/src/backend/pos_res_partner_view/*',
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_list.js
@@ -77,9 +77,16 @@ export class PartnerList extends Component {
         }
     }
     async editPartner(p = false) {
-        const partner = await this.pos.editPartner(p);
-        if (partner) {
-            this.clickPartner(partner);
+        if (this.state.query) {
+            this.pos.partnerSearchContext = this.state.query;
+        }
+        try {
+            const partner = await this.pos.editPartner(p);
+            if (partner) {
+                this.clickPartner(partner);
+            }
+        } finally {
+            delete this.pos.partnerSearchContext;
         }
     }
     async onEnter() {
@@ -157,6 +164,8 @@ export class PartnerList extends Component {
     }
     clickPartner(partner) {
         this.props.getPayload(partner);
+        this.state.query = "";
+        delete this.pos.partnerSearchContext;
         this.props.close();
     }
     async searchPartner() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1886,7 +1886,20 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     editPartnerContext(partner) {
-        return {};
+        const context = {};
+        if (this.partnerSearchContext) {
+            const isPhoneNumber = /^\+?[()\d\s-.]{8,18}$/.test(
+                this.partnerSearchContext.replace(/[+\s().-]/g, "")
+            );
+            if (isPhoneNumber) {
+                context.default_phone = this.partnerSearchContext;
+                context.default_focus = "phone";
+            } else {
+                context.default_name = this.partnerSearchContext;
+                context.default_focus = "name";
+            }
+        }
+        return context;
     }
     /**
      * @param {import("@point_of_sale/app/models/res_partner").ResPartner?} partner leave undefined to create a new partner

--- a/addons/point_of_sale/static/src/backend/pos_res_partner_view/res_partner_form_focus.js
+++ b/addons/point_of_sale/static/src/backend/pos_res_partner_view/res_partner_form_focus.js
@@ -1,0 +1,21 @@
+import { FormRenderer } from "@web/views/form/form_renderer";
+import { patch } from "@web/core/utils/patch";
+import { onMounted } from "@odoo/owl";
+
+patch(FormRenderer.prototype, {
+    setup() {
+        super.setup();
+
+        onMounted(() => {
+            const context = this.props.record.context || {};
+            const focusFieldName = context.default_focus;
+
+            if (focusFieldName) {
+                const input = document.querySelector(`[name=${focusFieldName}] input`);
+                if (input) {
+                    input.focus();
+                }
+            }
+        });
+    },
+});

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -19,6 +19,7 @@ import { checkPreparationTicketData } from "@point_of_sale/../tests/pos/tours/ut
 import * as Utils from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as BackendUtils from "@point_of_sale/../tests/pos/tours/utils/backend_utils";
 import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
+import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     steps: () =>
@@ -1347,5 +1348,38 @@ registry.category("web_tour.tours").add("test_orderline_merge_with_higher_price_
             ProductScreen.clickDisplayedProduct("High Precision Product"),
             ProductScreen.selectedOrderlineHas("High Precision Product", "2.0", "16.49"), // 8.245 * 2 = 16.49
             Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_customer_search_prefilled_on_create", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.searchCustomer("test customer"),
+            {
+                content: "Wait",
+                trigger: "body",
+                async run() {
+                    await delay(100); //Search input debounce 100
+                },
+            },
+            PartnerList.clickPartnerCreateBtn(),
+
+            PartnerList.checkInputForm("name", "test customer"),
+            PartnerList.selectFormDiscard(),
+
+            PartnerList.searchCustomer("+(123) 45.67-89"),
+            {
+                content: "Wait",
+                trigger: "body",
+                async run() {
+                    await delay(100); //Search input debounce 100
+                },
+            },
+            PartnerList.clickPartnerCreateBtn(),
+            PartnerList.checkInputForm("phone", "+(123) 45.67-89"),
+            PartnerList.selectFormDiscard(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -1,4 +1,5 @@
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
+import { selectButton } from "@point_of_sale/../tests/pos/tours/utils/common";
 
 export function clickPartner(name = "", { expectUnloadPage = false } = {}) {
     return {
@@ -115,9 +116,8 @@ export function checkCustomerShown(val) {
         trigger: `.partner-list .partner-info:nth-child(1):contains("${val}")`,
     };
 }
-
-export function searchCustomerValue(val, pressEnter = false) {
-    const steps = [
+export function searchCustomer(val) {
+    return [
         {
             isActive: ["mobile"],
             content: `Click search field`,
@@ -130,6 +130,10 @@ export function searchCustomerValue(val, pressEnter = false) {
             run: `edit ${val}`,
         },
     ];
+}
+
+export function searchCustomerValue(val, pressEnter = false) {
+    const steps = searchCustomer(val);
 
     if (pressEnter) {
         steps.push({
@@ -172,5 +176,42 @@ export function isShown() {
             content: "partner list screen is shown",
             trigger: ".modal .partner-list",
         },
+    ];
+}
+
+export function selectFormDiscard() {
+    return [
+        {
+            trigger: "button.o_form_button_cancel",
+            content: "Click on discard the customer form",
+            run: "click",
+        },
+    ];
+}
+
+export function checkInputForm(fieldName, expectedValue) {
+    return [
+        {
+            trigger: `div[name="${fieldName}"] .o_input`,
+            content: `Check if "${expectedValue}" in form div "${fieldName}"`,
+            run() {
+                const input = document.querySelector(`div[name="${fieldName}"] .o_input`);
+                if (!input) {
+                    throw new Error(`Element div[name="${fieldName}"] .o_input not found`);
+                }
+                if (input.value !== expectedValue) {
+                    throw new Error(
+                        `Validation failed: expected "${expectedValue}", got "${input.value}"`
+                    );
+                }
+            },
+        },
+    ];
+}
+
+export function clickPartnerCreateBtn() {
+    return [
+        { ...selectButton("Create"), isActive: ["desktop"] },
+        { ...selectButton("New"), isActive: ["mobile"] },
     ];
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -90,6 +90,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
                 (4, cls.env.ref('base.group_user').id),
                 (4, cls.env.ref('point_of_sale.group_pos_user').id),
                 (4, cls.env.ref('stock.group_stock_user').id),
+                (4, cls.env.ref('base.group_partner_manager').id),
             ],
             'tz': 'America/New_York',
         })
@@ -3988,6 +3989,10 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_pos_open_ui_button(self):
         """ Test the Open Register button click behavior in the dashboard. """
         self.start_tour("/odoo/point-of-sale", 'test_pos_open_ui_button', login="pos_user")
+
+    def test_customer_search_prefilled_on_create(self):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_customer_search_prefilled_on_create')
 
 
 # This class just runs the same tests as above but with mobile emulation


### PR DESCRIPTION
If a user searches for a partner and no match is found, clicking "Create" will now automatically transfer the search term into the appropriate field (name or phone) in the creation form. The matched input is also auto-focused.

Task-4991076

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
