### PR TITLE
[FIX] html_builder: avoid loading panel content before opening it

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.js
@@ -34,6 +34,7 @@ export class BuilderSlidingPanel extends Component {
         this.openButtonRef = useRef("openButton");
         this.state = useState({
             optionContainerName: "",
+            displayClass: "d-none",
         });
         onMounted(() => {
             this.optionsContainerEls = document.querySelectorAll("div.options-container");
@@ -48,7 +49,7 @@ export class BuilderSlidingPanel extends Component {
             }
         });
         useHotkey("escape", this.hideSlidingPanel.bind(this), {
-            isAvailable: () => !this.slidingPanelRef.el.classList.contains("d-none"),
+            isAvailable: () => this.state.displayClass !== "d-none",
         });
         onWillUnmount(() => {
             clearTimeout(this.updateDisplayTimeout);
@@ -56,31 +57,19 @@ export class BuilderSlidingPanel extends Component {
         });
     }
 
-    updateDisplay(className) {
-        const slidingPanelEl = this.slidingPanelRef.el;
-        if (!slidingPanelEl) {
-            return;
-        }
-        slidingPanelEl.classList.remove(
-            "d-none",
-            "d-block",
-            "hb-panel-slide-in",
-            "hb-panel-slide-out"
-        );
-        slidingPanelEl.classList.add(className);
-    }
-
     showSlidingPanel() {
-        this.updateDisplay("hb-panel-slide-in");
-        this.updateDisplayTimeout = setTimeout(() => this.updateDisplay("d-block"), 200);
+        clearTimeout(this.updateDisplayTimeout);
+        this.state.displayClass = "hb-panel-slide-in";
+        this.updateDisplayTimeout = setTimeout(() => (this.state.displayClass = "d-block"), 200);
     }
 
     hideSlidingPanel() {
-        this.updateDisplay("hb-panel-slide-out");
+        clearTimeout(this.updateDisplayTimeout);
+        this.state.displayClass = "hb-panel-slide-out";
         // We set a timeout slightly shorter than 200 because some flicker may
         // happen otherwise.
         this.updateDisplayTimeout = setTimeout(() => {
-            this.updateDisplay("d-none");
+            this.state.displayClass = "d-none";
             this.openButtonRef.el.focus();
         }, 180);
     }

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.xml
@@ -10,9 +10,9 @@
         <t t-out="props.textContent"/>
     </button>
     <div t-ref="slidingPanel"
-        class="hb-sliding-panel mb-1 h-100 d-none"
+        class="hb-sliding-panel mb-1 h-100"
         t-on-click="onBackdropClick"
-        t-att-class="{'hb-sliding-panel-dark': props.darkBackground}"
+        t-att-class="state.displayClass + ( props.darkBackground ? ' hb-sliding-panel-dark' : '' )"
     >
         <div class="hb-sliding-panel-content d-flex flex-column" t-att-class="props.fullHeight ? 'h-100' : 'pb-3'">
             <div class="hb-sliding-panel-header">
@@ -23,7 +23,7 @@
                     </button>
                 </div>
             </div>
-            <t t-slot="default" close="this.hideSlidingPanel.bind(this)"/>
+            <t t-if="state.displayClass !== 'd-none'" t-slot="default" close="this.hideSlidingPanel.bind(this)"/>
         </div>
     </div>
 </t>


### PR DESCRIPTION
This commit introduce the state "displayClass" to simplify the code of the builder sliding panel. It also uses this new state to prevent loading the content of the panel while it is not opened.
