### PR TITLE
[FIX] base: Handle AttributeError for ondelete on non-selection fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1778,6 +1778,10 @@ class IrModelSelection(models.Model):
             if not field or not field.store or not Model._auto:
                 continue
 
+            # Field changed its type, skip it.
+            if field.type not in ('selection', 'reference'):
+                continue
+
             ondelete = (field.ondelete or {}).get(selection.value)
             # special case for custom fields
             if ondelete is None and field.manual and not field.required:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fix AttributeError that occurs during module updates when processing selection field deletions.

Current behavior before PR:

When updating modules, an `AttributeError` occurs when trying to access the `ondelete` attribute on fields that are not Selection fields:
AttributeError: 'Char' object has no attribute 'ondelete'

Desired behavior after PR is merged:

Add validation to check if the field type is 'selection' or 'reference' before attempting to access field.ondelete as a dictionary. Skip processing for incompatible field types to prevent AttributeError.

@moduon MT-13588


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
