### PR TITLE
[FIX] account: Show inactive taxes in fiscal position mapping

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -300,6 +300,7 @@ class AccountFiscalPosition(models.Model):
             'res_model': 'account.tax',
             'views': [(list_view.id if list_view else False, 'list'), (False, 'form')],
             'domain': [('id', 'in', self.tax_ids.ids)],
+            'context': {'active_test': False},
         }
 
     def action_create_foreign_taxes(self):


### PR DESCRIPTION
Observed issue: inactive taxes are shown in "Replaces" `original_tax_ids` field if the form view of a tax is opened through "Configuration"->"Taxes", but not shown under "Replaces" in a fiscal position tree view, nor are they shown in the same "Replaces" field of the tax form view when opened from the fiscal position tree view.
Cause: the fiscal position link calls `action_open_related_taxes` on partner (path `/account.tax/[id]`), while the "Configuration"->"Taxes" calls `action_tax_form` on tax (path `/taxes/[id]`), which has additional context element `'active_test': False` among others.
Solution: adding the context to the fiscal position action produces the desired behavior, but it might break something else as it affects the whole view.
task-5917667

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
