### PR TITLE
[FIX] core: --dev=reload with no activated venv

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1569,8 +1569,8 @@ def _reexec(updated_modules=None):
     args = stripped_sys_argv()
     if updated_modules:
         args += ["-u", ','.join(updated_modules)]
-    if not args or args[0] != exe:
-        args.insert(0, exe)
+    if not args or args[0] not in (sys.executable, exe):
+        args.insert(0, sys.executable)
     # We should keep the LISTEN_* environment variabled in order to support socket activation on reexec
     os.execve(sys.executable, args, os.environ)
 


### PR DESCRIPTION
When running odoo-bin via a non-activated virtual environment (i.e. giving the full-path to $venv/bin/python3), `_reexec` wrongly uses the basename "python3" instead of the full-path. It means that it reexecutes using a different executable (in this case the system's one).

This commit fixes the problem by always using the full-path to the python executable.