### PR TITLE
[FIX] iot_handlers: ensure custom handlers re-download

### DIFF
--- a/addons/iot_drivers/tools/upgrade.py
+++ b/addons/iot_drivers/tools/upgrade.py
@@ -14,6 +14,7 @@ from odoo.addons.iot_drivers.tools.system import (
     git,
     pip,
     path_file,
+    update_conf,
 )
 
 _logger = logging.getLogger(__name__)
@@ -104,6 +105,7 @@ def checkout(branch):
 
     _logger.info("Cleaning the working directory")
     git("clean", "-dfx")
+    update_conf({"iot_handlers_etag": ""})  # Reset to trigger handlers re-download as `clean -dfx` deletes custom one
 
 
 def update_requirements():


### PR DESCRIPTION
The IoT Box will, most of the time, update before the database does.

In such event, the custom handlers will be removed from the IoT Box, but the etag of the files downloaded from the server will be kept, making the db return a 304 (not modified) when trying to download the handlers again.

We now ensure that this etag is removed, so that the database sends the files again.