### PR TITLE
[FIX] iot_drivers: fix pos_id not being sent to SE blackbox

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_se_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_blackbox_se_driver.py
@@ -197,7 +197,7 @@ class SwedishBlackBoxDriver(SerialDriver):
             return error
 
         message_fields = list(data.get("high_level_message").values())
-        request_fields = ["RH", *message_fields[0:2], " ", " ", *message_fields[2:]]
+        request_fields = ["RH", *message_fields[0:3], " ", " ", *message_fields[3:]]
         request = "#".join(request_fields)
         response = self._request_action(request, self._connection)
         error = self._check_error(request, response)


### PR DESCRIPTION
When using a v1 CleanCash blackbox, the command being sent to the blackbox was mistakenly sending a POS ID of " ". It just so happened this worked correctly when testing with our blackbox because it had " " registered as a POS ID. The POS ID is now sent correctly.

task-5077448

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
