### PR TITLE
[IMP] tools: add `safe_eval` runtime analysis

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -352,6 +352,7 @@ structure.
 """
 from __future__ import annotations
 
+import ast
 import fnmatch
 import io
 import logging
@@ -385,7 +386,14 @@ from odoo.modules import Manifest
 from odoo.modules.registry import _REGISTRY_CACHES
 from odoo.tools import BinaryValue, config, safe_eval, OrderedSet, frozendict, json
 from odoo.tools.constants import SUPPORTED_DEBUGGER, EXTERNAL_ASSET
-from odoo.tools.safe_eval import assert_valid_codeobj, _BUILTINS, to_opcodes, _EXPR_OPCODES, _BLACKLIST
+from odoo.tools.safe_eval import (
+    _BLACKLIST,
+    _BUILTINS,
+    _EXPR_OPCODES,
+    assert_valid_codeobj,
+    safe_transform,
+    to_opcodes,
+)
 from odoo.tools.lru import LRU
 from odoo.tools.misc import str2bool, file_open, file_path
 from odoo.tools.image import image_data_uri
@@ -1614,6 +1622,14 @@ class IrQweb(models.AbstractModel):
             raise ValueError(f"Can not compile expression: {expr}")
 
         expression = self._compile_expr_tokens(tokens, ALLOWED_KEYWORD, raise_on_missing=raise_on_missing)
+
+        if safe_eval.unsafe_policy():
+            # Note: if the generated safe expression is evaluated using `safe_eval`,
+            # there will be double wrapping: `CALL_ID(CALL_ID(...))`.
+            # Example: `_guess_qweb_variables.qweb_like_eval`
+            tree = ast.parse(expression.strip(), mode='eval')
+            tree = safe_transform(tree)
+            expression = ast.unparse(tree)
 
         assert_valid_codeobj(_SAFE_QWEB_OPCODES, compile(expression, '<>', 'eval'), expr)
 

--- a/odoo/addons/test_tools/tests/config/save_posix.conf
+++ b/odoo/addons/test_tools/tests/config/save_posix.conf
@@ -62,6 +62,7 @@ smtp_user =
 syslog = False
 transient_age_limit = 1.0
 unaccent = False
+unsafe_policy = log
 upgrade_path = 
 websocket_keep_alive_timeout = 3600
 websocket_rate_limit_burst = 10

--- a/odoo/addons/test_tools/tests/test_config.py
+++ b/odoo/addons/test_tools/tests/test_config.py
@@ -86,6 +86,7 @@ class TestConfigManager(TransactionCase):
             'pre_upgrade_scripts': [],
             'server_wide_modules': ['base', 'rpc', 'web'],
             'data_dir': DEFAULT_DATADIR,
+            'unsafe_policy': 'log',
 
             # HTTP
             'http_interface': '127.0.0.1',
@@ -205,6 +206,7 @@ class TestConfigManager(TransactionCase):
             'pre_upgrade_scripts': [],  # the path found in the config file is invalid
             'server_wide_modules': ['web', 'base', 'mail'],
             'data_dir': '/tmp/data-dir',
+            'unsafe_policy': 'log',
 
             # HTTP
             'http_interface': '10.0.0.254',
@@ -378,6 +380,7 @@ class TestConfigManager(TransactionCase):
             'transient_age_limit': 1.0,
             'translate_modules': "['all']",
             'unaccent': False,
+            'unsafe_policy': 'log',
             'update': {},
             'reinit': [],
             'upgrade_path': [],
@@ -502,6 +505,7 @@ class TestConfigManager(TransactionCase):
             'pre_upgrade_scripts': [],
             'server_wide_modules': ['web', 'base', 'mail'],
             'data_dir': '/tmp/data-dir',
+            'unsafe_policy': 'log',
 
             # HTTP
             'http_interface': '10.0.0.254',
@@ -632,6 +636,7 @@ class TestConfigManager(TransactionCase):
             'server_wide_modules': ['web', 'base', 'mail'],
             'skip_auto_install': False,
             'data_dir': '/tmp/data-dir',
+            'unsafe_policy': 'log',
 
             # HTTP
             'http_interface': '10.0.0.254',

--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -1,11 +1,18 @@
 import ast
 
 from textwrap import dedent
+from unittest.mock import patch
 
 from odoo import Command
-from odoo.tests.common import tagged, BaseCase
+from odoo.tests.common import tagged, BaseCase, TransactionCase
 from odoo.tools import mute_logger
-from odoo.tools.safe_eval import safe_eval, const_eval, expr_eval
+from odoo.tools.safe_eval import (
+    const_eval,
+    expr_eval,
+    safe_eval,
+    UnsafeObjectError,
+    UnsafePolicy,
+)
 
 
 @tagged('at_install', '-post_install')
@@ -185,3 +192,147 @@ class TestSafeEval(BaseCase):
                 c: int = a + b
                 return c
         """), mode="exec")
