### PR TITLE
[FIX] product: remove redundant HTML head in product labels

### DIFF
--- a/addons/product/report/product_product_templates.xml
+++ b/addons/product/report/product_product_templates.xml
@@ -127,83 +127,79 @@
         </template>
 
         <template id="report_productlabel">
-            <t t-call="web.html_container">
-                <t t-if="columns and rows">
-                    <t t-if="columns == 2 and rows == 7">
-                        <t t-set="padding_page" t-value="'padding: 14mm 3mm'"/>
-                        <t t-set="report_to_call" t-value="'2x7'"/>
-                    </t>
-                    <t t-if="columns == 4 and rows == 7">
-                        <t t-set="padding_page" t-value="'padding: 14mm 3mm'"/>
-                        <t t-set="report_to_call" t-value="'4x7'"/>
-                    </t>
-                    <t t-if="columns == 4 and rows == 12">
-                        <t t-set="padding_page" t-value="'padding: 20mm 8mm'"/>
-                        <t t-set="report_to_call" t-value="'4x12'"/>
-                    </t>
-                    <t t-foreach="range(page_numbers)" t-as="page">
-                        <div class="o_label_sheet" t-att-style="padding_page">
-                            <table class="my-0 table table-sm table-borderless">
-                                <t t-foreach="range(rows)" t-as="row">
-                                    <tr>
-                                        <t t-foreach="range(columns)" t-as="column">
-                                            <t t-if="not current_quantity and quantity and not (current_data and current_data[1])">
-                                                <t t-set="current_data" t-value="quantity.popitem()"/>
-                                                <t t-set="product" t-value="current_data[0]"/>
-                                                <t t-set="barcode_and_qty" t-value="current_data[1].pop()"/>
-                                                <t t-set="barcode" t-value="barcode_and_qty[0]"/>
-                                                <t t-set="current_quantity" t-value="barcode_and_qty[1]"/>
-                                            </t>
-                                            <t t-if="current_quantity">
-                                                <t t-set="make_invisible" t-value="False"/>
-                                                <t t-set="current_quantity" t-value="current_quantity - 1"/>
-                                            </t>
-                                            <t t-elif="current_data and current_data[1]">
-                                                <t t-set="barcode_and_qty" t-value="current_data[1].pop()"/>
-                                                <t t-set="barcode" t-value="barcode_and_qty[0]"/>
-                                                <t t-set="current_quantity" t-value="barcode_and_qty[1] - 1"/>
+            <t t-if="columns and rows">
+                <t t-if="columns == 2 and rows == 7">
+                    <t t-set="padding_page" t-value="'padding: 14mm 3mm'"/>
+                    <t t-set="report_to_call" t-value="'2x7'"/>
+                </t>
+                <t t-if="columns == 4 and rows == 7">
+                    <t t-set="padding_page" t-value="'padding: 14mm 3mm'"/>
+                    <t t-set="report_to_call" t-value="'4x7'"/>
+                </t>
+                <t t-if="columns == 4 and rows == 12">
+                    <t t-set="padding_page" t-value="'padding: 20mm 8mm'"/>
+                    <t t-set="report_to_call" t-value="'4x12'"/>
+                </t>
+                <t t-foreach="range(page_numbers)" t-as="page">
+                    <div class="o_label_sheet" t-att-style="padding_page">
+                        <table class="my-0 table table-sm table-borderless">
+                            <t t-foreach="range(rows)" t-as="row">
+                                <tr>
+                                    <t t-foreach="range(columns)" t-as="column">
+                                        <t t-if="not current_quantity and quantity and not (current_data and current_data[1])">
+                                            <t t-set="current_data" t-value="quantity.popitem()"/>
+                                            <t t-set="product" t-value="current_data[0]"/>
+                                            <t t-set="barcode_and_qty" t-value="current_data[1].pop()"/>
+                                            <t t-set="barcode" t-value="barcode_and_qty[0]"/>
+                                            <t t-set="current_quantity" t-value="barcode_and_qty[1]"/>
+                                        </t>
+                                        <t t-if="current_quantity">
+                                            <t t-set="make_invisible" t-value="False"/>
+                                            <t t-set="current_quantity" t-value="current_quantity - 1"/>
+                                        </t>
+                                        <t t-elif="current_data and current_data[1]">
+                                            <t t-set="barcode_and_qty" t-value="current_data[1].pop()"/>
+                                            <t t-set="barcode" t-value="barcode_and_qty[0]"/>
+                                            <t t-set="current_quantity" t-value="barcode_and_qty[1] - 1"/>
+                                        </t>
+                                        <t t-else="">
+                                            <t t-set="make_invisible" t-value="True"/>
+                                        </t>
+                                        <t t-set="table_style" t-value="'border: 1px solid %s;' % (product.env.user.company_id.primary_color or 'black')"/>
+                                        <!-- IMPORTANT: explictly call templates in place of {{template}} otherwise studio won't load report correctly -->
+                                        <t t-if="report_to_call == '2x7'">
+                                            <t t-call="product.report_simple_label2x7"/>
+                                        </t>
+                                        <t t-elif="report_to_call == '4x7'">
+                                            <t t-call="product.report_simple_label4x7"/>
+                                        </t>
+                                        <t t-elif="report_to_call == '4x12'">
+                                            <t t-if="price_included">
+                                                <t t-call="product.report_simple_label4x12"/>
                                             </t>
                                             <t t-else="">
