### PR TITLE
[FIX] stock_account: fix AVCO valuation with backdated stock moves

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from bisect import bisect
 from collections import defaultdict
+from datetime import datetime
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
@@ -216,7 +217,7 @@ class ProductProduct(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         products = super().create(vals_list)
-        products._change_standard_price({product: 0 for product in products if product.standard_price})
+        products.with_context(valuation_date=datetime.min)._change_standard_price({product: 0 for product in products if product.standard_price})
         return products
 
     def write(self, vals):
@@ -237,6 +238,7 @@ class ProductProduct(models.Model):
 
     def _change_standard_price(self, old_price):
         product_values = []
+        date = self.env.context.get('valuation_date') or fields.Datetime.now()
         for product in self:
             if product.cost_method == 'fifo' or product.standard_price == old_price.get(product):
                 continue
@@ -244,7 +246,7 @@ class ProductProduct(models.Model):
                 'product_id': product.id,
                 'value': product.standard_price,
                 'company_id': product.company_id.id or self.env.company.id,
-                'date': fields.Datetime.now(),
+                'date': date,
                 'description': _('Price update from %(old_price)s to %(new_price)s by %(user)s',
                     old_price=old_price.get(product), new_price=product.standard_price, user=self.env.user.name)
             })

--- a/addons/stock_account/tests/common.py
+++ b/addons/stock_account/tests/common.py
@@ -1,7 +1,5 @@
 import re
 from dateutil.relativedelta import relativedelta
-from datetime import timedelta
-from freezegun.api import freeze_time
 
 
 from odoo import Command, fields
@@ -410,44 +408,41 @@ class TestStockValuationCommon(BaseCommon):
             'property_valuation': 'real_time',
         })
 
-        # Clean context to avoid magic behavior later (e.g. copy with create_product_product to false)
-        # Use a freeze time to avoid a conflict between moves and default product_value generated during create
-        with freeze_time(fields.Datetime.now() - timedelta(seconds=10)):
-            product_common_vals = {
-                "standard_price": 10.0,
-                "list_price": 20.0,
-                "uom_id": cls.uom.id,
-                "is_storable": True,
-            }
-            cls.product = cls.env['product.product'].create(
-                {**product_common_vals, 'name': 'Storable Product'}).with_context(clean_context(cls.env.context))
-            cls.product_standard = cls.env['product.product'].create({
-                **product_common_vals,
-                'name': 'Standard Product',
-                'categ_id': cls.category_standard.id,
-            }).with_context(clean_context(cls.env.context))
-            cls.product_standard_auto = cls.env['product.product'].create({
-                **product_common_vals,
-                'name': 'Standard Product Auto',
-                'categ_id': cls.category_standard_auto.id,
-            }).with_context(clean_context(cls.env.context))
-            cls.product_fifo = cls.env['product.product'].create({
-                **product_common_vals,
-                'name': 'Fifo Product',
-                'categ_id': cls.category_fifo.id,
-            }).with_context(clean_context(cls.env.context))
-            cls.product_fifo_auto = cls.env['product.product'].create({
-                **product_common_vals,
-                'name': 'Fifo Product Auto',
-                'categ_id': cls.category_fifo_auto.id,
-            }).with_context(clean_context(cls.env.context))
-            cls.product_avco = cls.env['product.product'].create({
-                **product_common_vals,
-                'name': 'Avco Product',
-                'categ_id': cls.category_avco.id,
-            }).with_context(clean_context(cls.env.context))
-            cls.product_avco_auto = cls.env['product.product'].create({
-                **product_common_vals,
-                'name': 'Avco Product Auto',
-                'categ_id': cls.category_avco_auto.id,
-            }).with_context(clean_context(cls.env.context))
+        product_common_vals = {
+            "standard_price": 10.0,
+            "list_price": 20.0,
+            "uom_id": cls.uom.id,
+            "is_storable": True,
+        }
+        cls.product = cls.env['product.product'].create(
+            {**product_common_vals, 'name': 'Storable Product'}).with_context(clean_context(cls.env.context))
+        cls.product_standard = cls.env['product.product'].create({
+            **product_common_vals,
+            'name': 'Standard Product',
+            'categ_id': cls.category_standard.id,
+        }).with_context(clean_context(cls.env.context))
+        cls.product_standard_auto = cls.env['product.product'].create({
+            **product_common_vals,
+            'name': 'Standard Product Auto',
+            'categ_id': cls.category_standard_auto.id,
+        }).with_context(clean_context(cls.env.context))
+        cls.product_fifo = cls.env['product.product'].create({
+            **product_common_vals,
+            'name': 'Fifo Product',
+            'categ_id': cls.category_fifo.id,
+        }).with_context(clean_context(cls.env.context))
+        cls.product_fifo_auto = cls.env['product.product'].create({
+            **product_common_vals,
+            'name': 'Fifo Product Auto',
+            'categ_id': cls.category_fifo_auto.id,
+        }).with_context(clean_context(cls.env.context))
+        cls.product_avco = cls.env['product.product'].create({
+            **product_common_vals,
+            'name': 'Avco Product',
+            'categ_id': cls.category_avco.id,
+        }).with_context(clean_context(cls.env.context))
+        cls.product_avco_auto = cls.env['product.product'].create({
+            **product_common_vals,
+            'name': 'Avco Product Auto',
+            'categ_id': cls.category_avco_auto.id,
+        }).with_context(clean_context(cls.env.context))

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -787,6 +787,10 @@ class TestStockValuation(TestStockValuationCommon):
         move1.value_manual = 8.0
         self.assertEqual(product.qty_available, 8.0)
         self.assertEqual(product.total_value, 8.0)
