### PR TITLE
[FIX] hr_org_chart: Access organization chart multicompany

### DIFF
--- a/addons/hr_org_chart/controllers/hr_org_chart.py
+++ b/addons/hr_org_chart/controllers/hr_org_chart.py
@@ -43,7 +43,7 @@ class HrOrgChartController(http.Controller):
     @http.route('/hr/get_org_chart', type='jsonrpc', auth='user')
     def get_org_chart(self, employee_id, new_parent_id=None, **kw):
         employee = self._get_employee(employee_id, **kw)
-        new_parent = self._get_employee(new_parent_id, **kw)
+        new_parent = self._get_employee(new_parent_id, **kw).sudo()
         if not employee:  # to check
             return {
                 'managers': [],

--- a/addons/hr_org_chart/static/tests/tours/hr_employee_test.js
+++ b/addons/hr_org_chart/static/tests/tours/hr_employee_test.js
@@ -14,3 +14,23 @@ registry.category("web_tour.tours").add("indirect_subordinates_tour", {
         },
     ],
 });
+registry.category("web_tour.tours").add("employee_view_access_multicompany", {
+    steps: () => [
+        {
+            content: "Employee list view",
+            trigger: ".o_switch_view.o_list",
+            run: "click",
+        },
+        {
+            content: "Click on the employee C",
+            trigger: 'table.o_list_table tbody td:contains("Employee C")',
+            run: "click",
+        },
+        {
+            content: "Click the number next to employee C",
+            trigger: "div[name='child_ids'] .o_org_chart_entry button > .badge:contains('1')",
+            run: "click",
+        },
+    ],
+});
+

--- a/addons/hr_org_chart/tests/test_employee_ui.py
+++ b/addons/hr_org_chart/tests/test_employee_ui.py
@@ -24,3 +24,34 @@ class TestEmployeeUi(TestHrCommon, HttpCase):
         self.assertEqual(indirect_subordinates, 1,
             "Georges should have 1 indirect subordinates: Pierre."
         )
+
+    def test_employee_view_access_multicompany(self):
+        """checks that an employee still has access to the organization chart even if the manager was created with
+        another company, to which that employee doesn't have access."""
+        company_0, company_1 = self.env['res.company'].create([{
+            'name': "Company 0",
+        },
+            {
+                'name': "Company 1",
+            }])
+        self.env = self.env(context=dict(self.env.context, allowed_company_ids=[company_0.id, company_1.id]))
+
+        employee_a = self.env['hr.employee'].with_company(company_0).create({
+            'name': 'Employee A',
+        })
+        employee_b = self.env['hr.employee'].with_company(company_1).create({
+            'name': 'Employee B',
+            'parent_id': employee_a.id,
+        })
+        self.env['hr.employee'].with_company(company_1).create({
+            'name': 'Employee C',
+            'parent_id': employee_b.id,
+        })
+        self.env = self.env(context=dict(self.env.context, allowed_company_ids=[company_1.id]))
+        self.restricted_user = self.env['res.users'].with_company(company_1).create({
+            'name': 'Restricted User (Test)',
+            'login': 'restricted_user',
+            'password': 'restricted_user',
+            'group_ids': [(6, 0, self.res_users_hr_manager.group_ids.ids)],
+        })
+        self.start_tour("/odoo/employees", 'employee_view_access_multicompany', login="restricted_user")


### PR DESCRIPTION
## Short functional explanation of the error
When an employee A tries to access to the page of another employee B, if that employee has a manager belonging to a company to which employee A doesn't have access, the employee A will see an AccessError, even if employee A can have access to the page of employee B.

## Reproduction Steps
1. Create a second company to your database. Let's call these companies Company A and Company B.
2. Select Company A as your main company, but make sure Company B is also selected.
3. Create an Employee A.
4. Select Company B as tour main company; but make sure Company A is also selected.
5. Create an Employee B who has A as manager.
6. Create Employee C who has B as manager.
7. With a user only having access to Company B, log in and try to access Employee C's page.

### Expected behavior
Employee's C page loads correctly.

### Unexpected behavior
An access error occurs.

## Origin of the issue
A sudo() was missing.
__
opw-5910036





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
