### PR TITLE
[IMP] core: support selection_add display without database records

### DIFF
--- a/odoo/orm/fields_selection.py
+++ b/odoo/orm/fields_selection.py
@@ -206,11 +206,8 @@ class Selection(Field[str | typing.Literal[False]]):
             # force all values to be strings (check _get_year_selection)
             return [(str(key), str(label)) for key, label in selection]
 
-        # translate selection labels
-        if env.lang:
-            return env['ir.model.fields'].get_field_selection(self.model_name, self.name)
-        else:
-            return selection
+        translations = dict(env['ir.model.fields'].get_field_selection(self.model_name, self.name))
+        return [(key, translations.get(key, label)) for key, label in selection]
 
     def _default_group_expand(self, records, groups, domain):
         # return a group per selection option, in definition order


### PR DESCRIPTION
Previously, when developers use `selection_add` in stable versions, the new selection values could be written to the database (since `field._selection` contains them), but they would not appear in the UI due to missing `ir.model.fields.selection` records.

This commit allows newly added selections to be displayed in the field description without requiring database updates.

Note: the new selections still cannot be translated without database updates.

mainly for enterprise https://github.com/odoo/enterprise/pull/106612
may be also helpful for https://github.com/odoo/odoo/pull/217853

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
