### PR TITLE
[IMP] mail: standardize inconsistent Dropdown design

### DIFF
--- a/addons/mail/data/ir_actions_data.xml
+++ b/addons/mail/data/ir_actions_data.xml
@@ -11,7 +11,7 @@
             <field name="name">Voice &amp; Video Settings</field>
             <field name="tag">mail.discuss_call_settings_action</field>
             <field name="target">new</field>
-            <field name="context">{'dialog_size': 'medium', 'footer': false}</field>
+            <field name="context">{'dialog_size': 'small', 'footer': false}</field>
         </record>
         <record id="action_open_discuss_settings" model="ir.actions.act_url">
             <field name="name">Settings</field>

--- a/addons/mail/static/src/discuss/call/common/call_preview.xml
+++ b/addons/mail/static/src/discuss/call/common/call_preview.xml
@@ -28,13 +28,13 @@
         </div>
         <div t-if="props.hasSettingsAtBottom" class="d-flex flex-row justify-content-between mt-2 w-100 mw-100 flex-nowrap px-3">
             <div class="px-2" style="width: 30%">
-                <DeviceSelect icon="'fa fa-fw fa-microphone'" kind="'audioinput'" roundedType="'pill'"/>
+                <DeviceSelect icon="'fa fa-fw fa-microphone'" kind="'audioinput'"/>
             </div>
             <div class="px-2" style="width: 30%">
-                <DeviceSelect icon="'fa fa-fw fa-volume-up'" kind="'audiooutput'" roundedType="'pill'"/>
+                <DeviceSelect icon="'fa fa-fw fa-volume-up'" kind="'audiooutput'"/>
             </div>
             <div class="px-2" style="width: 30%">
