### PR TITLE
[FIX] point_of_sale: create move line for change when no cash pm

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -68,7 +68,11 @@ class PosPayment(models.Model):
         credit_line_ids = []
         change_payment = self.filtered(lambda p: p.is_change and p.payment_method_id.type == 'cash')
         payment_to_change = self.filtered(lambda p: not p.is_change and p.payment_method_id.type == 'cash')[:1]
-        for payment in self - change_payment:
+        payments = self
+        if change_payment and payment_to_change:
+            payments = self - change_payment
+
+        for payment in payments:
             order = payment.pos_order_id
             payment_method = payment.payment_method_id
             if payment_method.type == 'pay_later' or float_is_zero(payment.amount, precision_rounding=order.currency_id.rounding):


### PR DESCRIPTION
If an order in overpaid using bank, no move line is created for the change.

Steps to reproduce:
-------------------
* Make an order, add a customer
* During payment, select invoice, pay more than the order amount with bank pm
* Validate
* Close register
* Check customer
> Observation: It says we owe the customer money, although change was given.

Why the fix:
------------
Since this fix: https://github.com/odoo/odoo/commit/2c4764f111eec154375d94eb7052a12c470a513d the change gets deducted from cash payment method. However the use case where there would not be any cash payment used was not taken into account. The previous fix was removing the change from the payment methods to subtract its amount from any cash payment but in the case where there's none nothing is done with it.

Indeed it sometimes happen to pay a bit more in card to get some cash out. Currently, in this case, the change is just omitted.

opw-5149700