### PR TITLE
[IMP] pos_restaurant: correct changes count

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -162,7 +162,9 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
                 // if note update with qty add
                 changes[lineKey] = lineDetails;
                 changesCount += quantityDiff;
-                changeAbsCount += Math.abs(quantityDiff);
+                if (!lineDetails.isCombo) {
+                    changeAbsCount += Math.abs(quantityDiff);
+                }
                 if (noteChange) {
                     lineDetails.quantity = oldChanges[relatedKey].quantity || 0;
                     noteUpdate[lineKey] = lineDetails;
@@ -208,7 +210,9 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
                     group: lineResume["group"],
                     quantity: -quantity,
                 };
-                changeAbsCount += Math.abs(quantity);
+                if (!lineResume["isCombo"]) {
+                    changeAbsCount += Math.abs(quantity);
+                }
                 changesCount += quantity;
             } else {
                 changes[lineKey]["quantity"] -= quantity;

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -412,24 +412,26 @@ patch(PosStore.prototype, {
         const orderChanges = this.getOrderChanges(order);
         const linesChanges = orderChanges.orderlines;
 
-        const categories = Object.values(linesChanges).reduce((acc, curr) => {
-            const categories =
-                this.models["product.product"].get(curr.product_id)?.product_tmpl_id
-                    ?.pos_categ_ids || [];
+        const categories = Object.values(linesChanges)
+            .filter((l) => !l.isCombo)
+            .reduce((acc, curr) => {
+                const categories =
+                    this.models["product.product"].get(curr.product_id)?.product_tmpl_id
+                        ?.pos_categ_ids || [];
 
-            for (const category of categories.slice(0, 1)) {
-                if (!acc[category.id]) {
-                    acc[category.id] = {
-                        count: curr.quantity,
-                        name: category.name,
-                    };
-                } else {
-                    acc[category.id].count += curr.quantity;
+                for (const category of categories.slice(0, 1)) {
+                    if (!acc[category.id]) {
+                        acc[category.id] = {
+                            count: curr.quantity,
+                            name: category.name,
+                        };
+                    } else {
+                        acc[category.id].count += curr.quantity;
+                    }
                 }
-            }
 
-            return acc;
-        }, {});
+                return acc;
+            }, {});
         const noteCount = ["general_customer_note", "internal_note"].reduce(
             (count, note) => count + (note in orderChanges ? 1 : 0),
             0

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -552,6 +552,22 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt", {
             combo.select("Combo Product 5"),
             combo.select("Combo Product 8"),
             Dialog.confirm(),
+            {
+                content: "Check action pad category counts",
+                trigger:
+                    ".submit-order .product-category-label:contains('Category 1') + label:contains('2')",
+            },
+            {
+                trigger:
+                    ".submit-order .product-category-label:contains('Category 2') + label:contains('2')",
+            },
+            {
+                trigger:
+                    ".submit-order .product-category-label:contains('Category 3') + label:contains('2')",
+            },
+            Chrome.clickPlanButton(),
+            FloorScreen.orderCountSyncedInTableIs("5", "6"),
+            FloorScreen.clickTable("5"),
             checkPreparationTicketData([
                 { name: "Office Combo", qty: 1 },
                 { name: "Combo Product 2", qty: 1 },


### PR DESCRIPTION
    In pos_restaurant, when ordering, we show the number of items in each
    category that will be sent to preparation. For ex, if we add one pizza
    and one drink to the order, we expect to see something of the type
    `Food: 1, Drinks: 1` ( depending on the way the user configured their
    pos ).
    
    When using `combos`, the combo item itself, which is not a physical
    product, was counted as an item to be sent to preparation.
    
    Ex:
    1. Create a combo consisting of a pizza and a drink.
    2. Place the combo in the `food` category
    3. Add the combo to the order
    4. Observe that the pos shows `Food: 2. Drinks: 1`
    
    In this commit we prevent the pos from counting combos as products to be
    sent to preparation.
    
    In the same spirit, on the corner of each table in the floor plan we see
    a number indicating the number of items that were added on that table.
    This number also included combos in the count, which, as described, is
    wrong. We address the issue in this commit.
    
    Task: 5906779



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
