### PR TITLE
[IMP] html_editor: allow switching banner type via powerbox

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -28,8 +28,7 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert an info banner"),
                 icon: "fa-info-circle",
                 isAvailable: (selection) =>
-                    this.checkPredicates("is_banner_command_available_predicates", selection) ??
-                    true,
+                    this.checkPredicates("is_banner_command_available_predicates", selection, "info") ?? true,
                 run: () => {
                     this.insertBanner(_t("Banner Info"), "💡", "info");
                 },
@@ -40,8 +39,7 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert a success banner"),
                 icon: "fa-check-circle",
                 isAvailable: (selection) =>
-                    this.checkPredicates("is_banner_command_available_predicates", selection) ??
-                    true,
+                    this.checkPredicates("is_banner_command_available_predicates", selection, "success") ?? true,
                 run: () => {
                     this.insertBanner(_t("Banner Success"), "✅", "success");
                 },
@@ -52,8 +50,7 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert a warning banner"),
                 icon: "fa-exclamation-triangle",
                 isAvailable: (selection) =>
-                    this.checkPredicates("is_banner_command_available_predicates", selection) ??
-                    true,
+                    this.checkPredicates("is_banner_command_available_predicates", selection, "warning") ?? true,
                 run: () => {
                     this.insertBanner(_t("Banner Warning"), "⚠️", "warning");
                 },
@@ -64,8 +61,7 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert a danger banner"),
                 icon: "fa-exclamation-circle",
                 isAvailable: (selection) =>
-                    this.checkPredicates("is_banner_command_available_predicates", selection) ??
-                    true,
+                    this.checkPredicates("is_banner_command_available_predicates", selection, "danger") ?? true,
                 run: () => {
                     this.insertBanner(_t("Banner Danger"), "❌", "danger");
                 },
