### PR TITLE
[FIX] *: make basic sale/stock/purchase flows with minimal access rights

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -223,7 +223,7 @@ class AccountMove(models.Model):
         search='_search_reconciled_payment_ids',
         help='Payments that have been reconciled with this invoice.'
     )
-    payment_count = fields.Integer(compute='_compute_payment_count')
+    payment_count = fields.Integer(compute='_compute_payment_count', compute_sudo=True)
 
     # === Statement fields === #
     statement_line_id = fields.Many2one(

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -853,6 +853,7 @@
                                     </div>
                             </button>
                             <button name="open_payments"
+                                    groups="account.group_account_invoice,account.group_account_readonly"
                                     class="oe_stat_button"
                                     icon="fa-bars"
                                     type="object"

--- a/addons/purchase/static/tests/tours/purchase_flow_tour.js
+++ b/addons/purchase/static/tests/tours/purchase_flow_tour.js
@@ -1,0 +1,72 @@
+import { inputFiles } from "@web/../tests/utils";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_basic_purchase_flow_with_minimal_access_rights", {
+    steps: () => [
+        {
+            trigger: ".o_menuitem[href='/odoo/purchase']",
+            run: "click",
+        },
+        {
+            content: "Check that at least one RFQ is present in the view",
+            trigger: ".o_purchase_dashboard_list_view .o_data_row",
+        },
+        {
+            trigger: ".o_list_button_add",
+            run: "click",
+        },
+        {
+            trigger: ".o_input[id=partner_id_0]",
+            run: "edit partner_a",
+        },
+        {
+            trigger: ".dropdown-item:contains(partner_a)",
+            run: "click",
+        },
+        {
+            trigger: ".o_field_x2many_list_row_add > a",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_row .o_input",
+            run: "edit Test Product",
+        },
+        {
+            trigger: ".dropdown-item:contains('Test Product')",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_cell[name=price_unit]",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_cell[name=price_unit] .o_input",
+            run: "edit 3",
+        },
+        {
+            trigger: "button[name=button_confirm]",
+            run: "click",
+        },
+        {
+            trigger: ".o_statusbar_status .o_arrow_button_current:contains(Purchase Order)",
+        },
+        {
+            content: "Upload the vendor bill",
+            trigger: ".o_widget_purchase_file_uploader",
+            run: async () => {
+                const testFile = new File(["Vendor, Bill"], "my_vendor_bill.png", {
+                    type: "image/*",
+                });
+                await inputFiles(".o_widget_purchase_file_uploader input", [testFile]);
+            },
+        },
+        {
+            content: "Check that we are in the invoice form view",
+            trigger: ".o_statusbar_status:contains(Posted) .o_arrow_button_current:contains(Draft)",
+        },
+        {
+            content: "Check that the invoice is linked to the sale order",
+            trigger: "button[name=action_view_source_purchase_orders]",
+        },
+    ],
+});

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -3,6 +3,7 @@
 
 from . import test_purchase
 from . import test_purchase_downpayment
+from . import test_purchase_flow
 from . import test_purchase_order_product_catalog
 from . import test_purchase_order_report
 from . import test_purchase_invoice

--- a/addons/purchase/tests/test_purchase_flow.py
+++ b/addons/purchase/tests/test_purchase_flow.py
@@ -1,0 +1,32 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseFlowTourPostInstall(AccountTestInvoicingCommon, HttpCase):
+
+    def test_basic_purchase_flow_with_minimal_access_rights(self):
+        """
+        Test that a purchase user with minimal access rights can open both the list and form view,
+        create and process a purchase order, upload and open the associated vendor bill.
+        """
+        purchase_user = self.env['res.users'].create({
+            'name': 'Super Purchase Woman',
+            'login': 'SuperPurchaseWoman',
+            'group_ids': [Command.set([self.ref('purchase.group_purchase_user')])],
+        })
+        # create and confirm a PO to populate the list view
+        purchase_order = self.env['purchase.order'].with_user(purchase_user.id).create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'name': self.product.name,
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        purchase_order.button_approve()
+        self.start_tour('/odoo', 'test_basic_purchase_flow_with_minimal_access_rights', login='SuperPurchaseWoman')

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -17,7 +17,7 @@ class AccountMove(models.Model):
     campaign_id = fields.Many2one(ondelete='set null')
     medium_id = fields.Many2one(ondelete='set null')
     source_id = fields.Many2one(ondelete='set null')
