### PR TITLE
[IMP] mail,hr: improve auto-subscribe mechanism of discuss channels

### DIFF
--- a/addons/hr/models/discuss_channel.py
+++ b/addons/hr/models/discuss_channel.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.fields import Domain
 
 
 class DiscussChannel(models.Model):
@@ -10,7 +11,7 @@ class DiscussChannel(models.Model):
 
     subscription_department_ids = fields.Many2many(
         'hr.department', string='HR Departments',
-        help='Automatically subscribe members of those departments to the channel.')
+        help="Restrict auto-subscribe users based on their related employees' departments.")
 
     @api.constrains('subscription_department_ids')
     def _constraint_subscription_department_ids_channel(self):
@@ -18,15 +19,13 @@ class DiscussChannel(models.Model):
         if failing_channels:
             raise ValidationError(_("For %(channels)s, channel_type should be 'channel' to have the department auto-subscription.", channels=', '.join([ch.name for ch in failing_channels])))
 
-    def _subscribe_users_automatically_get_members(self):
-        """ Auto-subscribe members of a department to a channel """
-        new_members = super()._subscribe_users_automatically_get_members()
-        for channel in self:
-            new_members[channel.id] = list(
-                set(new_members[channel.id]) |
-                set((channel.subscription_department_ids.member_ids.user_id.partner_id.filtered(lambda p: p.active) - channel.channel_partner_ids).ids)
-            )
-        return new_members
+    def _get_auto_subscribe_domain(self):
+        domain = super()._get_auto_subscribe_domain()
+        # sudo: hr.department - ensure all departments and their members are accessible
+        departments_sudo = self.sudo().subscription_department_ids
+        if departments_sudo:
+            domain &= Domain('id', 'in', departments_sudo.member_ids.user_id.ids)
+        return domain
 
     def write(self, vals):
         res = super().write(vals)

--- a/addons/hr/models/discuss_channel.py
+++ b/addons/hr/models/discuss_channel.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.fields import Domain
 
 
 class DiscussChannel(models.Model):
@@ -18,15 +19,19 @@ class DiscussChannel(models.Model):
         if failing_channels:
             raise ValidationError(_("For %(channels)s, channel_type should be 'channel' to have the department auto-subscription.", channels=', '.join([ch.name for ch in failing_channels])))
 
