### PR TITLE
[IMP] web: cache avatars to make them available offline

### DIFF
--- a/addons/calendar/static/tests/calendar.test.js
+++ b/addons/calendar/static/tests/calendar.test.js
@@ -9,7 +9,10 @@ const serverData = {};
 
 beforeEach(async () => {
     const { env: pyEnv } = await makeMockServer();
-    serverData.partnerIds = pyEnv["res.partner"].create([{ name: "Zeus" }, { name: "Azdaha" }]);
+    serverData.partnerIds = pyEnv["res.partner"].create([
+        { name: "Zeus", write_date: "2023-02-13 10:00:00" },
+        { name: "Azdaha", write_date: "2023-02-13 10:00:00" },
+    ]);
     serverData.eventId = pyEnv["calendar.event"].create({
         name: "event 1",
         partner_ids: serverData.partnerIds,
@@ -50,7 +53,9 @@ test("Many2ManyAttendee: basic rendering", async () => {
     expect(".o_field_widget[name='partner_ids'] .o_tag:eq(0) img").toHaveCount(1);
     expect(".o_field_widget[name='partner_ids'] .o_tag:eq(0) img").toHaveAttribute(
         "data-src",
-        `${getOrigin()}/web/image/res.partner/${serverData.partnerIds[0]}/avatar_128`
+        `${getOrigin()}/web/image/res.partner/${
+            serverData.partnerIds[0]
+        }/avatar_128?unique=1676282400000`
     );
     expect.verifySteps(["get_attendee_detail"]);
 });
@@ -80,7 +85,9 @@ test("[Offline] Many2ManyAttendee: basic rendering", async () => {
     expect(".o_field_widget[name='partner_ids'] .o_tag:eq(0) img").toHaveCount(1);
     expect(".o_field_widget[name='partner_ids'] .o_tag:eq(0) img").toHaveAttribute(
         "data-src",
-        `${getOrigin()}/web/image/res.partner/${serverData.partnerIds[0]}/avatar_128`
+        `${getOrigin()}/web/image/res.partner/${
+            serverData.partnerIds[0]
+        }/avatar_128?unique=1676282400000`
     );
 });
 

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.js
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.js
@@ -45,12 +45,18 @@ export class KanbanMany2OneAvatarEmployeeField extends Component {
     get value() {
         return this.props.record.data[this.props.name];
     }
+
+    get uniqueId() {
+        // hr_leave_stats widget uses this field but doesn't provide the write_date
+        return this.value?.write_date ? this.value.write_date.toMillis() : undefined;
+    }
 }
 
 /** @type {import("registries").FieldsRegistryItemShape} */
 const fieldDescr = {
     ...buildM2OFieldDescription(KanbanMany2OneAvatarEmployeeField),
     additionalClasses: ["o_field_many2one_avatar_kanban", "o_field_many2one_avatar_user"],
+    relatedFields: [{ name: "write_date", type: "datetime" }],
     extractProps(staticInfo, dynamicInfo) {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -4,7 +4,7 @@
     <t t-name="hr.KanbanMany2OneAvatarEmployeeField">
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
-                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName"/>
+                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName" uniqueId="uniqueId"/>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.js
@@ -34,10 +34,15 @@ export class Many2OneAvatarEmployeeField extends Component {
     get relation() {
         return this.props.relation ?? (this.isHrUser ? "hr.employee" : "hr.employee.public");
     }
+
+    get uniqueId() {
+        return this.props.record.data[this.props.name].write_date.toMillis();
+    }
 }
 
 registry.category("fields").add("many2one_avatar_employee", {
     ...buildM2OFieldDescription(Many2OneAvatarEmployeeField),
+    relatedFields: [{ name: "write_date", type: "datetime" }],
     additionalClasses: [
         "o_field_many2one_avatar",
         "o_field_many2one_avatar_kanban",
@@ -47,9 +52,10 @@ registry.category("fields").add("many2one_avatar_employee", {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),
             relation: staticInfo.options.relation,
-            canOpen: "no_open" in staticInfo.options
-                ? !staticInfo.options.no_open
-                : staticInfo.viewType === "form",
+            canOpen:
+                "no_open" in staticInfo.options
+                    ? !staticInfo.options.no_open
+                    : staticInfo.viewType === "form",
         };
     },
 });

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
@@ -5,7 +5,7 @@
         <t t-set="value" t-value="props.record.data[props.name]"/>
         <div class="d-flex align-items-center gap-1">
             <t t-if="value !== false">
-                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true"/>
+                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" uniqueId="uniqueId"/>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">

--- a/addons/hr/static/tests/m2x_avatar_employee.test.js
+++ b/addons/hr/static/tests/m2x_avatar_employee.test.js
@@ -88,6 +88,7 @@ test("many2one in kanban view", async () => {
     const employeeId = env["hr.employee.public"].create({
         user_id: userId,
         user_partner_id: partnerId,
+        write_date: "2023-02-13 10:00:00",
     });
     env["m2x.avatar.employee"].create({
         employee_id: employeeId,
@@ -109,7 +110,7 @@ test("many2one in kanban view", async () => {
     await waitFor(".o_m2o_avatar");
     expect(".o_m2o_avatar > img:eq(0)").toHaveAttribute(
         "data-src",
-        `/web/image/hr.employee.public/${employeeId}/avatar_128`
+        `/web/image/hr.employee.public/${employeeId}/avatar_128?unique=1676282400000`
     );
 });
 
@@ -135,6 +136,7 @@ test("many2one with hr group widget in kanban view", async () => {
     const employeeId = env["hr.employee.public"].create({
         user_id: userId,
         user_partner_id: partnerId,
+        write_date: "2023-02-13 10:00:00",
     });
     env["m2x.avatar.employee"].create({
         employee_id: employeeId,
@@ -155,7 +157,7 @@ test("many2one with hr group widget in kanban view", async () => {
     await waitFor(".o_m2o_avatar");
     expect(".o_m2o_avatar > img:eq(0)").toHaveAttribute(
         "data-src",
-        `/web/image/hr.employee/${employeeId}/avatar_128`
+        `/web/image/hr.employee/${employeeId}/avatar_128?unique=1676282400000`
     );
 });
 
@@ -166,6 +168,7 @@ test("many2one with relation set in options", async () => {
     const employeeId = env["hr.employee.public"].create({
         user_id: userId,
         user_partner_id: partnerId,
+        write_date: "2023-02-13 10:00:00",
     });
     env["m2x.avatar.employee"].create({
         employee_id: employeeId,
@@ -186,7 +189,7 @@ test("many2one with relation set in options", async () => {
     await waitFor(".o_m2o_avatar");
     expect(".o_m2o_avatar > img:eq(0)").toHaveAttribute(
         "data-src",
-        `/web/image/hr.employee.public/${employeeId}/avatar_128`
+        `/web/image/hr.employee.public/${employeeId}/avatar_128?unique=1676282400000`
     );
 });
 
@@ -235,11 +238,13 @@ test("many2one in form view", async () => {
             user_partner_id: partnerId_1,
             name: "Mario",
             work_email: "Mario@partner.com",
+            write_date: "2023-02-13 10:00:00",
         },
         {
             name: "Luigi",
             user_id: userId_2,
             user_partner_id: partnerId_2,
+            write_date: "2023-02-13 10:00:00",
         },
     ]);
     const avatarId_1 = env["m2x.avatar.employee"].create({
@@ -256,7 +261,7 @@ test("many2one in form view", async () => {
     expect(".o_field_many2many_avatar_employee .o_tag").toHaveCount(2);
     expect(".o_field_many2many_avatar_employee .o_tag img:eq(0)").toHaveAttribute(
         "data-src",
-        `${getOrigin()}/web/image/hr.employee.public/${employeeId_1}/avatar_128`
+        `${getOrigin()}/web/image/hr.employee.public/${employeeId_1}/avatar_128?unique=1676282400000`
     );
 
     // Clicking on first employee's avatar
@@ -286,8 +291,8 @@ test("many2one with hr group widget in form view", async () => {
         { partner_id: partnerId_2 },
     ]);
     const [employeeData_1, employeeData_2] = [
-        { user_id: userId_1, user_partner_id: partnerId_1 },
-        { user_id: userId_2, user_partner_id: partnerId_2 },
+        { user_id: userId_1, user_partner_id: partnerId_1, write_date: "2023-02-13 10:00:00" },
+        { user_id: userId_2, user_partner_id: partnerId_2, write_date: "2023-02-13 10:00:00" },
     ];
     env["hr.employee"].create([{ ...employeeData_1 }, { ...employeeData_2 }]);
     const [employeeId_1, employeeId_2] = env["hr.employee.public"].create([
@@ -308,7 +313,7 @@ test("many2one with hr group widget in form view", async () => {
     expect(".o_field_many2many_avatar_employee .o_tag").toHaveCount(2);
     expect(".o_field_many2many_avatar_employee .o_tag img:eq(0)").toHaveAttribute(
         "data-src",
-        `${getOrigin()}/web/image/hr.employee/${employeeId_1}/avatar_128`
+        `${getOrigin()}/web/image/hr.employee/${employeeId_1}/avatar_128?unique=1676282400000`
     );
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(0)").click();
     await contains(".o_field_many2many_avatar_employee .o_tag .o_m2m_avatar:eq(1)").click();
@@ -384,11 +389,13 @@ test("many2many in kanban view", async () => {
             user_partner_id: partnerId_1,
             name: "Mario",
             work_email: "Mario@partner.com",
+            write_date: "2023-02-13 10:00:00",
         },
         {
             name: "Luigi",
             user_id: userId_2,
             user_partner_id: partnerId_2,
+            write_date: "2023-02-13 10:00:00",
         },
     ]);
     env["m2x.avatar.employee"].create({
@@ -416,13 +423,13 @@ test("many2many in kanban view", async () => {
         ".o_kanban_record .o_field_many2many_avatar_employee img.o_m2m_avatar:eq(0)"
     ).toHaveAttribute(
         "data-src",
-        `${getOrigin()}/web/image/hr.employee.public/${employeeId_2}/avatar_128`
+        `${getOrigin()}/web/image/hr.employee.public/${employeeId_2}/avatar_128?unique=1676282400000`
     );
     expect(
         ".o_kanban_record .o_field_many2many_avatar_employee img.o_m2m_avatar:eq(1)"
     ).toHaveAttribute(
         "data-src",
-        `${getOrigin()}/web/image/hr.employee.public/${employeeId_1}/avatar_128`
+        `${getOrigin()}/web/image/hr.employee.public/${employeeId_1}/avatar_128?unique=1676282400000`
     );
 
     // Clicking on first employee's avatar
@@ -452,11 +459,13 @@ test("many2many: click on an employee not associated with a user", async () => {
         {
             name: "Mario",
             work_email: "Mario@partner.com",
+            write_date: "2023-02-13 10:00:00",
         },
         {
             name: "Luigi",
             user_id: userId,
             user_partner_id: partnerId,
+            write_date: "2023-02-13 10:00:00",
         },
     ]);
     const avatarId = env["m2x.avatar.employee"].create({
@@ -473,7 +482,7 @@ test("many2many: click on an employee not associated with a user", async () => {
     expect(".o_field_many2many_avatar_employee .o_tag").toHaveCount(2);
     expect(".o_field_many2many_avatar_employee .o_tag img:eq(0)").toHaveAttribute(
         "data-src",
-        `${getOrigin()}/web/image/hr.employee.public/${employeeId_1}/avatar_128`
+        `${getOrigin()}/web/image/hr.employee.public/${employeeId_1}/avatar_128?unique=1676282400000`
     );
 
     // Clicking on first employee's avatar (employee with no user)

--- a/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
+++ b/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
@@ -16,6 +16,7 @@ test("many2one_avatar_employee widget in kanban view with skills on avatar card"
         name: "Pierre",
         user_id: pierreUid,
         user_partner_id: pierrePid,
+        write_date: "2023-02-13 10:00:00",
     });
     const [javaForPierre, tigrinyaForPierre] = pyEnv["hr.employee.skill"].create([
         { employee_id: pierreEid, skill_id: java },
@@ -43,7 +44,7 @@ test("many2one_avatar_employee widget in kanban view with skills on avatar card"
     await contains(".o_field_many2one_avatar_employee img", { count: 1 });
     expect(
         queryAttribute(".o_kanban_record .o_field_many2one_avatar_employee img", "data-src")
-    ).toBe(`/web/image/hr.employee.public/${pierreEid}/avatar_128`);
+    ).toBe(`/web/image/hr.employee.public/${pierreEid}/avatar_128?unique=1676282400000`);
     await click(".o_kanban_record .o_m2o_avatar > img");
     await contains(".o_avatar_card");
     await contains(".o_avatar_card .o_employee_skills_tags > .o_tag", { count: 2 });

--- a/addons/mail/static/src/views/web/fields/avatar/avatar.js
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.js
@@ -9,6 +9,7 @@ export class Avatar extends Component {
     static props = {
         resModel: { type: String },
         resId: { type: Number },
+        uniqueId: { type: Number, optional: true },
         canOpenPopover: { type: Boolean, optional: true },
         cssClass: { type: [String, Object], optional: true },
         displayName: { type: String, optional: true },
@@ -31,6 +32,14 @@ export class Avatar extends Component {
             id: this.props.resId,
             model: this.props.resModel,
         };
+    }
+
+    get src() {
+        let src = `/web/image/${this.props.resModel}/${this.props.resId}/avatar_128`;
+        if (this.props.uniqueId) {
+            src += `?unique=${this.props.uniqueId}`;
+        }
+        return src;
     }
 
     onClickAvatar(ev) {

--- a/addons/mail/static/src/views/web/fields/avatar/avatar.xml
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Avatar">
         <div class="o-mail-Avatar o_avatar d-flex align-items-center" t-att-class="props.cssClass">
             <img t-attf-class="rounded {{props.noSpacing ? '' : 'me-2'}}"
-                t-attf-src="/web/image/{{props.resModel}}/{{props.resId}}/avatar_128"
+                t-att-src="src"
                 t-on-click.stop.prevent="onClickAvatar"
             />
             <span t-if="props.displayName" class="text-truncate w-0 flex-grow-1" t-esc="props.displayName"/>

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.js
@@ -29,12 +29,17 @@ export class KanbanMany2OneAvatarUserField extends Component {
     get value() {
         return this.props.record.data[this.props.name];
     }
+
+    get uniqueId() {
+        return this.value ? this.value.write_date.toMillis() : undefined;
+    }
 }
 
 /** @type {import("registries").FieldsRegistryItemShape} */
 const fieldDescr = {
     ...buildM2OFieldDescription(KanbanMany2OneAvatarUserField),
     additionalClasses: ["o_field_many2one_avatar_kanban", "o_field_many2one_avatar"],
+    relatedFields: [{ name: "write_date", type: "datetime" }],
     extractProps(staticInfo, dynamicInfo) {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
@@ -5,7 +5,7 @@
         <t t-set="relation" t-value="props.record.fields[props.name].relation"/>
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
-                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName"/>
+                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" uniqueId="uniqueId" noSpacing="true" displayName="displayName"/>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -44,18 +44,24 @@ export class Many2OneAvatarUserField extends Component {
     get value() {
         return this.props.record.data[this.props.name];
     }
+
+    get uniqueId() {
+        return this.value ? this.value.write_date.toMillis() : undefined;
+    }
 }
 
 export const many2OneAvatarUserField = {
     ...buildM2OFieldDescription(Many2OneAvatarUserField),
     additionalClasses: ["o_field_many2one_avatar"],
+    relatedFields: [{ name: "write_date", type: "datetime" }],
     extractProps(staticInfo, dynamicInfo) {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),
             withCommand: ["form", "list"].includes(staticInfo.viewType),
-            canOpen: "no_open" in staticInfo.options
-                ? !staticInfo.options.no_open
-                : staticInfo.viewType === "form",
+            canOpen:
+                "no_open" in staticInfo.options
+                    ? !staticInfo.options.no_open
+                    : staticInfo.viewType === "form",
         };
     },
     listViewWidth: [110],

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Many2OneAvatarUserField">
         <div class="d-flex align-items-center gap-1">
             <t t-if="value !== false">
-                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true"/>
+                <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" uniqueId="uniqueId" noSpacing="true"/>
             </t>
             <Many2OneAvatarUser t-props="m2oProps" cssClass="'w-100'">
                 <t t-set-slot="inviteTeammates" t-slot-scope="inviteTeammatesScope">

--- a/addons/mail/static/tests/web/fields/avatar.test.js
+++ b/addons/mail/static/tests/web/fields/avatar.test.js
@@ -25,3 +25,18 @@ test("basic rendering", async () => {
     await click(".o-mail-Avatar img");
     await contains(".o_avatar_card");
 });
+
+test("avatar with uniqueId props", async () => {
+    await start();
+    await mountWithCleanup(Avatar, {
+        props: {
+            resId: serverState.userId,
+            resModel: "res.users",
+            displayName: "User display name",
+            uniqueId: 123789,
+        },
+    });
+    await contains(
+        ".o-mail-Avatar img[data-src='/web/image/res.users/7/avatar_128?unique=123789']"
+    );
+});

--- a/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
@@ -233,6 +233,7 @@ test("avatar_user widget displays the appropriate user image in list view", asyn
     const pyEnv = await startServer();
     const userId = pyEnv["res.users"].create({
         partner_id: pyEnv["res.partner"].create({ name: "Mario" }),
+        write_date: "2023-02-13 10:00:00",
     });
     const avatarUserId = pyEnv["m2x.avatar.user"].create({ user_id: userId });
     await start();
@@ -241,12 +242,14 @@ test("avatar_user widget displays the appropriate user image in list view", asyn
         arch: "<list><field name='user_id' widget='many2one_avatar_user'/></list>",
     });
 
-    await contains(`.o_m2o_avatar > img[data-src="/web/image/res.users/${userId}/avatar_128"]`);
+    await contains(
+        `.o_m2o_avatar > img[data-src="/web/image/res.users/${userId}/avatar_128?unique=1676282400000"]`
+    );
 });
 
 test("avatar_user widget displays the appropriate user image in kanban view", async () => {
     const pyEnv = await startServer();
-    const userId = pyEnv["res.users"].create({ name: "Mario" });
+    const userId = pyEnv["res.users"].create({ name: "Mario", write_date: "2023-02-13 10:00:00" });
     const avatarUserId = pyEnv["m2x.avatar.user"].create({ user_id: userId });
     await start();
     await openKanbanView("m2x.avatar.user", {
@@ -262,7 +265,9 @@ test("avatar_user widget displays the appropriate user image in kanban view", as
         `,
     });
     await start();
-    await contains(`.o_m2o_avatar > img[data-src="/web/image/res.users/${userId}/avatar_128"]`);
+    await contains(
+        `.o_m2o_avatar > img[data-src="/web/image/res.users/${userId}/avatar_128?unique=1676282400000"]`
+    );
 });
 
 test("avatar card preview", async () => {
@@ -366,6 +371,7 @@ test("avatar_user widget displays the appropriate user image in form view", asyn
     const pyEnv = await startServer();
     const userId = pyEnv["res.users"].create({
         partner_id: pyEnv["res.partner"].create({ name: "Mario" }),
+        write_date: "2023-02-13 10:00:00",
     });
     const avatarUserId = pyEnv["m2x.avatar.user"].create({ user_ids: [userId] });
     await start();
@@ -373,7 +379,7 @@ test("avatar_user widget displays the appropriate user image in form view", asyn
         arch: "<form><field name='user_ids' widget='many2many_avatar_user'/></form>",
     });
     await contains(
-        `.o_field_many2many_avatar_user.o_field_widget .o_avatar img[data-src="${getOrigin()}/web/image/res.users/${userId}/avatar_128"]`
+        `.o_field_many2many_avatar_user.o_field_widget .o_avatar img[data-src="${getOrigin()}/web/image/res.users/${userId}/avatar_128?unique=1676282400000"]`
     );
 });
 

--- a/addons/test_mail/static/tests/activity.test.js
+++ b/addons/test_mail/static/tests/activity.test.js
@@ -819,6 +819,7 @@ test("Activity view: many2one_avatar_user widget in activity view", async () => 
     const resUsersId1 = pyEnv["res.users"].create({
         display_name: "first user",
         avatar_128: "Atmaram Bhide",
+        write_date: "2023-02-13 10:00:00",
     });
     pyEnv["mail.test.activity"].write([mailTestActivityId1], { activity_user_id: resUsersId1 });
     registerArchs({
@@ -838,7 +839,7 @@ test("Activity view: many2one_avatar_user widget in activity view", async () => 
     });
     await contains(".o_m2o_avatar", { count: 1 });
     await contains(
-        `tr:nth-child(2) .o_m2o_avatar > img[data-src="/web/image/res.users/${resUsersId1}/avatar_128"]`
+        `tr:nth-child(2) .o_m2o_avatar > img[data-src="/web/image/res.users/${resUsersId1}/avatar_128?unique=1676282400000"]`
     );
     // "should not have text on many2one_avatar_user if onlyImage node option is passed"
     await contains(".o_m2o_avatar > span", { count: 0 });

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -185,6 +185,7 @@ export function patchActiveFields(activeField, patch) {
     activeField.isHandle = activeField.isHandle || patch.isHandle;
     // x2manys
     if (patch.related) {
+        activeField.related = activeField.related || { activeFields: {}, fields: {} };
         const related = activeField.related;
         for (const fieldName in patch.related.activeFields) {
             if (fieldName in related.activeFields) {

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -30,7 +30,9 @@ export class Many2ManyTagsAvatarField extends Many2ManyTagsField {
 
     getTagProps(record) {
         return {
-            imageUrl: imageUrl(this.relation, record.resId, "avatar_128"),
+            imageUrl: imageUrl(this.relation, record.resId, "avatar_128", {
+                unique: record.data.write_date,
+            }),
             onDelete: !this.props.readonly ? () => this.deleteTag(record.id) : undefined,
             text: record.data.display_name,
             tooltip: record.data.display_name,
@@ -41,6 +43,11 @@ export class Many2ManyTagsAvatarField extends Many2ManyTagsField {
 export const many2ManyTagsAvatarField = {
     ...many2ManyTagsField,
     component: Many2ManyTagsAvatarField,
+    relatedFields: (fieldInfo) => {
+        const relatedFields = many2ManyTagsField.relatedFields(fieldInfo);
+        relatedFields.push({ name: "write_date", type: "datetime" });
+        return relatedFields;
+    },
     extractProps({ viewType }, dynamicInfo) {
         const props = many2ManyTagsField.extractProps(...arguments);
         props.withCommand = viewType === "form" || viewType === "list";

--- a/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.js
@@ -19,6 +19,7 @@ export class KanbanMany2OneAvatarField extends Component {
 
 registry.category("fields").add("kanban.many2one_avatar", {
     ...buildM2OFieldDescription(KanbanMany2OneAvatarField),
+    relatedFields: [{ name: "write_date", type: "datetime" }],
     additionalClasses: ["o_field_many2one_avatar_kanban"],
     extractProps(staticInfo, dynamicInfo) {
         return {

--- a/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
@@ -3,10 +3,11 @@
 
     <t t-name="web.KanbanMany2OneAvatarField">
         <t t-set="relation" t-value="props.record.fields[props.name].relation"/>
+        <t t-set="value" t-value="props.record.data[props.name]"/>
         <KanbanMany2One t-props="m2oProps">
             <t t-set-slot="avatar">
                 <span class="o_avatar o_m2o_avatar">
-                    <img t-attf-src="/web/image/{{relation}}/{{props.record.data[props.name].id}}/avatar_128" class="rounded"/>
+                    <img t-attf-src="/web/image/{{relation}}/{{value.id}}/avatar_128?unique={{value.write_date.toMillis()}}" class="rounded"/>
                 </span>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.js
@@ -19,6 +19,7 @@ export class Many2OneAvatarField extends Component {
 
 export const many2OneAvatarField = {
     ...buildM2OFieldDescription(Many2OneAvatarField),
+    relatedFields: [{ name: "write_date", type: "datetime" }],
     extractProps(staticInfo, dynamicInfo) {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -7,7 +7,7 @@
         <div class="d-flex align-items-center gap-1">
             <span class="o_avatar o_m2o_avatar">
                 <t t-if="value">
-                    <img class="rounded" t-attf-src="/web/image/{{relation}}/{{value.id}}/avatar_128"/>
+                    <img class="rounded" t-attf-src="/web/image/{{relation}}/{{value.id}}/avatar_128?unique={{value.write_date.toMillis()}}"/>
                 </t>
                 <t t-elif="!props.readonly">
                     <span class="o_avatar_empty o_m2o_avatar_empty"/>

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -18,9 +18,9 @@ describe.current.tags("desktop");
 class Partner extends models.Model {
     name = fields.Char({ string: "Displayed name" });
     _records = [
-        { id: 1, name: "first record" },
-        { id: 2, name: "second record" },
-        { id: 4, name: "aaa" },
+        { id: 1, name: "first record", write_date: "2023-02-13 10:00:00" },
+        { id: 2, name: "second record", write_date: "2023-02-13 10:00:00" },
+        { id: 4, name: "aaa", write_date: "2023-02-13 10:00:00" },
     ];
 }
 
@@ -79,7 +79,7 @@ test("widget many2many_tags_avatar img src", async () => {
 
     expect(".o_field_many2many_tags_avatar.o_field_widget .o_avatar img").toHaveCount(2);
     expect(
-        `.o_field_many2many_tags_avatar.o_field_widget .o_avatar:nth-child(1) img[data-src='${getOrigin()}/web/image/partner/2/avatar_128']`
+        `.o_field_many2many_tags_avatar.o_field_widget .o_avatar:nth-child(1) img[data-src='${getOrigin()}/web/image/partner/2/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
 });
 
@@ -88,6 +88,7 @@ test("widget many2many_tags_avatar in list view", async () => {
         Partner._records.push({
             id,
             name: `record ${id}`,
+            write_date: "2023-02-13 10:00:00",
         });
     }
 
@@ -109,7 +110,7 @@ test("widget many2many_tags_avatar in list view", async () => {
             </list>`,
     });
     expect(
-        `.o_data_row:nth-child(1) .o_field_many2many_tags_avatar .o_avatar img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/1/avatar_128']`
+        `.o_data_row:nth-child(1) .o_field_many2many_tags_avatar .o_avatar img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/1/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     expect(
         ".o_data_row .o_many2many_tags_avatar_cell .o_field_many2many_tags_avatar:eq(0)"
@@ -127,16 +128,16 @@ test("widget many2many_tags_avatar in list view", async () => {
         ".o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
     ).toHaveText("+2");
     expect(
-        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(1) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/1/avatar_128']`
+        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(1) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/1/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     expect(
-        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(2) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/2/avatar_128']`
+        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(2) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/2/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     expect(
-        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(3) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128']`
+        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(3) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     expect(
-        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(4) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/5/avatar_128']`
+        `.o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_avatar:nth-child(4) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/5/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     expect(
         ".o_data_row:nth-child(3) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
@@ -156,9 +157,13 @@ test("widget many2many_tags_avatar in list view", async () => {
         ".o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
     );
     expect(tag).toHaveAttribute("data-tooltip-template", "web.TagsList.Tooltip");
-    expect(tag).toHaveAttribute("data-tooltip-info", JSON.stringify({ tags: ["record 6", "record 7"] }), {
-        message: "shows a tooltip on hover",
-    });
+    expect(tag).toHaveAttribute(
+        "data-tooltip-info",
+        JSON.stringify({ tags: ["record 6", "record 7"] }),
+        {
+            message: "shows a tooltip on hover",
+        }
+    );
 
     await contains(".o_data_row .o_many2many_tags_avatar_cell:eq(0)").click();
     await contains(
@@ -208,6 +213,7 @@ test("widget many2many_tags_avatar in kanban view", async () => {
         Partner._records.push({
             id,
             name: `record ${id}`,
+            write_date: "2023-02-13 10:00:00",
         });
     }
 
@@ -255,10 +261,10 @@ test("widget many2many_tags_avatar in kanban view", async () => {
         ".o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar img"
     ).toHaveCount(2);
     expect(
-        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(1 of .o_tag) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/5/avatar_128']`
+        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(1 of .o_tag) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/5/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     expect(
-        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(2 of .o_tag) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128']`
+        `.o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_avatar:nth-child(2 of .o_tag) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     expect(
         ".o_kanban_record:nth-child(3) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
@@ -299,7 +305,7 @@ test("widget many2many_tags_avatar in kanban view", async () => {
     expect(".o-overlay-container .o_tag").toHaveCount(5);
     expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(2);
     expect(
-        `.o_kanban_record:nth-child(2) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128']`
+        `.o_kanban_record:nth-child(2) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);
     await contains(".o_kanban_record .o_field_many2many_tags_avatar img.o_m2m_avatar").click();
 });

--- a/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
@@ -40,10 +40,12 @@ class Users extends models.Model {
         {
             id: 1,
             name: "Aline",
+            write_date: "2023-02-13 10:00:00",
         },
         {
             id: 2,
             name: "Christine",
+            write_date: "2023-02-13 10:00:00",
         },
     ];
 }
@@ -63,23 +65,31 @@ test("basic form view flow", async () => {
     });
 
     expect(".o_field_widget[name=user_id] input").toHaveValue("Aline");
-    expect('.o_m2o_avatar > img[data-src="/web/image/res.users/1/avatar_128"]').toHaveCount(1);
+    expect(
+        '.o_m2o_avatar > img[data-src="/web/image/res.users/1/avatar_128?unique=1676282400000"]'
+    ).toHaveCount(1);
     expect(".o_field_many2one_avatar > div").toHaveCount(1);
 
     expect(".o_input_dropdown").toHaveCount(1);
     expect(".o_input_dropdown input").toHaveValue("Aline");
     expect(".o_external_button").toHaveCount(1);
-    expect('.o_m2o_avatar > img[data-src="/web/image/res.users/1/avatar_128"]').toHaveCount(1);
+    expect(
+        '.o_m2o_avatar > img[data-src="/web/image/res.users/1/avatar_128?unique=1676282400000"]'
+    ).toHaveCount(1);
 
     await clickFieldDropdown("user_id");
     expect(".o_field_many2one_selection .o_avatar_many2x_autocomplete").toHaveCount(2);
     await clickFieldDropdownItem("user_id", "Christine");
 
-    expect('.o_m2o_avatar > img[data-src="/web/image/res.users/2/avatar_128"]').toHaveCount(1);
+    expect(
+        '.o_m2o_avatar > img[data-src="/web/image/res.users/2/avatar_128?unique=1676282400000"]'
+    ).toHaveCount(1);
     await clickSave();
 
     expect(".o_field_widget[name=user_id] input").toHaveValue("Christine");
-    expect('.o_m2o_avatar > img[data-src="/web/image/res.users/2/avatar_128"]').toHaveCount(1);
+    expect(
+        '.o_m2o_avatar > img[data-src="/web/image/res.users/2/avatar_128?unique=1676282400000"]'
+    ).toHaveCount(1);
 
     await contains('.o_field_widget[name="user_id"] input').clear({ confirm: "blur" });
 
@@ -95,11 +105,15 @@ test("onchange in form view flow", async () => {
     Partner._fields.int_field = fields.Integer({
         onChange: (obj) => {
             if (obj.int_field === 1) {
-                obj.user_id = [2, "Christine"];
+                obj.user_id = {
+                    id: 2,
+                    display_name: "Christine",
+                    write_date: "2023-02-13 10:00:00",
+                };
             } else if (obj.int_field === 2) {
                 obj.user_id = false;
             } else {
-                obj.user_id = [1, "Aline"]; // default value
+                obj.user_id = { id: 1, display_name: "Aline", write_date: "2023-02-13 10:00:00" }; // default value
             }
         },
     });
@@ -115,12 +129,16 @@ test("onchange in form view flow", async () => {
     });
 
     expect(".o_field_widget[name=user_id]").toHaveText("Aline");
-    expect('.o_m2o_avatar > img[data-src="/web/image/res.users/1/avatar_128"]').toHaveCount(1);
+    expect(
+        '.o_m2o_avatar > img[data-src="/web/image/res.users/1/avatar_128?unique=1676282400000"]'
+    ).toHaveCount(1);
 
     await contains("div[name=int_field] input").edit(1);
 
     expect(".o_field_widget[name=user_id]").toHaveText("Christine");
-    expect('.o_m2o_avatar > img[data-src="/web/image/res.users/2/avatar_128"]').toHaveCount(1);
+    expect(
+        '.o_m2o_avatar > img[data-src="/web/image/res.users/2/avatar_128?unique=1676282400000"]'
+    ).toHaveCount(1);
 
     await contains("div[name=int_field] input").edit(2);
 
@@ -142,9 +160,18 @@ test("basic list view flow", async () => {
         "",
     ]);
     const imgs = queryAll(".o_m2o_avatar > img");
-    expect(imgs[0]).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
-    expect(imgs[1]).toHaveAttribute("data-src", "/web/image/res.users/2/avatar_128");
-    expect(imgs[2]).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
+    expect(imgs[0]).toHaveAttribute(
+        "data-src",
+        "/web/image/res.users/1/avatar_128?unique=1676282400000"
+    );
+    expect(imgs[1]).toHaveAttribute(
+        "data-src",
+        "/web/image/res.users/2/avatar_128?unique=1676282400000"
+    );
+    expect(imgs[2]).toHaveAttribute(
+        "data-src",
+        "/web/image/res.users/1/avatar_128?unique=1676282400000"
+    );
 });
 
 test("basic flow in editable list view", async () => {
@@ -162,15 +189,24 @@ test("basic flow in editable list view", async () => {
     ]);
 
     const imgs = queryAll(".o_m2o_avatar > img");
-    expect(imgs[0]).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
-    expect(imgs[1]).toHaveAttribute("data-src", "/web/image/res.users/2/avatar_128");
-    expect(imgs[2]).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
+    expect(imgs[0]).toHaveAttribute(
+        "data-src",
+        "/web/image/res.users/1/avatar_128?unique=1676282400000"
+    );
+    expect(imgs[1]).toHaveAttribute(
+        "data-src",
+        "/web/image/res.users/2/avatar_128?unique=1676282400000"
+    );
+    expect(imgs[2]).toHaveAttribute(
+        "data-src",
+        "/web/image/res.users/1/avatar_128?unique=1676282400000"
+    );
 
     await contains(".o_data_row .o_data_cell:eq(0)").click();
 
     expect(".o_m2o_avatar > img:eq(0)").toHaveAttribute(
         "data-src",
-        "/web/image/res.users/1/avatar_128"
+        "/web/image/res.users/1/avatar_128?unique=1676282400000"
     );
 });
 
@@ -334,6 +370,7 @@ test("widget many2one_avatar in kanban view (load more dialog)", async () => {
         Users._records.push({
             id,
             display_name: `record ${id}`,
+            write_date: "2023-02-13 10:00:00",
         });
     }
 
@@ -365,7 +402,7 @@ test("widget many2one_avatar in kanban view (load more dialog)", async () => {
     await contains(".o_dialog .o_list_table .o_data_row .o_data_cell").click();
     expect(
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > img"
-    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
+    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128?unique=1676282400000");
 });
 
 test("widget many2one_avatar in kanban view", async () => {
@@ -387,7 +424,7 @@ test("widget many2one_avatar in kanban view", async () => {
 
     expect(
         ".o_kanban_record:nth-child(1) .o_field_many2one_avatar .o_m2o_avatar > img"
-    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
+    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128?unique=1676282400000");
     expect(
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > .o_quick_assign"
     ).toHaveCount(1);
@@ -399,10 +436,10 @@ test("widget many2one_avatar in kanban view", async () => {
     expect.verifySteps(["web_name_search"]);
     // select first input
     await contains(".o-overlay-container .o-autocomplete--dropdown-item").click();
-    expect.verifySteps(["web_save"]);
+    expect.verifySteps(["web_read", "web_save"]);
     expect(
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > img"
-    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
+    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128?unique=1676282400000");
     expect(
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > .o_quick_assign"
     ).toHaveCount(0);
@@ -426,7 +463,7 @@ test("widget many2one_avatar in kanban view without access rights", async () => 
     });
     expect(
         ".o_kanban_record:nth-child(1) .o_field_many2one_avatar .o_m2o_avatar > img"
-    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128");
+    ).toHaveAttribute("data-src", "/web/image/res.users/1/avatar_128?unique=1676282400000");
     expect(
         ".o_kanban_record:nth-child(4) .o_field_many2one_avatar .o_m2o_avatar > .o_quick_assign"
     ).toHaveCount(0);

--- a/addons/web/static/tests/views/fields/monetary_field.test.js
+++ b/addons/web/static/tests/views/fields/monetary_field.test.js
@@ -554,7 +554,7 @@ test("MonetaryField with currency set by an onchange", async () => {
     // onchange)
     Partner._onChanges = {
         int_field: function (obj) {
-            obj.currency_id = obj.int_field ? 2 : null;
+            obj.currency_id = obj.int_field ? 2 : false;
         },
     };
 


### PR DESCRIPTION
This PR adds the `unique` params to a bunch of avatar urls
generated by several field widgets, typically extensions of the
Many2one and Many2ManyTags fields displaying avatars.

Using the `unique` params enables the cache, which then allows to
 1) speedup image loading
 2) have images even offline

To determine the `unique` value to use, those field widgets now
load the `write_date` of the record as extra related field, which
ensures that the cache isn't hit if the record changed meanwhile.

Task~5489914