### PR TITLE
[FIX] pos_sale: prevent subscription_discount traceback

### DIFF
--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -98,7 +98,7 @@ patch(PosStore.prototype, {
         ]);
 
         for (const line of sale_order.order_line) {
-            if (line.display_type === "line_note") {
+            if (this.isSaleOrderLineNote(line)) {
                 if (previousProductLine) {
                     const previousNote = previousProductLine.customer_note;
                     previousProductLine.customer_note = previousNote
@@ -402,5 +402,8 @@ patch(PosStore.prototype, {
             });
         }
         return super.addLineToCurrentOrder(vals, opt, configure);
+    },
+    isSaleOrderLineNote(orderline) {
+        return orderline.display_type === "line_note";
     },
 });


### PR DESCRIPTION
**Steps to reproduce:**
- Make a subscription product
- Make a quotation with it, confirm it, then invoice it
- Go back to the sale order and upsell it
- Add another product
- Go to the PoS to settle the order
- A traceback appears

**Why the fix:**
Why tried to treat the informative line that says that this is a discount as a normal pos order line. We then tried to access the line's template, which caused a crash as the line's template was undefined.

We now treat the line as we do a note, meaning to add it to the previous line in the order.

We create a function to check if the line is a note and we override it in the **pos_sale_subscription** module.
Enterprise PR: https://github.com/odoo/enterprise/pull/107002
opw-5582448