### PR TITLE
[IMP] mail: access to notifications for portal users

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1269,7 +1269,7 @@ class MailMessage(models.Model):
             def needaction(message):
                 # sudo: mail.message - checking whether there is a notification for the current user is acceptable
                 return not message.env.user._is_public() and bool(
-                    message.notification_ids.filtered(
+                    message.sudo().notification_ids.filtered(
                         lambda n: not n.is_read
                         and n.res_partner_id == message.env.user.partner_id,
                     ),

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -35,6 +35,12 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         internal_member = self.channel.channel_member_ids.filtered(lambda m: internal_user.partner_id == m.partner_id)
         internal_member._rtc_join_call()
 
+        self.channel.message_post(
+            body="Hello @Internal Luigi",
+            message_type="comment",
+            partner_ids=[internal_user.partner_id.id],
+            subtype_xmlid="mail.mt_comment",
+        )
         self.group = self.env['discuss.channel']._create_group(partners_to=(internal_user + portal_user).partner_id.ids, name="Test group")
         self.group._add_members(guests=guest)
         self.tour = "discuss_channel_public_tour.js"


### PR DESCRIPTION
Since #236998, a sudo access to mail notifications has been removed, which was not intended. Without sudo, if a portal user tries to read some messages containing notifications for other users, it crashes with an access error to `mail.notification`. This change restores that access.

Steps to reproduce:
- Mention a non portal user in a public channel.
- Open that channel as a portal user.
- The channel does not load due to an access error to `mail.notification`.

