### PR TITLE
[FIX] point_of_sale: prevent card rounding on credit note

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -93,6 +93,14 @@ class AccountMove(models.Model):
             })
         return super().button_draft()
 
+    def _recompute_cash_rounding_lines(self):
+        self.ensure_one()
+        if self.reversed_entry_id:
+            pos_orders = self.reversed_entry_id.sudo().pos_order_ids
+            if pos_orders and self.reversed_entry_id.sudo().line_ids.filtered(lambda l: l.display_type == 'rounding' and not l.balance):
+                return
+        super()._recompute_cash_rounding_lines()
+
 
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'


### PR DESCRIPTION
**Steps to reproduce:**
- Setup a rounding of 0.05
- Add it to the PoS settings, turn on the only for cash setting
- Make a purchase for 13.01, pay by card
- Go to the backend, we have the correct price of 13.01
- Revert the invoice by making a credit note
- The price is only 13.00 and we have a rounding of -0.01

**Why the fix:**
When making a credit note, we round the price if we find a rounding method, not taking the **only_round_cash_method** setting into account.

After this commit, we now check if the reversed entry (the invoice) has a rounding line. If it does not, we skip the
rounding.

If a rounding is found on the reversed entry, we still round the current account move.

opw-5871514