### PR TITLE
[FIX] hr_timesheet: make sure we search favorite project when needed.

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -38,7 +38,7 @@ class AccountAnalyticLine(models.Model):
         result = super().default_get(fields)
         if not self.env.context.get('default_employee_id') and 'employee_id' in fields and result.get('user_id'):
             result['employee_id'] = self.env['hr.employee'].search([('user_id', '=', result['user_id']), ('company_id', '=', result.get('company_id', self.env.company.id))], limit=1).id
-        if not self.env.context.get('default_project_id') and self.env.context.get('is_timesheet'):
+        if not self.env.context.get('default_project_id') and self.env.context.get('is_timesheet') and 'project_id' in fields:
             employee_id = result.get('employee_id', self.env.context.get('default_employee_id', False))
             favorite_project_id = self._get_favorite_project_id(employee_id)
             if favorite_project_id:


### PR DESCRIPTION
Before this commit, each time the default_get method is called for `account.analytic.line` model, the favorite project is computed even if we don't expect to search the default value for `project_id` field.

This commit makes sure we will only compute the default project when it is really needed.