### PR TITLE
[FIX] website_sale: validate periodDays in DateFilterButton props

### DIFF
--- a/addons/website_sale/static/src/js/date_filter_button/date_filter_button.js
+++ b/addons/website_sale/static/src/js/date_filter_button/date_filter_button.js
@@ -20,6 +20,7 @@ export class DateFilterButton extends Component {
 			shape: {
 				id: String,
 				label: String,
+				periodDays: Number,
 			},
 		},
 		update: Function,


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install e-commerce.
2. Activate debug mode.
3. Website > Orders.

**Error:**
```
Uncaught Promise > Invalid props for component 'DateFilterButton': 'selectedDateFilter' 
doesn't have the correct shape (unknown key 'periodDays')
```
Here, the `selectedDateFilter` prop shape only defines id and label, while `DATE_OPTIONS` also provides the `periodDays` as a key.
In dev/debug mode, it will validate the props through `validateProps`, which raises an error - [1].

This commit extends the prop shape definition for periodDays as a Number.

[1]: https://github.com/odoo/odoo/blob/6db37f4891118c54886971fe10276a2438243274/addons/web/static/lib/owl/owl.js#L3183