### PR TITLE
[FIX] website: fix domain allocation on employee documents smart button

### DIFF
--- a/addons/website/models/ir_model.py
+++ b/addons/website/models/ir_model.py
@@ -26,6 +26,11 @@ class Base(models.AbstractModel):
             return super().get_base_url()
         self.ensure_one()
 
+        # When a model has a `website_id`, calling `get_base_url()` always returns
+        # the website domain. This context key acts as a gateway to bypass that
+        # behavior and use the web.base.url instead.
+        if self.env.context.get('use_config_parameter_domain'):
+            return super().get_base_url()
         if self._name == 'website':
             # Note that website_1.company_id.website_id might not be website_1
             return self.domain or super().get_base_url()


### PR DESCRIPTION
Steps to reproduce:
---------------------------------
1. Install `documents_hr` and `website_documents` modules
2. Go to website > configuration > websites
3. In My Website set any arbitary domain (e.g. https://test.com)
4. Open any employee record
5. Click on Documents smart button

Observation:
---------------------------------
It will try to open employee's documents with the website's domain, e.g. `https://test.com/odoo/documents/xyz`

Issue:
---------------------------------
After the following commit:
odoo@46c43c1

the smart button redirects to the document folder via an access token. The `access_url` is computed using `get_base_url()`, which is overridden by the website module to return the website domain instead of the system base URL.
https://github.com/odoo/odoo/blob/f6cf0d067e5f30e2b22ea513071cd7c5e3d9f44c/addons/website/models/ir_model.py#L10-L36

Solution:
---------------------------------
Added a context-based check to `get_base_url()`.
When the context key `use_config_parameter_domain` is set, and the record has a `website_id` field, the system base URL from the configuration parameters is used instead of the website domain. This allows any model to explicitly rely on the configured base URL when required

NOTE: No module installs `hr`, `documents` and `website`, so test case is not possible without bridge module of all three

Related Enterprise PR: https://github.com/odoo/enterprise/pull/106478
opw-5471683