### PR TITLE
[FIX] l10n_hu_edi: ensure softwareId meets NAV 18-character requirement

### DIFF
--- a/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
+++ b/addons/l10n_hu_edi/models/l10n_hu_edi_connection.py
@@ -366,7 +366,7 @@ class L10nHuEdiConnection:
             'passwordHash': self._calculate_password_hash(credentials['password']),
             'taxNumber': credentials['vat'][:8],
             'requestSignature': request_signature,
-            'softwareId': f'BE477472701-{module_version}'[:18],
+            'softwareId': f'BE477472701-{module_version}'.ljust(18, '0')[:18],
             'softwareName': 'Odoo Enterprise',
             'softwareOperation': 'ONLINE_SERVICE',
             'softwareMainVersion': odoo_version,


### PR DESCRIPTION
**Steps to reproduce:**
* Create a **Hungarian** database with **Accounting** or **Invoicing**.
* Set a valid **VAT number** on the company.
* Configure **NAV credentials** in **production mode**. (use credentials from ticket)
* Try to save the Settings.

**Observed behavior:**
* Authentication fails with error: `INVALID_REQUEST: Helytelen kérés!`
* NAV returns schema violation: `Value 'BE477472701-19110' is not facet-valid with respect to pattern '[0-9A-Z\-]{18}' for type 'SoftwareIdType'.`
* The softwareId is only 17 characters instead of required 18.

**Cause:**
* The `version` parameter was removed from the module manifest by this [commit](https://github.com/odoo/odoo/commit/717619571d1297d6b299b7c47b728841bcd81e69#diff-d96ba04bb478d9dcbade7b9bf9f07305d42a38ce7a906f3387879271cde35fecL7)
* This change shortened the module version string used to build the `softwareId`.
* Truncating the value to 18 characters therefore produced a string shorter than required.
* The NAV API requires the `softwareId` to be **exactly 18 characters**.

**Fix:**
* Pad the generated `softwareId` to **18 characters** using `ljust(18, '0')`.
* Ensures the value always complies with NAV schema validation rules.

opw-5902414