-    sale_order_count = fields.Integer(compute="_compute_origin_so_count", string='Sale Order Count')
+    sale_order_count = fields.Integer(compute="_compute_origin_so_count", string='Sale Order Count', compute_sudo=True)
     sale_warning_text = fields.Text(
         "Sale Warning",
         help="Internal warning for the partner or the products as set by the user.",

--- a/addons/sale_management/__manifest__.py
+++ b/addons/sale_management/__manifest__.py
@@ -62,6 +62,9 @@ The Dashboard for the Sales Manager will include
         'web.assets_frontend': [
             'sale_management/static/src/interactions/**/*',
         ],
+        'web.assets_tests': [
+            'sale_management/static/tests/tours/**/*',
+        ],
         'web.assets_unit_tests': [
             'sale_management/static/tests/**/*.test.js',
         ],

--- a/addons/sale_management/static/tests/tours/sale_flow_tour.js
+++ b/addons/sale_management/static/tests/tours/sale_flow_tour.js
@@ -1,0 +1,40 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
+
+registry.category("web_tour.tours").add("test_basic_sale_flow_with_minimal_access_rights", {
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Open the sales app"),
+        {
+            content: "Check that at least one quotation is present in the view",
+            trigger: ".o_sale_onboarding_list_view .o_data_row",
+        },
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer("partner_a"),
+        ...tourUtils.addProduct("Test Product"),
+        tourUtils.checkSOLDescriptionContains("Test Product"),
+        {
+            trigger: "button[name=action_confirm]",
+            run: "click",
+        },
+        {
+            trigger: ".o_statusbar_status .o_arrow_button_current:contains(Sales Order)",
+        },
+        {
+            trigger: "button[id=create_invoice]",
+            run: "click",
+        },
+        {
+            trigger: ".modal-content button[id=create_invoice_open]",
+            run: "click",
+        },
+        {
+            content: "Check that we are in the invoice form view",
+            trigger: ".o_statusbar_status:contains(Posted) .o_arrow_button_current:contains(Draft)",
+        },
+        {
+            content: "Check that the invoice is linked to the sale order",
+            trigger: "button[name=action_view_source_sale_orders] .o_stat_value:contains(1)",
+        },
+    ],
+});

--- a/addons/sale_management/tests/test_sale_ui.py
+++ b/addons/sale_management/tests/test_sale_ui.py
@@ -4,6 +4,7 @@ from odoo.fields import Command
 from odoo.tests.common import HttpCase, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.sale.tests.common import TestSaleCommon
 
 
 @tagged('post_install', '-at_install')
@@ -39,3 +40,29 @@ class TestUi(AccountTestInvoicingCommon, HttpCase):
         action = sales_order.action_preview_sale_order()
 
         self.start_tour(action['url'], 'sale_signature_without_name', login="admin")
+
+
+@tagged('-at_install', 'post_install')
+class TestSaleFlowTourPostInstall(TestSaleCommon, HttpCase):
+
+    def test_basic_sale_flow_with_minimal_access_rights(self):
+        """
+        Test that a sale user with minimal access rights (own document only) can open both the
+        list and form view, create and process a sale order and open the associated invoice.
+        """
+        sale_user = self.env['res.users'].create({
+            'name': 'Super Sale Woman',
+            'login': 'SuperSaleWoman',
+            'group_ids': [Command.set([self.ref('sales_team.group_sale_salesman')])],
+        })
+        # create and confirm a sale order to populate the list view
+        sale_order = self.env['sale.order'].with_user(sale_user.id).create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'name': self.product.name,
+                'product_id': self.product.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        sale_order.action_confirm()
+        self.start_tour('/odoo', 'test_basic_sale_flow_with_minimal_access_rights', login='SuperSaleWoman')

