### PR TITLE
[FIX] loyalty: add (copy) on program duplication

### DIFF
--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -678,3 +678,11 @@ class LoyaltyProgram(models.Model):
                 del vals['trigger_product_ids']
 
         return super().create(vals_list)
+
+    def copy_data(self, default=None):
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'name' not in default:
+            for program, vals in zip(self, vals_list):
+                vals['name'] = _("%s (copy)", program.name)
+        return vals_list


### PR DESCRIPTION
Currently, we don't have any visual indicator when duplicating a loyalty program. 
After this commit, when a loyalty program is duplicated "(copy)" it's added to its name.

task-5887481