### PR TITLE
[IMP] html_builder, website: replace 50% height option with 75%

### DIFF
--- a/addons/html_builder/static/src/sidebar/invisible_elements.edit.scss
+++ b/addons/html_builder/static/src/sidebar/invisible_elements.edit.scss
@@ -3,8 +3,8 @@
     opacity: 70%;
     position: relative;
 
-    &.d-lg-flex, &.d-md-flex, &.o_half_screen_height, &.o_full_screen_height {
-        // e.g. Useful if "Height" option (50% or 100%) is enabled.
+    &.d-lg-flex, &.d-md-flex, &.o_half_screen_height, &.o_three_quarter_height, &.o_full_screen_height {
+        // e.g. Useful if "Height" option is enabled.
         display: flex !important;
     }
 

--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -41,13 +41,17 @@
             [data-snippet="s_numbers_charts"] .s_chart {
                 display: none;
             }
-            .o_full_screen_height, .o_half_screen_height {
+            .o_full_screen_height, .o_half_screen_height, .o_three_quarter_height {
                 height: unset !important;
                 min-height: unset !important;
             }
             .o_full_screen_height {
                 aspect-ratio: 4 / 3;
             }
+            .o_three_quarter_height {
+                aspect-ratio: 6 / 3;
+            }
+            // This is kept for compatibility
             .o_half_screen_height {
                 aspect-ratio: 8 / 3;
             }

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
@@ -5,8 +5,10 @@
     <BuilderRow label="this.state.heightLabel">
         <BuilderButtonGroup action="'scrollButtonSectionHeightClass'">
             <BuilderButton id="'minheight_auto_opt'" actionParam="''" title.translate="Fit content">Auto</BuilderButton>
-            <BuilderButton actionParam="'o_half_screen_height'" title.translate="Half screen">50%</BuilderButton>
+            <BuilderButton actionParam="'o_three_quarter_height'" title.translate="75% of the screen">75%</BuilderButton>
             <BuilderButton id="'full_height_opt'" actionParam="'o_full_screen_height'" title.translate="Full screen">100%</BuilderButton>
+            <!-- A snippet can have .o_half_screen_height, but we don't want to offer it as an option, this is kept for compatibility -->
+            <BuilderButton actionParam="'o_half_screen_height'" className="'d-none'">50%</BuilderButton>
         </BuilderButtonGroup>
     </BuilderRow>
 

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -134,6 +134,8 @@ class AddPageTemplatePreview extends Component {
             const styleEl = document.createElement("style");
             // Prevent successive resizes.
             const fullHeight = getComputedStyle(document.querySelector(".o_action_manager")).height;
+            const threeQuarterHeight = `${Math.round((3 * parseInt(fullHeight)) / 4)}px`;
+            // This is kept for compatibility
             const halfHeight = `${Math.round(parseInt(fullHeight) / 2)}px`;
             const css = `
                 html, body {
@@ -161,6 +163,9 @@ class AddPageTemplatePreview extends Component {
                 }
                 section.o_half_screen_height {
                     min-height: ${halfHeight} !important;
+                }
+                section.o_three_quarter_height {
+                    min-height: ${threeQuarterHeight} !important;
                 }
                 section.o_full_screen_height {
                     min-height: ${fullHeight} !important;

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -941,7 +941,7 @@ table.table_desc tr td {
     border-radius: 0;
 }
 
-.o_full_screen_height {
+@mixin o_full_screen_height {
     display: flex;
     flex-direction: column;
     justify-content: space-around;
@@ -950,14 +950,24 @@ table.table_desc tr td {
     // Arc browser does not support this correctly at the moment.
     min-height: 100svh !important;
 }
+
+.o_full_screen_height {
+    @include o_full_screen_height;
+}
+
+.o_three_quarter_height {
+    @include o_full_screen_height;
+    min-height: 75vh !important;
+}
+
 .o_half_screen_height {
-    @extend .o_full_screen_height;
+    @include o_full_screen_height;
     min-height: 55vh !important;
 }
 
 // TODO remove cover_full and cover_mid classes (kept for compatibility for now)
 .cover_full {
-    @extend .o_full_screen_height;
+    @include o_full_screen_height;
 }
 .cover_mid {
     @extend .o_half_screen_height;
@@ -1449,7 +1459,7 @@ $-o-carousel-controllers-size: var(--CarouselControllers-size, #{map-get($spacer
             button {
                 color: inherit;
             }
-            
+
             &.s_carousel_indicators_numbers {
                 // For large screen, use the same size as the margin-bottom of
                 // the prev/next buttons (like other indicators; instead of
@@ -1779,7 +1789,7 @@ header {
             }
         }
         border-radius: o-website-value('menu-border-radius') !important;
-        
+
         @if o-website-value('menu-shadow-class') == 'shadow' {
             box-shadow: var(--box-shadow) !important;
         } @else if o-website-value('menu-shadow-class') == 'shadow-sm' {
@@ -1789,7 +1799,7 @@ header {
         } @else if o-website-value('menu-shadow-class') == 'o-shadow-custom' {
             box-shadow: o-website-value('menu-box-shadow-style') !important;
         }
-        
+
 
         &.o_header_force_no_radius {
             border-radius: 0 !important;
@@ -2350,7 +2360,7 @@ span.list-inline-item.o_add_language:last-child {
     &:focus {
         outline: none;
     }
-    
+
 }
 
 .anim-heartbeat {

--- a/addons/website/static/src/snippets/s_color_blocks_2/000.scss
+++ b/addons/website/static/src/snippets/s_color_blocks_2/000.scss
@@ -1,7 +1,8 @@
 .s_color_blocks_2 {
     // Needed to be able to stretch the inner container so that
-    // the snippet works with the 50% and 100% height
-    &.o_half_screen_height, &.o_full_screen_height {
+    // the snippet works with the 75% and 100% heights, and also
+    // 50%, which is kept for compatibility with previous versions
+    &.o_half_screen_height, &.o_three_quarter_height, &.o_full_screen_height {
         > :first-child { // container
             &, > .row {
                 min-height: inherit;

--- a/addons/website/static/tests/builder/options/height_option.test.js
+++ b/addons/website/static/tests/builder/options/height_option.test.js
@@ -1,0 +1,28 @@
+import { expect, queryFirst, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+
+defineWebsiteModels();
+const snippetHTML = `
+    <section class="s_banner o_half_screen_height" data-snippet="s_banner" data-name="Banner" contenteditable="false">
+        <div contenteditable="true" class="container">
+        </div>
+    </section>`;
+
+test("Can change the height of a snippet when it has o_half_screen_height class", async () => {
+    await setupWebsiteBuilder(snippetHTML, {
+        loadIframeBundles: true,
+    });
+    expect(":iframe .s_banner").toHaveClass("o_half_screen_height");
+    const snippetEl = queryFirst(":iframe .s_banner");
+    const initialHeight = getComputedStyle(snippetEl).height;
+    await contains(":iframe .s_banner").click();
+    expect("[data-action-param='o_three_quarter_height']").not.toHaveClass("active");
+    await contains("[data-action-param='o_three_quarter_height']").click();
+
+    expect(":iframe .s_banner").not.toHaveClass("o_half_screen_height");
+    expect(":iframe .s_banner").not.toHaveStyle({ height: initialHeight });
+});

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -20,7 +20,7 @@ registerWebsitePreviewTour(
         // a widgets_start_request is triggered.
         {
             content: "Hover an option which has a preview",
-            trigger: "[data-action-param='o_half_screen_height']",
+            trigger: "[data-action-param='o_three_quarter_height']",
             run: "hover",
         },
         {
@@ -36,7 +36,7 @@ registerWebsitePreviewTour(
                 // should not be *necessary* to simulate those for the editor
                 // flow to make some sense.
                 const previousAnchor = document.querySelector(
-                    "[data-action-param='o_half_screen_height']"
+                    "[data-action-param='o_three_quarter_height']"
                 );
                 previousAnchor.dispatchEvent(new Event("mouseout"));
                 previousAnchor.dispatchEvent(new Event("mouseleave"));

--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -618,7 +618,7 @@ overridden by modules), because:
 
 <template id="new_page_template_landing_4_s_cover" inherit_id="website.new_page_template_landing_s_cover" primary="True">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" remove="o_full_screen_height" separator=" "/>
+        <attribute name="class" add="o_three_quarter_height" remove="o_full_screen_height" separator=" "/>
     </xpath>
     <xpath expr="//h1" position="replace">
         <h1 style="text-align: center;">We Are Coming Soon</h1>
@@ -935,7 +935,7 @@ overridden by modules), because:
 
 <template id="new_page_template_services_s_parallax" inherit_id="website.new_page_template_s_parallax" primary="True">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pb168 pt256" remove="o_half_screen_height" separator=" "/>
+        <attribute name="class" add="pb168 pt256" remove="o_three_quarter_height" separator=" "/>
     </xpath>
     <xpath expr="//span[hasclass('s_parallax_bg')]" position="attributes">
         <attribute name="style" add="background-position: 0% 44.4099%;" remove="background-position: 50% 75%;" separator=";"/>
@@ -1040,7 +1040,7 @@ overridden by modules), because:
 <!-- Map: change height -->
 <template id="new_page_template_s_map" inherit_id="s_map" primary="True">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_half_screen_height" separator=" "/>
+        <attribute name="class" add="o_three_quarter_height" separator=" "/>
     </xpath>
 </template>
 

--- a/addons/website/views/snippets/s_big_number.xml
+++ b/addons/website/views/snippets/s_big_number.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_big_number" name="Big number">
-    <section class="s_big_number o_half_screen_height o_cc o_cc5 pt104 pb104" data-oe-shape-data="{'shape':'html_builder/Rainy/09_001','flip':[],'showOnMobile':false}">
+    <section class="s_big_number o_cc o_cc5 pt104 pb104" data-oe-shape-data="{'shape':'html_builder/Rainy/09_001','flip':[],'showOnMobile':false}">
         <div class="o_we_shape o_html_builder_Rainy_09_001"/>
         <div class="container">
             <div class="row s_nb_column_fixed">

--- a/addons/website/views/snippets/s_parallax.xml
+++ b/addons/website/views/snippets/s_parallax.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_parallax" name="Parallax">
-    <section class="s_parallax parallax s_parallax_is_fixed bg-black-50 o_half_screen_height" data-scroll-background-ratio="1">
+    <section class="s_parallax parallax s_parallax_is_fixed bg-black-50 o_three_quarter_height" data-scroll-background-ratio="1">
         <span class="s_parallax_bg_wrap">
             <span class="s_parallax_bg oe_img_bg" style="background-image: url('/web/image/website.s_parallax_default_image'); background-position: 50% 75%;"/>
         </span>


### PR DESCRIPTION
Users rarely want to define a 50% height, either they want Auto, or
100% or something that's close enough to show the visitor there's still
content below the snippet. We replace all occurrences of 50% height
snippets with 3/4 height, except for the cover (e.g. Blog Cover) as I
don't find replacing Half Screen Size with 75% Size useful there.

task-5921163