### PR TITLE
[FIX] web: use fields inside the records instead of the ones in filters

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -1065,11 +1065,11 @@ export class CalendarModel extends Model {
      * @protected
      */
     makeFilterRecord(filterInfo, previousFilter, rawRecord) {
-        const { colorFieldName, filterFieldName, writeFieldName } = filterInfo;
+        const { colorFieldName, filterFieldName, fieldName, writeFieldName } = filterInfo;
         const { fields, fieldMapping } = this.meta;
         const raw = rawRecord[writeFieldName];
         const value = Array.isArray(raw) ? raw[0] : raw;
-        const field = fields[writeFieldName];
+        const field = fields[fieldName];
         const isX2Many = ["many2many", "one2many"].includes(field.type);
         const formatter = registry.category("formatters").get(isX2Many ? "many2one" : field.type);
 
@@ -1079,7 +1079,7 @@ export class CalendarModel extends Model {
             (() => {
                 const sameRelatedModel = colorField.relation === field.relation;
                 const sameRelatedField =
-                    colorField.related === `${writeFieldName}.${colorFieldName}`;
+                    colorField.related === `${fieldName}.${colorFieldName}`;
                 const shouldHaveColor = sameRelatedModel || sameRelatedField;
                 const colorToUse = raw ? value : rawRecord[fieldMapping.color];
                 return shouldHaveColor ? colorToUse : null;

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -37,9 +37,6 @@ class Event extends models.Model {
     user_id = fields.Many2one({ relation: "calendar.user" });
     user_ids = fields.Many2many({ relation: "calendar.user" });
 
-    // FIXME: needed for the filter to work
-    filter_user_id = fields.Many2one({ relation: "calendar.user" });
-
     _records = [
         {
             id: 1,
@@ -136,7 +133,6 @@ class Event extends models.Model {
             
                 <!-- For filter to work -->
                 <field name="date_start" invisible="1"/>
-                <field name="filter_user_id" invisible="1"/>
             </calendar>
         `,
         "calendar,calendar_state": `


### PR DESCRIPTION
Before this commit, when the field of the model is not the same then the
writable field for the filters, the user cannot correctly load the
calendar view since the view does not find the write_field in the record to
get the value.

This commit fixes the issue to correctly use the right field depending on
which case we are.

task-5259036