### PR TITLE
[FIX] mail: no overlap of call cards when video stream in chat window

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -220,7 +220,7 @@ export class Call extends Component {
         this.grid.el.style.setProperty("--width", "0");
         this.grid.el.style.setProperty("--height", "0");
         const { width, height } = this.grid.el.getBoundingClientRect();
-        const aspectRatio = this.minimized ? 1 : 16 / 9;
+        const aspectRatio = this.minimized && this.channel.videoCount === 0 ? 1 : 16 / 9;
         const tileCount = this.grid.el.children.length;
         let optimal = {
             area: 0,

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.CallParticipantVideo">
-        <video class="h-100 cursor-pointer"
+        <video class="w-100 h-100 cursor-pointer"
             t-att-class="{ 'o-inset rounded-1': props.inset, 'rounded-3': !props.session.eq(props.session.channel?.activeRtcSession) }"
             t-att-type="props.type"
             t-att-data-facing-mode="store.settings.cameraFacingMode"


### PR DESCRIPTION
Before this commit, when in a call in a chat window and someone in call stream video, the cards were overlapping.

This happens because [1] removed the `w-100` on `<video>` which let them have bigger width than imposed by `arrangeTiles`.

This change was motivated because the card has aspect ratio of 1 in chat window and this was too small. However the correct fix was to impose the 16:9 ratio on cards when there's at least 1 video stream, which is what this commit does.

Task-5917628

[1]: https://github.com/odoo/odoo/pull/241924

Before / After
<img width="387" height="607" alt="Screenshot 2026-02-06 at 16 58 51" src="https://github.com/user-attachments/assets/39569572-4eea-4d58-a383-27f9c69e4bb5" />
<img width="386" height="600" alt="Screenshot 2026-02-06 at 16 58 29" src="https://github.com/user-attachments/assets/f9b60e9a-6980-4708-b475-14f9d5a77a36" />