--- a/addons/stock/static/tests/tours/stock_flow_tour.js
+++ b/addons/stock/static/tests/tours/stock_flow_tour.js
@@ -1,0 +1,120 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_basic_stock_flow_with_minimal_access_rights", {
+    steps: () => [
+        {
+            trigger: ".o_menuitem[href='/odoo/inventory']",
+            run: "click",
+        },
+        {
+            trigger: "button[data-menu-xmlid='stock.menu_stock_warehouse_mgmt']",
+            run: "click",
+        },
+        {
+            trigger: ".o-dropdown-item[data-menu-xmlid='stock.in_picking']",
+            run: "click",
+        },
+        {
+            content: "check that at least one picking is present in the view",
+            trigger: ".o_stock_list_view_view .o_data_row",
+        },
+        {
+            trigger: ".o_list_button_add",
+            run: "click",
+        },
+        {
+            trigger: ".o_input[id=partner_id_0]",
+            run: "edit Test Partner",
+        },
+        {
+            trigger: ".dropdown-item:contains('Test Partner')",
+            run: "click",
+        },
+        {
+            trigger: ".o_field_x2many_list_row_add > a",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_row .o_input",
+            run: "edit Test Product",
+        },
+        {
+            trigger: ".dropdown-item:contains('Test Product')",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_cell[name=product_uom_qty]",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_cell[name=product_uom_qty] .o_input",
+            run: "edit 1",
+        },
+        {
+            trigger: "button[name=action_confirm]",
+            run: "click",
+        },
+        {
+            trigger: "button[name=button_validate]",
+            run: "click",
+        },
+        {
+            trigger: ".o_arrow_button_current:contains(Done)",
+        },
+        {
+            trigger: "button[data-menu-xmlid='stock.menu_stock_warehouse_mgmt']",
+            run: "click",
+        },
+        {
+            trigger: ".o-dropdown-item[data-menu-xmlid='stock.out_picking']",
+            run: "click",
+        },
+        {
+            content: "check that at least one picking is present in the view",
+            trigger: ".o_stock_list_view_view .o_data_row",
+        },
+        {
+            trigger: "button:contains(New)",
+            run: "click",
+        },
+        {
+            trigger: ".o_input[id=partner_id_0]",
+            run: "edit Test Partner",
+        },
+        {
+            trigger: ".dropdown-item:contains('Test Partner')",
+            run: "click",
+        },
+        {
+            trigger: ".o_field_x2many_list_row_add > a",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_row .o_input",
+            run: "edit Test Product",
+        },
+        {
+            trigger: ".dropdown-item:contains('Test Product')",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_cell[name=product_uom_qty]",
+            run: "click",
+        },
+        {
+            trigger: ".o_data_cell[name=product_uom_qty] .o_input",
+            run: "edit 1",
+        },
+        {
+            trigger: "button[name=action_confirm]",
+            run: "click",
+        },
+        {
+            trigger: "button[name=button_validate]",
+            run: "click",
+        },
+        {
+            trigger: ".o_arrow_button_current:contains(Done)",
+        },
+    ],
+});

--- a/addons/stock_delivery/security/ir.model.access.csv
+++ b/addons/stock_delivery/security/ir.model.access.csv
@@ -2,5 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_delivery_carrier_stock_user,delivery.carrier stock_user,model_delivery_carrier,stock.group_stock_user,1,0,0,0
 access_delivery_carrier_stock_manager,delivery.carrier stock_manager,model_delivery_carrier,stock.group_stock_manager,1,1,1,1
 access_choose_delivery_carrier_stock_user,access.choose.delivery.carrier stock_user,model_choose_delivery_carrier,stock.group_stock_user,1,1,1,0
+access_delivery_zip_prefix_stock_user,delivery.zip.prefix stock_manager,delivery.model_delivery_zip_prefix,stock.group_stock_user,1,0,0,0
+access_delivery_price_rule_stock_user,delivery.price.rule stock_manager,delivery.model_delivery_price_rule,stock.group_stock_user,1,0,0,0
 access_delivery_zip_prefix_stock_manager,delivery.zip.prefix stock_manager,delivery.model_delivery_zip_prefix,stock.group_stock_manager,1,1,1,1
 access_delivery_price_rule_stock_manager,delivery.price.rule stock_manager,delivery.model_delivery_price_rule,stock.group_stock_manager,1,1,1,1


### PR DESCRIPTION
*: account,sale,stock_delivery

