### PR TITLE
[IMP] html_editor: Blocking browser plugin translation on editable content.

### DIFF
--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -105,6 +105,7 @@ export class Editor {
         }
         this.preparePlugins();
         editable.setAttribute("contenteditable", true);
+        editable.setAttribute("translate", "no");
         initElementForEdition(editable, { allowInlineAtRoot: !!this.config.allowInlineAtRoot });
         editable.classList.add("odoo-editor-editable");
         if (this.config.classList) {


### PR DESCRIPTION
Browser translation plugins were altering editable content by replacing the
original content with translated versions, which caused issues when paired 
with auto-save. To prevent this behavior, the attribute `translate="no"` has 
been added to editable fields.

task-5485078
