### PR TITLE
[IMP] website, *: js tracker

### DIFF
--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -15,7 +15,7 @@ from odoo.tools.urls import urljoin as url_join
 def MockRequest(
     env, *, path='/mockrequest', routing=True, multilang=True,
     context=frozendict(), cookies=frozendict(), country_code=None, city_name=None,
-    website=None, remote_addr=HOST, environ_base=None, url_root=None,
+    website=None, remote_addr=HOST, environ_base=None, url_root=None, referrer=None,
 ):
     """Mock of the ``http.request``.
 
@@ -45,7 +45,7 @@ def MockRequest(
                 REMOTE_ADDR=remote_addr,
             ),
             cookies=cookies,
-            referrer='',
+            referrer=referrer or '',
             remote_addr=remote_addr,
             url_root=url_root,
             args=[],

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -241,7 +241,7 @@ class Website(Home):
             params = dict(kwargs, res_model=res_model, res_id=res_id, url=url)
             extra_tracking_vals = request.env[res_model].browse(res_id).sudo()._get_extra_tracking_values(**params)
 
-        request.env['website.visitor']._get_visitor_from_request(
+        request.env['ir.http']._get_visitor_from_request(
             force_create=True,
             force_track_values={
                 'url': url,

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -226,6 +226,31 @@ class Website(Home):
         return super().web_login(*args, **kw)
 
     # ------------------------------------------------------
+    # Tracking
+    # ------------------------------------------------------
+
+    @http.route('/website/odoo_track', type='jsonrpc', auth='public', methods=['POST'], website=True, csrf=True)
+    def track(self, res_model, res_id, **kwargs):
+        url = request.httprequest.referrer
+        extra_tracking_vals = {}
+        if (
+            res_model and res_id
+            and res_model in request.env
+            and hasattr(request.env[res_model], '_get_extra_tracking_values')
+        ):
+            params = dict(kwargs, res_model=res_model, res_id=res_id, url=url)
+            extra_tracking_vals = request.env[res_model].browse(res_id).sudo()._get_extra_tracking_values(**params)
+
+        request.env['website.visitor']._get_visitor_from_request(
+            force_create=True,
+            force_track_values={
+                'url': url,
+                **extra_tracking_vals,
+            },
+        )
+        return {}
+
+    # ------------------------------------------------------
     # Business
     # ------------------------------------------------------
 

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -21,7 +21,7 @@
     </template>
     <template id="website.contactus" name="Contact Us">
         <t t-call="website.layout"
-            logged_partner="env['website.visitor']._get_visitor_from_request().partner_id">
+            logged_partner="env['ir.http']._get_visitor_from_request().partner_id">
             <t t-set="contactus_form_values" t-value="{
                 'email_to': res_company.email,
                 'name': request.params.get('name', ''),

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -195,27 +195,6 @@ class IrHttp(models.AbstractModel):
             super()._auth_method_public()
 
     @classmethod
-    def _register_website_track(cls, response):
-        if request.env['ir.http'].is_a_bot():
-            return False
-        if getattr(response, 'status_code', 0) != 200 or request.httprequest.headers.get('X-Disable-Tracking') == '1':
-            return False
-        template = False
-        if hasattr(response, '_cached_page'):
-            website_page, template = response._cached_page, response._cached_view_id
-        elif hasattr(response, 'qcontext'):  # classic response
-            main_object = response.qcontext.get('main_object')
-            website_page = getattr(main_object, '_name', False) == 'website.page' and main_object
-            template = response.qcontext.get('response_template')
-            if isinstance(template, str) and '.' not in template:
-                template = 'website.%s' % template
-
-        if template and not request.env.cr.readonly and request.env['ir.ui.view']._get_cached_template_info(template)['track']:
-            request.env['website.visitor']._handle_webpage_dispatch(website_page)
-
-        return False
-
-    @classmethod
     def _match(cls, path):
         if not hasattr(request, 'website_routing'):
             website = request.env['website'].with_context(lang=None).get_current_website()
@@ -282,7 +261,6 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _post_dispatch(cls, response):
         super()._post_dispatch(response)
-        cls._register_website_track(response)
 
     @api.model
     def get_nearest_lang(self, lang_code):

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -434,6 +434,45 @@ class IrHttp(models.AbstractModel):
         # is not restricted by the website module.
         return result
 
+    def _get_visitor_from_request(self, force_create=False, force_track_values=None):
+        """ Return the visitor as sudo from the request.
+
+        :param force_create: force a visitor creation if no visitor exists
+        :param force_track_values: an optional dict to create a track at the
+            same time.
+        :return: the website visitor if exists or forced, empty recordset
+            otherwise.
+        """
+
+        # This function can be called in json with mobile app.
+        # In case of mobile app, no uid is set on the jsonRequest env.
+        # In case of multi db, _env is None on request, and request.env unbound.
+        if not (request and request.env and request.env.uid):
+            return None
+
+        access_token = self.env['website.visitor']._get_access_token()
+
+        if force_create:
+            force_track_values = force_track_values or {}
+            visitor_id, _ = self.env['website.visitor']._upsert_visitor(
+                token_or_partner_id=access_token,
+                website_id=request.website.id,
+                lang_id=request.lang.id,
+                country_code=request.geoip.country_code,  # GEOIP might return a country code unknown to odoo
+                timezone=self.env['website.visitor']._get_visitor_timezone(),
+                **force_track_values
+            )
+            return self.env['website.visitor'].sudo().browse(visitor_id)
+
+        visitor = self.env['website.visitor'].sudo().search_fetch([('access_token', '=', access_token)])
+
+        if not force_create and not self.env.cr.readonly and visitor and not visitor.timezone:
+            tz = self.env['website.visitor']._get_visitor_timezone()
+            if tz:
+                visitor._update_visitor_timezone(tz)
+
+        return visitor
+
 
 class ModelConverter(ir_http.ModelConverter):
 

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -24,7 +24,7 @@ class IrUiView(models.Model):
     page_ids = fields.One2many('website.page', 'view_id')
     controller_page_ids = fields.One2many('website.controller.page', 'view_id')
     first_page_id = fields.Many2one('website.page', string='Website Page', help='First page linked to this view', compute='_compute_first_page_id')
-    track = fields.Boolean(string='Track', default=False, help="Allow to specify for one page of the website to be trackable or not")
+    track = fields.Boolean(string='Track', default=True, help="Allow to specify for one page of the website to be trackable or not")
     visibility = fields.Selection(
         [
             ('public', 'Public'),
@@ -237,6 +237,9 @@ class IrUiView(models.Model):
         result = super(IrUiView, self + specific_views).unlink()
         self.env.registry.clear_cache('templates')
         return result
+
+    def _get_extra_tracking_values(self, **kwargs):
+        return {}
 
     def _create_website_specific_pages_for_view(self, new_view, website):
         for page in self.page_ids:

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -221,6 +221,9 @@ class WebsiteLocatedMixin(models.AbstractModel):
             if record.website_url != '#':
                 record.website_absolute_url = url_join(record.get_base_url(), record.website_url)
 
+    def _get_extra_tracking_values(self, **kwargs):
+        return {}
+
 
 class WebsitePublishedMixin(models.AbstractModel):
     _name = 'website.published.mixin'

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -75,7 +75,7 @@ class ResUsers(models.Model):
         leads, ...) as possible. """
         visitor_pre_authenticate_sudo = None
         if request and request.env:
