### PR TITLE
[FIX] sale: handle saving on browser tab change with open product dialog

### DIFF
--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -3,7 +3,7 @@ import { Dialog } from '@web/core/dialog/dialog';
 import { formatCurrency } from '@web/core/currency';
 import { rpc } from '@web/core/network/rpc';
 import { useService } from '@web/core/utils/hooks';
-import { Component, useState, useSubEnv } from '@odoo/owl';
+import { Component, onMounted, onWillUnmount, useState, useSubEnv } from '@odoo/owl';
 import { ProductCard } from '../product_card/product_card';
 import { ProductCombo } from '../models/product_combo';
 import { ProductTemplateAttributeLine } from '../models/product_template_attribute_line';
@@ -59,6 +59,9 @@ export class ComboConfiguratorDialog extends Component {
         this._initSelectedComboItems();
         this.getPriceUrl = '/sale/combo_configurator/get_price';
         useSubEnv({ currency: { id: this.props.currency_id } });
+
+        onMounted(() => this.env.bus.trigger("FORM-CONTROLLER:FORM-IN-DIALOG:ADD"));
+        onWillUnmount(() => this.env.bus.trigger("FORM-CONTROLLER:FORM-IN-DIALOG:REMOVE"));
     }
 
     /**

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -1,4 +1,4 @@
-import { Component, onWillStart, useState, useSubEnv } from "@odoo/owl";
+import { Component, onMounted, onWillStart, onWillUnmount, useState, useSubEnv } from "@odoo/owl";
 import { Dialog } from '@web/core/dialog/dialog';
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
@@ -90,6 +90,9 @@ export class ProductConfiguratorDialog extends Component {
             // Use the currency id retrieved from the server if none was provided in the props.
             this.currency.id ??= currency_id;
         });
+
+        onMounted(() => this.env.bus.trigger("FORM-CONTROLLER:FORM-IN-DIALOG:ADD"));
+        onWillUnmount(() => this.env.bus.trigger("FORM-CONTROLLER:FORM-IN-DIALOG:REMOVE"));
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
## Versions
18.0+

## Issue
When the product configurator dialog is open, a browser tab change acts like a discard on the SOL: coming back to the Odoo tab displays the dialog but the SOL has been reverted to its previous state.

## Steps to reproduce
- Create a new SO for any customer:
  - Add a standard (non-combo/non-variant) product (e.g. "Apple Pie");
  - Save manually;
  - Change the product for a combo or variant one (e.g. "Customizable Desk");
  - With the opened dialog, change from browser tab then come back;
  - The SOL has been reset to the standard product ("Apple Pie") and confirming the dialog has no effect).

## Cause
The `beforeVisibilityChange` hook is triggered by the tab change and saves the form without updated values. This is because the hook checks for two conditions to be true: https://github.com/odoo/odoo/blob/2f00b0085574653ca1a8f734ef91893a4a1c1a7c/addons/web/static/src/views/form/form_controller.js#L479-L483 The tab change indeed changes the document's visibility to "hidden" but the controller has never been updated with the form's display in the dialog and, therefore, `this.formInDialog` is indeed equal to zero.

## Test
No test as we cannot simulate a browser tab change then come back to the first tab.


opw-5494089