### PR TITLE
[FIX] mass_mailing: unlink mail.message of test mails

### DIFF
--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -75,7 +75,7 @@ class MailingMailingTest(models.TransientModel):
                     'body': full_body,
                     'mailing_style': Markup(f'<style>{styles}</style>'),
                 }, minimal_qcontext=True),
-                'is_notification': True,
+                'is_notification': False,
                 'mailing_id': mailing.id,
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
                 'auto_delete': False,  # they are manually deleted after notifying the document

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -160,6 +160,21 @@ class TestMailingTest(TestMassMailCommon):
             "Should use the value of the previous record's email_to as default",
         )
 
+        # Also test that related messages were properly deleted
+        mailing.subject = 'Dummy Subject'
+
+        with self.mock_mail_gateway(mail_unlink_sent=True):
+            mailing_test.send_mail_test()
+
+        test_subject = '[TEST] %s' % mailing.subject
+        self.assertSentEmail(
+            self.env.user.partner_id,
+            ['test@test.com'],
+            subject=test_subject,
+        )
+        self.assertFalse(self.env['mail.mail'].search([('subject', '=', test_subject)]))
+        self.assertFalse(self.env['mail.message'].search([('subject', '=', test_subject)]))
+
 
 @tagged('mailing_manage', 'twilio')
 class TestMailingSMSTest(TestMassSMSCommon, MockSmsTwilioApi):


### PR DESCRIPTION
**Steps to reproduce:**
- Go to Email Marketing app
- Create a mailing campaign
- Set its recipients to Contact
- Click on the test button to send a test mail to any mail
- Go to the first contact record
- Chatter will show `This message has been removed` message

**Issue:**
Previously, message created for testing were ignored by the Chatter as they were empty. As we now keep empty messages visible but with removed content display, they shows up on related records.
```py
record = self.env[mailing.mailing_model_real].search([], limit=1)
```

**Fix:**
Ensure the related messages are unlinked at the same time as the test mail in `send_mail_test` by setting `is_notification` to `False` to trigger the `unlink` logic.
```py
def unlink(self):
    # cascade-delete the parent message for all mails that are not created for a notification
    mail_msg_cascade_ids = [mail.mail_message_id.id for mail in self if not mail.is_notification]
    res = super(MailMail, self).unlink()
    if mail_msg_cascade_ids:
        self.env['mail.message'].browse(mail_msg_cascade_ids).unlink()
    return res
```

related: https://github.com/odoo/odoo/commit/21f92550f83cbd38df2c223c65c61bd16dc8e2b0

opw-5502787