### PR TITLE
[FIX] mail: hydrate needaction counter on threads when fetching inbox messages

### DIFF
--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -11,9 +11,21 @@ class MailboxController(http.Controller):
         domain = [("needaction", "=", True)]
         res = request.env["mail.message"]._message_fetch(domain, **(fetch_params or {}))
         messages = res.pop("messages")
+        # sudo: bus.bus: reading non-sensitive last id
+        bus_last_id = request.env["bus.bus"].sudo()._bus_last_id()
+        store = Store().add(
+            messages,
+            extra_fields=[
+                Store.One("thread", [
+                    Store.Attr("message_needaction_counter"),
+                    Store.Attr("message_needaction_counter_bus_id", bus_last_id)
+                ], as_thread=True)
+            ],
+            add_followers=True
+        )
         return {
             **res,
-            "data": Store().add(messages, add_followers=True).get_result(),
+            "data": store.get_result(),
             "messages": messages.ids,
         }
 

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -72,7 +72,8 @@ export class MailCoreWeb {
                 if (
                     thread &&
                     message.needaction &&
-                    notifId > thread.message_needaction_counter_bus_id
+                    notifId > thread.message_needaction_counter_bus_id &&
+                    thread.message_needaction_counter > 0
                 ) {
                     thread.message_needaction_counter--;
                 }

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -78,5 +78,5 @@ class TestInboxPerformance(HttpCase, MailCommon):
                 rating_value="4",
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
-        with self.assertQueryCount(42):
+        with self.assertQueryCount(43):
             self.make_jsonrpc_request("/mail/inbox/messages")


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Thread unread counters should reflect the actual backend state 
as soon as Inbox messages are loaded, not only after a new bus 
notification is received.

**Steps to Reproduce:**
- Log in as User A and User B.
- Ensure User A preferences set to Handle in Odoo.
- From User B, mention User A in the chatter of a record.
- From User A, Open the messaging menu, counter for that related thread 
is correct.
- Refresh the page.
- Open the messaging menu again, the thread now shows a grey badge 
instead of the expected unread counter.

**Current behavior before PR:**
- When loading Inbox messages, related `mail.thread` records 
(such as project.task) did not include unread counters in the store payload. 
As a result, threads that already had unread messages appeared as (grey badge) 
after a refresh, leading to an incorrect counter state.

- Additionally, frontend-only counter adjustments could sometimes lead to 
inconsistent or even negative unread values due to missing initial sync.

**Desired behavior after PR is merged:**
- Threads with existing unread messages now receive the correct counter state, 
when Inbox messages are fetched.
- This also prevents inconsistent or negative counter values caused by 
frontend-only updates.

task-[5474143](https://www.odoo.com/odoo/project/1519/tasks/5474143)

Before/After (**on refresh**):
<img width="461" height="55" alt="image" src="https://github.com/user-attachments/assets/2fc57aba-049c-4129-95b1-1d2b2770ac66" />

<img width="469" height="57" alt="image" src="https://github.com/user-attachments/assets/111d10bb-2aec-4711-8f5a-af7f332021d8" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
