### PR TITLE
[FIX] point_of_sale: prevent NaN display in Tip popup

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -239,7 +239,7 @@ export class PaymentScreen extends Component {
                 this.onNewTip({ newValue, type, currentTipAmount: tip.amount, change }),
             formatDisplayedValue: (value, type) => {
                 if (type === "fixed") {
-                    return this.env.utils.formatCurrency(value, this.pos.currency);
+                    return this.env.utils.formatCurrency(parseFloat(value), this.pos.currency);
                 }
                 if (type === "percent") {
                     return `${value} %`;

--- a/addons/point_of_sale/static/src/app/services/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/services/number_buffer_service.js
@@ -65,7 +65,7 @@ class NumberBuffer extends EventBus {
         this.isReset = false;
         this.bufferHolderStack = [];
         this.sound = services["mail.sound_effects"];
-        this.defaultDecimalPoint = services.localization.decimalPoint;
+        this.localization = services.localization;
         this.overlay = services.overlay;
         window.addEventListener("keyup", this._onKeyboardInput.bind(this));
     }
@@ -157,7 +157,7 @@ class NumberBuffer extends EventBus {
         this.component = component;
         this.state = state;
         this.config = config;
-        this.decimalPoint = config.decimalPoint || this.defaultDecimalPoint;
+        this.decimalPoint = config.decimalPoint || this.localization.decimalPoint;
         this.maxTimeBetweenKeys = this.config.useWithBarcode
             ? barcodeService.maxTimeBetweenKeysInMs
             : 0;

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -7,6 +7,7 @@ import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_ut
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
+import * as NumberPopup from "@point_of_sale/../tests/generic_helpers/number_popup_util";
 import { inLeftSide } from "./utils/common";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
@@ -223,5 +224,56 @@ registry.category("web_tour.tours").add("test_add_money_button_with_different_de
             PaymentScreen.clickNumpad("+50"),
             PaymentScreen.fillPaymentLineAmountMobile("Bank", "53,20"),
             PaymentScreen.changeIs("50"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_payment_screen_tip_scenario", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Letter Tray", "1", "10"),
+            ProductScreen.clickPayButton(),
+
+            {
+                content: "Switch localization to comma",
+                trigger: ".payment-buttons",
+                run: () => {
+                    const env = odoo.__WOWL_DEBUG__.root.env;
+                    env.services.localization.decimalPoint = ",";
+                    env.services.localization.thousandsSep = ".";
+                    env.services.number_buffer._setUp();
+                },
+            },
+
+            PaymentScreen.clickTipButton(),
+            {
+                content: "Wait for NumberPopup to open",
+                trigger: ".modal",
+            },
+            NumberPopup.enterValue("1,50"),
+            NumberPopup.isShown("1,50"),
+            Dialog.confirm(),
+            PaymentScreen.totalIs("12,50"),
+            {
+                content: "Switch localization back to dot",
+                trigger: ".payment-buttons",
+                run: () => {
+                    const env = odoo.__WOWL_DEBUG__.root.env;
+                    env.services.localization.decimalPoint = ".";
+                    env.services.localization.thousandsSep = ",";
+                    env.services.number_buffer._setUp();
+                },
+            },
+
+            PaymentScreen.clickTipButton(),
+            {
+                content: "Wait for NumberPopup to open again",
+                trigger: ".modal",
+            },
+            NumberPopup.enterValue("2.5"),
+            NumberPopup.isShown("2.5"),
+            Dialog.confirm(),
+            PaymentScreen.totalIs("13.50"),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3761,6 +3761,13 @@ class TestUi(TestPointOfSaleHttpCommon):
         })
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_product_configurator_price', login="pos_user")
 
+    def test_payment_screen_tip_scenario(self):
+        self.main_pos_config.write({
+            'iface_tipproduct': True,
+            'tip_product_id': self.tip.id,
+        })
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_payment_screen_tip_scenario', login="pos_user")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Steps to reproduce:
1. Set the decimal separator to ',' in Settings.
2. Open PoS, click Add Tip, and type a number followed by a comma.
3. Observe the input field displays NaN.00.

Cause:
A mismatch exists in how the tip value is handled between display and confirmation:
- Display: NumberBuffer provides a localized string (e.g., '0,'). PaymentScreen passes this raw string directly to formatCurrency, which expects a standard numeric value. The internal cast fails on the localized separator, resulting in NaN.
- Confirmation: onNewTip correctly uses Odoo's localized parseFloat utility, which handles the separator properly.

Solution:
Update the formatDisplayedValue callback in PaymentScreen to parse the buffer string using the localized parseFloat before passing it to formatCurrency.

opw-5895622