### PR TITLE
[FIX] account: Add Filter to support selecting multiple journals

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -341,6 +341,7 @@
                     <filter string="Bank" name="bank" domain="[('journal_id.type', '=', 'bank')]" context="{'default_journal_type': 'bank'}"/>
                     <filter string="Cash" name="cash" domain="[('journal_id.type', '=', 'cash')]" context="{'default_journal_type': 'cash'}"/>
                     <filter string="Miscellaneous" domain="[('journal_id.type', '=', 'general')]" name="misc_filter" context="{'default_journal_type': 'general'}"/>
+                    <filter string="Journals" name="journal_ids" domain="[('journal_id', 'in', context.get('journal_ids'))]" invisible="not context.get('journal_ids')"/>
                     <separator/>
                     <filter string="Payable" domain="[('account_id.account_type', '=', 'liability_payable'), ('account_id.non_trade', '=', False)]" help="From Trade Payable accounts" name="trade_payable"/>
                     <filter string="Receivable" domain="[('account_id.account_type', '=', 'asset_receivable'), ('account_id.non_trade', '=', False)]" help="From Trade Receivable accounts" name="trade_receivable"/>


### PR DESCRIPTION
In accounting reports, we want to be able to filter on multiples journals if needed. This filter will allow us to do this.

Using `context['search_default_journal_id'] = journal_ids` doesn't work as only the first id is passed to the filter.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
