### PR TITLE
[FIX] website_sale: align arrows in dynamic product snippet

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -63,6 +63,19 @@
         }
     }
 
+    // Prevented horizontal overflow of control buttons.
+    .container-fluid {
+        @include media-breakpoint-up(md) {
+            .carousel-control-prev {
+                transform: translateX(50%);
+            }
+
+            .carousel-control-next {
+                transform: translateX(-50%);
+            }
+        }
+    }
+
     // Applies arrows' alignment except when title is on the left + desktop
     &:where(.o_wsale_products_opt_design_thumbs) {
         &:not(:has(.s_dynamic_snippet_title_aside)) {
@@ -75,17 +88,6 @@
                 @include o-aligns-controlers;
                 @include o-adapts-col-size;
             }
-        }
-    }
-}
-.s_dynamic_snippet_products .container-fluid .s_dynamic_snippet_title_aside + .s_dynamic_snippet_content {
-    @include media-breakpoint-up(md) {
-        // Prevented horizontal overflow of control buttons.
-        .carousel-control-prev {
-            transform: translateX(50%) scaleX(var(--o-wsale-dynamic-snippet-control-scale, 1));
-        }
-        .carousel-control-next {
-            transform: translateX(-50%) scaleX(var(--o-wsale-dynamic-snippet-control-scale, 1));
         }
     }
 }


### PR DESCRIPTION
Steps to reproduce:
1. Drag and drop the dynamic products snippet.
2. Select it and change the content width to max.

Issue:
The "next" and "previous" arrows are misaligned in the dynamic product snippet when the content width is set to "**max**".

Reason:
The `transform: scaleX(.2);` property was overriden by `transform: translateX(XX%);` property, which was applied to prevent the horizontal scrolling.

task-5921530