### PR TITLE
[IMP] sale_project: Allow projects on draft SO

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -62,6 +62,8 @@ class ProjectProject(models.Model):
                 'reinvoiced_sale_order_id': order_id,
                 'sale_line_id': sale_line_id,
             })
+        if defaults.get('sale_order_id') and self.env['sale.order'].search([('id', '=', defaults['sale_order_id']), ('state', '=', 'draft')]):
+            defaults.pop('sale_line_id', False)
         return defaults
 
     @api.model
@@ -185,38 +187,15 @@ class ProjectProject(models.Model):
         if not self.reinvoiced_sale_order_id and self.sale_line_id:
             self.reinvoiced_sale_order_id = self.sale_line_id.order_id
 
-    def _ensure_sale_order_linked(self, sol_ids):
-        """ Orders created from project/task are supposed to be confirmed to match the typical flow from sales, but since
-        we allow SO creation from the project/task itself we want to confirm newly created SOs immediately after creation.
-        However this would leads to SOs being confirmed without a single product, so we'd rather do it on record save.
-        """
-        quotations = self.env['sale.order.line'].sudo()._read_group(
-            domain=[('state', '=', 'draft'), ('id', 'in', sol_ids)],
-            aggregates=['order_id:recordset'],
-        )[0][0]
-        if quotations:
-            quotations.action_confirm()
-
     @api.model_create_multi
     def create(self, vals_list):
         projects = super().create(vals_list)
-        sol_ids = set()
         for project, vals in zip(projects, vals_list):
-            if (vals.get('sale_line_id')):
-                sol_ids.add(vals['sale_line_id'])
             if project.sale_order_id and not project.sale_order_id.project_id:
                 project.sale_order_id.project_id = project.id
             elif project.sudo().reinvoiced_sale_order_id and not project.sudo().reinvoiced_sale_order_id.project_id:
                 project.sudo().reinvoiced_sale_order_id.project_id = project.id
-        if sol_ids:
-            projects._ensure_sale_order_linked(list(sol_ids))
         return projects
-
-    def write(self, vals):
-        project = super().write(vals)
-        if sol_id := vals.get('sale_line_id'):
-            self._ensure_sale_order_linked([sol_id])
-        return project
 
     def _get_sale_orders_domain(self, all_sale_orders):
         return [("id", "in", all_sale_orders.ids)]

--- a/addons/sale_project/models/project_task.py
+++ b/addons/sale_project/models/project_task.py
@@ -155,36 +155,6 @@ class ProjectTask(models.Model):
                         product_id=task.sale_line_id.product_id.display_name,
                     ))
 
-    def _ensure_sale_order_linked(self, sol_ids):
-        """ Orders created from project/task are supposed to be confirmed to match the typical flow from sales, but since
-        we allow SO creation from the project/task itself we want to confirm newly created SOs immediately after creation.
-        However this would leads to SOs being confirmed without a single product, so we'd rather do it on record save.
-        """
-        quotations = self.env['sale.order.line'].sudo()._read_group(
-            domain=[('state', '=', 'draft'), ('id', 'in', sol_ids)],
-            aggregates=['order_id:recordset'],
-        )[0][0]
-        if quotations:
-            quotations.action_confirm()
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        tasks = super().create(vals_list)
-        sol_ids = {
-            vals['sale_line_id']
-            for vals in vals_list
-            if vals.get('sale_line_id')
-        }
-        if sol_ids:
-            tasks._ensure_sale_order_linked(list(sol_ids))
-        return tasks
-
-    def write(self, vals):
-        task = super().write(vals)
-        if sol_id := vals.get('sale_line_id'):
-            self._ensure_sale_order_linked([sol_id])
-        return task
-
     # ---------------------------------------------------
     # Actions
     # ---------------------------------------------------

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -52,18 +52,9 @@ class SaleOrder(models.Model):
 
     def _compute_show_project_and_task_button(self):
         is_project_manager = self.env.user.has_group('project.group_project_manager')
-        show_button_ids = self.env['sale.order.line']._read_group([
-            ('order_id', 'in', self.ids),
-            ('order_id.state', 'not in', ['draft', 'sent']),
-        ], aggregates=['order_id:array_agg'])[0][0]
         for order in self:
-            state = order.state not in ['draft', 'sent']
-            order.show_project_button = state and order.project_count
-            order.show_create_project_button = (
-                is_project_manager
-                and order.id in show_button_ids
-                and not order.project_count
-            )
+            order.show_project_button = order.project_count
+            order.show_create_project_button = is_project_manager
 
     @api.model
     def _search_tasks_ids(self, operator, value):
