### PR TITLE
[FIX] purchase_stock: compute correct svl multiple move same prod

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -112,7 +112,8 @@ class StockMove(models.Model):
                 self.quantity, self.purchase_line_id.product_uom, rounding_method='HALF-UP'
             )
             batch_moves = self._get_batch_moves()
-            for move in batch_moves:
+            same_product_moves = self.picking_id.move_ids.filtered(lambda m: m.product_id == self.product_id)
+            for move in (batch_moves | same_product_moves):
                 if move == self or move.state != 'done' or move.purchase_line_id != self.purchase_line_id:
                     continue
                 qty_received -= move.product_uom._compute_quantity(


### PR DESCRIPTION
**Steps to reproduce:**
- create a storable avco automated product
- in the purchase tab, select control policy : "on invoice quantitites"
- create and confirm a purchase order for 100 qty at 1 unit price
- on the picking, unhide the description column
- change the description for the move
- go back to the purchase order and change the quantity to 105
- (because we changed the description, the new move created 
with a quantity of 5 is not merged to the existing one of 100 and 
we now have two moves on the picking)
- create and confirm the bill
- validate the picking
- select the valuation smart button

**Current behavior:**
the svl with a quantity of 100 has a total value of 105
the svl with a quantity of 5 has a total value of 105

**Expected behavior:**
the svl with a quantity of 100 should have a value of 100
the svl with a quanitty of 5 shoul have a total value of 5

**Cause of the issue:**
When the picking is validated, action_done is created on the 
two moves. 
In the stock_account override: 
- first the super method is called
As a consequence the state of the two moves becomes 'done'
and the qty_received of the linked purchase order line becomes 105.
- then product_price_update_before_done is called on the two 
moves before creating the svls.
https://github.com/odoo/odoo/blob/2f00b0085574653ca1a8f734ef91893a4a1c1a7c/addons/stock_account/models/stock_move.py#L352

Inside product_price_update_before_done, for each move, 
we call _get_price_unit.
https://github.com/odoo/odoo/blob/2f00b0085574653ca1a8f734ef91893a4a1c1a7c/addons/stock_account/models/stock_move.py#L426

For the first move, in the purchase_stock override 
of _get_price_unit : 
- to get the received qty we call _get_qty_received_without_self()
https://github.com/odoo/odoo/blob/2f00b0085574653ca1a8f734ef91893a4a1c1a7c/addons/purchase_stock/models/stock_move.py#L50
and because the super method of action_done was already called, 
qty_received of the purchase order line is 105, so _get_qty_received_without_self
will return 5. 
https://github.com/odoo/odoo/blob/2f00b0085574653ca1a8f734ef91893a4a1c1a7c/addons/purchase_stock/models/stock_move.py#L108-L113
So received_qty is 5 and later remaining_qty will be 100
https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/purchase_stock/models/stock_move.py#L86
- but because no svl was created yet receipt_value will stay 0 and later 
remaining_value will be 105
https://github.com/odoo/odoo/blob/dc57ea4d306f8745d37f2c5d2c3d3fa4bcaf7253/addons/purchase_stock/models/stock_move.py#L55-L60
Therefore price_unit will be 1.05 (105/100) instead of 1
https://github.com/odoo/odoo/blob/2f00b0085574653ca1a8f734ef91893a4a1c1a7c/addons/purchase_stock/models/stock_move.py#L95

For the second move, the problem is the same and 
the price unit ends up being 21 (105/5)

**fix**
We do not take into account the move(s) for the same product
of the same picking in the remaining value (because svls are not created yet)
so we should not take them into account in the remaining quantity.

the problem is very similar to https://github.com/odoo/odoo/pull/235601
In this other PR it happend because we had multiple move for 
the same product because they were in a batch, and in this PR we 
have the issue because we have multiple move for the same product 
because they didn't merge due to the description difference. 

opw-5429501