### PR TITLE
[FIX] website: prevent badge option merging issues

### DIFF
--- a/addons/website/static/src/builder/plugins/options/badge_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/badge_option_plugin.js
@@ -16,6 +16,7 @@ class BadgeOptionPlugin extends Plugin {
     resources = {
         builder_options: [withSequence(before(ANIMATE), BadgeOption)],
         so_content_addition_selector: [".s_badge"],
+        unsplittable_node_predicates: (node) => node.classList?.contains("s_badge"),
     };
 }
 registry.category("website-plugins").add(BadgeOptionPlugin.id, BadgeOptionPlugin);

--- a/addons/website/static/tests/builder/options/badge_option.test.js
+++ b/addons/website/static/tests/builder/options/badge_option.test.js
@@ -1,0 +1,17 @@
+import { expect, test } from "@odoo/hoot";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+
+test("adjacent s_badge elements should not be merged", async () => {
+    const { getEditor } = await setupWebsiteBuilder(
+        `<p><span class="s_badge badge rounded-pill text-bg-primary">Badge 1</span><span class="s_badge badge rounded-pill text-bg-primary">Badge 2</span></p>`
+    );
+    const editor = getEditor();
+    // Trigger mergeAdjacentInlines
+    editor.shared.history.addStep();
+    expect(editor.editable.querySelectorAll(".s_badge")).toHaveLength(2);
+});


### PR DESCRIPTION
Steps to reproduce:
- Go to Website > Edit a page
- Add a badge using editor
- Duplicate that badge more than once
- Save

-> badges intersect each other

Cause:
======
When saving, `cleanForSave` will be triggered which then will call `mergeAdjacentInlines`, since badges are inline elements, they will be merged into one single badge causing that issue.

Solution:
=========
We add a predicate to `unsplittable_node_predicates` to prevent `mergeAdjacentInlines` from merging badges.

opw-5790891

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
