### PR TITLE
[FIX] account: allow translation reload without all companies

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1313,6 +1313,7 @@ class AccountChartTemplate(models.AbstractModel):
         for company in companies:
             chart_template_data = template_data or self.env['account.chart.template'] \
                 .with_company(company) \
+                .sudo() \
                 ._get_chart_template_data(company.chart_template)
             chart_template_data.pop('template_data', None)
             for mname, data in chart_template_data.items():


### PR DESCRIPTION
When a user doesn't have access to all companies, he couldn't reload the translation terms.

However, the exception occurs in the call to _get_chart_template_data, which doesn't especially require privileges, because it is static data.

With this commit, we bypass the lack of company access to retrieve this data, and let the user continue the language reloading process.

Task-id: [5916490](https://www.odoo.com/odoo/project.task/5916490)