### PR TITLE
[IMP] sale, website_sale: improve configuator performance

### DIFF
--- a/addons/event_booth_sale/static/src/js/sale_product_mixin.js
+++ b/addons/event_booth_sale/static/src/js/sale_product_mixin.js
@@ -15,7 +15,7 @@ const eventBoothSaleProductMixin = () => ({
     get hasConfigurationButton() {
         return super.hasConfigurationButton || this.isEventBooth;
     },
-    onEditConfiguration() {
+    async onEditConfiguration() {
         if (this.isEventBooth) {
             this._openEventBoothConfigurator(true);
         } else {

--- a/addons/event_sale/static/src/js/sale_product_mixin.js
+++ b/addons/event_sale/static/src/js/sale_product_mixin.js
@@ -14,7 +14,7 @@ const eventSaleProductMixin = () => ({
     get hasConfigurationButton() {
         return super.hasConfigurationButton || this.isEvent;
     },
-    onEditConfiguration() {
+    async onEditConfiguration() {
         if (this.isEvent) {
             this._openEventConfigurator();
         } else {

--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -44,30 +44,32 @@ class SaleProductConfiguratorController(Controller):
             request.update_context(allowed_company_ids=[company_id])
         product_template = self._get_product_template(product_template_id)
 
-        combination = self.env["product.template.attribute.value"]
-        if ptav_ids:
-            combination = (
-                self
-                .env["product.template.attribute.value"]
-                .browse(ptav_ids)
-                .filtered(lambda ptav: ptav.product_tmpl_id.id == product_template_id)
-            )
-            # Set missing attributes (unsaved no_variant attributes, or new attribute on existing
-            # product)
-            unconfigured_ptals = (
-                product_template.attribute_line_ids - combination.attribute_line_id
-            ).filtered(lambda ptal: ptal.attribute_id.display_type != "multi")
-            combination += unconfigured_ptals.mapped(
-                lambda ptal: ptal.product_template_value_ids._only_active()[:1]
-            )
-        if not combination:
-            combination = product_template._get_first_possible_combination()
-        currency = self.env["res.currency"].browse(currency_id)
-        pricelist = self.env["product.pricelist"].browse(pricelist_id)
-        so_date = datetime.fromisoformat(so_date)
+        res = product_template.get_single_product_variant()
 
-        return {
-            "products": [
+        if self.should_show_product_configurator(res, product_template, **kwargs):
+            combination = self.env["product.template.attribute.value"]
+            if ptav_ids:
+                combination = (
+                    self
+                    .env["product.template.attribute.value"]
+                    .browse(ptav_ids)
+                    .filtered(lambda ptav: ptav.product_tmpl_id.id == product_template_id)
+                )
+                # Set missing attributes (unsaved no_variant attributes, or new attribute on
+                # existing product)
+                unconfigured_ptals = (
+                    product_template.attribute_line_ids - combination.attribute_line_id
+                ).filtered(lambda ptal: ptal.attribute_id.display_type != "multi")
+                combination += unconfigured_ptals.mapped(
+                    lambda ptal: ptal.product_template_value_ids._only_active()[:1]
+                )
+            if not combination:
+                combination = product_template._get_first_possible_combination()
+            currency = self.env["res.currency"].browse(currency_id)
+            pricelist = self.env["product.pricelist"].browse(pricelist_id)
+            so_date = datetime.fromisoformat(so_date)
+
+            res["products"] = [
                 dict(
                     **self._get_product_information(
                         product_template,
@@ -80,26 +82,38 @@ class SaleProductConfiguratorController(Controller):
                         **kwargs,
                     )
                 )
-            ],
-            "optional_products": [
-                dict(
-                    **self._get_product_information(
-                        optional_product_template,
-                        optional_product_template._get_first_possible_combination(),
-                        currency,
-                        pricelist,
-                        so_date,
-                        **kwargs,
-                    ),
-                    parent_product_tmpl_id=product_template.id,
-                )
-                for optional_product_template in product_template.optional_product_ids
-                if self._should_show_product(optional_product_template)
             ]
-            if not only_main_product
-            else [],
-            "currency_id": currency_id,
-        }
+
+            res["optional_products"] = (
+                [
+                    dict(
+                        **self._get_product_information(
+                            optional_product_template,
+                            optional_product_template._get_first_possible_combination(),
+                            currency,
+                            pricelist,
+                            so_date,
+                            **kwargs,
+                        ),
+                        parent_product_tmpl_id=product_template.id,
+                    )
+                    for optional_product_template in product_template.optional_product_ids
+                    if self._should_show_product(optional_product_template)
+                ]
+                if not only_main_product
+                else []
+            )
+
+            res["currency_id"] = currency_id
+
+        return res
+
+    def should_show_product_configurator(
+        self, single_product_variant_dict, product_template, **kwargs
+    ):
+        return not single_product_variant_dict.get("product_id") or single_product_variant_dict.get(
+            "has_optional_products"
+        )
 
     @route(
         route="/sale/product_configurator/create_product",

--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -44,30 +44,35 @@ class SaleProductConfiguratorController(Controller):
             request.update_context(allowed_company_ids=[company_id])
         product_template = self._get_product_template(product_template_id)
 
-        combination = request.env["product.template.attribute.value"]
-        if ptav_ids:
-            combination = (
-                request
-                .env["product.template.attribute.value"]
-                .browse(ptav_ids)
-                .filtered(lambda ptav: ptav.product_tmpl_id.id == product_template_id)
-            )
-            # Set missing attributes (unsaved no_variant attributes, or new attribute on existing
-            # product)
-            unconfigured_ptals = (
-                product_template.attribute_line_ids - combination.attribute_line_id
-            ).filtered(lambda ptal: ptal.attribute_id.display_type != "multi")
-            combination += unconfigured_ptals.mapped(
-                lambda ptal: ptal.product_template_value_ids._only_active()[:1]
-            )
-        if not combination:
-            combination = product_template._get_first_possible_combination()
-        currency = request.env["res.currency"].browse(currency_id)
-        pricelist = request.env["product.pricelist"].browse(pricelist_id)
-        so_date = datetime.fromisoformat(so_date)
+        res = (
+            request.env["product.template"].browse(product_template_id).get_single_product_variant()
+        )
 
-        return {
-            "products": [
+        is_template_configurable = not res.get("product_id") or res.get("has_optional_products")
+        if is_template_configurable:
+            combination = request.env["product.template.attribute.value"]
+            if ptav_ids:
+                combination = (
+                    request
+                    .env["product.template.attribute.value"]
+                    .browse(ptav_ids)
+                    .filtered(lambda ptav: ptav.product_tmpl_id.id == product_template_id)
+                )
+                # Set missing attributes (unsaved no_variant attributes, or new attribute on
+                # existing product)
+                unconfigured_ptals = (
+                    product_template.attribute_line_ids - combination.attribute_line_id
+                ).filtered(lambda ptal: ptal.attribute_id.display_type != "multi")
+                combination += unconfigured_ptals.mapped(
+                    lambda ptal: ptal.product_template_value_ids._only_active()[:1]
+                )
+            if not combination:
+                combination = product_template._get_first_possible_combination()
+            currency = request.env["res.currency"].browse(currency_id)
+            pricelist = request.env["product.pricelist"].browse(pricelist_id)
+            so_date = datetime.fromisoformat(so_date)
+
+            res["products"] = [
                 dict(
                     **self._get_product_information(
                         product_template,
@@ -80,26 +85,31 @@ class SaleProductConfiguratorController(Controller):
                         **kwargs,
                     )
                 )
-            ],
-            "optional_products": [
-                dict(
-                    **self._get_product_information(
-                        optional_product_template,
-                        optional_product_template._get_first_possible_combination(),
-                        currency,
-                        pricelist,
-                        so_date,
-                        **kwargs,
-                    ),
-                    parent_product_tmpl_id=product_template.id,
-                )
-                for optional_product_template in product_template.optional_product_ids
-                if self._should_show_product(optional_product_template)
             ]
-            if not only_main_product
-            else [],
-            "currency_id": currency_id,
-        }
+
+            res["optional_products"] = (
+                [
+                    dict(
+                        **self._get_product_information(
+                            optional_product_template,
+                            optional_product_template._get_first_possible_combination(),
+                            currency,
+                            pricelist,
+                            so_date,
+                            **kwargs,
+                        ),
+                        parent_product_tmpl_id=product_template.id,
+                    )
+                    for optional_product_template in product_template.optional_product_ids
+                    if self._should_show_product(optional_product_template)
+                ]
+                if not only_main_product
+                else []
+            )
+
+            res["currency_id"] = currency_id
+
+        return res
 
     @route(
         route="/sale/product_configurator/create_product",

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -55,7 +55,8 @@ export class ComboConfiguratorDialog extends Component {
         });
         this._initSelectedComboItems();
         this.getPriceUrl = '/sale/combo_configurator/get_price';
-        useSubEnv({ currency: { id: this.props.currency_id } });
+        this.getValuesUrl = '/sale/product_configurator/get_values';
+        useSubEnv({ currencyId: this.props.currency_id });
 
         this.unconfigurableCombos = this.props.combos.filter(combo => !combo.isConfigurable);
         this.configurableCombos = this.props.combos.filter(combo => combo.isConfigurable);
@@ -76,11 +77,25 @@ export class ComboConfiguratorDialog extends Component {
         comboItem = this.getSelectedOrProvidedComboItem(comboId, comboItem);
         let product = comboItem.product;
         if (comboItem.is_configurable) {
+            const productConfiguratorData = await rpc(this.getValuesUrl,
+                {
+                    product_template_id: product.product_tmpl_id,
+                    quantity: 1,
+                    currency_id: this.props.currency_id,
+                    so_date: this.props.date,
+                    company_id: this.props.company_id,
+                    pricelist_id: this.props.pricelist_id,
+                    ptav_ids:  product.selectedPtavIds,
+                    only_main_product: true,
+                    show_packaging: false,
+                    ...this._getAdditionalRpcParams(),
+                });
+            const { products } = productConfiguratorData;
             this.dialog.add(ProductConfiguratorDialog, {
                 productTemplateId: product.product_tmpl_id,
-                ptavIds: product.selectedPtavIds,
+                products: products,
+                optionalProducts: [],
                 customPtavs: product.selectedCustomPtavs,
-                quantity: 1,
                 companyId: this.props.company_id,
                 pricelistId: this.props.pricelist_id,
                 currencyId: this.props.currency_id,
@@ -90,7 +105,6 @@ export class ComboConfiguratorDialog extends Component {
                     canChangeVariant: false,
                     showQuantity: false,
                     showPrice: false,
-                    showPackaging: false,
                 },
                 size: "md",
                 save: async configuredProduct => {

--- a/addons/sale/static/src/js/product/product.js
+++ b/addons/sale/static/src/js/product/product.js
@@ -47,7 +47,7 @@ export class Product extends Component {
      * @return {String} - The price, in the format of the given currency.
      */
     getFormattedPrice(price) {
-        return formatCurrency(price, this.env.currency.id);
+        return formatCurrency(price, this.env.currencyId);
     }
 
     /**

--- a/addons/sale/static/src/js/product_card/product_card.xml
+++ b/addons/sale/static/src/js/product_card/product_card.xml
@@ -31,7 +31,7 @@
                     <BadgeExtraPrice
                         t-if="this.props.extraPrice"
                         price="this.props.extraPrice"
-                        currencyId="this.env.currency.id"
+                        currencyId="this.env.currencyId"
                     />
                 </div>
             </article>

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -1,5 +1,5 @@
 import { useSubEnv } from "@web/owl2/utils";
-import { Component, onMounted, onWillStart, onWillUnmount, props, proxy, t } from "@odoo/owl";
+import { Component, onMounted, onWillUnmount, props, proxy, t } from "@odoo/owl";
 import { Dialog } from '@web/core/dialog/dialog';
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
@@ -11,20 +11,18 @@ export const productConfiguratorDialogOptionsShape = {
     canChangeVariant: t.boolean().optional(),
     showQuantity: t.boolean().optional(),
     showPrice: t.boolean().optional(),
-    showPackaging: t.boolean().optional(),
 };
 
 export const productConfiguratorDialogProps = {
     productTemplateId: t.number(),
-    ptavIds: t.array(t.number()),
+    products: t.array(),
+    optionalProducts: t.array(),
     customPtavs: t.array(
         t.object({
             id: t.number(),
             value: t.string(),
         })
     ),
-    quantity: t.number(),
-    productUOMId: t.number().optional(),
     companyId: t.number().optional(),
     pricelistId: t.number().optional(),
     currencyId: t.number().optional(),
@@ -57,10 +55,6 @@ export class ProductConfiguratorDialog extends Component {
             products: [],
             optionalProducts: [],
         });
-        // Nest the currency id in an object so that it stays up to date in the `env`, even if we
-        // modify it in `onWillStart` afterwards.
-        this.currency = { id: this.props.currencyId };
-        this.getValuesUrl = '/sale/product_configurator/get_values';
         this.createProductUrl = '/sale/product_configurator/create_product';
         this.updateCombinationUrl = '/sale/product_configurator/update_combination';
         this.getOptionalProductsUrl = '/sale/product_configurator/get_optional_products';
@@ -69,10 +63,9 @@ export class ProductConfiguratorDialog extends Component {
 
         useSubEnv({
             mainProductTmplId: this.props.productTemplateId,
-            currency: this.currency,
+            currencyId: this.props.currency_id,
             canChangeVariant: this.props.options?.canChangeVariant ?? true,
             showQuantity: this.props.options?.showQuantity ?? true,
-            showPackaging: this.props.options?.showPackaging ?? true,
             showPrice: this.props.options?.showPrice ?? true,
             addProduct: this._addProduct.bind(this),
             removeProduct: this._removeProduct.bind(this),
@@ -83,32 +76,23 @@ export class ProductConfiguratorDialog extends Component {
             isPossibleCombination: this._isPossibleCombination,
         });
 
-        onWillStart(async () => {
-            const {
-                products,
-                optional_products,
-                currency_id,
-            } = await this._loadData(this.props.edit);
+        // If the product configurator is opened after the combo configurator (which happens if
+        // a combo product has optional products), props.products will contain a single product
+        // (i.e. the combo product), which should be linked to the previously selected combo
+        // items.
 
-            // If the product configurator is opened after the combo configurator (which happens if
-            // a combo product has optional products), `_loadData` will return a single product
-            // (i.e. the combo product), which should be linked to the previously selected combo
-            // items.
-            products[0].selectedComboItems = this.props.selectedComboItems || [];
+        this.props.products[0].selectedComboItems = this.props.selectedComboItems || [];
 
-            this.state.products = products;
-            this.state.optionalProducts = optional_products;
-            for (const customPtav of this.props.customPtavs) {
-                this._updatePTAVCustomValue(
-                    this.env.mainProductTmplId,
-                    customPtav.id,
-                    customPtav.value
-                );
-            }
-            this._checkExclusions(this.state.products[0]);
-            // Use the currency id retrieved from the server if none was provided in the props.
-            this.currency.id ??= currency_id;
-        });
+        this.state.products = this.props.products;
+        this.state.optionalProducts = this.props.optionalProducts;
+        for (const customPtav of this.props.customPtavs) {
+            this._updatePTAVCustomValue(
+                this.env.mainProductTmplId,
+                customPtav.id,
+                customPtav.value
+            );
+        }
+        this._checkExclusions(this.state.products[0]);
 
         onMounted(() => this.env.bus.trigger("FORM-CONTROLLER:FORM-IN-DIALOG:ADD"));
         onWillUnmount(() => this.env.bus.trigger("FORM-CONTROLLER:FORM-IN-DIALOG:REMOVE"));
@@ -128,28 +112,12 @@ export class ProductConfiguratorDialog extends Component {
             (sum, product) => sum + product.price * product.quantity,
             0
         );
-        return formatCurrency(total, this.currency.id);
+        return formatCurrency(total, this.props.currency_id);
     }
 
     //--------------------------------------------------------------------------
     // Data Exchanges
     //--------------------------------------------------------------------------
-
-    async _loadData(onlyMainProduct) {
-        return rpc(this.getValuesUrl, {
-            product_template_id: this.props.productTemplateId,
-            quantity: this.props.quantity,
-            currency_id: this.currency.id,
-            so_date: this.props.soDate,
-            product_uom_id: this.props.productUOMId,
-            company_id: this.props.companyId,
-            pricelist_id: this.props.pricelistId,
-            ptav_ids: this.props.ptavIds,
-            only_main_product: onlyMainProduct,
-            show_packaging: this.env.showPackaging,
-            ...this._getAdditionalRpcParams(),
-        });
-    }
 
     async _createProduct(product) {
         return rpc(this.createProductUrl, {
@@ -162,7 +130,7 @@ export class ProductConfiguratorDialog extends Component {
         return rpc(this.updateCombinationUrl, {
             product_template_id: product.product_tmpl_id,
             ptav_ids: this._getCombination(product),
-            currency_id: this.currency.id,
+            currency_id: this.props.currencyId,
             so_date: this.props.soDate,
             quantity: quantity,
             product_uom_id: uomId,
@@ -175,7 +143,7 @@ export class ProductConfiguratorDialog extends Component {
     async _getOptionalProducts(product) {
         return rpc(this.getOptionalProductsUrl, {
             product_template_id: product.product_tmpl_id,
-            currency_id: this.currency.id,
+            currency_id: this.props.currencyId,
             so_date: this.props.soDate,
             company_id: this.props.companyId,
             pricelist_id: this.props.pricelistId,

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -12,6 +12,10 @@ export class ProductConfiguratorDialog extends Component {
     static props = {
         productTemplateId: Number,
         ptavIds: { type: Array, element: Number },
+        preloadedData: {
+            type: Object,
+            optional: true,
+        },
         customPtavs: {
             type: Array,
             element: Object,
@@ -94,7 +98,7 @@ export class ProductConfiguratorDialog extends Component {
                 products,
                 optional_products,
                 currency_id,
-            } = await this._loadData(this.props.edit);
+            } = this.props.preloadedData ?? await this._loadData(this.props.edit);
 
             // If the product configurator is opened after the combo configurator (which happens if
             // a combo product has optional products), `_loadData` will return a single product

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
@@ -116,7 +116,7 @@ export class ProductTemplateAttributeLine extends Component {
     getPTAVSelectName(ptav) {
         if (ptav.price_extra) {
             const sign = ptav.price_extra > 0 ? '+' : '-';
-            const price = formatCurrency(Math.abs(ptav.price_extra), this.env.currency.id);
+            const price = formatCurrency(Math.abs(ptav.price_extra), this.env.currencyId);
             return ptav.name +" ("+ sign + " " + price + ")";
         } else {
             return ptav.name;

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -58,7 +58,7 @@
                         <BadgeExtraPrice
                             t-if="ptav.price_extra"
                             price="ptav.price_extra"
-                            currencyId="this.env.currency.id"
+                            currencyId="this.env.currencyId"
                         />
                     </label>
                     <input
@@ -88,7 +88,7 @@
                     <BadgeExtraPrice
                         t-if="ptav.price_extra"
                         price="ptav.price_extra"
-                        currencyId="this.env.currency.id"
+                        currencyId="this.env.currencyId"
                     />
                 </label>
                 <input
@@ -182,7 +182,7 @@
                         <BadgeExtraPrice
                             t-if="ptav.price_extra"
                             price="ptav.price_extra"
-                            currencyId="this.env.currency.id"
+                            currencyId="this.env.currencyId"
                         />
                     </label>
                 </div>

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -186,24 +186,35 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         return this.props.record.data[this.props.name];
     }
 
-    async _onProductTemplateUpdate() {
-        const result = await this.orm.call(
-            'product.template',
-            'get_single_product_variant',
-            [this.props.record.data.product_template_id.id],
+    async _getPreloadedConfigData() {
+        const saleOrderRecord = this.props.record.model.root;
+        const saleOrderLine = this.props.record.data;
+        const ptavIds = this._getVariantPtavIds(saleOrderLine);
+        return rpc('/sale/product_configurator/get_values',
             {
-                context: this.props.context,
-            }
-        );
+                product_template_id: saleOrderLine.product_template_id.id,
+                quantity: saleOrderLine.product_uom_qty,
+                currency_id: saleOrderLine.currency_id.id,
+                so_date: serializeDateTime(saleOrderRecord.data.date_order),
+                product_uom_id: saleOrderLine.product_uom_id.id,
+                company_id: saleOrderRecord.data.company_id.id,
+                pricelist_id: saleOrderRecord.data.pricelist_id.id,
+                ptav_ids: ptavIds,
+                ...this._getAdditionalRpcParams(),
+            });
+    }
+
+    async _onProductTemplateUpdate() {
+        const result = await this._getPreloadedConfigData();
         if (result && result.product_id) {
             if (this.props.record.data.product_id != result.product_id.id) {
                 if (result.is_combo) {
                     await this.props.record.update({
                         product_id: { id: result.product_id, display_name: result.product_name },
                     });
-                    this._openComboConfigurator(false, result.has_optional_products);
+                    this._openComboConfigurator(false, result.has_optional_products, result);
                 } else if (result.has_optional_products) {
-                    this._openProductConfigurator();
+                    this._openProductConfigurator({ preloadedData: result });
                 } else {
                     await this.props.record.update({
                         product_id: { id: result.product_id, display_name: result.product_name },
@@ -212,7 +223,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
                 }
             }
         } else if (!result.mode || result.mode === 'configurator') {
-            this._openProductConfigurator();
+            this._openProductConfigurator({ preloadedData: result });
         } else {
             // only triggered when sale_product_matrix is installed.
             this._openGridConfigurator();
@@ -227,11 +238,15 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         if (this.isCombo) {
             this._openComboConfigurator(true);
         } else if (this.isConfigurableTemplate) {
-            this._openProductConfigurator(true);
+            this._openProductConfigurator({edit: true});
         }
     }
 
-    async _openProductConfigurator(edit = false, selectedComboItems = []) {
+    async _openProductConfigurator({
+        edit = false,
+        selectedComboItems = [],
+        preloadedData,
+    } = {}) {
         const saleOrderRecord = this.props.record.model.root;
         const saleOrderLine = this.props.record.data;
         const ptavIds = this._getVariantPtavIds(saleOrderLine);
@@ -249,6 +264,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         this.dialog.add(ProductConfiguratorDialog, {
             productTemplateId: saleOrderLine.product_template_id.id,
             ptavIds: ptavIds,
+            preloadedData: preloadedData,
             customPtavs: customPtavs,
             quantity: saleOrderLine.product_uom_qty,
             productUOMId: saleOrderLine.product_uom_id.id,
@@ -292,7 +308,7 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         });
     }
 
-    async _openComboConfigurator(edit = false, hasOptionalProducts = false) {
+    async _openComboConfigurator(edit = false, hasOptionalProducts = false, preloadedData) {
         const saleOrder = this.props.record.model.root.data;
         const comboLineRecord = this.props.record;
         const comboItemLineRecords = getLinkedSaleOrderLines(comboLineRecord).filter(record => !!record.data.combo_item_id);
@@ -321,7 +337,8 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
                 { 'quantity' : remainingData.quantity },
                 preselectedComboItems,
                 edit,
-                hasOptionalProducts
+                hasOptionalProducts,
+                preloadedData
             );
         }
         this.dialog.add(ComboConfiguratorDialog, {
@@ -344,7 +361,13 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         });
     }
 
-    async handleComboSave(comboProductData, selectedComboItems, edit, hasOptionalProducts) {
+    async handleComboSave(
+        comboProductData,
+        selectedComboItems,
+        edit,
+        hasOptionalProducts,
+        preloadedData,
+    ) {
         const saleOrder = this.props.record.model.root.data;
         const comboLineRecord = this.props.record;
         saleOrder.order_line.leaveEditMode();
@@ -365,7 +388,10 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
             const selectedComboProducts = selectedComboItems.map(
                 item => ({ name: item.product.display_name })
             );
-            await this._openProductConfigurator(false, selectedComboProducts);
+            await this._openProductConfigurator({
+                selectedComboItems: selectedComboProducts,
+                preloadedData: preloadedData,
+            });
         }
     }
 

--- a/addons/sale/static/src/js/sale_product_mixin.js
+++ b/addons/sale/static/src/js/sale_product_mixin.js
@@ -75,34 +75,50 @@ export const saleProductMixin = () => ({
         return _t("Edit Configuration");
     },
 
+    async _getProductConfiguratorData(edit = false) {
+        const saleOrder = this.props.record.model.root.data;
+        const saleOrderLine = this.props.record.data;
+        const ptavIds = [...this._getVariantPtavIds(saleOrderLine)];
+        if (edit) {
+            // no_variant attributes don't need to be given to the configurator for new products.
+            ptavIds.push(...this._getNoVariantPtavIds(saleOrderLine));
+        }
+        return rpc('/sale/product_configurator/get_values',
+            {
+                product_template_id: saleOrderLine.product_template_id.id,
+                quantity: saleOrderLine.product_uom_qty,
+                currency_id: saleOrderLine.currency_id.id,
+                so_date: serializeDateTime(saleOrder.date_order),
+                product_uom_id: saleOrderLine.product_uom_id.id,
+                company_id: saleOrder.company_id.id,
+                pricelist_id: saleOrder.pricelist_id.id,
+                ptav_ids: ptavIds,
+                only_main_product: edit,
+                ...this._getAdditionalRpcParams(),
+            });
+    },
+
     async _onProductTemplateUpdate() {
         super._onProductTemplateUpdate();
-        const result = await this.orm.call(
-            "product.template",
-            "get_single_product_variant",
-            [this.props.record.data.product_template_id.id],
-            {
-                context: this.props.context,
-            }
-        );
-        if (result && result.product_id) {
-            if (this.props.record.data.product_id != result.product_id.id) {
-                if (result.is_combo) {
+        const data = await this._getProductConfiguratorData();
+        if (data && data.product_id) {
+            if (this.props.record.data.product_id != data.product_id.id) {
+                if (data.is_combo) {
                     await this.props.record.update({
-                        product_id: { id: result.product_id, display_name: result.product_name },
+                        product_id: { id: data.product_id, display_name: data.product_name },
                     });
-                    this._openComboConfigurator(false, result.has_optional_products);
-                } else if (result.has_optional_products) {
-                    this._openProductConfigurator();
+                    this._openComboConfigurator({edit: false, data: data});
+                } else if (data.has_optional_products) {
+                    this._openProductConfigurator({ data: data });
                 } else {
                     await this.props.record.update({
-                        product_id: { id: result.product_id, display_name: result.product_name },
+                        product_id: { id: data.product_id, display_name: data.product_name },
                     });
                     this._onProductUpdate();
                 }
             }
-        } else if (!result.mode || result.mode === "configurator") {
-            this._openProductConfigurator();
+        } else if (!data.mode || data.mode === 'configurator') {
+            this._openProductConfigurator({ data: data });
         } else {
             // only triggered when sale_product_matrix is installed.
             this._openGridConfigurator();
@@ -113,40 +129,35 @@ export const saleProductMixin = () => ({
 
     async _onProductUpdate() {}, // event_booth_sale, event_sale, sale_renting
 
-    onEditConfiguration() {
+    async onEditConfiguration() {
         super.onEditConfiguration();
         if (this.isCombo) {
-            this._openComboConfigurator(true);
+            this._openComboConfigurator({edit: true});
         } else if (this.isConfigurableTemplate) {
-            this._openProductConfigurator(true);
+            const data = await this._getProductConfiguratorData(true)
+            this._openProductConfigurator({edit: true, data: data});
         }
     },
 
-    async _openProductConfigurator(edit = false, selectedComboItems = []) {
-        const saleOrderRecord = this.props.record.model.root;
+    async _openProductConfigurator({ edit = false, selectedComboItems = [], data } = {}) {
+        const saleOrder = this.props.record.model.root.data;
         const saleOrderLine = this.props.record.data;
-        const ptavIds = [...this._getVariantPtavIds(saleOrderLine)];
         let customPtavs = [];
 
         if (edit) {
-            /**
-             * no_variant and custom attribute don't need to be given to the configurator for new
-             * products.
-             */
-            ptavIds.push(...this._getNoVariantPtavIds(saleOrderLine));
+            // custom attributes don't need to be given to the configurator for new products.
             customPtavs = await this._getCustomPtavs(saleOrderLine);
         }
-
+        const { products, optional_products } = data;
         this.dialog.add(ProductConfiguratorDialog, {
             productTemplateId: saleOrderLine.product_template_id.id,
-            ptavIds: ptavIds,
+            products: products,
+            optionalProducts: optional_products,
             customPtavs: customPtavs,
-            quantity: saleOrderLine.product_uom_qty,
-            productUOMId: saleOrderLine.product_uom_id.id,
-            companyId: saleOrderRecord.data.company_id.id,
-            pricelistId: saleOrderRecord.data.pricelist_id.id,
+            companyId: saleOrder.company_id.id,
+            pricelistId: saleOrder.pricelist_id.id,
             currencyId: saleOrderLine.currency_id.id,
-            soDate: serializeDateTime(saleOrderRecord.data.date_order),
+            soDate: serializeDateTime(saleOrder.date_order),
             selectedComboItems: selectedComboItems,
             edit: edit,
             save: async (mainProduct, optionalProducts) => {
@@ -158,10 +169,10 @@ export const saleProductMixin = () => ({
 
                 for (const [i, product] of optionalProducts.entries()) {
                     const index =
-                        saleOrderRecord.data.order_line.records.indexOf(this.props.record)
+                    saleOrder.order_line.records.indexOf(this.props.record)
                         + selectedComboItems.length
                         + i;
-                    const line = await saleOrderRecord.data.order_line.addNewRecordAtIndex(index, {
+                    const line = await saleOrder.order_line.addNewRecordAtIndex(index, {
                         mode: 'readonly',
                     });
                     const productData = this._prepareNewLineData(line, product);
@@ -175,14 +186,14 @@ export const saleProductMixin = () => ({
                 if (!selectedComboItems.length) {
                     // Don't delete the main product if it's a combo product as it has been added
                     // from combo configurator
-                    saleOrderRecord.data.order_line.delete(this.props.record);
+                    saleOrder.order_line.delete(this.props.record);
                 }
             },
             ...this._getAdditionalDialogProps(),
         });
     },
 
-    async _openComboConfigurator(edit = false, hasOptionalProducts = false) {
+    async _openComboConfigurator({ edit = false, data } = {}) {
         const saleOrder = this.props.record.model.root.data;
         const comboLineRecord = this.props.record;
         const comboItemLineRecords = getLinkedSaleOrderLines(comboLineRecord).filter(record => !!record.data.combo_item_id);
@@ -211,7 +222,7 @@ export const saleProductMixin = () => ({
                 { 'quantity': remainingData.quantity },
                 preselectedComboItems,
                 edit,
-                hasOptionalProducts
+                data
             );
         }
         this.dialog.add(ComboConfiguratorDialog, {
@@ -226,7 +237,7 @@ export const saleProductMixin = () => ({
                     comboProductData,
                     selectedComboItems,
                     edit,
-                    hasOptionalProducts
+                    data,
                 );
             },
             discard: () => saleOrder.order_line.delete(comboLineRecord),
@@ -234,7 +245,7 @@ export const saleProductMixin = () => ({
         });
     },
 
-    async handleComboSave(comboProductData, selectedComboItems, edit, hasOptionalProducts) {
+    async handleComboSave(comboProductData, selectedComboItems, edit, data ) {
         const saleOrder = this.props.record.model.root.data;
         const comboLineRecord = this.props.record;
         saleOrder.order_line.leaveEditMode();
@@ -249,11 +260,14 @@ export const saleProductMixin = () => ({
         // Ensure that the order lines are sorted according to their sequence.
         await saleOrder.order_line._sort();
 
-        if (hasOptionalProducts && !edit) {
+        if (!edit && data.has_optional_products) {
             const selectedComboProducts = selectedComboItems.map(
                 item => ({ name: item.product.display_name })
             );
-            await this._openProductConfigurator(false, selectedComboProducts);
+            await this._openProductConfigurator({
+                selectedComboItems: selectedComboProducts,
+                data: data,
+            });
         }
     },
 

--- a/addons/sale/static/tests/sale_product_field.test.js
+++ b/addons/sale/static/tests/sale_product_field.test.js
@@ -10,9 +10,11 @@ import {
     models,
     mountView,
     onRpc,
+    patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
 import { saleModels } from "./sale_test_helpers";
+import { SaleOrderLineProductField } from "@sale/js/sale_product_field/sale_product_field";
 
 class SaleOrderLine extends saleModels.SaleOrderLine {
     product_template_attribute_value_ids = fields.Many2many({
@@ -63,6 +65,16 @@ test("pressing tab with incomplete text will create a product", async () => {
                 </form>`,
     });
 
+    patchWithCleanup(SaleOrderLineProductField.prototype, {
+        async _getProductConfiguratorData() {
+            expect.step("_getProductConfiguratorData");
+            return {
+                product_id: { id: 42, display_name: "Test Product" },
+                product_name: "Test Product",
+            };
+        },
+    });
+
     // add a line and enter new product name
     await contains(".o_field_x2many_list .o_field_x2many_list_row_add button").click();
     await contains("[name='product_template_id'] input").edit("new product");
@@ -74,7 +86,7 @@ test("pressing tab with incomplete text will create a product", async () => {
         "onchange",
         "web_name_search",
         "name_create",
-        "get_single_product_variant",
+        "_getProductConfiguratorData",
     ]);
 });
 

--- a/addons/sale/static/tests/sale_product_field.test.js
+++ b/addons/sale/static/tests/sale_product_field.test.js
@@ -10,9 +10,11 @@ import {
     models,
     mountView,
     onRpc,
+    patchWithCleanup,
     serverState,
 } from "@web/../tests/web_test_helpers";
 import { saleModels } from "./sale_test_helpers";
+import { SaleOrderLineProductField } from "../src/js/sale_product_field";
 
 class SaleOrderLine extends saleModels.SaleOrderLine {
     product_template_attribute_value_ids = fields.Many2many({
@@ -63,6 +65,16 @@ test("pressing tab with incomplete text will create a product", async () => {
                 </form>`,
     });
 
+    patchWithCleanup(SaleOrderLineProductField.prototype, {
+        async _getPreloadedConfigData() {
+            expect.step("_getPreloadedConfigData");
+            return {
+                product_id: { id: 42, display_name: "Test Product" },
+                product_name: "Test Product",
+            };
+        },
+    });
+
     // add a line and enter new product name
     await contains(".o_field_x2many_list .o_field_x2many_list_row_add button").click();
     await contains("[name='product_template_id'] input").edit("new product");
@@ -74,7 +86,7 @@ test("pressing tab with incomplete text will create a product", async () => {
         "onchange",
         "web_name_search",
         "name_create",
-        "get_single_product_variant",
+        "_getPreloadedConfigData",
     ]);
 });
 

--- a/addons/sale_product_matrix/static/src/js/sale_product_field.js
+++ b/addons/sale_product_matrix/static/src/js/sale_product_field.js
@@ -12,7 +12,7 @@ patch(SaleOrderLineProductField.prototype, {
         return this.matrixConfigurator.open(this.props.record, edit);
     },
 
-    async _openProductConfigurator(edit=false, selectedComboItems=[]) {
+    async _openProductConfigurator(edit=false, selectedComboItems=[], preloadedData) {
         if (edit && this.props.record.data.product_add_mode == 'matrix') {
             this._openGridConfigurator(true);
         } else {

--- a/addons/sale_product_matrix/static/src/js/sale_product_mixin.js
+++ b/addons/sale_product_matrix/static/src/js/sale_product_mixin.js
@@ -19,7 +19,7 @@ const saleMatrixProductMixin = () => ({
         return this.matrixConfigurator.open(this.props.record, edit);
     },
 
-    async _openProductConfigurator(edit = false, selectedComboItems = []) {
+    async _openProductConfigurator({ edit = false, selectedComboItems = [], data } = {}) {
         if (edit && this.props.record.data.product_add_mode == "matrix") {
             this._openGridConfigurator(true);
         } else {

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -8,32 +8,44 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController, WebsiteSale):
     @route(
-        route="/website_sale/should_show_product_configurator",
+        route="/website_sale/product_configurator/get_values",
         type="jsonrpc",
         auth="public",
         website=True,
         readonly=True,
     )
-    def website_sale_should_show_product_configurator(
-        self, product_template_id, is_product_configured
+    def website_sale_product_configurator_get_values(self, *args, **kwargs):
+        product_template_id = kwargs.get("product_template_id")
+        product_template = self._get_product_template(product_template_id)
+        if product_template._is_donation():
+            return {}
+        self._populate_currency_and_pricelist(kwargs)
+        return super().sale_product_configurator_get_values(*args, **kwargs)
+
+    def should_show_product_configurator(
+        self, single_product_variant_dict, product_template, is_product_configured=False, **kwargs
     ):
         """Return whether the product configurator dialog should be shown.
 
-        :param int product_template_id: The product being checked, as a `product.template` id.
+        :param dict single_product_variant_dict: Information about the single product variant.
+        :param product.template product_template: The product.template record being checked.
         :param bool is_product_configured: Whether the product is already configured.
         :rtype: bool
         :return: Whether the product configurator dialog should be shown.
         """
-        product_template = self.env["product.template"].browse(product_template_id)
-        if product_template._is_donation():
-            return False
-        single_product_variant = product_template.get_single_product_variant()
+        if not request.is_frontend:
+            return super().should_show_product_configurator(
+                single_product_variant_dict,
+                product_template,
+                is_product_configured=is_product_configured,
+                **kwargs,
+            )
         has_optional_products = bool(
             product_template.optional_product_ids.filtered(self._should_show_product)
         )
         return (
             has_optional_products
-            or not (single_product_variant.get("product_id") or is_product_configured)
+            or not (single_product_variant_dict.get("product_id") or is_product_configured)
             or (len(product_template._get_available_uoms()) > 1 and not is_product_configured)
         )
 
@@ -51,17 +63,6 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
             ]):
                 return self.env["product.template"].sudo().browse(product_template_id)
         return super()._get_product_template(product_template_id)
-
-    @route(
-        route="/website_sale/product_configurator/get_values",
-        type="jsonrpc",
-        auth="public",
-        website=True,
-        readonly=True,
-    )
-    def website_sale_product_configurator_get_values(self, *args, **kwargs):
-        self._populate_currency_and_pricelist(kwargs)
-        return super().sale_product_configurator_get_values(*args, **kwargs)
 
     @route(
         route="/website_sale/product_configurator/create_product",

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -203,19 +203,25 @@ export class CartService {
             });
         }
 
-        const shouldShowProductConfigurator = await this.rpc(
-            '/website_sale/should_show_product_configurator',
-            {
-                product_template_id: productTemplateId,
-                is_product_configured: isConfigured,
-            }
-        );
-        if (shouldShowProductConfigurator) {
+        const ptavIds = ptavs.concat(noVariantAttributeValues);
+        const configDataParams = {
+            product_template_id: productTemplateId,
+            quantity: quantity,
+            ptav_ids: ptavIds,
+            product_uom_id: uomId,
+            so_date: serializeDateTime(DateTime.now()),
+            is_product_configured: isConfigured,
+            ...rest
+        };
+
+        const result = await this.rpc('/website_sale/product_configurator/get_values', configDataParams);
+        if (result.products) {
+            const { products, optional_products, currency_id } = result;
             return this._openProductConfigurator(
                 productTemplateId,
-                quantity,
-                uomId,
-                ptavs.concat(noVariantAttributeValues),
+                products,
+                optional_products,
+                currency_id,
                 productCustomAttributeValues,
                 {
                     isBuyNow: isBuyNow,
@@ -334,9 +340,9 @@ export class CartService {
      */
     async _openProductConfigurator(
         productTemplateId,
-        quantity,
-        uomId,
-        combination,
+        products,
+        optionalProducts,
+        currencyId,
         productCustomAttributeValues,
         options,
         additionalData
@@ -344,13 +350,13 @@ export class CartService {
         return await new Promise((resolve) => {
             this.dialog.add(ProductConfiguratorDialog, {
                 productTemplateId: productTemplateId,
-                ptavIds: combination,
+                products: products,
+                optionalProducts: optionalProducts,
+                currencyId: currencyId,
                 customPtavs: productCustomAttributeValues.map(customPtav => ({
                     id: customPtav.custom_product_template_attribute_value_id,
                     value: customPtav.custom_value,
                 })),
-                quantity: quantity,
-                productUOMId: uomId,
                 soDate: serializeDateTime(DateTime.now()),
                 edit: false,
                 isFrontend: true,

--- a/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -24,6 +24,7 @@ patch(ComboConfiguratorDialog.prototype, {
 
         if (this.props.isFrontend) {
             this.getPriceUrl = '/website_sale/combo_configurator/get_price';
+            this.getValuesUrl = '/website_sale/product_configurator/get_values';
         }
     },
 

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -23,7 +23,6 @@ patch(ProductConfiguratorDialog.prototype, {
         super.setup(...arguments);
 
         if (this.props.isFrontend) {
-            this.getValuesUrl = '/website_sale/product_configurator/get_values';
             this.createProductUrl = '/website_sale/product_configurator/create_product';
             this.updateCombinationUrl = '/website_sale/product_configurator/update_combination';
             this.getOptionalProductsUrl = '/website_sale/product_configurator/get_optional_products';

--- a/addons/website_sale/tests/test_product_configurator.py
+++ b/addons/website_sale/tests/test_product_configurator.py
@@ -312,7 +312,7 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             )
 
         self.assertFalse(show_configurator)
-        self.assertListEqual(configurator_values["optional_products"], [])
+        self.assertNotIn("optional_products", configurator_values)
 
     def test_product_configurator_extra_price_taxes(self):
         """Test that the product configurator applies taxes to PTAV extra prices."""

--- a/addons/website_sale/tests/test_product_configurator.py
+++ b/addons/website_sale/tests/test_product_configurator.py
@@ -125,9 +125,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             ],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=False
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=False
             )
 
         self.assertTrue(show_configurator)
@@ -147,9 +149,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             "optional_product_ids": [Command.set(optional_product.ids)],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=False
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=False
             )
 
         self.assertFalse(show_configurator)
@@ -171,9 +175,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             ],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=False
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=False
             )
 
         self.assertFalse(show_configurator)
@@ -199,9 +205,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             ],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=True
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=True
             )
 
         self.assertFalse(show_configurator)
@@ -226,9 +234,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             ],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=False
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=False
             )
 
         self.assertTrue(show_configurator)
@@ -253,9 +263,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             ],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=False
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=False
             )
 
         self.assertTrue(show_configurator)
@@ -279,9 +291,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             ],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=False
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=False
             )
 
         self.assertTrue(show_configurator)
@@ -299,9 +313,11 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             "optional_product_ids": [Command.set(optional_product.ids)],
         })
 
+        single_product_variant_dict = main_product.get_single_product_variant()
+
         with self.mock_request():
-            show_configurator = self.pc_controller.website_sale_should_show_product_configurator(
-                product_template_id=main_product.id, is_product_configured=False
+            show_configurator = self.pc_controller.should_show_product_configurator(
+                single_product_variant_dict, main_product, is_product_configured=False
             )
             configurator_values = self.pc_controller.website_sale_product_configurator_get_values(
                 product_template_id=main_product.id,
@@ -312,7 +328,9 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
             )
 
         self.assertFalse(show_configurator)
-        self.assertListEqual(configurator_values["optional_products"], [])
+        self.assertFalse(configurator_values["has_optional_products"])
+        self.assertNotIn("products", configurator_values)
+        self.assertNotIn("optional_products", configurator_values)
 
     def test_product_configurator_extra_price_taxes(self):
         """Test that the product configurator applies taxes to PTAV extra prices."""


### PR DESCRIPTION
Refactor to improve performance when opening the product configurator dialog.
- preloading configurator data to avoid an extra RPC roundtrip when opening the configurator

Enterprise PR: https://github.com/odoo/enterprise/pull/121341

task-3891049
