### PR TITLE
[REF] html_editor: make focus requirement explicit

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -117,7 +117,9 @@ export class EditorOverlay extends Component {
         if (!selection || !selection.rangeCount || !this.props.isOverlayOpen()) {
             return null;
         }
-        const inEditable = selectionData.currentSelectionIsInEditable;
+        const inEditable =
+            selectionData.documentSelectionIsInEditable &&
+            this.props.shared.editableDocumentHasFocus();
         let range;
         if (inEditable) {
             range = selection.getRangeAt(0);

--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -85,6 +85,8 @@ export class Overlay {
                     shared: {
                         ignoreDOMMutations: this.plugin.dependencies.history.ignoreDOMMutations,
                         getSelectionData: this.plugin.dependencies.selection.getSelectionData,
+                        editableDocumentHasFocus:
+                            this.plugin.dependencies.selection.editableDocumentHasFocus,
                     },
                 }),
                 {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -53,7 +53,6 @@ import { weakMemoize } from "@html_editor/utils/functions";
  * @property { boolean } documentSelectionIsInEditable
  * @property { boolean } documentSelectionIsProtected
  * @property { boolean } documentSelectionIsProtecting
- * @property { boolean } currentSelectionIsInEditable
  */
 
 /**
@@ -198,6 +197,7 @@ export class SelectionPlugin extends Plugin {
         "isNodeEditable",
         "selectAroundNonEditable",
         "selectElement",
+        "editableDocumentHasFocus",
     ];
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -262,6 +262,9 @@ export class SelectionPlugin extends Plugin {
             this.addDomListener(document, "pointerdown", unFocusEditable, { capture: true });
         }
         this.preservedCursors = [];
+    }
+    editableDocumentHasFocus() {
+        return this.focusEditableDocument;
     }
 
     selectAll() {
@@ -525,8 +528,6 @@ export class SelectionPlugin extends Plugin {
             documentSelection: documentSelection,
             editableSelection: editableSelection,
             documentSelectionIsInEditable: documentSelectionIsInEditable,
-            currentSelectionIsInEditable:
-                documentSelectionIsInEditable && this.focusEditableDocument,
         };
 
         Object.defineProperty(selectionData, "deepEditableSelection", {
@@ -1117,8 +1118,12 @@ export class SelectionPlugin extends Plugin {
     }
 
     focusEditable() {
-        const { editableSelection, currentSelectionIsInEditable } = this.getSelectionData();
-        if (this.editable.contains(this.document.activeElement) && currentSelectionIsInEditable) {
+        const { editableSelection, documentSelectionIsInEditable } = this.getSelectionData();
+        if (
+            this.editable.contains(this.document.activeElement) &&
+            documentSelectionIsInEditable &&
+            this.editableDocumentHasFocus()
+        ) {
             // Editor has focus — nothing to do.
             return;
         }
@@ -1141,7 +1146,7 @@ export class SelectionPlugin extends Plugin {
             this.setSelection(editableSelection, { normalize: false });
         }
 
-        if (!currentSelectionIsInEditable) {
+        if (!(documentSelectionIsInEditable && this.editableDocumentHasFocus())) {
             // Selection is outside the editor — restore it.
             const { anchorNode, anchorOffset, focusNode, focusOffset } = editableSelection;
             const selection = this.document.getSelection();

--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -38,7 +38,13 @@ export class HintPlugin extends Plugin {
 
         /** Providers */
         hint_targets_providers: (selectionData, editable) => {
-            if (!selectionData.currentSelectionIsInEditable || !selectionData.documentSelection) {
+            if (
+                !(
+                    selectionData.documentSelectionIsInEditable &&
+                    this.dependencies.selection.editableDocumentHasFocus()
+                ) ||
+                !selectionData.documentSelection
+            ) {
                 return [];
             }
             const blockEl = closestBlock(selectionData.documentSelection.anchorNode);

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -820,7 +820,13 @@ export class LinkPlugin extends Plugin {
         const isSelectionInProtected =
             this.document.getSelection()?.isCollapsed &&
             (isProtecting(anchorNode) || isProtected(anchorNode));
-        if (!selectionData.currentSelectionIsInEditable || isSelectionInProtected) {
+        if (
+            !(
+                selectionData.documentSelectionIsInEditable &&
+                this.dependencies.selection.editableDocumentHasFocus()
+            ) ||
+            isSelectionInProtected
+        ) {
             const popoverEl = document.querySelector(".o-we-linkpopover");
             const anchorNode = document.getSelection()?.anchorNode;
             if (

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -122,9 +122,14 @@ export class PowerButtonsPlugin extends Plugin {
 
     updatePowerButtons() {
         this.powerButtonsContainer.classList.add("d-none");
-        const { documentSelection, editableSelection, currentSelectionIsInEditable } =
+        const { documentSelection, editableSelection, documentSelectionIsInEditable } =
             this.dependencies.selection.getSelectionData();
-        if (!currentSelectionIsInEditable) {
+        if (
+            !(
+                documentSelectionIsInEditable &&
+                this.dependencies.selection.editableDocumentHasFocus()
+            )
+        ) {
             return;
         }
         const block = closestBlock(documentSelection.anchorNode);

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -362,7 +362,10 @@ export class ToolbarPlugin extends Plugin {
         // Prevent toolbar to open if the selection is not in the editable area,
         // or if the selection is protected or protecting.
         if (
-            !selectionData.currentSelectionIsInEditable ||
+            !(
+                selectionData.documentSelectionIsInEditable &&
+                this.dependencies.selection.editableDocumentHasFocus()
+            ) ||
             selectionData.documentSelectionIsProtected ||
             selectionData.documentSelectionIsProtecting
         ) {


### PR DESCRIPTION
During the development of `html_builder`, the support of `iframe` was added, and the need to determine whether the current selection was in the editable AND in the currently focused document arised.

This led to having two properties inside `selectionData`:
- `documentSelectionIsInEditable` and
- `currentSelectionIsInEditable`

This creates confusion when having to choose between both.

This commit removes `currentSelectionIsInEditable` and explicitly checks `this.document.hasFocus()` where is was used.

task-4749374
