### PR TITLE
[FIX] point_of_sale: ensure NumberBuffer uses live localization separators

### DIFF
--- a/addons/point_of_sale/static/src/app/services/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/services/number_buffer_service.js
@@ -65,7 +65,7 @@ class NumberBuffer extends EventBus {
         this.isReset = false;
         this.bufferHolderStack = [];
         this.sound = services["mail.sound_effects"];
-        this.defaultDecimalPoint = services.localization.decimalPoint;
+        this.localization = services.localization;
         this.overlay = services.overlay;
         window.addEventListener("keyup", this._onKeyboardInput.bind(this));
     }
@@ -157,7 +157,7 @@ class NumberBuffer extends EventBus {
         this.component = component;
         this.state = state;
         this.config = config;
-        this.decimalPoint = config.decimalPoint || this.defaultDecimalPoint;
+        this.decimalPoint = config.decimalPoint || this.localization.decimalPoint;
         this.maxTimeBetweenKeys = this.config.useWithBarcode
             ? barcodeService.maxTimeBetweenKeysInMs
             : 0;

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
@@ -7,6 +9,7 @@ import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_ut
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
+import * as NumberPopup from "@point_of_sale/../tests/generic_helpers/number_popup_util";
 import { inLeftSide } from "./utils/common";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
@@ -223,5 +226,47 @@ registry.category("web_tour.tours").add("test_add_money_button_with_different_de
             PaymentScreen.clickNumpad("+50"),
             PaymentScreen.fillPaymentLineAmountMobile("Bank", "53,20"),
             PaymentScreen.changeIs("50"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_payment_screen_tip_scenario", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Letter Tray", "1", "10"),
+            ProductScreen.clickPayButton(),
+
+            {
+                content: "Switch localization to comma",
+                trigger: "body",
+                run: () => {
+                    posmodel.numberBuffer.localization.decimalPoint = ",";
+                    posmodel.numberBuffer.localization.thousandsSep = ".";
+                    posmodel.numberBuffer._setUp();
+                },
+            },
+
+            PaymentScreen.clickTipButton(),
+            NumberPopup.enterValue("1,50"),
+            NumberPopup.isShown("1,50"),
+            Dialog.confirm(),
+            PaymentScreen.totalIs("12,50"),
+
+            {
+                content: "Switch localization back to dot",
+                trigger: "body",
+                run: () => {
+                    posmodel.numberBuffer.localization.decimalPoint = ".";
+                    posmodel.numberBuffer.localization.thousandsSep = ",";
+                    posmodel.numberBuffer._setUp();
+                },
+            },
+
+            PaymentScreen.clickTipButton(),
+            NumberPopup.enterValue("2.5"),
+            NumberPopup.isShown("2.5"),
+            Dialog.confirm(),
+            PaymentScreen.totalIs("13.50"),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3706,6 +3706,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         created_order = self.env['pos.order'].search([('partner_id', '=', partner.id)], limit=1)
         self.assertNotEqual(created_order.pricelist_id, not_available_pricelist)
 
+    def test_payment_screen_tip_scenario(self):
+        self.main_pos_config.write({
+            'iface_tipproduct': True,
+            'tip_product_id': self.tip.id,
+        })
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_payment_screen_tip_scenario', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Steps to reproduce:
1. Open the Point of Sale.
2. In Odoo Settings, change the Decimal Separator (e.g., from '.' to ',').
3. Go back to the PoS and add a Tip.
4. Observe that the tip math is wrong.

Cause:
The 'NumberBuffer' service is a singleton initialized at PoS startup. During initial setup, it caches the decimal point from 'services.localization.decimalPoint' into 'this.defaultDecimalPoint'. Because the service is a singleton, this value remains stale if settings are changed without a server refresh. When the 'NumberPopup' is opened, it uses the cached stale separator, causing parsing issues in methods like 'addTip'.

Solution:
Modify the 'NumberBuffer' service to fetch the decimal separator directly from the 'localization' service during the '_setUp' process.

opw-5895622