### PR TITLE
[FIX] hr_recruitment: fix applicant priority issue

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -25,7 +25,7 @@ AVAILABLE_PRIORITIES = [
 class HrApplicant(models.Model):
     _name = 'hr.applicant'
     _description = "Applicant"
-    _order = "priority desc, id desc"
+    _order = "priority desc, sequence, id desc"
     _inherit = ['mail.thread.cc',
                'mail.thread.main.attachment',
                'mail.thread.blacklist',
@@ -38,7 +38,6 @@ class HrApplicant(models.Model):
     _mailing_enabled = True
     _primary_email = 'email_from'
     _track_duration_field = 'stage_id'
-    _order = "sequence"
 
     sequence = fields.Integer(string='Sequence', index=True, default=10)
     active = fields.Boolean("Active", default=True, help="If the active field is set to false, it will allow you to hide the case without removing it.", index=True)


### PR DESCRIPTION
Steps to reproduce:
----------------------------------------
1. Install the Recruitment module
2. Navigate to Recruitment > Applications > All Applications
3. Go to Kanban view
4. Make any application Very High Priority (3 star)
5. Refresh the page

Observation:
----------------------------------------
Applications marked as Very High Priority are not displayed on top, Applicants with higher priority should be displayed first within the same stage.

Issue:
----------------------------------------
The `_order` attribute on the applicant model is declared twice, causing the intended priority-based ordering to be overridden by `sequence`. https://github.com/odoo/odoo/blob/6fed805389d878558e4139b270ee7a70269af767/addons/hr_recruitment/models/hr_applicant.py#L28-L41

Solution:
----------------------------------------
Reorder the fields in the `_order` attribute so that priority is applied before sequence, ensuring higher-priority applicants are shown first

opw-5893371