### PR TITLE
[FIX] account: don't block edition of opening date if an opening move is posted

### DIFF
--- a/addons/account/wizard/setup_wizards.py
+++ b/addons/account/wizard/setup_wizards.py
@@ -50,9 +50,11 @@ class AccountFinancialYearOp(models.TransientModel):
                 'fiscalyear_last_month': vals.get('fiscalyear_last_month') or wiz.company_id.fiscalyear_last_month,
                 'account_opening_date': vals.get('opening_date') or wiz.company_id.account_opening_date,
             })
-            wiz.company_id.account_opening_move_id.write({
-                'date': fields.Date.from_string(vals.get('opening_date') or wiz.company_id.account_opening_date) - timedelta(days=1),
-            })
+            opening_move = wiz.company_id.account_opening_move_id
+            if opening_move.state == 'draft':
+                opening_move.write({
+                    'date': fields.Date.from_string(vals.get('opening_date') or wiz.company_id.account_opening_date) - timedelta(days=1),
+                })
 
         vals.pop('opening_date', None)
         vals.pop('fiscalyear_last_day', None)

--- a/addons/account/wizard/setup_wizards_view.xml
+++ b/addons/account/wizard/setup_wizards_view.xml
@@ -13,7 +13,7 @@
                     <sheet>
                         <group>
                             <field name="opening_move_posted" invisible="1"/>
-                            <field name="opening_date" readonly="opening_move_posted"/>
+                            <field name="opening_date"/>
 
                             <label for="fiscalyear_last_month" string="Fiscal Year End"/>
                             <div>


### PR DESCRIPTION
To reproduce the issue (in enterprise):
- Go to accounting > configuration
- click on "Review Manually" (under Accounting Import)
- add a balance to 1 or 2 accounts
- Search for the created draft opening move in the journal entries, and post it
- On the dashboard, click on "Tax returns" ====> The opening date is not set in the wizard, and still, it's not editable. You're stuck

The opening date was originally introduced in the setup bar flows, years ago. Today, this field isn't really used anymore, except for creating the returns, and it then does not especially always correspond to the date of the opening move. To solve the issue, we just always allow editing it in the wizard. To keep things comfortable for users who would be used to the previous way it worked, we still modify the date of the opening move when doing so if it's still in draft.
