### PR TITLE
[FIX] hr_expense: Employee cant use chatter on his own expenses

### DIFF
--- a/addons/hr_expense/static/src/views/expense_attach_documents.js
+++ b/addons/hr_expense/static/src/views/expense_attach_documents.js
@@ -1,0 +1,38 @@
+import { registry } from "@web/core/registry";
+import { checkFileSize } from "@web/core/utils/files";
+import { AttachDocumentWidget } from "@web/views/widgets/attach_document/attach_document";
+
+export class ExpenseAttachDocumentWidget extends AttachDocumentWidget {
+    async onInputChange() {
+        const ufile = [...this.fileInput.files];
+        for (const file of ufile) {
+            if (!checkFileSize(file.size, this.notification)) {
+                return null;
+            }
+        }
+        const fileData = await this.http.post("/mail/attachment/upload", {
+            csrf_token: odoo.csrf_token,
+            ufile: ufile,
+            thread_model: this.props.record.resModel,
+            thread_id: this.props.record.resId,
+        });
+        if (fileData.error) {
+            throw new Error(fileData.error);
+        }
+        await this.onFileUploaded(fileData.data["ir.attachment"] || []);
+    }
+}
+
+export const attachDocumentWidget = {
+    component: ExpenseAttachDocumentWidget,
+    extractProps: ({ attrs }) => {
+        const { action, highlight, string } = attrs;
+        return {
+            action,
+            highlight: !!highlight,
+            string,
+        };
+    },
+};
+
+registry.category("view_widgets").add("expense_attach_document", attachDocumentWidget);

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
+from odoo import http
 from odoo.exceptions import AccessError, UserError
 from odoo.tests import HttpCase, tagged, new_test_user
 
@@ -188,3 +189,90 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
         })
         self.start_tour("/odoo", 'hr_expense_access_rights_test_tour', login="test-expense")
         self.assertRecordValues(expense_sheet, [{'state': 'submit'}])
+
+    def test_expense_create_and_post_message_on_submitted(self):
+        """ Test than different users can post (or not) a message and an attachment when the expense is submitted.
+        """
+
+        standard_user = self.expense_user_employee
+        another_standard_user = new_test_user(self.env, login='another_standard_user', groups='base.group_user')
+        standard_user_manager = self.expense_user_manager
+        admin_user = self.env.ref('base.user_admin')
+        admin_user.company_ids |= self.env.companies
+
+        expense = self.env['hr.expense'].with_user(standard_user).create({
+            'name': "Superboy costume washing",
+            'employee_id': self.expense_employee.id,
+            'product_id': self.product_a.id,
+            'quantity': 1,
+            'price_unit': 1,
+        })
+
+        expense.with_user(standard_user).action_submit()
+
+        expense.with_user(standard_user).message_post(body="Standard user posts a message on his own expense.")
+        with self.assertRaises(AccessError):
+            expense.with_user(another_standard_user).message_post(body="Another standard user tries to post a message on the expense.")
+        expense.with_user(standard_user_manager).message_post(body="Manager user posts a message on the expense.")
+        expense.with_user(admin_user).message_post(body="Admin user posts a message on the expense.")
+
+        self.assertEqual(len(expense.message_ids), 3)
+
+        # When testing for uploading the attachments, we can simulate it through a tour as using inputFiles isn't possible
+        # with a AttachDocumentWidget since the input is added to the DOM.
+        self.authenticate(standard_user.login, standard_user.login)
+        response_user = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('salut.txt', b"Salut !\n", 'text/plain')},
+        )
+        expense.with_user(standard_user).attach_document(attachment_ids=[data['id'] for data in response_user.json()['data']['ir.attachment']])
+        self.assertEqual(response_user.status_code, 200)
+        self.assertEqual(len(expense.attachment_ids), 1)
+        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['ir.attachment'][0]['id'])
+
+        self.authenticate(another_standard_user.login, another_standard_user.login)
+        response_user2 = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('fail.txt', b"Fail\n", 'text/plain')},
+        )
+        with self.assertRaises(AccessError):
+            expense.with_user(another_standard_user).attach_document(attachment_ids=None)
+        self.assertEqual(response_user2.status_code, 404)
+        self.assertEqual(len(expense.attachment_ids), 1)  # No new attachment
+        self.assertEqual(expense.message_main_attachment_id.id, response_user.json()['data']['ir.attachment'][0]['id'])
+
+        self.authenticate(standard_user_manager.login, standard_user_manager.login)
+        response_manager = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('manager.txt', b"Manager\n", 'text/plain')},
+        )
+        expense.with_user(standard_user_manager).attach_document(attachment_ids=[data['id'] for data in response_manager.json()['data']['ir.attachment']])
+        self.assertEqual(response_manager.status_code, 200)
+        self.assertEqual(len(expense.attachment_ids), 2)
+        self.assertEqual(expense.message_main_attachment_id.id, response_manager.json()['data']['ir.attachment'][0]['id'])
+
+        self.authenticate(admin_user.login, admin_user.login)
+        response_admin = self.url_open("/mail/attachment/upload",
+            {
+            "csrf_token": http.Request.csrf_token(self),
+            "thread_id": expense.id,
+            "thread_model": "hr.expense",
+            },
+            files={'ufile': ('admin.txt', b"Admin\n", 'text/plain')},
+        )
+        expense.with_user(admin_user).attach_document(attachment_ids=[data['id'] for data in response_admin.json()['data']['ir.attachment']])
+        self.assertEqual(response_admin.status_code, 200)
+        self.assertEqual(len(expense.attachment_ids), 3)
+        self.assertEqual(expense.message_main_attachment_id.id, response_admin.json()['data']['ir.attachment'][0]['id'])

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -130,8 +130,8 @@
                   <button name="action_submit_expenses" string="Create Report" type="object"
                           class="oe_highlight o_expense_submit" invisible="nb_attachment &lt;= 0 or sheet_id" data-hotkey="v"/>
                   <button name="action_view_sheet" type="object" string="View Report" class="oe_highlight" invisible="not sheet_id or nb_attachment &lt; 1" data-hotkey="w"/>
-                  <widget name="attach_document" string="Attach Receipt" action="attach_document" invisible="nb_attachment &lt; 1"/>
-                  <widget name="attach_document" string="Attach Receipt" action="attach_document" highlight="1" invisible="nb_attachment &gt;= 1"/>
+                  <widget name="expense_attach_document" string="Attach Receipt" action="attach_document" invisible="nb_attachment &lt; 1"/>
+                  <widget name="expense_attach_document" string="Attach Receipt" action="attach_document" highlight="1" invisible="nb_attachment &gt;= 1"/>
                   <button name="action_submit_expenses" string="Create Report" type="object" class="o_expense_submit"
                           invisible="nb_attachment &gt;= 1 or sheet_id" data-hotkey="v"/>
                   <field name="state" widget="statusbar" statusbar_visible="draft,reported,submitted,approved,done"


### PR DESCRIPTION
An employee that created his expense was only able to add attachments and post message in the chatter when the expense was in draft.

After this, it will still be able to attach attachment and post message without having the right to edit the expense. This is better as the employee will be able to answer questions that have been asked or add more proof if required.

task-4966942

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
