### PR TITLE
[FIX] analytic, account: Allow (set/not set) filter for analytic distribution search

### DIFF
--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -1351,3 +1351,18 @@ class TestAccountMove(AccountTestInvoicingCommon):
         }])
         move.line_ids.account_id = shared_account
         move.action_post()
+
+    def test_journal_entry_analytic_distribution_search_is_set(self):
+        """ Verify searching on analytic_distribution with 'is set', 'is not set'."""
+        analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan'})
+        analytic_account = self.env['account.analytic.account'].create({
+            'name': "Test Account",
+            'plan_id': analytic_plan.id,
+        })
+        self.assertFalse(self.env['account.move.line'].search([('analytic_distribution', '!=', False)]))
+        self.test_move.line_ids[0]['analytic_distribution'] = {str(analytic_account.id): 100}
+        self.assertEqual(
+            self.env['account.move.line'].search([('analytic_distribution', '!=', False)]),
+            self.test_move.line_ids[0],
+            ""
+        )

--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -74,7 +74,7 @@ class AnalyticMixin(models.AbstractModel):
         # Don't use this override when account_report_analytic_groupby is truly in the context
         # Indeed, when account_report_analytic_groupby is in the context it means that `analytic_distribution`
         # doesn't have the same format and the table is a temporary one, see _prepare_lines_for_analytic_groupby
-        if field_expr != 'analytic_distribution' or self.env.context.get('account_report_analytic_groupby'):
+        if field_expr != 'analytic_distribution' or self.env.context.get('account_report_analytic_groupby') or (isinstance(value, bool) and operator in ('=', '!=')):
             return super()._condition_to_sql(alias, field_expr, operator, value, query)
 
         def search_value(value: str, exact: bool):
@@ -98,11 +98,6 @@ class AnalyticMixin(models.AbstractModel):
         if not ids:
             # not ids found, just call super with an empty list
             return super()._condition_to_sql(alias, field_expr, operator, ids, query)
-
-        if isinstance(value, int) and operator in ('=', '!='):
-            value = [value]
-            operator = 'in' if operator == '=' else 'not in'
-
         # keys can be comma-separated ids, we will split those into an array and then make an array comparison with the list of ids to check
         analytic_accounts_query = self._query_analytic_accounts()
         ids = [str(id_) for id_ in ids if id_]  # list of ids -> list of string


### PR DESCRIPTION
**Problem:** 
When filtering by "Analytic Distribution" in views, using "is set" or "is not set" filters (or searching for False) causes a "search domain not valid" error or returns incorrect results.

**Steps to reproduce:**
1) Go to Accounting > Journal Entries.
2) Apply a filter for Invoice lines > Distribution Analytic Account.
3) Select "is set" or "is not set".
4) Check records.

Issue produces error "search domain not valid". Also reproduceable on Purchase Orders.

**Cause:** 
The `_condition_to_sql` method did not handle the `('=', '!=')` operators early enough, so it always went to the "operation not supported" error.

**Solution:**
- We need to move the handling of the operators '=', '!=' early enough in the `_condition_to_sql` method.

opw-5478688

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
