### PR TITLE
[FIX] purchase_requisition: correct company for blanket order vendor pricelist

### DIFF
--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -257,6 +257,7 @@ class PurchaseRequisitionLine(models.Model):
                 'product_tmpl_id': self.product_id.product_tmpl_id.id,
                 'price': self.price_unit,
                 'currency_id': self.requisition_id.currency_id.id,
+                'company_id': self.requisition_id.company_id.id,
                 'purchase_requisition_line_id': self.id,
             })
 

--- a/doc/cla/individual/derick-david.md
+++ b/doc/cla/individual/derick-david.md
@@ -1,0 +1,11 @@
+Lebanon, 2026-02-06
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Derick David mailtoderick@gmail.com https://github.com/derick-david


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In a multi-company environment, confirming a Purchase Agreement (Blanket Order) automatically generates Vendor Pricelist (product.supplierinfo) entries for the linked
products. Currently, these entries default to the user's current active company rather than the company specified on the Purchase Agreement. This leads to data
inconsistency where pricelists are visible and owned by the wrong company.

Current behavior before PR:
When a Blanket Order belonging to Company A is confirmed by a user who has Company B as their current active company, the resulting Vendor Pricelist record is
assigned to Company B. This is because the company_id is not explicitly passed during the creation of the product.supplierinfo record, causing it to fall back to the
environment default.

Desired behavior after PR is merged:
The Vendor Pricelist record will explicitly use the company_id from the Purchase Agreement it originated from. This ensures that the pricelist is correctly assigned
to the agreement's company rather than from the active company

related to ticket i made 5909892
