### PR TITLE
[FIX] web_editor: detect drop outside of dropzone in a RTL language

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3803,7 +3803,12 @@ class SnippetsMenu extends Component {
                         dropped = true;
                     }
                 }
-                if (!dropped && y > 3 && x + helper.getBoundingClientRect().height < this.el.getBoundingClientRect().left) {
+                const sidebarRect = this.el.getBoundingClientRect();
+                const isRTL = document.body.classList.contains("o_rtl");
+                const isOutOfSidebar = isRTL
+                    ? sidebarRect.left + sidebarRect.width < x - helper.getBoundingClientRect().width / 2
+                    : x + helper.getBoundingClientRect().width / 2 < sidebarRect.left;
+                if (!dropped && y > 3 && isOutOfSidebar) {
                     const point = { x, y };
                     let droppedOnNotNearest = touching(doc.body.querySelectorAll('.oe_structure_not_nearest'), point);
                     // If dropped outside of a dropzone with class oe_structure_not_nearest,


### PR DESCRIPTION
When dropping outside a dropzone but still on the page, the code checks
if the drop happened well outside of the sidebar (so on its left).
However, in RTL languages, the sidebar is positioned on the left, so we
need to check if the drop is on the right side of it instead.

The fix checks if the sidebar is at the left edge (the body of the
document should have the `o_rtl` class) and verifies the drop position
is on the right of the sidebar.

Steps to reproduce:
- Set your profile to Arabic
- Drag and drop a snippet outside of a dropzone

=> It's not dropped, but it should, as it would with an LTR language.

task-5484936