@@ -76,8 +72,7 @@ export class BannerPlugin extends Plugin {
                 description: _t("Insert a monospace banner"),
                 icon: "fa-laptop",
                 isAvailable: (selection) =>
-                    this.checkPredicates("is_banner_command_available_predicates", selection) ??
-                    true,
+                    this.checkPredicates("is_banner_command_available_predicates", selection, "secondary") ?? true,
                 run: () => {
                     this.insertBanner(
                         _t("Monospace Banner"),
@@ -88,10 +83,10 @@ export class BannerPlugin extends Plugin {
                 },
             },
         ],
-        is_banner_command_available_predicates: (selection) => {
+        is_banner_command_available_predicates: (selection, bannerType) => {
             if (
                 !isHtmlContentSupported(selection) ||
-                closestElement(selection.anchorNode, ".o_editor_banner")
+                closestElement(selection.anchorNode, `.o_editor_banner.alert-${bannerType}`)
             ) {
                 return false;
             }
@@ -149,7 +144,31 @@ export class BannerPlugin extends Plugin {
         containerClass = containerClass ? `${containerClass} ` : "";
         contentClass = contentClass ? `${contentClass} ` : "";
 
+        const bannerClasses = `${containerClass}o_editor_banner user-select-none o-contenteditable-false ${
+            emoji ? "lh-1 " : ""
+        }d-flex align-items-center alert alert-${alertClass} pb-0 pt-3`;
+        const bannerContentClasses = `${contentClass}o_editor_banner_content o-contenteditable-true w-100 px-3`;
+        const emojiHtml = emoji
+            ? `<i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="${htmlEscape(
+                  title
+              )}">${htmlEscape(emoji)}</i>`
+            : "";
         const selection = this.dependencies.selection.getEditableSelection();
+        const currentBanner = closestElement(selection.anchorNode, ".o_editor_banner");
+        if (currentBanner) {
+            currentBanner.className = bannerClasses;
+            const bannerContentEl = currentBanner.querySelector(".o_editor_banner_content");
+            bannerContentEl.className = bannerContentClasses;
+            const icon = currentBanner.querySelector(".o_editor_banner_icon");
+            if (emojiHtml) {
+                const newIcon = parseHTML(this.document, emojiHtml).firstChild;
+                icon ? icon.replaceWith(newIcon) : currentBanner.prepend(newIcon);
+            } else {
+                icon.remove();
+            }
+            this.dependencies.history.addStep();
+            return;
+        }
         const blockEl = closestBlock(selection.anchorNode);
         let baseContainer;
         if (isParagraphRelatedElement(blockEl)) {
@@ -164,18 +183,11 @@ export class BannerPlugin extends Plugin {
             fillShrunkPhrasingParent(baseContainer);
         }
         const baseContainerHtml = baseContainer.outerHTML;
-        const emojiHtml = emoji
-            ? `<i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="${htmlEscape(
-                  title
-              )}">${emoji}</i>`
-            : "";
         const bannerElement = parseHTML(
             this.document,
-            `<div class="${containerClass}o_editor_banner user-select-none o-contenteditable-false ${
-                emoji ? "lh-1 " : ""
-            }d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" data-oe-role="status">
+            `<div class="${bannerClasses}" data-oe-role="status">
                 ${emojiHtml}
-                <div class="${contentClass}o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <div class="${bannerContentClasses}">
                     ${baseContainerHtml}
                 </div>
             </div>`

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -3,7 +3,7 @@ import { click, manuallyDispatchProgrammaticEvent, press, waitFor } from "@odoo/
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
-import { insertLineBreak, insertText, keydownShiftTab, keydownTab } from "./_helpers/user_actions";
+import { insertLineBreak, insertText, keydownShiftTab, keydownTab, undo } from "./_helpers/user_actions";
 import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { execCommand } from "./_helpers/userCommands";
 import { unformat } from "./_helpers/format";
@@ -26,14 +26,6 @@ test("should insert a banner with focus inside followed by a paragraph", async (
                 </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         )
     );
-
-    await insertText(editor, "/");
-    await animationFrame();
-    await expectElementCount(".o-we-powerbox", 1);
-
-    await insertText(editor, "banner");
-    await animationFrame();
-    await expectElementCount(".o-we-powerbox", 0);
 });
 
 test("press 'ctrl+a' inside a banner should select all the banner content", async () => {
@@ -408,5 +400,106 @@ test("Monospace banner should unindent on shift+tab", async () => {
     await keydownShiftTab(editor);
     expect(unformat(getContent(el))).toBe(
         unformat(wrap([`\u200b\u200b[a() {`, `\u200b\u200bx = 1;`, `\u200b\u200b}]`]))
+    );
+});
+
+test("should be able to switch banner type", async () => {
+    const { el, editor } = await setupEditor("<p>Test[]</p>");
+    await insertText(editor, "/bannerinfo");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Info");
+
+    await press("enter");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                        <p>Test[]</p>
+                    </div>
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+    await insertText(editor, "/bannersuccess");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Success");
+    await press("enter");
+
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success" aria-label="Banner Success">✅</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                        <p>Test[]</p>
+                    </div>
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+});
+
+test("powerbox should not suggest the active banner type", async () => {
+    const { el, editor } = await setupEditor("<p>Test[]</p>");
+    await insertText(editor, "/bannerinfo");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Info");
+    await press("enter");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                        <p>Test[]</p>
+                    </div>
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+    await insertText(editor, "/banner");
+    await animationFrame();
+    expect(".o-we-command-name").not.toHaveText("Banner Info");
+});
+
+test("undo restores previous banner style after switching banner type", async () => {
+    const { el, editor } = await setupEditor("<p>Test[]</p>");
+    await insertText(editor, "/bannerinfo");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Info");
+
+    await press("enter");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                        <p>Test[]</p>
+                    </div>
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+    await insertText(editor, "/bannersuccess");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Banner Success");
+    await press("enter");
+
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-success pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Success" aria-label="Banner Success">✅</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                        <p>Test[]</p>
+                    </div>
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+    undo(editor);
+    await animationFrame();
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p><div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert pb-0 pt-3 alert-info" data-oe-role="status" contenteditable="false" role="status">
+                    <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="Banner Info" aria-label="Banner Info">💡</i>
+                    <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                        <p>Test[]</p>
+                    </div>
+                </div><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
     );
 });


### PR DESCRIPTION
feature this PR addresses:

- Previously, it was not possible to change the banner type from inside the banner. To change the banner type, the existing banner had to be removed and a new one added.
- Now, the banner type can be switched directly from within the banner using the powerbox.
- Also, when opening the powerbox inside a banner, the command for the current banner type is not shown.

task-5895288