### PR TITLE
[FIX] l10n_tw_edi_ecpay_website_sale: fix paper invoice option for guest checkout

### DIFF
--- a/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
@@ -167,8 +167,9 @@ class WebsiteSaleL10nTW(WebsiteSale):
         **kwargs
     ):
         rendering_values = super()._prepare_address_form_values(*args, callback=callback, order_sudo=order_sudo, **kwargs)
-        if order_sudo:
-            rendering_values["l10n_tw_edi_require_paper_format"] = order_sudo.partner_id.l10n_tw_edi_require_paper_format
+        partner_sudo = kwargs.get('partner_sudo') or (args[0] if args else None)
+        if partner_sudo and request.website.sudo().company_id.country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
+            rendering_values["l10n_tw_edi_require_paper_format"] = partner_sudo.l10n_tw_edi_require_paper_format
         return rendering_values
 
     def _validate_address_values(self, address_values, partner_sudo, address_type, *args, **kwargs):
@@ -192,8 +193,27 @@ class WebsiteSaleL10nTW(WebsiteSale):
 
         return invalid_fields, missing_fields, error_messages
 
-    def _handle_extra_form_data(self, extra_form_data, address_values):
-        super()._handle_extra_form_data(extra_form_data, address_values)
+    def _create_or_update_address(
+            self,
+            partner_sudo,
+            address_type='billing',
+            use_delivery_as_billing=False,
+            callback='/my/addresses',
+            required_fields=False,
+            verify_address_values=True,
+            **form_data
+    ):
+        partner_sudo, res = super()._create_or_update_address(
+            partner_sudo,
+            address_type=address_type,
+            use_delivery_as_billing=use_delivery_as_billing,
+            callback=callback,
+            required_fields=required_fields,
+            verify_address_values=verify_address_values,
+            **form_data
+        )
+
+        address_values, extra_form_data = self._parse_form_data(form_data)
 
         if request.website.sudo().company_id.country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
             order_sudo = request.cart
@@ -203,21 +223,22 @@ class WebsiteSaleL10nTW(WebsiteSale):
                 l10n_tw_edi_is_print = extra_form_data.get('l10n_tw_edi_require_paper_format') == "1"
             if address_values.get('company_name'):  # B2B customer
                 # Create company contact if it does not exist
-                if not order_sudo.partner_id.parent_id:
+                if not partner_sudo.parent_id:
                     company_contact = request.env['res.partner'].sudo().create({
                         'name': address_values.get('company_name'),
                         'vat': address_values.get('vat'),
                         'company_type': 'company',
                         'l10n_tw_edi_require_paper_format': l10n_tw_edi_is_print,
                     })
-                    order_sudo.partner_id.parent_id = company_contact
+                    partner_sudo.parent_id = company_contact
                 else:
-                    order_sudo.partner_id.parent_id.write({
+                    partner_sudo.parent_id.write({
                         'name': address_values.get('company_name'),
                         'vat': address_values.get('vat'),
                         'l10n_tw_edi_require_paper_format': l10n_tw_edi_is_print,
                     })
             else:  # B2C customer
-                order_sudo.partner_id.l10n_tw_edi_require_paper_format = l10n_tw_edi_is_print
+                partner_sudo.l10n_tw_edi_require_paper_format = l10n_tw_edi_is_print
 
             order_sudo.l10n_tw_edi_is_print = l10n_tw_edi_is_print
+        return partner_sudo, res

--- a/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
@@ -168,7 +168,7 @@ class WebsiteSaleL10nTW(WebsiteSale):
     ):
         rendering_values = super()._prepare_address_form_values(*args, callback=callback, order_sudo=order_sudo, **kwargs)
         partner_sudo = kwargs.get('partner_sudo') or (args[0] if args else None)
-        if partner_sudo and request.website.sudo().company_id.country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
+        if partner_sudo and request.website.sudo().company_id.account_fiscal_country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
             rendering_values["l10n_tw_edi_require_paper_format"] = partner_sudo.l10n_tw_edi_require_paper_format
         return rendering_values
 
@@ -177,7 +177,7 @@ class WebsiteSaleL10nTW(WebsiteSale):
             address_values, partner_sudo, address_type, *args, **kwargs
         )
 
-        if address_type == 'billing' and request.website.sudo().company_id.country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
+        if address_type == 'billing' and request.website.sudo().company_id.account_fiscal_country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
             phone = address_values.get('phone')
             if phone:
                 formatted_phone = request.env['account.move']._reformat_phone_number(phone)
@@ -215,7 +215,7 @@ class WebsiteSaleL10nTW(WebsiteSale):
 
         address_values, extra_form_data = self._parse_form_data(form_data)
 
-        if request.website.sudo().company_id.country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
+        if request.website.sudo().company_id.account_fiscal_country_id.code == 'TW' and request.website.sudo().company_id._is_ecpay_enabled():
             order_sudo = request.cart
             if address_values.get('company_name'):
                 l10n_tw_edi_is_print = True

--- a/addons/l10n_tw_edi_ecpay_website_sale/models/sale_order.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/models/sale_order.py
@@ -23,7 +23,7 @@ class SaleOrder(models.Model):
 
     def _prepare_invoice(self):
         res = super()._prepare_invoice()
-        if self.company_id.country_id.code == 'TW' and self.company_id._is_ecpay_enabled():
+        if self.company_id.account_fiscal_country_id.code == 'TW' and self.company_id._is_ecpay_enabled():
             res.update(
                 {
                     "l10n_tw_edi_is_print": self.l10n_tw_edi_is_print,


### PR DESCRIPTION
In Taiwan e-invoicing, B2C customers can request a paper copy of their invoice. When selected, the "Invoicing Info" step—which collects data like donation codes or carriers—should be skipped as it is not applicable to physical copies.

Previously, this logic failed during guest checkouts because the partner initially associated with the order is an archived public user. The persistent partner is only created/assigned after the address form is submitted.

This commit:
- Overrides `_create_or_update_address` instead of `_handle_extra_form_data` to ensure the paper format preference is saved on the correct, newly generated partner.
- Updates `_prepare_address_form_values` to correctly load existing preferences from the partner for registered users.
- Ensures the `l10n_tw_edi_is_print` flag on the Sales Order stays in sync with the partner's preference.

Task-5912985

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
