### PR TITLE
[FIX] stock_account: only check lock date for validated pickings

### DIFF
--- a/addons/stock_account/models/stock_picking.py
+++ b/addons/stock_account/models/stock_picking.py
@@ -16,7 +16,7 @@ class StockPicking(models.Model):
             return
         for picking in self:
             if picking._is_date_in_lock_period():
-                raise ValidationError(self.env._("You cannot modify the scheduled date of this operation because it falls within a locked fiscal period."))
+                raise ValidationError(self.env._("You cannot modify the scheduled date of operation %s because it falls within a locked fiscal period.", picking.display_name))
 
     def _compute_is_date_editable(self):
         super()._compute_is_date_editable()
@@ -26,7 +26,9 @@ class StockPicking(models.Model):
 
     def _is_date_in_lock_period(self):
         self.ensure_one()
-        lock = self.company_id._get_lock_date_violations(self.scheduled_date.date(), fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
+        lock = []
+        if self.state == "done":
+            lock += self.company_id._get_lock_date_violations(self.scheduled_date.date(), fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
         if self.date_done:
             lock += self.company_id._get_lock_date_violations(self.date_done.date(), fiscalyear=True, sale=False, purchase=False, tax=False, hard=True)
         return bool(lock)

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -300,8 +300,8 @@ class TestAccountMove(TestStockValuationCommon):
         # Receipts can not be backdated prior to lock date
         receipt.scheduled_date = post_to_lock_date
         receipt_done.date_done = post_to_lock_date
-        with self.assertRaises(UserError):
-            receipt.scheduled_date = prior_to_lock_date
+        # Lock dates should not affect un-validated scheduled_date
+        receipt.scheduled_date = prior_to_lock_date
         with self.assertRaises(UserError):
             receipt_done.date_done = prior_to_lock_date
 
@@ -313,8 +313,8 @@ class TestAccountMove(TestStockValuationCommon):
         # Receipts can not be backdated prior to lock date
         receipt.scheduled_date = post_to_lock_date
         receipt_done.date_done = post_to_lock_date
-        with self.assertRaises(UserError):
-            receipt.scheduled_date = prior_to_lock_date
+        # Lock dates should not affect un-validated scheduled_date
+        receipt.scheduled_date = prior_to_lock_date
         with self.assertRaises(UserError):
             receipt_done.date_done = prior_to_lock_date
 


### PR DESCRIPTION
A recent improvement task (ID [5065601](https://www.odoo.com/odoo/project.task/5065601)) allows `stock.picking` to backdate deliveries, as long as the `scheduled_date` and `date_done` fields are both after the lock date. Related: PR #222169

When validating a `stock.picking` record, the constraint `_check_backdate_allowed()` can fail on a different `stock.picking` record. This is confusing for the end user and makes finding the erroneous `stock.picking` difficult.

## Steps to reproduce.
**setup**:
1. install stock, sale, purchase. Use the demo data.
2. Navigate to Inventory > Configuration > Warehouse and click into the Warehouse for the active company.
3. Select the Routes smart button, then select the Buy route. Ensure that the "Product" option is selected for the Buy route. 
4. Navigate to Inventory > Product > Product.
5. Create a test product that is:
    1. tracked by quantity (General Information tab)
    2. Has a vendor listed (in the Purchases tab)
    3. Uses the "buy" route (in the Inventory tab)
    4. Has a reordering rule for the Buy route (reordering rules smart button)
6. Do not add any stock for this product.

**reproduction**:
1. Navigate to Sale > Orders.
2. Create and confirm a sale order for the configured product, such that more products will need to be created.
3. Navigate into the delivery order for the sale and set its scheduled date to be December 1st.
4. In Accounting > Accounting > lock dates, set all the lock dates to be December 3rd.
5. Navigate back to the sales order, then use the Purchase order smart button to view the purchase order.
7. Use the Deliveries smart button to view the purchase delivery.
8. Validate the delivery - > Validation error thrown

> You cannot modify the scheduled date of this operation because it falls within a locked fiscal period.

**Solution**: add the name of the stock.picking to the error message & only check the lock date when `date_done` is altered, not `scheduled_date`.


[opw-5428179](https://www.odoo.com/odoo/unassigned-tasks/5428179)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr