### PR TITLE
[IMP] l10n_es_pos: add deprecated tag in the name of the app

### DIFF
--- a/addons/l10n_es_pos/__manifest__.py
+++ b/addons/l10n_es_pos/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
-    'name': 'Spain - Point of Sale',
+    'name': '[Deprecated] Spain - Point of Sale',
     'category': 'Accounting/Localizations/Point of Sale',
     'summary': """Spanish localization for Point of Sale""",
     'depends': ['point_of_sale', 'l10n_es'],


### PR DESCRIPTION
- We are waiting for the `saas-19.2` version to be released with the new Spain POS module with SII compatibility.
- Until then, we are just adding `[Deprecated]` tag to the `Spain - Point of Sale` module name.

- TODO: remove this `l10n_es_pos` module in the master, after `saas-19.2` version release.

Task-5354717