### PR TITLE
[FIX] html_builder: avoid looking for shapes in shallow clones for drag

### DIFF
--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option_plugin.js
@@ -639,7 +639,7 @@ export class BackgroundShapeOptionPlugin extends Plugin {
     getNeighborShapeEls(previousEl, nextEl) {
         const getBgShapedSnippetSiblingEl = (siblingEl, elementSibling) => {
             while (siblingEl) {
-                if (this.isVisibleSnippet(siblingEl)) {
+                if (this.isVisibleSnippet(siblingEl) && !siblingEl.matches(".oe_drop_clone")) {
                     return siblingEl.dataset.oeShapeData ? siblingEl : null;
                 }
                 siblingEl = siblingEl[elementSibling];

--- a/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
+++ b/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
@@ -63,6 +63,21 @@ test("Drag and drop at the same position should not add a step in the history", 
     expect(".o-website-builder_sidebar .fa-undo").not.toBeEnabled();
 });
 
+test("Drag and drop at the same place a section with connection shape", async () => {
+    await setupWebsiteBuilderWithSnippet("s_banner_connected");
+
+    await contains(":iframe .s_banner_connected").click();
+    expect(".overlay .o_overlay_options .o_move_handle.o_draggable").toHaveCount(1);
+
+    const { moveTo, drop } = await contains(".o_overlay_options .o_move_handle").drag();
+    expect(":iframe .oe_drop_zone").toHaveCount(1);
+    await moveTo(":iframe .oe_drop_zone");
+    await drop(getDragMoveHelper());
+    expect(":iframe .oe_drop_zone").toHaveCount(0);
+    await waitForEndOfOperation();
+    expect(":iframe .s_banner_connected").toHaveCount(1);
+});
+
 test("Drag and drop a column toggles the grid mode", async () => {
     await setupWebsiteBuilderWithSnippet(["s_text_image", "s_three_columns"], {
         loadIframeBundles: true,


### PR DESCRIPTION
Commit e591ea77f4a800bf79cb19f80529eed0d8ded927 adds logic to enhance colors of connection shapes. But when looking for a neighboring section with a shape at the end of a drag and drop (within the page), it could find the temporary shallow clone of the element from the drag and drop logic.

This commit skips the clone made for drag and drop when looking for a neighbor with a connection shape.

Steps to reproduce:
- Drop s_banner_connected on an empty page
- Click on it
- Move it by drag with the "overlay buttons"
- Drop it
- Bug: crash because no shape container is found in the shallow clone

task-5916502