### PR TITLE
[FIX] portal: fix error 500 when info edit with no country

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -491,7 +491,7 @@
             <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" t-att-disabled="None if partner_can_edit_vat else '1'">
                 <option value="">Country...</option>
                 <t t-foreach="countries or []" t-as="country">
-                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
+                    <option t-att-value="country.id" t-att-selected="country.id == (False if country_id == 'False' else int(country_id)) if country_id else country.id == partner.country_id.id">
                         <t t-esc="country.name" />
                     </option>
                 </t>


### PR DESCRIPTION
How to reproduce:
- Create a company with no country
- Set a contact's company to that company
- Grant portal access to that contact
- Login as that contact
- Go to the edit information tab
- Leave some of the required fields (Phone, Street & City) empty
- Click on save

The problem:
The page displays an error 500

Why:
When you try to submit the form with some required field missing, the page will try to evaluate this expression : 'int(country_id)''. But since this commit (https://github.com/odoo/odoo/commit/d6d6bee087fe2d3dc17974054353430c2662aecf), the post variable country_id is set to "False" if the partner has no country. 'int("False")' will then raise an error.

opw-5867975

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
