### PR TITLE
[FIX] portal, website_slides: empty messages should not be fetched in portal

### DIFF
--- a/addons/portal/controllers/thread.py
+++ b/addons/portal/controllers/thread.py
@@ -93,8 +93,13 @@ class PortalThreadController(ThreadController):
         }
 
     def _get_non_empty_message_domain(self):
-        return Domain(
-            "body", "not in", [False, '<span class="o-mail-Message-edited"></span>']
+        return (
+            Domain("body", "!=", False)
+            & Domain(
+                "body",
+                "not like",
+                '<span class="o-mail-Message-edited" data-o-datetime="%"></span>',
+            )
         ) | Domain("attachment_ids", "!=", False)
 
     def _setup_portal_message_fetch_extra_domain(self, data) -> Domain:

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -99,6 +99,10 @@ registry.category("web_tour.tours").add("course_review_modification", {
             trigger:
                 "#chatterRoot:shadow .o-mail-Message:contains(Second review) .o_website_rating_static[title='3 stars on 5']",
         },
+        // If it fails here, it means that empty messages are also being fetched.
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Chatter .o-mail-Message:count(1)",
+        },
         {
             trigger: "span:contains(Edit Review)",
             run: "click",


### PR DESCRIPTION
PR #246783 added a new `data-o-datetime` metadata attribute to the `edited` tag.
 The fetch domain in portal uses the same tag to filter empty messages and
 prevent them from being fetched. This change adapts the fetch domain in portal
 to take into account the recent change to the `edited` tag.

