### PR TITLE
[FIX] l10n_ar_withholding: remove deactivated tax from invoice

### DIFF
--- a/addons/l10n_ar_withholding/wizards/account_payment_register.py
+++ b/addons/l10n_ar_withholding/wizards/account_payment_register.py
@@ -138,7 +138,8 @@ class AccountPaymentRegister(models.TransientModel):
                 '|', ('from_date', '>=', date), ('from_date', '=', False),
                 '|', ('to_date', '<=', date), ('to_date', '=', False),
                 ('partner_id', '=', wizard.partner_id.commercial_partner_id.id),
-                ('tax_id.l10n_ar_withholding_payment_type', '=', wizard.partner_type)
+                ('tax_id.l10n_ar_withholding_payment_type', '=', wizard.partner_type),
+                ('tax_id.active', '=', True)
             ])
             wizard.l10n_ar_withholding_ids = [Command.clear()] + [Command.create({'tax_id': x.tax_id.id}) for x in partner_taxes]
 


### PR DESCRIPTION
# How to reproduce
- Install the l10n_ar_withholding module
- Pick a Vendor and add a Purchase Withholding tax in the accounting tab
- Go into configuration and disable that tax
- Create a Vendor Bill with that Vendor
- Confirm the bill and create a payment

# The problem
The deactivated tax is still computed in the payment

# Why
The function that fetches the withholding taxes does not check if the taxes are active or not

# The fix
I though of 2 solution : 
- Add an override to remove the taxes from the Vendor when they are deactivated
- Add a filter to the fetch function to check if the taxes are active

I chose the 2nd solution as it is the least invasive one.

opw-5917257