@@ -145,15 +136,22 @@ class SaleOrder(models.Model):
             for order in self:
                 order.order_line.sudo().with_company(order.company_id)._timesheet_service_generation()
 
-        # If the order has exactly one project and that project comes from a template, set the company of the template
-        # on the project.
         for order in self.sudo(): # Salesman may not have access to projects
+            sale_line_to_assign = next((sol for sol in order.order_line if sol.is_service), False)
+            if not sale_line_to_assign:
+                continue
+            for project in order.project_ids.sudo():
+                if not project.sale_line_id and project.reinvoiced_sale_order_id:
+                    project.sale_line_id = sale_line_to_assign
+            # If the order has exactly one project and that project comes from a template, set the company of the template
+            # on the project.
             if len(order.project_ids) == 1:
                 project = order.project_ids[0]
                 for sol in order.order_line:
                     if project == sol.project_id and (project_template := sol.product_template_id.project_template_id):
                         project.sudo().company_id = project_template.sudo().company_id
                         break
+
         return super()._action_confirm()
 
     def _tasks_ids_domain(self):
@@ -167,10 +165,9 @@ class SaleOrder(models.Model):
                 'tag': 'display_notification',
                 'params': {
                     'type': 'danger',
-                    'message': self.env._("The project couldn't be created as the Sales Order must be confirmed or is already linked to a project."),
+                    'message': self.env._("The project couldn't be created because you don't have the right to create a project"),
                 }
             }
