### PR TITLE
Fold options (with extra button to select)

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -11,7 +11,7 @@ declare module "plugins" {
     import { after_replication_handlers } from "@html_builder/core/field_change_replication_plugin";
     import { MediaWebsiteShared } from "@html_builder/core/media_website_plugin";
     import { OperationShared } from "@html_builder/core/operation_plugin";
-    import { get_overlay_buttons, OverlayButtonsShared } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
+    import { get_overlay_buttons, OverlayButtonsShared, show_overlay_buttons_of_ancestor_predicates } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
     import { empty_node_predicates, is_unremovable_selector, on_removed_handlers, on_will_remove_handlers, RemoveShared } from "@html_builder/core/remove_plugin";
     import { after_save_handlers, before_save_handlers, get_dirty_els, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
     import { after_setup_editor_handlers, before_setup_editor_handlers, savable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
@@ -114,6 +114,7 @@ declare module "plugins" {
         filter_for_sibling_dropzone_predicates: filter_for_sibling_dropzone_predicates;
         is_draggable_handlers: is_draggable_handlers;
         keep_overlay_options: keep_overlay_options;
+        show_overlay_buttons_of_ancestor_predicates: show_overlay_buttons_of_ancestor_predicates;
 
         // Processors
 

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -7,6 +7,7 @@ import { getElementsWithOption, isElementInViewport } from "@html_builder/utils/
 import { OptionsContainer } from "@html_builder/sidebar/option_container";
 import { shouldEditableMediaBeEditable } from "@html_builder/utils/utils_css";
 import { _t } from "@web/core/l10n/translation";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 
 /** @typedef {import("@html_builder/core/utils").BaseOptionComponent} BaseOptionComponent */
 /** @typedef {import("@odoo/owl").Component} Component */
@@ -44,6 +45,7 @@ import { _t } from "@web/core/l10n/translation";
 /**
  * @typedef { Object } BuilderOptionsShared
  * @property { BuilderOptionsPlugin['checkElement'] } checkElement
+ * @property { BuilderOptionsPlugin['closestWithOption'] } closestWithOption
  * @property { BuilderOptionsPlugin['computeContainers'] } computeContainers
  * @property { BuilderOptionsPlugin['findOption'] } findOption
  * @property { BuilderOptionsPlugin['getContainers'] } getContainers
@@ -116,6 +118,7 @@ export class BuilderOptionsPlugin extends Plugin {
     static dependencies = ["operation", "history"];
     static shared = [
         "checkElement",
+        "closestWithOption",
         "computeContainers",
         "findOption",
         "getContainers",
@@ -315,6 +318,14 @@ export class BuilderOptionsPlugin extends Plugin {
         this.target = null;
         this.lastContainers = [];
         this.dispatchTo("change_current_options_containers_listeners", this.lastContainers);
+    }
+
+    closestWithOption(el) {
+        return closestElement(el, (el) =>
+            this.builderOptions.some(
+                (Option) => el.matches(Option.selector) && this.checkElement(el, Option)
+            )
+        );
     }
 
     computeContainers(target) {

--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.js
@@ -34,6 +34,7 @@ export class BuilderOverlay {
             isMobileView,
             mobileBreakpoint,
             isRtl,
+            isHoverOverlay = false,
         }
     ) {
         this.history = history;
@@ -58,6 +59,7 @@ export class BuilderOverlay {
         this.mobileBreakpoint = mobileBreakpoint;
         this.isRtl = isRtl;
 
+        this.overlayElement.classList.toggle("o_hover_overlay", isHoverOverlay);
         this.initHandles();
         this.initSizing();
         this.refreshHandles();
@@ -79,7 +81,7 @@ export class BuilderOverlay {
 
     isActive() {
         // TODO active still necessary ? (check when we have preview mode)
-        return this.overlayElement.matches(".oe_active, .o_we_overlay_preview");
+        return this.overlayElement.matches(".oe_active, .o_we_overlay_preview, .o_hover_overlay");
     }
 
     refreshPosition() {

--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
@@ -1,3 +1,12 @@
+@keyframes o_hover_overlay_fade_in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 0.3;
+    }
+}
+
 div[data-oe-local-overlay-id="builder-overlay-container"] {
     position: absolute;
     pointer-events: none;
@@ -17,13 +26,33 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
         }
 
         &.oe_active,
+        &.o_hover_overlay,
         &.o_we_overlay_preview {
             display: block;
             z-index: 1;
         }
 
+        &.o_hover_overlay,
         &.o_we_overlay_preview {
             transition: none;
+        }
+
+        &.o_hover_overlay {
+            opacity: 0.3;
+            animation: o_hover_overlay_fade_in 0.1s ease-in-out forwards;
+            .o_side {
+                &::before {
+                    background: rgb(126, 114, 114) !important;
+                }
+                background-color: transparent !important;
+                border-bottom: none !important;
+                border-top: none !important;
+                border-left: none !important;
+                border-right: none !important;
+            }
+            .o_handle_indicator {
+                display: none !important;
+            }
         }
 
         // HANDLES

--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -31,6 +31,7 @@ export class BuilderOverlayPlugin extends Plugin {
     };
 
     setup() {
+        this.hoverOverlay = null;
         // TODO find how to not overflow the mobile preview.
         this.iframe = this.editable.ownerDocument.defaultView.frameElement;
         this.overlayContainer = this.dependencies.localOverlay.makeLocalOverlay(
@@ -84,6 +85,14 @@ export class BuilderOverlayPlugin extends Plugin {
             }),
             { capture: true }
         );
+
+        this.addDomListener(this.editable, "mouseleave", () => {
+            this.removeHoverOverlay();
+        });
+        this.addDomListener(this.editable, "mousemove", (ev) => {
+            const el = this.dependencies.builderOptions.closestWithOption(ev.target);
+            el ? this.showHoverOverlay(el) : this.removeHoverOverlay();
+        });
 
         this._cleanups.push(() => {
             this.removeBuilderOverlays();
@@ -139,7 +148,17 @@ export class BuilderOverlayPlugin extends Plugin {
         }
     }
 
+    removeHoverOverlay() {
+        if (this.hoverOverlay) {
+            this.hoverOverlay.destroy();
+            this.hoverOverlay.overlayElement.remove();
+            this.resizeObserver.unobserve(this.hoverOverlay.overlayTarget);
+            this.hoverOverlay = null;
+        }
+    }
+
     removeBuilderOverlays() {
+        this.removeHoverOverlay();
         this.overlays.forEach((overlay) => {
             overlay.destroy();
             overlay.overlayElement.remove();
@@ -156,15 +175,40 @@ export class BuilderOverlayPlugin extends Plugin {
     }
 
     refreshPositions() {
+        this.hoverOverlay?.refreshPosition();
         this.overlays.forEach((overlay) => {
             overlay.refreshPosition();
         });
     }
 
     toggleOverlaysVisibility(show) {
+        if (!show) {
+            this.removeHoverOverlay();
+        }
         this.overlays.forEach((overlay) => {
             overlay.toggleOverlayVisibility(show);
         });
+    }
+
+    showHoverOverlay(el) {
+        if (this.hoverOverlay && this.hoverOverlay?.overlayTarget === el) {
+            return;
+        }
+        this.removeHoverOverlay();
+        const overlay = new BuilderOverlay(el, {
+            iframe: this.iframe,
+            overlayContainer: this.overlayContainer,
+            history: this.dependencies.history,
+            hasOverlayOptions: false,
+            next: this.dependencies.operation.next,
+            isMobileView: this.config.isMobileView,
+            mobileBreakpoint: this.config.mobileBreakpoint,
+            isRtl: this.config.isEditableRTL,
+            isHoverOverlay: true,
+        });
+        this.hoverOverlay = overlay;
+        this.overlayContainer.append(overlay.overlayElement);
+        this.resizeObserver.observe(overlay.overlayTarget, { box: "border-box" });
     }
 
     showOverlayPreview(el) {

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -17,6 +17,7 @@ import { withSequence } from "@html_editor/utils/resource";
  * @typedef {{
  *      getButtons: (target: HTMLElement) => BuilderButtonDescriptor;
  * }[]} get_overlay_buttons
+ * @typedef {((target: HTMLElement) => bool)[]} show_overlay_buttons_of_ancestor_predicates
  */
 
 export class OverlayButtonsPlugin extends Plugin {
@@ -171,7 +172,11 @@ export class OverlayButtonsPlugin extends Plugin {
 
         // Find the innermost option needing the overlay buttons.
         const optionWithOverlayButtons = optionsContainer.findLast(
-            (option) => option.hasOverlayOptions
+            (option) =>
+                option.hasOverlayOptions &&
+                !this.getResource("show_overlay_buttons_of_ancestor_predicates").some((p) =>
+                    p(option.element)
+                )
         );
         if (optionWithOverlayButtons) {
             this.target = optionWithOverlayButtons.element;

--- a/addons/html_builder/static/src/sidebar/customize_tab.xml
+++ b/addons/html_builder/static/src/sidebar/customize_tab.xml
@@ -18,6 +18,8 @@
                 <t t-else="" t-foreach="currentOptionsContainers" t-as="optionsContainer" t-key="optionsContainer.id">
                     <OptionsContainer
                         snippetModel="props.snippetModel"
+                        folded="optionsContainer.folded"
+                        toggleFold="() => optionsContainer.folded = !optionsContainer.folded"
                         editingElement="optionsContainer.element"
                         options="optionsContainer.options"
                         containerTitle="optionsContainer.containerTitle"

--- a/addons/html_builder/static/src/sidebar/option_container.js
+++ b/addons/html_builder/static/src/sidebar/option_container.js
@@ -24,6 +24,8 @@ export class OptionsContainer extends BaseOptionComponent {
         options: { type: Array },
         editingElement: true, // HTMLElement from iframe
         isRemovable: false,
+        toggleFold: { type: Function, optional: true },
+        folded: { type: Boolean, optional: true },
         removeDisabledReason: { type: String, optional: true },
         isClonable: false,
         cloneDisabledReason: { type: String, optional: true },
@@ -90,10 +92,6 @@ export class OptionsContainer extends BaseOptionComponent {
             : "";
 
         return (title || getSnippetName(this.env.getEditingElement())) + titleExtraInfo;
-    }
-
-    selectElement() {
-        this.dependencies.builderOptions.updateContainers(this.props.editingElement);
     }
 
     toggleOverlayPreview(el, show) {

--- a/addons/html_builder/static/src/sidebar/option_container.xml
+++ b/addons/html_builder/static/src/sidebar/option_container.xml
@@ -7,19 +7,20 @@
          t-on-pointerenter="onPointerEnter" t-on-pointerleave="onPointerLeave">
         <div class="options-container-header d-flex align-items-center justify-content-between">
             <t t-set="isActionable" t-value="Object.keys(props.snippetModel).length > 0"></t>
-            <span
-                class="options-container-label ps-2 py-2"
+            <div
+                class="options-container-label py-2 flex-grow-1 d-flex align-items-center"
                 t-att-class="{
                     'options-container-label-actionable cursor-pointer': isActionable,
                 }"
-                t-out="title"
                 t-att-role="isActionable ? 'button' : 'heading'"
-                t-on-click="selectElement"
-            />
-            <t t-if="props.optionTitleComponents" t-foreach="props.optionTitleComponents" t-as="optionTitleComponent" t-key="optionTitleComponent.id">
-                <t t-component="optionTitleComponent.Component" t-props="optionTitleComponent.props || {}"/>
-            </t>
-            <span class="flex-grow-1" />
+                t-on-click="this.props.toggleFold ?? (() => {})"
+            >
+                <i t-if="this.props.toggleFold" class="fa fa-fw mx-1" role="img" t-att-class="this.props.folded ? 'fa-caret-right' : 'fa-caret-down'"></i>
+                <span t-att-class="{'ms-2': !this.props.toggleFold}" t-out="title"/>
+                <t t-if="props.optionTitleComponents" t-foreach="props.optionTitleComponents" t-as="optionTitleComponent" t-key="optionTitleComponent.id">
+                    <t t-component="optionTitleComponent.Component" t-props="optionTitleComponent.props || {}"/>
+                </t>
+            </div>
 
             <div class="d-flex align-items-center gap-1 p-2">
                 <div t-if="props.headerMiddleButtons">
@@ -59,7 +60,7 @@
                 </t>
             </div>
         </div>
-        <div class="we-bg-options-container pb-3" t-ref="content">
+        <div t-if="!this.props.folded" class="we-bg-options-container pb-3" t-ref="content">
             <t t-foreach="props.options" t-as="OptionClass" t-key="OptionClass.name + '-' + OptionClass.template">
                 <BuilderContext applyTo="OptionClass.applyTo" t-if="hasAccess(OptionClass.groups)">
                     <t t-component="OptionClass"></t>

--- a/addons/html_builder/static/src/utils/utils.js
+++ b/addons/html_builder/static/src/utils/utils.js
@@ -31,6 +31,9 @@ export function getSnippetName(snippetEl) {
     if (snippetEl.matches(".btn")) {
         return _t("Button");
     }
+    if (snippetEl.matches("[data-snippet=s_website_form]")) {
+        return _t("Form");
+    }
     return _t("Block");
 }
 

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -10,7 +10,7 @@ import { insertText } from "@html_editor/../tests/_helpers/user_actions";
 import { LocalOverlayContainer } from "@html_editor/local_overlay_container";
 import { Plugin } from "@html_editor/plugin";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
-import { after, queryFirst } from "@odoo/hoot";
+import { after, click, queryAll, queryFirst } from "@odoo/hoot";
 import { animationFrame, waitForNone, queryOne, waitFor, advanceTime, tick } from "@odoo/hoot-dom";
 import { Component, onMounted, useRef, useState, useSubEnv, xml } from "@odoo/owl";
 import {
@@ -550,4 +550,11 @@ export async function editBuilderRangeValue(selector, newValue) {
     await delay();
     input.dispatchEvent(new Event("change"));
     await delay();
+}
+
+export async function unfoldAllOptionsGroups() {
+    for (const i of queryAll(".options-container-header i.fa-caret-right")) {
+        await click(i);
+    }
+    await animationFrame();
 }

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -1,4 +1,8 @@
-import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import {
+    insertSnippet,
+    registerWebsitePreviewTour,
+    unfoldOptionsGroup,
+} from "@website/js/tours/tour_utils";
 
 import { FileSelectorControlPanel } from "@html_editor/main/media/media_dialog/file_selector";
 import { patch } from "@web/core/utils/patch";
@@ -93,6 +97,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe #wrap .s_image_gallery .img",
             run: "click",
         },
+        ...unfoldOptionsGroup("Image Gallery"),
         {
             content: "click on add images to open image dialog (in multi mode)",
             trigger: "button[data-action-id='addImage']",

--- a/addons/website/static/src/builder/plugins/options/carousel_slides_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/carousel_slides_option_plugin.js
@@ -22,6 +22,7 @@ export class CarouselSlidesOptionPlugin extends Plugin {
         },
         clean_for_save_handlers: this.cleanForSave.bind(this),
         legit_empty_link_predicates: (linkEl) => linkEl.matches(".carousel-item a.slide-link"),
+        show_overlay_buttons_of_ancestor_predicates: (el) => el.matches("div.carousel-item"),
     };
 
     /**

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -459,6 +459,16 @@ export function selectSnippetColumn(snippet, index = 0, position = "bottom") {
     };
 }
 
+export function unfoldOptionsGroup(name) {
+    return [
+        {
+            content: `Unfold the "${name}" group`,
+            trigger: `.options-container[data-container-title="${name}"] .options-container-label i.fa-caret-right`,
+            run: "click",
+        },
+    ];
+}
+
 export function prepend_trigger(steps, prepend_text = "") {
     for (const step of steps) {
         if (!step.noPrepend && prepend_text) {

--- a/addons/website/static/tests/builder/builder_overlay.test.js
+++ b/addons/website/static/tests/builder/builder_overlay.test.js
@@ -9,6 +9,28 @@ import { animationFrame } from "@odoo/hoot-mock";
 
 defineWebsiteModels();
 
+test("Show an overlay when hovering an element with options", async () => {
+    await setupWebsiteBuilder(`
+        <section>
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-3">
+                        <p>TEST</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    `);
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(0);
+    await contains(":iframe section").hover();
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(1);
+    expect(".oe_overlay.o_hover_overlay").toHaveRect(":iframe section");
+
+    await contains(":iframe .col-lg-3").hover();
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(1);
+    expect(".oe_overlay.o_hover_overlay").toHaveRect(":iframe .col-lg-3");
+});
+
 test("Toggle the overlays when clicking on an option element", async () => {
     // TODO improve when more options will be defined.
     await setupWebsiteBuilder(`

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -7,6 +7,7 @@ import {
     addPlugin,
     addActionOption,
     waitForSnippetDialog,
+    setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import {
     dummyBase64Img,
@@ -286,7 +287,7 @@ test("Use the sidebar 'create anchor' buttons", async () => {
     expect(":iframe section.sixth div").toHaveAttribute("id", "Card");
 });
 
-test("Clicking on the options container title selects the corresponding element", async () => {
+test("Clicking on the select element button in container's header selects the corresponding element", async () => {
     await setupWebsiteBuilder(dummySnippet);
 
     await contains(":iframe .col-lg-7").click();
@@ -294,7 +295,9 @@ test("Clicking on the options container title selects the corresponding element"
     expect(".o_customize_tab .options-container").toHaveCount(2);
     expect(".oe_overlay.oe_active").toHaveRect(":iframe .col-lg-7");
 
-    await contains(".o_customize_tab .options-container span:contains('Dummy Section')").click();
+    await contains(
+        ".o_customize_tab .options-container-header:has(span:contains('Dummy Section')) button[title='Select only this block']"
+    ).click();
     expect(".o_customize_tab .options-container").toHaveCount(1);
     expect(".oe_overlay.oe_active").toHaveRect(":iframe section");
 });
@@ -384,4 +387,14 @@ test("applying option container button should wait for actions in progress", asy
 
     undo(editor);
     expect(editable).toHaveInnerHTML(`<p class="test-options-target">plop</p>`);
+});
+
+test("Use the sidebar 'target' button", async () => {
+    await setupWebsiteBuilderWithSnippet("s_banner");
+    await contains(":iframe h1").click();
+    expect(".options-container").toHaveCount(2);
+    await contains(
+        ".o_customize_tab .options-container[data-container-title='Banner'] button[title='Select only this block']"
+    ).click();
+    expect(".options-container").toHaveCount(1);
 });

--- a/addons/website/static/tests/builder/options/layout_option.test.js
+++ b/addons/website/static/tests/builder/options/layout_option.test.js
@@ -5,6 +5,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
+import { unfoldAllOptionsGroups } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
 
@@ -53,6 +54,7 @@ test("Changing the number of columns to 'None' (0)", async () => {
 
     await contains("[data-label='Layout'] .dropdown").click();
     await contains("[data-action-id='changeColumnCount'][data-action-value='1']").click();
+    await unfoldAllOptionsGroups();
     expect(":iframe .s_text_block .container > .row:only-child > .col-lg-12").toHaveCount(1);
 
     await contains("[data-label='Layout'] .dropdown").click();
@@ -76,6 +78,7 @@ test("Changing the number of columns (base case)", async () => {
     await contains("[data-label='Layout'] .dropdown").click();
     await contains("[data-action-id='changeColumnCount'][data-action-value='2']").click();
     expect(":iframe .s_kickoff .row > .col-lg-6").toHaveCount(2);
+    await unfoldAllOptionsGroups();
     await contains("[data-label='Layout'] .dropdown").click();
     await contains("[data-action-id='changeColumnCount'][data-action-value='3']").click();
     expect(":iframe .s_kickoff .row > .col-lg-4").toHaveCount(3);

--- a/addons/website/static/tests/builder/options/pricelist_boxed_option.test.js
+++ b/addons/website/static/tests/builder/options/pricelist_boxed_option.test.js
@@ -5,12 +5,14 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
+import { unfoldAllOptionsGroups } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
 
 test("toggle price list description items", async () => {
     await setupWebsiteBuilderWithSnippet("s_pricelist_boxed");
     await contains(":iframe .s_pricelist_boxed_section").click();
+    await unfoldAllOptionsGroups();
     await waitFor("[data-action-id='togglePriceListDescription']");
     expect(
         "[data-action-id='togglePriceListDescription'] .o-checkbox .form-check-input:checked"

--- a/addons/website/static/tests/builder/snippets_menu.test.js
+++ b/addons/website/static/tests/builder/snippets_menu.test.js
@@ -107,24 +107,24 @@ test("Clicking on the 'Blocks' or 'Theme' tab should deactivate the options", as
 
     await contains(":iframe .s_banner").click();
     await animationFrame();
-    expect(".oe_overlay").toHaveCount(1);
+    expect(".oe_overlay:not(.o_hover_overlay)").toHaveCount(1);
     expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(1);
 
     await contains(".o-snippets-tabs button:contains('Blocks')").click();
-    expect(".oe_overlay").toHaveCount(0);
+    expect(".oe_overlay:not(.o_hover_overlay)").toHaveCount(0);
     await contains(".o-snippets-tabs button:contains('Style')").click();
     expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(1);
 
     await contains(":iframe .s_banner").click();
     await waitFor(".o_customize_tab .options-container");
-    expect(".oe_overlay").toHaveCount(1);
+    expect(".oe_overlay:not(.o_hover_overlay)").toHaveCount(1);
     expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(1);
 
     await contains(".o-snippets-tabs button:contains('Theme')").click();
-    expect(".oe_overlay").toHaveCount(0);
+    expect(".oe_overlay:not(.o_hover_overlay)").toHaveCount(0);
     await contains(".o-snippets-tabs button:contains('Style')").click();
     expect(".o-snippets-tabs button:contains('Style')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(1);

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -18,6 +18,7 @@ import {
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { formSelectXml } from "@website/../tests/interactions/snippets/helpers";
+import { unfoldAllOptionsGroups } from "@html_builder/../tests/helpers";
 
 class HrJob extends models.Model {
     _name = "hr.job";
@@ -686,6 +687,7 @@ describe("Many2one Field", () => {
     });
 
     test("SelectMenu to add records", async () => {
+        await unfoldAllOptionsGroups();
         await contains(addRecordButtonSelector).click();
         await expectElementCount(".o_select_menu_menu .o_select_menu_item", records.length - 1);
         expect(queryOne(".o_select_menu_menu").getBoundingClientRect().top).toBeLessThan(

--- a/addons/website/static/tests/builder/website_builder/image_gallery.test.js
+++ b/addons/website/static/tests/builder/website_builder/image_gallery.test.js
@@ -1,6 +1,7 @@
 import {
     confirmAddSnippet,
     dummyBase64Img,
+    unfoldAllOptionsGroups,
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
 import { expect, test } from "@odoo/hoot";
@@ -40,7 +41,7 @@ test("Add image in gallery", async () => {
         return dataURItoBlob(base64Image);
     });
 
-    await setupWbsiteBuilderWithImageWall();
+    const { waitSidebarUpdated } = await setupWbsiteBuilderWithImageWall();
     onRpc("/html_editor/get_image_info", () => {
         expect.step("get_image_info");
         return {
@@ -55,7 +56,8 @@ test("Add image in gallery", async () => {
         };
     });
     await contains(":iframe .o_masonry_col img[data-index='1']").click();
-    await waitFor("[data-action-id='addImage']");
+    await waitSidebarUpdated();
+    await unfoldAllOptionsGroups();
     expect("[data-action-id='addImage']").toHaveCount(1);
     await contains("[data-action-id='addImage']").click();
     // We use "click" instead of contains.click because contains wait for the image to be visible.
@@ -112,6 +114,7 @@ test("Change gallery layout", async () => {
 
     await contains(":iframe img").click();
     await waitSidebarUpdated();
+    await unfoldAllOptionsGroups();
     expect("[data-label='Mode']").toHaveCount(1);
     expect(queryOne("[data-label='Mode'] .dropdown-toggle").textContent).toBe("Masonry");
     await contains("[data-label='Mode'] .dropdown-toggle").click();
@@ -135,6 +138,8 @@ test("Change gallery restore the container to the cloned equivalent image", asyn
     };
 
     await contains(":iframe img[data-index='1']").click();
+    await builder.waitSidebarUpdated();
+    await unfoldAllOptionsGroups();
     await contains("[data-label='Mode'] button").click();
 
     await contains("[data-action-param='grid']").click();
@@ -150,9 +155,11 @@ test("Change gallery restore the container to the cloned equivalent image", asyn
 });
 
 test("Change gallery layout when images have a link", async () => {
-    await setupWbsiteBuilderWithImageWall();
+    const { waitSidebarUpdated } = await setupWbsiteBuilderWithImageWall();
 
     await contains(":iframe img[data-index='1']").click();
+    await waitSidebarUpdated();
+    await unfoldAllOptionsGroups();
     await waitFor("[data-label='Mode']");
     await contains("[data-label='Media'] button[data-action-id='setLink']").click();
 
@@ -221,6 +228,7 @@ test("Changing layout of an image gallery to grid should remove size option on i
     );
     await contains(":iframe .first_img").click();
     await waitSidebarUpdated();
+    await unfoldAllOptionsGroups();
     expect("[data-label='Mode']").toHaveCount(1);
     expect(queryOne("[data-label='Mode'] .dropdown-toggle").textContent).toBe("Masonry");
     expect("[data-label='Size']").toHaveCount(1);
@@ -267,6 +275,7 @@ test("Change gallery layout still works when img.decode() fails", async () => {
     });
     await images.at(0).click();
     await builder.waitSidebarUpdated();
+    await unfoldAllOptionsGroups();
     await contains("[data-label='Mode'] .dropdown-toggle").click();
 
     // This should NOT throw an error even img.decode() call will fail
@@ -276,5 +285,6 @@ test("Change gallery layout still works when img.decode() fails", async () => {
     // Verify the layout change worked despite decode failures
     expect(":iframe .o_grid").toHaveCount(1);
     expect(":iframe .o_masonry_col").toHaveCount(0);
+    await unfoldAllOptionsGroups();
     expect("[data-label='Mode'] .dropdown-toggle").toHaveText("Grid");
 });

--- a/addons/website/static/tests/builder/website_builder/size_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/size_option.test.js
@@ -5,6 +5,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
+import { unfoldAllOptionsGroups } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
 
@@ -12,6 +13,7 @@ test("Size option should be present when scroll down button is enabled", async (
     const sizeOptionSelector = ".hb-row-sublevel-1[data-label='Size']";
     await setupWebsiteBuilderWithSnippet("s_banner", { loadIframeBundles: true });
     await contains(":iframe img").click();
+    await unfoldAllOptionsGroups();
     await contains("[data-label='Height'] [data-action-param='o_full_screen_height']").click();
     await contains("[data-label='Scroll Down Button'] input").click();
     await waitFor(sizeOptionSelector);

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -4,7 +4,11 @@ import {
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
-import { getDragHelper, waitForEndOfOperation } from "@html_builder/../tests/helpers";
+import {
+    getDragHelper,
+    unfoldAllOptionsGroups,
+    waitForEndOfOperation,
+} from "@html_builder/../tests/helpers";
 import { ensureDistinctHistoryStep } from "@html_editor/../tests/_helpers/user_actions";
 import { click, queryOne, animationFrame, edit, waitFor } from "@odoo/hoot-dom";
 
@@ -50,7 +54,8 @@ async function testSocialSnippetOptions(snippetName, containerTitle, iconName) {
 
     expect(snippetSelector).toHaveCount(1);
     await click(`${snippetSelector} i:first-child`);
-    await animationFrame();
+    await core.waitSidebarUpdated();
+    await unfoldAllOptionsGroups();
     await click(
         `[data-container-title='${containerTitle}'] [data-label='Color'] input[type='checkbox']`
     );

--- a/addons/website/static/tests/builder/website_builder/table_of_content_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/table_of_content_option.test.js
@@ -24,6 +24,7 @@ import {
     insertStructureSnippet,
     setupWebsiteBuilderWithSnippet,
 } from "@website/../tests/builder/website_helpers";
+import { unfoldAllOptionsGroups } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
 
@@ -75,6 +76,7 @@ test("click on addItem option button", async () => {
     ]);
 
     await contains(":iframe .s_table_of_content_main h2").click();
+    await unfoldAllOptionsGroups();
     await contains("[data-action-id='addItem']").click();
     expect(
         queryAllTexts(":iframe .s_table_of_content_vertical_navbar a.table_of_content_link_depth_0")

--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -9,6 +9,7 @@ import {
     clickOnSave,
     registerWebsitePreviewTour,
     goBackToBlocks,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 const carouselInnerSelector = ":iframe .carousel-inner";
@@ -104,6 +105,7 @@ registerWebsitePreviewTour(
         },
         checkSlides(3, 1),
         // Add a slide (with the "Carousel" option).
+        ...unfoldOptionsGroup("Carousel"),
         changeOption("Carousel", "[data-action-id='addSlide']"),
         checkSlides(4, 2),
         {

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -6,6 +6,7 @@ import {
     insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 const snippets = [
@@ -239,6 +240,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_text_image[data-snippet=s_image_text] img",
             run: "click",
         },
+        ...unfoldOptionsGroup("Column"),
         {
             content: "Change visibility of the 'Image - Text' snippet",
             trigger:

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -7,6 +7,7 @@ import {
     openLinkPopup,
     registerWebsitePreviewTour,
     clickToolbarButton,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 const toggleMegaMenu = (stepOptions) =>
@@ -265,6 +266,7 @@ registerWebsitePreviewTour(
             run: "click",
         },
         // Change MegaMenu template
+        ...unfoldOptionsGroup("Mega Menu"),
         ...changeOptionInPopover("Mega Menu", "Template", "[title='Big Icons Subtitles']"),
         ...clickToolbarButton(
             "h4 of first menu link of the first column",

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -42,6 +42,11 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
+            content: `Target the "Text - Image" group`,
+            trigger: `.options-container[data-container-title="Text - Image"]:has(.options-container-label i.fa-caret-right) button[title="Select only this block"]`,
+            run: "click",
+        },
+        {
             content: "Add new image column",
             trigger: "[data-action-id='addGridElement'][data-action-param='image']",
             run: "click",

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -6,6 +6,7 @@ import {
     goBackToBlocks,
     registerWebsitePreviewTour,
     selectFullText,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 import { browser } from "@web/core/browser/browser";
 import { delay } from "@web/core/utils/concurrency";
@@ -45,6 +46,7 @@ registerWebsitePreviewTour(
         selectFullText("first paragraph", ".s_text_image p:not([data-selection-placeholder])"),
         checkIfParagraphSelected(":iframe .s_text_image p:not([data-selection-placeholder])"),
         checkIfTextToolbarVisible,
+        ...unfoldOptionsGroup("Text - Image"),
         {
             content: "Click on the width option.",
             trigger: "[data-action-param='o_container_small']",
@@ -120,6 +122,7 @@ registerWebsitePreviewTour(
         checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         // Test keeping the text selection when removing all columns of a
         // snippet.
+        ...unfoldOptionsGroup("Text"),
         ...changeOptionInPopover("Text", "Layout", "[data-action-value='0']"),
         {
             content: "The snippet should have the correct number of columns.",

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -9,6 +9,7 @@ import {
     changeOptionInPopover,
     clickOnEditAndWaitEditMode,
     assertCssVariable,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
@@ -160,6 +161,7 @@ registerWebsitePreviewTour(
             trigger:
                 ".o_customize_tab [data-container-title='Image'] [data-label='Filter'] .o-dropdown:contains('Blur')",
         },
+        ...unfoldOptionsGroup("Image Gallery"),
         {
             content: "Change the height of the snippet",
             trigger: `.o_customize_tab [data-container-title="Image Gallery"] [data-label="Height"] input`,

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -3,6 +3,7 @@ import {
     insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 const snippets = [
@@ -99,6 +100,11 @@ registerWebsitePreviewTour(
             run: "click",
         },
         checkScrollbar(true),
+        {
+            content: "Wait s_media_list is removed from popup",
+            trigger: "body:not(:has(.o_customize_tab [data-container-title='Media List']))",
+        },
+        ...unfoldOptionsGroup("Popup"),
         toggleBackdrop("Popup"), // show Popup backdrop
         {
             content: "Close the Popup that has now backdrop.",

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -5,6 +5,7 @@ import {
     insertSnippet,
     registerWebsitePreviewTour,
     openLinkPopup,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 import { browser } from "@web/core/browser/browser";
 
@@ -25,6 +26,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_popup .s_banner",
             run: "click",
         },
+        ...unfoldOptionsGroup("Popup"),
         {
             content: "Click on Display option",
             trigger:

--- a/addons/website/static/tests/tours/snippet_popup_open_on_top.js
+++ b/addons/website/static/tests/tours/snippet_popup_open_on_top.js
@@ -4,6 +4,7 @@ import {
     clickOnSave,
     insertSnippet,
     registerWebsitePreviewTour,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
@@ -24,6 +25,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_popup p.lead",
             run: "editor " + " hello world".repeat(300),
         },
+        ...unfoldOptionsGroup("Popup"),
         {
             content: "Set delay to 0 second",
             trigger: '[data-action-id="setPopupDelay"] input',

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -4,6 +4,7 @@ import {
     clickOnSnippet,
     insertSnippet,
     registerWebsitePreviewTour,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 // TODO: Remove following steps once fix of task-3212519 is done.
@@ -59,7 +60,7 @@ const replaceIconByImage = function (url) {
 
 const addNewSocialNetwork = function (optionIndex, linkIndex, url, replaceIcon = false) {
     const replaceIconByImageSteps = replaceIcon
-        ? replaceIconByImage("https://www.example.com")
+        ? [...replaceIconByImage("https://www.example.com"), ...unfoldOptionsGroup("Social Media")]
         : [];
     return [
         {
@@ -221,11 +222,13 @@ registerWebsitePreviewTour(
                 ":has(a:eq(8)[href='https://whatever.it/1EdSw9X']:has(i.fa-heart))" +
                 ":has(a:eq(9)[href='https://instagr.am/odoo.official/']:has(i.fa-instagram))",
         },
+        ...unfoldOptionsGroup("Social Media"),
         // Create a social network but replace its icon by an image before setting
         // the link (`replaceIcon` parameter set to `true`).
         ...addNewSocialNetwork(10, 10, "https://google.com", true),
         // Create a social network after replacing the first icon by an image.
         ...replaceIconByImage("/website/social/twitter"),
+        ...unfoldOptionsGroup("Social Media"),
         ...addNewSocialNetwork(11, 11, "https://facebook.com"),
         {
             content: "Check if the result is correct after adding images",

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -4,6 +4,7 @@ import {
     insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 const scrollToHeading = function (position) {
@@ -71,6 +72,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_table_of_content:eq(0) h2",
             run: "click",
         },
+        ...unfoldOptionsGroup("Table of Content"),
         {
             content: "Hide the first TOC on mobile",
             trigger: '[data-action-param="no_mobile"]',
@@ -83,6 +85,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_table_of_content:eq(1) h2",
             run: "click",
         },
+        ...unfoldOptionsGroup("Table of Content"),
         {
             content: "Hide the second TOC on desktop",
             trigger: '[data-action-param="no_desktop"]',

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -6,6 +6,7 @@ import {
     goBackToBlocks,
     registerWebsitePreviewTour,
     changeOptionInPopover,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 import { stepUtils } from "@web_tour/tour_utils";
 import { editorsWeakMap } from "@html_editor/../tests/tours/helpers/editor";
@@ -687,6 +688,7 @@ registerWebsitePreviewTour(
         // while field B's visibility is also tied to another field.
         ...clickOnEditAndWaitEditMode(),
         ...selectFieldByLabel("field A"),
+        ...unfoldOptionsGroup("Form"),
         {
             content: "Verify that the form editor appeared",
             trigger: ".o_customize_tab div[data-container-title='Form'] .we-bg-options-container",
@@ -801,6 +803,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_website_form_send",
             run: "click",
         },
+        ...unfoldOptionsGroup("Form"),
         {
             content: "Change the Recipient Email",
             trigger: '[data-label="Recipient Email"] input',
@@ -919,6 +922,7 @@ registerWebsitePreviewTour(
     },
     () =>
         editContactUs([
+            ...unfoldOptionsGroup("Form"),
             {
                 content: "Change the Recipient Email",
                 trigger: "div[data-label='Recipient Email'] input",
@@ -934,6 +938,7 @@ registerWebsitePreviewTour(
     },
     () =>
         editContactUs([
+            ...unfoldOptionsGroup("Form"),
             {
                 content: "Change a random option",
                 trigger: "[data-action-id='setMark'] input",
@@ -1112,6 +1117,7 @@ registerWebsitePreviewTour(
     },
     () =>
         editContactUs([
+            ...unfoldOptionsGroup("Form"),
             {
                 content: "Change a random option",
                 trigger: "[data-action-id='setMark'] input",

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -4,6 +4,7 @@ import {
     registerWebsitePreviewTour,
     toggleMobilePreview,
     changeOptionInPopover,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 const columnCountOptSelector = "div[data-label='Layout'] .dropdown-toggle";
@@ -88,6 +89,11 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
+            content: `Target the "Columns" group`,
+            trigger: `.options-container[data-container-title="Columns"]:has(.options-container-label i.fa-caret-right) button[title="Select only this block"]`,
+            run: "click",
+        },
+        {
             content: "Check that there is 1 column on mobile and click on the selector",
             trigger: `${columnCountOptSelector}:contains('1')`,
             run: "click",
@@ -136,6 +142,7 @@ registerWebsitePreviewTour(
                 triggerPointerEvent("pointerup", 150, 100);
             },
         },
+        ...unfoldOptionsGroup("Columns"),
         {
             content: "Check that the counter shows 'Custom'",
             trigger: `${columnCountOptSelector}:contains('Custom')`,

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -17,7 +17,7 @@ function setFormActionToCreateOpportunity() {
         {
             content: "Open action select",
             trigger:
-                ".o-snippets-menu [data-container-title='Block'] [data-label='Action'] .dropdown-toggle",
+                ".o-snippets-menu [data-container-title='Form'] [data-label='Action'] .dropdown-toggle",
             run: "click",
         },
         {
@@ -120,7 +120,7 @@ registerWebsitePreviewTour(
         {
             content: "Open Sales Team select",
             trigger:
-                ".o-snippets-menu [data-container-title='Block'] [data-label='Sales Team'] .dropdown-toggle",
+                ".o-snippets-menu [data-container-title='Form'] [data-label='Sales Team'] .dropdown-toggle",
             run: "click",
         },
         {

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -3,6 +3,7 @@ import {
     clickOnSave,
     insertSnippet,
     registerWebsitePreviewTour,
+    unfoldOptionsGroup,
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
@@ -36,6 +37,7 @@ registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
         trigger: ':iframe .s_newsletter_block .s_newsletter_subscribe_form',
         run: "click",
     },
+    ...unfoldOptionsGroup("Newsletter Block"),
     {
         content: 'Toggle the option to display the Thanks message',
         trigger: "div[data-action-id='toggleThanksMessage'] input[type='checkbox']",

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -4,6 +4,7 @@ import {
     registerWebsitePreviewTour,
     insertSnippet,
     changeOptionInPopover,
+    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
@@ -128,6 +129,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_donation_donate_btn",
             run: "click",
         },
+        ...unfoldOptionsGroup("Donation Button"),
         ...changeOptionInPopover("Donation Button", "Custom Amount", "[data-action-param='slider']"),
         ...clickOnSave(),
     ]

--- a/addons/website_sale/static/src/website_builder/website_sale.editor.scss
+++ b/addons/website_sale/static/src/website_builder/website_sale.editor.scss
@@ -1,9 +1,5 @@
 .options-container:has(.o_wsale_products_list_page_options),
 .options-container:has(.o_wsale_product_page_options) {
-    > div:first-child { // Title
-        display: none !important;
-    }
-
     > .we-bg-options-container {
         margin-top: -4px; // Cancel margin
         padding-top: 8px; // Avoid margin collapse, like bootstrap's pt-2


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/107029

### [IMP] html_builder, website: show overlay buttons of carousel from slide

When the user clicks in a "Carousel" snippet, the target of the click
is the slide in the carousel, not the carousel itself, thus the overlay
buttons of the carousel do not appear.

To make it easier to move the carousel around, this commit shows the
overlay buttons of the carousel when he user clicks inside the slide
(because there is no overlay buttons for the slides).

task-5470590

### [FIX] html_builder: add a fallback rule to name blocks "Form"

Some forms snippet have the attribute `data-name=Form` on their form,
but some do not have it. For those that don't, the name of the option
group is the default fallback "Block".

This commit adds a fallback rule to name the snippets `s_website_form`
as "Form".

task-5470590

### [IMP] html_builder, website, *: fold groups of options but the last

*: test_website, website_mass_mailing, website_payment

To have a quicker access to the options related to the element the user
clicked, the groups above the last one are folded.

The user can fold/unfold a group by clicking on its header (with the
name of the element).

Clicking on the header used to select just the corresponding element,
this action is sill possible on `section` elements (as they are the ones
for which this action might be useful)

task-5470590

### [FIX] website_sale: always show header of product page options

Commit e8019e39f1e8dd7cdea2d6cb3070de4c073ab94d, added a css rule to
hide the header of the product page group (it reproduced what was done
in 328c241fa58976bd5029dc526789113a88a333f2). With the changes from the
previous commit, this leads to the very weird behavior when clicking on
a block inside the page: the header for the options of the page appears
as folded, and if unfolded the header disappears.

This commit remove the rule that make the header disappear.

task-5470590

### [IMP] html_builder, website: show temporary overlay on mouse move

To help the user click on a specific block, this commit adds an overlay
on the first element with options on hover.

task-5470590