-            visitor_pre_authenticate_sudo = request.env['website.visitor']._get_visitor_from_request()
+            visitor_pre_authenticate_sudo = self.env['ir.http']._get_visitor_from_request()
         auth_info = super().authenticate(credential, user_agent_env)
         if auth_info.get('uid') and visitor_pre_authenticate_sudo:
             env = self.env(user=auth_info['uid'])

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1269,6 +1269,11 @@ class Website(models.CachedModel):
             page_temp = page_url + (inc and "-%s" % inc or "")
         return page_temp
 
+    def _is_tracking_enabled(self, main_object):
+        if main_object._name in ['ir.ui.view', 'website.page']:
+            return main_object.track
+        return True
+
     def _get_plausible_script_url(self):
         return self.env['ir.config_parameter'].sudo().get_str(
             'website.plausible_script') or 'https://plausible.io/js/plausible.js'

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -353,6 +353,15 @@ class WebsitePage(models.Model):
         """
         return True
 
+    def _get_extra_tracking_values(self, **kwargs):
+        extra_tracking_values = super()._get_extra_tracking_values(**kwargs)
+        if (
+            kwargs.get('res_model') == self._name
+            and (res_id := kwargs.get('res_id'))
+        ):
+            extra_tracking_values['page_id'] = res_id
+        return extra_tracking_values
+
     @api.model
     def _post_process_response_from_cache(self, request, response) -> None:
         """ A hook called after a response is retrieved from the cache. This

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -16,7 +16,7 @@ from odoo.http import request
 class WebsiteTrack(models.Model):
     _name = 'website.track'
     _description = 'Visited Page'
-    _order = 'visit_datetime DESC'
+    _order = 'visit_datetime DESC, id DESC'
     _log_access = False
 
     visitor_id = fields.Many2one('website.visitor', ondelete="cascade", index=True, required=True, readonly=True)
@@ -190,32 +190,35 @@ class WebsiteVisitor(models.Model):
             'context': compose_ctx,
         }
 
-    def _upsert_visitor(self, access_token, force_track_values=None):
+    def _upsert_visitor(self, token_or_partner_id, website_id, lang_id=None, country_code=None, timezone=None, url=None, **kwargs):
         """ Based on the given `access_token`, either create or return the
         related visitor if exists, through a single raw SQL UPSERT Query.
 
         It will also create a tracking record if requested, in the same query.
 
-        :param access_token: token to be used to upsert the visitor
-        :param force_track_values: an optional dict to create a track at the
-            same time.
+        :param token_or_partner_id: token (or partner id) to be used to identify the visitor
+        :param website_id: every visit is typically for a particular website
+        :param lang_id: visitors language id
+        :param country_code: visitors country code
+        :param timezone: visitors time zone
+        :param url: optional url to create a track record at the same time
+        :param kwargs: additional values to include in the track record, including
+            page_id: the id of the page visited
         :return: a tuple containing the visitor id and the upsert result (either
             `inserted` or `updated).
         """
         create_values = {
-            'access_token': access_token,
-            'lang_id': request.lang.id,
-            # Note that it's possible for the GEOIP database to return a country
-            # code which is unknown in Odoo
-            'country_code': request.geoip.country_code,
-            'website_id': request.website.id,
-            'timezone': self._get_visitor_timezone() or None,
+            'access_token': token_or_partner_id,
+            'lang_id': lang_id,
+            'country_code': country_code,
+            'website_id': website_id,
+            'timezone': timezone,
             'write_uid': self.env.uid,
             'create_uid': self.env.uid,
             # If the access_token is not a 32 length hexa string, it means that the
             # visitor is linked to a logged in user, in which case its partner_id is
             # used instead as the token.
-            'partner_id': None if len(str(access_token)) == 32 else access_token,
+            'partner_id': None if len(str(token_or_partner_id)) == 32 else token_or_partner_id,
         }
         query = SQL("""
             INSERT INTO website_visitor (
@@ -231,30 +234,42 @@ class WebsiteVisitor(models.Model):
             ON CONFLICT (access_token)
             DO UPDATE SET
                 last_connection_datetime=excluded.last_connection_datetime,
+                write_date = excluded.write_date,
                 visit_count = CASE WHEN website_visitor.last_connection_datetime < NOW() AT TIME ZONE 'UTC' - INTERVAL '8 hours'
                                     THEN website_visitor.visit_count + 1
                                     ELSE website_visitor.visit_count
                                 END
-            RETURNING id, CASE WHEN create_date = now() at time zone 'UTC' THEN 'inserted' ELSE 'updated' END AS upsert
+            RETURNING id, CASE WHEN create_date = write_date THEN 'inserted' ELSE 'updated' END AS upsert
         """, **create_values)
 
-        if force_track_values:
+        if url:
+            cols_extra, vals_extra = self._get_additional_track_query_parts(**kwargs)
             query = SQL("""
                 WITH visitor AS (
-                    %(query)s, %(url)s AS url, %(page_id)s AS page_id
+                    %(query)s
                 ), track AS (
-                    INSERT INTO website_track (visitor_id, url, page_id, visit_datetime)
-                    SELECT id, url, page_id::integer, now() at time zone 'UTC' FROM visitor
+                    INSERT INTO website_track (visitor_id, url, visit_datetime %(cols_extra)s)
+                    SELECT id, %(url)s, now() at time zone 'UTC' %(vals_extra)s FROM visitor
                 )
                 SELECT id, upsert from visitor;
                 """,
                 query=query,
-                url=force_track_values['url'],
-                page_id=force_track_values.get('page_id'),
+                url=url,
+                cols_extra=cols_extra,
+                vals_extra=vals_extra,
             )
 
         [result] = self.env.execute_query(query)
         return result
+
+    def _get_additional_track_query_parts(self, **kwargs):
+        TrackModel = self.env['website.track']
+        cols, vals = [], []
+        for fname, val in kwargs.items():
+            if fname in TrackModel._fields and val:
+                cols.append(SQL(", %s", SQL.identifier(fname)))
+                vals.append(SQL(", %s", val))
+        return SQL().join(cols), SQL().join(vals)
 
     def _get_visitor_from_request(self, force_create=False, force_track_values=None):
         """ Return the visitor as sudo from the request.
@@ -275,7 +290,15 @@ class WebsiteVisitor(models.Model):
         access_token = self._get_access_token()
 
         if force_create:
-            visitor_id, _ = self._upsert_visitor(access_token, force_track_values)
+            force_track_values = force_track_values or {}
+            visitor_id, _ = self._upsert_visitor(
+                token_or_partner_id=access_token,
+                website_id=request.website.id,
+                lang_id=request.lang.id,
+                country_code=request.geoip.country_code,  # GEOIP might return a country code unknown to odoo
+                timezone=self._get_visitor_timezone(),
+                **force_track_values
+            )
             return self.env['website.visitor'].sudo().browse(visitor_id)
 
         visitor = self.env['website.visitor'].sudo().search_fetch([('access_token', '=', access_token)])
@@ -286,29 +309,6 @@ class WebsiteVisitor(models.Model):
                 visitor._update_visitor_timezone(tz)
 
         return visitor
-
-    def _handle_webpage_dispatch(self, website_page):
-        """ Create a website.visitor if the http request object is a tracked
-        website.page or a tracked ir.ui.view.
-        Since this method is only called on tracked elements, the
-        last_connection_datetime might not be accurate as the visitor could have
-        been visiting only untracked page during his last visit."""
-
-        url = request.httprequest.url
-        website_track_values = {'url': url}
-        if website_page:
-            website_track_values['page_id'] = website_page.id
-
-        self._get_visitor_from_request(force_create=True, force_track_values=website_track_values)
-
-    def _add_tracking(self, domain, website_track_values):
-        """ Add the track and update the visitor"""
-        domain = Domain.AND([domain, Domain('visitor_id', '=', self.id)])
-        last_view = self.env['website.track'].sudo().search(domain, limit=1)
-        if not last_view or last_view.visit_datetime < datetime.now() - timedelta(minutes=30):
-            website_track_values['visitor_id'] = self.id
-            self.env['website.track'].create(website_track_values)
-        self._update_visitor_last_visit()
 
     def _merge_visitor(self, target):
         """ Merge an anonymous visitor data to a partner visitor then unlink

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -271,45 +271,6 @@ class WebsiteVisitor(models.Model):
                 vals.append(SQL(", %s", val))
         return SQL().join(cols), SQL().join(vals)
 
