### PR TITLE
[IMP] html_editor: make buttonShapeData labels translatable

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -77,13 +77,13 @@ export class LinkPopover extends Component {
         { style: "double", label: "═══" },
     ];
     buttonShapeData = [
-        { shape: "", label: "Default" },
-        { shape: "rounded-circle", label: "Default + Rounded" },
-        { shape: "outline", label: "Outline" },
-        { shape: "outline rounded-circle", label: "Outline + Rounded" },
-        { shape: "fill", label: "Fill" },
-        { shape: "fill rounded-circle", label: "Fill + Rounded" },
-        { shape: "flat", label: "Flat" },
+        { shape: "", label: _t("Default") },
+        { shape: "rounded-circle", label: _t("Default + Rounded") },
+        { shape: "outline", label: _t("Outline") },
+        { shape: "outline rounded-circle", label: _t("Outline + Rounded") },
+        { shape: "fill", label: _t("Fill") },
+        { shape: "fill rounded-circle", label: _t("Fill + Rounded") },
+        { shape: "flat", label: _t("Flat") },
     ];
     setup() {
         this.ui = useService("ui");


### PR DESCRIPTION
Button shape labels are currently not translatable, even though buttonSizesData and colorsData already support translations. Shape labels vary across languages, and keeping them hardcoded in English makes the UI confusing and frustrating for non-English users. Several of our customers have explicitly requested that these labels be translatable.

I initially attempted to handle this through l10n addons, but the required effort and maintenance overhead were significantly higher than simply marking the strings as translatable. For this reason, I opened this pull request to address the issue at the source.

By wrapping these labels with the _t(...) function, they can be exported normally through the translation workflow, allowing translators to provide appropriate, language-specific terms.

I hope this improvement is useful and will be considered for inclusion. Thank you for your time and review.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
