### PR TITLE
[IMP] mail: primary button for 'join channel' button

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -8,6 +8,7 @@ import { Reactive } from "@web/core/utils/reactive";
 export const ACTION_TAGS = Object.freeze({
     DANGER: "DANGER",
     SUCCESS: "SUCCESS",
+    PRIMARY: "PRIMARY",
     IMPORTANT_BADGE: "IMPORTANT_BADGE",
     WARNING_BADGE: "WARNING_BADGE",
     CALL_LAYOUT: "CALL_LAYOUT",

--- a/addons/mail/static/src/core/common/action_list.dark.scss
+++ b/addons/mail/static/src/core/common/action_list.dark.scss
@@ -1,12 +1,8 @@
 .o-mail-ActionList {
-    --mail-ActionList-activeItemColor: #{white};
-    --mail-ActionList-activeItemBgColor: #{rgba(mix($gray-300, $gray-400), .75)};
-    --mail-ActionList-dangerBgColor: #{rgba(saturate($danger, 20%), .5)};
-    --mail-ActionList-successBgColor: #{rgba(saturate($success, 20%), .5)};
     --mail-ActionList-buttonInlineIconOpacity: #{85%};
-    --mail-ActionList-dangerColor: #{lighten($danger, 5%)};
     --o-mail-ActionList-successNoBgColor: #{lighten($success, 10%)};
     --o-mail-ActionList-dangerNoBgColor: #{lighten($danger, 10%)};
+    --o-mail-ActionList-primaryNoBgColor: #{lighten($primary, 10%)};
 
     .o-hasBtnBg.o-tag-SUCCESS {
         @include button-variant(darken($success, 10%), darken($success, 10%));

--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -85,14 +85,20 @@
             }
         }
 
-        @each $status, $color in (danger: $danger, success: $success) {
+        @each $status, $color in (danger: $danger, success: $success, primary: $primary) {
             &.o-dropdown-item.btn-#{$status}:not(.o-tag-JOIN_LEAVE_CALL) {
                 &.focus {
                     background-color: rgba($color, 0.75);
                     color: white;
+                    &.o-tag-PRIMARY {
+                        background-color: rgba($color, .9);
+                    }
                 }
                 &:not(.focus) {
                     color: var(--o-mail-ActionList-#{$status}NoBgColor, #{$color});
+                    &.o-tag-PRIMARY {
+                        background-color: rgba($color, .35);
+                    }
                 }
             }
             &.o-inline.btn-#{$status}:not(.o-tag-JOIN_LEAVE_CALL):not(.o-hasBtnBg) {

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -46,13 +46,15 @@
     <t t-set="isInlineCircleButton" t-value="env.inComposer or (action.tags.includes('JOIN_LEAVE_CALL') and action.icon and !action.inlineName)"/>
     <!-- core-->
     <t t-set="btnClass" t-value="attClassObjectToString({
-        'o-mail-ActionList-button btn btn-secondary btn-group-item position-relative': true,
+        'o-mail-ActionList-button btn btn-group-item position-relative': true,
         'o-first': props.isFirstInGroup,
         'o-last': props.isLastInGroup,
         'active': action.isActive,
         'o-odooControlPanelSwitchStyle': props.odooControlPanelSwitchStyle,
         'o-hasBtnBg': hasBtnBg,
         'o-inline': props.inline,
+        'btn-secondary': !action.tags.includes('PRIMARY') and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS'),
+        'btn-primary': action.tags.includes('PRIMARY'),
         'btn-danger': action.tags.includes('DANGER'),
         'btn-success': action.tags.includes('SUCCESS'),
     })"/>
@@ -102,7 +104,7 @@
     <t t-set="btnClass" t-value="attClassObjectToString({
         [btnClass]: true,
         'o-text-white border-0 o-simulateDarkTheme': store.shouldSimulateDarkTheme(this),
-        'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and hasBtnBg,
+        'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and !action.tags.includes('PRIMARY') and hasBtnBg,
         'bg-transparent': store.shouldSimulateDarkTheme(this) and !hasBtnBg,
     })"/>
     <!-- dynamic classes-->

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -14,7 +14,7 @@ export const joinChannelAction = {
     name: _t("Join Channel"),
     sequence: 20,
     sequenceGroup: ({ owner }) => (owner.isDiscussContent ? undefined : 5),
-    tags: [ACTION_TAGS.SUCCESS],
+    tags: [ACTION_TAGS.PRIMARY],
 };
 registerThreadAction("join-channel", joinChannelAction);
 registerThreadAction("expand-discuss", {


### PR DESCRIPTION
Before this commit, the thread action "Join Channel" had the style "SUCCESS" to attract eyes and show a positive action.

While on its own this is a good color, the problem is that some other less important actions also have this success look, notably the "Start a call" buttons.

We want the "Join Channel" button to be very catchy, therefore this commit sets the `btn-primary` style. This commit introduces `PRIMARY` as a new style for discuss actions, giving this look in all modes (inline, dropdown, dark theme, etc.).

Part of Task-5867464

Before / After
<img width="422" height="49" alt="Screenshot 2026-02-06 at 18 52 29" src="https://github.com/user-attachments/assets/c1e6e2cc-14c0-45fb-969c-2f2abce446cf" />
<img width="426" height="50" alt="Screenshot 2026-02-06 at 18 51 52" src="https://github.com/user-attachments/assets/729b4ead-e4bf-48e2-a41a-e53a1edd7cc2" />
