### PR TITLE
[IMP] point_of_sale: currency symbol on cdis

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -5,13 +5,12 @@ import { formatDate, formatDateTime, serializeDateTime } from "@web/core/l10n/da
 import { omit } from "@web/core/utils/objects";
 import { parseUTCString, qrCodeSrc, random5Chars, uuidv4, gte, lt } from "@point_of_sale/utils";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
-import { roundCurrency } from "@point_of_sale/app/models/utils/currency";
+import { formatCurrency, roundCurrency } from "@point_of_sale/app/models/utils/currency";
 import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { toRaw } from "@odoo/owl";
 
 const { DateTime } = luxon;
-const formatCurrency = registry.subRegistries.formatters.content.monetary[1];
 
 export class PosOrder extends Base {
     static pythonModel = "pos.order";
@@ -1088,12 +1087,12 @@ export class PosOrder extends Base {
                 imageSrc: `/web/image/product.product/${l.product_id.id}/image_128`,
             })),
             finalized: this.finalized,
-            amount: formatCurrency(this.get_total_with_tax() || 0),
+            amount: formatCurrency(this.get_total_with_tax() || 0, this.currency),
             paymentLines: this.payment_ids.map((pl) => ({
                 name: pl.payment_method_id.name,
-                amount: formatCurrency(pl.get_amount()),
+                amount: formatCurrency(pl.get_amount(), this.currency),
             })),
-            change: this.get_change() && formatCurrency(this.get_change()),
+            change: this.get_change() && formatCurrency(this.get_change(), this.currency),
             generalNote: this.general_note || "",
             qrPaymentData: toRaw(this.get_selected_paymentline()?.qrPaymentData),
         };


### PR DESCRIPTION
This PR adds the currency symbol on the customer display for point of sale for the total amount + change. (formatted based on the currency, e.g. $ before, eur after the amount) This is required by the scale certification 

Before:
<img width="777" height="604" alt="image" src="https://github.com/user-attachments/assets/28688075-b387-477a-930d-410f1107cc83" />



After:
<img width="787" height="638" alt="image" src="https://github.com/user-attachments/assets/724a1360-78a7-4630-a034-e115dd09f057" />





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
