### PR TITLE
[IMP] sale_gelato: allow using PDF file as Gelato print file

### DIFF
--- a/addons/sale_gelato/models/product_document.py
+++ b/addons/sale_gelato/models/product_document.py
@@ -21,7 +21,7 @@ class ProductDocument(models.Model):
             raise UserError(_("Print images must be set on products before they can be ordered."))
 
         query_string = f'access_token={self.ir_attachment_id.generate_access_token()[0]}'
-        url = f'{self.get_base_url()}{self.ir_attachment_id.image_src}?{query_string}'
+        url = f'{self.get_base_url()}/web/content/{self.ir_attachment_id.id}?{query_string}'
         return {
             'type': self.name.lower(),  # Gelato requires lowercase types.
             'url': url,

--- a/addons/sale_gelato/views/product_document_views.xml
+++ b/addons/sale_gelato/views/product_document_views.xml
@@ -8,7 +8,8 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
-                    <field name="datas" widget="image" nolabel="True"/>
+                    <field name="datas" widget="image" nolabel="True"
+                           options='{"accepted_file_extensions": "application/pdf,image/png,image/tiff,image/svg+xml,image/jpeg"}'/>
                 </sheet>
             </form>
         </field>


### PR DESCRIPTION
When Gelato print a Mug or a Tshirt, using an image (PNG or JPEG) as source "print file" could introduce slight difference of colors.

This commit allow using a PDF as "print file" for better color accuracy.

Task-Id: 4637331

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
