### PR TITLE
[FIX] website: clean popup on save snippet

### DIFF
--- a/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
@@ -71,6 +71,11 @@ export class PopupVisibilityPlugin extends Plugin {
     }
 
     cleanForSave(rootEl) {
+        // Do not hide a popup if it is saved as a custom snippet, otherwise it
+        // appears empty in the snippet dialog.
+        if (rootEl.matches(".s_popup")) {
+            return;
+        }
         // Hide the popups manually, as we cannot rely on the `onTargetHide`
         // flow since the cleaned popup is a clone and is not in the DOM.
         for (const modalEl of rootEl.querySelectorAll(".s_popup .modal.show")) {

--- a/addons/website/static/src/builder/snippet_model.js
+++ b/addons/website/static/src/builder/snippet_model.js
@@ -53,13 +53,6 @@ export class WebsiteSnippetModel extends SnippetModel {
         return label;
     }
 
-    cleanSnippetForSave(snippetCopyEl, cleanForSaveProcessors) {
-        const rootEl = snippetCopyEl.matches(".s_popup")
-            ? snippetCopyEl.firstElementChild
-            : snippetCopyEl;
-        super.cleanSnippetForSave(rootEl, cleanForSaveProcessors);
-    }
-
     getContext(snippetEl) {
         const context = super.getContext(...arguments);
         const editableParentEl = snippetEl.closest("[data-oe-model][data-oe-field][data-oe-id]");


### PR DESCRIPTION
There was a special handling for `s_popup` snippet when saving snippets: if the snippet was popup, it would not be cleaned directly, but instead its child would be cleaned. The goal was to avoid saving a hidden popup (like it normally is when saving a page), because it would show as an empty custom snippet.

This commit instead do not close the popup if it is the root of what is saved. And do not make special cases inside the snippet service.

Steps to reproduce:
- Open website builder
- Drop a popup
- Click on the eye to hide the popup
- Click on the eye to show the popup
- Save the snippet as a custom snippet
- Click to add a custom snippet
- Bug: with the inspector, you can see that the `o_draggable` class has not been cleaned from the popup

task-5149984