-    def _get_visitor_from_request(self, force_create=False, force_track_values=None):
-        """ Return the visitor as sudo from the request.
-
-        :param force_create: force a visitor creation if no visitor exists
-        :param force_track_values: an optional dict to create a track at the
-            same time.
-        :return: the website visitor if exists or forced, empty recordset
-            otherwise.
-        """
-
-        # This function can be called in json with mobile app.
-        # In case of mobile app, no uid is set on the jsonRequest env.
-        # In case of multi db, _env is None on request, and request.env unbound.
-        if not (request and request.env and request.env.uid):
-            return None
-
-        access_token = self._get_access_token()
-
-        if force_create:
-            force_track_values = force_track_values or {}
-            visitor_id, _ = self._upsert_visitor(
-                token_or_partner_id=access_token,
-                website_id=request.website.id,
-                lang_id=request.lang.id,
-                country_code=request.geoip.country_code,  # GEOIP might return a country code unknown to odoo
-                timezone=self._get_visitor_timezone(),
-                **force_track_values
-            )
-            return self.env['website.visitor'].sudo().browse(visitor_id)
-
-        visitor = self.env['website.visitor'].sudo().search_fetch([('access_token', '=', access_token)])
-
-        if not force_create and not self.env.cr.readonly and visitor and not visitor.timezone:
-            tz = self._get_visitor_timezone()
-            if tz:
-                visitor._update_visitor_timezone(tz)
-
-        return visitor
-
     def _merge_visitor(self, target):
         """ Merge an anonymous visitor data to a partner visitor then unlink
         that anonymous visitor.

--- a/addons/website/static/src/interactions/odoo_tracker.js
+++ b/addons/website/static/src/interactions/odoo_tracker.js
@@ -1,0 +1,23 @@
+import { registry } from "@web/core/registry";
+import { rpc } from '@web/core/network/rpc';
+import { Interaction } from "@web/public/interaction";
+
+export const recordRE = /^([^(]+)\((\d+)/;
+
+export class OdooTracker extends Interaction {
+    static selector = "#wrapwrap";
+
+    start() {
+        const { trackingEnabled, mainObject } = document.documentElement.dataset;
+        const matches = mainObject?.match(recordRE);
+        if (trackingEnabled && matches) {
+            rpc('/website/odoo_track', {
+                res_model: matches[1],
+                res_id: matches[2],
+            });
+        }
+    }
+}
+
+
+registry.category("public.interactions").add("website.tracker", OdooTracker);

--- a/addons/website/static/tests/tours/tracking.js
+++ b/addons/website/static/tests/tours/tracking.js
@@ -1,0 +1,12 @@
+import {
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour("visitor_tracking", {}, () => [
+    {
+        content: "link to tracked page",
+        trigger: "#tracked_link",
+        run: "click",
+        expectUnloadPage: true,
+    },
+]);

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -263,12 +263,6 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 }
                 expected_query_count = 2 if cache else 7
                 insert_tables_perf = {}
-                if not readonly_enabled:
-                    insert_tables_perf = {
-                        'website_visitor': 1,
-                        # Visitor upsert
-                    }
-                    expected_query_count += 1
                 self.page.track = True
 
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
@@ -285,12 +279,6 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 }
                 expected_query_count = 1
                 insert_tables_perf = {}
-                if not readonly_enabled:
-                    insert_tables_perf = {
-                        'website_visitor': 1,
-                        # Visitor upsert
-                    }
-                    expected_query_count += 1
                 self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf)
                 self.assertEqual(self._get_url_hot_query('/'), expected_query_count)
 
@@ -307,12 +295,6 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                 }
                 expected_query_count = 6
                 insert_tables_perf = {}
-                if not readonly_enabled:
-                    insert_tables_perf = {
-                        'website_visitor': 1,
-                        # Visitor upsert
-                    }
-                    expected_query_count += 1
                 self._check_url_hot_query('/', expected_query_count, select_tables_perf, insert_tables_perf, nocache=True)
                 self.assertEqual(self._get_url_hot_query('/', nocache=True), expected_query_count)
 

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from odoo.tests import HttpCase, common, tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
-from odoo.addons.website.models.website_visitor import WebsiteVisitor
+from odoo.addons.website.models.ir_http import IrHttp
 
 
 class MockVisitor(common.BaseCase):
@@ -22,8 +22,8 @@ class MockVisitor(common.BaseCase):
         def _get_visitor_from_request(model, *args, **kwargs):
             return force_visitor
 
-        with patch.object(WebsiteVisitor, '_get_visitor_from_request',
-                          autospec=True, wraps=WebsiteVisitor,
+        with patch.object(IrHttp, '_get_visitor_from_request',
+                          autospec=True, wraps=IrHttp,
                           side_effect=_get_visitor_from_request) as _get_visitor_from_request_mock:
             yield
 

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -1,8 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
 import random
+import re
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from lxml import html
 from unittest.mock import patch
 
 from odoo.tests import HttpCase, common, tagged
@@ -41,6 +44,7 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
             'arch': '''<t name="Homepage" t-name="test.untracked_page">
                         <t t-call="website.layout">
                             I am a generic page²
+                            <a id="tracked_link" href="/tracked_view">Link to tracked page</a>
                         </t>
                     </t>''',
             'key': 'test.untracked_page',
@@ -206,14 +210,51 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
         super().setUpClass()
         cls.set_registry_readonly_mode(False)
 
+    def _url_open_with_tracking(self, url):
+        """ Simulate the js tracking request"""
+        res = self.url_open(url)
+        self.assertEqual(res.status_code, 200)
+        tree = html.fromstring(res.content)
+        html_content = tree.xpath("//html")[0]
+        main_object_attr = html_content.attrib.get('data-main-object')
+        tracking_enabled_attr = html_content.attrib.get('data-tracking-enabled')
+
+        match = re.search(r'^([^(]+)\((\d+)', main_object_attr)
+        res_model = match.group(1)
+        res_id = match.group(2)
+
+        if tracking_enabled_attr:
+            tracking_url = "/website/odoo_track"
+            payload = {
+                "params": {
+                    "res_model": res_model,
+                    "res_id": int(res_id),
+                }
+            }
+            track_res = self.url_open(
+                tracking_url,
+                data=json.dumps(payload),
+                headers={'Content-Type': 'application/json', 'referer': url},
+            )
+            self.assertEqual(track_res.status_code, 200)
+        return res
+
+    def test_tracking_interaction(self):
+        existing_visitors = self.env['website.visitor'].search([])
+        existing_tracks = self.env['website.track'].search([])
+        self.start_tour(self.untracked_page.url, "visitor_tracking")
+        self.assertEqual(self.env['website.visitor'].search_count([]), len(existing_visitors) + 1)
+        new_tracks = self.env['website.track'].search([('id', 'not in', existing_tracks.ids)])
+        self.assertIn(self.tracked_page.url, new_tracks.url, "1 tracked page expected")
+
     def test_visitor_creation_on_tracked_page(self):
         """ Test various flows involving visitor creation and update. """
 
         existing_visitors = self.env['website.visitor'].search([])
         existing_tracks = self.env['website.track'].search([])
-        self.url_open(self.untracked_page.url)
-        self.url_open(self.tracked_page.url)
-        self.url_open(self.tracked_page.url)
+        self._url_open_with_tracking(self.untracked_page.url)
+        self._url_open_with_tracking(self.tracked_page.url)
+        self._url_open_with_tracking(self.tracked_page.url)
 
         new_visitor = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
         new_track = self.env['website.track'].search([('id', 'not in', existing_tracks.ids)])
@@ -231,7 +272,7 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
 
         visitor_admin = new_visitor
         # visit a page
-        self.url_open(self.tracked_page_2.url)
+        self._url_open_with_tracking(self.tracked_page_2.url)
 
         # check tracking and visitor / user sync
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -258,9 +299,9 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
             "No extra visitor should be created")
 
         # visit a page
-        self.url_open(self.tracked_page.url)
-        self.url_open(self.untracked_page.url)
-        self.url_open(self.tracked_page_2.url)
+        self._url_open_with_tracking(self.tracked_page.url)
+        self._url_open_with_tracking(self.untracked_page.url)
+        self._url_open_with_tracking(self.tracked_page_2.url)
 
         # new visitor is created
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -284,9 +325,9 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
         )
 
         # visit some pages
-        self.url_open(self.tracked_page.url)
-        self.url_open(self.untracked_page.url)
-        self.url_open(self.tracked_page_2.url)
+        self._url_open_with_tracking(self.tracked_page.url)
+        self._url_open_with_tracking(self.untracked_page.url)
+        self._url_open_with_tracking(self.tracked_page_2.url)
 
         # new visitor is created
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -324,9 +365,9 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
         )
 
         # visit some pages
-        self.url_open(self.tracked_page.url)
-        self.url_open(self.untracked_page.url)
-        self.url_open(self.tracked_page_2.url)
+        self._url_open_with_tracking(self.tracked_page.url)
+        self._url_open_with_tracking(self.untracked_page.url)
+        self._url_open_with_tracking(self.tracked_page_2.url)
 
         # new visitor created
         new_visitors = self.env['website.visitor'].search([('id', 'not in', existing_visitors.ids)])
@@ -354,14 +395,14 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
             track.write({'visit_datetime': track.visit_datetime - timedelta(minutes=30)})
 
         # visit a page
-        self.url_open(self.tracked_page.url)
+        self._url_open_with_tracking(self.tracked_page.url)
         visitor_portal.invalidate_model(['website_track_ids'])
         # tracks are created
         self.assertEqual(len(visitor_portal.website_track_ids), 5, "There should be 5 tracked page for the portal user")
 
         # simulate the portal user comes back 8hours later
         visitor_portal.write({'last_connection_datetime': visitor_portal.last_connection_datetime - timedelta(hours=9)})
-        self.url_open(self.tracked_page.url)
+        self._url_open_with_tracking(self.tracked_page.url)
         visitor_portal.invalidate_model(['visit_count'])
         # check number of visits
         self.assertEqual(visitor_portal.visit_count, 2, "There should be 2 visits for the portal user")

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -86,6 +86,7 @@
             'data-edit_translations': '1' if edit_translations else None,
             'data-main-object': repr(main_object) if main_object else None,
             'data-seo-object': repr(seo_object) if seo_object else None,
+            'data-tracking-enabled': website._is_tracking_enabled(main_object) if main_object else None,
         }"/>
         <t t-if="not env.user._is_public()" t-set="nothing" t-value="html_data.update({
             'data-is-published': 'website_published' in main_object._fields and main_object.sudo().website_published,

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -163,7 +163,7 @@ list of filtered posts (by date or tag).
 
 <!-- ====== Blog Post Complete Layout ==========================================
 ============================================================================ -->
-<template id="website_blog.blog_post_complete" name="Blog Post" track="1">
+<template id="website_blog.blog_post_complete" name="Blog Post">
     <t t-call="website_blog.index">
 
         <t t-set="opt_blog_post_regular_cover" t-value="is_view_active('website_blog.opt_blog_post_regular_cover')"/>

--- a/addons/website_crm/controllers/website_form.py
+++ b/addons/website_crm/controllers/website_form.py
@@ -9,7 +9,7 @@ from odoo.http import request
 class WebsiteForm(form.WebsiteForm):
 
     def _get_country(self):
-        visitor_partner = request.env['website.visitor']._get_visitor_from_request().partner_id
+        visitor_partner = request.env['ir.http']._get_visitor_from_request().partner_id
         if visitor_partner:
             # match same behaviour as in partner._phone_format()
             country = visitor_partner.country_id or request.env.company.country_id
@@ -59,7 +59,7 @@ class WebsiteForm(form.WebsiteForm):
         is_lead_model = model_sudo.model == 'crm.lead'
         if is_lead_model:
             values_email_normalized = tools.email_normalize(values.get('email_from'))
-            visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
+            visitor_sudo = request.env['ir.http']._get_visitor_from_request(force_create=True)
             visitor_partner = visitor_sudo.partner_id
             if values_email_normalized and visitor_partner and visitor_partner.email_normalized == values_email_normalized:
                 # Here, 'phone' in values has already been formatted, see _handle_website_form.

--- a/addons/website_crm_iap_reveal/models/ir_http.py
+++ b/addons/website_crm_iap_reveal/models/ir_http.py
@@ -17,7 +17,7 @@ class IrHttp(models.AbstractModel):
     def _serve_page(cls):
         response = super(IrHttp, cls)._serve_page()
         if response and getattr(response, 'status_code', 0) == 200 and request.env.user._is_public():
-            visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
+            visitor_sudo = request.env['ir.http']._get_visitor_from_request()
             # We are avoiding to create a reveal_view if a lead is already
             # created from another module, e.g. website_form
             if not (visitor_sudo and visitor_sudo.lead_ids):

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -93,7 +93,7 @@ class WebsiteEventController(http.Controller):
             country = request.env["res.country"]
             if not request.env.user._is_public() and request.env.user.country_id:
                 country = request.env.user.country_id
-            elif (visitor := request.env['website.visitor']._get_visitor_from_request()) and visitor.country_id:
+            elif (visitor := request.env['ir.http']._get_visitor_from_request()) and visitor.country_id:
                 country = visitor.country_id
             elif request.geoip.country_code:
                 country = request.env['res.country'].search([('code', '=', request.geoip.country_code)])
@@ -356,7 +356,7 @@ class WebsiteEventController(http.Controller):
                 "phone": request.env.user.phone,
             }
         else:
-            visitor = request.env['website.visitor']._get_visitor_from_request()
+            visitor = request.env['ir.http']._get_visitor_from_request()
             if visitor.email:
                 default_first_attendee = {
                     "name": visitor.display_name,
@@ -460,7 +460,7 @@ class WebsiteEventController(http.Controller):
         a partner (if visitor linked to a user for example). Purpose is to gather
         as much informations as possible, notably to ease future communications.
         Also try to update visitor informations based on registration info. """
