### PR TITLE
[FIX] account_peppol: allow PEPPOL with audit trail

### DIFF
--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -248,6 +248,7 @@ class AccountMoveSend(models.TransientModel):
 
                     if new_message.attachment_ids.ids:
                         self.env.cr.execute("UPDATE ir_attachment SET res_id = NULL WHERE id IN %s", [tuple(new_message.attachment_ids.ids)])
+                        new_message.attachment_ids.invalidate_recordset(['res_id', 'res_model'], flush=False)
                     new_message.attachment_ids.write({
                         'res_model': new_message._name,
                         'res_id': new_message.id,


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_de
- Switch to a German company (e.g. DE Company)
- In Accounting settings, activate Peppol

- Create an invoice:
  * Customer: [a German customer with VAT]
  * Invoice Lines: [a line with a tax]
- Confirm the invoice
- Send the invoice via PEPPOL

**Issue:**
A UserError is raised:
"You cannot remove parts of the audit trail.".

**Cause:**
The audit trail prevent modifying an attachment.
When sending an invoice to PEPPOL, a message is logged in the chatter with both the invoice PDF and XML as attachment.
During the process, "res_model" and "res_id" fields of the attachments are set to the message record.
Before doing it, "res_id" is removed in SQL to prevent raising the audit trail error.
However, it fails because the value is still in cache.

**Solution:**
Invalidate these fields as it is done when sending the invoice without PEPPOL.
https://github.com/odoo/odoo/commit/e0229d5c7fa89d32f67151d307161482c300ff20

opw-5916696




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
