### PR TITLE
[FIX] im_livechat, *: fix traceback and displayName bug in chatbot

### DIFF
--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -32,6 +32,7 @@ declare module "models" {
     export interface DiscussChannel {
         chatbot: Chatbot;
         livechat_agent_history_ids: LivechatChannelMemberHistory[];
+        livechat_bot_history_ids: LivechatChannelMemberHistory[];
         livechat_channel_id: LivechatChannel;
         livechat_channel_member_history_ids: LivechatChannelMemberHistory[];
         livechat_customer_history_ids: LivechatChannelMemberHistory[];

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -14,6 +14,9 @@ const discussChannelPatch = {
         this.livechat_agent_history_ids = fields.Many("im_livechat.channel.member.history", {
             inverse: "channelAsAgentHistory",
         });
+        this.livechat_bot_history_ids = fields.Many("im_livechat.channel.member.history", {
+            inverse: "channelAsBotHistory",
+        });
         this.livechat_channel_id = fields.One("im_livechat.channel", { inverse: "channel_ids" });
         this.livechat_channel_member_history_ids = fields.Many(
             "im_livechat.channel.member.history",
@@ -86,10 +89,12 @@ const discussChannelPatch = {
             })
             .map((m) => m.name);
         if (!memberNames.length) {
-            const histories =
-                selfMemberType === "visitor"
+            let histories = this.livechat_customer_history_ids;
+            if (selfMemberType === "visitor") {
+                histories = this.livechat_agent_history_ids.length
                     ? this.livechat_agent_history_ids
-                    : this.livechat_customer_history_ids;
+                    : this.livechat_bot_history_ids;
+            }
             memberNames = histories
                 .map((h) => this.getPersonaName(h.partner_id || h.guest_id))
                 .filter(Boolean);

--- a/addons/im_livechat/static/src/core/common/livechat_channel_member_history_model.js
+++ b/addons/im_livechat/static/src/core/common/livechat_channel_member_history_model.js
@@ -13,6 +13,15 @@ export class LivechatChannelMemberHistory extends Record {
             return false;
         },
     });
+    channelAsBotHistory = fields.One("discuss.channel", {
+        inverse: "livechat_bot_history_ids",
+        compute() {
+            if (this.livechat_member_type === "bot") {
+                return this.channel_id;
+            }
+            return false;
+        },
+    });
     channelAsCustomerHistory = fields.One("discuss.channel", {
         inverse: "livechat_customer_history_ids",
         compute() {

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -84,7 +84,7 @@ export class LivechatService {
             // flickering, we do not want another load that would result in the
             // same issue.
             savedChannel.scrollUnread = false;
-            temporaryThread.channel.chatWindow?.close();
+            temporaryThread.channel?.chatWindow?.close();
             savedChannel.openChatWindow({ focus: true });
         });
         return savedChannel;

--- a/addons/test_discuss_full/static/tests/tours/chatbot_redirect_to_portal_tour.js
+++ b/addons/test_discuss_full/static/tests/tours/chatbot_redirect_to_portal_tour.js
@@ -8,6 +8,9 @@ registry.category("web_tour.tours").add("chatbot_redirect_to_portal", {
             run: "click",
         },
         {
+            trigger: ".o-livechat-root:shadow .o-mail-ChatWindow-header:contains(Redirection Bot)",
+        },
+        {
             trigger:
                 ".o-livechat-root:shadow .o-mail-Message:contains(Hello, were do you want to go?)",
             run: "click",


### PR DESCRIPTION
*=test_discuss_full

Before this PR:
- When starting a session with a chatbot, the name of conversation is not visible on livechat channel. Because the name is computed from agent/customer history and not from bot history.
- Using a chatbot while the website editor is active could trigger a TypeError traceback.

This PR:
- computes the name properly from bot history.
- adds a guard that closes the transient channel

Steps to reproduce traceback:
 - go to localhost:8069/@/contactus
 - start chatbot and select some answer
 - receive traceback

task-[5881970](https://www.odoo.com/odoo/project/1519/tasks/5881970)