### PR TITLE
[IMP] point_of_sale, pos_*: revamp control buttons in Actions modal

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.scss
@@ -1,11 +1,75 @@
-.control-buttons-modal {
-    grid-template-columns: repeat(3, 1fr);
-
+.modal-dialog:has(.control-button:nth-child(10)){
     @include media-breakpoint-down(lg) {
-        grid-template-columns: repeat(2, 1fr);
+        @media (orientation: landscape) {
+            --modal-width: 80vw;
+        }
+    }
+}
+
+.control-buttons-modal {
+    grid-template-columns: repeat(var(--grid-columns, 1), 1fr);
+    
+    .control-button {
+        aspect-ratio: var(--controlButton-aspectRatio, auto);
+        
+        &:last-child {
+            --controlButton-aspectRatio: auto;
+        }
+
+        .o_guests_number {
+            
+            @include media-breakpoint-down(md) {
+                font-size: map-get($font-sizes, 6);
+            }
+        }
     }
 
-    @include media-breakpoint-down(sm) {
-        grid-template-columns: 1fr;
+    // Handle button layout and size based on the number of buttons and screen orientation
+    @include media-breakpoint-up(md) {
+        --controlButton-aspectRatio: 1.1;
+        
+        @media (orientation: portrait) {
+            --grid-columns: 3;
+        }
+
+        @media (orientation: landscape) {
+            --grid-columns: 4;  
+
+            @media (max-height: 940px) {
+                --controlButton-aspectRatio: 1.5;
+            }
+
+            &:has(.control-button:nth-child(10)):not(:has(.control-button:nth-child(11))){
+                --controlButton-aspectRatio: 1.5;
+            }
+        }
+        
+        &:has(.control-button:nth-child(9)):not(:has(.control-button:nth-child(11))) {
+                --grid-columns: 3;
+                
+                @media (max-height: 940px) {
+                    --controlButton-aspectRatio: 1.5;
+                }
+                
+                @media (max-height: 600px) {
+                    --controlButton-aspectRatio: 2;
+                }
+        }
+        
+        // When there are 10 or 13 buttons, the last button is alone on the last row (and should always be the Cancel button)
+        // so we make it take up the whole width of the grid, adapt the aspect ratio and place the icon next to the text
+        &:has(.control-button:nth-child(10)):not(:has(.control-button:nth-child(11))), 
+        &:has(.control-button:nth-child(13)):not(:has(.control-button:nth-child(14))) {
+            .control-button:last-child {
+                --controlButton-aspectRatio: auto;
+                --oi-font-size: 1.5rem;
+                
+                grid-column: 1 / -1;
+                flex-direction: row !important;
+                align-items: center !important;
+                gap: map-get($spacers, 2);
+                height: 5rem;
+            }
+        }
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -1,63 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.controlButton">
+        <button 
+        t-attf-class="control-button btn btn-lg {{btnClasses ? btnClasses : ''}} d-inline-flex flex-md-column justify-content-md-center gap-1 overflow-hidden"
+        t-on-click="onClick"
+        t-att-disabled="disabled ? 'disabled' : ''">
+            <i t-if="iconClasses" t-attf-class="{{iconClasses}} {{!this.ui.isSmall ? ' fa-2x fa-fw' : ''}} align-self-center opacity-50" role="img" aria-hidden="true"/>
+            <t t-if="badge" t-out="badge"/>
+            <span t-attf-class="d-flex flex-md-column flex-grow-1 flex-md-grow-0 align-items-center align-items-md-stretch min-w-0 {{this.ui.isSmall ? ' lh-sm' : ''}} text-start text-md-center">
+                <span class="px-1" t-esc="btnText"/>
+                <t t-if="subText" t-out="subText"/>
+            </span>
+        </button>
+    </t>
     <t t-name="point_of_sale.ControlButtons">
         <!-- All buttons always displayed -->
-        <SelectPartnerButton partner="this.partner" t-if="!this.props.showRemainingButtons"/>
-        <t t-if="!this.props.showRemainingButtons || (this.ui.isSmall and this.props.showRemainingButtons)">
-            <InternalNoteButton label.translate="Note" class="this.buttonClass"/>
+        <t t-if="!this.props.showRemainingButtons">
+            <SelectPartnerButton partner="this.partner"/>
+            <InternalNoteButton label.translate="Note" class="'btn-secondary '"/>
+            <button 
+                t-if="this.pos.config.use_presets"
+                class="btn btn-secondary btn-lg flex-shrink-0 border-0 lh-lg text-truncate"
+                t-attf-class="{{this.currentOrder.preset_id?.color and `o_colorlist_item_color_${this.currentOrder.preset_id?.color}`}}"
+                t-on-click="() => this.pos.selectPreset()">
+                <span t-if="this.currentOrder.preset_id?.name" t-out="this.currentOrder.preset_id?.name" />
+                <span t-else="">Preset</span>
+            </button>
+            <button t-if="!this.ui.isSmall and this.pos.showSaveOrderButton" t-att-disabled="this.pos.getOrder().isEmpty()" t-attf-class="{{ buttonClass }} ms-auto" t-on-click="() => this.pos.clickSaveOrder()">
+                <i class="fa fa-upload" aria-hidden="true"/>
+            </button>
+            <button t-if="!this.ui.isSmall and this.props.onClickMore" class="more-btn btn btn-secondary btn-lg flex-shrink-0 ms-auto lh-lg" t-on-click="this.props.onClickMore">
+                <i class="oi oi-fw oi-ellipsis-v" aria-hidden="true" />
+            </button>
         </t>
-        <button t-if="this.pos.config.use_presets and !this.props.showRemainingButtons"
-            class="btn btn-secondary btn-lg border-0 text-truncate"
-            t-attf-class="{{this.currentOrder.preset_id?.color and `o_colorlist_item_color_${this.currentOrder.preset_id?.color}`}}"
-            t-on-click="() => this.pos.selectPreset()">
-            <span t-if="this.currentOrder.preset_id?.name" t-out="this.currentOrder.preset_id?.name" />
-            <span t-else="">Preset</span>
-        </button>
-        <button t-if="!this.props.showRemainingButtons and !this.ui.isSmall and this.pos.showSaveOrderButton" t-att-disabled="this.pos.getOrder().isEmpty()" t-attf-class="{{ this.buttonClass }} ms-auto" t-on-click="() => this.pos.clickSaveOrder()">
-            <i class="fa fa-upload"/>
-        </button>
-        <button class="btn btn-secondary btn-lg flex-shrink-0 more-btn" t-att-class="{'ms-auto': !this.pos.showSaveOrderButton}" t-if="!this.props.showRemainingButtons and !this.ui.isSmall and this.props.onClickMore" t-on-click="this.props.onClickMore">
-            <i class="oi oi-fw oi-ellipsis-v" aria-hidden="true" />
-        </button>
         <!-- All these buttons will only be displayed in a dialog -->
         <t t-if="this.props.showRemainingButtons">
-            <div class="control-buttons control-buttons-modal d-grid gap-2 mt-2">
+            <div class="control-buttons control-buttons-modal d-grid grid-auto-flow-columns gap-2">
+                <t t-if="(this.ui.isSmall and this.props.showRemainingButtons)">
+                    <InternalNoteButton label.translate="Note" class="'btn-secondary '"/>
+                </t>
                 <NoteButton
                     label.translate="Customer Note"
-                    class="this.buttonClass"
+                    class="'btn-secondary '"
                     icon="'fa fa-sticky-note'"/>
-                <button t-if="this.pos.config.iface_printbill" t-att-class="this.buttonClass"
-                    t-att-disabled="!this.pos.getOrder()?.getOrderlines()?.length"
-                    t-on-click="this.clickPrintBill">
-                    <i class="fa fa-print me-1"></i>Bill
-                </button>
-                <button t-if="this.pos.cashier._role != 'minimal'" class="o_pricelist_button" t-att-class="this.buttonClass" t-on-click="() => this.clickPricelist()">
-                    <i class="fa fa-th-list me-2" role="img" aria-label="Price list" title="Price list" />
-                    <t t-if="this.currentOrder?.pricelist_id" t-out="this.currentOrder.pricelist_id.display_name" />
-                    <t t-else="">Pricelist</t>
-                </button>
-                <button t-if="this.pos.config.fiscal_position_ids.length and this.pos.cashier._role != 'minimal'"
-                    class="control-button o_fiscal_position_button"
-                    t-att-class="this.buttonClass"
-                    t-on-click="() => this.clickFiscalPosition()">
-                    <i class="fa fa-book me-1" role="img" aria-label="Set fiscal position"
-                    title="Set fiscal position" />
-                    <t t-if="this.currentOrder?.fiscal_position_id" t-out="this.currentOrder.fiscal_position_id.display_name" />
-                    <t t-else="">Tax</t>
-                </button>
-                <button t-if="this.displayProductInfoBtn()" t-att-class="this.buttonClass" t-on-click="() => this.pos.onProductInfoClick(this.currentOrder.getSelectedOrderline().product_id.product_tmpl_id, this.currentOrder.getSelectedOrderline().product_id)">
-                    <i class="fa fa-info-circle me-1" role="img" aria-label="Product Info" title="Product Info" /> Info
-                </button>
-                <button t-if="this.pos.isSelectedLineCombo" class="break-combo-button" t-att-class="this.buttonClass" t-on-click="() => this.breakSelectedCombo()">
-                    <i class="fa fa-outdent" role="img" aria-label="Break combo" title="Brean combo" /> Break combo
-                </button>
-                <button
-                    t-if="this.pos.cashier._role != 'minimal'"
-                    t-att-class="this.buttonClass" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())"
-                    t-att-disabled="!this.pos.getOrder()?.getOrderlines()?.length"
-                >
-                    <i class="fa fa-trash me-1" role="img" /> Cancel Order
-                </button>
+                <!-- Bill Button -->
+                <t t-if="this.pos.config.iface_printbill"> 
+                    <t t-call="point_of_sale.controlButton">
+                        <t t-set="iconClasses" t-value="'fa fa-print'"/>
+                        <t t-set="btnText">Bill</t>
+                        <t t-set="btnClasses" t-value="'btn-secondary '"/>
+                        <t t-set="disabled" t-value="!this.pos.getOrder()?.getOrderlines()?.length"/>
+                        <t t-set="onClick" t-value="this.clickPrintBill"/>
+                    </t>
+                </t>
+                <!-- Pricelist Button -->
+                <t t-if="this.pos.cashier._role != 'minimal'" t-call="point_of_sale.controlButton" name="o_pricelist_button">
+                    <t t-set="iconClasses" t-value="'fa fa-th-list'"/>
+                    <t t-set="btnText">Pricelist</t>
+                    <t t-set="btnClasses" t-value="'o_pricelist_button btn-secondary '"/>
+                    <t t-set="onClick" t-value="() => this.clickPricelist()"/>
+                    <t t-set="subText">
+                        <t t-if="this.currentOrder?.pricelist_id">
+                            <small t-out="this.currentOrder.pricelist_id.display_name" class="ms-auto ms-md-0 text-truncate text-muted text-end text-md-center"/>  
+                        </t>
+                    </t>
+                </t>
+                <!-- Tax Button -->
+                <t t-if="this.pos.config.fiscal_position_ids.length and this.pos.cashier._role != 'minimal'" t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-book'"/>
+                    <t t-set="btnText">Tax</t>
+                    <t t-set="btnClasses" t-value="'o_fiscal_position_button btn-secondary '"/>
+                    <t t-set="onClick" t-value="() => this.clickFiscalPosition()"/>
+                    <t t-set="subText">
+                        <t t-if="this.currentOrder?.fiscal_position_id">
+                            <small t-out="this.currentOrder.fiscal_position_id.display_name" class="ms-auto ms-md-0 text-truncate text-muted text-end text-md-center"/>
+                        </t>
+                    </t>
+                </t>
+                <!-- Product Info Button -->
+                <t t-if="this.displayProductInfoBtn()" t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-info-circle'"/>
+                    <t t-set="btnText">Info</t>
+                    <t t-set="btnClasses" t-value="'btn-secondary '"/>
+                    <t t-set="onClick" t-value="() => this.pos.onProductInfoClick(this.currentOrder.getSelectedOrderline().product_id.product_tmpl_id, this.currentOrder.getSelectedOrderline().product_id)"/>
+                </t>
+                <!-- Break Combo Button -->
+                <t t-if="this.pos.isSelectedLineCombo" t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-outdent'"/>
+                    <t t-set="btnText">Break Combo</t>
+                    <t t-set="btnClasses" t-value="'break-combo-button btn-secondary '"/>
+                    <t t-set="onClick" t-value="() => this.breakSelectedCombo()"/>
+                </t>
+                <!-- Cancel Order Button -->
+                <t t-if="this.pos.cashier._role != 'minimal'" t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-trash'"/>
+                    <t t-set="btnText">Cancel Order</t>
+                    <t t-set="btnClasses" t-value="'btn-danger '"/>
+                    <t t-set="onClick" t-value="() => this.pos.onDeleteOrder(this.pos.getOrder())"/>
+                    <t t-set="disabled" t-value="!this.pos.getOrder()?.getOrderlines()?.length"/>
+                </t>
             </div>
         </t>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.js
@@ -15,6 +15,7 @@ export class NoteButton extends Component {
 
     setup() {
         this.pos = usePos();
+        this.ui = useService("ui");
         this.dialog = useService("dialog");
     }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/orderline_note_button/orderline_note_button.xml
@@ -2,12 +2,11 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.NoteButton">
         <button
-            t-attf-class="{{this.props.class}} flex-shrink-0"
-            t-att-disabled="this.pos.getOrder()?.isEmpty()" t-on-click="this.onClick">
-            <t t-if="this.props.icon">
-                <i t-attf-class="{{this.props.icon}} me-1"/>
-            </t>
-            <span t-out="this.props.label"/>
+            t-attf-class="control-button btn btn-lg {{this.props.class}} d-inline-flex flex-md-column justify-content-md-center align-items-center gap-1"
+            t-att-disabled="this.pos.getOrder()?.isEmpty()" 
+            t-on-click="this.onClick">
+            <i t-if="this.props.icon" t-attf-class="{{this.props.icon}} {{!this.ui.isSmall ? ' fa-2x fa-fw' : ''}} fa-fw opacity-50" aria-hidden="true"/>
+            <span t-attf-class="{{this.props.icon ? 'ps-1' : ''}}" t-out="this.props.label"/>
         </button>
     </t>
 </templates>

--- a/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_discount.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
-        <xpath
-            expr="//t[@t-if='this.props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
-            position="before">
-            <button t-if="this.pos.config.module_pos_discount and this.pos.config.discount_product_id and this.pos.cashier._role !== 'minimal'"
-                class="js_discount"
-                t-att-class="this.buttonClass"
-                t-on-click="() => this.clickDiscount()">
-                <i class="fa fa-tag me-1"/>Discount
-            </button>
+        <xpath expr="//t[@t-if='this.props.showRemainingButtons']/div/t[@name='o_pricelist_button']" position="before">
+            <t t-if="this.pos.config.module_pos_discount and this.pos.config.discount_product_id and this.pos.cashier._role !== 'minimal'" t-call="point_of_sale.controlButton">
+                <t t-set="iconClasses" t-value="'fa fa-tag'"/>
+                <t t-set="btnText">Discount</t>
+                <t t-set="btnClasses" t-value="'js_discount btn-secondary '"/>
+                <t t-set="onClick" t-value="() => this.clickDiscount()"/>
+            </t>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -2,42 +2,45 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_loyalty.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
         <xpath
-            expr="//t[@t-if='this.props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
+            expr="//t[@t-if='this.props.showRemainingButtons']/div/t[@name='o_pricelist_button']"
             position="before">
             <t t-if="this.pos.models['loyalty.program'].some((p) => p.program_type == 'ewallet')">
                 <t t-set="_orderTotal" t-value="this.pos.getOrder().priceIncl" />
                 <t t-set="_eWalletPrograms" t-value="this._getEWalletPrograms()" />
                 <t t-set="_eWalletRewards" t-value="this._getEWalletRewards(this.pos.getOrder())" />
-                <button t-att-class="this.buttonClass"
-                    t-on-click="this.onClickWallet"
-                    t-attf-class="{{(_orderTotal lt 0 and _eWalletPrograms.length gte 1) or _eWalletRewards.length gte 1 ? 'highlight text-action': 'disabled'}}">
-                    <i class="fa fa-credit-card me-1" />
-                    <t t-if="_orderTotal lt 0 and _eWalletPrograms.length">eWallet Refund</t>
-                    <t t-elif="_eWalletRewards.length">eWallet Pay</t>
-                    <t t-else="">eWallet</t>
-                </button>
+                
+                <t t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-credit-card '"/>
+                    <t t-set="btnText">
+                        <t t-if="_orderTotal lt 0 and _eWalletPrograms.length">eWallet Refund</t>
+                        <t t-elif="_eWalletRewards.length">eWallet Pay</t>
+                        <t t-else="">eWallet</t>
+                    </t>
+                    <t t-set="btnClasses" t-value="'btn-secondary ' + ((_orderTotal lt 0 and _eWalletPrograms.length gte 1) or _eWalletRewards.length gte 1 ? ' highlight text-action': ' disabled')"/>
+                    <t t-set="onClick" t-value="this.onClickWallet"/>
+                </t>
             </t>
-            <t t-if="this.pos.models['loyalty.program'].some((p) => ['coupons', 'promotion', 'gift_card', 'promo_code', 'next_order_coupons'].includes(p.program_type))">
-                <button t-att-class="this.buttonClass"
-                    t-on-click="() => this.clickPromoCode()">
-                    <i class="fa fa-barcode me-1"/>Enter Code
-                </button>
+            <t t-if="this.pos.models['loyalty.program'].some((p) => ['coupons', 'promotion', 'gift_card', 'promo_code', 'next_order_coupons'].includes(p.program_type))" t-call="point_of_sale.controlButton">
+                <t t-set="iconClasses" t-value="'fa fa-percent'"/>
+                <t t-set="btnText">Enter Code</t>
+                <t t-set="btnClasses" t-value="'btn-secondary '"/>
+                <t t-set="onClick" t-value="() => this.clickPromoCode()"/>
             </t>
-            <t t-if="this.pos.models['loyalty.program'].length and this.pos.cashier._role !== 'minimal'">
-                <button class="control-button"
-                    t-att-class="this.buttonClass"
-                    t-attf-class="{{this.state.nbrRewards ? 'highlight' : 'disabled'}}"
-                    t-on-click="() => this.clickRewards()">
-                    <i class="fa fa-star me-1 text-favourite"/>Reward
-                </button>
+            <t t-if="this.pos.models['loyalty.program'].length and this.pos.cashier._role !== 'minimal'" t-call="point_of_sale.controlButton">
+                <t t-set="iconClasses" t-value="'fa fa-star'"/>
+                <t t-set="btnText">Reward</t>
+                <t t-set="btnClasses" t-value="'btn-secondary ' + (this.state.nbrRewards ? ' highlight' : 'disabled')"/>
+                <t t-set="disabled" t-value="!this.state.nbrRewards"/>
+                <t t-set="onClick" t-value="() => this.clickRewards()"/>
             </t>
         </xpath>
-        <xpath expr="//t[@t-if='this.props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]" position="before">
-            <t t-if="this.pos.models['loyalty.program'].some((p) => ['coupons', 'promotion'].includes(p.program_type)) and this.pos.cashier._role !== 'minimal'">
-                <button class="btn btn-secondary btn-lg py-5" t-att-class="{'disabled': !this.pos.getOrder().isProgramsResettable()}"
-                    t-on-click="() => this.pos.resetPrograms()">
-                    <i class="fa fa-star me-1"/>Reset Programs
-                </button>
+        <xpath expr="//t[@t-if='this.props.showRemainingButtons']/div/t[@name='o_pricelist_button']" position="before">
+             <t t-if="this.pos.models['loyalty.program'].some((p) => ['coupons', 'promotion'].includes(p.program_type)) and this.pos.cashier._role !== 'minimal'" t-call="point_of_sale.controlButton">
+                <t t-set="iconClasses" t-value="'fa fa-star'"/>
+                <t t-set="btnText">Reset Programs</t>
+                <t t-set="btnClasses" t-value="'btn-secondary '"/>
+                <t t-set="disabled" t-value="!this.pos.getOrder().isProgramsResettable()"/>
+                <t t-set="onClick" t-value="() => this.pos.resetPrograms()"/>
             </t>
         </xpath>
         <xpath expr="//button[hasclass('more-btn')]" position="attributes">

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_restaurant.ActionpadWidget" t-inherit="point_of_sale.ActionpadWidget" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('actionpad')]//button[hasclass('mobile-more-button')]" position="before">
             <button t-if="this.pos.config.module_pos_restaurant and !this.currentOrder.isRefund"
-                    class="btn btn-secondary btn-lg flex-shrink-0 border-0" t-on-click="()=>this.pos.addCourse()">
+                    class="btn btn-secondary btn-lg flex-shrink-0 lh-lg" t-on-click="()=>this.pos.addCourse()">
                 <span>Course</span>
             </button>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -1,39 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
-       <xpath
-            expr="//button[hasclass('more-btn')]"
-            position="before">
-           <button class="course-btn" t-if="this.pos.config.module_pos_restaurant and !this.props.showRemainingButtons and !this.pos.getOrder()?.isRefund"
-                   t-att-class="this.buttonClass" t-on-click="()=>this.pos.addCourse()">
+       <xpath expr="//button[hasclass('more-btn')]" position="before">
+           <button class="course-btn btn btn-lg btn-secondary lh-lg" t-if="this.pos.config.module_pos_restaurant and !this.props.showRemainingButtons and !this.pos.getOrder()?.isRefund" t-on-click="()=>this.pos.addCourse()">
                 <span>Course</span>
            </button>
        </xpath>
-        <xpath
-            expr="//t[@t-if='this.props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
-            position="before">
+        <xpath expr="//t[@t-if='this.props.showRemainingButtons']/div/t[@name='o_pricelist_button']" position="before">
             <!-- All these buttons will only be displayed in a dialog -->
             <t t-if="this.pos.config.module_pos_restaurant">
-                <button t-att-class="this.buttonClass" t-on-click="this.clickTableGuests">
-                    <span t-out="this.currentOrder?.getCustomerCount() || 0" t-attf-class="rounded-circle text-bg-dark fw-bolder small me-1 {{this.ui.isSmall ? 'px-1' : 'px-2 py-1'}}"/>
-                    <span>Guests</span>
+                <t t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-user d-md-none'"/>
+                    <t t-set="badge">
+                        <span t-out="this.currentOrder?.getCustomerCount() || 0" class="o_guests_number order-last order-md-first rounded-5 text-bg-500 d-md-block ms-auto me-md-auto px-2"/>
+                    </t>
+                    <t t-set="btnText">
+                        <t t-if="this.currentOrder?.getCustomerCount() === 1">Guest</t>
+                        <t t-else="">Guests</t>
+                    </t>
+                    <t t-set="btnClasses" t-value="'o_guests_button btn-secondary '"/>
+                    <t t-set="onClick" t-value="this.clickTableGuests"/>
+                </t>
+                <!-- Split Button -->
+                <t t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-files-o'"/>
+                    <t t-set="btnText">Split</t>
+                    <t t-set="btnClasses" t-value="'btn-secondary '"/>
+                    <t t-set="onClick" t-value="this.openSplitPage"/>
+                    <t t-set="disabled" t-value="this.pos.getOrder()?.getOrderlines()?.reduce((sum, line) => sum + line.qty, 0) lt 2"/>
+                </t>
+                <!-- Transfer / Merge Button -->
+                <!-- No t-call controlButton because of t-on-click.stop -->
+                <button 
+                    class="control-button btn btn-lg btn-secondary d-inline-flex flex-md-column justify-content-md-center gap-1 overflow-hidden"
+                    t-on-click.stop="() => this.clickTransferOrder()">
+                    <i t-attf-class="oi oi-arrow-right {{!this.ui.isSmall ? ' fa-2x fa-fw' : ''}} align-self-center opacity-50" role="img" aria-hidden="true"/>
+                    <span t-attf-class="d-flex flex-md-column flex-grow-1 flex-md-grow-0 align-items-center align-items-md-stretch min-w-0 {{this.ui.isSmall ? ' lh-sm' : ''}} text-start text-md-center">
+                        <span class="px-1">Transfer / Merge</span>
+                    </span>
                 </button>
-            </t>
-            <t t-if="this.pos.config.module_pos_restaurant">
-                <button t-att-class="this.buttonClass"
-                    t-att-disabled="this.pos.getOrder()?.getOrderlines()?.reduce((sum, line) => sum + line.qty, 0) lt 2"
-                    t-on-click="this.openSplitPage">
-                    <i class="fa fa-files-o me-1"/>Split
+                <!-- Transfer Course Button -->
+                <button 
+                    class="control-button btn btn-lg btn-secondary d-inline-flex flex-md-column justify-content-md-center gap-1 overflow-hidden"
+                    t-on-click.stop="() => this.clickTransferCourse()"
+                    t-att-disabled="!this.showTransferCourse()">
+                    <i t-attf-class="oi oi-arrow-down {{!this.ui.isSmall ? ' fa-2x fa-fw' : ''}} align-self-center opacity-50" role="img" aria-hidden="true"/>
+                    <span t-attf-class="d-flex flex-md-column flex-grow-1 flex-md-grow-0 align-items-center align-items-md-stretch min-w-0 {{this.ui.isSmall ? ' lh-sm' : ''}} text-start text-md-center">
+                        <span class="px-1">Transfer Course</span>
+                    </span>
                 </button>
-                <button t-att-class="this.buttonClass" t-on-click.stop="() => this.clickTransferOrder()">
-                    <i class="oi oi-arrow-right me-1" />Transfer / Merge
-                </button>
-                   <button t-att-disabled="!this.showTransferCourse()" t-att-class="this.buttonClass" t-on-click.stop="() => this.clickTransferCourse()">
-                    <i class="oi oi-arrow-down me-1" />Transfer course
-                </button>
-                <button t-if="!this.pos.getOrder()?.table_id" t-att-class="this.buttonClass" t-on-click="() => this.pos.editFloatingOrderName(this.pos.getOrder())">
-                    <i class="fa fa-pencil-square-o me-1" />Set Order Name
-                </button>
+                <!-- Edit Order Name Button -->
+                <t t-if="!this.pos.getOrder()?.table_id" t-call="point_of_sale.controlButton">
+                    <t t-set="iconClasses" t-value="'fa fa-pencil-square-o'"/>
+                    <t t-set="btnText">Set Order Name</t>
+                    <t t-set="btnClasses" t-value="'btn-secondary '"/>
+                    <t t-set="onClick" t-value="() => this.pos.editFloatingOrderName(this.pos.getOrder())"/>
+                </t>
             </t>
         </xpath>
     </t>

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -66,7 +66,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             ProductScreen.addOrderline("Water", "8", "1", "8.0"),
 
             // Test GuestButton
-            ProductScreen.clickControlButton("Guests"),
+            ProductScreen.clickControlButton("Guest"),
             {
                 content: `click numpad button: 1`,
                 trigger: ".modal div.numpad button:text(1)",
@@ -82,7 +82,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             ProductScreen.guestNumberIs("15"),
             {
                 content: `click guests 15 button`,
-                trigger: `.modal .control-buttons button:contains(15Guests)`,
+                trigger: `.modal .control-buttons .o_guests_button:contains("15")`,
                 run: "click",
             },
             {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -442,7 +442,7 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             FloorScreen.clickTable("5"),
-            ProductScreen.clickControlButton("Guests"),
+            ProductScreen.clickControlButton("Guest"),
             NumberPopup.enterValue("5"),
             NumberPopup.isShown("5"),
             Dialog.confirm(),

--- a/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/tip_screen_tour.js
@@ -63,7 +63,7 @@ registry.category("web_tour.tours").add("PosResTipScreenTour", {
             // order 4
             ProductScreen.addOrderline("Coca-Cola", "4", "2"),
             ProductScreen.totalAmountIs("8.0"),
-            ProductScreen.clickControlButton("Guests"),
+            ProductScreen.clickControlButton("Guest"),
             NumberPopup.enterValue("2"),
             NumberPopup.isShown("2"),
             Dialog.confirm(),

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -26,7 +26,7 @@ export function guestNumberIs(num) {
         ...ProductScreen.clickControlButtonMore(),
         {
             content: `guest number is ${num}`,
-            trigger: ProductScreen.controlButtonTrigger("Guests") + `:contains(${num})`,
+            trigger: ProductScreen.controlButtonTrigger("Guest") + `:contains(${num})`,
         },
     ];
 }

--- a/addons/pos_sale/static/src/app/components/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/pos_sale/static/src/app/components/screens/product_screen/control_buttons/control_buttons.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_sale.ControlButtons" t-inherit="point_of_sale.ControlButtons" t-inherit-mode="extension">
-        <xpath
-            expr="//t[@t-if='this.props.showRemainingButtons']/div/button[hasclass('o_pricelist_button')]"
-            position="before">
-            <button t-if="this.pos.cashier._role != 'minimal'" t-att-class="this.buttonClass" t-on-click="() => this.onClickQuotation()">
-                <i class="fa fa-link me-1" role="img" aria-label="Set Sale Order" title="Set Sale Order" /> Quotation/Order
-            </button>
+        <xpath expr="//t[@t-if='this.props.showRemainingButtons']/div/t[@name='o_pricelist_button']" position="before">
+            <t t-if="this.pos.cashier._role != 'minimal'" t-call="point_of_sale.controlButton">
+                <t t-set="iconClasses" t-value="'fa fa-link'"/>
+                <t t-set="btnText">Quotation / Order</t>
+                <t t-set="btnClasses" t-value="'btn-secondary '"/>
+                <t t-set="onClick" t-value="() =>   this.onClickQuotation()"/>
+            </t>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -358,7 +358,7 @@ registry.category("web_tour.tours").add("PosOrdersListDifferentCurrency", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            ProductScreen.clickControlButton("Quotation/Order"),
+            ProductScreen.clickControlButton("Quotation / Order"),
             {
                 content: "Check that no orders are displayed",
                 trigger: '.o_nocontent_help p:contains("No record found")',

--- a/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
+++ b/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
@@ -9,7 +9,7 @@ import { registry } from "@web/core/registry";
 function addDownPayment(percentage, soNth, downPaymentType) {
     const downPaymentTypeLabel = downPaymentType === "percent" ? "percentage" : "fixed amount";
     return [
-        ProductScreen.clickControlButton("Quotation/Order"),
+        ProductScreen.clickControlButton("Quotation / Order"),
         {
             content: "Select the first SO",
             trigger: `.o_sale_order .o_data_row:nth-child(${soNth}) .o_data_cell:nth-child(1)`,

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -4,7 +4,7 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 
 export function selectNthOrder(n) {
     return [
-        ...ProductScreen.clickControlButton("Quotation/Order"),
+        ...ProductScreen.clickControlButton("Quotation / Order"),
         {
             content: `select nth order`,
             trigger: `.modal:not(.o_inactive_modal) table.o_list_table tbody tr.o_data_row:nth-child(${n}) td`,
@@ -15,7 +15,7 @@ export function selectNthOrder(n) {
 
 export function settleSaleOrderByPrice(price) {
     return [
-        ...ProductScreen.clickControlButton("Quotation/Order"),
+        ...ProductScreen.clickControlButton("Quotation / Order"),
         {
             content: `select sale order with price ${price}`,
             trigger: `.modal:not(.o_inactive_modal) table.o_list_table tbody tr.o_data_row td:contains('${price}')`,
@@ -75,7 +75,7 @@ export function downPaymentFirstOrder(amount) {
 
 export function checkOrdersListEmpty() {
     return [
-        ...ProductScreen.clickControlButton("Quotation/Order"),
+        ...ProductScreen.clickControlButton("Quotation / Order"),
         {
             content: "Check that the orders list is empty",
             trigger: "p:contains(No record found)",
@@ -94,7 +94,7 @@ export function selectedOrderLinesHasLots(productName, lots) {
 
 export function checkOrdersListNotEmpty() {
     return [
-        ...ProductScreen.clickControlButton("Quotation/Order"),
+        ...ProductScreen.clickControlButton("Quotation / Order"),
         {
             content: "Check that the orders list is not empty",
             trigger: ".o_data_row",


### PR DESCRIPTION
In this PR we've redesigned the control buttons inside the Actions modal for more clarity.

|Before|After|
|---|---|
| <img width="1507" height="1001" alt="Screenshot 2026-02-09 at 10 08 24" src="https://github.com/user-attachments/assets/a8ef142c-79ca-47c8-9233-b5feef94276a" /> | <img width="1501" height="1034" alt="Screenshot 2026-02-09 at 10 07 36" src="https://github.com/user-attachments/assets/088a2d24-306d-4fee-9445-69544ed06bce" /> |

task-5187160





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
