### PR TITLE
[FIX] html_builder, website: use resize observer to detect mobile view switch

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -19,7 +19,7 @@ declare module "plugins" {
     import { default_shape_providers, image_shape_groups_providers, on_shape_computed_handlers } from "@html_builder/plugins/image/image_shape_option_plugin";
     import { background_filter_target_providers, target_element_providers, on_bg_image_hidden_handlers } from "@html_builder/plugins/background_option/background_image_option_plugin";
     import { is_draggable_predicates, on_element_dragged_handlers, on_element_dropped_handlers, on_element_dropped_near_handlers, on_element_dropped_over_handlers, on_element_move_handlers, on_element_out_dropzone_handlers, on_element_over_dropzone_handlers, on_prepare_drag_handlers } from "@html_builder/core/drag_and_drop_plugin";
-    import { lower_panel_entries, on_mobile_preview_clicked_handlers, on_dom_updated_handlers } from "@html_builder/builder";
+    import { lower_panel_entries, on_dom_updated_handlers, on_mobile_view_switched_handlers } from "@html_builder/builder";
     import { on_target_revealed_handlers } from "@html_builder/sidebar/invisible_elements_panel";
     import { on_snippet_dragged_handlers, on_snippet_dropped_handlers, on_snippet_dropped_near_handlers, on_snippet_dropped_over_handlers, on_snippet_move_handlers, on_snippet_out_dropzone_handlers, on_snippet_over_dropzone_handlers } from "@html_builder/sidebar/block_tab";
     import { snippet_preview_dialog_bundles, snippet_preview_dialog_stylesheets_processors } from "@html_builder/snippets/add_snippet_dialog";
@@ -68,6 +68,7 @@ declare module "plugins" {
         on_bg_image_hidden_handlers: on_bg_image_hidden_handlers;
         on_cloned_handlers: on_cloned_handlers;
         on_current_options_containers_changed_handlers: on_current_options_containers_changed_handlers;
+        on_mobile_view_switched_handlers: on_mobile_view_switched_handlers;
         on_dom_updated_handlers: on_dom_updated_handlers;
         on_element_arrow_moved_handlers: on_element_arrow_moved_handlers;
         on_element_dragged_handlers: on_element_dragged_handlers;
@@ -77,7 +78,6 @@ declare module "plugins" {
         on_element_move_handlers: on_element_move_handlers;
         on_element_out_dropzone_handlers: on_element_out_dropzone_handlers;
         on_element_over_dropzone_handlers: on_element_over_dropzone_handlers;
-        on_mobile_preview_clicked_handlers: on_mobile_preview_clicked_handlers;
         on_prepare_drag_handlers: on_prepare_drag_handlers;
         on_removed_handlers: on_removed_handlers;
         on_replicated_handlers: on_replicated_handlers;

--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -7,7 +7,6 @@ import {
     onWillDestroy,
     onWillStart,
     onWillUnmount,
-    onWillUpdateProps,
     status,
 } from "@odoo/owl";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
@@ -34,7 +33,8 @@ const ONLY_ALLOW_INLINE_TAGS = new Set([
 ]);
 
 /**
- * @typedef {(() => void)[]} on_mobile_preview_clicked_handlers
+ * @typedef {((args: {isMobileView: boolean}) => ())[]} on_mobile_view_switched_handlers
+ * called when the screen size switches between mobile and desktop view
  * @typedef {(() => void)[]} on_dom_updated_handlers
  * @typedef {{ Component: Component; props: object; }[]} lower_panel_entries
  */
@@ -82,7 +82,7 @@ export class Builder extends Component {
         });
         this.invisibleElementsPanelState = useState({
             invisibleEls: [],
-            invisibleSelector: this.getInvisibleSelector(),
+            invisibleSelector: "",
         });
         useHotkey("control+z", () => this.undo());
         useHotkey("control+y", () => this.redo());
@@ -140,8 +140,9 @@ export class Builder extends Component {
                     on_dom_updated_handlers: () => {
                         this.triggerDomUpdated();
                     },
-                    on_mobile_preview_clicked_handlers: withSequence(20, () => {
+                    on_mobile_view_switched_handlers: withSequence(20, () => {
                         this.triggerDomUpdated();
+                        this.updateInvisibleEls();
                     }),
                     on_will_save_handlers: () => {
                         const snippetMenuEl = this.builder_sidebarRef.el;
@@ -245,6 +246,19 @@ export class Builder extends Component {
                     ev.stopPropagation();
                 }
             };
+
+            // Use a resize observer to trigger `on_mobile_view_switched_handlers`
+            // when the view size switches between desktop and mobile view
+            let isMobileView = this.editor.config.isMobileView(this.editableEl);
+            this.resizeObserver = new ResizeObserver(() => {
+                const wasMobileView = isMobileView;
+                isMobileView = this.editor.config.isMobileView(this.editableEl);
+                if (wasMobileView !== isMobileView) {
+                    this.editor.trigger("on_mobile_view_switched_handlers", { isMobileView });
+                }
+            });
+            this.resizeObserver.observe(this.editableEl);
+
             this.editor.attachTo(this.editableEl);
         });
 
@@ -256,6 +270,7 @@ export class Builder extends Component {
             editShadow: this.editShadow.bind(this),
         });
         onWillDestroy(() => {
+            this.resizeObserver.disconnect();
             this.editor.destroy();
         });
 
@@ -269,14 +284,6 @@ export class Builder extends Component {
         onWillUnmount(() => {
             this.editableEl.removeEventListener("dragstart", this.onDragStart);
         });
-        onWillUpdateProps((nextProps) => {
-            if (nextProps.isMobile !== this.props.isMobile) {
-                this.updateInvisibleEls(nextProps.isMobile);
-                this.invisibleElementsPanelState.invisibleSelector = this.getInvisibleSelector(
-                    nextProps.isMobile
-                );
-            }
-        });
     }
     async triggerDomUpdated() {
         this.lastTrigerUpdateId++;
@@ -287,12 +294,6 @@ export class Builder extends Component {
         await Promise.allSettled(getStatePromises);
         const isLastTriggerId = this.lastTrigerUpdateId === currentTriggerId;
         resolve(isLastTriggerId);
-    }
-
-    getInvisibleSelector(isMobile = this.props.isMobile) {
-        return `.o_snippet_invisible, ${
-            isMobile ? ".o_snippet_mobile_invisible" : ".o_snippet_desktop_invisible"
-        }`;
     }
 
     /**
@@ -337,12 +338,16 @@ export class Builder extends Component {
 
     onMobilePreviewClick() {
         this.props.toggleMobile();
-        this.editor.resources["on_mobile_preview_clicked_handlers"].forEach((handler) => handler());
     }
 
-    updateInvisibleEls(isMobile = this.props.isMobile) {
+    updateInvisibleEls() {
+        const isMobile = this.editor.config.isMobileView(this.editor.editable);
+        const invisibleSelector = `.o_snippet_invisible, ${
+            isMobile ? ".o_snippet_mobile_invisible" : ".o_snippet_desktop_invisible"
+        }`;
+        this.invisibleElementsPanelState.invisibleSelector = invisibleSelector;
         this.invisibleElementsPanelState.invisibleEls = [
-            ...this.editor.editable?.querySelectorAll(this.getInvisibleSelector(isMobile)) || [],
+            ...this.editor.editable.querySelectorAll(invisibleSelector),
         ];
     }
 

--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -17,7 +17,7 @@ export class DisableSnippetsPlugin extends Plugin {
         on_removed_handlers: this.disableUndroppableSnippets.bind(this),
         on_undone_handlers: this.disableUndroppableSnippets.bind(this),
         on_redone_handlers: this.disableUndroppableSnippets.bind(this),
-        on_mobile_preview_clicked_handlers: withSequence(
+        on_mobile_view_switched_handlers: withSequence(
             20,
             this.disableUndroppableSnippets.bind(this)
         ),

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -35,7 +35,7 @@ export class OverlayButtonsPlugin extends Plugin {
         on_selection_leave_handlers: this.showOverlayButtonsUi.bind(this),
         on_step_added_handlers: this.refreshButtons.bind(this),
         on_current_options_containers_changed_handlers: this.addOverlayButtons.bind(this),
-        on_mobile_preview_clicked_handlers: withSequence(20, this.refreshButtons.bind(this)),
+        on_mobile_view_switched_handlers: withSequence(20, this.refreshButtons.bind(this)),
     };
 
     setup() {

--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -1,6 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
 import { getElementsWithOption } from "@html_builder/utils/utils";
-import { withSequence } from "@html_editor/utils/resource";
 
 /**
  * @typedef { Object } VisibilityShared
@@ -30,10 +29,7 @@ export class VisibilityPlugin extends Plugin {
     ];
     /** @type {import("plugins").BuilderResources} */
     resources = {
-        on_mobile_preview_clicked_handlers: withSequence(
-            10,
-            this.onMobilePreviewClicked.bind(this)
-        ),
+        on_mobile_view_switched_handlers: this.onMobileViewSwitched.bind(this),
         system_attributes: ["data-invisible"],
         system_classes: ["o_snippet_override_invisible"],
         clean_for_save_processors: this.cleanForSaveVisibility.bind(this),
@@ -128,7 +124,7 @@ export class VisibilityPlugin extends Plugin {
         }
     }
 
-    onMobilePreviewClicked() {
+    onMobileViewSwitched() {
         const deviceInvisibleEls = this.editable.querySelectorAll(deviceInvisibleSelector);
         const currentContainerTargetEl = this.dependencies["builderOptions"].getTarget();
         for (const deviceInvisibleEl of [...deviceInvisibleEls]) {

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -19,7 +19,12 @@ import {
     onRpc,
     patchWithCleanup,
 } from "@web/../tests/web_test_helpers";
-import { addPlugin, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
+import {
+    addPlugin,
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+    toggleMobilePreview,
+} from "./website_helpers";
 import { WebsiteBuilderClientAction } from "@website/client_actions/website_preview/website_builder_action";
 
 beforeEach(defineWebsiteModels);
@@ -27,7 +32,7 @@ beforeEach(defineWebsiteModels);
 test("trigger mobile view", async () => {
     await setupWebsiteBuilder(`<h1> Homepage </h1>`);
     expect(".o_website_preview.o_is_mobile").toHaveCount(0);
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".o_website_preview.o_is_mobile").toHaveCount(1);
 });
 

--- a/addons/website/static/tests/builder/invisibility_options.test.js
+++ b/addons/website/static/tests/builder/invisibility_options.test.js
@@ -5,6 +5,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
     setupWebsiteBuilderWithSnippet,
+    toggleMobilePreview,
 } from "@website/../tests/builder/website_helpers";
 import { insertText, undo } from "@html_editor/../tests/_helpers/user_actions";
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
@@ -103,7 +104,7 @@ test("check invisible element after save", async () => {
 test("click on 'Show/hide on mobile' in mobile view", async () => {
     await setupWebsiteBuilder(websiteContent);
     await contains(":iframe .col-lg-3").click();
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
 
     await contains("button[data-action-id='toggleDeviceVisibility']:last").click();
     expect(".o-snippets-tabs button:contains('Blocks')").toHaveClass("active");
@@ -122,7 +123,7 @@ test("click on 'Show/hide on mobile' in desktop view", async () => {
 test("click on 'Show/hide on desktop' in mobile view", async () => {
     await setupWebsiteBuilder(websiteContent);
     await contains(":iframe .col-lg-3").click();
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
 
     await contains(
         "[data-container-title='Column']  button[data-action-id='toggleDeviceVisibility']"
@@ -138,13 +139,13 @@ test("hide on mobile and toggle mobile view", async () => {
     await contains(":iframe .col-lg-3").click();
 
     await contains("button[data-action-id='toggleDeviceVisibility']:last").click();
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(":iframe .col-lg-3").not.toHaveClass("o_snippet_override_invisible");
     expect(queryOne(".o_we_invisible_el_panel .o_we_invisible_entry i")).toHaveClass(
         "fa-eye-slash"
     );
 
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".o_we_invisible_el_panel").not.toHaveCount();
 });
 

--- a/addons/website/static/tests/builder/invisible_elements.test.js
+++ b/addons/website/static/tests/builder/invisible_elements.test.js
@@ -14,6 +14,7 @@ import {
     defineWebsiteModels,
     invisibleEl,
     setupWebsiteBuilder,
+    toggleMobilePreview,
     waitForSnippetDialog,
 } from "./website_helpers";
 
@@ -104,7 +105,7 @@ test("mobile and desktop invisible elements panel", async () => {
         "Popup1",
         "Popup3",
     ]);
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(queryAllTexts(".o_we_invisible_el_panel .o_we_invisible_entry")).toEqual([
         "Popup1",
         "Popup2",
@@ -117,9 +118,9 @@ test("mobile and desktop option container", async () => {
     `);
     await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
     expect(".options-container").toBeVisible();
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".options-container").toBeVisible();
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".options-container").not.toHaveCount();
 });
 
@@ -147,7 +148,7 @@ test("keep the option container of a visible snippet even if there are hidden sn
     `);
     await contains(":iframe #my_el").click();
     expect(".options-container").toBeVisible();
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".options-container").toBeVisible();
 });
 
@@ -166,6 +167,6 @@ test("invisible elements efficiency", async () => {
         <div class="o_snippet_desktop_invisible" data-name="Popup3"></div>
     `);
     expect.verifySteps(["update invisible panel"]);
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect.verifySteps(["update invisible panel"]);
 });

--- a/addons/website/static/tests/builder/options/layout_option.test.js
+++ b/addons/website/static/tests/builder/options/layout_option.test.js
@@ -4,6 +4,7 @@ import { contains } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
     setupWebsiteBuilderWithSnippet,
+    toggleMobilePreview,
 } from "@website/../tests/builder/website_helpers";
 import { unfoldAllOptionsGroups } from "@html_builder/../tests/helpers";
 
@@ -37,7 +38,7 @@ test("switch to mobile mode should update number of columns", async () => {
     expect("[data-label='Layout'] .dropdown-toggle").toBeVisible();
     expect("[data-label='Layout'] .dropdown-toggle").toHaveText("3");
 
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect("[data-label='Layout'] .dropdown-toggle").toHaveText("1");
 });
 

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -12,6 +12,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
     setupWebsiteBuilderWithSnippet,
+    toggleMobilePreview,
 } from "./website_helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
@@ -204,12 +205,12 @@ test("Refresh the overlay buttons when toggling the mobile preview", async () =>
     );
 
     await contains(":iframe .g-col-lg-4").click();
-    await contains("[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".overlay .o_send_back, .overlay .o_bring_front").toHaveCount(0);
     expect(".overlay .fa-angle-up").toHaveCount(1);
     expect(".overlay .fa-angle-down").toHaveCount(1);
 
-    await contains("[data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".overlay .o_send_back").toHaveCount(1);
     expect(".overlay .o_bring_front").toHaveCount(1);
     expect(".overlay .fa-angle-left, .overlay .fa-angle-right").toHaveCount(0);

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -8,6 +8,7 @@ import {
     addPlugin,
     defineWebsiteModels,
     setupWebsiteBuilder,
+    toggleMobilePreview,
 } from "@website/../tests/builder/website_helpers";
 import { patchDragImage } from "@website/../tests/builder/image_test_helpers";
 
@@ -185,7 +186,7 @@ test("Background position overlay layout", async () => {
     };
 
     await testLayout(false);
-    await contains("button[data-action=mobile]").click();
+    await toggleMobilePreview();
     await testLayout(true);
 });
 

--- a/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
+++ b/addons/website/static/tests/builder/website_builder/drag_and_drop.test.js
@@ -4,6 +4,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
     setupWebsiteBuilderWithSnippet,
+    toggleMobilePreview,
 } from "@website/../tests/builder/website_helpers";
 import {
     dummyBase64Img,
@@ -131,7 +132,7 @@ test("Drag and drop an image should drag the closest draggable element but not i
 
 test("A column in mobile view should not be draggable", async () => {
     await setupWebsiteBuilderWithSnippet("s_text_image");
-    await contains("button[data-action='mobile']").click();
+    await toggleMobilePreview();
 
     await contains(":iframe section.s_text_image").click();
     expect(".overlay .o_overlay_options .o_move_handle").toHaveClass("o_draggable");
@@ -219,8 +220,7 @@ test("Dragging an inner content from the sidebar in mobile view should not make 
     await waitForEndOfOperation();
     expect(":iframe .s_alert").toHaveCount(0);
 
-    // Toggle the mobile preview.
-    await contains(".o-snippets-top-actions [data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".o_website_preview").toHaveClass("o_is_mobile");
     dragUtils = await contains("#snippet_content [name='Alert'] .o_snippet_thumbnail").drag();
     expect(":iframe .oe_grid_zone").toHaveCount(0);
@@ -246,7 +246,7 @@ test("Dragging an inner content from the page should not make grid dropzones app
     await waitForEndOfOperation();
 
     // Check in mobile view.
-    await contains(".o-snippets-top-actions [data-action='mobile']").click();
+    await toggleMobilePreview();
     expect(".o_website_preview").toHaveClass("o_is_mobile");
     const { cancel } = await contains(".o_overlay_options .o_move_handle").drag();
     expect(":iframe .oe_grid_zone").toHaveCount(0);

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -538,3 +538,11 @@ export async function insertStructureSnippet(editor, snippetName) {
     parentEl.append(snippetEl);
     editor.shared.history.addStep();
 }
+
+export async function toggleMobilePreview() {
+    await contains("button[data-action='mobile']").click();
+    // The click above will cause a resize of the iframe containing the builder.
+    // Resize observers that react to that change and update the ui accordingly
+    // will need one more animation frame to have their changes reflected
+    await animationFrame();
+}


### PR DESCRIPTION
For elements that are invisible based on the size of the window, the "Invisible Elements" panel did not update its state when the size of the window changed (but instead it only did when the "Mobile Preview" button was toggled).

This commit observes the size of the window to trigger the update when the mobile breakpoint size is crossed.

All the implementations of `on_mobile_preview_clicked_handlers` need to know if the builder is currently in mobile view, so this commit updates them all to use the new resource `on_mobile_view_switched_handlers` which is triggered by the observer of the window size (and remove the old resource as it is now unused).

Steps to reproduce:
- Open website builder
- Drop a section snippet and click on it
- Set the "Visibility" option to make it invisible on mobile
- Toggle the "Mobile Preview" button
- Observe the snippet becomes hidden and is listed in the "Invisible Elements" panel
- Toggle the "Mobile Preview" button back to desktop view
- Reduce the size of the window
- Bug: the snippet becomes hidden, but is not listed in the "Invisible Elements" panel, and it is still the target of the builder

task-5149984
