### PR TITLE
[FIX] im_livechat: do not show leave warning on closed chatbot conversation

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -62,7 +62,23 @@ class LivechatChatbotScriptController(http.Controller):
             # sudo: visitor cannot write on channel otherwise. Just writing a
             # boolean is safe
             discuss_channel.sudo().livechat_active = False
-            return None
+            step_message = next(
+                # sudo - chatbot.message.id: visitor can access chat bot messages.
+                m.mail_message_id for m in discuss_channel.sudo().chatbot_message_ids
+                if m.script_step_id == current_step
+                and m.mail_message_id.author_id == chatbot.operator_partner_id
+            )
+            store = Store(discuss_channel)
+            store.add(
+                "ChatbotStep",
+                {
+                    "id": (current_step.id, step_message.id),
+                    "scriptStep": current_step.id,
+                    "message": step_message.id,
+                    "isLast": True,
+                }
+            )
+            return store.get_result()
 
         posted_message = next_step._process_step(discuss_channel)
         store = Store(posted_message, for_current_user=True)
@@ -71,7 +87,6 @@ class LivechatChatbotScriptController(http.Controller):
             "ChatbotStep",
             {
                 "id": (next_step.id, posted_message.id),
-                "isLast": next_step._is_last_step(discuss_channel),
                 "message": Store.one(posted_message, only_id=True),
                 "operatorFound": next_step.step_type == "forward_operator"
                 and len(discuss_channel.channel_member_ids) > 2,

--- a/addons/im_livechat/static/src/embed/common/chat_window_patch.js
+++ b/addons/im_livechat/static/src/embed/common/chat_window_patch.js
@@ -20,7 +20,11 @@ patch(ChatWindow.prototype, {
 
     async close() {
         const chatWindow = toRaw(this.props.chatWindow);
-        if (chatWindow.thread.id > 0 && !this.livechatState.showCloseConfirmation) {
+        if (
+            chatWindow.thread.id > 0 &&
+            chatWindow.thread.livechat_active &&
+            !this.livechatState.showCloseConfirmation
+        ) {
             this.state.actionsDisabled = true;
             this.livechatState.showCloseConfirmation = true;
         } else {

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -83,8 +83,7 @@ export class Chatbot extends Record {
 
     get completed() {
         return (
-            (this.currentStep?.isLast &&
-                (!this.currentStep.expectAnswer || this.currentStep?.completed)) ||
+            this.currentStep?.isLast ||
             this.currentStep?.operatorFound ||
             !this.thread.livechat_active
         );
@@ -94,7 +93,7 @@ export class Chatbot extends Record {
      * Go to the next step of the chatbot, fetch it if needed.
      */
     async _goToNextStep() {
-        if (!this.thread || this.currentStep?.isLast) {
+        if (!this.thread) {
             return;
         }
         if (this.steps.at(-1)?.eq(this.currentStep)) {
@@ -102,11 +101,10 @@ export class Chatbot extends Record {
                 channel_id: this.thread.id,
                 chatbot_script_id: this.script.id,
             });
-            if (!storeData) {
-                this.currentStep.isLast = true;
+            const { ChatbotStep: steps } = this.store.insert(storeData, { html: true });
+            if (this.currentStep.isLast) {
                 return;
             }
-            const { ChatbotStep: steps } = this.store.insert(storeData, { html: true });
             this.steps.push(steps[0]);
         } else {
             const nextStepIndex = this.steps.lastIndexOf(this.currentStep) + 1;

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -41,6 +41,7 @@ export class DiscussChannel extends mailModels.DiscussChannel {
                 } else {
                     channelInfo.operator = false;
                 }
+                channelInfo["livechat_active"] = channel.livechat_active;
                 channelInfo.livechatChannel = mailDataHelpers.Store.one(
                     this.env["im_livechat.channel"].browse(channel.livechat_channel_id),
                     makeKwArgs({ fields: ["name"] })

--- a/addons/website_livechat/static/tests/tours/website_livechat_question_selection_overlapping_answers.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_question_selection_overlapping_answers.js
@@ -32,5 +32,11 @@ registry.category("web_tour.tours").add("website_livechat.question_selection_ove
             run: "click",
         },
         { trigger: ".o-livechat-root:shadow .o-mail-Message:contains(You selected maybe X)" },
+        { trigger: ".o-livechat-root:shadow span:contains(Conversation ended...)" },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-ChatWindow-command[title*=Close]",
+            run: "click",
+        },
+        { trigger: ".o-livechat-root:shadow p:contains(Did we correctly answer your question?)" },
     ],
 });


### PR DESCRIPTION
Before this commit:
When a user finishes a chatbot script and the conversation is already ended, clicking on close / continue still triggers the leave conversation warning.

After this commit:
The leave conversation warning is no longer shown when the chatbot conversation is already closed or ended. The warning is only shown for active conversations.

[Task-5882084](https://www.odoo.com/odoo/project/1519/tasks/5882084)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
