### PR TITLE
[IMP] pos_self_order: add avg prep time

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -3,6 +3,7 @@ import { Component } from "@odoo/owl";
 import { useSelfOrder } from "@pos_self_order/app/services/self_order_service";
 import { useService } from "@web/core/utils/hooks";
 import { useScrollShadow } from "../../utils/scroll_shadow_hook";
+import { SIZES } from "@web/core/ui/ui_service";
 
 export class EatingLocationPage extends Component {
     static template = "pos_self_order.EatingLocationPage";
@@ -13,6 +14,8 @@ export class EatingLocationPage extends Component {
         this.router = useService("router");
         this.scrollContainerRef = useRef("scrollContainer");
         this.scrollShadow = useScrollShadow(this.scrollContainerRef);
+        this.ui = useService("ui");
+        this.SIZES = SIZES;
     }
 
     onClickBack() {

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
@@ -11,19 +11,32 @@
                             t-as="preset" t-key="preset.id"
                             t-on-click="() => this.selectPreset(preset)"
                             role="button"
-                            class="preset_btn fs-2 fw-medium g-col-12 g-col-sm-6 d-flex flex-row-inverse flex-sm-column align-items-center border border-light shadow-sm overflow-hidden bg-white rounded cursor-pointer rounded-4"
+                            class="preset_btn fs-2 fw-medium g-col-12 g-col-sm-6 d-flex flex-row-inverse flex-sm-column align-items-center border border-light shadow-sm overflow-hidden bg-white rounded cursor-pointer rounded-4 position-relative"
                             t-att-class="{
                                 'justify-content-center': !preset.has_image,
                                 'g-col-md-6': this.presets.length &lt; 3,
                                 'g-col-md-4': this.presets.length &gt; 2,
-                                'w-50': this.presets.length === 1
                             }">
                             <t t-if="preset.has_image">
-                                <div class="img_container flex-shrink-0 w-25 w-sm-100 ratio ratio-1x1">
-                                    <img class="object-fit-cover" t-attf-src="/web/image/pos.preset/#{preset.id}/image_512?unique=#{preset.write_date} "/>
+                                <div class="img_container flex-shrink-0 w-25 w-sm-100 position-relative">
+                                    <div class="ratio ratio-1x1">
+                                        <img class="object-fit-cover" t-attf-src="/web/image/pos.preset/#{preset.id}/image_512?unique=#{preset.write_date} "/>
+                                    </div>
+                                    <span t-if="this.ui.size gt this.SIZES.XS and preset.use_timing" class="badge text-bg-secondary rounded-pill p-2 m-2 bg-opacity-75 position-absolute bottom-0 end-0">
+                                        Average time: <t t-esc="preset.interval_time"/> minutes
+                                    </span>
                                 </div>
                             </t>
-                           <span class="px-3 py-3 fw-bold"  t-out="preset.name"/>
+                            <t t-elif="this.ui.size gt this.SIZES.XS and preset.use_timing">
+                                <span class="badge text-bg-secondary rounded-pill p-2 m-2 bg-opacity-75 position-absolute bottom-0 end-0">
+                                    Average time: <t t-esc="preset.interval_time"/> minutes
+                                </span>
+                            </t>
+                            <span class="px-3 py-3 fw-bold"  t-out="preset.name"/>
+                            <span t-if="this.ui.size lte this.SIZES.XS and preset.use_timing" class="badge text-bg-secondary rounded-pill p-2 m-2 bg-opacity-75 position-absolute end-0">
+                                <i class="fa fa-clock-o pe-1" />
+                                <t t-esc="preset.interval_time"/> min
+                            </span>
                        </article>
                    </div>
                 </div>

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -58,6 +58,10 @@ registry.category("web_tour.tours").add("self_order_preset_slot_tour", {
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
+        {
+            content: "Check that average preparation time badge is displayed on Takeaway preset",
+            trigger: ".preset_btn:contains('Takeaway') .badge:contains('20 min')",
+        },
         LandingPage.selectLocation("Takeaway"),
         ProductPage.clickProduct("Coca-Cola"),
         Utils.clickBtn("Checkout"),

--- a/addons/pos_self_order/tests/test_self_order_preset.py
+++ b/addons/pos_self_order/tests/test_self_order_preset.py
@@ -77,7 +77,8 @@ class TestSelfOrderPreset(SelfOrderCommonTest):
         })
         self.preset_takeaway.write({
             'use_timing': True,
-            'resource_calendar_id': resource_calendar
+            'resource_calendar_id': resource_calendar,
+            'interval_time': 20,
         })
         self.pos_config.with_user(self.pos_user).open_ui()
         self.pos_config.current_session_id.set_opening_control(0, "")


### PR DESCRIPTION
Allow store managers to configure and display average preparation times for takeout presets in the self-order kiosk interface.

A new 'Average preparation time' field (in minutes) has been added to the preset configuration form in the backend. When configured, a badge displaying "Average X min" appears on the preset card image in the self-order kiosk.

Added test coverage in test_preset_takeaway_email_tour.

|Mobile|Desktop|
|----------|------------|
|<img width="635" height="1027" alt="image" src="https://github.com/user-attachments/assets/f90b2cba-3b2a-4a20-b588-c226584eec5e" />| <img width="1427" height="1041" alt="image" src="https://github.com/user-attachments/assets/303b24b5-38fd-4f5a-bfe9-b9b756a36dfe" />



Task: 5917835





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
