### PR TITLE
[FIX] hr_timesheet: correctly display timesheet negative values in calendar view

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -182,18 +182,20 @@ class AccountAnalyticLine(models.Model):
                 )
             else:
                 minutes = round(line.unit_amount * 60)
-                hours, minutes = divmod(minutes, 60)
+                hours, minutes = divmod(abs(round(minutes)), 60)
                 if minutes:
                     line.calendar_display_name = self.env._(
-                        "%(project_name)s (%(hours)sh%(minutes)s)",
+                        "%(project_name)s (%(sign)s%(hours)sh%(minutes)s)",
                         project_name=line.project_id.display_name,
+                        sign='-' if line.unit_amount < 0 else '',
                         hours=hours,
                         minutes=minutes,
                     )
                 else:
                     line.calendar_display_name = self.env._(
-                        "%(project_name)s (%(hours)sh)",
+                        "%(project_name)s (%(sign)s%(hours)sh)",
                         project_name=line.project_id.display_name,
+                        sign='-' if line.unit_amount < 0 else '',
                         hours=hours,
                     )
 

--- a/doc/cla/corporate/qulix.md
+++ b/doc/cla/corporate/qulix.md
@@ -1,0 +1,16 @@
+Poland, 2026-02-09
+
+Qulix agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Aliaksandr Sliborski ASliborsky@qulix.com https://github.com/ASliborsky
+
+List of contributors:
+
+Aliaksandr Sliborski ASliborsky@qulix.com https://github.com/ASliborsky
+Stanislav Kostenko Skostenko@qulix.com https://github.com/kubanez-create


### PR DESCRIPTION
The calendar view used Python's `divmod` for time calculations, which
renders -45 minutes as -1h 15m. This representation is misleading for
timesheet entries, while the list view already displays the values
correctly. Adjust the calendar view logic to ensure consistent and
accurate handling of negative durations.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
