### PR TITLE
[18.0][FIX] certificate: support certificate records in TLS context-based requests (Veri*Factu PKCS12)

### DIFF
--- a/addons/certificate/tests/__init__.py
+++ b/addons/certificate/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_keys_certificates
+from . import test_certificate_adapter

--- a/addons/certificate/tests/test_certificate_adapter.py
+++ b/addons/certificate/tests/test_certificate_adapter.py
@@ -1,0 +1,61 @@
+import base64
+
+from unittest import mock
+
+from odoo.addons.certificate.tools import CertificateAdapter
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import file_open
+
+
+class _DummyConnection:
+    def __init__(self, ssl_context):
+        self.conn_kw = {'ssl_context': ssl_context}
+
+
+@tagged('post_install', '-at_install')
+class TestCertificateAdapter(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        certificate_content = file_open('certificate/tests/data/cert.pfx', 'rb').read()
+        cls.certificate = cls.env['certificate.certificate'].create({
+            'name': 'PKCS12 test certificate',
+            'pkcs12_password': 'example',
+            'content': base64.b64encode(certificate_content),
+        })
+
+    def test_cert_verify_with_certificate_record(self):
+        ssl_context = mock.Mock()
+        ssl_context._ctx = mock.Mock()
+        original_load_cert_chain = ssl_context.load_cert_chain = mock.Mock()
+        conn = _DummyConnection(ssl_context)
+        adapter = CertificateAdapter()
+
+        with mock.patch('requests.adapters.HTTPAdapter.cert_verify') as cert_verify:
+            adapter.cert_verify(conn, 'https://example.com', True, self.certificate)
+
+        cert_verify.assert_called_once_with(conn, 'https://example.com', True, None)
+        self.assertEqual(conn.cert_file, self.certificate)
+        self.assertIsNone(conn.key_file)
+        self.assertNotEqual(ssl_context.load_cert_chain, original_load_cert_chain)
+
+        ssl_context.load_cert_chain(self.certificate)
+        ssl_context._ctx.use_certificate.assert_called_once()
+        ssl_context._ctx.use_privatekey.assert_called_once()
+
+    def test_cert_verify_with_cert_path_tuple(self):
+        ssl_context = mock.Mock()
+        original_load_cert_chain = ssl_context.load_cert_chain = mock.Mock()
+        conn = _DummyConnection(ssl_context)
+        adapter = CertificateAdapter()
+        cert_paths = ('/tmp/cert.pem', '/tmp/key.pem')
+
+        with mock.patch('requests.adapters.HTTPAdapter.cert_verify') as cert_verify:
+            adapter.cert_verify(conn, 'https://example.com', True, cert_paths)
+
+        cert_verify.assert_called_once_with(conn, 'https://example.com', True, cert_paths)
+        self.assertFalse(hasattr(conn, 'cert_file'))
+        self.assertFalse(hasattr(conn, 'key_file'))
+        ssl_context.load_cert_chain(*cert_paths)
+        original_load_cert_chain.assert_called_once_with(*cert_paths)


### PR DESCRIPTION
## Summary

This PR fixes a crash when sending Veri*Factu documents with PKCS12 certificates in 18.0 (`TypeError: expected str, bytes or os.PathLike object, not certificate`, issue [#236570](https://github.com/odoo/odoo/issues/236570)).

## Root Cause

`session.cert` is set to a `certificate.certificate` record.  
In some `requests/urllib3` TLS-context code paths, the `CertificateAdapter` patch was not consistently applied at the right stage, so PyOpenSSL attempted to treat the certificate record as a filesystem path.

## Fix

`CertificateAdapter` was hardened to support both in-memory certificate records and standard file-based certs:

- Patch SSL context in both connection flows:
  - `get_connection`
  - `get_connection_with_tls_context`
- Update `cert_verify` to handle two explicit cases:
  - `certificate.certificate` record: keep in-memory loading (skip path checks)
  - path / `(cert_path, key_path)` tuple: preserve native `requests` behavior
- Add defensive validation when `pem_certificate` or `private_key_id.pem_key` is missing.

## Tests

Added regression tests in `addons/certificate/tests/test_certificate_adapter.py`:

- `test_cert_verify_with_certificate_record`
- `test_cert_verify_with_cert_path_tuple`

Also registered the test module in `addons/certificate/tests/__init__.py`.

## Impact

- Fixes Veri*Factu PKCS12 submissions.
- Preserves compatibility with standard `requests.Session.cert` usage.
- Improves robustness for other modules using `CertificateAdapter` (e.g. SII/TBAI).
