### PR TITLE
[FIX] account: remove comments while parsing XMLs

### DIFF
--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -226,7 +226,7 @@ class AccountEdiFormat(models.Model):
         """
         to_process = []
         try:
-            xml_tree = etree.fromstring(content)
+            xml_tree = etree.fromstring(content, parser=etree.XMLParser(remove_comments=True, resolve_entities=False))
         except Exception as e:
             _logger.exception("Error when converting the xml content to etree: %s" % e)
             return to_process

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -182,6 +182,39 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'zip': '8010',
         }])
 
+    def test_import_bill(self):
+        partner = self.env['res.partner'].create({
+            'name': "My Belgian Partner",
+            'vat': "BE0477472701",
+            'email': "mypartner@email.com",
+        })
+        invoice = self.env['account.move'].create({
+            'partner_id': partner.id,
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id})]
+        })
+        invoice.action_post()
+        my_invoice_raw = self.env['account.edi.xml.ubl_bis3']._export_invoice(invoice)[0]
+        my_invoice_root = etree.fromstring(my_invoice_raw)
+        modifying_xpath = """
+            <xpath expr="(//*[local-name()='PaymentMeans']/*[local-name()='PaymentID'])" position="after">
+                <PayeeFinancialAccount><ID>Test account</ID></PayeeFinancialAccount>
+            </xpath>
+            <xpath expr="(//*[local-name()='LegalMonetaryTotal']/*[local-name()='TaxExclusiveAmount'])" position="replace">
+                <TaxExclusiveAmount currencyID="EUR"><!--Some valid XML
+                comment-->1000.0</TaxExclusiveAmount>
+            </xpath>"""
+        xml_attachment = self.env['ir.attachment'].create({
+            'raw': etree.tostring(self.with_applied_xpath(my_invoice_root, modifying_xpath)),
+            'name': 'test_invoice.xml',
+        })
+        imported_invoice = self.env['account.journal']\
+                .with_context(default_journal_id=self.company_data['default_journal_purchase'].id)\
+                ._create_document_from_attachment(xml_attachment.id)
+        self.assertRecordValues(imported_invoice.invoice_line_ids, [{
+            'amount_currency': 1000.00,
+            'quantity': 1.0}])
+
     def test_import_bill_without_tax(self):
         """ Test that no tax is set (even the default one) when importing a bill without tax."""
         file_path = "bis3_bill_without_tax.xml"


### PR DESCRIPTION
Issue:
Comments in node with data as text may cause issue while reading data

Step to reproduce:
- In European company create an invoice to a company in the same country
- Send it with peppol
- Download the XML of the invoice
- Add a comment right before the value in TaxExclusiveAmount like this <cbc:TaxExclusiveAmount><!-- -->0.00</cbc:TaxExclusiveAmount>
- Go to accounting Dashboard
- Click on "Upload" in the vendor dashboard
- Select the previously modified XML

Current behavior:
- an empty invoice is created as the invoice builder failed

Expected behavior:
- Invoice should be recognized

Cause:
lxml treat data like this:
<parentNode>parent_text<childNode>child_text</childNode>child_tail</parentNode>parent_tail So `tax_exclusive_amount_node.text` return '' instead of `0.00`

opw-5462664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
