### PR TITLE
[FIX] sale_{loyalty, timesheet}: apply loyalty reward with non-unit uom

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -1168,7 +1168,10 @@ class SaleOrder(models.Model):
         products = order_lines.product_id
         products_qties = dict.fromkeys(products, 0)
         for line in order_lines:
-            products_qties[line.product_id] += line.product_uom_qty
+            product_qty = line.product_uom._compute_quantity(
+                line.product_uom_qty, line.product_id.uom_id
+            )
+            products_qties[line.product_id] += product_qty
         # Contains the products that can be applied per rule
         products_per_rule = programs._get_valid_products(products)
 

--- a/addons/sale_loyalty/tests/test_program_rules.py
+++ b/addons/sale_loyalty/tests/test_program_rules.py
@@ -482,3 +482,33 @@ class TestProgramRules(TestSaleCouponCommon, PaymentCommon):
                 order.amount_total, tx.amount,
                 msg="Discount should still apply if transaction gets confirmed post-expiration",
             )
+
+    def test_buy_x_get_y_free_applies_correctly_with_non_unit_uom(self):
+        buy_x_get_y = self.env['loyalty.program'].create({
+            'name': 'Buy 12 Take 6',
+            'program_type': 'buy_x_get_y',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({
+                'reward_point_mode': 'unit',
+                'product_ids': self.product_A.ids,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'product',
+                'reward_product_id': self.product_A.id,
+                'required_points': 12,
+                'reward_product_qty': 6,
+            })],
+        })
+        order = self.empty_order
+        order.order_line = [
+            Command.create({
+                'product_id': self.product_A.id,
+                'product_uom': self.ref('uom.product_uom_dozen'),
+                'product_uom_qty': 1,
+            }),
+        ]
+        self._auto_rewards(order, buy_x_get_y)
+        reward_line = order.order_line.filtered('is_reward_line')
+        self.assertTrue(reward_line)
+        self.assertEqual(reward_line.product_uom_qty, 6)

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -695,12 +695,11 @@ class TestSaleService(TestCommonSaleTimesheet):
             The conversion to time should be processed as follows :
                 H : qty = uom_qty [Hours]
                 D : qty = uom_qty * 8 [Hours]
-                U : qty =  uom_qty [Hours]
                 Other : qty = 0
 
             Test Cases:
             ==========
-            1) Create a 4 SOL on a SO With different UOM
+            1) Create a 3 SOL on a SO With different UOM
             2) Confirm the SO
             3) Check the project allocated hour is correctly set
             4) Repeat with different timesheet encoding UOM
@@ -718,18 +717,13 @@ class TestSaleService(TestCommonSaleTimesheet):
             'product_uom': self.env.ref('uom.product_uom_hour').id, # 8 hours
         }, {
             'order_id': self.sale_order.id,
-            'product_id': self.product_delivery_timesheet3.id,
+            'product_id': self.product_service_delivered_timesheet.id,
             'product_uom_qty': 1,
             'product_uom': self.env.ref('uom.product_uom_dozen').id, # 0 hours
-        }, {
-            'order_id': self.sale_order.id,
-            'product_id': self.product_delivery_timesheet3.id,
-            'product_uom_qty': 6,
-            'product_uom': self.env.ref('uom.product_uom_unit').id, # 6 hours
         }])
         self.sale_order.action_confirm()
         allocated_hours = self.sale_order.project_ids.allocated_hours
-        self.assertEqual(16 + 8 + 6, allocated_hours,
+        self.assertEqual(16 + 8, allocated_hours,
                          "Project's allocated hours should add up correctly.")
 
         self.env.company.timesheet_encode_uom_id = self.env.ref('uom.product_uom_day')


### PR DESCRIPTION
### Issue:
Due to this issue, applying a different uom than unit one, will not apply the reward regarding to quantities.

#### Steps to reproduce:
1- Create a program: buy 12 get 6 free.
2- Create a SO, add a dozen of product to SOL.
3- Click on reward.

Expect: 6 free unit is added.
Current outcome: Nothing is added. Unless you add 12 dozens which is going to add 6 units.

### Cause:
In checking rules, `product_uom_qty` is directly used without conversion to quantity.

Note:
`test_different_uom_to_hours_on_sale_order_confirmation` is failing due to this fix, because the uom_id unit/dozens and hours/days are not compatible. As this is not possible in UI, IMO we can delete the breaking SOL in that test.

opw-5913638
