### PR TITLE
[FIX] html_editor: allow re-uploading file in link popover

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -29,7 +29,7 @@
                                 placeholder="e.g. https://www.odoo.com"
                                 t-on-keydown="onKeydownEnter"
                                 t-on-input="this.onChange"/>
-                            <span class="ms-1" t-if="props.canUpload and !state.url">
+                            <span class="ms-1" t-if="props.canUpload">
                                 or <button class="btn btn-light btn-sm" t-on-click="uploadFile"><i class="fa fa-upload"/></button>
                             </span>
 

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1533,7 +1533,7 @@ describe("link in contenteditable=false", () => {
 });
 
 describe("upload file via link popover", () => {
-    test("should display upload button when url input is empty", async () => {
+    test("should display upload button whether url input is empty or filled.", async () => {
         const { editor } = await setupEditor("<p>[]<br></p>");
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");
@@ -1542,11 +1542,7 @@ describe("upload file via link popover", () => {
         await click(".o_we_href_input_link");
         await press("a");
         await animationFrame();
-        // Upload button should NOT be visible
-        expect("button i[class='fa fa-upload']").toHaveCount(0);
-        await press("Backspace");
-        await animationFrame();
-        // Upload button should be visible again
+        // Still upload button should be visible
         expect("button i[class='fa fa-upload']").toHaveCount(1);
     });
     const patchUpload = (editor) => {


### PR DESCRIPTION
Specification:
- When a user uploads a file in the link popover, user can not re-upload another
file without manually removing previous URL.

<img width="320" height="231" alt="image" src="https://github.com/user-attachments/assets/9e67535a-22a1-4d41-808d-a91d07593251" />
<img width="320" height="231" alt="image" src="https://github.com/user-attachments/assets/92a33d8c-a325-4979-9956-42e81b369bd7" />

After this commit:
- This commit allows user to re-upload a file without removing previously
generated URL first.
- TL;DR : upload button won't disappear.

task-5470111

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