-        visitor_sudo = request.env['website.visitor']._get_visitor_from_request(force_create=True)
+        visitor_sudo = request.env['ir.http']._get_visitor_from_request(force_create=True)
 
         registrations_to_create = []
         for registration_values in registration_data:
@@ -507,7 +507,7 @@ class WebsiteEventController(http.Controller):
     @http.route(['/event/<model("event.event"):event>/registration/success'], type='http', auth="public", methods=['GET'], website=True, sitemap=False)
     def event_registration_success(self, event, registration_ids):
         # fetch the related registrations, make sure they belong to the correct visitor / event pair
-        visitor = request.env['website.visitor']._get_visitor_from_request()
+        visitor = request.env['ir.http']._get_visitor_from_request()
         if not visitor:
             raise NotFound()
         attendees_sudo = request.env['event.registration'].sudo().search([

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -129,7 +129,7 @@ class EventEvent(models.Model):
           * logged as visitor: check partner or visitor are linked to a
             registration;
         """
-        current_visitor = self.env['website.visitor']._get_visitor_from_request()
+        current_visitor = self.env['ir.http']._get_visitor_from_request()
         if self.env.user._is_public() and not current_visitor:
             return self.env['event.event']
 

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <!-- Index -->
-<template id="index" name="Events" track="1">
+<template id="index" name="Events">
     <t t-set="head">
         <meta t-if="search_tags" name="robots" content="none"/>
     </t>

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -13,7 +13,7 @@
 </template>
 
 <!-- Event - Description -->
-<template id="event_description_full" name="Event Description" track="1">
+<template id="event_description_full" name="Event Description">
     <t t-set="hide_submenu" t-value="True"/>
     <t t-set="hide_register_cta" t-value="True"/>
     <t t-set="opt_event_description_cover_hidden" t-value="is_view_active('website_event.opt_event_description_cover_hidden')"/>

--- a/addons/website_event_booth/controllers/event_booth.py
+++ b/addons/website_event_booth/controllers/event_booth.py
@@ -58,7 +58,7 @@ class WebsiteEventBoothController(WebsiteEventController):
                 'phone': request.env.user.partner_id.phone,
             }
         else:
-            visitor = request.env['website.visitor']._get_visitor_from_request()
+            visitor = request.env['ir.http']._get_visitor_from_request()
             if visitor.email:
                 default_contact = {
                     'name': visitor.name,

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -477,7 +477,7 @@ class EventTrackController(http.Controller):
         valid_tag_indices = request.env['event.track.tag'].search([('id', 'in', input_tag_indices)]).ids
 
         contact = request.env['res.partner']
-        visitor_partner = request.env['website.visitor']._get_visitor_from_request().partner_id
+        visitor_partner = request.env['ir.http']._get_visitor_from_request().partner_id
         # Contact name is required. Therefore, empty contacts are not considered here. At least one of contact_phone
         # and contact_email must be filled. Email is verified. If the post tries to create contact with no valid entry,
         # raise exception. If normalized email is the same as logged partner, use its partner_id on track instead.

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -328,7 +328,7 @@ class EventTrack(models.Model):
                  'event_track_visitor_ids.is_blacklisted')
     @api.depends_context('uid')
     def _compute_is_reminder_on(self):
-        current_visitor = self.env['website.visitor']._get_visitor_from_request()
+        current_visitor = self.env['ir.http']._get_visitor_from_request()
         if self.env.user._is_public() and not current_visitor:
             for track in self:
                 track.is_reminder_on = track.wishlisted_by_default
@@ -604,7 +604,7 @@ class EventTrack(models.Model):
         self.ensure_one()
 
         force_visitor_create = self.env.user._is_public()
-        visitor_sudo = self.env['website.visitor']._get_visitor_from_request(force_create=force_visitor_create)
+        visitor_sudo = self.env['ir.http']._get_visitor_from_request(force_create=force_visitor_create)
         if visitor_sudo:
             visitor_sudo._update_visitor_last_visit()
 

--- a/addons/website_event_track/static/src/js/service_worker.js
+++ b/addons/website_event_track/static/src/js/service_worker.js
@@ -243,18 +243,13 @@ const matchCache = async (request) => {
  *
  * @param {Request} request
  * @param {object} [options]
- * @param {Boolean} [options.disableTracking] whether adding a header preventing the server to track the request
  * @returns {Promise<Response>}
  */
 const processFetchRequest = async (request, options) => {
     const requestCopy = request.clone();
     let response;
     try {
-        if (options && options.disableTracking) {
-            response = await fetch(request, { headers: { 'X-Disable-Tracking': '1' } });
-        } else {
-            response = await fetch(request);
-        }
+        response = await fetch(request);
         await cacheRequest(request, response);
     } catch (requestError) {
         if (isCachableRequest(requestCopy)) {
@@ -319,7 +314,7 @@ const prefetchUrls = async (urls = []) => {
             continue;
         }
         try {
-            await processFetchRequest(new Request(url), { disableTracking: true });
+            await processFetchRequest(new Request(url));
         } catch (error) {
             console.error(`fail to prefetch ${url} : ${error}`);
         }

--- a/addons/website_event_track/tests/test_track_internals.py
+++ b/addons/website_event_track/tests/test_track_internals.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import fields
-from odoo.addons.website.models.website_visitor import WebsiteVisitor
+from odoo.addons.website.models.ir_http import IrHttp
 from odoo.addons.website_event.tests.common import TestEventOnlineCommon
 from odoo.tests.common import tagged, users
 
@@ -238,7 +238,7 @@ class TestTrackSuggestions(TestEventOnlineCommon):
             'is_wishlisted': True,
         })
 
-        with patch.object(WebsiteVisitor, '_get_visitor_from_request', lambda *args, **kwargs: emp_visitor), \
+        with patch.object(IrHttp, '_get_visitor_from_request', lambda *args, **kwargs: emp_visitor), \
                 self.with_user('user_employee'):
             current_track = self.env['event.track'].browse(track_1.id)
             all_suggestions = current_track._get_track_suggestions()

--- a/addons/website_event_track_quiz/controllers/community.py
+++ b/addons/website_event_track_quiz/controllers/community.py
@@ -54,7 +54,7 @@ class WebsiteEventTrackQuizCommunityController(EventCommunityController):
         return values
 
     def _get_leaderboard(self, event, searched_name=None):
-        current_visitor = request.env['website.visitor']._get_visitor_from_request()
+        current_visitor = request.env['ir.http']._get_visitor_from_request()
         track_visitor_data = request.env['event.track.visitor'].sudo()._read_group(
             [('track_id', 'in', event.track_ids.ids),
              ('visitor_id', '!=', False),

--- a/addons/website_event_track_quiz/models/event_track.py
+++ b/addons/website_event_track_quiz/models/event_track.py
@@ -32,7 +32,7 @@ class EventTrack(models.Model):
         (self - tracks_quiz).is_quiz_completed = False
         (self - tracks_quiz).quiz_points = 0
         if tracks_quiz:
-            current_visitor = self.env['website.visitor']._get_visitor_from_request()
+            current_visitor = self.env['ir.http']._get_visitor_from_request()
             if self.env.user._is_public() and not current_visitor:
                 for track in tracks_quiz:
                     track.is_quiz_completed = False

--- a/addons/website_forum/controllers/__init__.py
+++ b/addons/website_forum/controllers/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from . import legacy
+from . import website
 from . import website_forum
 from . import website_mail

--- a/addons/website_forum/controllers/website.py
+++ b/addons/website_forum/controllers/website.py
@@ -1,0 +1,16 @@
+from odoo import http
+
+from odoo.addons.website.controllers.main import Website
+
+
+class ForumWebsite(Website):
+
+    @http.route()
+    def track(self, res_model, res_id, **kwargs):
+        # EXTENDS website
+        res = super().track(res_model, res_id, **kwargs)
+        if res_model == 'forum.post':
+            # increment view counter
+            question = self.env['forum.post'].browse(int(res_id))
+            question.sudo()._set_viewed()
+        return res

--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -335,8 +335,6 @@ class WebsiteForum(WebsiteProfile):
             redirect_url = f"/forum/{slug(forum)}/{slug(question.parent_id)}#answer-{question.id}"
             return request.redirect(redirect_url, 301)
         values = self._prepare_question_template_vals(forum, post, question)
-        # increment view counter
-        question.sudo()._set_viewed()
 
         return request.render("website_forum.post_description_full", values)
 

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -98,7 +98,7 @@
 </template>
 
 <!-- Job Detail -->
-<template id="detail" name="Job Detail" track="1">
+<template id="detail" name="Job Detail">
     <t t-call="website.layout">
         <!-- Topbar -->
         <nav class="navbar navbar-light border-top shadow-sm d-print-none">

--- a/addons/website_livechat/controllers/__init__.py
+++ b/addons/website_livechat/controllers/__init__.py
@@ -4,3 +4,4 @@
 from . import chatbot
 from . import main
 from . import webclient
+from . import website

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -8,5 +8,5 @@ from odoo.addons.im_livechat.controllers.main import LivechatController
 class WebsiteLivechat(LivechatController):
 
     def _get_guest_name(self):
-        visitor_sudo = request.env["website.visitor"]._get_visitor_from_request()
+        visitor_sudo = request.env["ir.http"]._get_visitor_from_request()
         return _('Visitor #%d', visitor_sudo.id) if visitor_sudo else super()._get_guest_name()

--- a/addons/website_livechat/controllers/webclient.py
+++ b/addons/website_livechat/controllers/webclient.py
@@ -19,7 +19,7 @@ class WebClient(WebclientController):
         to the chat request channel. Channel will then be returned as part of
         the mail store initialization (/mail/data).
         """
-        visitor = request.env['website.visitor']._get_visitor_from_request()
+        visitor = request.env['ir.http']._get_visitor_from_request()
         if not visitor:
             return
         # get active chat_request linked to visitor

--- a/addons/website_livechat/controllers/website.py
+++ b/addons/website_livechat/controllers/website.py
@@ -1,0 +1,15 @@
+from odoo import http
+from odoo.http import request
+from odoo.addons.im_livechat.tools.misc import force_guest_env
+from odoo.addons.website.controllers.main import Website
+
+
+class WebsiteLivechat(Website):
+
+    @http.route()
+    def track(self, res_model, res_id, **kwargs):
+        # Since _upsert_visitor needs the guest in the context
+        guest_token = request.httprequest.cookies.get(request.env['mail.guest']._cookie_name)
+        if guest_token:
+            force_guest_env(guest_token)
+        return super().track(res_model=res_model, res_id=res_id, **kwargs)

--- a/addons/website_livechat/models/im_livechat_channel.py
+++ b/addons/website_livechat/models/im_livechat_channel.py
@@ -16,7 +16,7 @@ class Im_LivechatChannel(models.Model):
         )
         if not discuss_channel_vals:
             return False
-        visitor_sudo = self.env['website.visitor']._get_visitor_from_request()
+        visitor_sudo = self.env['ir.http']._get_visitor_from_request()
         if visitor_sudo:
             discuss_channel_vals['livechat_visitor_id'] = visitor_sudo.id
             # As chat requested by the visitor, delete the chat requested by an operator if any to avoid conflicts between two flows

--- a/addons/website_livechat/models/website_visitor.py
+++ b/addons/website_livechat/models/website_visitor.py
@@ -59,7 +59,7 @@ class WebsiteVisitor(models.Model):
         This creates a chat_request and a discuss_channel with livechat active flag.
         But for the visitor to get the chat request, the operator still has to speak to the visitor.
         The visitor will receive the chat request the next time he navigates to a website page.
-        (see _handle_webpage_dispatch for next step)"""
+        """
         # check if visitor is available
         unavailable_visitors_count = self.env["discuss.channel"].search_count(
             [("livechat_visitor_id", "in", self.ids), ("livechat_end_dt", "=", False)]
@@ -123,8 +123,8 @@ class WebsiteVisitor(models.Model):
         ]
         return super()._merge_visitor(target)
 
-    def _upsert_visitor(self, access_token, force_track_values=None):
-        visitor_id, upsert = super()._upsert_visitor(access_token, force_track_values=force_track_values)
+    def _upsert_visitor(self, token_or_partner_id, website_id, lang_id=None, country_code=None, timezone=None, url=None, **kwargs):
+        visitor_id, upsert = super()._upsert_visitor(token_or_partner_id, website_id, lang_id, country_code, timezone, url, **kwargs)
         if upsert == 'inserted':
             visitor_sudo = self.sudo().browse(visitor_id)
             if guest := self.env["mail.guest"]._get_guest_from_context():

--- a/addons/website_livechat/tests/common.py
+++ b/addons/website_livechat/tests/common.py
@@ -6,6 +6,7 @@ import random
 from odoo import fields
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.website.models.ir_http import IrHttp
 
 
 class TestLivechatCommon(MailCommon, TransactionCaseWithUserDemo):
@@ -101,7 +102,7 @@ class TestLivechatCommon(MailCommon, TransactionCaseWithUserDemo):
         self.target_visitor = self.visitor
         def get_visitor_from_request(self_mock, **kwargs):
             return self.target_visitor
-        self.patch(type(self.env['website.visitor']), '_get_visitor_from_request', get_visitor_from_request)
+        self.patch(IrHttp, '_get_visitor_from_request', get_visitor_from_request)
 
     def _send_message(self, channel, email_from, body, author_id=False):
         # As bus is unavailable in test mode, we cannot call /mail/message/post route to post a message.

--- a/addons/website_livechat/tests/test_website_visitor.py
+++ b/addons/website_livechat/tests/test_website_visitor.py
@@ -67,7 +67,13 @@ class WebsiteVisitorTestsLivechat(WebsiteVisitorTestsCommon):
         self.env["mail.presence"]._update_presence(operator)
 
         # Anonymous user
-        self.url_open(self.tracked_page.url)  # visitor created
+        self.make_jsonrpc_request(
+            route='/website/odoo_track',
+            params={
+                'res_model': self.tracked_page._name,
+                'res_id': self.tracked_page.id,
+            },
+        )  # visitor created
         res_1 = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
@@ -101,7 +107,13 @@ class WebsiteVisitorTestsLivechat(WebsiteVisitorTestsCommon):
                 "csrf_token": self.csrf_token(),
             },
         )
