### PR TITLE
[FIX] website_sale: fix wishlist Add to Cart button rendering

### DIFF
--- a/addons/website_sale/templates/wishlist_templates.xml
+++ b/addons/website_sale/templates/wishlist_templates.xml
@@ -74,8 +74,15 @@
                                                 t-att-href="website._get_contact_us_url(combination_info['display_name'])"
                                                 class="o_wsale_product_btn_primary btn btn-primary"
                                             >
-                                                <i class="fa fa-fw fa-envelope o_not-animable me-2" role="presentation"/>
-                                                Contact Us
+                                                <span class="d-inline-flex align-items-baseline">
+                                                    <i
+                                                        class="fa fa-fw fa-envelope o_not-animable"
+                                                        role="presentation"
+                                                    />
+                                                    <span class="o_label small ms-1">
+                                                        Contact Us
+                                                    </span>
+                                                </span>
                                             </a>
                                             <button
                                                 t-else=""
@@ -87,8 +94,15 @@
                                                 t-att-data-ptav-ids="json.dumps(product_variant.product_template_attribute_value_ids.ids)"
                                                 t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                             >
-                                                <i class="fa fa-fw fa-shopping-cart o_not-animable me-2" role="presentation"/>
-                                                Add to Cart
+                                                <span class="d-inline-flex align-items-baseline">
+                                                    <i
+                                                        class="fa fa-fw fa-shopping-cart o_not-animable"
+                                                        role="presentation"
+                                                    />
+                                                    <span class="o_label small ms-1">
+                                                        Add to Cart
+                                                    </span>
+                                                </span>
                                             </button>
                                             <t t-if="is_view_active('website_sale.add_to_compare')">
                                                 <button


### PR DESCRIPTION
Before:
The wishlist page `Add to Cart` and `Contact Us` buttons use bare text and me-2 margin on the icon, not matching the standard shop_product_buttons template structure. The missing <span class=`o_label`> wrapper prevents CSS display variables from controlling button label visibility across different tile layouts and sizes.

After:
Button text is wrapped in <span class=`o_label small ms-1`> and icon margin changed from me-2 to match the shop page button structure, allowing proper responsive rendering across all tile designs.

Steps to reproduce:
1.Log in and add products to the wishlist
2.Go to the wishlist page — buttons display correctly (inline)
3.Open the website editor and switch the wishlist design from
  Thumbnails to Cards, save. Switch back to Thumbnails, save.
4.The Add to Cart and Compare buttons are not rendering properly their icon with
  the correct size.

opw-5924433
<img width="1635" height="530" alt="image" src="https://github.com/user-attachments/assets/ba44e669-d234-49f5-b7b8-fe99a1381bd9" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
