### PR TITLE
[IMP] web: display raw value for unknown selection options

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -411,6 +411,7 @@ export function formatMany2oneReference(value) {
 
 /**
  * Returns a string of the value of the selection.
+ * If the value is not found in the selection options, falls back to the raw value.
  *
  * @param {Object} [options={}]
  * @param {[string, string][]} [options.selection]
@@ -420,7 +421,7 @@ export function formatMany2oneReference(value) {
 export function formatSelection(value, options = {}) {
     const selection = options.selection || (options.field && options.field.selection) || [];
     const option = selection.find((option) => option[0] === value);
-    return option ? option[1] : "";
+    return option ? option[1] : value || "";
 }
 
 /**

--- a/addons/web/static/src/views/fields/selection/selection_field.js
+++ b/addons/web/static/src/views/fields/selection/selection_field.js
@@ -44,7 +44,24 @@ export class SelectionField extends Component {
     }
 
     get choices() {
-        return this.options.map(([value, label]) => ({ value, label }));
+        const choices = this.options.map(([value, label]) => ({ value, label }));
+
+        // For selection fields, if the current value is not in the options list,
+        // add it as a temporary choice so it can be displayed in the SelectMenu.
+        // Mark it as disabled so it appears in dropdown but cannot be selected.
+        if (this.type === "selection") {
+            const currentValue = this.value;
+            if (currentValue !== false && !choices.some((c) => c.value === currentValue)) {
+                // Add the unknown value as a disabled choice
+                choices.unshift({
+                    value: currentValue,
+                    label: String(currentValue),
+                    enabled: false, // Appears grayed out and cannot be selected
+                });
+            }
+        }
+
+        return choices;
     }
     get isBottomSheet() {
         return this.env.isSmall && hasTouch();
@@ -67,10 +84,12 @@ export class SelectionField extends Component {
                 return this.props.record.data[this.props.name]
                     ? this.props.record.data[this.props.name].display_name
                     : "";
-            case "selection":
-                return this.props.record.data[this.props.name] !== false
-                    ? this.options.find((o) => o[0] === this.props.record.data[this.props.name])[1]
+            case "selection": {
+                const value = this.props.record.data[this.props.name];
+                return value !== false
+                    ? this.options.find((o) => o[0] === value)?.[1] ?? value
                     : "";
+            }
             default:
                 return "";
         }


### PR DESCRIPTION
When a selection field contains a value not found in the current options list, display the raw value instead of leaving it blank. This behavior aligns with the backend handling for record values and exported data.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
