### PR TITLE
[FIX] website: prevent crash when clicking image with popup on click

### DIFF
--- a/addons/website/static/src/builder/plugins/image/image_popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_popup_option_plugin.js
@@ -17,7 +17,7 @@ export class ImagePopUpOptionPlugin extends Plugin {
 export class ImagePopUpOption extends BaseOptionComponent {
     static template = "website.ImagePopUpOption";
     static selector = "img";
-    static exclude = "a img, header img, footer img, .s_image_gallery img";
+    static exclude = "a img, header img, footer img, .s_image_gallery img, .o_product_detail_img_wrapper img";
 }
 
 registry.category("website-plugins").add(ImagePopUpOptionPlugin.id, ImagePopUpOptionPlugin);

--- a/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
@@ -23,6 +23,7 @@ export class GallerySlider extends Interaction {
     };
 
     setup() {
+        this.liEls = [];
         this.hideOnClickIndicator = true;
         this.carouselEl = this.el.classList.contains("carousel")
             ? this.el
@@ -142,7 +143,7 @@ export class GallerySlider extends Interaction {
     }
 
     onSlidCarousel() {
-        if (this.liEls) {
+        if (this.liEls.length > 0) {
             const active = [...this.liEls].filter((el) => el.classList.contains("active"));
             const index = active.length ? [...this.liEls].indexOf(active[0]) : 0;
             this.page = Math.floor(index / this.realNbPerPage);

--- a/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
+++ b/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
@@ -1,4 +1,5 @@
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
+import { contains } from "@web/../tests/web_test_helpers";
 
 import { describe, expect, getFixture, test } from "@odoo/hoot";
 import { animationFrame, click, leave, press, queryOne } from "@odoo/hoot-dom";
@@ -150,6 +151,18 @@ const defaultOldLightbox = `
     </main>
 `;
 
+const singleImagePopupGallery = `
+    <section class="s_image_gallery o_slideshow o_image_popup">
+        <div id="slideshow_sample" class="carousel">
+            <div class="carousel-inner">
+                <div class="carousel-item active">
+                    <img class="img img-fluid d-block" data-name="Image" src="/web/image/website.library_image_16" alt="">
+                </div>
+            </div>
+        </div>
+    </section>
+`;
+
 test("gallery_slider does nothing if there is no o_slideshow s_image_gallery", async () => {
     const { core } = await startInteractions(`
         <div id="wrapwrap">
@@ -242,4 +255,11 @@ test("carousel autoplay pauses while lightbox is open and resumes after closing"
     expect(".carousel .carousel-item:nth-child(1)").not.toHaveClass("active");
     expect(".carousel .carousel-item:nth-child(2)").toHaveClass("active");
     expect(".carousel .carousel-item:nth-child(3)").not.toHaveClass("active");
+});
+
+test("slideshow with one image and popup on image doesn't crash on click", async () => {
+    const { core } = await startInteractions(singleImagePopupGallery);
+    expect(core.interactions).toHaveLength(2);
+    await contains("img").click();
+    expect(".o_image_lightbox").not.toBe(null);
 });


### PR DESCRIPTION
Steps to produce:
---
- Install `website_sale` module.
- Go to website > open editor.
- Add an image snippet to the homepage.
- Click on the image and enable `Pop-up on Click`, then save.
- Click on the image.

Traceback:
---
`TypeError: Cannot read properties of undefined (reading 'length')`

Root cause:
---
- In the `setup` method, when the image is not part of a carousel,
  the element `.carousel-indicators` does not exist. As a result,
  `indicatorEl` is null, and the guarded block(at [1]) is skipped.
  Because of this, `this.liEls` is never initialized.
- Later, when the `onSlidCarousel` method is executed,
  its internal condition evaluates and find `liEls` as null and
  then `hide` method is called(see [2]).
- Inside the `hide` method, the code attempts to iterate
  over `this.liEls`(see [3]).

Solution:
---
- Initialized `liEls` in `setup()` to ensure it is always defined.
- Added a length check in `onSlidCarousel()` to execute the logic
  only when `liEls.length > 0`.
- This prevents this.page from being computed using invalid
  values and avoids it being set to `NaN`.
- Additionally, as requested by the boje(po), hide the popup
  on click setting on product images.
  
**Alternative approaches:**

1. We can also call the `onSlideCarousel` method from `setup`
    when multiple images are present.
2. Also, we can add a simple check inside the `onSlideCarousel`
    method to ensure that `liEls` is defined before proceeding.

[1]: https://github.com/odoo/odoo/blob/945f44e55f9a67b0744a183200de728b00202b1c/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js#L31-L57
[2]: https://github.com/odoo/odoo/blob/945f44e55f9a67b0744a183200de728b00202b1c/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js#L144-L152
[3]: https://github.com/odoo/odoo/blob/945f44e55f9a67b0744a183200de728b00202b1c/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js#L119-L120

opw-5921123
---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
