### PR TITLE
[FIX] html_editor: fix undeterministic toolbar test

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -90,7 +90,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  */
 
 /** Delay in ms for toolbar open after keyup, double click or triple click. */
-const DELAY_TOOLBAR_OPEN = 300;
+export const DELAY_TOOLBAR_OPEN = 300;
 /** Number of buttons below which toolbar will open directly in its expanded form */
 const MIN_SIZE_FOR_COMPACT = 7;
 /** Special namespace that prevents the toolbar from opening */

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -48,7 +48,7 @@ import { insertText } from "./_helpers/user_actions";
 import { expandToolbar } from "./_helpers/toolbar";
 import { nodeSize } from "@html_editor/utils/position";
 import { expectElementCount } from "./_helpers/ui_expectations";
-import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
+import { DELAY_TOOLBAR_OPEN, ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
 import { ImageCrop } from "@html_editor/main/media/image_crop";
 import { Editor } from "@html_editor/editor";
 
@@ -634,7 +634,7 @@ test("toolbar works: displays correct font size on input", async () => {
     await press("8");
     expect(inputEl).toHaveValue("8");
     await advanceTime(200);
-    expect(".o_font_size_selector_menu").toHaveCount(1);
+    expectElementCount(".o_font_size_selector_menu", 1);
     expect(getContent(el)).toBe(`<p><span style="font-size: 8px;">[test]</span></p>`);
     await expectElementCount(".o-we-toolbar", 1);
 });
@@ -1648,7 +1648,8 @@ describe("toolbar open and close on user interaction", () => {
             await simulateDoubleClickSelect(p);
             expect(getContent(el)).toBe("<p>[test]</p>");
             // toolbar open after double click is debounced
-            await advanceTime(500);
+            await advanceTime(DELAY_TOOLBAR_OPEN);
+            await animationFrame();
             await expectElementCount(".o-we-toolbar", 1);
         });
 
@@ -1659,7 +1660,7 @@ describe("toolbar open and close on user interaction", () => {
             await simulateTripleClickSelect(p);
             expect(getContent(el)).toBe("<p>[test text]</p>");
             // toolbar open after triple click is debounced
-            await advanceTime(500);
+            await advanceTime(DELAY_TOOLBAR_OPEN);
             await expectElementCount(".o-we-toolbar", 1);
         });
 
@@ -1673,12 +1674,12 @@ describe("toolbar open and close on user interaction", () => {
             expect(getContent(el)).toBe("<p>[test] text</p>");
             await advanceTime(100);
             // Toolbar is not open yet, waiting for a possible third click
-            await expectElementCount(".o-we-toolbar", 0);
+            expect(".o-we-toolbar").toHaveCount(0);
 
             // Third click
             await thirdClick(p);
             expect(getContent(el)).toBe("<p>[test text]</p>");
-            await advanceTime(500);
+            await advanceTime(DELAY_TOOLBAR_OPEN);
             await expectElementCount(".o-we-toolbar", 1);
         });
 
@@ -1692,14 +1693,14 @@ describe("toolbar open and close on user interaction", () => {
             setSelection({ anchorNode: p, anchorOffset: 0, focusOffset: 1 });
             await tick(); // selectionChange
             expect(getContent(el)).toBe("<p>[test text]</p>");
-            await advanceTime(500);
+            await advanceTime(DELAY_TOOLBAR_OPEN);
             // Toolbar is not open yet, waiting for mouseup
             await expectElementCount(".o-we-toolbar", 0);
 
             // Mouse up
             manuallyDispatchProgrammaticEvent(p, "mouseup", { detail: 3 });
             manuallyDispatchProgrammaticEvent(p, "click", { detail: 3 });
-            await advanceTime(500);
+            await advanceTime(DELAY_TOOLBAR_OPEN);
             await expectElementCount(".o-we-toolbar", 1);
         });
 
@@ -1739,7 +1740,7 @@ describe("toolbar open and close on user interaction", () => {
 
             await keyUp(["Shift", "ArrowRight"]);
 
-            await advanceTime(500); // Toolbar open on keyup is debounced
+            await advanceTime(DELAY_TOOLBAR_OPEN); // Toolbar open on keyup is debounced
             await expectElementCount(".o-we-toolbar", 1);
         });
 
@@ -1757,7 +1758,7 @@ describe("toolbar open and close on user interaction", () => {
             // Toolbar should open after keyup
             await keyUp(["Shift", "ArrowRight"]);
 
-            await advanceTime(500); // toolbar open on keyup is debounced
+            await advanceTime(DELAY_TOOLBAR_OPEN); // toolbar open on keyup is debounced
             await expectElementCount(".o-we-toolbar", 1);
         });
 
@@ -1794,7 +1795,7 @@ describe("toolbar open and close on user interaction", () => {
             await tick(); // selectionChange
             await keyUp(["Shift", "ArrowRight"]);
             await advanceTime(100);
-            await expectElementCount(".o-we-toolbar", 0);
+            expect(".o-we-toolbar").toHaveCount(0);
 
             // Keystroke # 2
             await keyDown(["Shift", "ArrowRight"]);
@@ -1802,10 +1803,10 @@ describe("toolbar open and close on user interaction", () => {
             await tick(); // selectionChange
             await keyUp(["Shift", "ArrowRight"]);
             await advanceTime(100);
-            await expectElementCount(".o-we-toolbar", 0);
+            expect(".o-we-toolbar").toHaveCount(0);
 
             // Toolbar opens some time after the last keyup
-            await advanceTime(500);
+            await advanceTime(DELAY_TOOLBAR_OPEN);
             await expectElementCount(".o-we-toolbar", 1);
         });
 


### PR DESCRIPTION
Because a timeout in js only ensures to wait at least for that
amount of time while giving no upper bound to the actual awaited
time, it was possible for advanceTime(100) to actually wait for
more than 300ms when the runbot was slow enough. In that case,
since enough time has elapsed between the action and checking that
the toolbar hadn't opened yet, well it was actually already opened,
since we had waited too much, and the test failed non-deterministically.

This is actually a special case here. Usually we want to use `waitFor`
or `expectElementCount` with the toolbar since it's a popover and is
therefore affected by [1]. But we cannot use them to check if the
toolbar hasn't opened too early, lest we find ourselves with the same
problem than explained above. Using only advanceTime with a timeout of
100ms and a synchronous `expect` check ensures that, in the general
case when the runbot is fast, the test will fail in case of a regression,
since there would have been ample time to have multiple animation
frames during 100ms. The regression will only be hidden when the
runbot is very slow and no animation frame has happened during the
100ms timeout, which is an acceptable tradeoff.

The same issue appeared in another test so I fixed it as well.

Timeouts throughout this test file were excessive, with multiple uses
of `advanceTime(500)` while OPEN_TOOLBAR_DELAY is 300ms. This is because
the commit dates from before [1] and so it was hard to ensure that
enough time and animation frames had passed before we could check with
`expect`, which is synchronous. Now we are using `expectElementCount`,
which uses `waitFor` under the hood which has a proper mechanism to wait
for enough animation frames with an  additional internal delay. With
these, there is no more need for a manual timeout to exceed the value of
OPEN_TOOLBAR_DELAY. Note that this only applies to the cases where we
check that the toolbar should be displayed, since cases where it should
NOT be displayed before a certain timeout should NOT use those utils,
as explained above.

runbot-238562

[1]: https://github.com/odoo/odoo/commit/54da715df84789f9a1acc0cfc91be41dcdbab140

Co-authored-by: Sébastien Geelen <sge@odoo.com>