### PR TITLE
[FIX] point_of_sale: stock valuation reversal

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -992,7 +992,7 @@ class PosOrder(models.Model):
                 product_accounts = stock_move.product_id._get_product_accounts()
                 expense_account = product_accounts['expense']
                 stock_account = product_accounts['stock_valuation']
-                balance = -sum(stock_move.mapped('value'))
+                balance = stock_move.value if stock_move.is_out else -stock_move.value
                 aml_vals_list_per_nature['stock'].append({
                     'name': _("Stock variation for %s", stock_move.product_id.name),
                     'account_id': expense_account.id,


### PR DESCRIPTION
When invoicing a pos order from a closed session, we create a reversal move to "neutralize" the invoice. If the order contained storable products, the part of the reversal move that should neutralize the stock valuation was wrong. It would instead debit the same account two times.

Steps to reproduce:
-------------------
* Create a storable product with a cost price different than 0 and a category with automated inventory valuation
* Create a pos order with that product, validate it and close the session
* Invoice the order from the backend
> Observation: The reversal move lines that should neutralize the stock
  valuation credit and debit the same account as the invoice.

Why the fix:
------------
After the `stock.valuation.layer` was removed, the value of the stock move are now directly stored on the `stock.move`. But they are not signed so we need to rely on `is_out` to determine if we should inverse the value or not.

opw-5359646