+
+
+@tagged('at_install', '-post_install')
+class TestSafeEvalRuntime(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.startClassPatcher(patch(
+            'odoo.tools.safe_eval.unsafe_policy',
+            lambda: UnsafePolicy.RAISE
+        ))
+
+        class UnsafeClass:
+            __module__ = 'odoo.unsafe_module'
+
+            def __init__(self, *args, **kwargs): ...
+
+        cls.unsafe_context = {'UnsafeClass': UnsafeClass}
+
+    def test_transform_decorators(self):
+        steps = []
+
+        def make_deco(x):
+            steps.append(f'make_deco_{x}')
+
+            def deco(func):
+                steps.append(f'deco_{x}')
+
+                def wrapper(*args, **kwargs):
+                    steps.append(f'wrapper_{x}')
+                    return func(*args, **kwargs)
+
+                return wrapper
+
+            return deco
+
+        expr = """
+            @make_deco('A')
+            @make_deco('B')
+            def func(*args, **kwargs):
+                return
+
+            func()
+        """
+        safe_eval(dedent(expr), {'make_deco': make_deco}, mode='exec')
+        self.assertListEqual(steps, [
+            'make_deco_A', 'make_deco_B',  # Evaluation order
+            'deco_B', 'deco_A',  # Wrapping order (reversed)
+            'wrapper_A', 'wrapper_B',  # Evaluation order
+        ])
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_check_callee(self):
+        expr = """
+            UnsafeClass()
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_check_args(self):
+        expr = """
+            callee = lambda *args, **kwargs: ...
+            callee(UnsafeClass)
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_check_kwargs(self):
+        expr = """
+            callee = lambda *args, **kwargs: ...
+            callee(kw=UnsafeClass)
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_check_structure(self):
+        expr = """
+            callee = lambda *args, **kwargs: ...
+            struct = {'a': {'b': {'c': UnsafeClass}}}
+            callee(struct)
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+        expr = """
+            callee = lambda *args, **kwargs: ...
+            struct = ['a', 'b', 'c', UnsafeClass]
+            callee(struct)
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_check_builtin_callee(self):
+        expr = """
+            map(UnsafeClass, ['foo'])
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+        expr = """
+            filter(UnsafeClass, ['foo'])
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+        expr = """
+            sorted(['foo'], key=UnsafeClass)
+        """
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_check_callee_qweb(self):
+        arch = '''
+            <t t-name="template">
+                <div>
+                    <t t-out="UnsafeClass()"/>
+                </div>
+            </t>
+        '''
+        view = self.env['ir.ui.view'].create({
+            'name': 'test',
+            'type': 'qweb',
+            'arch_db': arch,
+        })
+        with self.assertRaises(UnsafeObjectError):
+            self.env['ir.qweb']._render(view.id, self.unsafe_context)
+
+    def test_override_call(self):
+        expr = """
+            # Override in locals
+            _save_eval_call = lambda callee, *args, **kwargs: callee(*args, **kwargs)
+            UnsafeClass()
+        """
+        with self.assertRaisesRegex(ValueError, '^AssertionError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+        # Note that without the assert protection, we get a `RecursionError`,
+        # because after transformer, the code becomes:
+        # `_save_eval_call = lambda callee, *args, **kwargs: _save_eval_call(callee, *args, **kwargs)`

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -19,6 +19,7 @@ from odoo.tools import (
     frozendict,
     sql,
 )
+from odoo.tools.safe_eval import safe_checker
 from odoo.tools.translate import FIELD_TRANSLATE
 
 if typing.TYPE_CHECKING:
@@ -227,6 +228,7 @@ def add_to_registry(registry: Registry, model_def: type[BaseModel]) -> type[Base
     for model_name in registry.descendants([name], '_inherit', '_inherits'):
         registry[model_name]._setup_done__ = False
 
+    safe_checker.add_hook(model_cls, None)  # Optimization to serialize recordset(s) faster
     return model_cls
 
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -53,7 +53,7 @@ from odoo.tools.constants import PREFETCH_MAX
 from odoo.tools.func import deprecated
 from odoo.tools.lru import LRU
 from odoo.tools.misc import ReversedIterable, exception_to_unicode, unquote
-from odoo.tools.safe_eval import _UNSAFE_ATTRIBUTES
+from odoo.tools.safe_eval import _UNSAFE_ATTRIBUTES, safe_checker
 from odoo.tools.translate import _, LazyTranslate
 
 from . import decorators as api
@@ -309,6 +309,8 @@ class MetaModel(type):
                 add_default('write_date', Datetime(
                     string='Last Updated on', readonly=True))
 
+
+safe_checker.add_hook(MetaModel, None)  # Optimization to serialize model class(es) faster
 
 # special columns automatically created by the ORM
 LOG_ACCESS_COLUMNS = ['create_uid', 'create_date', 'write_uid', 'write_date']

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -75,6 +75,7 @@ from odoo.tools import SQL, DotDict, config, file_open, float_compare, mute_logg
 from odoo.tools.binary import BinaryBytes
 from odoo.tools.mail import single_email_re
 from odoo.tools.misc import diff_zip, find_in_path, lower_logging, str2bool
+from odoo.tools.safe_eval import safe_whitelist
 from odoo.tools.xml_utils import _validate_xml
 
 import odoo.addons.base
@@ -2847,3 +2848,12 @@ class freeze_time:
 
 
 freezegun.freeze_time = freeze_time
+
+safe_whitelist.add_class('freezegun.api.FakeDate')
+safe_whitelist.add_class('freezegun.api.FakeDatetime')
+safe_whitelist.add_function('FakeDate.*')
+safe_whitelist.add_function('FakeDatetime.*')
+safe_whitelist.add_instance('odoo.sql_db.TestCursor')
+safe_whitelist.add_instance('odoo.tests.*')
+safe_whitelist.add_instance('unittest.mock.MagicMock')
+safe_whitelist.add_instance('unittest.mock.Mock')

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -260,6 +260,14 @@ class configmanager:
                          help="Comma-separated list of server-wide modules.")
         group.add_option("-D", "--data-dir", dest="data_dir", type='path',  # sensitive default set in _load_default_options
                          help="Directory where to store Odoo data")
+        group.add_option("--unsafe-policy", dest='unsafe_policy', type='choice', my_default='log',
+                         choices=['disable', 'log', 'raise', 'terminate'],
+                         help="Policy if an unsafe object is detected during          "
+                              "arbitrary code execution                               "
+                              "- disable: No action taken                             "
+                              "- log: Log a warning with unsafe object information    "
+                              "- raise: Raise an exception (BaseException)            "
+                              "- terminate: Terminate the current worker process      ")
         parser.add_option_group(group)
 
         # HTTP

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -14,24 +14,71 @@ condition/math builtins.
 #  - http://code.activestate.com/recipes/286134/
 #  - safe_eval in lp:~xrg/openobject-server/optimize-5.0
 #  - safe_eval in tryton http://hg.tryton.org/hgwebdir.cgi/trytond/rev/bbb5f73319ad
+import ast
+import contextvars
 import dis
 import functools
+import gc
 import logging
+import os
+import re
 import sys
 import types
 import typing
 import zoneinfo
+from collections import defaultdict, OrderedDict
+from enum import auto, IntEnum
+from json.encoder import c_make_encoder
 from opcode import opmap, opname
 from types import CodeType
+from weakref import WeakKeyDictionary
 
 import werkzeug
 from psycopg2 import OperationalError
 
 import odoo.exceptions
+from .config import config
+from .func import lazy
+from .misc import OrderedSet
 
 unsafe_eval = eval
 
 __all__ = ['const_eval', 'safe_eval']
+
+_logger = logging.getLogger(__name__)
+_logger_runtime = logging.getLogger(f'{__name__}.runtime')
+
+
+class UnsafePolicy(IntEnum):
+    DISABLE = 0
+    LOG = auto()
+    RAISE = auto()
+    TERMINATE = auto()
+
+
+@functools.cache
+def unsafe_policy():
+    policy = UnsafePolicy[config['unsafe_policy'].upper()]
+
+    if policy and c_make_encoder is None:
+        _logger_runtime.warning(
+            "Unsafe object policy '%s' is configured, but it is not supported on this runtime "
+            "(missing native encoder). The policy will be ignored.",
+            policy.name,
+        )
+        policy = UnsafePolicy.DISABLE
+
+    return policy
+
+
+class UnsafeObjectError(BaseException):
+
+    def __init__(self, obj):
+        obj_path = safe_whitelist.get_full_path(obj)
+        super().__init__(
+            f'Unsafe object access (type {type(obj)!r}): {obj!r} (path: {obj_path})',
+        )
+
 
 # The time module is usually already provided in the safe_eval environment
 # but some code, e.g. datetime.datetime.now() (Windows/Python 2.5.2, bug
@@ -195,8 +242,6 @@ _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([
 ])) - _BLACKLIST
 
 
-_logger = logging.getLogger(__name__)
-
 def assert_no_dunder_name(code_obj, expr):
     """ assert_no_dunder_name(code_obj, expr) -> None
 
@@ -264,12 +309,20 @@ def compile_codeobj(expr: str, /, filename: str = '<unknown>', mode: typing.Lite
     try:
         if mode == 'eval':
             expr = expr.strip()  # eval() does not like leading/trailing whitespace
-        code_obj = compile(expr, filename or '', mode)
+
+        if unsafe_policy():
+            tree = ast.parse(expr, mode=mode)
+            tree = safe_transform(tree)
+            code_obj = compile(tree, filename or '', mode)
+            add_monitoring(code_obj)
+            return code_obj
+
+        return compile(expr, filename or '', mode)
+
     except (SyntaxError, TypeError, ValueError):
         raise
     except Exception as e:
         raise ValueError('%r while compiling\n%r' % (e, expr))
-    return code_obj
 
 
 def const_eval(expr):
@@ -409,7 +462,7 @@ def safe_eval(expr, /, context=None, *, mode="eval", filename=None):
     except _BUBBLEUP_EXCEPTIONS:
         raise
 
-    except Exception as e:
+    except (Exception, UnsafeObjectError) as e:  # noqa: BLE001
         raise ValueError('%r while evaluating\n%r' % (e, expr))
 
     finally:
@@ -493,3 +546,541 @@ dateutil = wrap_module(dateutil, {
 json = wrap_module(__import__('json'), ['loads', 'dumps'])
 time = wrap_module(__import__('time'), ['time', 'strptime', 'strftime', 'sleep'])
 dateutil.tz.gettz = zoneinfo.ZoneInfo
+
+
+# Runtime verification is performed using three objects:
+# - safe_transformer: modifies the code to use the `safe_call` function
+#                     for each function call
+# - safe_checker: verifies the objects used during a call
+# - safe_whitelist: used during verifications
+
+
+class _SafeTransformer(ast.NodeTransformer):
+    """
+    Code transformer that wraps calls with :func:`_save_eval_call` in
+    order to check that the arguments are "safe".
+    """
+
+    # In Qweb, we use the transformer to modify the python expression.
+    # The ast will not be compiled, but instead "unparsed" in the transpiled template.
+    # The expression will be used later and therefore re-parsed.
+    # It is therefore necessary for the identifiers to be valid.
+
+    CALL_ID = '_save_eval_call'
+
+    def visit_Call(self, node):
+        """
+        Transforms:
+            func(*args, **kwargs)
+
+        Into:
+            _save_eval_call(func, *args, **kwargs)
+        """
+        self.generic_visit(node)
+        call = ast.Call(
+            func=ast.Name(id=self.CALL_ID, ctx=ast.Load()),
+            args=[node.func, *node.args],
+            keywords=node.keywords)
+        ast.copy_location(call, node)
+        ast.copy_location(call.func, node)
+        return call
+
+    def visit_FunctionDef(self, node):
+        """
+        Transforms:
+            @decorator_A()
+            @decorator_B()
+            def func():
+                pass
+
+        Into:
+            def func():
+                pass
+
+            func = _save_eval_call(_save_eval_call(decorator_A), _save_eval_call(_save_eval_call(decorator_B), func))
+        """
+        self.generic_visit(node)
+        if not node.decorator_list:
+            return node
+
+        current_wrapper = ast.Name(id=node.name, ctx=ast.Load())
+        ast.copy_location(current_wrapper, node)
+
+        while node.decorator_list:
+            decorator = node.decorator_list.pop()
+            current_wrapper = ast.Call(
+                func=ast.Name(id=self.CALL_ID, ctx=ast.Load()),
+                args=[
+                    decorator,
+                    current_wrapper,
+                ],
+                keywords=[],
+            )
+            ast.copy_location(current_wrapper, node)
+            ast.copy_location(current_wrapper.func, node)
+
+        assign = ast.Assign(
+            targets=[ast.Name(id=node.name, ctx=ast.Store())],
+            value=current_wrapper,
+        )
+        ast.copy_location(assign, node)
+        ast.copy_location(assign.targets[0], node)
+
+        return [node, assign]
+
+
+encoder_ctx = contextvars.ContextVar('encoder_ctx')
+
+
+class _SafeChecker:
+    """
+    Callable object that checks whether a value is considered "safe".
+    It does so by using on a JSON encoder, for which one can add type-specific hooks.
+    An empty hook simply considers the given type as completely safe,
+    while other hooks may check a value and return values to be recursively checked.
+    """
+
+    MAPPINGS = frozenset((dict, defaultdict, OrderedDict, types.MappingProxyType))
+    SEQUENCES = frozenset((list, tuple, set, frozenset, OrderedSet))
+
+    def __init__(self):
+        self.__hooks: WeakKeyDictionary[type, typing.Callable | None] = WeakKeyDictionary()
+        # Add hooks
+        for t in _SafeWhitelist.TRUSTED_TYPES: self.add_hook(t, None)  # Optimization to save time when serializing these types  # noqa: E701
+        for t in self.SEQUENCES: self.add_hook(t, list)  # noqa: E701
+        for t in self.MAPPINGS: self.add_hook(t, dict)  # noqa: E701
+        self.add_hook(type, self._hook_class)
+        self.add_hook(types.ModuleType, self._hook_module)
+        self.add_hook(types.BuiltinFunctionType, self._hook_builtin_function)
+        self.add_hook(types.BuiltinMethodType, self._hook_builtin_function)
+        self.add_hook(types.FunctionType, self._hook_function)
+        self.add_hook(types.MethodType, self._hook_function)
+        self.add_hook(types.MethodDescriptorType, self._hook_descriptor)
+        self.add_hook(functools.partial, self._hook_partial)
+        self.add_hook(lazy, self._hook_lazy)
+        self.add_hook(type(reversed([])), self._hook_simple_iterator)
+        d = {}
+        self.add_hook(type(d.items()), list)
+        self.add_hook(type(d.keys()), list)
+        self.add_hook(type(d.values()), list)
+        d = OrderedDict()
+        self.add_hook(type(d.items()), list)
+        self.add_hook(type(d.keys()), list)
+        self.add_hook(type(d.values()), list)
+        self.add_hook(types.GeneratorType, None)  # TODO: Make the hook (to listen for the yield event)
+
+    def add_hook(self, type_: type, hook: typing.Callable | None = None) -> None:
+        self.__hooks[type_] = hook
+
+    @property
+    def _encoder(self):
+        # Encoder must be thread safe (because of the markers structure)
+        try:
+            encoder = encoder_ctx.get()
+        except LookupError:
+            # markers, default, encoder, indent, key_separator, item_separator, sort_keys, skipkeys, allow_nan
+            encoder = c_make_encoder({}, self._default, lambda x: '', None, '', '', False, False, False)
+            encoder_ctx.set(encoder)
+        encoder.markers.clear()
+        return encoder
+
+    def check(self, obj) -> None:
+        """
+        Check whether the given object is considered "safe" according to
+        the rules defined in `SafeWhitelist`.
+
+        This method attempts to encode the object using a JSON encoder,
+        which validates the object's type and contents recursively.
+
+        :param obj: The object to be checked for safety.
+        :raises UnsafeObjectError: If the object or any nested element
+                                   is determined to be unsafe.
+        """
+        try:
+            self._encoder(obj, 0)
+            return
+        except (ValueError, TypeError, KeyError):
+            pass
+
+        stack = [obj]
+        seen = set()
+        while stack:
+            o = stack.pop()
+            if (id_o := id(o)) in seen:
+                continue
+            seen.add(id_o)
+            try:
+                self._encoder(o, 0)
+            except (ValueError, TypeError, KeyError) as e:
+                collection_o = self._default(o)
+                if type(collection_o) in self.MAPPINGS:
+                    stack.extend(collection_o.keys())
+                    stack.extend(collection_o.values())
+                    continue
+                if type(collection_o) in self.SEQUENCES:
+                    stack.extend(collection_o)
+                    continue
+                # Serialisation failure
+                _logger_runtime.warning('_json.c_make_encoder: %s %r', e, o)
+
+    def _default(self, obj):
+        """ Dispatch to the default check-serialisation function of `obj`. """
+        t_obj = type(obj)
+        try:
+            hook = self.__hooks[t_obj]
+        except KeyError:
+            if isinstance(obj, type):
+                hook = self._hook_class
+            else:
+                hook = self._hook_instance
+            self.__hooks[t_obj] = hook
+
+        if not hook:
+            return None
+
+        return hook(obj)
+
+    def _hook_simple_iterator(self, obj):
+        return gc.get_referents(obj)[-1]
+
+    def _hook_module(self, obj):
+        safe_whitelist.check_module(obj)
+
+    def _hook_builtin_function(self, obj):
+        if obj in safe_whitelist.TRUSTED_BUILTIN_FUNCTIONS:
+            return
+        safe_whitelist.check_function(obj)
+
+    def _hook_function(self, obj):
+        if obj is safe_call:
+            return
+        if getattr(obj, '__module__', False):  # Not user-defined
+            safe_whitelist.check_function(obj)
+
+    def _hook_descriptor(self, obj):
+        if hasattr(obj, '__objclass__'):  # Not bound
+            safe_whitelist.check_function(obj)
+
+    def _hook_partial(self, obj):
+        return (obj.func, obj.args, obj.keywords)
+
+    def _hook_lazy(self, obj):
+        if getattr(obj, '_func', None) is None:
+            return obj._cached_value
+        return (obj._func, obj._args, obj._kwargs)
+
+    def _hook_class(self, obj):
+        if obj in safe_whitelist.TRUSTED_TYPES:
+            return
+        safe_whitelist.check_class(obj)
+
+    def _hook_instance(self, obj):
+        safe_whitelist.check_instance(obj)
+
+
+class _SafeWhitelist:
+    """
+    Maintains a whitelist of trusted objects, which can be defined using
+    three methods: `add_class`, `add_instance` and `add_function`.
+
+    Each method accepts the fully qualified name of the object to trust.
+    A wildcard '*' at the end of a qualified name to trust all objects
+    within subpath namespace.
+
+    .. code-block:: python
+        safe_whitelist.add_class('odoo.orm.models.*')
+        safe_whitelist.add_instance('odoo.orm.environments.Environment')
+        safe_whitelist.add_function('odoo.tools.float_utils.float_compare')
+    """
+
+    RE_NOTHING = re.compile(r'(?!)')
+    TRUSTED_TYPES = frozenset((
+        *_SafeChecker.MAPPINGS, *_SafeChecker.SEQUENCES,
+        object, bool, int, float, str, bytes, bytearray, memoryview,
+        types.NoneType,
+        filter, map, enumerate, range, zip, reversed,
+        Exception, ValueError, TypeError, AttributeError, KeyError, ZeroDivisionError, UnboundLocalError,
+    ))
+    TRUSTED_BUILTIN_FUNCTIONS = frozenset((
+        min, max, sum, abs, sorted, round, len, repr, all, any, ord, chr, divmod,
+        isinstance, hasattr,
+    ))
+
+    @staticmethod
+    def get_full_path(cls_obj: type) -> str:
+        try:
+            qualname = cls_obj.__qualname__
+        except (AttributeError, RuntimeError):
+            qualname = ''
+
+        if module := getattr(cls_obj, '__module__', None):
+            if module in sys.modules:
+                return f'{module}.{qualname}'.strip('.')
+
+            # The object can be defined in a module which is not register,
+            # for example via `load_script`. It is the case for upgrade.
+            if code := getattr(cls_obj, '__code__', None):
+                file_path = os.path.abspath(code.co_filename)
+                for upgrade_path in config['upgrade_path']:
+                    upgrade_path = os.path.abspath(upgrade_path)
+                    if os.path.commonpath([file_path, upgrade_path]) == upgrade_path:
+                        return f'odoo.upgrade.{qualname}'.strip('.')
+
+        if type(cls_obj) is types.ModuleType:
+            return cls_obj.__name__
+        return qualname
+
+    def __init__(self):
+        self._classes = list()
+        self._instances = list()
+        self._functions = list()
+
+    def add_class(self, qualname: str) -> None:
+        self._classes.append(qualname)
+        self.add_instance(qualname)
+        vars(self).pop('_re_class', None)
+
+    def add_instance(self, qualname: str) -> None:
+        self._instances.append(qualname)
+        # Trust function of the class/instance implicitly
+        if not qualname.endswith('.*'):
+            qualname += '.*'
+        self.add_function(qualname)
+        vars(self).pop('_re_instance', None)
+
+    def add_function(self, qualname: str) -> None:
+        self._functions.append(qualname)
+        vars(self).pop('_re_function', None)
+
+    _re_class = functools.cached_property(lambda self: self._re_compile(self._classes))
+    _re_instance = functools.cached_property(lambda self: self._re_compile(self._instances))
+    _re_function = functools.cached_property(lambda self: self._re_compile(self._functions))
+
+    def _re_compile(self, trusted: list) -> typing.Pattern:
+        _initialize_safe_whitelist()
+        if not trusted:
+            return self.RE_NOTHING
+
+        # Make the trie
+        trie = {}
+        for path in trusted:
+            node = trie
+            for part in path.split('.'):
+                node = node.setdefault(part, {})
+
+        # Convert the trie to regex
+        def _trie_to_regex(trie):
+            if not trie:
+                return ''
+
+            re_parts = []
+            for key, subtree in trie.items():
+                assert key != '*' or not subtree
+                subpattern = '.+' if key == '*' else re.escape(key)
+                if child_pattern := _trie_to_regex(subtree):
+                    re_parts.append(fr'{subpattern}\.{child_pattern}')
+                else:
+                    re_parts.append(subpattern)
+
+            # non-capturing group only if multiple alternatives
+            if len(re_parts) == 1:
+                return re_parts[0]
+            return '(?:' + '|'.join(re_parts) + ')'
+
+        return re.compile(_trie_to_regex(trie))
+
+    def check_class(self, obj):
+        if not self._re_class.fullmatch(self.get_full_path(obj)):
+            raise UnsafeObjectError(obj)
+
+    def check_instance(self, obj):
+        obj = type(obj)
+        if not self._re_instance.fullmatch(self.get_full_path(obj)):
+            raise UnsafeObjectError(obj)
+
+    def check_function(self, obj):
+        if not self._re_function.fullmatch(self.get_full_path(obj)):
+            raise UnsafeObjectError(obj)
+
+    def check_module(self, obj):
+        raise UnsafeObjectError(obj)
+
+
+safe_transformer = _SafeTransformer()
+safe_transform = safe_transformer.visit
+safe_checker = _SafeChecker()
+safe_whitelist = _SafeWhitelist()
+
+
+def safe_call(callee, /, *args, **kwargs):
+    """ Ensure objects used for the call are safe """
+    try:
+        safe_checker.check((callee, args, kwargs))
+    except UnsafeObjectError as e:
+        _logger_runtime.warning(e)
+        if unsafe_policy() is UnsafePolicy.RAISE:
+            raise
+        if unsafe_policy() is UnsafePolicy.TERMINATE:
+            os._exit(1)
+    return callee(*args, **kwargs)
+
+
+def monitoring_call(code, instruction_offset, callee, arg0):
+    """ Ensure `_save_eval_call` is not overridden """
+    if callee is safe_call:
+        return
+    frame = sys._getframe(1)
+    call_id = safe_transformer.CALL_ID
+    assert call_id not in frame.f_locals or frame.f_locals[call_id] is safe_call
+    assert call_id not in frame.f_globals or frame.f_globals[call_id] is safe_call
+    assert frame.f_builtins[call_id] is safe_call
+
+
+_BUILTINS[safe_transformer.CALL_ID] = safe_call
+
+EVENTS = sys.monitoring.events
+TOOL_ID = 4  # Not prevent other tools from using "official IDs"
+sys.monitoring.use_tool_id(TOOL_ID, 'ODOO_UNSAFE_POLICY_TOOL')
+sys.monitoring.register_callback(TOOL_ID, EVENTS.CALL, monitoring_call)
+
+
+def add_monitoring(code):
+    codes = [code]
+    while codes:
+        code = codes.pop()
+        sys.monitoring.set_local_events(TOOL_ID, code, EVENTS.CALL)
+        codes.extend(const for const in code.co_consts if isinstance(const, types.CodeType))
+
+
+@functools.cache
+def _initialize_safe_whitelist():
+    # Primitive types and builtins (C functions)
+    safe_whitelist.add_function('bool.*')
+    safe_whitelist.add_function('int.*')
+    safe_whitelist.add_function('float.*')
+    safe_whitelist.add_function('str.*')
+    safe_whitelist.add_function('bytes.*')
+    safe_whitelist.add_function('list.*')
+    safe_whitelist.add_function('tuple.*')
+    safe_whitelist.add_function('set.*')
+    safe_whitelist.add_function('dict.*')
+    safe_whitelist.add_function('mappingproxy.*')
+    safe_whitelist.add_function('defaultdict.*')
+    safe_whitelist.add_function('OrderedDict.*')
+    safe_whitelist.add_function('_functools.reduce')
+    # Monkey patches
+    safe_whitelist.add_instance('odoo._monkeypatches.zoneinfo.ZoneInfo')
+    safe_whitelist.add_function('odoo._monkeypatches.*')
+    # Core
+    safe_whitelist.add_class('odoo.addons.*')  # TODO: Restrict addons
+    safe_whitelist.add_class('odoo.upgrade.*')
+    safe_whitelist.add_class('odoo.orm.domains.*')
+    safe_whitelist.add_class('odoo.orm.fields.*')
+    safe_whitelist.add_class('odoo.orm.fields_binary.*')
+    safe_whitelist.add_class('odoo.orm.fields_selection.*')
+    safe_whitelist.add_class('odoo.orm.models.*')
+    safe_whitelist.add_class('odoo.orm.commands.Command')
+    safe_whitelist.add_instance('odoo.orm.environments.Environment')
+    safe_whitelist.add_instance('odoo.orm.identifiers.NewId')
+    safe_whitelist.add_instance('odoo.orm.registry.Registry')
+    safe_whitelist.add_class('odoo.exceptions.AccessDenied')
+    safe_whitelist.add_class('odoo.exceptions.AccessError')
+    safe_whitelist.add_class('odoo.exceptions.MissingError')
+    safe_whitelist.add_class('odoo.exceptions.UserError')
+    safe_whitelist.add_class('odoo.exceptions.ValidationError')
+    # HTTP
+    safe_whitelist.add_instance('odoo.http._facade.HTTPRequest')
+    safe_whitelist.add_instance('odoo.http._facade.SafeResponse')
+    safe_whitelist.add_instance('odoo.http.geoip.GeoIP')
+    safe_whitelist.add_instance('odoo.http.requestlib.Request')
+    safe_whitelist.add_instance('odoo.http.response.Response')
+    safe_whitelist.add_instance('odoo.http.session.Session')
+    # Database
+    safe_whitelist.add_instance('odoo.sql_db.Cursor')
+    # Tools
+    safe_whitelist.add_class('odoo.tools.binary.*')
+    safe_whitelist.add_class('odoo.tools.convert.xml_import')
+    safe_whitelist.add_class('odoo.tools.func.lazy')
+    safe_whitelist.add_class('odoo.tools.json._ScriptSafe')
+    safe_whitelist.add_class('odoo.tools.json.JSON')
+    safe_whitelist.add_class('odoo.tools.profiler.QwebTracker')
+    safe_whitelist.add_class('odoo.tools.safe_eval.wrap_module')
+    safe_whitelist.add_instance('odoo.tools.misc.OrderedSet')
+    safe_whitelist.add_instance('odoo.tools.misc.ReversedIterable')
+    safe_whitelist.add_instance('odoo.tools.query.Query')
+    safe_whitelist.add_instance('odoo.tools.translate.LazyGettext')
+    safe_whitelist.add_function('odoo.tools.float_utils.float_compare')
+    safe_whitelist.add_function('odoo.tools.float_utils.float_is_zero')
+    safe_whitelist.add_function('odoo.tools.float_utils.float_repr')
+    safe_whitelist.add_function('odoo.tools.float_utils.float_round')
+    safe_whitelist.add_function('odoo.tools.mail.formataddr')
+    safe_whitelist.add_function('odoo.tools.mail.html2plaintext')
+    safe_whitelist.add_function('odoo.tools.mail.is_html_empty')
+    safe_whitelist.add_function('odoo.tools.misc.format_amount')
+    safe_whitelist.add_function('odoo.tools.misc.format_date')
+    safe_whitelist.add_function('odoo.tools.misc.format_duration')
+    safe_whitelist.add_function('odoo.tools.misc.street_split')
+    safe_whitelist.add_function('odoo.tools.safe_eval._import')
+    safe_whitelist.add_function('odoo.tools.translate.html_translate')
+    # Psycopg2
+    safe_whitelist.add_class('psycopg2.InterfaceError')
+    safe_whitelist.add_class('psycopg2.OperationalError')
+    safe_whitelist.add_class('psycopg2.ProgrammingError')
+    safe_whitelist.add_class('psycopg2.errors.*')
+    safe_whitelist.add_class('psycopg2.extensions.TransactionRollbackError')
+    # Cursor
+    safe_whitelist.add_function('cursor.fetchall')
+    safe_whitelist.add_function('cursor.fetchone')
+    # Dates - Times - Timezone
+    safe_whitelist.add_function('date.*')
+    safe_whitelist.add_class('datetime.date')
+    safe_whitelist.add_class('datetime.datetime')
+    safe_whitelist.add_class('datetime.time')
+    safe_whitelist.add_class('datetime.timedelta')
+    safe_whitelist.add_class('datetime.timezone')
+    safe_whitelist.add_function('datetime.*')
+    safe_whitelist.add_class('dateutil.relativedelta.relativedelta')
+    safe_whitelist.add_function('time.*')
+    safe_whitelist.add_instance('pytz.tzfile.UTC')
+    safe_whitelist.add_function('pytz.tzinfo.DstTzInfo.localize')
+    safe_whitelist.add_function('pytz.UTC.localize')
+    # Collections
+    safe_whitelist.add_class('collections.defaultdict')
+    safe_whitelist.add_class('collections.OrderedDict')
+    safe_whitelist.add_class('collections.abc.Mapping')
+    safe_whitelist.add_class('collections.abc.Sized')
+    safe_whitelist.add_class('collections.abc.ValuesView')
+    safe_whitelist.add_class('itertools.islice')
+    # Markup
+    safe_whitelist.add_class('markupsafe.*')
+    # Email
+    safe_whitelist.add_instance('email.headerregistry._UniqueAddressHeader')
+    safe_whitelist.add_instance('email.message.EmailMessage')
+    # JSON
+    safe_whitelist.add_instance('json.decoder.JSONDecodeError')
+    # XML
+    safe_whitelist.add_instance('lxml.etree._Element')
+    # UUID
+    safe_whitelist.add_instance('uuid.UUID')
+    # Math
+    safe_whitelist.add_function('math.*')
+    # Base64
+    safe_whitelist.add_function('base64.b64decode')
+    safe_whitelist.add_function('base64.b64encode')
+    safe_whitelist.add_function('base64.urlsafe_b64decode')
+    safe_whitelist.add_function('base64.urlsafe_b64encode')
+    # URL
+    safe_whitelist.add_function('urllib.parse.quote')
+    # Standard Numbers
+    safe_whitelist.add_function('stdnum.pl.nip.compact')
+    # Werkzeug
+    safe_whitelist.add_class('werkzeug.datastructures.structures.ImmutableMultiDict')
+    safe_whitelist.add_class('werkzeug.datastructures.structures.MultiDict')
+    safe_whitelist.add_class('werkzeug.exceptions.BadRequest')
+    safe_whitelist.add_class('werkzeug.exceptions.Forbidden')
+    safe_whitelist.add_class('werkzeug.exceptions.NotFound')
+    safe_whitelist.add_class('werkzeug.exceptions.RequestEntityTooLarge')
+    safe_whitelist.add_class('werkzeug.exceptions.Unauthorized')
+    safe_whitelist.add_instance('werkzeug.datastructures.file_storage.FileStorage')
+    safe_whitelist.add_instance('werkzeug.local.LocalProxy')
+    safe_whitelist.add_function('werkzeug.datastructures.structures.TypeConversionDict.*')

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -40,6 +40,8 @@ from .i18n import format_list
 from .misc import file_open, file_path, frozendict, get_iso_codes, split_every, OrderedSet, SKIPPED_ELEMENT_TYPES
 
 if typing.TYPE_CHECKING:
+    import types
+
     from odoo.api import Environment
 
 __all__ = [
@@ -84,6 +86,25 @@ FIELD_TRANSLATE = {
     None: False,
     'standard': True,
 }
+
+
+def _get_frame(stack_level: int = 0) -> types.FrameType | None:
+    from odoo.tools.safe_eval import safe_call as wrapper_func  # noqa: PLC0415
+
+    stack_level += 1  # +1 to skip this function
+    frame = origin_frame = inspect.currentframe()
+
+    while frame:
+        if frame.f_code is not wrapper_func.__code__:
+            if stack_level == 0:
+                return frame
+            stack_level -= 1
+        frame = frame.f_back
+
+    _logger.warning(
+        'Impossible to retrieve frame for translation language, skipping translation %s',
+        origin_frame, stack_info=True,
+    )
 
 
 def is_translatable_attrib(key, node):
@@ -482,10 +503,7 @@ def get_translated_module(arg: str | int | typing.Any) -> str:  # frame not repr
             return arg
     else:
         if isinstance(arg, int):
-            frame = inspect.currentframe()
-            while arg > 0:
-                arg -= 1
-                frame = frame.f_back
+            frame = _get_frame(arg)
         else:
             frame = arg
         if not frame:
@@ -570,9 +588,7 @@ def _get_lang(frame, default_lang='') -> str:
 
 def _get_translation_source(stack_level: int, module: str = '', lang: str = '', default_lang: str = '') -> tuple[str, str]:
     if not (module and lang):
-        frame = inspect.currentframe()
-        for _index in range(stack_level + 1):
-            frame = frame.f_back
+        frame = _get_frame(stack_level + 1)  # +1 to skip this function
         lang = lang or _get_lang(frame, default_lang)
     if lang and lang != 'en_US':
         return get_translated_module(module or frame), lang


### PR DESCRIPTION
The execution of arbitrary code in Odoo via `safe_eval` already takes place in a restricted environment, in particular via prior opcode, `co_names` static analysis and specific builtins in the evaluation context.

The purpose of this commit is to introduce the ability to dynamically analyse code executed via the `safe_eval` tool.

The dangerous situation we want to avoid is transferring logic to code that is considered untrusted. In other words, we want to avoid calls that use objects that are not in the whitelist.

The behavior to adopt when detecting an unsafe object depends on the `--unsafe-policy` configuration parameter:
- `disable`: Disable the feature
- `log`: Log a warning (default)
- `raise`: Raise an exception
- `terminate`: Terminate the process

Note:
Python 3.12+ is required since the [sys.monitoring](https://docs.python.org/3.12/library/sys.monitoring.html) API is used.
The presence of the JSON C extension library is required (`_json`) for performance reasons.

_This is not a sandbox in general, but it helps prevent dangerous behavior in the context of `safe_eval`._

Task-4658036