### PR TITLE
[FIX] website_sale_collect: pick-up location opening hours with full days

### DIFF
--- a/addons/website_sale_collect/models/stock_warehouse.py
+++ b/addons/website_sale_collect/models/stock_warehouse.py
@@ -47,7 +47,7 @@ class StockWarehouse(models.Model):
         if self.opening_hours:
             opening_hours_dict = {str(i): [] for i in range(7)}
             for att in self.opening_hours.attendance_ids:
-                if att.day_period in ('morning', 'afternoon'):
+                if att.day_period in ('morning', 'afternoon', 'full_day'):
                     opening_hours_dict[att.dayofweek].append(
                         f'{format_duration(att.hour_from)} - {format_duration(att.hour_to)}'
                     )


### PR DESCRIPTION
## Versions
19.0+

## Issue
The website's pick-up in store dialog doesn't show up full opening days.

## Steps to reproduce
*Ensure "Click & Collect" is enabled in the Settings*
- Go to "Delivery Methods" and edit "Pick up in store":
  - Click on the warehouse under the "Stores" tab:
    - Change the "Opening Hours" values (set one if needed) by clicking on the internal link:
      - Under the "Working Hours" tab, change or add a line with its "Day Period" set to "Full Day" and save.
    - Save.
  - Ensure the method is "Published".
- Go to the website's shop:
  - Look for a product that can be retrieved from the store (e.g. "Chair floor protection");
  - Go to checkout and fill forms in until you arrive on the delivery form where you can select a store location:
    - Select the warehouse you changed:
      - Check the opening hours not displaying the full day's data.

## Cause
`full_day` has been introduced in the calendar via commit 77f860f5d3757e5a56861ac1de95b9ad29ea0dff but its retrieval in `website_sale_collect` was skipped du to `day_period` restrictions. These restrictions exist because we don't want to consider breaks in the opening hours

opw-5904377