### PR TITLE
[FIX] point_of_sale: correct VAT name in Info popup

### DIFF
--- a/addons/l10n_in_pos/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/l10n_in_pos/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -1,0 +1,13 @@
+import { _t } from "@web/core/l10n/translation";
+import { ProductInfoPopup } from "@point_of_sale/app/components/popups/product_info_popup/product_info_popup";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductInfoPopup.prototype, {
+    get vatLabel() {
+        return this.pos.company.country_id.code === "IN" ? _t("GST:") : super.vatLabel;
+    },
+    get totalVatLabel() {
+        return this.pos.company.country_id.code === "IN" ? _t("Total GST:") : super.totalVatLabel;
+    },
+});

--- a/addons/l10n_in_pos/static/tests/tours/product_screen_tour.js
+++ b/addons/l10n_in_pos/static/tests/tours/product_screen_tour.js
@@ -1,0 +1,19 @@
+import { registry } from "@web/core/registry";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+
+registry.category("web_tour.tours").add("test_product_long_press_india", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.longPressProduct("Test Product"),
+            Dialog.is(),
+            {
+                content: "Check that VAT label is present in the product details popup",
+                trigger: ".section-financials .vat-label:contains('GST')",
+            },
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/l10n_in_pos/tests/__init__.py
+++ b/addons/l10n_in_pos/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_hsn_summary
 from . import common
 from . import test_pos_flow
 from . import test_gstr_section
+from . import test_product_screen

--- a/addons/l10n_in_pos/tests/test_product_screen.py
+++ b/addons/l10n_in_pos/tests/test_product_screen.py
@@ -1,0 +1,25 @@
+from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestGenericIN(TestGenericLocalization):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.main_pos_config.company_id.write({
+            'country_id': cls.env.ref("base.in")
+        })
+
+    def test_product_long_press_india(self):
+        """ Test the long press on product to open the product info """
+        self.main_pos_config.company_id.country_id.vat_label = 'Should stay GST even after editing vat_label'
+
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'list_price': 100,
+            'available_in_pos': True,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_product_long_press_india')

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.js
@@ -35,6 +35,9 @@ export class ProductInfoPopup extends Component {
         });
     }
     get vatLabel() {
-        return this.pos.company.country_id.vat_label || _t("VAT");
+        return _t("VAT:");
+    }
+    get totalVatLabel() {
+        return _t("Total VAT:");
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_info_popup/product_info_popup.xml
@@ -76,7 +76,7 @@
                     <div class="grid gap-2">
                         <label class="fw-bold">Price excl. Tax:</label>
                         <span><t t-esc="env.utils.formatCurrency(props.info.productInfo.all_prices.price_without_tax)"/></span>
-                        <label class="fw-bold vat-label"><t t-out="vatLabel"/>:</label>
+                        <label class="fw-bold vat-label"><t t-esc="vatLabel"/></label>
                         <span class="vat-value">
                             <t t-esc="props.info.taxAmount"/>
                             (<t t-esc="props.info.taxName"/>)
@@ -102,7 +102,7 @@
                     <div class="grid gap-2">
                         <label class="fw-bold">Total Price excl. Tax:</label>
                         <span t-esc="props.info.orderPriceWithoutTaxCurrency"/>
-                        <label class="fw-bold">Total VAT:</label>
+                        <label class="fw-bold"><t t-esc="totalVatLabel"/></label>
                         <span t-esc="props.info.orderTaxTotalCurrency"/>
                         <label class="fw-bold">Total Price incl. Tax:</label>
                         <span t-esc="props.info.orderPriceWithTaxCurrency"/>

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2464,6 +2464,7 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_product_long_press(self):
         """ Test the long press on product to open the product info """
         archive_products(self.env)
+        self.main_pos_config.company_id.country_id.vat_label = 'Should stay VAT even after editing vat_label'
         group_tax = self.env['account.tax'].create({
             'name': 'Parent Tax',
             'amount_type': 'group',


### PR DESCRIPTION
How to reproduce;
- Use a company from a country with a different vat_label (Mexico for example)
- Go to the frontend of POS
- Select a product > ... > Info

The problem:
Under the "Financials" section, "RFC" is displayed instead of "VAT" or "IVA". RFC is the tax identification number, not the tax name

Why:
This commit (https://github.com/odoo/odoo/commit/4fa9f9b849016f312efcb73f9a76b223e429aec0) introduced the usage of vat_label to display the tax name in a dynamic way. However, the vat_label field is used to store the tax identification number, not the tax name

opw-5915087

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
