### PR TITLE
[FIX] html_editor: copy full table selection in clipboard block

### DIFF
--- a/addons/html_editor/static/src/components/html_viewer/html_viewer.js
+++ b/addons/html_editor/static/src/components/html_viewer/html_viewer.js
@@ -15,7 +15,6 @@ import { fillHtmlTransferData } from "@html_editor/utils/clipboard";
 import { fixInvalidHTML, instanceofMarkup } from "@html_editor/utils/sanitize";
 import { HtmlUpgradeManager } from "@html_editor/html_migrations/html_upgrade_manager";
 import { TableOfContentManager } from "@html_editor/others/embedded_components/core/table_of_content/table_of_content_manager";
-import { getDeepestPosition } from "@html_editor/utils/dom_info";
 import { scrollAndHighlightHeading } from "@html_editor/utils/url";
 
 export class HtmlViewer extends Component {
@@ -152,19 +151,7 @@ export class HtmlViewer extends Component {
     onCopy(ev) {
         ev.preventDefault();
         const selection = ev.target.ownerDocument.defaultView.getSelection();
-        const [deepAnchorNode, deepAnchorOffset] = getDeepestPosition(
-            selection.anchorNode,
-            selection.anchorOffset
-        );
-        const [deepFocusNode, deepFocusOffset] = getDeepestPosition(
-            selection.focusNode,
-            selection.focusOffset
-        );
-
-        const range = new Range();
-        range.setStart(deepAnchorNode, deepAnchorOffset);
-        range.setEnd(deepFocusNode, deepFocusOffset);
-        const clonedContents = range.cloneContents();
+        const clonedContents = selection.getRangeAt(0).cloneContents();
         fillHtmlTransferData(ev, "clipboardData", clonedContents, {
             textContent: selection.toString(),
         });

--- a/addons/html_editor/static/tests/html_viewer.test.js
+++ b/addons/html_editor/static/tests/html_viewer.test.js
@@ -66,3 +66,40 @@ test(`copy from HtmlViewer must support application/vnd.odoo.odoo-editor`, async
         clipboardData.getData("text/html")
     );
 });
+
+test(`copy from HtmlViewer should copy all the selection`, async () => {
+    await mountWithCleanup(WebClient);
+
+    registry.category("main_components").add("mycomponent", {
+        Component: HtmlViewer,
+        props: {
+            config: {
+                value: markup(`
+                    <table class="table table-bordered o_table">
+                        <tbody>
+                            <tr style="height: 49.1875px;">
+                                <td style="background-color: rgba(214, 239, 214, 0.6); color: rgb(55, 65, 81);">
+                                    <p>A</p>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            },
+        },
+    });
+    await animationFrame();
+    const tableParent = (await waitFor("table")).parentElement;
+    const range = new Range();
+    range.setStart(tableParent, 0);
+    range.setEnd(tableParent, 1);
+    getSelection().addRange(range);
+    await animationFrame();
+    const clipboardData = new DataTransfer();
+    tableParent.dispatchEvent(new ClipboardEvent("copy", { bubbles: true, clipboardData }));
+
+    expect(clipboardData.getData("text/html")).toInclude("table");
+    expect(clipboardData.getData("application/vnd.odoo.odoo-editor")).toBe(
+        clipboardData.getData("text/html")
+    );
+});


### PR DESCRIPTION
Problem:
In Knowledge, when adding a clipboard block and inserting a table inside it, clicking on the copy button only copies the text inside the table instead of the full table structure.

Cause:
In `html_viewer`, the copy logic clones only the deepest selected node. In contrast, `html_editor` (via `clipboard_plugin`) copies the entire selection range. This difference causes inconsistent behavior between editable and locked content.

Solution:
Align the behavior by copying the full selection in `html_viewer`, ensuring tables and other complex structures are copied entirely and consistently.

Steps to reproduce:
- Open Knowledge.
- Add a clipboard block.
- Insert a table inside the block.
- Lock the content.
- Click the copy button.
- Paste into any editable field.
- Observe that only the text (not the table) is pasted.

opw-5476320

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
