### PR TITLE
[FIX] point_of_sale: persist frozen time in tours across reloads

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -304,6 +304,35 @@ export function freezeDateTime(millis) {
     ];
 }
 
+const originalNow = DateTime.now;
+
+export function withTimeFreeze(millis, steps) {
+    return [
+        {
+            content: `Freeze time to ${millis}`,
+            trigger: "body",
+            run: () => {
+                sessionStorage.setItem("pos_test_frozen_time", millis);
+                DateTime.now = () => DateTime.fromMillis(millis);
+            },
+        },
+        ...steps,
+        {
+            content: "Unfreeze time",
+            trigger: "body",
+            run: () => {
+                sessionStorage.removeItem("pos_test_frozen_time");
+                DateTime.now = originalNow;
+            },
+        },
+    ].flat();
+}
+
+if (sessionStorage.getItem("pos_test_frozen_time")) {
+    const millis = parseInt(sessionStorage.getItem("pos_test_frozen_time"));
+    DateTime.now = () => DateTime.fromMillis(millis);
+}
+
 export function selectPresetDateButton(formattedDate) {
     return {
         trigger: `.modal-body button:contains("${formattedDate}")`,


### PR DESCRIPTION
Mocking time in tours via `freezeDateTime` is lost when the page reloads , causing date-filtered data to disappear and tests to fail.

Introduce `withTimeFreeze(millis, steps)`, which persists the mock timestamp in `sessionStorage`. POS now checks this storage on module load to automatically re-apply the freeze, ensuring the clock survives refreshes while handling cleanup after the steps finish.

runbot-232601

Related Enterprise PR: odoo/enterprise#106724