### PR TITLE
[REM] website: remove `undeterministicTour_doNotCopy` key for some tours

### DIFF
--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -22,9 +22,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "test_custom_snippet",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -30,9 +30,6 @@ const selectImageSteps = [
 registerWebsitePreviewTour(
     "test_image_link",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -226,9 +226,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "test_image_upload_progress_unsplash",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/test_image_progress",
         edition: true,
     },

--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -120,8 +120,8 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "test_restricted_editor_test_admin",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
+        // Remove this key to make the tour fail with error:
+        // "Element has not been found." at step "Open Edit menu"
         undeterministicTour_doNotCopy: true,
         url: "/",
     },

--- a/addons/test_website/static/tests/tours/snippet_background_video.js
+++ b/addons/test_website/static/tests/tours/snippet_background_video.js
@@ -7,9 +7,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "snippet_background_video",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/test_website/static/tests/tours/translation.js
+++ b/addons/test_website/static/tests/tours/translation.js
@@ -191,9 +191,6 @@ const ensureEnSite = {
 registerWebsitePreviewTour(
     "translation_single_language_fr_user_fr_site",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
     },
     () => [ensureFrUser, ensureFrSite, ...singleLanguage()]
@@ -202,9 +199,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "translation_single_language_en_user_fr_site",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
     },
     () => [ensureEnUser, ensureFrSite, ...singleLanguage()]
