### PR TITLE
[IMP] hr_attendance: restrict schedules and ruleset countries by wizard

### DIFF
--- a/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
@@ -14,6 +14,7 @@ class HrAttendanceOvertimeRuleset(models.Model):
     country_id = fields.Many2one(
         'res.country',
         default=lambda self: self.env.company.country_id,
+        domain=lambda self: [('id', 'in', self.env.companies.country_id.ids)],
     )
     rate_combination_mode = fields.Selection([
             ('max', "Maximum Rate"),

--- a/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_rule_views.xml
@@ -49,7 +49,7 @@
                                     <label for="expected_hours_from_contract" string="and"/>
                                     <field nolabel="1" name="timing_stop" widget="float_time" style="width:10ch"/>
                                 </span>
-                                <field name="resource_calendar_id" string="Schedule" invisible="base_off != 'timing' or timing_type != 'schedule'"/>
+                                <field name="resource_calendar_id" string="Schedule" invisible="base_off != 'timing' or timing_type != 'schedule'" domain="['|', ('company_id', '=', False), ('company_id', 'in', allowed_company_ids)]"/>
                             </group>
                             <group 
                                 name="action_section"


### PR DESCRIPTION
- Limit the working schedules to those belonging to the companies selected in the wizard, as well as common schedules not linked to any specific company.
- Restrict the country field on the overtime ruleset to only allow countries corresponding to the companies selected in the wizard.

task-5912498