### PR TITLE
[18.0][FIX] product: Return product record with a clean context

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -721,7 +721,8 @@ class ProductProduct(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        return super(ProductProduct, self.with_context(create_product_product=False)).create(vals_list)
+        products = super(ProductProduct, self.with_context(create_product_product=False)).create(vals_list)
+        return products.with_env(self.env)
 
     def action_archive(self):
         records = self.filtered('active')

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -248,6 +248,12 @@ class TestVariants(ProductVariantsCommon):
         self.assertEqual(variant_copy.name, 'Test Copy (copy) (copy)')
         self.assertEqual(len(variant_copy.product_variant_ids), 2)
 
+        # test copy of variant from variant
+        variant = self.env['product.product'].create({'name': 'Test Copy Variant'})
+        variant_copy = variant.copy()
+        self.assertTrue(variant_copy.exists())
+        self.assertEqual(variant_copy.name, 'Test Copy Variant (copy)')
+
     def test_dynamic_variants_copy(self):
         self.color_attr = self.env['product.attribute'].create({'name': 'Color', 'create_variant': 'dynamic'})
         self.color_attr_value_r = self.env['product.attribute.value'].create({'name': 'Red', 'attribute_id': self.color_attr.id})
@@ -266,10 +272,6 @@ class TestVariants(ProductVariantsCommon):
         self.assertEqual(template_dyn.name, 'Test Dynamical')
 
         variant_dyn = template_dyn._create_product_variant(template_dyn._get_first_possible_combination())
-        if 'create_product_product' in variant_dyn.env.context:
-            new_context = dict(variant_dyn.env.context)
-            new_context.pop('create_product_product')
-            variant_dyn = variant_dyn.with_context(new_context)
         self.assertEqual(len(template_dyn.product_variant_ids), 1)
 
         variant_dyn_copy = variant_dyn.copy()


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Creating a new product and then copying it should works correctly.

**Current behavior before PR:**

If you create a new product
```
    item_a = self.env["product.product"].create({"name": "ItemA"})
```
And then copy it
```
    item_b = item_a.copy({"name": "ItemB"})
    print(item_b.name) -> False
```

You will have the surprise to see that "item_b" is en empty recordset >  `item_b == product.product()`

Why ? Simply because a context key is set by odoo (`create_product_product=False`) when creating a `product.product`

So to avoid this issue, re-browse your newly created record to have a clean context:
```
    item_a = self.env["product.product"].create({"name": "ItemA"})
    item_a = self.env["product.product"].browse(item_a.id)
    item_b = item_a.copy({"name": "ItemB"})
```

_Or fix Odoo by returning a clean context: a good rule should be that any context key set in `create`/`copy`  be unset before returning the recordset._

**Desired behavior after PR is merged:**

```
    item_a = self.env["product.product"].create({"name": "ItemA"})
    item_b = item_a.copy({"name": "ItemB"})
    print(item_b.name) -> "ItemB"
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
