### PR TITLE
[FIX] website: enable custom javascript on website

### DIFF
--- a/addons/website/static/src/js/user_custom_javascript.js
+++ b/addons/website/static/src/js/user_custom_javascript.js
@@ -1,3 +1,4 @@
+/* @odoo-module */
 //
 // This file is meant to regroup your javascript code. You can either copy/past
 // any code that should be executed on each page loading or write your own


### PR DESCRIPTION
[FIX] website: enable custom javascript on website
Steps to reproduce the problem:
- Go to the "HTML/ CSS Editor".
- Go to the JS tab.
- Uncomment the example and save.

-> Problem: the confirmation dialog does not appear.

The problem is that since [1], `/* @odoo-module */` has been removed
from the file as since [2], js files in `/static/src` and
`/static/tests` are considered as odoo module without the need of the
annotation `odoo-module`. In order to understand the problem, here is a
summary of what happens when a custom js code is saved;
- An attachment is created with the custom js code.
- An asset is created to replace the user custom rules of
`user_custom_javascript.js` by the one of the newly created attachment.

Because the url of the newly created attachment looks like
`/_custom/web.assets_frontend_lazy/website/static/src/js/user_custom_javascript.js`,
the transpiler does not recognize it as an odoo module.

task-5925607

[1]: https://github.com/odoo/odoo/commit/6d2fda172ec9cc7642abe9625ca486c7769e8297
[2]: https://github.com/odoo/odoo/commit/5f2c505836002ac7851c29c28d612f721d467bc4