### PR TITLE
[FIX] web: fix copy button submitting form

### DIFF
--- a/addons/web/static/src/views/fields/copy_clipboard/copy_button.xml
+++ b/addons/web/static/src/views/fields/copy_clipboard/copy_button.xml
@@ -3,6 +3,7 @@
 
     <t t-name="web.CopyButton" owl="1">
         <button
+            type="button"
             class="text-nowrap"
             t-ref="button"
             t-attf-class="btn btn-sm btn-primary o_clipboard_button {{ props.className || '' }}"


### PR DESCRIPTION
Previously, the type of the button in the template of the CopyButton utility component was left unspecified. Because the default type for buttons is "submit", the copy button will not work if it is placed within a `<form>` element, and will instead submit the form (see [1]).

This commit just forces the type of the button to "button" which has no default behavior, meaning it can be used even inside of `<form>` elements without issues.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#type