-
         sorted_line = self.order_line.sorted('sequence')
         default_sale_line = next((
             sol for sol in sorted_line

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -175,16 +175,18 @@ class SaleOrderLine(models.Model):
     def _timesheet_create_project_prepare_values(self):
         """Generate project values"""
         # create the project or duplicate one
-        return {
+        values = {
             'name': '%s - %s' % (self.order_id.client_order_ref, self.order_id.name) if self.order_id.client_order_ref else self.order_id.name,
             'account_id': self.env.context.get('project_account_id') or self.order_id.project_account_id.id or self.env['account.analytic.account'].create(self.order_id._prepare_analytic_account_data()).id,
             'partner_id': self.order_id.partner_id.id,
-            'sale_line_id': self.id,
             'active': True,
             'company_id': self.company_id.id,
             'allow_billable': True,
             'user_id': self.product_id.project_template_id.user_id.id,
         }
+        if self.order_id.state != 'draft':
+            values['sale_line_id'] = self.id
+        return values
 
     def _timesheet_create_project(self):
         """ Generate project for the given so line, and link it.
@@ -200,15 +202,16 @@ class SaleOrderLine(models.Model):
                 project = project_template.action_create_from_template(values)
             else:
                 project = project_template.copy(values)
-            project.tasks.write({
-                'sale_line_id': self.id,
-                'partner_id': self.order_id.partner_id.id,
-            })
-            # duplicating a project doesn't set the SO on sub-tasks
-            project.tasks.filtered('parent_id').write({
-                'sale_line_id': self.id,
-                'sale_order_id': self.order_id.id,
-            })
+            if (self.order_id.state != 'draft'):
+                project.tasks.write({
+                    'sale_line_id': self.id,
+                    'partner_id': self.order_id.partner_id.id,
+                })
+                # duplicating a project doesn't set the SO on sub-tasks
+                project.tasks.filtered('parent_id').write({
+                    'sale_line_id': self.id,
+                    'sale_order_id': self.order_id.id,
+                })
         else:
             project_only_sol_count = self.env['sale.order.line'].search_count([
                 ('order_id', '=', self.order_id.id),

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -387,7 +387,6 @@ class TestSaleProject(TestSaleProjectCommon):
         # add a project to the SO
         line_delivered_milestone.project_id = self.project_global
         sale_order_1._compute_show_project_and_task_button()
-        self.assertFalse(sale_order_1.show_create_project_button, "There is a product service with the service_policy set on 'delivered on milestone' and a project on the sale order, the button should be hidden")
         self.assertTrue(sale_order_1.show_project_button, "There is a product service with the service_policy set on 'delivered on milestone' and a project on the sale order, the button should be displayed")
 
         # add an ordered_prepaid service product
@@ -1097,7 +1096,7 @@ class TestSaleProject(TestSaleProjectCommon):
             copy.order_line.project_id._get_analytic_distribution(),
         )
 
-    def test_confirm_sale_order_on_task_save(self):
+    def test_non_confirm_sale_order_on_task_save(self):
         sale_order = self.env['sale.order'].create({
             'name': 'Sale Order',
             'partner_id': self.partner.id,
@@ -1113,9 +1112,9 @@ class TestSaleProject(TestSaleProjectCommon):
             'project_id': self.project_global.id,
         })
         task.write({'sale_line_id': sale_order_line.id})
-        self.assertEqual(sale_order.state, 'sale')
+        self.assertEqual(sale_order.state, 'draft')
 
-    def test_confirm_sale_order_on_project_creation(self):
+    def test_non_confirm_sale_order_on_project_creation(self):
         sale_order = self.env['sale.order'].create({
             'name': 'Sale Order',
             'partner_id': self.partner.id,
@@ -1130,7 +1129,7 @@ class TestSaleProject(TestSaleProjectCommon):
             'name': 'Project',
             'sale_line_id': sale_order_line.id,
         })
-        self.assertEqual(sale_order.state, 'sale')
+        self.assertEqual(sale_order.state, 'draft')
 
     def test_create_project_on_fly(self):
         """
@@ -1375,7 +1374,7 @@ class TestSaleProject(TestSaleProjectCommon):
             =========
             When the user clicks on the stat button `Make Billable`, the `create_for_project_id` is added
             to the contex. With that context, we will make sure the action_confirm will do nothing if the
-            user clicks on it since the SO will automatically be confirmed in that use case.
+            user clicks on it since the SO will not automatically be confirmed in that use case.
         """
         self.project_global.partner_id = self.partner
         action_dict = self.project_global.with_context(
@@ -1391,7 +1390,7 @@ class TestSaleProject(TestSaleProjectCommon):
         })
         self.assertEqual(sale_order.partner_id, self.partner)
         self.assertEqual(sale_order.project_id, self.project_global)
-        self.assertEqual(sale_order.state, 'sale')
+        self.assertEqual(sale_order.state, 'draft')
         self.assertEqual(self.project_global.sale_line_id, sale_order.order_line)
 
         sale_order.action_confirm()  # no error should be raised even if the SO is already confirmed
@@ -1641,8 +1640,8 @@ class TestSaleProject(TestSaleProjectCommon):
             - Create a project and link it to the sale order.
             - Create a task and link it to the project.
             - Verify that the project is linked to the sale order.
-            - Verify that the task without SO item is not linked to the sale order.
-            - Verify that the project & task smart button is hidden.
+            - Verify that the task is linked to the sale order.
+            - Verify that the project & task smart button is visible.
             - Confirm the sale order.
             - Verify the visibility of the project & task smart button.
         """
@@ -1674,9 +1673,9 @@ class TestSaleProject(TestSaleProjectCommon):
             (1, 0),
             "Project must be linked and tasks without SO lines should not be linked to the sales order."
         )
-        self.assertFalse(
+        self.assertTrue(
             sale_order.show_project_button,
-            "The project smart buttons should be hidden in the sale order."
+            "The project smart buttons should be visible in the sale order."
         )
 
         sale_order.action_confirm()

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -343,6 +343,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
         })
 
         self.assertEqual(self.so1_line_deliver_no_task.qty_delivered, timesheet1.unit_amount)
+        self.sale_order_1.action_confirm()
         invoice1 = self.sale_order_1._create_invoices()[0]
         invoice1.action_post()
 

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -737,7 +737,7 @@ class TestSaleService(TestCommonSaleTimesheet):
         self.assertFalse(sale_order_1.show_project_button, "There is no project on the sale order, the button should be hidden")
         line_1.project_id = self.project_global.id
         sale_order_1._compute_show_project_and_task_button()
-        self.assertFalse(sale_order_1.show_create_project_button, "There is a product service with the service_policy set on 'delivered on timesheet' and a project on the sale order, the button should be hidden")
+        self.assertTrue(sale_order_1.show_create_project_button, "The 'create Project Button' should be displayed reguardless of the service product type")
         self.assertTrue(sale_order_1.show_project_button, "There is a product service with the service_policy set on 'delivered on timesheet' and a project on the sale order, the button should be displayed")
 
     def test_compute_show_timesheet_button(self):


### PR DESCRIPTION
 ## Behavior Before Commit:
- When a user selected "Create Project" on an SO that was not confirmed or already had a project, Odoo did not create the project and showed a warning.

## Expected Behavior After Commit:
- Users can create multiple projects for the same SO.
- Users can create a project regardless of the SO state.
- Project SOLs remain empty when the SO is in draft.
- Project SOLs are auto-filled when the SO is confirmed.
- SO are no longer auto confirmed once the are connected to a project to make it possible for a draft SO tro be attached to a project.

## Task
[5872486](https://www.odoo.com/odoo/project/4105/tasks/5872486)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
