### PR TITLE
[FIX] html_editor: adapt useNativeDraggable to hook changes

### DIFF
--- a/addons/html_editor/static/src/utils/drag_and_drop.js
+++ b/addons/html_editor/static/src/utils/drag_and_drop.js
@@ -81,7 +81,12 @@ export function useNativeDraggable(hookParams, initialParams) {
         state: draggableState,
         update: (newParams) => {
             Object.assign(currentParams, newParams);
-            setupFunctions.forEach((depsFn, setupFn) => setupFn(...depsFn()));
+            setupFunctions.forEach((depsFn, setupFn) => {
+                const cleanUp = setupFn(...depsFn());
+                if (cleanUp) {
+                    cleanupFunctions.push(cleanUp);
+                }
+            });
         },
         destroy: () => {
             cleanupFunctions.forEach((cleanupFn) => cleanupFn());


### PR DESCRIPTION
Since [1] the lifecycle of the draggable hook changed:
`setupHooks.addListener` is not called anymore.
This leads to an accumulation of listeners being added but never removed
when drag is not even started.

This commit fixes this by adapting `useNativeDraggable` so that cleanup
functions are properly called on `update` of the draggable component.

Steps to reproduce:
- Go to a "To do" note
- Have several blocks of text
- Drag blocks around

=> The drag became slower and slower, and sometimes even produced a
traceback.

[1]: https://github.com/odoo/odoo/commit/e6643388a8101e28e9543ccb735437f9281c7400

Co-authored-by: Lucas Perais (lpe) <lpe@odoo.com>

task-5917218