### PR TITLE
[FIX] l10n_it_edi: fix total in company currency

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -370,7 +370,7 @@ class AccountMove(models.Model):
 
         # Self-invoices are technically -100%/+100% repartitioned
         # but functionally need to be exported as 100%
-        document_total = self.amount_total
+        document_total = self.amount_total_signed if convert_to_euros else self.amount_total
         if is_self_invoice:
             document_total += sum([abs(v['tax_amount_currency']) for k, v in tax_details['tax_details'].items()])
             if reverse_charge_refund:

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_discount.xml
@@ -58,7 +58,7 @@
         <Divisa>EUR</Divisa>
         <Data>2024-08-07</Data>
         <Numero>INV/2024/00003</Numero>
-        <ImportoTotaleDocumento>512.07</ImportoTotaleDocumento>
+        <ImportoTotaleDocumento>474.63</ImportoTotaleDocumento>
       </DatiGeneraliDocumento>
     </DatiGenerali>
     <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_simple_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_simple_discount.xml
@@ -59,7 +59,7 @@
         <Divisa>EUR</Divisa>
         <Data>2024-08-06</Data>
         <Numero>INV/2024/00002</Numero>
-        <ImportoTotaleDocumento>505.26</ImportoTotaleDocumento>
+        <ImportoTotaleDocumento>468.31</ImportoTotaleDocumento>
       </DatiGeneraliDocumento>
     </DatiGenerali>
     <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_simple_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_simple_discount.xml
@@ -58,7 +58,7 @@
         <Divisa>EUR</Divisa>
         <Data>2024-08-07</Data>
         <Numero>INV/2024/00001</Numero>
-        <ImportoTotaleDocumento>907.89</ImportoTotaleDocumento>
+        <ImportoTotaleDocumento>841.50</ImportoTotaleDocumento>
       </DatiGeneraliDocumento>
     </DatiGenerali>
     <DatiBeniServizi>


### PR DESCRIPTION
With an `l10n_it` company:
- Create an invoice in a foreign currency and export the XML.

In the XML, the field `ImportoTotaleDocumento` is expressed in the invoice currency, while `Divisa` is set to the company currency.
`ImportoTotaleDocumento` must be expressed in EUR, as stated in the following document:
https://www.agenziaentrate.gov.it/portale/documents/20143/0/10FAQ+pubblicate+il+19+luglio+2019+(aggiornate+il+1+luglio+2021).pdf/6e8acb34-b7c5-730e-6a39-79c0a296e02b

> L'art. 21, comma 2, lettera l) del d.P.R. n. 633/72 specifica che
> “aliquota, ammontare dell'imposta e dell'imponibile con arrotondamento al centesimo di euro”.
> Conseguentemente, se la fattura è emessa da soggetti residenti o stabiliti il codice da inserire nel campo `<Divisa>`
> deve essere obbligatoriamente “EUR”.

> Article 21, paragraph 2, letter (l) of Presidential Decree No. 633/72 specifies that
> “the tax rate, the amount of the tax, and the taxable amount must be stated with rounding to the euro cent.”
> Consequently, if the invoice is issued by resident or established taxpayers, the code to be entered in the `<Divisa>`
> field must mandatorily be “EUR”.

As a result, we now use the **company currency amount** for the `ImportoTotaleDocumento` field
(assuming the company currency is always EUR for `l10n_it`).

Ticket [link](https://www.odoo.com/odoo/project.task/5913088)
opw-5913088