### PR TITLE
[FIX] mail: add domain to force activity assignment to internal users only.

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -41,8 +41,7 @@
                             </group>
                             <group>
                                 <field name="date_deadline"/>
-                                <field name="activity_user_id" widget="many2one_avatar_user"
-                                       required="not plan_id"/>
+                                <field name="activity_user_id" widget="many2one_avatar_user" required="not plan_id" domain="[('share', '=', False)]"/>
                             </group>
                             <field name="note" class="oe-bordered-editor" placeholder="Log a note..."/>
                         </group>


### PR DESCRIPTION
Description:
Added an domain on the 'activity_user_id' field in the mail_activity_schedule_views
xml file. The domain blocks the assignment of activities to users who are not 
internal. 

task-5424577