-                <DeviceSelect icon="'fa fa-fw fa-video-camera'" kind="'videoinput'" roundedType="'pill'"/>
+                <DeviceSelect icon="'fa fa-fw fa-video-camera'" kind="'videoinput'"/>
             </div>
             <div class="d-flex align-items-center flex-grow-0 flex-shrink-0 px-2 text-muted">
                 <a role="button" t-on-click="onClickSettings" title="Advanced Settings">

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -125,7 +125,7 @@ export class CallSettings extends Component {
 
 export class CallSettingsDialog extends Component {
     static template = xml`
-        <Dialog size="medium" footer="false" title.translate="Voice &amp; Video Settings">
+        <Dialog size="'small'" footer="false" title.translate="Voice &amp; Video Settings">
             <CallSettings withActionPanel="false"/>
         </Dialog>
     `;

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -74,7 +74,7 @@
                 </div>
                 <span t-if="store.settings.isRegisteringKey">Press a key to register it as the push-to-talk shortcut.</span>
             </div>
-            <hr class="o-discuss-separator my-2"/>
+            <hr class="o-discuss-separator my-4"/>
             <h4>Audio</h4>
             <label class="d-flex align-items-baseline mb-2" title="Speakers" aria-label="Speakers">
                 <span class="flex-shrink-0 pe-2">
@@ -83,7 +83,7 @@
                 <div class="flex-grow-1"/>
                 <DeviceSelect kind="'audiooutput'"/>
             </label>
-            <hr class="o-discuss-separator my-2"/>
+            <hr class="o-discuss-separator my-4"/>
             <h4>Video</h4>
             <label class="d-flex align-items-baseline mb-2" title="Camera" aria-label="Camera">
                 <span class="flex-shrink-0 pe-2">
@@ -135,7 +135,7 @@
                     </div>
                 </div>
             </t>
-            <hr class="o-discuss-separator my-2"/>
+            <hr class="o-discuss-separator my-4"/>
             <h4>Technical Settings</h4>
             <t t-if="env.debug">
                 <div class="d-flex flex-column my-1">

--- a/addons/mail/static/src/discuss/call/common/device_select.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/device_select.dark.scss
@@ -1,3 +1,0 @@
-.o-mail-DeviceSelect-button {
-  --o-mail-device-select-button-color: #{$gray-300};
-}

--- a/addons/mail/static/src/discuss/call/common/device_select.js
+++ b/addons/mail/static/src/discuss/call/common/device_select.js
@@ -19,10 +19,6 @@ export class DeviceSelect extends Component {
             type: String,
             optional: true,
         },
-        roundedType: {
-            type: String,
-            optional: true,
-        },
     };
     static components = { Dropdown, DropdownItem };
     static template = "discuss.CallDeviceSelect";
@@ -36,7 +32,6 @@ export class DeviceSelect extends Component {
         this.state = useState({
             userDevices: [],
             selectedDevice: undefined,
-            isSelectOpen: false,
         });
         this.abortController = new AbortController();
         this.isBrowserChrome = isBrowserChrome();
@@ -63,14 +58,6 @@ export class DeviceSelect extends Component {
 
     get selectLabel() {
         return this.state.selectedDevice?.label;
-    }
-
-    openSelect(state) {
-        if (state === true) {
-            this.state.isSelectOpen = true;
-        } else if (state === false) {
-            this.state.isSelectOpen = false;
-        }
     }
 
     async updateDevicesList() {

--- a/addons/mail/static/src/discuss/call/common/device_select.scss
+++ b/addons/mail/static/src/discuss/call/common/device_select.scss
@@ -1,3 +1,0 @@
-.o-mail-DeviceSelect-button {
-  color: var(--o-mail-device-select-button-color, $gray-600);
-}

--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -3,48 +3,42 @@
 
     <t t-name="discuss.CallDeviceSelect">
         <Dropdown
-            onStateChanged.bind="openSelect"
             disabled="!isPermissionGranted(props.kind)"
             openOnMouseEnter="false"
         >
             <button
                 t-if="isPermissionGranted(props.kind)"
-                class="o-mail-DeviceSelect-button btn cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret overflow-hidden"
+                t-attf-class="o-mail-DeviceSelect-button btn btn-secondary o-dropdown-caret {{ env.inDialog ? 'w-50' : 'w-100' }}"
                 t-att-data-kind="props.kind"
-                t-attf-class="{{ props.roundedType === 'pill' ? 'rounded-pill' : 'rounded' }}"
              >
                 <i t-if="props.icon" t-att-class="props.icon"/>
                 <span
-                    class="pe-2 d-inline-block text-truncate flex-grow-1 min-w-0"
+                    class="pe-2 text-start text-truncate"
                     t-attf-class="{{ props.icon ? 'ps-2' : '' }}"
                     t-esc="selectLabel || BROWSER_DEFAULT"/>
-                <span t-attf-class="oi smaller {{state.isSelectOpen ? 'oi-chevron-up': 'oi-chevron-down'}}"/>
             </button>
             <button
                 t-else=""
-                class="o-mail-DeviceSelect-button btn cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret"
+                t-attf-class="o-mail-DeviceSelect-button btn btn-secondary {{ env.inDialog ? 'w-50' : 'w-100' }}"
                 t-att-data-kind="props.kind"
-                t-attf-class="{{ props.roundedType === 'pill' ? 'rounded-pill' : 'rounded' }}"
                 t-on-pointerdown.prevent="() => this.showPermissionDialog(props.kind)"
                 t-on-keydown.prevent="() => this.showPermissionDialog(props.kind)"
             >
                 <i t-if="props.icon" t-att-class="props.icon"/>
                 <span
-                    class="d-inline-block text-truncate flex-grow-1 min-w-0"
+                    class="text-start"
                     t-attf-class="{{ props.icon ? 'ps-2' : '' }}"
                 >
                     <t t-esc="PERMISSION_NEEDED"/>
                 </span>
             </button>
             <t t-set-slot="content">
-                <DropdownItem t-if="!isBrowserChrome or props.kind === 'videoinput'" onSelected="onSelectAudioDevice.bind(this)">
-                    <i class="fa fa-check me-2" t-if="isSelected()"/>
-                    <span t-esc="BROWSER_DEFAULT"/>
+                <DropdownItem t-if="!isBrowserChrome or props.kind === 'videoinput'" class="{ 'active': isSelected() }" onSelected="onSelectAudioDevice.bind(this)">
+                    <t t-esc="BROWSER_DEFAULT"/>
                 </DropdownItem>
                 <t t-foreach="state.userDevices" t-as="device" t-key="device_index">
-                    <DropdownItem t-if="device.kind === props.kind" onSelected="onSelectAudioDevice.bind(this, device)">
-                        <i t-if="isSelected(device.deviceId)" class="fa fa-check me-2"/>
-                        <span t-esc="device.label || 'device ' + device_index"/>
+                    <DropdownItem t-if="device.kind === props.kind" class="{ 'active': isSelected(device.deviceId) }" onSelected="onSelectAudioDevice.bind(this, device)">
+                        <t t-esc="device.label || 'device ' + device_index"/>
                     </DropdownItem>
                 </t>
             </t>

--- a/addons/mail/static/src/discuss/call/web/quick_video_settings_patch.js
+++ b/addons/mail/static/src/discuss/call/web/quick_video_settings_patch.js
@@ -11,7 +11,7 @@ patch(QuickVideoSettings.prototype, {
     onClickVideoSettings() {
         this.actionService.doAction({
             context: {
-                dialog_size: "medium",
+                dialog_size: "small",
                 footer: false,
             },
             name: _t("Voice & Video Settings"),

--- a/addons/mail/static/src/discuss/call/web/quick_voice_settings_patch.js
+++ b/addons/mail/static/src/discuss/call/web/quick_voice_settings_patch.js
@@ -11,7 +11,7 @@ patch(QuickVoiceSettings.prototype, {
     onClickVoiceSettings() {
         this.actionService.doAction({
             context: {
-                dialog_size: "medium",
+                dialog_size: "small",
                 footer: false,
             },
             name: _t("Voice & Video Settings"),

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -64,12 +64,12 @@ test("Renders the call settings", async () => {
     rtc.microphonePermission = "granted";
     const browserDefaultLabel = isBrowserChrome() ? "Default" : "Browser Default";
     await click(".o-mail-DeviceSelect-button[data-kind='audioinput']:has(:text('Default'))");
-    await contains(".o-dropdown-item:has(:text('mockAudioDeviceLabel'))");
-    await contains(`.o-dropdown-item:has(:text(${browserDefaultLabel}))`);
+    await contains(".o-dropdown-item:text('mockAudioDeviceLabel')");
+    await contains(`.o-dropdown-item:text(${browserDefaultLabel})`);
     rtc.cameraPermission = "granted";
     await click(".o-mail-DeviceSelect-button[data-kind='videoinput']:has(:text('Default'))");
-    await contains(".o-dropdown-item:has(:text('mockVideoDeviceLabel'))");
-    await contains(`.o-dropdown-item:has(:text(${browserDefaultLabel}))`);
+    await contains(".o-dropdown-item:text('mockVideoDeviceLabel')");
+    await contains(`.o-dropdown-item:text(${browserDefaultLabel})`);
     await contains("button:text('Voice Detection')");
     await contains("button:text('Push to Talk')");
     await contains("span:text('Voice detection sensitivity')");


### PR DESCRIPTION
This PR fixes inconsistent `Dropdown` that were used to select the input and output devices when starting a call within the `mail` module.

As this custom design was creating inconsistencies with the rest of the UI as well as accessibility flaws, we remove all the custom styling to rely on the default `Dropdown` component.

task-5921830

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
