### PR TITLE
[FIX] mail: fix style of mention suggestion

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -67,3 +67,7 @@
     padding-bottom: 10px;
     line-height: 1.42857143 !important; // so that input is rounded to 20px = 14px (base font) * 1.42857143 (line-height)
 }
+
+.o-mail-Composer-suggestionPartner-name.o-has-email {
+    max-width: 70%;
+}

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -123,10 +123,12 @@
     <t t-name="mail.Composer.suggestionPartner">
         <t t-set="partner" t-value="option.partner"/>
         <ImStatus t-if="partner" persona="partner"/>
-        <strong class="px-2 py-1 align-self-center flex-shrink-0 text-truncate">
+        <t t-set="title" t-value="partner.name"/>
+        <t t-if="partner.email" t-set="title" t-value="`${title} (${partner.email})`"/>
+        <strong class="o-mail-Composer-suggestionPartner-name px-2 py-1 align-self-center flex-shrink-0 text-truncate" t-att-class="{'o-has-email': partner.email, 'mw-100': !partner.email}" t-att-title="title">
             <t t-esc="partner.name"/>
         </strong>
-        <span t-if="partner.email" class="text-600 text-truncate align-self-center">(<t t-esc="partner.email"/>)</span>
+        <span t-if="partner.email" class="text-600 text-truncate align-self-center" t-att-title="title">(<t t-esc="partner.email"/>)</span>
     </t>
 
     <t t-name="mail.Composer.suggestionThread">

--- a/addons/mail/static/src/core/web/mention_list.js
+++ b/addons/mail/static/src/core/web/mention_list.js
@@ -76,22 +76,25 @@ export class MentionList extends Component {
         };
         switch (this.props.type) {
             case "partner":
-                this.state.options.forEach((option) => {
-                    props.options.push({
-                        label: option.name,
-                        partner: option,
-                    });
+                props.optionTemplate = "mail.Composer.suggestionPartner";
+                props.options = this.state.options.map((suggestion) => {
+                    return {
+                        label: suggestion.name,
+                        partner: suggestion,
+                        classList: "o-mail-Composer-suggestion",
+                    };
                 });
                 break;
-            case "channel": {
-                this.state.options.forEach((option) => {
-                    props.options.push({
-                        label: option.name,
-                        channel: option,
-                    });
+            case "channel":
+                props.optionTemplate = "mail.Composer.suggestionThread";
+                props.options = this.state.options.map((suggestion) => {
+                    return {
+                        label: suggestion.displayName,
+                        thread: suggestion,
+                        classList: "o-mail-Composer-suggestion",
+                    };
                 });
                 break;
-            }
         }
         return props;
     }

--- a/addons/mail/static/src/core/web/mention_list.scss
+++ b/addons/mail/static/src/core/web/mention_list.scss
@@ -1,0 +1,3 @@
+.o-mail-MentionList {
+    width: Min(80vw, 450px);
+}

--- a/addons/mail/static/src/core/web/mention_list.xml
+++ b/addons/mail/static/src/core/web/mention_list.xml
@@ -13,7 +13,7 @@
     </t>
 
     <t t-name="mail.MentionList">
-        <div class="search d-flex">
+        <div class="o-mail-MentionList search d-flex">
             <input type="text" class="form-control border-0 flex-grow-1 rounded-end-0" t-ref="autofocus" t-att-placeholder="placeholder" t-model="state.searchTerm" t-on-keydown="onKeydown"/>
             <i class="oi oi-search p-2 fs-5 rounded-end" title="Search..." role="img" aria-label="Search..."/>
         </div>


### PR DESCRIPTION
Use the same style in full composer than in small composer.

Tweak style to account for small device, better handle overflows

task-5916878


Before / After (small composer)

<img width="342" height="466" alt="image" src="https://github.com/user-attachments/assets/234ff152-3c5a-4c82-b257-2800a752dd3a" />

<img width="496" height="476" alt="image" src="https://github.com/user-attachments/assets/60b3d12d-38ea-429a-9dec-441886ac022e" />

Before / After (full)

<img width="413" height="394" alt="image" src="https://github.com/user-attachments/assets/c51e053f-7eb2-4ee0-8a9a-bd068ee9ded0" />

<img width="487" height="555" alt="image" src="https://github.com/user-attachments/assets/d0a3514d-aa1f-4d89-8fe4-7964ec20a288" />
