### PR TITLE
[FIX] pos*: ensure invoice selection before order validation in tour

### DIFF
--- a/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
+++ b/addons/l10n_be_pos_sale/static/tests/tours/l10n_be_pos_sale_tour.js
@@ -30,7 +30,6 @@ registry.category("web_tour.tours").add("PosSettleOrderIsInvoice", {
             ProductScreen.clickPayButton(),
             negateStep(...PaymentScreen.isInvoiceButtonChecked()),
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.isInvoiceButtonChecked(),
         ].flat(),
 });
 
@@ -42,7 +41,6 @@ registry.category("web_tour.tours").add("PosSettleOrderTryInvoice", {
             PosSale.settleNthOrder(1),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.isInvoiceButtonChecked(),
         ].flat(),
 });
 

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -32,7 +32,6 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
             Dialog.confirm(),
 
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.isInvoiceOptionSelected(),
             PaymentScreen.clickValidate(),
             // verify that the pos requires the selection of a partner
             Dialog.confirm(),

--- a/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
+++ b/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
@@ -42,6 +42,5 @@ registry.category("web_tour.tours").add("ZATCA_invoice_mandatory_if_not_settleme
             PaymentScreen.isInvoiceButtonChecked(),
             // Try to uncheck it and verify it remains checked
             PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.isInvoiceButtonChecked(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -107,14 +107,18 @@ export function clickPaymentline(name, amount) {
         },
     ];
 }
-export function clickInvoiceButton() {
-    return [
+export function clickInvoiceButton(isHighlighted = true) {
+    const steps = [
         {
             content: "click invoice button",
             trigger: ".payment-buttons .js_invoice",
             run: "click",
         },
     ];
+    if (isHighlighted) {
+        steps.push(...isInvoiceButtonChecked());
+    }
+    return steps;
 }
 export function clickValidate() {
     return [
@@ -251,14 +255,6 @@ export function changeIs(amount) {
         {
             content: `change is ${amount}`,
             trigger: `.payment-status-amount .amount:contains("${amount}")`,
-        },
-    ];
-}
-export function isInvoiceOptionSelected() {
-    return [
-        {
-            content: "Invoice option is selected",
-            trigger: ".payment-buttons .js_invoice.highlight",
         },
     ];
 }

--- a/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
+++ b/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
@@ -30,7 +30,6 @@ export function assertTaxTotals(baseAmount, taxAmount, totalAmount) {
         PaymentScreen.remainingIs("0.0"),
 
         PaymentScreen.clickInvoiceButton(),
-        PaymentScreen.isInvoiceButtonChecked(),
         PaymentScreen.clickValidate(),
         FeedbackScreen.isShown(),
         FeedbackScreen.checkTicketData({

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -177,20 +177,6 @@ registry.category("web_tour.tours").add("PosSettleOrderWithNote", {
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder", {
-    steps: () =>
-        [
-            Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
-            PosSale.settleNthOrder(1),
-            Order.hasLine({}),
-            ProductScreen.clickPayButton(),
-            PaymentScreen.clickPaymentMethod("Bank"),
-            PaymentScreen.clickInvoiceButton(),
-            PaymentScreen.clickValidate(),
-        ].flat(),
-});
-
 registry.category("web_tour.tours").add("PosSettleAndInvoiceOrder2", {
     steps: () =>
         [


### PR DESCRIPTION
pos*: point_of_sale, pos_sale, l10n_sa_edi_pos, l10n_es_pos,l10n_be_pos_sale

When invoice selection takes longer, and the order validation button is clicked immediately after, the tour may serialize data before the invoice field has settled. This can cause invoice generation to be skipped during order validation

Since the delay between tour steps was removed, this commit adds an explicit step to ensure the invoice is selected before validating the order.

Additionally, removed unused tour `PosSettleAndInvoiceOrder`

Task-5897375
Err-237600, 238502

Related-https://github.com/odoo/enterprise/pull/106863
