### PR TITLE
[FIX] mass_mailing: make background color responsive to picker

### DIFF
--- a/addons/mass_mailing/static/src/themes/theme_wrapper.xml
+++ b/addons/mass_mailing/static/src/themes/theme_wrapper.xml
@@ -9,7 +9,7 @@
     <t t-name="mass_mailing.ThemeWrapper">
         <div class="container o_mail_wrapper o_mail_regular oe_unremovable">
             <div class="row mw-100 mx-0">
-                <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure" t-out="html"/>
+                <div class="col o_mail_no_options o_mail_wrapper_td oe_structure" t-out="html"/>
             </div>
         </div>
     </t>


### PR DESCRIPTION
The `o_mail_wrapper_td` element in the `ThemeWrapper` template had a hardcoded `bg-white` class. The intent was for the wrapper background to default to white, but doing it this way meant the color didn't participate in the CSS variable system. Whenever a user set a custom Content Background color and a border-radius on a text block, the corners would reveal white underneath instead of the actual Content Background color.

Removed the `bg-white` class from the template and set white as the proper default for the `--wrapper-background-color` variable instead, so the wrapper is still white by default but correctly responds to the Content Background color picker.

Steps to reproduce:
1. Create a new Mailing
2. Set the Content Background color to something other than white
3. Add a Text block
4. Set a border-radius value on the block

=> white shows behind the rounded corners instead of the Content Background

Ticket [link](https://www.odoo.com/odoo/project.task/5868955) 
opw-5868955

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