+        move1.date = Date.today() - timedelta(days=7)
+        # Just to retrigger the total_value computation without influenting it
+        future_date = Date.today() + timedelta(days=1)
+        self.assertEqual(product.with_context(to_date=future_date).total_value, 8.0)
 
     def test_average_perpetual_1(self):
         # http://accountingexplained.com/financial/inventories/avco-method


### PR DESCRIPTION
**Issue**:
If the date of some stock moves is anterior to the creation date of the product
in the database, the associated valuation is replaced by the initial standard
price of the product.

**Steps to reproduce**:
- Create a new product with a standard price of 0 and AVCO cost method
- Create a PO for that product with a unit cost of 1,000,000, confirm it and
  validate the receipt
- Go to Accounting > Review > Inventory > Inventory Valuation
  -> Observe that the valuation correctly takes the purchase into account
- Go back to the receipt, unlock it and change the effective date to one week
  in the past
- Go back to Inventory Valuation
  -> Observe that the valuation no longer takes the purchase into account
- Change the valuation date to yesterday
  -> Observe that the valuation takes it into account again

**Cause**:
When a product is created, a `product.value` record is instantiated with
today’s date:
https://github.com/odoo/odoo/blob/bbaf38aa99143be4679cf951c5c0f1a1c8ecf716/addons/stock_account/models/product.py#L174
https://github.com/odoo/odoo/blob/bbaf38aa99143be4679cf951c5c0f1a1c8ecf716/addons/stock_account/models/product.py#L202

In the AVCO computation, a manually set product value (`product.value`) takes
precedence over move values when it is anterior, either here:
https://github.com/odoo/odoo/blob/bbaf38aa99143be4679cf951c5c0f1a1c8ecf716/addons/stock_account/models/product.py#L309-L312
or here:
https://github.com/odoo/odoo/blob/bbaf38aa99143be4679cf951c5c0f1a1c8ecf716/addons/stock_account/models/product.py#L334-L338

Since the stock move date is set one week in the past, the initial product value
(0.0) takes precedence over the move valuation. When the valuation date is moved
forward to yesterday, this initial product value is ignored and the move value
is correctly applied again.

**Solution**:
Setting the initial `product.value` date to the product creation date is
arbitrary, as it makes inventory valuation depend on when the product was
encoded rather than on real stock history. Instead, set the date of the first
`product.value` to the earliest possible epoch, ensuring that any real stock
move always takes precedence in AVCO valuation.

opw-5882080