-        self.url_open(self.tracked_page.url)
+        self.make_jsonrpc_request(
+            route='/website/odoo_track',
+            params={
+                'res_model': self.tracked_page._name,
+                'res_id': self.tracked_page.id,
+            },
+        )
         visitor_3 = self._get_last_visitor()
         self.assertEqual(channel_1.livechat_visitor_id, visitor_3)
         self.assertNotEqual(visitor_3, visitor_2)

--- a/addons/website_profile/models/res_users.py
+++ b/addons/website_profile/models/res_users.py
@@ -71,3 +71,6 @@ class ResUsers(models.Model):
         if token == validation_token and self.karma == 0:
             return self.write({'karma': VALIDATION_KARMA_GAIN})
         return False
+
+    def _get_extra_tracking_values(self, **kwargs):
+        return {}

--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -12,7 +12,7 @@ class WebsiteForm(form.WebsiteForm):
     def insert_record(self, request, model_sudo, values, custom, meta=None):
         model_name = model_sudo.model
         if model_name == 'project.task':
-            visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
+            visitor_sudo = request.env['ir.http']._get_visitor_from_request()
             visitor_partner = visitor_sudo.partner_id
             if visitor_partner:
                 values['partner_id'] = visitor_partner.id

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -2079,7 +2079,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def products_recently_viewed_delete(self, product_id=None, product_template_id=None, **_kwargs):
         if not (product_id or product_template_id):
             return None