Since [19.0](https://github.com/odoo/odoo/pull/217277#issue-3198442339), read access rights are checks on comodels when trying to read the value of a many2many fields you have read acccess to. This change highlight numerous access right issues in basic flows for users with minimal access.

Here is a list of examples (each performed with every other access rights disabled):
- With a `stock user`, open the delivery list or form view
 #### > Access error
- With a `purchase user` create and confirm a PO > Upload Bill
####  > the Bill will be created but an access error will prevent the draft bill from opening.
- With a `sale user` create and confrim an SO > Create invoice
####  > the invoice will be created but an access error will prevent the draft invoice from opening.

## Solutions:

### Use case: Open an invoice (`acount.move`) linked to one of your SO/PO with a basic `sale`/`purchase` user:

1) For basic `sale` and `purchase` users to be able to open the `account.move` Form on which they have read, update, create, delete access rights, it is necessary for the `payment_count` to be compute sudo since it is used in the view:
https://github.com/odoo/odoo/blob/4ea42f8b16a8619cced4255f5bba8de6427345b7/addons/account/views/account_move_views.xml#L859 And these users do not have the read access of the `account.payment` model.

Similarily the `_compute_asset_ids` needs to be compute sudo because it relies on the related `asset_ids` of `account.move.line`s or on values of these `account.asset`s for which the users shoud not have read access: https://github.com/odoo/enterprise/blob/06cf3f2b6663c61f1fcc158678dfb1fa43ece4e1/account_asset/models/account_move.py#L27-L30 https://github.com/odoo/enterprise/blob/06cf3f2b6663c61f1fcc158678dfb1fa43ece4e1/account_asset/models/account_move.py#L317-L323 and the `asset_ids`, `count_asset`, `asset_id_display_name` and `draft_asset_exists` are all used in the view.

#### Note for master:

IMO, the `asset_ids` field of the `account.move` model should probably be in a separate compute to not be computed in sudo and removed from the views as it is currently used only to determine if there is or not `asset_ids`. An information that is provided by the `count_asset`. E.G. here:
https://github.com/odoo/enterprise/blob/06cf3f2b6663c61f1fcc158678dfb1fa43ece4e1/account_asset/views/account_move_views.xml#L10 https://github.com/odoo/enterprise/blob/06cf3f2b6663c61f1fcc158678dfb1fa43ece4e1/account_asset/views/account_move_views.xml#L35-L40 https://github.com/odoo/enterprise/blob/06cf3f2b6663c61f1fcc158678dfb1fa43ece4e1/account_asset/views/account_move_views.xml#L44-L52

2) For basic `purchase` users to open the invoice linked to one of their PO, it is necessary that the `sale_order_count` is computed in sudo as they do not have access to the related `sale_line_ids` field and the field is used in the `account.move` form:
https://github.com/odoo/odoo/blob/4ea42f8b16a8619cced4255f5bba8de6427345b7/addons/sale/models/account_move.py#L46-L49 https://github.com/odoo/odoo/blob/4ea42f8b16a8619cced4255f5bba8de6427345b7/addons/sale/views/account_views.xml#L53

### Use case: Open a `stock.picking` views as basic stock user:

3) The basic `stock` users have a read access on the `delivery.carrier` model and should also on the related `delivery.zip.prefix` and `delivery.price.rule` models. First as it make sense functionally but also as it currently blocks them on basic flows. For instance basic stock users can not open the `stock.picking` list or form view as the `carrier_id` is part of these view:
https://github.com/odoo/odoo/blob/4ea42f8b16a8619cced4255f5bba8de6427345b7/addons/stock_delivery/views/delivery_view.xml#L125-L132 This is problematic as this field has a domain relying on the related `allowed_carrier_ids` field:
https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/stock_delivery/models/stock_picking.py#L23-L24 As such, when the view is opened, the related field needs to be read. However, the `_compute_allowed_carrier_ids` fails if you do not have read access rights on the `delivery.zip.prefix` model: https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/delivery/models/delivery_carrier.py#L198 https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/delivery/models/delivery_carrier.py#L70-L72 Similarily `delivery.price.rule` model should be readable for `stock` users in order to be able to get be able to rely on the `price_rule_ids` when necessary such as here:
https://github.com/odoo/odoo/blob/93fa6d9fff63534cfa9251e21fc82797d8b83468/addons/delivery/models/delivery_carrier.py#L492-L496

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

opw-5461135
opw-5417749