### PR TITLE
[FIX] spreadsheet_dashboard: mark model as raw

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_loader_service.js
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_loader_service.js
@@ -1,4 +1,4 @@
-import { reactive } from "@odoo/owl";
+import { reactive, markRaw } from "@odoo/owl";
 import { Model } from "@odoo/o-spreadsheet";
 import { registry } from "@web/core/registry";
 import { OdooDataProvider } from "@spreadsheet/data_sources/odoo_data_provider";
@@ -258,6 +258,7 @@ export class DashboardLoader {
         config.custom.odooDataProvider.addEventListener("data-source-updated", () =>
             model.dispatch("EVALUATE_CELLS")
         );
+        markRaw(model);
         return model;
     }
 


### PR DESCRIPTION
Since we split o-spreadsheet in two:
- core engine, independent from owl and DOM
- UI

The `Model` doesn't mark itself as raw for owl's reactivity.

It must be done manually at every call site where it's needed.

Here the entire `DashboardLoader` is made reactive, including its properties.

We cannot let the model be reactive as it would hurt performance very badly.

From a DX POV, the current situation is a bad design because the developer doesn't know the model needs to be marked as raw, and even if the developer knows it, it's very easy to overlook (as we did and this commit proves)

It would be probably better with a private constructor and factory methods with clear names.

Task-5916564

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
