### PR TITLE
[FIX] website, html_builder: show invisible snippets in preview dialog

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -75,6 +75,65 @@
                         }
                     }
                 }
+
+                // Force visibility on root snippets if desktop/mobile invisible
+                &.o_snippet_desktop_invisible {
+                    @include media-breakpoint-up(lg) {
+                        display: block !important;
+                        opacity: 70%;
+                        position: relative;
+
+                        &.d-lg-flex, &.d-md-flex, &.o_half_screen_height, &.o_full_screen_height {
+                            // e.g. Useful if "Height" option (50% or 100%) is enabled.
+                            display: flex !important;
+                        }
+
+                        &::before {
+                            position: absolute;
+                            // Content is 0px wide => use available width.
+                            width: -webkit-fill-available;
+                            width: -moz-available;
+                            right: 20px;
+                            z-index: 100;
+                            background-color: $o-we-color-accent;
+                            font-size: 0px;
+                            pointer-events: none;
+                            content: "."; // Content is mandatory.
+                            
+                            height: 50px;
+                            -webkit-mask: url("/html_builder/static/img/options/desktop_invisible.svg") no-repeat 100% 100%;
+                        }
+                    }
+                }
+
+                &.o_snippet_mobile_invisible {
+                    @include media-breakpoint-down(lg) {
+                        display: block !important;
+                        opacity: 70%;
+                        position: relative;
+
+                        &.d-lg-flex, &.d-md-flex, &.o_half_screen_height, &.o_full_screen_height {
+                            // e.g. Useful if "Height" option (50% or 100%) is enabled.
+                            display: flex !important;
+                        }
+
+                        &::before {
+                            position: absolute;
+                            // Content is 0px wide => use available width.
+                            width: -webkit-fill-available;
+                            width: -moz-available;
+                            right: 20px;
+                            z-index: 100;
+                            background-color: $o-we-color-accent;
+                            font-size: 0px;
+                            pointer-events: none;
+                            content: "."; // Content is mandatory.
+                            
+                            height: 30px;
+                            -webkit-mask: url("/html_builder/static/img/options/mobile_invisible.svg") no-repeat 100% 100%;
+                        }
+                    }
+                }
             }
             &[data-label]:not([data-label=""])::before {
                 content: attr(data-label);

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2400,7 +2400,7 @@ $ribbon-padding: 100px;
 }
 
 // Conditional visibility
-.o_conditional_hidden {
+.o_conditional_hidden:not(.o_snippet_preview_wrap *) {
     display: none !important;
 }
 


### PR DESCRIPTION
The (saved custom) snippets which were invisible on desktop or conditionally invisible, appeared as empty in the dialog to preview snippet.

This commit changes the css rules so that
- conditionally visible elements are always visible in preview
- snippet that are device invisible are show with the overlay (and inner elements that are device invisible are not shown)

Steps to reproduce:
- Open website builder
- Drop a section
- Change the "Visibility" to hide on desktop
- Click on the eye to show it
- Save the snippet as a custom snippet
- Open the dialog to add a snippet
- Bug: the newly saved snippet is shown as empty

Same for "Visibility" to "Conditionally". And Same for "Visibility" to hide on mobile, if the window size is reduced when showing the dialog.

task-5149984