### PR TITLE
[FIX] account_edi_ubl_cii: enable discount for null price product with charges

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_discount_on_price_zero.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/import/bis3/invoice/be/test_import_invoice_discount_on_price_zero.xml
@@ -1,0 +1,127 @@
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+    <cbc:ID>INV/2026/00001</cbc:ID>
+    <cbc:IssueDate>2026-04-15</cbc:IssueDate>
+    <cbc:DueDate>2026-04-15</cbc:DueDate>
+    <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    <cac:OrderReference>
+        <cbc:ID>INV/2026/00001</cbc:ID>
+    </cac:OrderReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+                <cbc:CityName>Ramillies</cbc:CityName>
+                <cbc:PostalZone>1367</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+                <cbc:CityName>Ramillies</cbc:CityName>
+                <cbc:PostalZone>1367</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+                <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Name>partner_a</cbc:Name>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:Delivery><cac:DeliveryParty><cac:PartyName><cbc:Name>partner_a</cbc:Name></cac:PartyName></cac:DeliveryParty></cac:Delivery>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+        <cbc:PaymentID>INV/2026/00001</cbc:PaymentID><cac:PayeeFinancialAccount><cbc:ID>BE15001559627230</cbc:ID></cac:PayeeFinancialAccount></cac:PaymentMeans>
+    <cac:PaymentTerms>
+        <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+    </cac:PaymentTerms>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">0.23</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="EUR">1.50</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">0.23</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>15.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">1.50</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">1.50</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">1.73</cbc:TaxInclusiveAmount>
+        <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+        <cbc:PayableAmount currencyID="EUR">1.73</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">1.50</cbc:LineExtensionAmount>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+            <cbc:AllowanceChargeReason>FREIGHT</cbc:AllowanceChargeReason>
+            <cbc:Amount currencyID="EUR">2.00</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:AllowanceCharge>
+            <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+            <cbc:AllowanceChargeReason>DISCOUNTED FUEL SURCHARGE</cbc:AllowanceChargeReason>
+            <cbc:Amount currencyID="EUR">0.50</cbc:Amount>
+        </cac:AllowanceCharge>
+        <cac:Item>
+            <cbc:Description>product_a</cbc:Description>
+            <cbc:Name>product_a</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>15.0</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">0.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_decode_invoice_line.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_import_bis3_invoice_be_decode_invoice_line.py
@@ -119,3 +119,13 @@ class TestUblImportBis3InvoiceBEDecodeInvoiceLine(TestUblImportBis3InvoiceBE):
     def test_partial_import_invoice_line_zero_line_extension_amount(self):
         invoice = self._import_invoice_as_attachment_on(test_name='test_partial_import_invoice_line_zero_line_extension_amount')
         self.assertFalse(invoice.invoice_line_ids)
+
+    def test_import_charge_and_discount_for_price_zero(self):
+        imported_invoice = self._import_invoice_as_attachment_on(test_name='test_import_invoice_discount_on_price_zero')
+        self.assertRecordValues(imported_invoice, [{'amount_total': 1.73}])
+        self.assertRecordValues(imported_invoice.invoice_line_ids, [{
+            'name': self.product_a.name,
+            'price_subtotal': 1.5,
+            'price_unit': 2.0,
+            'discount': 25.0,
+        }])


### PR DESCRIPTION
Allowances for Product with price as 0.00 aren't applied

Step to reproduce:
- import vendor bill from an XML having a product:
	- price: 0.00
	- charge: any positive amount
	- allowance: any positive amount

Current behavior:
- allowance isn't apply resulting in a difference between the XML total and Odoo total

Cause of the issue:
Before this commit the discount was applied as a percent of price only. Having a price as 0 prevent doing so.

opw-5499525

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr