### PR TITLE
 [IMP] point_of_sale: allow configuring printer paper sizes

### DIFF
--- a/addons/point_of_sale/models/pos_printer.py
+++ b/addons/point_of_sale/models/pos_printer.py
@@ -2,6 +2,7 @@
 
 from base64 import b32encode
 from hashlib import sha256
+
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
@@ -23,6 +24,17 @@ def format_epson_certified_domain(serial_number):
     sha256_hash = sha256(serial_number.encode()).digest()
     base32_text = b32encode(sha256_hash).decode().rstrip("=")
     return f"{base32_text.lower()}.{epson_domain}"
+
+
+EPSON_MODELS = [
+    ('tm_u22_76', 'TM-U220 series (76mm)'),
+    ('tm_u22_70', 'TM-U220 series (70mm)'),
+    ('tm_u22_58', 'TM-U220 series (58mm)'),
+    ('tm_u33_76', 'TM-U330 series (76mm)'),
+    ('tm_u33_70', 'TM-U330 series (70mm)'),
+    ('tm_p60_60', 'TM-P60 series (60mm)'),
+    ('tm_l100_40', 'TM-L100 series (40mm)'),
+]
 
 
 class PosPrinter(models.Model):
@@ -53,6 +65,13 @@ class PosPrinter(models.Model):
         ),
     )
     use_lna = fields.Boolean(string="Use Local Network Access")
+    paper_size = fields.Selection(string="Paper Size", selection=[
+        ('80', 'Standard 80mm'),
+        ('58', 'Standard 58mm'),
+        *EPSON_MODELS,
+    ], required=True, default='80')
+    paper_size_keys = fields.Char(compute='_compute_paper_size_keys')
+    timeout = fields.Integer(string="Connection Timeout (ms)", default=3000, help="Time in milliseconds before considering that the printer is not responding.")
 
     def copy_data(self, default=None):
         default = dict(default or {}, pos_config_ids=[(5, 0, 0)], printer_ip="0.0.0.0")
@@ -62,13 +81,24 @@ class PosPrinter(models.Model):
                 vals['name'] = _("%s (copy)", printer.name)
         return vals_list
 
+    @api.depends('printer_type')
+    def _compute_paper_size_keys(self):
+        for record in self:
+            standard_size = ['58', '80']
+
+            if record.printer_type == 'epson_epos':
+                epson_models = [key for key, _ in EPSON_MODELS]
+                standard_size.extend(epson_models)
+
+            record.paper_size_keys = ",".join(standard_size)
+
     @api.model
     def _load_pos_data_domain(self, data, config):
         return [('id', 'in', config.preparation_printer_ids.ids + config.receipt_printer_ids.ids)]
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['id', 'name', 'product_categories_ids', 'printer_type', 'use_type', 'use_lna', 'printer_ip']
+        return ['id', 'name', 'product_categories_ids', 'printer_type', 'use_type', 'use_lna', 'printer_ip', 'paper_size', 'timeout']
 
     @api.constrains('printer_ip')
     def _constrains_printer_ip(self):
@@ -81,3 +111,9 @@ class PosPrinter(models.Model):
         for rec in self:
             if rec.printer_ip:
                 rec.printer_ip = format_epson_certified_domain(rec.printer_ip)
+
+    @api.onchange('printer_type')
+    def _onchange_printer_type(self):
+        for rec in self:
+            if rec.paper_size not in rec.paper_size_keys.split(","):
+                rec.paper_size = '80'

--- a/addons/point_of_sale/receipt/pos_receipt_common.xml
+++ b/addons/point_of_sale/receipt/pos_receipt_common.xml
@@ -32,6 +32,7 @@
                 #pos-receipt { line-height: 1.5 !important; width: 576px !important; color: #000000 !important; font-size: 22px !important; box-sizing: border-box; font-family: Arial, sans-serif !important; }
                 #pos-receipt .top { vertical-align: top !important; }
                 #pos-receipt .overflow-hidden { overflow: hidden !important; }
+                #pos-receipt img { max-width: 100% !important; height: auto !important; }
 
                 /** Width classes **/
                 #pos-receipt .w-100 { width: 100% !important }