-    def _subscribe_users_automatically_get_members(self):
-        """ Auto-subscribe members of a department to a channel """
-        new_members = super()._subscribe_users_automatically_get_members()
-        for channel in self:
-            new_members[channel.id] = list(
-                set(new_members[channel.id]) |
-                set((channel.subscription_department_ids.member_ids.user_id.partner_id.filtered(lambda p: p.active) - channel.channel_partner_ids).ids)
+    def _get_extra_domain(self):
+        domain = super()._get_extra_domain()
+        # sudo: hr.department - ensure all departments and its members are accesible
+        departments_sudo = self.sudo().subscription_department_ids
+        if departments_sudo:
+            department_domain = Domain(
+                'id', 'in', departments_sudo.member_ids.user_id.ids,
             )
-        return new_members
+            if self.group_ids:
+                domain |= department_domain
+            else:
+                domain &= department_domain
+        return domain
 
     def write(self, vals):
         res = super().write(vals)

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1782,7 +1782,8 @@ class HrEmployee(models.Model):
                 employee_sudo.work_contact_id.image_1920 = employee_sudo.image_1920
         employee_departments = employees.department_id
         if employee_departments:
-            self.env['discuss.channel'].sudo().search([
+            self.env['discuss.channel'].sudo().search_fetch([
+                ('auto_subscribe', '=', True),
                 ('subscription_department_ids', 'in', employee_departments.ids)
             ])._subscribe_users_automatically()
         onboarding_notes_bodies = {}
@@ -1868,8 +1869,9 @@ class HrEmployee(models.Model):
         if vals.get('department_id') or vals.get('user_id'):
             department_id = vals['department_id'] if vals.get('department_id') else self[:1].department_id.id
             # When added to a department or changing user, subscribe to the channels auto-subscribed by department
-            self.env['discuss.channel'].sudo().search([
-                ('subscription_department_ids', 'in', department_id)
+            self.env['discuss.channel'].sudo().search_fetch([
+                ('auto_subscribe', '=', True),
+                ('subscription_department_ids', 'in', department_id),
             ])._subscribe_users_automatically()
         if res and ('resource_calendar_id' in vals or 'hours_per_week' in vals or 'hours_per_day' in vals):
             resources = self.env['resource.resource']

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1690,6 +1690,7 @@ class HrEmployee(models.Model):
         employee_departments = employees.department_id
         if employee_departments:
             self.env['discuss.channel'].sudo().search([
+                ('auto_join', '=', True),
                 ('subscription_department_ids', 'in', employee_departments.ids)
             ])._subscribe_users_automatically()
         onboarding_notes_bodies = {}
@@ -1721,12 +1722,6 @@ class HrEmployee(models.Model):
                     users_to_update |= employee.user_id
             if users_to_update:
                 users_to_update.write({'tz': vals['tz']})
-        if vals.get('department_id') or vals.get('user_id'):
-            department_id = vals['department_id'] if vals.get('department_id') else self[:1].department_id.id
-            # When added to a department or changing user, subscribe to the channels auto-subscribed by department
-            self.env['discuss.channel'].sudo().search([
-                ('subscription_department_ids', 'in', department_id)
-            ])._subscribe_users_automatically()
         if vals.get('departure_description'):
             for employee in self:
                 employee.message_post(body=_(
@@ -1762,6 +1757,13 @@ class HrEmployee(models.Model):
                 else:
                     msg = self.env._("Modified")
                 employee._track_set_log_message(Markup("<b>%s</b>") % msg)
+        if vals.get('department_id') or vals.get('user_id'):
+            department_id = vals['department_id'] if vals.get('department_id') else self[:1].department_id.id
+            # When added to a department or changing user, subscribe to the channels auto-subscribed by department
+            self.env['discuss.channel'].sudo().search([
+                ('auto_join', '=', True),
+                ('subscription_department_ids', 'in', department_id),
+            ])._subscribe_users_automatically()
         if res and ('resource_calendar_id' in vals or 'hours_per_week' in vals or 'hours_per_day' in vals):
             resources = self.env['resource.resource']
             for employee in self:

--- a/addons/hr/tests/test_channel.py
+++ b/addons/hr/tests/test_channel.py
@@ -27,6 +27,7 @@ class TestChannel(TestHrCommon):
         self.assertEqual(self.department.member_ids, self.emp0)
 
         self.channel.write({
+            'auto_subscribe': True,
             'subscription_department_ids': [(4, self.department.id)]
         })
 
@@ -34,6 +35,7 @@ class TestChannel(TestHrCommon):
 
     def test_auto_subscribe_when_updating_employee_department(self):
         self.channel.write({
+            'auto_subscribe': True,
             'subscription_department_ids': [(4, self.department.id)],
         })
         self.assertEqual(self.channel.channel_partner_ids, self.env['res.partner'])
@@ -41,4 +43,14 @@ class TestChannel(TestHrCommon):
 
         self.emp0.write({'department_id': self.department.id})
 
+        self.assertEqual(self.channel.channel_partner_ids, self.emp0.user_id.partner_id)
+
+    def test_auto_subscribe_group_department(self):
+        self.department.invalidate_recordset(['member_ids'])
+        self.emp0.write({'department_id': self.department.id})
+        self.channel.write({
+            'auto_subscribe': True,
+            'group_ids': [(4, self.env.ref("base.group_user").id)],
+            'subscription_department_ids': [(4, self.department.id)],
+        })
         self.assertEqual(self.channel.channel_partner_ids, self.emp0.user_id.partner_id)

--- a/addons/hr/tests/test_channel.py
+++ b/addons/hr/tests/test_channel.py
@@ -13,19 +13,31 @@ class TestChannel(TestHrCommon):
 
         cls.channel = cls.env['discuss.channel'].create({'name': 'Test'})
 
-        emp0 = cls.env['hr.employee'].create({
+        cls.emp0 = cls.env['hr.employee'].create({
             'user_id': cls.res_users_hr_officer.id,
         })
         cls.department = cls.env['hr.department'].create({
             'name': 'Test Department',
-            'member_ids': [(4, emp0.id)],
+            'member_ids': [(4, cls.emp0.id)],
         })
 
-    def test_auto_subscribe_department(self):
+    def test_auto_join_department(self):
         self.assertEqual(self.channel.channel_partner_ids, self.env['res.partner'])
 
         self.channel.write({
+            'auto_join': True,
             'subscription_department_ids': [(4, self.department.id)]
         })
 
         self.assertEqual(self.channel.channel_partner_ids, self.department.mapped('member_ids.user_id.partner_id'))
+
+    def test_auto_join_group_department(self):
+        self.department.invalidate_recordset(['member_ids'])
+        channel = self.env['discuss.channel'].create({
+            'name': 'Test group and department',
+            'auto_join': True,
+            'group_ids': [(4, self.env.ref("base.group_system").id)],
+            'subscription_department_ids': [(4, self.department.id)],
+        })
+        both_partners = self.env.ref('base.user_admin').partner_id | self.emp0.user_id.partner_id
+        self.assertEqual(channel.channel_partner_ids, both_partners)

--- a/addons/hr/views/discuss_channel_views.xml
+++ b/addons/hr/views/discuss_channel_views.xml
@@ -5,10 +5,9 @@
         <field name="model">discuss.channel</field>
         <field name="inherit_id" ref="mail.discuss_channel_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='group_ids']" position="after">
+            <xpath expr="//field[@name='auto_subscribe_company_ids']" position="after">
                 <field name="subscription_department_ids" widget="many2many_tags"
-                    invisible="channel_type != 'channel'"
-                    string="Auto Subscribe Departments"/>
+                    placeholder="All departments" string="Departments" invisible="not auto_subscribe"/>
             </xpath>
         </field>
     </record>

--- a/addons/hr/views/discuss_channel_views.xml
+++ b/addons/hr/views/discuss_channel_views.xml
@@ -5,10 +5,9 @@
         <field name="model">discuss.channel</field>
         <field name="inherit_id" ref="mail.discuss_channel_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='group_ids']" position="after">
+            <xpath expr="//field[@name='company_ids']" position="after">
                 <field name="subscription_department_ids" widget="many2many_tags"
-                    invisible="channel_type != 'channel'"
-                    string="Auto Subscribe Departments"/>
+                    placeholder="All departments" string="Departments" invisible="not auto_join"/>
             </xpath>
         </field>
     </record>

--- a/addons/mail/data/discuss_channel_data.xml
+++ b/addons/mail/data/discuss_channel_data.xml
@@ -28,6 +28,7 @@
 
         <!-- link group after creating the members to avoid autosubscribe too early -->
         <record model="discuss.channel" id="mail.channel_all_employees">
+            <field name="auto_subscribe">True</field>
             <field name="group_ids" eval="[Command.link(ref('base.group_user'))]"/>
         </record>
 
@@ -38,6 +39,7 @@
 
         <!-- link group after creating the members to avoid autosubscribe too early -->
         <record model="discuss.channel" id="mail.channel_admin">
+            <field name="auto_subscribe">True</field>
             <field name="group_ids" eval="[Command.link(ref('base.group_system'))]"/>
         </record>
     </data>

--- a/addons/mail/data/discuss_channel_data.xml
+++ b/addons/mail/data/discuss_channel_data.xml
@@ -28,6 +28,7 @@
 
         <!-- link group after creating the members to avoid autosubscribe too early -->
         <record model="discuss.channel" id="mail.channel_all_employees">
+            <field name="auto_join">True</field>
             <field name="group_ids" eval="[Command.link(ref('base.group_user'))]"/>
         </record>
 
@@ -38,6 +39,7 @@
 
         <!-- link group after creating the members to avoid autosubscribe too early -->
         <record model="discuss.channel" id="mail.channel_admin">
+            <field name="auto_join">True</field>
             <field name="group_ids" eval="[Command.link(ref('base.group_system'))]"/>
         </record>
     </data>

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -129,11 +129,19 @@ class DiscussChannel(models.Model):
         index=True,
         help="Contains the date and time of the last interesting event that happened in this channel. This updates itself when new message posted.",
     )
+    auto_subscribe = fields.Boolean(
+        string="Auto Subscribe", default=False,
+        help="Auto-subscribe authorized users to this channel. "
+             "Users can leave anytime and won't be re-added automatically.")
     group_ids = fields.Many2many(
         'res.groups', string='Auto Subscription',
-        help="Members of those groups will automatically added as followers. "
-             "Note that they will be able to manage their subscription manually "
-             "if necessary.")
+        help="Restrict auto-subscribe users to the selected groups.")
+    auto_subscribe_company_ids = fields.Many2many(
+        "res.company", string="Companies",
+        help="Restrict auto-subscribe users to the selected companies.")
+    auto_subscribed_partner_ids = fields.Many2many(
+        "res.partner", "auto_subscribed_partners", export_string_translation=False,
+    )
     # access
     uuid = fields.Char('UUID', size=50, default=_generate_random_token, copy=False)
     group_public_id = fields.Many2one('res.groups', string='Authorized Group', compute='_compute_group_public_id', recursive=True, readonly=False, store=True)
@@ -203,12 +211,20 @@ class DiscussChannel(models.Model):
             if len(ch.channel_member_ids) > 2:
                 raise ValidationError(_("A channel of type 'chat' cannot have more than two users."))
 
-    @api.constrains('group_public_id', 'group_ids')
+    @api.constrains("auto_subscribe", "group_public_id", "group_ids")
     def _constraint_group_id_channel(self):
         # sudo: discuss.channel - skipping ACL for constraint, more performant and no sensitive information is leaked
-        failing_channels = self.sudo().filtered(lambda channel: channel.channel_type != 'channel' and (channel.group_public_id or channel.group_ids))
+        failing_channels = self.sudo().filtered(
+            lambda channel: channel.channel_type != "channel" and (
+                channel.group_public_id or channel.auto_subscribe or channel.group_ids
+            ),
+        )
         if failing_channels:
-            raise ValidationError(_("For %(channels)s, channel_type should be 'channel' to have the group-based authorization or group auto-subscription.", channels=', '.join([ch.name for ch in failing_channels])))
+            raise ValidationError(_(
+                "For %(channels)s, channel_type should be 'channel' to have the group-based "
+                "authorization or auto-subscription",
+                channels=[ch.name for ch in failing_channels],
+            ))
 
     # COMPUTE / INVERSE
 
@@ -594,7 +610,9 @@ class DiscussChannel(models.Model):
                         )
                     )
         result = super().write(vals)
-        if vals.get('group_ids'):
+        if {
+            "auto_subscribe", "auto_subscribe_company_ids", "group_ids", "group_public_id",
+        } & set(vals):
             self._subscribe_users_automatically()
         return result
 
@@ -734,7 +752,10 @@ class DiscussChannel(models.Model):
     # ------------------------------------------------------------
 
     def _subscribe_users_automatically(self):
-        if not (new_members_to_create := self._subscribe_users_automatically_get_members()):
+        channels = self.filtered(lambda c: c.auto_subscribe)
+        if not channels:
+            return
+        if not (new_members_to_create := channels._subscribe_users_automatically_get_members()):
             return
         to_create = [
             {"channel_id": channel_id, "partner_id": partner_id}
@@ -743,7 +764,9 @@ class DiscussChannel(models.Model):
         ]
         # sudo: discuss.channel.member - adding member of other users based on channel auto-subscribe
         new_members = self.env["discuss.channel.member"].sudo().create(to_create)
+        auto_subscribed_members = []
         for member, store in new_members._get_member_store_list():
+            auto_subscribed_members.append((member.channel_id.id, member.partner_id.id))
             store.add(member.channel_id, "_store_channel_fields").add(
                 member,
                 lambda res: (
@@ -751,14 +774,23 @@ class DiscussChannel(models.Model):
                     res.attr("unpin_dt"),
                 ),
             )
+        self.env.cr.execute_values("""
+            INSERT INTO auto_subscribed_partners (discuss_channel_id, res_partner_id)
+                 VALUES %s
+            ON CONFLICT DO NOTHING
+            """, auto_subscribed_members,
+        )
 
     def _subscribe_users_automatically_get_members(self):
         """ Return new members per channel ID """
-        return dict(
-            (channel.id,
-             ((channel.group_ids.all_user_ids.partner_id.filtered(lambda p: p.active) - channel.channel_partner_ids).ids))
-                for channel in self
-            )
+        partners_by_channel = {}
+        users = self.env["res.users"].search_fetch([])
+        for channel in self:
+            filtered_users = users.filtered_domain(channel._get_auto_subscribe_domain())
+            if not filtered_users:
+                continue
+            partners_by_channel[channel.id] = filtered_users.partner_id.filtered("active").ids
+        return partners_by_channel
 
     def action_unfollow(self):
         if self.channel_type in self._types_allowing_unfollow():
@@ -904,6 +936,22 @@ class DiscussChannel(models.Model):
                     # sudo: discuss.channel.rtc.session - current user can invite new members in call
                     channel.self_member_id.sudo()._rtc_invite_members(member_ids=new_members.ids)
         return all_new_members
+
+    def _get_auto_subscribe_domain(self):
+        joined_partners = self.channel_member_ids.partner_id | self.auto_subscribed_partner_ids
+        user_domain = Domain([
+            ("active", "=", True),
+            ("partner_id", "not in", joined_partners.ids),
+        ])
+        # sudo: res_company - can access all companies for auto-subscribing
+        company_ids = self.sudo().auto_subscribe_company_ids.ids
+        if self.group_public_id:
+            user_domain &= Domain("all_group_ids", "in", self.group_public_id.ids)
+        if company_ids:
+            user_domain &= Domain("company_ids", "in", company_ids)
+        if self.group_ids:
+            user_domain &= Domain("all_group_ids", "in", self.group_ids.ids)
+        return user_domain
 
     def _get_member_join_notification(self, member):
         if member.is_self:

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -112,11 +112,14 @@ class DiscussChannel(models.Model):
         index=True,
         help="Contains the date and time of the last interesting event that happened in this channel. This updates itself when new message posted.",
     )
+    auto_join = fields.Boolean(string="Auto Join", default=False)
     group_ids = fields.Many2many(
         'res.groups', string='Auto Subscription',
         help="Members of those groups will automatically added as followers. "
              "Note that they will be able to manage their subscription manually "
              "if necessary.")
+    company_ids = fields.Many2many("res.company", string="Companies")
+    auto_joined_partner_ids = fields.Many2many("res.partner", "auto_joined_partners")
     # access
     uuid = fields.Char('UUID', size=50, default=_generate_random_token, copy=False)
     group_public_id = fields.Many2one('res.groups', string='Authorized Group', compute='_compute_group_public_id', recursive=True, readonly=False, store=True)
@@ -186,12 +189,21 @@ class DiscussChannel(models.Model):
             if len(ch.channel_member_ids) > 2:
                 raise ValidationError(_("A channel of type 'chat' cannot have more than two users."))
 
-    @api.constrains('group_public_id', 'group_ids')
+    @api.constrains("group_public_id", "auto_join", "group_ids")
     def _constraint_group_id_channel(self):
         # sudo: discuss.channel - skipping ACL for constraint, more performant and no sensitive information is leaked
-        failing_channels = self.sudo().filtered(lambda channel: channel.channel_type != 'channel' and (channel.group_public_id or channel.group_ids))
+        failing_channels = self.sudo().filtered(
+            lambda channel: channel.channel_type != "channel" and (
+                channel.group_public_id or channel.auto_join or channel.group_ids
+            ),
+        )
         if failing_channels:
-            raise ValidationError(_("For %(channels)s, channel_type should be 'channel' to have the group-based authorization or group auto-subscription.", channels=', '.join([ch.name for ch in failing_channels])))
+            raise ValidationError(
+                _(
+                    "For %(channels)s, channel_type should be 'channel' to have the group-based authorization or auto-join or groups",
+                    channels=', '.join([ch.name for ch in failing_channels]),
+                ),
+            )
 
     # COMPUTE / INVERSE
 
@@ -547,7 +559,7 @@ class DiscussChannel(models.Model):
                         )
                     )
         result = super().write(vals)
-        if vals.get('group_ids'):
+        if {"auto_join", "company_ids", "group_ids", "group_public_id"} & set(vals):
             self._subscribe_users_automatically()
         return result
 
@@ -569,7 +581,10 @@ class DiscussChannel(models.Model):
     # ------------------------------------------------------------
 
     def _subscribe_users_automatically(self):
-        if not (new_members_to_create := self._subscribe_users_automatically_get_members()):
+        channels = self.filtered(lambda c: c.auto_join)
+        if not channels:
+            return
+        if not (new_members_to_create := channels._subscribe_users_automatically_get_members()):
             return
         to_create = [
             {"channel_id": channel_id, "partner_id": partner_id}
@@ -579,7 +594,9 @@ class DiscussChannel(models.Model):
         # sudo: discuss.channel.member - adding member of other users based on channel auto-subscribe
         new_members = self.env["discuss.channel.member"].sudo().create(to_create)
         stores = Store.Stores()
+        auto_joined_members = []
         for member, store in new_members._get_member_store_list(stores):
+            auto_joined_members.append((member.channel_id.id, member.partner_id.id))
             store.add(member.channel_id, "_store_channel_fields").add(
                 member,
                 lambda res: (
@@ -588,14 +605,23 @@ class DiscussChannel(models.Model):
                 ),
             )
         stores.bus_send()
+        self.env.cr.execute_values("""
+            INSERT INTO auto_joined_partners (discuss_channel_id, res_partner_id)
+                 VALUES %s
+            ON CONFLICT DO NOTHING
+            """, auto_joined_members,
+        )
 
     def _subscribe_users_automatically_get_members(self):
         """ Return new members per channel ID """
-        return dict(
-            (channel.id,
-             ((channel.group_ids.all_user_ids.partner_id.filtered(lambda p: p.active) - channel.channel_partner_ids).ids))
-                for channel in self
-            )
+        partners_by_channel = {}
+        users = self.env["res.users"].search_fetch([], ["partner_id"])
+        for channel in self:
+            filtered_users = users.filtered_domain(channel._get_auto_subscribe_domain())
+            if not filtered_users:
+                continue
+            partners_by_channel[channel.id] = filtered_users.partner_id.ids
+        return partners_by_channel
 
     def action_unfollow(self):
         if self.channel_type in self._types_allowing_unfollow():
@@ -730,6 +756,27 @@ class DiscussChannel(models.Model):
                     # sudo: discuss.channel.rtc.session - current user can invite new members in call
                     channel.self_member_id.sudo()._rtc_invite_members(member_ids=new_members.ids)
         return all_new_members
+
+    def _get_auto_subscribe_domain(self):
+        joined_partners = self.channel_member_ids.partner_id | self.auto_joined_partner_ids
+        user_domain = Domain([
+            ("partner_id.active", "=", True),
+            ("partner_id", "not in", joined_partners.ids),
+        ])
+        # sudo: res_company - can access all companies for auto-subscribing
+        company_ids = self.sudo().company_ids.ids
+        if self.group_public_id:
+            user_domain &= Domain("all_group_ids", "in", self.group_public_id.ids)
+        if company_ids:
+            user_domain &= Domain("company_ids", "in", company_ids)
+        user_domain &= self._get_extra_domain()
+        return user_domain
+
+    def _get_extra_domain(self):
+        domain = Domain(True)
+        if self.group_ids:
+            domain &= Domain("all_group_ids", "in", self.group_ids.ids)
+        return domain
 
     def _get_member_join_notification(self, member):
         if member.is_self:

--- a/addons/mail/models/discuss/res_groups.py
+++ b/addons/mail/models/discuss/res_groups.py
@@ -9,5 +9,9 @@ class ResGroups(models.Model):
     def write(self, vals):
         res = super().write(vals)
         if vals.get("user_ids"):
-            self.env["discuss.channel"].search([("group_ids", "in", self.all_implied_ids._ids)])._subscribe_users_automatically()
+            self.env["discuss.channel"].search([
+                ("auto_join", "=", True),
+                "|", ("group_ids", "in", self.all_implied_ids._ids),
+                ("group_public_id", "in", self.all_implied_ids._ids),
+            ])._subscribe_users_automatically()
         return res

--- a/addons/mail/models/discuss/res_groups.py
+++ b/addons/mail/models/discuss/res_groups.py
@@ -9,5 +9,9 @@ class ResGroups(models.Model):
     def write(self, vals):
         res = super().write(vals)
         if vals.get("user_ids"):
-            self.env["discuss.channel"].search([("group_ids", "in", self.all_implied_ids._ids)])._subscribe_users_automatically()
+            self.env["discuss.channel"].search_fetch([
+                ("auto_subscribe", "=", True),
+                "|", ("group_ids", "in", self.all_implied_ids._ids),
+                ("group_public_id", "in", self.all_implied_ids._ids),
+            ])._subscribe_users_automatically()
         return res

--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -13,19 +13,29 @@ class ResUsers(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         users = super().create(vals_list)
-        self.env["discuss.channel"].search([("group_ids", "in", users.all_group_ids.ids)])._subscribe_users_automatically()
+        self.env["discuss.channel"].search_fetch([
+            ("auto_subscribe", "=", True),
+        ])._subscribe_users_automatically()
         return users
 
     def write(self, vals):
         res = super().write(vals)
         if "active" in vals and not vals["active"]:
             self._unsubscribe_from_non_public_channels(reset_role=True)
-        if vals.get("group_ids"):
-            # form: {'group_ids': [(3, 10), (3, 3), (4, 10), (4, 3)]} or {'group_ids': [(6, 0, [ids]}
-            user_group_ids = [command[1] for command in vals["group_ids"] if command[0] == 4]
-            user_group_ids += [id for command in vals["group_ids"] if command[0] == 6 for id in command[2]]
-            user_group_ids = self.env['res.groups'].browse(user_group_ids).all_implied_ids._ids
-            self.env["discuss.channel"].search([("group_ids", "in", user_group_ids)])._subscribe_users_automatically()
+        if {"company_ids", "group_ids"} & vals.keys():
+            domain = Domain("auto_subscribe", "=", True)
+            if vals.get("company_ids"):
+                domain &= Domain("auto_subscribe_company_ids", "in", self.company_ids.ids)
+            if vals.get("group_ids"):
+                # form: {'group_ids': [(3, 10), (3, 3), (4, 10), (4, 3)]} or {'group_ids': [(6, 0, [ids]}
+                user_group_ids = [command[1] for command in vals["group_ids"] if command[0] == 4]
+                user_group_ids += [id for command in vals["group_ids"] if command[0] == 6 for id in command[2]]
+                user_group_ids = self.env['res.groups'].browse(user_group_ids).all_implied_ids._ids
+                domain &= Domain.OR([
+                    [("group_public_id", "in", user_group_ids)],
+                    [("group_ids", "in", user_group_ids)],
+                ])
+            self.env["discuss.channel"].search_fetch(domain)._subscribe_users_automatically()
         return res
 
     def unlink(self):

--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -13,7 +13,9 @@ class ResUsers(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         users = super().create(vals_list)
-        self.env["discuss.channel"].search([("group_ids", "in", users.all_group_ids.ids)])._subscribe_users_automatically()
+        self.env["discuss.channel"].search([
+            ("auto_join", "=", True),
+        ])._subscribe_users_automatically()
         return users
 
     def write(self, vals):
@@ -25,7 +27,15 @@ class ResUsers(models.Model):
             user_group_ids = [command[1] for command in vals["group_ids"] if command[0] == 4]
             user_group_ids += [id for command in vals["group_ids"] if command[0] == 6 for id in command[2]]
             user_group_ids = self.env['res.groups'].browse(user_group_ids).all_implied_ids._ids
-            self.env["discuss.channel"].search([("group_ids", "in", user_group_ids)])._subscribe_users_automatically()
+            self.env["discuss.channel"].search([
+                ("auto_join", "=", True),
+                "|", ("group_public_id", "in", user_group_ids),
+                ("group_ids", "in", user_group_ids),
+            ])._subscribe_users_automatically()
+        if vals.get("company_ids"):
+            self.env["discuss.channel"].search([
+                ("auto_join", "=", True), ("company_ids", "in", self.company_ids.ids),
+            ])._subscribe_users_automatically()
         return res
 
     def unlink(self):

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -9,6 +9,7 @@ from . import test_discuss_action
 from . import test_discuss_channel
 from . import test_discuss_channel_access
 from . import test_discuss_channel_as_guest
+from . import test_discuss_channel_auto_subscribe
 from . import test_discuss_channel_last_interest
 from . import test_discuss_channel_member
 from . import test_discuss_channel_readonly

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -9,6 +9,7 @@ from . import test_discuss_action
 from . import test_discuss_channel
 from . import test_discuss_channel_access
 from . import test_discuss_channel_as_guest
+from . import test_discuss_channel_auto_join
 from . import test_discuss_channel_member
 from . import test_discuss_channel_readonly
 from . import test_discuss_mail_presence

--- a/addons/mail/tests/discuss/test_discuss_channel_auto_join.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_auto_join.py
@@ -1,0 +1,93 @@
+from odoo import Command
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.tests import TransactionCase
+
+
+class TestChannelAutoJoin(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.group_user = cls.env.ref("base.group_user")
+        cls.group_admin = cls.env.ref("base.group_system")
+        cls.user_admin = cls.env.ref('base.user_admin')
+        cls.company_a, cls.company_b = cls.env["res.company"].create([
+            {"name": "Company A"}, {"name": "Company B"},
+        ])
+        cls.user_a = mail_new_test_user(
+            cls.env,
+            login='User A',
+            company_id=cls.company_a.id,
+            groups="base.group_system",
+        )
+        cls.user_b = mail_new_test_user(
+            cls.env,
+            login='User B',
+            company_id=cls.company_b.id,
+            groups="base.group_user",
+        )
+        cls.both_partners = cls.user_a.partner_id | cls.user_b.partner_id
+        cls.all_partners = cls.user_admin.partner_id | cls.both_partners
+
+    def test_channel_auto_join_all_users(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test all auto join",
+            "auto_join": True,
+        })
+        self.assertEqual(channel.channel_partner_ids, self.all_partners)
+
+    def test_channel_company_auto_join(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test company auto join",
+            "auto_join": True,
+            "company_ids": [Command.link(self.company_a.id)],
+        })
+        self.assertEqual(channel.channel_partner_ids, self.user_a.partner_id)
+
+        channel.write({"company_ids": [Command.link(self.company_b.id)]})
+        self.assertEqual(
+            channel.channel_partner_ids, self.both_partners,
+        )
+
+    def test_channel_group_auto_join(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test group auto join",
+            "auto_join": True,
+            "group_ids": [Command.link(self.group_admin.id)],
+        })
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id | self.user_a.partner_id,
+        )
+        channel.write({"group_ids": [Command.link(self.group_user.id)]})
+        self.assertEqual(channel.channel_partner_ids, self.all_partners)
+
+    def test_channel_company_group_auto_join(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test company group auto join",
+            "auto_join": True,
+            "company_ids": [Command.link(self.company_a.id)],
+            "group_ids": [Command.link(self.group_user.id)],
+        })
+        # only users of 'Company A' who belong to group 'Role / User' should be joined.
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_a.partner_id,
+        )
+
+    def test_user_auto_join_only_once(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test group auto join",
+            "auto_join": True,
+            "group_ids": [Command.link(self.group_admin.id)],
+        })
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id | self.user_a.partner_id,
+        )
+        # 'User A' leaves the channel
+        channel.with_user(self.user_a).action_unfollow()
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id,
+        )
+        channel.write({"group_ids": [Command.link(self.group_user.id)]})
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id | self.user_b.partner_id,
+        )
+        self.assertNotIn(self.user_a.partner_id, channel.channel_partner_ids)

