### PR TITLE
[IMP] im_livechat: improve view contact button ui

### DIFF
--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -2,8 +2,12 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelInfoList">
         <ActionPanel title.translate="Information" minWidth="200" initialWidth="env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
-            <a t-if="visitorProfileURL" class="btn btn-primary mt-1" t-on-click.prevent="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
-                View Contact
+            <a t-if="visitorProfileURL" class="btn btn-primary mt-1 d-flex align-items-center justify-content-between" t-on-click.prevent="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
+                <span class="flex-grow-1 text-center">
+                    <i class="fa fa-address-book-o opacity-50 me-1"/>
+                    View Contact
+                </span>
+                <i class="oi oi-chevron-right opacity-50 small"/>
             </a>
             <div t-if="!props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Status</h6>


### PR DESCRIPTION
**Purpose of this PR:**

Before this commit, the `'View Contact'` action was missing visual cues about how the contact form would be opened.

This commit adds icons to clarify the action and completes the button UI.

| Before | After |
|--------|-------|
| <img width="382" height="627" alt="Before" src="https://github.com/user-attachments/assets/22ba6ba5-2406-44fb-b601-b76f1f65c45f" /> | <img width="373" height="609" alt="After" src="https://github.com/user-attachments/assets/e385c61c-3f4a-4391-b131-91229d83259f" /> |


task-5873878

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
