### PR TITLE
[IMP] *: consistently use Journal Entry and Journal Item in UI

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3873,7 +3873,7 @@ class AccountMove(models.Model):
                     and 'journal_id' in vals and move.journal_id.id != vals['journal_id']
                     and not (move.name == '/' or not move.name or ('name' in vals and (vals['name'] == '/' or not vals['name'])))
             ):
-                raise UserError(_('You cannot edit the journal of an account move if it has been posted once, unless the name is removed or set to "/". This might create a gap in the sequence.'))
+                raise UserError(_('You cannot edit the journal of a journal entry if it has been posted once, unless the name is removed or set to "/". This might create a gap in the sequence.'))
             if (
                     move.name and move.name != '/'
                     and move.sequence_number not in (0, 1)
@@ -3881,7 +3881,7 @@ class AccountMove(models.Model):
                     and not move.quick_edit_mode
                     and not ('name' in vals and (vals['name'] == '/' or not vals['name']))
             ):
-                raise UserError(_('You cannot edit the journal of an account move with a sequence number assigned, unless the name is removed or set to "/". This might create a gap in the sequence.'))
+                raise UserError(_('You cannot edit the journal of a journal entry with a sequence number assigned, unless the name is removed or set to "/". This might create a gap in the sequence.'))
 
             # You can't change the date or name of a move being inside a locked period.
             if move.state == "posted" and (

--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -16,7 +16,7 @@ class AccountMoveSend(models.AbstractModel):
     and 'account.move.send.wizard' for single invoice sending wizard (sync).
     """
     _name = 'account.move.send'
-    _description = "Account Move Send"
+    _description = "Shared Send Invoice Wizard Functions"
 
     # -------------------------------------------------------------------------
     # DEFAULTS

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -4934,9 +4934,9 @@ class AccountTaxRepartitionLine(models.Model):
         default=100,
         digits=(16, 12),
         required=True,
-        help="Factor to apply on the account move lines generated from this distribution line, in percents",
+        help="Factor to apply on the journal items generated from this distribution line, in percents",
     )
-    factor = fields.Float(string="Factor Ratio", compute="_compute_factor", help="Factor to apply on the account move lines generated from this distribution line")
+    factor = fields.Float(string="Factor Ratio", compute="_compute_factor", help="Factor to apply on the journal items generated from this distribution line")
     repartition_type = fields.Selection(string="Based On", selection=[('base', 'Base'), ('tax', 'of tax')], required=True, default='tax', help="Base on which the factor will be applied.")
     document_type = fields.Selection(string="Related to", selection=[('invoice', 'Invoice'), ('refund', 'Refund')], required=True)
     account_id = fields.Many2one(string="Account",

--- a/addons/account/static/tests/account_move_form.test.js
+++ b/addons/account/static/tests/account_move_form.test.js
@@ -76,7 +76,7 @@ class AccountMoveLine extends models.Model {
         relation:"product",
     });
     move_id = fields.Many2one({
-        string: "Account Move",
+        string: "Journal Entry",
         relation: "account.move",
     })
 }

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -1042,7 +1042,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         self.test_move.button_draft()  # move has posted_before == True
         self.assertEqual(self.test_move.journal_id, self.company_data['default_journal_misc'])
         self.assertEqual(self.test_move.name, 'MISC/2016/01/0001')
-        with self.assertRaisesRegex(UserError, 'You cannot edit the journal of an account move if it has been posted once, unless the name is removed or set to "/". This might create a gap in the sequence.'):
+        with self.assertRaisesRegex(UserError, 'You cannot edit the journal of a journal entry if it has been posted once, unless the name is removed or set to "/". This might create a gap in the sequence.'):
             self.test_move.write({'journal_id': False})
         # Once move name in draft is changed to '/', changing the journal is allowed
         self.test_move.name = '/'
@@ -1065,7 +1065,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         test_move_2 = self.test_move.copy({'name': 'TEST/2016/01/0002', 'date': '2016-01-01'})
         self.assertEqual(test_move_2.sequence_number, 2)
         self.assertEqual(test_move_2.journal_id, self.company_data['default_journal_misc'])
-        with self.assertRaisesRegex(UserError, 'You cannot edit the journal of an account move with a sequence number assigned, unless the name is removed or set to "/". This might create a gap in the sequence.'):
+        with self.assertRaisesRegex(UserError, 'You cannot edit the journal of a journal entry with a sequence number assigned, unless the name is removed or set to "/". This might create a gap in the sequence.'):
             test_move_2.write({'journal_id': False})
         # Once move name in draft is changed to '/', changing the journal is allowed
         test_move_2.write({'name': False, 'journal_id': journal.id})

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -9,7 +9,7 @@ class AccountMoveReversal(models.TransientModel):
     Account move reversal wizard, it cancel an account move by reversing it.
     """
     _name = 'account.move.reversal'
-    _description = 'Account Move Reversal'
+    _description = 'Journal Entry Reversal'
     _check_company_auto = True
 
     move_ids = fields.Many2many('account.move', 'account_move_reversal_move', 'reversal_id', 'move_id', domain=[('state', '=', 'posted')])

--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -8,7 +8,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
     """Wizard that handles the sending of multiple invoices."""
     _name = 'account.move.send.batch.wizard'
     _inherit = ['account.move.send']
-    _description = "Account Move Send Batch Wizard"
+    _description = "Send Invoice Batch Wizard"
 
     move_ids = fields.Many2many(comodel_name='account.move', required=True)
     summary_data = fields.Json(compute='_compute_summary_data')

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -9,7 +9,7 @@ class AccountMoveSendWizard(models.TransientModel):
     """Wizard that handles the sending a single invoice."""
     _name = 'account.move.send.wizard'
     _inherit = ['account.move.send', 'mail.composer.mixin']
-    _description = "Account Move Send Wizard"
+    _description = "Send Invoice Wizard"
 
     move_id = fields.Many2one(comodel_name='account.move', required=True)
     company_id = fields.Many2one(comodel_name='res.company', related='move_id.company_id')

--- a/addons/account/wizard/account_validate_account_move.py
+++ b/addons/account/wizard/account_validate_account_move.py
@@ -4,7 +4,7 @@ from odoo.exceptions import UserError
 
 class ValidateAccountMove(models.TransientModel):
     _name = 'validate.account.move'
-    _description = "Validate Account Move"
+    _description = "Validate Journal Entry"
 
     move_ids = fields.Many2many('account.move')
     force_post = fields.Boolean(string="Force", help="Entries in the future are set to be auto-posted by default. Check this checkbox to post them now.")

--- a/addons/account_fleet/models/fleet_vehicle_log_services.py
+++ b/addons/account_fleet/models/fleet_vehicle_log_services.py
@@ -24,7 +24,7 @@ class FleetVehicleLogServices(models.Model):
 
     def _inverse_amount(self):
         if any(service.account_move_line_id for service in self):
-            raise UserError(_("You cannot modify amount of services linked to an account move line. Do it on the related accounting entry instead."))
+            raise UserError(_("You cannot modify the amount of services linked to a journal item. Do it on the related accounting entry instead."))
 
     @api.depends('account_move_line_id.price_subtotal')
     def _compute_amount(self):

--- a/addons/analytic/static/tests/analytic_distribution.test.js
+++ b/addons/analytic/static/tests/analytic_distribution.test.js
@@ -94,7 +94,7 @@ class Aml extends models.Model {
     label = fields.Char({ string: "Label" });
     amount = fields.Float({ string: "Amount" });
     analytic_distribution = fields.Json({ string: "Analytic" });
-    move_id = fields.Many2one({ string: "Account Move", relation: "move" });
+    move_id = fields.Many2one({ string: "Journal Entry", relation: "move" });
     analytic_precision = fields.Integer({ string: "Analytic Precision" });
     company_id = fields.Many2one({ relation: "res.company" });
 

--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -52,14 +52,14 @@
         </record>
 
         <record id="hr_expense_team_approver_account_move_rule" model="ir.rule">
-            <field name="name">Expense Team Approver Account Move</field>
+            <field name="name">Expense Team Approver Journal Entry</field>
             <field name="model_id" ref="account.model_account_move"/>
             <field name="domain_force">[('expense_ids', '!=', False)]</field>
             <field name="groups" eval="[(4, ref('hr_expense.group_hr_expense_team_approver'))]"/>
         </record>
 
         <record id="hr_expense_team_approver_account_move_line_rule" model="ir.rule">
-            <field name="name">Expense Team Approver Account Move Line</field>
+            <field name="name">Expense Team Approver Journal Item</field>
             <field name="model_id" ref="account.model_account_move_line"/>
             <field name="domain_force">[('expense_id', '!=', False)]</field>
             <field name="groups" eval="[(4, ref('hr_expense.group_hr_expense_team_approver'))]"/>

--- a/addons/l10n_es_edi_tbai/models/res_company.py
+++ b/addons/l10n_es_edi_tbai/models/res_company.py
@@ -144,7 +144,7 @@ class ResCompany(models.Model):
         if not self.l10n_es_tbai_chain_sequence_id:
             self_sudo = self.sudo()
             self_sudo.l10n_es_tbai_chain_sequence_id = self_sudo.env['ir.sequence'].create({
-                'name': f'TicketBAI account move sequence for {self.name} (id: {self.id})',
+                'name': f'TicketBAI journal entry sequence for {self.name} (id: {self.id})',
                 'code': f'l10n_es.edi.tbai.account.move.{self.id}',
                 'implementation': 'no_gap',
                 'company_id': self.id,

--- a/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
+++ b/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
@@ -17,7 +17,7 @@ class L10n_LatamDocumentType(models.Model):
         'res.country', required=True, index=True, help='Country in which this type of document is valid')
     name = fields.Char(required=True, help='The document name', translate=True)
     doc_code_prefix = fields.Char(
-        'Document Code Prefix', help="Prefix for Documents Codes on Invoices and Account Moves. For eg. 'FA ' will"
+        'Document Code Prefix', help="Prefix for Documents Codes on Invoices and Journal Entries. For eg. 'FA ' will"
         " build 'FA 0001-0000001' Document Number")
     code = fields.Char(help='Code used by different localizations')
     report_name = fields.Char('Name on Reports', help='Name that will be printed in reports, for example "CREDIT NOTE"', translate=True)

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -383,7 +383,7 @@ class AccountJournal(models.Model):
     def _l10n_sa_edi_create_new_chain(self):
         self.ensure_one()
         return self.env['ir.sequence'].create({
-            'name': f'ZATCA account move sequence for Journal {self.name} (id: {self.id})',
+            'name': f'ZATCA journal entry sequence for Journal {self.name} (id: {self.id})',
             'code': f'l10n_sa_edi.account.move.{self.id}',
             'implementation': 'no_gap',
             'company_id': self.company_id.id,

--- a/addons/mrp_account/wizard/mrp_wip_accounting.py
+++ b/addons/mrp_account/wizard/mrp_wip_accounting.py
@@ -8,7 +8,7 @@ from odoo.exceptions import UserError
 
 class MrpAccountWipAccountingLine(models.TransientModel):
     _name = 'mrp.account.wip.accounting.line'
-    _description = 'Account move line to be created when posting WIP account move'
+    _description = 'Journal item to be created when posting WIP journal entry'
 
     account_id = fields.Many2one('account.account', "Account")
     label = fields.Char("Label")
@@ -37,7 +37,7 @@ class MrpAccountWipAccountingLine(models.TransientModel):
 
 class MrpAccountWipAccounting(models.TransientModel):
     _name = 'mrp.account.wip.accounting'
-    _description = 'Wizard to post Manufacturing WIP account move'
+    _description = 'Wizard to post Manufacturing WIP journal entry'
 
     @api.model
     def default_get(self, fields):

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -384,8 +384,8 @@ class PosOrder(models.Model):
     reversed_move_ids = fields.One2many(
         'account.move',
         'reversed_pos_order_id',
-        string="Reversal Account Moves",
-        help="List of account moves created when this POS order was reversed and invoiced after session close."
+        string="Reversal Journal Entries",
+        help="List of journal entries created when this POS order was reversed and invoiced after session close."
     )
     source = fields.Selection(string="Origin", selection=[('pos', 'Point of Sale')], default='pos')
 

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -61,13 +61,13 @@
     </record>
 
     <record id="purchase_user_account_move_line_rule" model="ir.rule">
-        <field name="name">Purchase User Account Move Line</field>
+        <field name="name">Purchase User Journal Item</field>
         <field name="model_id" ref="account.model_account_move_line"/>
         <field name="domain_force">[('move_id.move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]</field>
         <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>
     </record>
     <record id="purchase_user_account_move_rule" model="ir.rule">
-        <field name="name">Purchase User Account Move</field>
+        <field name="name">Purchase User Journal Entry</field>
         <field name="model_id" ref="account.model_account_move"/>
         <field name="domain_force">[('move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]</field>
         <field name="groups" eval="[(4, ref('purchase.group_purchase_user'))]"/>

--- a/addons/stock_landed_costs/models/product.py
+++ b/addons/stock_landed_costs/models/product.py
@@ -18,7 +18,7 @@ class ProductTemplate(models.Model):
         for product in self:
             if (('type' in vals and vals['type'] != 'service') or ('landed_cost_ok' in vals and not vals['landed_cost_ok'])) and product.type == 'service' and product.landed_cost_ok:
                 if self.env['account.move.line'].search_count([('product_id', 'in', product.product_variant_ids.ids), ('is_landed_costs_line', '=', True)]):
-                    raise UserError(_("You cannot change the product type or disable landed cost option because the product is used in an account move line."))
+                    raise UserError(_("You cannot change the product type or disable landed cost option because the product is used in a journal item."))
                 vals['landed_cost_ok'] = False
 
         return super().write(vals)


### PR DESCRIPTION
*account,account_fleet,analytic,hr_expense,l10n_es_edi_tbai, l10n_latam_invoice_document,l10n_sa_edi,mrp_account,point_of_sale, purchase,stock_landed_costs

Currently we use both the terms "Journal Entry" and "Account Move" in the UI to refer to the technical model `account.move`. The same goes for "Journal Item" and "Account Move Line" for the technical model `account.move.line`. This is confusing for users, especially since the term "Account Move" is more technical and doesn't reflect the actual term in business use.

This commit aims to harmonize the terminology by using "Journal Entry" and "Journal Item" consistently in the UI.

task-5489700

Related: https://github.com/odoo/enterprise/pull/106635