### PR TITLE
[FIX] website_sale: close global search modal when entering edit mode

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -669,7 +669,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
 publicWidget.registry.WebsiteSale = WebsiteSale
 
 publicWidget.registry.WebsiteSaleSearchModal = publicWidget.Widget.extend({
-    selector: '#o_wsale_search_modal',
+    selector: "#o_wsale_search_modal, #o_wsale_product_search_modal",
     disabledInEditableMode: true,
 
     //--------------------------------------------------------------------------
@@ -682,6 +682,9 @@ publicWidget.registry.WebsiteSaleSearchModal = publicWidget.Widget.extend({
             ev.target.querySelector('.oe_search_box').focus();
         });
     },
+    destroy() {
+        Modal.getInstance(this.el)?.hide();
+    }
 });
 
 publicWidget.registry.WebsiteSaleAccordionProduct = publicWidget.Widget.extend({


### PR DESCRIPTION
Steps to reproduce:
- Go to the Shop and enable the floating toolbar.
- Click the search icon in the header.
- When the search modal opens, click 'Edit' to enable website editing.
- Try to add a snippet from the floating toolbar.
=> The same issue also occurs on individual product pages.

Observed behavior:
Snippets cannot be added while the global search modal remains open.

Expected behavior:
Snippets should be draggable and added normally in edit mode.

This PR ensures that the global search modal is closed when entering edit mode, preventing it from blocking add snippet.

task-5905963