### PR TITLE
[IMP] l10n_my: is_company as per vat

### DIFF
--- a/addons/l10n_my/models/__init__.py
+++ b/addons/l10n_my/models/__init__.py
@@ -1,2 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import product_template, template_my
+from . import product_template
+from . import res_partner
+from . import template_my

--- a/addons/l10n_my/models/res_partner.py
+++ b/addons/l10n_my/models/res_partner.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def _compute_is_company(self):
+        super()._compute_is_company()
+        for partner in self:
+            if partner.country_code == 'MY' and partner.is_company and partner.vat.upper().startswith("IG"):
+                partner.is_company = False

--- a/addons/l10n_my/tests/__init__.py
+++ b/addons/l10n_my/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_partner

--- a/addons/l10n_my/tests/test_res_partner.py
+++ b/addons/l10n_my/tests/test_res_partner.py
@@ -1,0 +1,43 @@
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class L10nMYTest(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.partner_a.write({
+            'name': 'Başhisar Elektronik dan Perkhidmatan Sdn. Bhd.',
+            'vat': 'IG115002000',
+            'street': 'Jalan Tun Razak 15',
+            'street2': 'Suite 8-3, Wisma Sentral',
+            'city': 'Johor Bahru',
+            'country_id': cls.env.ref('base.my').id,
+            'state_id': cls.env.ref('base.state_my_jhr').id,
+            'zip': '80000',
+            'phone': '+60 13-987 2489',
+        })
+
+        cls.partner_b.write({
+            'name': 'MY Company',
+            'vat': 'C20880050010',
+            'street': 'Jalan Ampang 3281',
+            'street2': 'Level 5, Menara Mutiara',
+            'city': 'Kuala Lumpur',
+            'country_id': cls.env.ref('base.my').id,
+            'state_id': cls.env.ref('base.state_my_jhr').id,
+            'zip': '06810',
+            'phone': '+60 12-345 8899'
+        })
+
+    def test_my_company_definition(self):
+        """
+        Ensure MY Partners are categorized correctly based on Tax ID:
+            - (Company): TIN not start with IG
+            - (Individual): TIN start with IG
+        """
+        self.assertFalse(self.partner_a.is_company, "MY Partner with a VAT starting with 'IG' should be treated as an individual.")
+        self.assertTrue(self.partner_b.is_company, "MY Partner with a VAT not starting with 'IG' should be treated as a company.")


### PR DESCRIPTION
In this commit:
- For Malaysia, TIN is distinguishable between an individual and a company by prefix
- if vat starts with 'IG', 'is_company' should remain False

Task [link](https://www.odoo.com/odoo/project.task/5912436)
task-5912436
