### PR TITLE
[FIX] point_of_sale: set payment term on invoice with 'pay_later'

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -772,6 +772,12 @@ class PosOrder(models.Model):
             if orderline.refunded_orderline_id and orderline.refunded_orderline_id.order_id.account_move:
                 pos_refunded_invoice_ids.append(orderline.refunded_orderline_id.order_id.account_move.id)
 
+        invoice_payment_term_id = (
+            self.partner_id.property_payment_term_id.id
+            if self.partner_id.property_payment_term_id and any(p.payment_method_id.type == 'pay_later' for p in self.payment_ids)
+            else False
+        )
+
         vals = {
             'invoice_origin': self.name,
             'pos_refunded_invoice_ids': pos_refunded_invoice_ids,
@@ -787,7 +793,7 @@ class PosOrder(models.Model):
             'invoice_date': invoice_date.astimezone(timezone).date(),
             'fiscal_position_id': self.fiscal_position_id.id,
             'invoice_line_ids': self._prepare_invoice_lines(),
-            'invoice_payment_term_id': False,
+            'invoice_payment_term_id': invoice_payment_term_id,
             'invoice_cash_rounding_id': self.config_id.rounding_method.id,
         }
         if self.refunded_order_id.account_move:


### PR DESCRIPTION
Payment terms set on contact form do not reflect on invoice.

Steps to reproduce:
-------------------
- Create a new Contact and add a payment term to this contact (30 days)
- Open POS and create an order
- Select the new contact as the customer
- Go to payment, select the option to create an invoice and validate
> The invoice shows today as the due date.

If instead we're settling an order with this payment term and the customer account then the due date is in 30 days.

Why the fix:
------------
Initially payment terms have been removed here as they were not supported: https://github.com/odoo/odoo/commit/1010aaaad0e09f0e5f2d5e824a28d9e39b877912

They were brought back later only when using 'pay_later' payment method. https://github.com/odoo/odoo/commit/b5a502cbe530b2fef87548af66c67bfc0d13b01e

We backport it.

opw-5911241