### PR TITLE
[IMP] l10n_ro_edi: download official bill PDF from ANAF

### DIFF
--- a/addons/l10n_ro_edi/models/ciusro_document.py
+++ b/addons/l10n_ro_edi/models/ciusro_document.py
@@ -17,16 +17,22 @@ def make_efactura_request(session, company, endpoint, method, params, data=None)
 
     :param session: ``requests`` or ``requests.Session()`` object
     :param company: ``res.company`` object containing l10n_ro_edi_test_env, l10n_ro_edi_access_token
-    :param endpoint: ``upload`` (for sending) | ``stareMesaj`` (for fetching status) | ``descarcare`` (for downloading answer)
+    :param endpoint: ``upload`` (for sending) | ``stareMesaj`` (for fetching status) | ``descarcare`` (for downloading answer)  | ``transformare`` (to get the official PDF from efactura)
     :param method: ``post`` (for `upload`) | ``get`` (for `stareMesaj` | `descarcare`)
     :param params: Dictionary of query parameters
     :param data: XML data for ``upload`` request
     :return: Dictionary of {'error': <str>} or {'content': <response.content>} from E-Factura
     """
     send_mode = 'test' if company.l10n_ro_edi_test_env else 'prod'
-    url = f"https://api.anaf.ro/{send_mode}/FCTEL/rest/{endpoint}"
-    headers = {'Content-Type': 'application/xml',
-               'Authorization': f'Bearer {company.l10n_ro_edi_access_token}'}
+    if endpoint == 'transformare':
+        url = "https://webservicesp.anaf.ro/prod/FCTEL/rest/transformare/FACT1/DA"
+        headers = {'Content-Type': 'text/plain'}
+    else:
+        url = f"https://api.anaf.ro/{send_mode}/FCTEL/rest/{endpoint}"
+        headers = {
+            'Content-Type': 'application/xml',
+            'Authorization': f'Bearer {company.l10n_ro_edi_access_token}',
+        }
 
     try:
         response = session.request(method=method, url=url, params=params, data=data, headers=headers, timeout=60)

--- a/addons/l10n_ro_efactura_synchronize/models/ciusro_document.py
+++ b/addons/l10n_ro_efactura_synchronize/models/ciusro_document.py
@@ -126,3 +126,21 @@ class L10nRoEdiDocument(models.Model):
             'sent_invoices_refused_messages': sent_invoices_refused_messages,
             'received_bills_messages': received_bills_messages,
         }
+
+    @api.model
+    def _request_ciusro_xml_to_pdf(self, company, xml_data):
+        """
+        This method makes a 'transformare' request to get the official PDF of an invoice.
+        :param company: ``res.company`` object
+        :param xml_data: String of XML data to be sent
+        :return: response dict from E-Factura
+        """
+        return make_efactura_request(
+            session=requests,
+            company=company,
+            endpoint='transformare',
+            method='POST',
+            params={'standard': 'FACT1',
+                    'novld': 'DA'},
+            data=xml_data,
+        )


### PR DESCRIPTION
### Before

For bills from the Romanian ANAF we only downloaded an XML and imported the data. There is no visual aid for the accountant to see and compare the received document. 

### Now

We use the ANAF service to get the  official "PDF" version of the invoice. This is requested for any new bill we get through ANAF that doesn't already contain a pdf from the vendor and it is set as the main attachment. 

task-5877171