### PR TITLE
[FIX] resource: resource half day is not correct if day period is full day

### DIFF
--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_leave_requests
 from . import test_out_of_office
 from . import test_company_leave
 from . import test_res_partner
+from . import test_resource_calendar
 from . import test_mandatory_days
 from . import test_global_leaves
 from . import test_uninstall

--- a/addons/hr_holidays/tests/test_resource_calendar.py
+++ b/addons/hr_holidays/tests/test_resource_calendar.py
@@ -1,0 +1,75 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date
+
+from odoo import Command
+from odoo.tests.common import tagged
+
+from odoo.addons.hr_holidays.tests.common import TestHolidayContract
+
+
+@tagged('post_install', '-at_install')
+class TestResourceCalendar(TestHolidayContract):
+
+    def test_time_off_half_day_duration(self):
+        """if working schedule is of full day period, Duration should be correct"""
+
+        new_calendar_40h = self.env['resource.calendar'].create({
+            'name': '40h calendar new',
+            'attendance_ids': [
+                Command.create({
+                    'name': 'Monday full day',
+                    'dayofweek': '0',
+                    'hour_from': 10,
+                    'hour_to': 18,
+                    'day_period': 'full_day',
+                }),
+                Command.create({
+                    'name': 'Tuesday full day',
+                    'dayofweek': '1',
+                    'hour_from': 10,
+                    'hour_to': 18,
+                    'day_period': 'full_day',
+                }),
+            ],
+        })
+        self.jules_emp.version_id.resource_calendar_id = new_calendar_40h.id
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Test half day type',
+            'requires_allocation': False,
+            'leave_validation_type': 'no_validation',
+            'request_unit': 'half_day',
+        })
+
+        leave_morning, leave_afternoon, leave_one_and_half = self.env['hr.leave'].create([
+            {
+                'name': 'Half Day Leave(morning)',
+                'employee_id': self.jules_emp.id,
+                'holiday_status_id': leave_type.id,
+                'request_date_from': date(2025, 4, 21),
+                'request_date_to': date(2025, 4, 21),
+                'request_date_from_period': 'am',
+                'request_date_to_period': 'am',
+            },
+            {
+                'name': 'Half Day Leave(afternoon)',
+                'employee_id': self.jules_emp.id,
+                'holiday_status_id': leave_type.id,
+                'request_date_from': date(2025, 4, 22),
+                'request_date_to': date(2025, 4, 22),
+                'request_date_from_period': 'pm',
+                'request_date_to_period': 'pm',
+            },
+            {
+                'name': 'One and half Day Leave',
+                'employee_id': self.jules_emp.id,
+                'holiday_status_id': leave_type.id,
+                'request_date_from': date(2025, 4, 14),
+                'request_date_to': date(2025, 4, 15),
+                'request_date_from_period': 'am',
+                'request_date_to_period': 'am',
+            },
+        ])
+        self.assertEqual(leave_morning.number_of_days, 0.5)
+        self.assertEqual(leave_afternoon.number_of_days, 0.5)
+        self.assertEqual(leave_one_and_half.number_of_days, 1.5)

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -975,9 +975,11 @@ class ResourceCalendar(models.Model):
         if day_period:
             attendances = [att for att in init_attendances if att.day_period == day_period]
             for attendance in filter(lambda att: att.day_period == 'full_day', init_attendances):
+                # Split full-day attendances at their midpoint.
+                half_time = (attendance.hour_from + attendance.hour_to) / 2
                 attendances.append(attendance._replace(
-                    hour_from=attendance.hour_from if day_period == 'morning' else 12,
-                    hour_to=attendance.hour_to if day_period == 'afternoon' else 12,
+                    hour_from=attendance.hour_from if day_period == 'morning' else half_time,
+                    hour_to=attendance.hour_to if day_period == 'afternoon' else half_time,
                 ))
 
         else:


### PR DESCRIPTION
### Steps to reproduce:
- Go to any working schedule of an employee.
- Add a working hour line for any day and choose day period as full day.
- Change work from 10:00, and work to 18:00.

### Issue:
- Resource was explicitly setting 12  if any hour_from/hour_to was missing.
- Resource always consider that the working time is 8AM-5PM.

### Fix:
- We will calculate the avg of working hours( hour_from + hour_to)/2
- Doing this we will always get the middle of day.

task: 5912748

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