-        visitor_sudo = request.env["website.visitor"]._get_visitor_from_request()
+        visitor_sudo = request.env["ir.http"]._get_visitor_from_request()
         if visitor_sudo:
             domain = [("visitor_id", "=", visitor_sudo.id)]
             if product_id:

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -2075,13 +2075,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
     # --------------------------------------------------------------------------
     # Products Recently Viewed
     # --------------------------------------------------------------------------
-    @route("/shop/products/recently_viewed_update", type="jsonrpc", auth="public", website=True)
-    def products_recently_viewed_update(self, product_id, **_kwargs):
-        res = {}
-        visitor_sudo = request.env["website.visitor"]._get_visitor_from_request(force_create=True)
-        visitor_sudo._add_viewed_product(product_id)
-        return res
-
     @route("/shop/products/recently_viewed_delete", type="jsonrpc", auth="public", website=True)
     def products_recently_viewed_delete(self, product_id=None, product_template_id=None, **_kwargs):
         if not (product_id or product_template_id):

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -273,3 +273,12 @@ class ProductProduct(models.Model):
         if self.env.context.get("website_id"):
             return self._get_available_uoms()[:1] or self.uom_id
         return super()._get_main_uom()
+
+    def _get_extra_tracking_values(self, **kwargs):
+        extra_tracking_values = {}
+        if (
+            kwargs.get('res_model') == self._name
+            and (res_id := kwargs.get('res_id'))
+        ):
+            extra_tracking_values['product_id'] = res_id
+        return extra_tracking_values

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -240,7 +240,7 @@ class WebsiteSnippetFilter(models.Model):
 
     def _get_products_latest_viewed(self, _website, limit, domain, **_kwargs):
         products = self.env["product.product"]