--- a/addons/mail/tests/discuss/test_discuss_channel_auto_subscribe.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_auto_subscribe.py
@@ -1,0 +1,93 @@
+from odoo import Command
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.tests import TransactionCase
+
+
+class TestChannelAutoSubscribe(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.group_user = cls.env.ref("base.group_user")
+        cls.group_admin = cls.env.ref("base.group_system")
+        cls.user_admin = cls.env.ref('base.user_admin')
+        cls.company_a, cls.company_b = cls.env["res.company"].create([
+            {"name": "Company A"}, {"name": "Company B"},
+        ])
+        cls.user_a = mail_new_test_user(
+            cls.env,
+            login='User A',
+            company_id=cls.company_a.id,
+            groups="base.group_system",
+        )
+        cls.user_b = mail_new_test_user(
+            cls.env,
+            login='User B',
+            company_id=cls.company_b.id,
+            groups="base.group_user",
+        )
+        cls.both_partners = cls.user_a.partner_id | cls.user_b.partner_id
+        cls.all_partners = cls.user_admin.partner_id | cls.both_partners
+
+    def test_channel_auto_subscribe_all_users(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test all auto subscribe",
+            "auto_subscribe": True,
+        })
+        self.assertEqual(channel.channel_partner_ids, self.all_partners)
+
+    def test_channel_company_auto_subscribe(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test company auto subscribe",
+            "auto_subscribe": True,
+            "auto_subscribe_company_ids": [Command.link(self.company_a.id)],
+        })
+        self.assertEqual(channel.channel_partner_ids, self.user_a.partner_id)
+
+        channel.write({"auto_subscribe_company_ids": [Command.link(self.company_b.id)]})
+        self.assertEqual(
+            channel.channel_partner_ids, self.both_partners,
+        )
+
+    def test_channel_group_auto_subscribe(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test group auto subscribe",
+            "auto_subscribe": True,
+            "group_ids": [Command.link(self.group_admin.id)],
+        })
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id | self.user_a.partner_id,
+        )
+        channel.write({"group_ids": [Command.link(self.group_user.id)]})
+        self.assertEqual(channel.channel_partner_ids, self.all_partners)
+
+    def test_channel_company_group_auto_subscribe(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test company group auto subscribe",
+            "auto_subscribe": True,
+            "auto_subscribe_company_ids": [Command.link(self.company_a.id)],
+            "group_ids": [Command.link(self.group_user.id)],
+        })
+        # only users of 'Company A' who belong to group 'Role / User' should be subscribed.
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_a.partner_id,
+        )
+
+    def test_user_auto_subscribed_only_once(self):
+        channel = self.env["discuss.channel"].create({
+            "name": "Test user auto subscribed only once",
+            "auto_subscribe": True,
+            "group_ids": [Command.link(self.group_admin.id)],
+        })
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id | self.user_a.partner_id,
+        )
+        # 'User A' leaves the channel
+        channel.with_user(self.user_a).action_unfollow()
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id,
+        )
+        channel.write({"group_ids": [Command.link(self.group_user.id)]})
+        self.assertEqual(
+            channel.channel_partner_ids, self.user_admin.partner_id | self.user_b.partner_id,
+        )
+        self.assertNotIn(self.user_a.partner_id, channel.channel_partner_ids)

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -103,12 +103,16 @@
                                 </field>
                             </page>
                             <page string="Privacy" name="privacy" invisible="channel_type != 'channel'">
