### PR TITLE
[FIX] l10n_pl_edi: update KSeF production URL

### DIFF
--- a/addons/l10n_pl_edi/tools/ksef_api_service.py
+++ b/addons/l10n_pl_edi/tools/ksef_api_service.py
@@ -30,7 +30,7 @@ class KsefApiService:
     def _get_api_url(self):
         """Gets the correct KSeF API URL from the company's settings."""
         if self.mode == 'prod':
-            return 'https://ksef.mf.gov.pl/api/v2'
+            return 'https://api.ksef.mf.gov.pl/v2'
         return 'https://api-test.ksef.mf.gov.pl/v2'
 
     def _make_headers(self, token):


### PR DESCRIPTION
The production URL for the Polish EDI (KSeF) was incorrect. This commit updates the endpoint to the current valid URL to ensure proper connectivity.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
