### PR TITLE
[FIX] tools: relax PDF mimetype check using startswith

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -223,7 +223,7 @@ def to_pdf_stream(attachment) -> io.BytesIO | None:
         _logger.warning("%s has no raw data.", attachment)
         return None
     stream = io.BytesIO(attachment.raw)
-    if attachment.mimetype == 'application/pdf':
+    if attachment.mimetype.startswith('application/pdf'):
         return stream
     elif attachment.mimetype.startswith('image'):
         output_stream = io.BytesIO()


### PR DESCRIPTION
The mimetype check was too strict and rejected values like `application/pdf;base64`.

This change fixes the issue by only verifying that the mimetype starts with `application/pdf`, ignoring any additional parameters.

runbot-231598
