### PR TITLE
[FIX] web: middle clicking url field

### DIFF
--- a/addons/web/static/src/views/fields/url/url_field.xml
+++ b/addons/web/static/src/views/fields/url/url_field.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.UrlField">
         <t t-if="props.readonly">
-            <a class="o_field_widget o_form_uri" t-on-click.stop="" t-att-href="formattedHref" t-esc="props.text || props.record.data[props.name] || ''" target="_blank"/>
+            <a class="o_field_widget o_form_uri" t-on-click.stop="" t-on-auxclick.stop="" t-att-href="formattedHref" t-esc="props.text || props.record.data[props.name] || ''" target="_blank"/>
         </t>
         <t t-else="">
             <div class="d-inline-flex w-100">


### PR DESCRIPTION
This commit fixes the obtrusive opening of the record's modal when middle clicking on a x2many's url field, in a form view. It applies the same logic as the one used for regular click (letting the url be opened, but not the modal).

Note: originally spotted in the Runbot build error's form view (Builds page or Error content...).

_Note to reviewers : doesn't look to apply to small screens, but not sure why... Feedback requested :pray:_