-        visitor = self.env["website.visitor"]._get_visitor_from_request()
+        visitor = self.env["ir.http"]._get_visitor_from_request()
         if visitor:
             excluded_products = request.cart.order_line.product_id.ids
             tracked_products = (

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -256,7 +256,7 @@ class WebsiteSnippetFilter(models.Model):
                     ],
                     ["product_id"],
                     limit=limit,
-                    order="visit_datetime:max DESC",
+                    order="visit_datetime:max DESC, id:max DESC",
                 )
             )
             if self.env.context.get("hide_variants"):

--- a/addons/website_sale/models/website_visitor.py
+++ b/addons/website_sale/models/website_visitor.py
@@ -48,11 +48,3 @@ class WebsiteVisitor(models.Model):
             visitor.product_ids = [(6, 0, visitor_info["product_ids"])]
             visitor.visitor_product_count = visitor_info["product_count"]
             visitor.product_count = len(visitor_info["product_ids"])
-
-    def _add_viewed_product(self, product_id):
-        """Add a website_track with a page marked as viewed."""
-        self.ensure_one()
-        if product_id and self.env["product.product"].browse(product_id)._is_variant_possible():
-            domain = [("product_id", "=", product_id)]
-            website_track_values = {"product_id": product_id}
-            self._add_tracking(domain, website_track_values)

