### PR TITLE
[FIX] stock_account: use lot std price for move value

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -450,6 +450,9 @@ class StockMove(models.Model):
         std_price = std_price if std_price else self.product_id.standard_price
         if at_date and self.product_id.cost_method == 'standard':
             std_price = std_price or self.product_id._get_standard_price_at_date(at_date)
+        # If multiple lots keep standard_price from product
+        elif self.product_id.lot_valuated and len(self.lot_ids) == 1:
+            std_price = self.lot_ids.standard_price
         return {
             'value': std_price * quantity,
             'quantity': quantity,

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -791,3 +791,44 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertRecordValues(delivery.move_ids, [
             {'quantity': 5.0, 'state': 'done', 'lot_ids': self.lot1.ids}
         ])
+
+    def test_in_move_lot_valuated_standard_price(self):
+        """Check that when the standard price is used to value a move
+        with a single lot, the standard price of the lot is used instead of the
+        standard price of the product
+        """
+        lot_product = self.product_avco_auto
+        lot_product.write({
+            'lot_valuated': True,
+            'tracking': 'lot',
+        })
+        lot1, lot2 = self.env['stock.lot'].create([
+            {'name': 'lot1', 'product_id': lot_product.id},
+            {'name': 'lot2', 'product_id': lot_product.id},
+        ])
+        self._make_in_move(lot_product, 1, 10, lot_ids=[lot1])
+        self._make_in_move(lot_product, 1, 16, lot_ids=[lot2])
+        self.assertEqual(lot_product.standard_price, 13)
+        self.assertEqual(lot1.standard_price, 10)
+        self.assertEqual(lot2.standard_price, 16)
+
+        # not using _make_in_move to not a create a product.value linked to this move
+        move = self.env['stock.move'].create({
+            'product_id': lot_product.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'product_uom': self.uom.id,
+            'product_uom_qty': 1,
+            'picking_type_id': self.picking_type_in.id,
+            'move_line_ids': [Command.create({
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
+                'quantity': 1,
+                'product_id': lot_product.id,
+                'lot_id': lot1.id,
+            })]
+        })
+        move.picked = True
+        move._action_done()
+        self.assertEqual(lot1.standard_price, 10)
+        self.assertEqual(lot_product.standard_price, 12)


### PR DESCRIPTION
**Problem:**
when adding quantities to a lot via the physical inventory 
the move created, uses the standard_price of the product
and not the standard_price from the lot even if the product
is valued by lot.

**Steps to reproduce:**
- create an avco perpetual product, tracked and valued by lot
- confirm a PO for a quantity of 1 and a price of 10
- on the picking set the lot as 'lot1' and validate the picking
- confirm a PO for a quantity of 1 and a price of 16
- on the picking set the lot as 'lot2' and validate the picking
- open "Inventory/ Operations/ Adjustments/ Physical Inventory"
- on the quant line of the lot1 change the quantity from  1 to 2 
and apply
- open the product form

**Current behavior:**
the move created has a value of 13 (the standard price of the product),
so :
1) the standard price of the product is still at 13 
2) if you select the smart button for lots/serial number and select lot1 
you can see that the new cost is 11.5

**Expected behavior:**
the move created should have a value of 10 because we added a quantity
without specifying a cost in a lot which has a value of 10,
so:
1) the standard price of the product should now be 12
2) the cost of the lot should stay 10

**Cause of the issue:**
when calling _get_value_data on the move, and that we use 
_get_value_from_std_price (because there is remaining_qty 
after previous steps), 
https://github.com/odoo/odoo/blob/555df96ac87a51405767c32f0396f762d458fd29/addons/stock_account/models/stock_move.py#L382-L384
inside _get_value_from_std_price, we use the standard 
price of the product
https://github.com/odoo/odoo/blob/555df96ac87a51405767c32f0396f762d458fd29/addons/stock_account/models/stock_move.py#L450-L452

But if : 
- the product is valued by lots, 
- we're not in the case where we want to call _get_standard_price_at_date
(when the product is standard_price and at_date is set)


in this case we should use the standard_price of the lot 

**fix**
in case there is multiple lots on the move, we stay with the 
standard_price of the product because it's not clear that 
a weighted average would be better

opw-5898837