### PR TITLE
[IMP] project_todo: reorder tags based on use

### DIFF
--- a/addons/project/models/project_tags.py
+++ b/addons/project/models/project_tags.py
@@ -100,6 +100,8 @@ class ProjectTags(models.Model):
                     JOIN project_task_user_rel AS user_rel
                         ON user_rel.task_id = task.id
                         AND user_rel.user_id = %(user_id)s
+                        AND task.active = TRUE
+                        AND task.project_id IS NULL
                     ORDER BY task.id DESC
                     LIMIT 1000
                 ) AS project_tasks_tags

--- a/addons/project/models/project_tags.py
+++ b/addons/project/models/project_tags.py
@@ -87,6 +87,24 @@ class ProjectTags(models.Model):
                 ) AS project_tasks_tags
             )""", project_id=self.env.context['project_id'])
             tags += self.search_fetch(Domain('id', 'in', tag_sql) & domain, ['display_name'], limit=limit)
+        elif self.env.context.get('use_user_history'):
+            # optimisation for large projects, we look first for tags present on the last 1000 tasks of said project.
+            # when not enough results are found, we complete them with a fallback on a regular search
+            tag_sql = SQL("""
+                (SELECT DISTINCT project_tasks_tags.id
+                FROM (
+                    SELECT rel.project_tags_id AS id
+                    FROM project_tags_project_task_rel AS rel
+                    JOIN project_task AS task
+                        ON task.id=rel.project_task_id
+                    JOIN project_task_user_rel AS user_rel
+                        ON user_rel.task_id = task.id
+                        AND user_rel.user_id = %(user_id)s
+                    ORDER BY task.id DESC
+                    LIMIT 1000
+                ) AS project_tasks_tags
+            )""", user_id=self.env.user.id)
+            tags += self.search_fetch(Domain('id', 'in', tag_sql) & domain, ['display_name'], limit=limit)
         if len(tags) < limit:
             tags += self.search_fetch(Domain('id', 'not in', tags.ids) & domain, ['display_name'], limit=limit - len(tags))
         return [(tag.id, tag.display_name) for tag in tags.sudo()]

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -31,7 +31,7 @@
                         <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value)}">
                             <field name="name" class="fw-bold fs-5" widget="name_with_subtask_count"/>
                             <field t-if="record.date_deadline.raw_value" name="date_deadline" widget="remaining_days"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" context="{'use_user_history':True}"/>
                             <field t-if="record.displayed_image_id.value" name="displayed_image_id" widget="attachment_image"/>
                         </div>
                         <div class="d-flex pt-2">
@@ -69,7 +69,7 @@
                 <field name="priority" widget="priority" optional="hidden" width="70px"/>
                 <field name="date_deadline" optional="show" widget="remaining_days"/>
                 <field name="activity_ids" optional="show" widget="list_activity"/>
-                <field name="tag_ids" optional="show" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"/>
+                <field name="tag_ids" optional="show" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}" context="{'use_user_history': True}"/>
                 <field name="personal_stage_type_id" string="Stage" optional="hide"/>
             </list>
         </field>
@@ -119,6 +119,7 @@
                             <field name="tag_ids"
                                 widget="many2many_tags"
                                 options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"
+                                context="{'use_user_history': True}"
                                 class="me-2"/>
                             <field name="date_deadline"
                                 decoration-danger="date_deadline &lt; current_date"/>
@@ -181,7 +182,7 @@
                                widget="many2many_avatar_user"/>
                         <field name="tag_ids" widget="many2many_tags"
                                options="{'color_field': 'color', 'on_tag_click': 'edit_color', 'no_create_edit': True}"
-                               context="{'project_id': project_id}"
+                               context="{'use_user_history': True}"
                                placeholder="Choose tags from the selected project"/>
                     </group>
                 </sheet>
@@ -205,7 +206,7 @@
                       scales="day,week,month,year">
                 <field name="name"/>
                 <field name="priority" widget="priority"/>
-                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" invisible="not tag_ids"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'on_tag_click': 'edit_color'}" invisible="not tag_ids" context="{'use_user_history': True}"/>
                 <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="not personal_stage_id"/>
             </calendar>
         </field>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Tags for todo tasks were not ordered by usage, which made them difficult to find in large databases.

## Current behavior before this PR:

When a user tried to add a tag to a todo task, the tag list was not ordered by usage.

## Desired behavior after this PR is merged:

The list of tags available for a todo task is now ordered in the same way as within the Project app. Tags already used by the current user appear at the top of the search results.

## Task:
[5173891](https://www.odoo.com/odoo/project/4105/tasks/5173891)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr