### PR TITLE
[FIX] html_editor: skip syntax highlighting for very large pre blocks

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -23,6 +23,9 @@ export class SyntaxHighlightingPlugin extends Plugin {
         "protectedNode",
         "embeddedComponents",
     ];
+    static defaultConfig = {
+        syntaxHighlightingTextLimit: 1_000_000,
+    };
     /** @type {import("plugins").EditorResources} */
     resources = {
         // Ensure focus can be preserved within the textarea:
@@ -127,6 +130,12 @@ export class SyntaxHighlightingPlugin extends Plugin {
             (pre) => !pre.closest(CODE_BLOCK_SELECTOR)
         );
         for (const pre of nonEmbeddedPres) {
+            // Do not convert large <pre> elements into syntax-highlighted
+            // components. If the content exceeds the defined limit, original
+            // <pre> is preserved to avoid performance issues.
+            if (pre.textContent.length > this.config.syntaxHighlightingTextLimit) {
+                continue;
+            }
             const isPreInSelection = !targetedNodes.some((node) => !pre.contains(node));
             const embeddedProps = JSON.stringify(
                 Object.assign(

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -52,10 +52,26 @@ const testEditorWithHighlightedContent = async (config) =>
     await testEditor({
         ...config,
         compareFunction: compareHighlightedContent,
-        config: configWithEmbeddings,
+        config: {
+            ...configWithEmbeddings,
+            // Reduce the syntax highlighting limit for tests.
+            // Real limit (e.g. 1 million characters) is too large to use
+            // in unit test, so use smaller value to reliably test behavior.
+            syntaxHighlightingTextLimit: 50,
+        },
     });
 
 beforeEach(patchPrism);
+
+test("should not syntax-highlight when content exceeds the highlighting limit", async () => {
+    await testEditorWithHighlightedContent({
+        contentBefore: "<p>[]Lorem ipsum dolor sit amet consectetur adipiscing elit</p>", // exceeds limit
+        stepFunction: async (editor) => {
+            await insertPre(editor);
+        },
+        contentAfter: "<pre>[]Lorem ipsum dolor sit amet consectetur adipiscing elit</pre>",
+    });
+});
 
 test("starting edition with a pre activates syntax highlighting", async () => {
     await testEditorWithHighlightedContent({


### PR DESCRIPTION
### Purpose of this PR:

- Large `<pre>` blocks that use syntax highlighting can severely impact performance when opening a task or when applying transformations (e.g. converting to paragraph). In extreme cases, this can even crash the browser.
- To avoid this, `<pre>` elements whose text content exceeds the syntax highlighting size limit are no longer converted into syntax-highlighted embedded code components (with textarea and Prism). Instead, they are kept as plain `<pre>` elements.

task-5907330

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
