### PR TITLE
[FIX] web_editor, html_editor: remove checklist indent

### DIFF
--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -7,7 +7,6 @@ ul.o_checklist {
     > li {
         list-style: none;
         position: relative;
-        margin-left: 20px;
 
         &:not(.oe-nested):before {
             content: '';

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/checklist.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/checklist.scss
@@ -2,7 +2,6 @@ ul.o_checklist {
     > li {
         list-style: none;
         position: relative;
-        margin-left: 20px;
 
         &:not(.oe-nested):before {
             content: '';

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -148,8 +148,6 @@ ul.o_checklist {
     >li {
         list-style: none;
         position: relative;
-        margin-left: $o-checklist-margin-left;
-        margin-right: $o-checklist-margin-left;
 
         &:not(.oe-nested)::before {
             content: '';


### PR DESCRIPTION
The checklist has different indents than bullet list and numbered list. It should not be the case.

This commit removes the extra indent from checklist entries.

Steps to reproduce:
- Go to a "To do" note
- Create a checklist with indented items
- Create a bullet list with indented items

=> Both list were not aligned

task-5916723
