### PR TITLE
[FIX] hr_attendance: Fix Duration Format in Reports

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -472,3 +472,28 @@ class HrAttendance(models.Model):
             'url': get_google_maps_url(self.out_latitude, self.out_longitude),
             'target': 'new'
         }
+
+    def export_data(self, fields_to_export):
+        result = super().export_data(fields_to_export)
+        time_fields = ['worked_hours', 'overtime_hours', 'validated_overtime_hours']
+        indices = [i for i, f in enumerate(fields_to_export) if f in time_fields]
+
+        if not indices:
+            return result
+
+        formatted_data = []
+        for row in result['datas']:
+            new_row = list(row)
+            for index in indices:
+                val = new_row[index]
+                hours = int(abs(val))
+                minutes = round((abs(val) - hours) * 60)
+                if minutes == 60:
+                    hours += 1
+                    minutes = 0
+                sign = '-' if val < 0 else ''
+                new_row[index] = f"{sign}{hours:02d}:{minutes:02d}"
+            formatted_data.append(new_row)
+
+        result['datas'] = formatted_data
+        return result

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -62,3 +62,26 @@ class TestHrAttendance(TransactionCase):
         # now = 2019/3/2 14:00 in the employee's timezone
         with patch.object(fields.Datetime, 'now', lambda: tz_datetime(2019, 3, 2, 14, 0).astimezone(pytz.utc).replace(tzinfo=None)):
             self.assertEqual(employee.hours_today, 5, "It should have counted 5 hours")
+
+    def test_export_data_formatting(self):
+        """ Test that worked_hours is converted from float to HH:MM string on export """
+        att = self.env['hr.attendance'].create({
+            'employee_id': self.test_employee.id,
+            'check_in': datetime(2024, 1, 2, 9, 0),
+            'check_out': datetime(2024, 1, 2, 18, 0),
+        })
+
+        export_result = att.export_data(['worked_hours'])
+        exported_value = export_result['datas'][0][0]
+        self.assertEqual(exported_value, "08:00")
+
+    def test_export_data_zero_attendance(self):
+        """ Test 0 Attendance """
+        zero_attendance = self.env['hr.attendance'].create({
+            'employee_id': self.test_employee.id,
+            'check_in': fields.Datetime.to_datetime('2024-01-01 08:00:00'),
+            'check_out': fields.Datetime.to_datetime('2024-01-01 08:00:00'),
+        })
+
+        export_result = zero_attendance.export_data(['worked_hours'])
+        self.assertEqual(export_result['datas'][0][0], "00:00")


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
. When Attendance data is exported from the list view, the duration values are automatically converted from HH:MM format to decimals. Although this conversion is mathematically correct, it creates confusion and a poor user experience, as the values shown in Odoo differ from those in the exported file. 

Current behavior before PR:
. The duration values are formatted on decimals

Desired behavior after PR is merged:
. Override the export_data() method and adjust the format of exported data for float fields.

task-5914073

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
