### PR TITLE
[IMP] html_editor: support separator command within list

### DIFF
--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -2,11 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "../plugin";
 import { closestBlock } from "../utils/blocks";
 import { closestElement, firstLeaf, lastLeaf, selectElements } from "../utils/dom_traversal";
-import {
-    isEmptyBlock,
-    isListItemElement,
-    paragraphRelatedElementsSelector,
-} from "../utils/dom_info";
+import { isEmptyBlock, paragraphRelatedElementsSelector } from "../utils/dom_info";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { fillEmpty, removeClass, splitTextNode } from "@html_editor/utils/dom";
 import { DIRECTIONS, nodeSize, rightPos } from "@html_editor/utils/position";
@@ -58,11 +54,11 @@ export class SeparatorPlugin extends Plugin {
     };
 
     insertSeparator() {
-        const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        let selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
         const block = closestBlock(selection.startContainer);
-        const element =
-            closestElement(selection.startContainer, paragraphRelatedElementsSelector) ||
-            (block && !isListItemElement(block) ? block : null);
+        this.dispatchTo("before_insert_separator_handlers", block);
+        selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
+        const element = closestElement(selection.startContainer, paragraphRelatedElementsSelector);
 
         if (element && element !== this.editable) {
             const sep = this.document.createElement("hr");


### PR DESCRIPTION
Currently when a user attempts to use the separator command within a list, no action is triggered. This PR ensures that separator command is supported within a list. If the separator is inserted on a list item, list is split into two and separator is inserted after first list.

task-5912576





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
