### PR TITLE
[FIX] html_editor: show toolbar when selecting list text with icons

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -103,7 +103,7 @@ export class MediaPlugin extends Plugin {
         selectors_for_feff_providers: () =>
             `:is(${paragraphRelatedElementsSelector}, ${FORMATTABLE_TAGS.join(
                 ", "
-            )}, A) > :is(${ICON_SELECTOR})`,
+            )}, A, LI) > :is(${ICON_SELECTOR})`,
         before_save_handlers: this.savePendingImages.bind(this),
     };
 

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -1,11 +1,12 @@
 import { expect, test, describe } from "@odoo/hoot";
 import { click, tick, waitFor } from "@odoo/hoot-dom";
-import { setupEditor } from "./_helpers/editor";
+import { setupEditor, testEditor } from "./_helpers/editor";
 import { animationFrame } from "@odoo/hoot-mock";
 import { getContent, setContent, setSelection } from "./_helpers/selection";
 import { splitBlock, undo } from "./_helpers/user_actions";
 import { contains } from "@web/../tests/web_test_helpers";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { unformat } from "./_helpers/format";
 
 test("icon toolbar is displayed", async () => {
     const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
@@ -338,4 +339,19 @@ test("should insert two empty paragraphs when Enter is pressed twice before the 
     expect(getContent(el)).toBe(
         `<p><br></p><p><br></p><p>\ufeff[]<span class="fa fa-glass" contenteditable="false">\u200B</span>\ufeff</p>`
     );
+});
+
+test("should wrap icons in feff when under list item", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+                <ul>
+                    <li><span class="fa fa-glass" contenteditable="false"></span></li>
+                </ul>
+            `),
+        contentBeforeEdit: unformat(`
+            <ul>
+                <li>\ufeff<span class="fa fa-glass" contenteditable="false">\u200B</span>\ufeff</li>
+            </ul>
+        `),
+    });
 });


### PR DESCRIPTION
Problem:
When triple-clicking on text inside a list item that contains an icon, the toolbar is not shown.

Cause:
The toolbar is not displayed when the selection anchor node is inside an element with `contenteditable="false"`.
This happens in cases like:

`<li><span class="…" contenteditable="false"></span>abc</li>`

When triple-clicking on "abc", the selection anchorNode becomes the `span` and the offset is `0` and offset is "abc" offset 3. In that case, `selection.toString()` returns an empty string.

While this may also be a browser related issue as the selection includes text but `toString()` still returns empty string, the root cause here is that normalization does not wrap the icon with `feff` because the corresponding selector is missing.

Solution:
Include icons under `li` elements when wrapping nodes with `feff`, so the selection is normalized correctly and the toolbar can be shown.

Steps to reproduce:
- Open Email Marketing.
- Drop the "Comparison" snippet.
- Triple-click on one of the texts with check icons.
- Observe that the toolbar is not shown.

task-5913202

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
