### PR TITLE
[FIX] hr: avoid access error editing bank account

### DIFF
--- a/addons/hr/views/res_partner_bank_views.xml
+++ b/addons/hr/views/res_partner_bank_views.xml
@@ -14,7 +14,7 @@
                     <span invisible="not employee_salary_amount_is_percentage">%</span>
                     <field name="currency_id" invisible="employee_salary_amount_is_percentage" readonly="True"/>
                 </div>
-                <field name="employee_id" invisible="not employee_id" widget="many2many_avatar_employee"/>
+                <field name="employee_id" invisible="not employee_id" groups="hr.group_hr_user" widget="many2many_avatar_employee"/>
             </xpath>
             <xpath expr="//page" position="before">
                 <page string="Bank Information" invisible="not bank_id">


### PR DESCRIPTION
**Steps to reproduce**
- have `hr` and `account` installed
- add a bank account to a contact
- switch to a user with accounting rights but no HR rights
- on the contact form, click on the tag of the bank account in the "Bank accounts" field
- Access Error due to missing rights related to employee model

**Cause**
The `_compute_employee_id` method requires read access on the `hr.employee` model.

**Solution**
Hide the field for non-HR users.

opw-5217072