### PR TITLE
[FIX] web: do not allow edition of user group field in readonly

### DIFF
--- a/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.xml
+++ b/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_field.xml
@@ -3,7 +3,7 @@
 
 <t t-name="web.ResUserGroupIdsField">
     <Record fields="fields" fieldNames="Object.keys(fields)" values="values" hooks="hooks" t-slot-scope="data">
-        <FormRenderer record="data.record" archInfo="archInfo"/>
+        <FormRenderer record="data.record" archInfo="archInfo" readonly="props.readonly"/>
     </Record>
 </t>
 

--- a/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
+++ b/addons/web/static/tests/webclient/res_user_group_ids_field.test.js
@@ -269,6 +269,27 @@ test("simple rendering", async () => {
     expect(".o_group_info_button").toHaveCount(0); // not displayed in non debug mode
 });
 
+test("simple rendering in readonly", async () => {
+    await mountView({
+        type: "form",
+        arch: `
+            <form edit="0">
+                <sheet>
+                    <field name="group_ids" widget="res_user_group_ids"/>
+                </sheet>
+            </form>`,
+        resModel: "res.users",
+        resId: 1,
+    });
+
+    expect(".o_field_widget[name=group_ids] input").toHaveCount(0);
+    expect(queryAllTexts(".o_field_res_user_group_ids_privilege span")).toEqual([
+        "Access Rights",
+        "Project User",
+        "",
+    ]);
+});
+
 test("simple rendering (debug)", async () => {
     serverState.debug = "1";
     await mountView({


### PR DESCRIPTION
Before this commit, the res_user_group_ids field introduced in [1] didn't care about the `readonly` props. As a consequence, when the field (or the whole view, via `edit="0"`) was readonly, the widget still rendered editable SelectMenu. Obviously, editing it and then triggering a save would raise a validation error, so it was only an UI issue.

This commit fixes it by properly setting the field in readonly if its props states it.

[1] https://github.com/odoo/odoo/pull/179354

task~5922282

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
