### PR TITLE
[FIX] stock_account: fix fetched accounts

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -236,7 +236,7 @@ class ResCompany(models.Model):
         for account in accounts:
             account_variation = account.account_stock_variation_id
             if not account_variation:
-                account_variation = self.env.company.expense_account_id
+                account_variation = self.expense_account_id
             if not account_variation:
                 continue
             balance = inventory_data.get(account, 0) - accounting_data.get(account, 0)


### PR DESCRIPTION
Prior to this PR:
In my test setup, there are 2 companies.
The cron '_cron_post_stock_valuation()'is manually triggered while the user is in Company 1. Processing for Company 1 works correctly.
When the loop reaches Company 2, the process crashes as the account fetched is the one from self.env.company which is the wrong company.

After this PR:
The correct company is being used to fetch the accounts. therefore everything is posted correctly.

OPW - 5447337




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
