### PR TITLE
[FIX] hr_skills: make skills_tour more reliable

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -198,7 +198,7 @@ registry.category("web_tour.tours").add("hr_skills_tour", {
         },
         {
             content: "Close validation error popup",
-            trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary",
+            trigger: ".modal:contains(validation error) .modal-footer .btn-primary",
             run: "click",
         },
         {


### PR DESCRIPTION
During the skills_tour, a validation error dialog is closed, and this dialog is over another dialog that was being validated.

Before this commit, the close button that was selected was "the one of the not-inactive modal footer", just after a step that was also a click on a button in a modal.

Since the delay between tour steps has been reduced, it happened that the step labeled "Close validation error popup" was executed before the inactivation of the modal, and then the button to be clicked was the one of the underlying modal, because the validation error was not displayed yet.

With this commit, we specifically expect the validation error modal to contain the string "validation error", which makes this issue disappear.

Runbot-build-error: [238886](https://runbot.odoo.com/odoo/runbot.build.error/238886)