-                                <group class="o_label_nowrap">
-                                    <field name="group_public_id"
-                                        invisible="channel_type != 'channel' or parent_channel_id" readonly="not is_editable"/>
-                                    <field name="group_ids" widget="many2many_tags"
-                                        invisible="channel_type != 'channel'"
-                                        string="Auto Subscribe Groups" readonly="not is_editable"/>
+                                <group string="Channel Visibility" invisible="parent_channel_id">
+                                    <field name="group_public_id" placeholder="Public - anyone with the link can access"
+                                        readonly="not is_editable"/>
+                                </group>
+                                <group string="Auto-Subscribe Rules">
+                                    <field name="auto_subscribe" string="Auto-Subscribe to channel"/>
+                                    <field name="auto_subscribe_company_ids" widget="many2many_tags" placeholder="All companies"
+                                        string="Companies" readonly="not is_editable" invisible="not auto_subscribe"/>
+                                    <field name="group_ids" widget="many2many_tags" placeholder="All groups"
+                                        string="Groups" readonly="not is_editable" invisible="not auto_subscribe"/>
                                 </group>
                             </page>
                             <page string="Extra info" name="extra_info" groups="base.group_no_one">

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -103,12 +103,17 @@
                                 </field>
                             </page>
                             <page string="Privacy" name="privacy" invisible="channel_type != 'channel'">