-                                                <t t-set="make_invisible" t-value="True"/>
-                                            </t>
-                                            <t t-set="table_style" t-value="'border: 1px solid %s;' % (product.env.user.company_id.primary_color or 'black')"/>
-                                            <!-- IMPORTANT: explictly call templates in place of {{template}} otherwise studio won't load report correctly -->
-                                            <t t-if="report_to_call == '2x7'">
-                                                <t t-call="product.report_simple_label2x7"/>
-                                            </t>
-                                            <t t-elif="report_to_call == '4x7'">
-                                                <t t-call="product.report_simple_label4x7"/>
-                                            </t>
-                                            <t t-elif="report_to_call == '4x12'">
-                                                <t t-if="price_included">
-                                                    <t t-call="product.report_simple_label4x12"/>
-                                                </t>
-                                                <t t-else="">
-                                                    <t t-call="product.report_simple_label4x12_no_price"/>
-                                                </t>
+                                                <t t-call="product.report_simple_label4x12_no_price"/>
                                             </t>
                                         </t>
-                                    </tr>
-                                </t>
-                            </table>
-                        </div>
-                    </t>
+                                    </t>
+                                </tr>
+                            </t>
+                        </table>
+                    </div>
                 </t>
             </t>
         </template>
 
         <template id="report_productlabel_dymo">
-            <t t-call="web.html_container">
-                <t t-foreach="quantity.items()" t-as="barcode_and_qty_by_product">
-                    <t t-set="product" t-value="barcode_and_qty_by_product[0]"/>
-                    <t t-foreach="barcode_and_qty_by_product[1]" t-as="barcode_and_qty">
-                        <t t-set="barcode" t-value="barcode_and_qty[0]"/>
-                        <t t-foreach="range(barcode_and_qty[1])" t-as="qty">
-                            <t t-call="product.report_simple_label_dymo"
-                                barcode_size.f="width:45.5mm;height:7.5mm"
-                                table_style.f="width:100%;height:32mm;"
-                                padding_page.f="padding: 2mm"/>
-                        </t>
+            <t t-foreach="quantity.items()" t-as="barcode_and_qty_by_product">
+                <t t-set="product" t-value="barcode_and_qty_by_product[0]"/>
+                <t t-foreach="barcode_and_qty_by_product[1]" t-as="barcode_and_qty">
+                    <t t-set="barcode" t-value="barcode_and_qty[0]"/>
+                    <t t-foreach="range(barcode_and_qty[1])" t-as="qty">
+                        <t t-call="product.report_simple_label_dymo"
+                            barcode_size.f="width:45.5mm;height:7.5mm"
+                            table_style.f="width:100%;height:32mm;"
+                            padding_page.f="padding: 2mm"/>
                     </t>
                 </t>
             </t>

--- a/doc/cla/individual/gergoe.md
+++ b/doc/cla/individual/gergoe.md
@@ -1,0 +1,11 @@
+Hungary, 2026-01-26
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Gergely Zayzon gergoe@harras.be https://github.com/gergoe


### PR DESCRIPTION
Both product.report_productlabel and product.report_productlabel_dymo are called from a template which already includes the necessary DOM for the HTML (via web.basic_layout), having a web.html_container call in these two templates seems to be redundant and generates a malformed HTML output.

Current behavior before PR:
Duplicate/redundant DOM structure in reports generated when printing product labels

Desired behavior after PR is merged:
Correct DOM structure, valid HTML

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