--- a/addons/website_sale/static/src/interactions/recently_viewed_products.js
+++ b/addons/website_sale/static/src/interactions/recently_viewed_products.js
@@ -26,8 +26,9 @@ export class RecentlyViewedProducts extends Interaction {
         if (this.el.querySelector('.js_product.css_not_available')) {
             return; // Product not available.
         }
-        await this.waitFor(rpc('/shop/products/recently_viewed_update', {
-            product_id: productId,
+        await this.waitFor(rpc('/website/odoo_track', {
+            res_model: 'product.product',
+            res_id: productId,
         }));
         cookie.set(cookieName, productId, 30 * 60, 'optional');
     }

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -10,7 +10,7 @@
         />/<span class="oe_custom_base_unit" t-field="product.base_unit_name"/>
     </template>
 
-    <template id="website_sale.product" name="Product" track="1">
+    <template id="website_sale.product" name="Product">
         <!-- Qweb variable defining the class suffix for navbar items.
              Change accordingly to the derired visual result (eg. `primary`, `dark`...)-->
         <t t-set="navClass" t-valuef="light"/>

--- a/addons/website_sale/tests/test_product_filters.py
+++ b/addons/website_sale/tests/test_product_filters.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
-from freezegun import freeze_time
 from lxml import html
 from odoo import Command, fields
 from odoo.tests import HttpCase, tagged
@@ -229,7 +228,7 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestProductAttributeValue
         viewed_products = self.black_case_M + self.pink_case_L + self.computer.product_variant_id
         dyn_filter = self.env.ref("website_sale.dynamic_filter_latest_viewed_products")
         with self.mock_request(user=self.env.user):
-            visitor = self.env["website.visitor"]._upsert_visitor(self.env.user.partner_id.id)
+            visitor = self.env["website.visitor"]._upsert_visitor(self.env.user.partner_id.id, website_id=self.website.id)
             self.env["website.track"].create([
                 {"visitor_id": visitor[0], "product_id": product_id}
                 for product_id in viewed_products.ids
@@ -252,12 +251,19 @@ class TestWebsiteSaleProductFilters(WebsiteSaleCommon, TestProductAttributeValue
                 'When hiding variants, "Latest viewed" filter should return 1 variant per template',
             )
 
-        now = datetime.now()
         for i, product in enumerate(viewed_products):
-            with freeze_time(now - timedelta(seconds=i)):
-                self.url_open("/shop/products/recently_viewed_update", json={"params": {"product_id": product.id}})
+            self.url_open(
+                "/website/odoo_track",
+                headers={'referer': product.website_url},
+                json={
+                    "params": {
+                        "res_model": "product.product",
+                        "res_id": product.id,
+                    }
+                },
+            )
 
-        self.assert_snippet_filters_route_public_access(dyn_filter, viewed_products)
+        self.assert_snippet_filters_route_public_access(dyn_filter, self.env['product.product'].browse(reversed(viewed_products.ids)))
 
     def test_recently_sold_with_filter(self):
         """Check the recently-sold-with filter after selling 1 computer, 1 monitor & 1 case.

--- a/addons/website_sale/tests/test_snippets.py
+++ b/addons/website_sale/tests/test_snippets.py
@@ -45,36 +45,46 @@ class TestSnippets(HttpCase):
     def test_02_snippet_products_remove(self):
         Visitor = self.env["website.visitor"]
         user = self.env["res.users"].search([("login", "=", "admin")])
-        website_visitor = Visitor.search([("partner_id", "=", user.partner_id.id)])
-        if not website_visitor:
-            with MockRequest(
-                user.with_user(user).env, website=self.env["website"].get_current_website()
-            ):
-                website_visitor = Visitor.create({"partner_id": user.partner_id.id})
-        self.assertEqual(
-            website_visitor.name,
-            user.name,
-            "The visitor should be linked to the admin user, not OdooBot or anything.",
-        )
-        self.product = self.env["product.product"].create({
+        product = self.env["product.product"].create({
             "name": "Storage Box",
             "website_published": True,
             "image_512": b"/product/static/img/product_product_9-image.jpg",
             "display_name": "Bin",
             "description_sale": "Pedal-based opening system",
         })
-        before_tour_product_ids = website_visitor.product_ids.ids
-        website_visitor._add_viewed_product(self.product.id)
+
+        self.authenticate('admin', 'admin')
+        self.url_open(
+            "/website/odoo_track",
+            headers={"referer": product.website_url},
+            json={
+                "params": {
+                    "res_model": "product.product",
+                    "res_id": product.id,
+                }
+            },
+        )
+        website_visitor = Visitor.search([("partner_id", "=", user.partner_id.id)])
+
+        self.assertEqual(
+            website_visitor.name,
+            user.name,
+            "The visitor should be linked to the admin user, not OdooBot or anything.",
+        )
+        self.assertIn(
+            product.id,
+            website_visitor.product_ids.ids,
+            "The product should be recently viewed",
+        )
 
         self.start_tour(
             self.env["website"].get_client_action_url("/", True),
             "website_sale.products_snippet_recently_viewed",
             login="admin",
         )
-        self.assertEqual(
-            before_tour_product_ids,
+        self.assertFalse(
             website_visitor.product_ids.ids,
-            "There shouldn't be any new product in recently viewed after this tour",
+            "There shouldn't be any product in recently viewed after this tour",
         )
 
     def test_website_category_url(self):

--- a/addons/website_sale/tests/test_website_visitor.py
+++ b/addons/website_sale/tests/test_website_visitor.py
@@ -2,7 +2,7 @@
 
 from odoo.tests import tagged
 
-from odoo.addons.website_sale.controllers.main import WebsiteSale
+from odoo.addons.website.controllers.main import Website
 from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 
 
@@ -10,14 +10,14 @@ from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 class WebsiteSaleVisitorTests(WebsiteSaleCommon):
     def setUp(self):
         super().setUp()
-        self.WebsiteSaleController = WebsiteSale()
+        self.WebsiteController = Website()
 
     def test_create_visitor_on_tracked_product(self):
         existing_visitors = self.env["website.visitor"].search([])
         existing_tracks = self.env["website.track"].search([])
 
-        with self.mock_request():
-            cookies = self.WebsiteSaleController.products_recently_viewed_update(self.product.id)
+        with self.mock_request(referrer=self.product.website_url):
+            cookies = self.WebsiteController.track(res_model='product.product', res_id=self.product.id)
 
         new_visitors = self.env["website.visitor"].search([("id", "not in", existing_visitors.ids)])
         new_tracks = self.env["website.track"].search([("id", "not in", existing_tracks.ids)])
@@ -28,20 +28,14 @@ class WebsiteSaleVisitorTests(WebsiteSaleCommon):
             len(new_tracks), 1, "A track should be created after visiting a tracked product"
         )
 
-        with self.mock_request(cookies=cookies):
-            self.WebsiteSaleController.products_recently_viewed_update(self.product.id)
+        with self.mock_request(cookies=cookies, referrer=self.product.website_url):
+            self.WebsiteController.track(res_model='product.product', res_id=self.product.id)
 
         new_visitors = self.env["website.visitor"].search([("id", "not in", existing_visitors.ids)])
-        new_tracks = self.env["website.track"].search([("id", "not in", existing_tracks.ids)])
         self.assertEqual(
             len(new_visitors),
             1,
             "No visitor should be created after visiting another tracked product",
-        )
-        self.assertEqual(
-            len(new_tracks),
-            1,
-            "No track should be created after visiting the same tracked product before 30 min",
         )
 
         product = self.env["product.product"].create({
@@ -50,8 +44,8 @@ class WebsiteSaleVisitorTests(WebsiteSaleCommon):
             "list_price": 320.0,
         })
 
-        with self.mock_request(cookies=cookies):
-            self.WebsiteSaleController.products_recently_viewed_update(product.id)
+        with self.mock_request(cookies=cookies, referrer=product.website_url):
+            self.WebsiteController.track(res_model='product.product', res_id=product.id)
 
         new_visitors = self.env["website.visitor"].search([("id", "not in", existing_visitors.ids)])
         new_tracks = self.env["website.track"].search([("id", "not in", existing_tracks.ids)])
@@ -61,7 +55,7 @@ class WebsiteSaleVisitorTests(WebsiteSaleCommon):
             "No visitor should be created after visiting another tracked product",
         )
         self.assertEqual(
-            len(new_tracks), 2, "A track should be created after visiting another tracked product"
+            len(new_tracks), 3, "New tracks should be created after visiting other tracked products"
         )
 
     def test_dynamic_filter_newest_products(self):
@@ -113,8 +107,8 @@ class WebsiteSaleVisitorTests(WebsiteSaleCommon):
         self.assertFalse(res)
 
         # AFTER VISITING THE PRODUCT
-        with self.mock_request():
-            cookies = self.WebsiteSaleController.products_recently_viewed_update(product.id)
+        with self.mock_request(referrer=product.website_url):
+            cookies = self.WebsiteController.track(res_model='product.product', res_id=product.id)
         with self.mock_request(cookies=cookies):
             res = snippet_filter._prepare_values(limit=16, search_domain=[])
         res_products = [res_product["_record"] for res_product in res]

--- a/addons/website_sale/views/website_sale_visitor_views.xml
+++ b/addons/website_sale/views/website_sale_visitor_views.xml
@@ -48,6 +48,9 @@
             <field name="url" position="after">
                 <field name="product_id"/>
             </field>
+            <filter name="type_url" position="attributes">
+                <attribute name="domain">[('url', '!=', False), ('product_id', '=', False)]</attribute>
+            </filter>
             <filter name="type_url" position="after">
                 <filter string="Products" name="type_product" domain="[('product_id', '!=', False)]"/>
             </filter>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -103,7 +103,7 @@
 
 
 <!-- Channel main template -->
-<template id='course_main' name="Course Main" track="1">
+<template id='course_main' name="Course Main">
     <t t-set="head">
         <script type="module" src="/web/static/lib/pdfjs/build/pdf.js"/>
         <script type="module" src="/web/static/lib/pdfjs/build/pdf.worker.js"/>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -2,7 +2,7 @@
 <odoo><data>
 
 <!-- Slide: main template: detailed view -->
-<template id="slide_main" name="Slide Detailed View" track="1">
+<template id="slide_main" name="Slide Detailed View">
     <t t-set="body_classname" t-value="'o_wslides_body'"/>
     <t t-call="website.layout">
         <div id="wrap" class="wrap o_wslides_wrap">


### PR DESCRIPTION
*: website_blog, website_event, website_event_track, website_forum, website_hr_recruitment, website_livechat, website_profile, website_sale, website_slides

There are currently some issues with the existing tracker (extension of `ir.http`'s `_post_dispatch`)
1. Writing a tracking event to the DB prevents the readonly capability of odoo.
2. Number of bots crawling odoo pages consume resources.

By using a JS based tracker, we can
1. improve the performance of browsing website pages as we don't need a write to the DB
2. enable readonly routes on the website - allowing for spreading the db load.
3. potentially reduce the number of tracking events caused by bots (which don't normally execute js)

Additionally, tracking is activated by default on all website templates/views.

Performance Analysis

Using a sample of 115 loads of a blank website home page, we seem to save approximately 10ms on page load time.

| Description       | _register_website_track (old) | js track (this pr) |
|-------------------|-------------------------------|--------------------|
| Average load time*|    0.0197652 s                |    0.0093054 s     |
| Tracking request  |    0 s                        |    0.0154167 s **  |

&ast; This average includes the response time for the first uncached response of approx 500 ms
** Due to the js loading delay, the tracking request only executed on approximately 10% of the page loads.

Task-4939052