-                                <group class="o_label_nowrap">
-                                    <field name="group_public_id"
-                                        invisible="channel_type != 'channel' or parent_channel_id" readonly="not is_editable"/>
-                                    <field name="group_ids" widget="many2many_tags"
-                                        invisible="channel_type != 'channel'"
-                                        string="Auto Subscribe Groups" readonly="not is_editable"/>
+                                <group string="Channel Visibility" invisible="parent_channel_id">
+                                    <field name="group_public_id" placeholder="Public - anyone with the link can access"
+                                        readonly="not is_editable"/>
+                                </group>
+                                <group string="Auto-Join Rules">
+                                        <field name="auto_join" string="Auto-Join channel"/>
+                                        <field name="company_ids" widget="many2many_tags" placeholder="All companies"
+                                                string="Companies" readonly="not is_editable" invisible="not auto_join"/>
+                                        <field name="group_ids" widget="many2many_tags" placeholder="All groups"
+                                                string="Groups" domain="[('all_implied_ids', 'in', group_public_id)]"
+                                                readonly="not is_editable" invisible="not auto_join"/>
                                 </group>
                             </page>
                             <page string="Extra info" name="extra_info" groups="base.group_no_one">

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -602,8 +602,8 @@ class TestUsers2(UsersCommonCase):
         # Process any tracking message at flush for cleaner queryCount
         self.flush_tracking()
 
-        # all modules: 37, base: 9; nightly: +1
-        with self.assertQueryCount(38):
+        # all modules: 41, base: 9; nightly: +1
+        with self.assertQueryCount(42):
             self.user_internal.write({
                 "group_ids": [Command.link(contact_creation_group.id)],
             })


### PR DESCRIPTION
**Current behavior before PR,**
We could only auto-subscribe users based on their groups or a department of
their related employee. this was often too broad, making the feature less
effective.

**Desired behavior after PR is merged,**
It is now possible to subscribe users by company, which also works in
combination with groups and departments.

we also track users added via auto-subscribe to ensure they are not re-added if
they have already left the channel.

additionally, we added an 'Auto-Subscribe' checkbox under the 'Channel Visibility'
section which is disabled by default, related fields only appear when
'Auto-Subscribe' is enabled.

when active, all authorized users are subscribed by default.

enterprise: https://github.com/odoo/enterprise/pull/117048
upgrade: odoo/upgrade#9436
upgrade-util: odoo/upgrade-util#416

task-4804991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