--- a/addons/point_of_sale/static/src/app/services/pos_ticket_printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/pos_ticket_printer_service.js
@@ -105,7 +105,9 @@ export class PosTicketPrinterService {
     }
 
     async print({ printer, iframe, image = null }) {
-        const finalImage = image || (await this.generateImage(iframe));
+        const finalImage =
+            image ||
+            (this.setIframeSizeFromPrinter(iframe, printer) && (await this.generateImage(iframe)));
         let status;
         try {
             status = await printer._instance.print(finalImage);
@@ -248,6 +250,7 @@ export class PosTicketPrinterService {
                 }
 
                 const iframe = await this.generateIframe(template, ticket);
+                this.setIframeSizeFromPrinter(iframe, printer);
                 const image = await this.generateImage(iframe);
                 const result = await this.print({ printer, image });
                 if (result.successful) {
@@ -328,6 +331,40 @@ export class PosTicketPrinterService {
         container.appendChild(iframe);
         await new Promise((resolve) => (iframe.onload = resolve));
         return iframe;
+    }
+
+    async setIframeSizeFromPrinter(iframe, printer) {
+        const doc = iframe.contentDocument || iframe.contentWindow.document;
+        const iframeEl = doc.getElementById("pos-receipt");
+        const iframeHead = iframeEl.querySelector("head");
+        const { maxWidth, fontSize } = printer._instance.getStyle();
+
+        const style = document.createElement("style");
+        style.id = "printer-receipt-style";
+
+        const LINE_HEIGHT_RATIO = 1.4;
+
+        const getFontRules = (multiplier) => {
+            const size = fontSize * multiplier;
+            const height = size * LINE_HEIGHT_RATIO;
+            return `
+                font-size: ${size}px !important;
+                line-height: ${height}px !important;
+            `;
+        };
+
+        const cssRules = `
+            #pos-receipt { width: ${maxWidth}px !important; font-size: ${fontSize}px !important; }
+            /** Text classes **/
+            #pos-receipt .text-small { ${getFontRules(0.8)} }
+            #pos-receipt .text-normal { ${getFontRules(1.0)} }
+            #pos-receipt .text-large { ${getFontRules(1.2)} }
+            #pos-receipt .text-huge { ${getFontRules(1.5)} }
+            #pos-receipt .text-insane { ${getFontRules(2.2)} }
+        `;
+
+        style.textContent = cssRules;
+        iframeHead.appendChild(style);
     }
 
     async generateImage(iframe) {

--- a/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/base_printer.js
@@ -13,6 +13,19 @@ export class BasePrinter {
         this.product_categories_ids = printer.product_categories_ids;
         this.pos_config_ids = printer.pos_config_ids;
         this.use_lna = printer.use_lna;
+        this.paperSize = printer.paper_size || 80;
+        this.timeout = printer.timeout || 3000;
+    }
+
+    get STYLE_MAPPING() {
+        return {
+            58: { fontSize: 22, maxWidth: 360 },
+            80: { fontSize: 22, maxWidth: 512 },
+        };
+    }
+
+    getStyle() {
+        return this.STYLE_MAPPING[this.paperSize];
     }
 
     async print(image) {

--- a/addons/point_of_sale/static/src/app/utils/printer/epson_printer.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/epson_printer.js
@@ -129,7 +129,21 @@ export class EpsonPrinter extends BasePrinter {
 
     get address() {
         const protocol = this.use_lna ? "http:" : "https:";
-        return `${protocol}//${this.printer_ip}/cgi-bin/epos/service.cgi?devid=local_printer&timeout=3000`;
+        return `${protocol}//${this.printer_ip}/cgi-bin/epos/service.cgi?devid=local_printer&timeout=${this.timeout}`;
+    }
+
+    get STYLE_MAPPING() {
+        const base = super.STYLE_MAPPING;
+        return {
+            ...base,
+            tm_u22_76: { maxWidth: 200, fontSize: 12 },
+            tm_u22_70: { maxWidth: 180, fontSize: 12 },
+            tm_u22_58: { maxWidth: 150, fontSize: 12 },
+            tm_u33_76: { maxWidth: 400, fontSize: 22 },
+            tm_u33_70: { maxWidth: 380, fontSize: 22 },
+            tm_p60_60: { maxWidth: 375, fontSize: 22 },
+            tm_l100_40: { maxWidth: 240, fontSize: 14 },
+        };
     }
 
     openCashbox() {
@@ -152,7 +166,7 @@ export class EpsonPrinter extends BasePrinter {
         const params = {
             method: "POST",
             body: processed,
-            signal: AbortSignal.timeout(3000),
+            signal: AbortSignal.timeout(this.timeout),
         };
 
         if (this.use_lna) {

--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -18,6 +18,9 @@
                             <field name="printer_type" widget="radio" options="{'horizontal': True}" class="pb-1" invisible="True" />  <!-- Invisble to be overrided -->
                             <field name="printer_ip" invisible="printer_type != 'epson_epos'" placeholder="10.100.50.87" required="printer_type == 'epson_epos'"/>
                             <field name="use_lna"/>
+                            <field name="paper_size_keys" invisible="True"/>
+                            <field name="paper_size" widget="dynamic_selection" options="{'available_field': 'paper_size_keys'}" groups="base.group_no_one"/>
+                            <field name="timeout" widget="integer" options="{'type': 'number', 'step': 1000}" placeholder="3000" groups="base.group_no_one"/>
                             <field name="product_categories_ids" invisible="use_type != 'preparation'" widget="many2many_tags" required="use_type == 'preparation'"/>
                         </group>
                     </group>

--- a/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
@@ -419,6 +419,9 @@ describe("printOrderChanges", () => {
                 printedData.push(data.changes.data.map((line) => line.name));
                 return document.createElement("iframe");
             },
+            setIframeSizeFromPrinter(iframe, printer) {
+                return;
+            },
             async generateImage() {
                 return "fake_image_data";
             },


### PR DESCRIPTION
This update natively guarantees correct formatting by adding support for
standard 80mm and 58mm rolls, along with specific dimensions for IoT devices
like iMin and various Epson series (TM-U220, TM-U330, TM-P60, and TM-L100).

To prevent misaligned receipts across different hardware, a new setting now
dynamically adjusts POS ticket sizes based on the printer type and installed
modules. This guarantees correct formatting by supporting standard 80mm and
58mm rolls, along with specific dimensions for IoT devices like iMin and
various Epson series (TM-U220, TM-U330, TM-P60, and TM-L100).

task-5244833