### PR TITLE
[FIX] digest: Count users based on allowed companies

### DIFF
--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -410,8 +410,10 @@ class Digest(models.Model):
         """
         start, end, companies = self._get_kpi_compute_parameters()
 
+        company_field = self._get_company_field(model)
+
         base_domain = [
-            ('company_id', 'in', companies.ids),
+            (company_field, 'in', companies.ids),
             (date_field, '>=', start),
             (date_field, '<', end),
         ]
@@ -421,7 +423,7 @@ class Digest(models.Model):
 
         values = self.env[model]._read_group(
             domain=base_domain,
-            groupby=['company_id'],
+            groupby=[company_field],
             aggregates=[f'{sum_field}:sum'] if sum_field else ['__count'],
         )
 
@@ -429,6 +431,9 @@ class Digest(models.Model):
         for digest in self:
             company = digest.company_id or self.env.company
             digest[digest_kpi_field] = values_per_company.get(company.id, 0)
+
+    def _get_company_field(self, model):
+        return 'company_ids' if model in ['res.users'] else 'company_id'
 
     def _get_kpi_fields(self):
         return [field_name for field_name, field in self._fields.items()

--- a/addons/digest/tests/test_digest.py
+++ b/addons/digest/tests/test_digest.py
@@ -106,6 +106,11 @@ class TestDigest(TestDigestCommon):
         self.assertEqual(self.digest_3.kpi_res_users_connected_value, 2,
             msg='This KPI has no company, should take the current one')
 
+        self.user_employee.company_ids |= self.company_2
+
+        self.assertEqual(self.digest_2.kpi_res_users_connected_value, 1,
+            msg='The employee user should be counted in the other company if in allowed companies')
+
     @users('admin')
     def test_digest_numbers(self):
         digest = self.env['digest.digest'].browse(self.digest_1.ids)


### PR DESCRIPTION
**Problem:**
Currently, the digest KPI for connected users checks the "company_id" field (as with all other models), but this field corresponds to "Default Company" on res.users, meaning a user can only be considered for one company when computing the digest KPI. This can cause misleading digest KPIs if users work in multiple companies, or mainly in a company that isn't their default company.

**Solution:**
Instead of always using the "company_id" field, we use the "company_ids" field if present on the model.

opw-5404940