### PR TITLE
[IMP] point_of_sale: mark invoices as reviewed

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1169,6 +1169,7 @@ class PosOrder(models.Model):
         invoice_vals = self._prepare_invoice_vals()
         invoice = self._create_invoice(invoice_vals)
         invoice.sudo().with_company(company).with_context(**self._get_invoice_post_context())._post()
+        invoice.sudo().with_context(skip_is_manually_modified=True).write({'review_state': 'no_review'})
 
         # invoice payments
         payment_moves_from_closed_sessions = {}

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1183,6 +1183,7 @@ class PosOrder(models.Model):
         invoice_vals = self._prepare_invoice_vals()
         invoice = self._create_invoice(invoice_vals)
         invoice.sudo().with_company(company).with_context(**self._get_invoice_post_context())._post()
+        invoice.sudo().with_context(skip_is_manually_modified=True).write({'review_state': ''})
 
         # invoice payments
         payment_moves_from_closed_sessions = {}

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -1452,3 +1452,26 @@ class TestPoSBasicConfig(TestPoSCommon):
             special_product.unlink()
         with self.assertRaisesRegex(UserError, "You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."):
             special_product.product_variant_ids[0].unlink()
+
+    def test_pos_invoice_not_to_review_pos_only_user(self):
+        """POS invoices must not be 'marked as 'to review' even when
+        the invoicing user has no accounting review permissions."""
+        self.open_new_session()
+
+        pos_only_user = self.env['res.users'].create({
+            'name': 'POS Only User',
+            'login': 'pos_only_user',
+            'password': 'pos_only_user',
+            'group_ids': [self.env.ref('point_of_sale.group_pos_manager').id],
+        })
+
+        orders = self._create_orders([{
+            'pos_order_lines_ui_args': [(self.product1, 1)],
+            'customer': self.customer,
+            'is_invoiced': False,
+        }])
+        orders = sum(orders.values(), self.env['pos.order'])
+
+        orders.with_user(pos_only_user)._generate_pos_order_invoice()
+
+        self.assertEqual(orders.account_move.review_state, 'no_review')

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -1497,3 +1497,26 @@ class TestPoSBasicConfig(TestPoSCommon):
             special_product.unlink()
         with self.assertRaisesRegex(UserError, "You cannot archive a product that is set as a special product in a Point of Sale configuration. Please change the configuration first."):
             special_product.product_variant_ids[0].unlink()
+
+    def test_pos_invoice_not_to_review_pos_only_user(self):
+        """POS invoices must not be 'marked as 'to review' even when
+        the invoicing user has no accounting review permissions."""
+        self.open_new_session()
+
+        pos_only_user = self.env['res.users'].create({
+            'name': 'POS Only User',
+            'login': 'pos_only_user',
+            'password': 'pos_only_user',
+            'group_ids': [self.env.ref('point_of_sale.group_pos_manager').id],
+        })
+
+        orders = self._create_orders([{
+            'pos_order_lines_ui_args': [(self.product1, 1)],
+            'customer': self.customer,
+            'is_invoiced': False,
+        }])
+        orders = sum(orders.values(), self.env['pos.order'])
+
+        orders.with_user(pos_only_user)._generate_pos_order_invoice()
+
+        self.assertEqual(orders.account_move.review_state, False)


### PR DESCRIPTION
Commit af368c872fcbdd952dffde47abcdc7d1fd02f298
introduced the `review_state` field on invoices.

With this, invoices from pos were marked with the default `To review` state. This does not make sense in pos, as pos only creates invoices after customer payment.

In this commit we ensure that pos invoices are marked as 'reviewed'.

Task: 5917658


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
