### PR TITLE
[FIX] pos_sale,sale: set tax on down payment

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6605,3 +6605,6 @@ class AccountMove(models.Model):
         :returns: True if commit is acceptable, False otherwise.
         """
         return not tools.config['test_enable'] and not modules.module.current_test
+
+    def require_tax_ids_on_invoice_lines(self):
+        return False

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -4348,6 +4348,25 @@ class AccountTax(models.Model):
             return ''
         return html2plaintext(self.description)
 
+    def _get_zero_tax(self):
+        """ Return the 0% tax for the current company, creating it if it does not exist yet.
+        """
+        zero_tax = self.search([
+            ('amount_type', '=', 'percent'),
+            ('amount', '=', 0),
+            ('type_tax_use', 'in', ['sale']),
+            *self.env['account.tax']._check_company_domain(self.env.company),
+        ], limit=1)
+        if not zero_tax:
+            zero_tax = self.create({
+                'name': '0% Tax',
+                'amount_type': 'percent',
+                'amount': 0,
+                'type_tax_use': 'sale',
+                'company_id': self.env.company.id,
+            })
+        return zero_tax
+
 
 class AccountTaxRepartitionLine(models.Model):
     _name = "account.tax.repartition.line"

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -70,3 +70,7 @@ class AccountMove(models.Model):
                 'partner_on_peppol': invoice.commercial_partner_id.peppol_verification_state in ('valid', 'not_valid_format'),
             }
         return render_context
+
+    @api.model
+    def require_tax_ids_on_invoice_lines(self):
+        return super().require_tax_ids_on_invoice_lines() or self.env.company.peppol_can_send

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -29,6 +29,10 @@ class PosOrder(models.Model):
             order.currency_rate = self.env['res.currency']._get_conversion_rate(order.company_id.currency_id, order.currency_id, order.company_id, date_order.date())
 
     def _prepare_invoice_vals(self):
+        if self.env['account.move'].require_tax_ids_on_invoice_lines():
+            for line in self.lines.filtered(lambda l: not l.tax_ids and l.product_id == self.config_id.down_payment_product_id):
+                line.tax_ids = self.env['account.tax']._get_zero_tax()
+
         invoice_vals = super(PosOrder, self)._prepare_invoice_vals()
         invoice_vals['team_id'] = self.crm_team_id.id
         sale_orders = self.lines.mapped('sale_order_origin_id')

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -2,6 +2,7 @@
 
 import odoo
 from uuid import uuid4
+from unittest.mock import patch
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
@@ -2164,6 +2165,76 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         sale_order.action_confirm()
         self.main_pos_config.open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_settle_groupable_lot_total_amount', login="accountman")
+
+    def test_downpayment_fixed_tax_require_tax(self):
+        """Make sure that when a tax is required for all invoice line, fixed tax downpayment have a tax"""
+        fixed_tax = self.env['account.tax'].sudo().create({
+            'name': 'Fixed Tax',
+            'amount_type': 'fixed',
+            'amount': 10,
+        })
+
+        product_a = self.env['product.product'].sudo().create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'lst_price': 100,
+            'taxes_id': [fixed_tax.id],
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+        self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
+
+        self.main_pos_config.open_ui()
+        pos_order = {
+           'amount_paid': 20,
+           'amount_return': 0,
+           'amount_tax': 0,
+           'amount_total': 20,
+           'company_id': self.env.company.id,
+           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+           'fiscal_position_id': False,
+           'to_invoice': True,
+           'partner_id': self.partner_a.id,
+           'pricelist_id': self.main_pos_config.available_pricelist_ids[0].id,
+           'lines': [[0,
+             0,
+             {'discount': 0,
+              'pack_lot_ids': [],
+              'price_unit': 20,
+              'product_id': self.main_pos_config.down_payment_product_id.id,
+              'price_subtotal': 20,
+              'price_subtotal_incl': 20,
+              'sale_order_line_id': sale_order.order_line[0].id,
+              'sale_order_origin_id': sale_order.id,
+              'qty': 1,
+              'tax_ids': []}]],
+           'name': 'Order 00044-003-0014',
+           'session_id': self.main_pos_config.current_session_id.id,
+           'sequence_number': self.main_pos_config.journal_id.id,
+           'payment_ids': [[0,
+             0,
+             {'amount': 20,
+              'name': fields.Datetime.now(),
+              'payment_method_id': self.main_pos_config.payment_method_ids[0].id}]],
+           'user_id': self.env.uid,
+           'uuid': str(uuid4()),
+            }
+
+        with patch('odoo.addons.account.models.account_move.AccountMove.require_tax_ids_on_invoice_lines', return_value=True):
+            res = self.env['pos.order'].sync_from_ui([pos_order])
+            tax_0_percent = self.env['account.tax'].search([('amount_type', '=', 'percent'), ('amount', '=', 0)], limit=1)
+            self.assertTrue(tax_0_percent)
+            pos_order = self.env['pos.order'].browse(res['pos.order'][0]['id'])
+            self.assertEqual(pos_order.account_move.line_ids.tax_ids, tax_0_percent, "The downpayment line should have the fixed tax applied")
 
 
 @odoo.tests.tagged('post_install', '-at_install')

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -317,7 +317,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 line_vals['analytic_distribution'] = line_analytic_distribution
             # round price unit
             line_vals['price_unit'] = order.currency_id.round(line_vals['price_unit'] * ratio)
-
+            if self.env['account.move'].require_tax_ids_on_invoice_lines() and not line_vals['tax_id']:
+                tax_0 = self.env['account.tax']._get_zero_tax()
+                line_vals['tax_id'] = (tax_0.id,)
             lines_values.append(line_vals)
             accounts.append(key['account_id'])
 


### PR DESCRIPTION
In certain conditions all lines in invoice require a tax. When making
a down payment from an order containing products using fixed price tax,
the corresponding invoice line was created without tax. The issue appear
both when making the down payment from the sale order and from the PoS.

Steps to reproduce:
-------------------
* Create a fixed price tax of 10€
* Create a product with this tax
* Create a sale order with this product and make a downpayment of 10%
> Observation: The down payment line has no tax set.
* Open PoS and make a down payment of 10% for the same order
* Pay and invoice the order
> Observation: The down payment line has no tax set.

Why the fix:
------------
If the tax is required on every invoice line we manually add a 0% tax to
the down payment line to ensure that the invoice is compliant.

At the moment we only add the tax when peppol is activated on the
current company. But the `_require_tax_ids_on_invoice_lines` method can
be overriden by other modules if downpayment lines also require tax.

opw-5853070