### PR TITLE
[FIX] tests: restore watch mode launcher in tours

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1989,7 +1989,7 @@ class HttpCase(TransactionCase):
             timeout = max(timeout*10, 3600)
             devtool_query_string = self.browser.dev_tools_frontend_url.partition('/inspector.html')[2]
             debug_front_end = f'http://127.0.0.1:{self.browser.devtools_port}/devtools/inspector.html{devtool_query_string}'
-            self.browser._chrome_without_limit([self.browser.executable, debug_front_end])
+            subprocess.Popen([self.browser.executable, debug_front_end], stderr=subprocess.DEVNULL, preexec_fn=_preexec)
             time.sleep(3)
         try:
             self.http_request_key = self.canonical_tag + '_browser_js'


### PR DESCRIPTION
Commit 38fad878ebc0e8496bfb66e70e00d9c9356ff0c6 removed ChromeBrowser._chrome_without_limit while browser_js still calls it for watch=True, causing AttributeError and breaking watch mode in 16.0.

Replace the call with a direct subprocess.Popen using the existing _preexec hook. This is a minimal, targeted change to restore watch mode behavior without altering the headless flow.

Description of the issue/feature this PR addresses:

Current behavior before PR: AttributeError is thrown as tours are started in watch mode as _chrome_without_limit() is not defined.

Desired behavior after PR is merged: Web browser window is spawned with DevTools opened.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
