### PR TITLE
[FIX] sale_stock: allow access to sale order lines

### DIFF
--- a/addons/sale_stock/security/sale_stock_security.xml
+++ b/addons/sale_stock/security/sale_stock_security.xml
@@ -9,5 +9,16 @@
             <field name="domain_force">['|', ('partner_id', '=', user.partner_id.id), ('sale_id.partner_id', '=', user.partner_id.id)]</field>
             <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         </record>
+
+        <record id="sale_order_line_rule_stock_user" model="ir.rule">
+            <field name="name">Stock User Sales Orders Line</field>
+            <field name="model_id" ref="sale.model_sale_order_line"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[(4, ref('stock.group_stock_user'))]"/>
+            <field name="perm_create" eval="0"/>
+            <field name="perm_read" eval="1"/>
+            <field name="perm_write" eval="0"/>
+            <field name="perm_unlink" eval="0"/>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
Users with the project_manager role and no access on sale cannot open stock moves

Steps to reproduce:
1. Install Sales, Inventory and Project
2. Create a Sale order for any company with an address and any product and confirm it (a delivery should be automatically created)
3. Go to Settings > Users and open user Marc Demo
4. Set Marc Demo's role on Sales to "No" and on Project to "Administrator"
5. Log in as Marc Demo
6. Go to Inventory > Operations > Deliveries and try to access the delivery previously created
7. An error occurs

Problem:
https://github.com/odoo/odoo/blob/6b2d3af64a076654e04494972acc4c42d7c54bd8/addons/sale_stock/models/stock.py#L32-L38
stock.move's description is computed based on the related sale order lines which will cause an access error because users with role `project.group_project_manager` can only access sale order lines of projects or tasks because of this rule:
https://github.com/odoo/odoo/blob/3909bef741ebb5c879beb383c395e1a310ba78eb/addons/sale_project/security/sale_project_security.xml#L4-L13
even though the group `stock.group_stock_user` are expected to always have read access to sale order lines because of this right:
https://github.com/odoo/odoo/blob/3909bef741ebb5c879beb383c395e1a310ba78eb/addons/sale_stock/security/ir.model.access.csv#L6

Note that the issue doesn't happen when the user is a sale user because of this rule that adds the rights on sale order lines:
https://github.com/odoo/odoo/blob/3909bef741ebb5c879beb383c395e1a310ba78eb/addons/sale/security/ir_rules.xml#L78-L83

This fix also solves the issue for `mrp.group_mrp_user` because they inherit the group `stock.group_stock_user`:
https://github.com/odoo/odoo/blob/cda011dc8590773f6c3a26f4ae9d5242a3147024/addons/mrp/security/mrp_security.xml#L11-L16

Therefore the rule on `project.group_project_manager` needs to be
overridden when the user is a stock user

Solution:
Create a record rule with a truthy domain to force stock users to have access to sale order lines even if other rules remove this access

opw-5492232