### PR TITLE
[FIX] point_of_sale: fix combo item price computation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
+++ b/addons/point_of_sale/static/src/app/models/utils/compute_combo_items.js
@@ -28,7 +28,7 @@ export const computeComboItems = (
         remainingTotal -= priceUnit * conf.qty;
 
         if (comboItem.id == childLineConf[childLineConf.length - 1].combo_item_id.id) {
-            priceUnit += remainingTotal;
+            priceUnit += remainingTotal / conf.qty;
         }
         const attribute_value_ids = conf.configuration?.attribute_value_ids?.map(
             (id) => productTemplateAttributeValueById[id]


### PR DESCRIPTION
Before this commit, if a combo product with price 100 had one combo item with 3 free quantity, adding the product to the order in PoS with 3 qty, the total price of the combo line would be 100.02, because the remaining after computing the unit price of the item 100 - 3 * 33.33 = 0.01 was added to the unit price of the item instead of being distributed on the total quantity of the item.

opw-5915595

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