@@ -213,9 +207,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "translation_single_language_fr_user_en_site",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
     },
     () => [ensureFrUser, ensureEnSite, ...singleLanguage()]

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -546,9 +546,6 @@ export function registerThemeHomepageTour(name, steps) {
     return registerWebsitePreviewTour(
         "homepage", // it overrides the community tour with the associated theme tour
         {
-            // Remove this key to get warning should not have any "characterData", "remove"
-            // or "add" mutations in current step when you update the selection
-            undeterministicTour_doNotCopy: true,
             url: "/",
         },
         () => [

--- a/addons/website/static/tests/tours/anchor_on_accordion_tour.js
+++ b/addons/website/static/tests/tours/anchor_on_accordion_tour.js
@@ -11,8 +11,6 @@ import { registry } from "@web/core/registry";
 registerWebsitePreviewTour(
     "anchor_behaviour_on_accordion_same_tab",
     {
-        // should not have any "characterData", "remove" or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
         url: "/",
     },
@@ -79,8 +77,6 @@ registerWebsitePreviewTour(
 );
 
 registry.category("web_tour.tours").add("anchor_behaviour_on_accordion_new_tab", {
-    // should not have any "characterData", "remove" or "add" mutations in current step when you update the selection
-    undeterministicTour_doNotCopy: true,
     url: "/#What-services-does-your-company-offer-%3F",
     steps: () => [
         {

--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -16,9 +16,6 @@ const carouselInnerSelector = ":iframe .carousel-inner";
 registerWebsitePreviewTour(
     "carousel_content_removal",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },
@@ -85,9 +82,6 @@ const checkSlides = (number, position) => {
 registerWebsitePreviewTour(
     "snippet_carousel",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/colorpicker.js
+++ b/addons/website/static/tests/tours/colorpicker.js
@@ -43,9 +43,6 @@ function checkBackgroundColorWithHEX(hexCode) {
 registerWebsitePreviewTour(
     "website_background_colorpicker",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
         url: "/",
     },

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -55,9 +55,6 @@ function checkEyesIconAfterSave(footerIsHidden = true) {
 registerWebsitePreviewTour(
     "conditional_visibility_1",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
         url: "/",
     },
@@ -118,9 +115,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "conditional_visibility_3",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
         url: "/",
     },
@@ -181,9 +175,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "conditional_visibility_4",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
         url: "/",
     },

--- a/addons/website/static/tests/tours/conditional_visibility_frontend.js
+++ b/addons/website/static/tests/tours/conditional_visibility_frontend.js
@@ -1,9 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("conditional_visibility_2", {
-    // Remove this key to get warning should not have any "characterData", "remove"
-    // or "add" mutations in current step when you update the selection
-    undeterministicTour_doNotCopy: true,
     url: "/?utm_medium=Email",
     steps: () => [
         {

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -8,9 +8,6 @@ import {
 registerWebsitePreviewTour(
     "default_shape_gets_palette_colors",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
+++ b/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
@@ -8,9 +8,6 @@ import { onceAllImagesLoaded } from "@website/utils/images";
 registerWebsitePreviewTour(
     "drop_404_ir_attachment_url",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -70,9 +70,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "scroll_to_new_grid_item",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -189,7 +189,8 @@ registerWebsitePreviewTour(
         },
         {
             content: "Click on the 'Icons' tab",
-            trigger: '.o_select_media_dialog .o_notebook_headers .nav-item button:contains("Icons")',
+            trigger:
+                '.o_select_media_dialog .o_notebook_headers .nav-item button:contains("Icons")',
             run: "click",
         },
         {
@@ -208,9 +209,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_media_dialog_insert_media",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -12,9 +12,6 @@ const coverSnippet = { id: "s_cover", name: "Cover", groupName: "Intro" };
 registerWebsitePreviewTour(
     "test_parallax",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/popup_visibility_option.js
+++ b/addons/website/static/tests/tours/popup_visibility_option.js
@@ -3,9 +3,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "website_popup_visibility_option",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/powerbox_snippet.js
+++ b/addons/website/static/tests/tours/powerbox_snippet.js
@@ -7,9 +7,6 @@ import {
 registerWebsitePreviewTour(
     "website_powerbox_snippet",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
     },
     () => [
@@ -56,9 +53,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_powerbox_keyword",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -9,9 +9,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_countdown",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -32,9 +32,6 @@ const oldWriteText = browser.navigator.clipboard.writeText;
 registerWebsitePreviewTour(
     "snippet_editor_panel_options",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -17,9 +17,6 @@ function removeSelectedBlock() {
 registerWebsitePreviewTour(
     "snippet_empty_parent_autoremove",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -35,9 +35,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "snippet_image_gallery_remove",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },
@@ -181,9 +178,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "snippet_image_gallery_thumbnail_update",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_images_wall.js
+++ b/addons/website/static/tests/tours/snippet_images_wall.js
@@ -57,9 +57,6 @@ const reselectSignImageSteps = [
 registerWebsitePreviewTour(
     "snippet_images_wall",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -49,8 +49,8 @@ function scrollToSnippet(snippetId) {
 registerWebsitePreviewTour(
     "snippet_popup_and_animations",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
+        // Remove this key to make the tour fail with error:
+        // "The scroll animation in the modal did not start properly"
         undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
@@ -122,7 +122,7 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ":iframe:not(:has(.o_loading_screen))",
+            trigger: ".o_website_preview :iframe:not(:has(.o_loading_screen))",
         },
         clickOnElement("3rd columns", ":iframe .s_popup .s_three_columns .row > :last-child"),
         ...setOnScrollAnim(),

--- a/addons/website/static/tests/tours/snippet_tabs.js
+++ b/addons/website/static/tests/tours/snippet_tabs.js
@@ -8,9 +8,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_tabs",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         edition: true,
         url: "/",
     },

--- a/addons/website/static/tests/tours/text_animations.js
+++ b/addons/website/static/tests/tours/text_animations.js
@@ -28,9 +28,6 @@ function setTextAnimation(trigger, value) {
 registerWebsitePreviewTour(
     "text_animations",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/text_highlights.js
+++ b/addons/website/static/tests/tours/text_highlights.js
@@ -31,8 +31,8 @@ function countLines(el) {
 registerWebsitePreviewTour(
     "text_highlights",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
+        // Remove this key to make the tour fail with error:
+        // "The highlight svgs are not correctly applied to text lines"
         undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,

--- a/addons/website/static/tests/tours/translate_text_options.js
+++ b/addons/website/static/tests/tours/translate_text_options.js
@@ -9,9 +9,6 @@ import {
 registerWebsitePreviewTour(
     "translate_text_options",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/website_click_tests.js
+++ b/addons/website/static/tests/tours/website_click_tests.js
@@ -17,9 +17,6 @@ const cover = {
 registerWebsitePreviewTour(
     "website_click_tour",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
     },
     () => [

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -1150,9 +1150,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_editable_content",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },
@@ -1265,9 +1262,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_duplicate_field_ids",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -119,9 +119,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_no_dirty_lazy_image",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/website_text_edition.js
+++ b/addons/website/static/tests/tours/website_text_edition.js
@@ -12,9 +12,6 @@ const WEBSITE_MAIN_COLOR = "#ABCDEF";
 registerWebsitePreviewTour(
     "website_text_edition",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -212,9 +212,6 @@ function getAllFontSizesTestSteps() {
 registerWebsitePreviewTour(
     "website_text_font_size",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -47,9 +47,6 @@ const checkIfNoMobileOrder = (snippetRowSelector) => ({
 registerWebsitePreviewTour(
     "website_update_column_count",
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: "/",
         edition: true,
     },

--- a/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
@@ -5,9 +5,6 @@ import { clickOnSave, clickOnEditAndWaitEditMode, registerWebsitePreviewTour } f
 registerWebsitePreviewTour(
     'website_sale.category_page_and_products_snippet_edition',
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: '/shop',
     },
     () => [
@@ -35,7 +32,7 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ":iframe:not(:has(.o_loading_screen))",
+            trigger: ".o_website_preview :iframe:not(:has(.o_loading_screen))",
         },
         {
             content: "Click on the product snippet to show its options",

--- a/addons/website_sale/static/tests/tours/snippet_products.js
+++ b/addons/website_sale/static/tests/tours/snippet_products.js
@@ -12,9 +12,6 @@ const productsSnippet = { id: "s_dynamic_snippet_products", name: "Products", gr
 registerWebsitePreviewTour(
     'website_sale.snippet_products',
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: '/',
         edition: true,
     },
@@ -35,9 +32,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     'website_sale.products_snippet_recently_viewed',
     {
-        // Remove this key to get warning should not have any "characterData", "remove"
-        // or "add" mutations in current step when you update the selection
-        undeterministicTour_doNotCopy: true,
         url: '/',
         edition: true,
     },


### PR DESCRIPTION
[`e2918f8`] fixed the undeterministic tours that used `insertSnippet`. `undeterministicTour_doNotCopy` is therefore useless for them.

Moreover, by removing this key the delay between steps is removed which considerably enhances their robustness and speed.

[`e2918f8`]: https://github.com/odoo/odoo/commit/e2918f8