### PR TITLE
[FIX] payment: allow unarchiving express payment tokens

### DIFF
--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -83,7 +83,10 @@ class PaymentToken(models.Model):
         if 'active' in vals:
             if vals['active']:
                 if any(
-                    not token.payment_method_id.active
+                    (
+                        token.payment_method_id != self.env.ref('payment.payment_method_unknown')
+                        and not token.payment_method_id.active
+                    )
                     or token.provider_id.state == 'disabled'
                     for token in self
                 ):

--- a/addons/payment/tests/test_payment_token.py
+++ b/addons/payment/tests/test_payment_token.py
@@ -38,6 +38,7 @@ class TestPaymentToken(PaymentCommon):
     def test_unarchiving_token_requires_active_payment_method(self):
         """ Test that unarchiving disabled tokens is forbidden if the method is disabled. """
         token = self._create_token(active=False)
+        token.payment_method_id = self.quick_ref('payment.payment_method_card')
         token.payment_method_id.active = False
         with self.assertRaises(UserError):
             token.active = True


### PR DESCRIPTION
### Issue:
Due to this issue payment tokens with an express checkout payment, once archived cannot be unarchived.

#### Steps to reproduce:
1- Enable an express checkout method. We can use Demo.
2- On website, add a payment_subscription product to the cart.
3- Navigate to the cart. Pay using express checkout.
4- Navigate to payment tokens, and archive the created token.
5- Add archived filter to the list and unarchive the token.

You will get an error:
`You can't unarchive tokens linked to inactive payment methods.`

### Cause:
`payment_method_id` of express payments is set to `payment_method_unknown`. However, this payment method is not active, raising this user error.

opw-5886048