### PR TITLE
[PERF] orm: unique on relational prefetch on x2m fields

### DIFF
--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -5,7 +5,7 @@ from collections.abc import Set as AbstractSet
 import dateutil.relativedelta
 
 from odoo.exceptions import ValidationError
-from odoo.tools import SQL
+from odoo.tools import SQL, unique
 
 regex_alphanumeric = re.compile(r'^[a-z0-9_]+$')
 regex_object_name = re.compile(r'^[a-z0-9_.]+$')
@@ -145,7 +145,7 @@ class PrefetchRelational(Reversible):  # noqa: PLW1641
                 if (coid := field_cache.get(id_)) is not None:
                     yield coid
         else:
-            for id_ in self._records._prefetch_ids:
+            for id_ in unique(self._records._prefetch_ids):
                 if (coids := field_cache.get(id_)):
                     yield from coids
 


### PR DESCRIPTION
When iterating over `records.some_rel_id.tag_ids.name` we avoid doing lookups for multiple values in cache for the same id. In any case, the yielded values are deduplicated, but we can deduplicate at the source first.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
