### PR TITLE
[FIX] l10n_pl_edi: update KSeF API base URL for production

### DIFF
--- a/addons/l10n_pl_edi/tools/ksef_api_service.py
+++ b/addons/l10n_pl_edi/tools/ksef_api_service.py
@@ -30,7 +30,7 @@ class KsefApiService:
     def _get_api_url(self):
         """Gets the correct KSeF API URL from the company's settings."""
         if self.mode == 'prod':
-            return 'https://ksef.mf.gov.pl/api/v2'
+            return 'https://api.ksef.mf.gov.pl/v2'
         return 'https://api-test.ksef.mf.gov.pl/v2'
 
     def _make_headers(self, token):


### PR DESCRIPTION
Resolves #247360. Updates the KSeF production URL to 'https://api.ksef.mf.gov.pl' as 'https://ksef.mf.gov.pl/api' is decommissioned.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
