### PR TITLE
[FIX] website_sale: fix product configurator dialog border radius styling.

### DIFF
--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
@@ -1,5 +1,4 @@
 .o_sale_product_configurator_dialog {
-    --modal-border-radius: #{$btn-border-radius};
     --product-configurator-img-size-lg: 6rem;
 
     .modal-header .btn.oi-arrow-left {


### PR DESCRIPTION
`Description of the issue this PR addresses:`
The Product Configurator dialog border radius was unintentionally affected by button styling. The dialog inherited its border radius from the $btn-border-radius variable, which is intended only for buttons and is customized in the design template.

`Current behavior before PR:`
- The Product Configurator dialog uses --modal-border-radius: #{$btn-border-radius};.
- $btn-border-radius is customized to make buttons fully rounded.
- Due to this linkage, the dialog border radius changes unintentionally.
- The issue is reproducible across multiple industries such as electronic_store, outdoor_activities, and team_sports_club.

`Desired behavior after PR is merged:`
- The Product Configurator dialog no longer depends on $btn-border-radius.
- Dialog border radius remains consistent and independent of button styling.
- Button border radius customization does not affect modal dialogs.
- Styling remains consistent across all affected industries.

Task ID: 5913300