### PR TITLE
[REF] html_builder: use resource to tell which snippets connect shape

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -23,7 +23,7 @@ declare module "plugins" {
     import { on_reveal_target_handlers } from "@html_builder/sidebar/invisible_elements_panel";
     import { on_snippet_dragged_handlers, on_snippet_dropped_handlers, on_snippet_dropped_near_handlers, on_snippet_dropped_over_handlers, on_snippet_move_handlers, on_snippet_out_dropzone_handlers, on_snippet_over_dropzone_handlers } from "@html_builder/sidebar/block_tab";
     import { snippet_preview_dialog_bundles, snippet_preview_dialog_stylesheets_handlers } from "@html_builder/snippets/add_snippet_dialog";
-    import { background_shape_groups_providers, background_shape_target_providers } from "@html_builder/plugins/background_option/background_shape_option_plugin";
+    import { background_shape_groups_providers, background_shape_target_providers, is_element_in_invisible_panel_predicates } from "@html_builder/plugins/background_option/background_shape_option_plugin";
     import { mark_color_level_selector_params } from "@html_builder/plugins/background_option/background_option_plugin";
     import { is_movable_selector, on_element_arrow_moved_handlers } from "@html_builder/core/move_plugin";
     import { content_editable_selectors, content_not_editable_selectors } from "@html_builder/core/builder_content_editable_plugin";
@@ -114,6 +114,7 @@ declare module "plugins" {
         empty_node_predicates: empty_node_predicates;
         filter_for_sibling_dropzone_predicates: filter_for_sibling_dropzone_predicates;
         is_draggable_handlers: is_draggable_handlers;
+        is_element_in_invisible_panel_predicates: is_element_in_invisible_panel_predicates;
         keep_overlay_options: keep_overlay_options;
         show_overlay_buttons_of_ancestor_predicates: show_overlay_buttons_of_ancestor_predicates;
 

--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -8,7 +8,6 @@ import { withSequence } from "@html_editor/utils/resource";
  * @property { VisibilityPlugin['toggleTargetVisibility'] } toggleTargetVisibility
  * @property { VisibilityPlugin['onOptionVisibilityUpdate'] } onOptionVisibilityUpdate
  * @property { VisibilityPlugin['hideElement'] } hideElement
- * @property { VisibilityPlugin['getInvisibleElements'] } getInvisibleElements
  */
 
 /**
@@ -28,7 +27,6 @@ export class VisibilityPlugin extends Plugin {
         "toggleTargetVisibility",
         "onOptionVisibilityUpdate",
         "hideElement",
-        "getInvisibleElements",
     ];
     /** @type {import("plugins").BuilderResources} */
     resources = {
@@ -38,6 +36,14 @@ export class VisibilityPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSaveVisibility.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         on_restore_containers_handlers: (newTargetEl) => this.makeTargetVisible(newTargetEl),
+        is_element_in_invisible_panel_predicates: (el) => {
+            const invisibleSelector = `.o_snippet_invisible, ${
+                this.config.isMobileView(this.editable)
+                    ? ".o_snippet_mobile_invisible"
+                    : ".o_snippet_desktop_invisible"
+            }`;
+            return el.matches(invisibleSelector);
+        },
     };
 
     setup() {
@@ -211,14 +217,6 @@ export class VisibilityPlugin extends Plugin {
         this.dependencies.builderOptions.deactivateContainers();
         this.config.updateInvisibleElementsPanel();
         this.dependencies.disableSnippets.disableUndroppableSnippets();
-    }
-    getInvisibleElements() {
-        const invisibleSelector = `.o_snippet_invisible, ${
-            this.config.isMobileView(this.editable)
-                ? ".o_snippet_mobile_invisible"
-                : ".o_snippet_desktop_invisible"
-        }`;
-        return [...this.editable.querySelectorAll(invisibleSelector)];
     }
 }
 


### PR DESCRIPTION
Commit e591ea77f4a800bf79cb19f80529eed0d8ded927 added the recomputation of shape colors based on background of sibling snippets.

This computation needs to ignore (among other things) the snippets that can be invisible. And used a new shared function of the visibility plugin.

This commit instead uses a resource, as we are planning to move the visibility plugin to the website module; and implements the loop to search for the sibling only once.

task-5149984