### PR TITLE
[IMP] point_of_sale: add bg color to button

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -149,7 +149,7 @@
                             t-on-click="() => this.setOrder(_selectedSyncedOrder)">
                             <span class="d-block">Load Order</span>
                         </button>
-                        <button class="btn-switchpane btn btn-lg lh-lg w-50 py-3 secondary review-button" t-att-class="{'btn-primary': isOrderSynced, 'btn-light': !isOrderSynced}" t-on-click="switchPane">
+                        <button class="btn-switchpane btn btn-lg lh-lg w-50 py-3 btn-secondary review-button" t-att-class="{'btn-primary': isOrderSynced, 'btn-light': !isOrderSynced}" t-on-click="switchPane">
                             <span class="d-block">Review</span>
                         </button>
                     </div>


### PR DESCRIPTION
The `Review` button accidentally had the class `secondary` instead of the class `btn-secondary`. It thus has not discernable border or bg color, making it hard unclear that it was a button.

This commit fixes the issue.

Task : 5910329


Before             |  After
:-------------------------:|:-------------------------:
 <img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/9231e8c8-5e47-40a0-a6f6-a185e0fa98a3" /> |  <img width="437" height="782" alt="image" src="https://github.com/user-attachments/assets/b7acc182-894d-424b-b402-10842bacb75c" />




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
