### PR TITLE
[FIX] pos_mrp: correctly compute the cost of a kit

### DIFF
--- a/addons/pos_mrp/models/__init__.py
+++ b/addons/pos_mrp/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import pos_order
+from . import stock_move

--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -16,7 +16,7 @@ class PosOrderLine(models.Model):
         #Get a flat list of all bom_line_ids
         bom_line_ids = [item.id for x in boms for item in x[0].bom_line_ids if set(item.bom_product_template_attribute_value_ids.ids).issubset(product.product_template_variant_value_ids.ids)]
         ml_product_to_consider = (product.bom_ids and [comp[0].product_id.id for comp in components]) or [product.id]
-        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and (ml.bom_line_id.id in bom_line_ids))
+        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and (ml.bom_line_id.id in bom_line_ids)).with_context(pos_order_line_id=self.id, bom_id=bom.id)
 
 
 class PosOrder(models.Model):

--- a/addons/pos_mrp/models/stock_move.py
+++ b/addons/pos_mrp/models/stock_move.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _get_price_unit(self):
+        pos_order_line_id = self.env.context.get('pos_order_line_id')
+        bom_id = self.env.context.get('bom_id')
+        if not pos_order_line_id or not bom_id:
+            return super()._get_price_unit()
+        pos_order_line = self.env['pos.order.line'].browse(pos_order_line_id)
+        bom = self.env['mrp.bom'].browse(bom_id)
+        if pos_order_line and bom:
+            return self._get_kit_price_unit(pos_order_line.product_id, bom, pos_order_line.qty)
+        return super()._get_price_unit()

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -7,7 +7,6 @@ from odoo import Command, fields
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-@skip('Temporary to fast merge new valuation')
 class TestPosMrp(CommonPosMrpTest):
     def test_bom_kit_order_total_cost(self):
         order, _ = self.create_backend_pos_order({
@@ -22,6 +21,7 @@ class TestPosMrp(CommonPosMrpTest):
         self.pos_config_usd.current_session_id.action_pos_session_closing_control()
         self.assertEqual(order.lines[0].total_cost, 10.0)
 
+    @skip('Temporary to fast merge new valuation')
     def test_bom_kit_with_kit_invoice_valuation(self):
         self.product_product_kit_one.categ_id = self.category_fifo_realtime
         self.product_product_kit_two.categ_id = self.category_fifo_realtime
@@ -62,6 +62,7 @@ class TestPosMrp(CommonPosMrpTest):
             lambda l: l.product_id == self.product_product_kit_three).debit, 0.0)
         self.pos_config_usd.current_session_id.action_pos_session_closing_control()
 
+    @skip('Temporary to fast merge new valuation')
     def test_bom_kit_different_uom_invoice_valuation(self):
         """This test make sure that when a kit is made of product using UoM A but the bom line uses UoM B
            the price unit is correctly computed on the invoice lines.


### PR DESCRIPTION
Before this commit, if a kit had multiple components, the cost of the line was counted as zero if the product cost method was FIFO or average.

opw-5911338

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
