### PR TITLE
[FIX] web: Allow to skip search optimization on Many2XAutocomplete

### DIFF
--- a/addons/product/static/src/product_name_and_description/product_name_and_description.js
+++ b/addons/product/static/src/product_name_and_description/product_name_and_description.js
@@ -122,6 +122,7 @@ export class ProductNameAndDescriptionField extends Component {
             ...p,
             canOpen: !this.props.readonly || this.isProductClickable,
             placeholder: _t("Search a product"),
+            preventMemoization: true,
             value,
         };
     }

--- a/addons/web/static/src/views/fields/many2one/many2one.js
+++ b/addons/web/static/src/views/fields/many2one/many2one.js
@@ -58,6 +58,7 @@ export function computeM2OProps(fieldProps) {
         readonly: fieldProps.readonly,
         relation: fieldProps.record.fields[fieldProps.name].relation,
         searchThreshold: fieldProps.searchThreshold,
+        preventMemoization: fieldProps.preventMemoization,
         string: fieldProps.string || fieldProps.record.fields[fieldProps.name].string || "",
         update: (value, options = {}) =>
             fieldProps.record.update({ [fieldProps.name]: value }, options),
@@ -94,6 +95,7 @@ export class Many2One extends Component {
         relation: { type: String },
         searchMoreLabel: { type: String, optional: true },
         searchThreshold: { type: Number, optional: true },
+        preventMemoization: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },
         specification: { type: Object, optional: true },
         string: { type: String, optional: true },
@@ -173,6 +175,7 @@ export class Many2One extends Component {
             resModel: this.props.relation,
             searchMoreLabel: this.props.searchMoreLabel,
             searchThreshold: this.props.searchThreshold,
+            preventMemoization: this.props.preventMemoization,
             setInputFloats: (isFloating) => {
                 this.state.isFloating = isFloating;
             },

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -220,6 +220,7 @@ export class Many2XAutocomplete extends Component {
         searchMoreLimit: { type: Number, optional: true },
         searchThreshold: { type: Number, optional: true },
         setInputFloats: { type: Function, optional: true },
+        preventMemoization: { type: Boolean, optional: true },
         slots: { optional: true },
         specification: { type: Object, optional: true },
         update: Function,
@@ -357,6 +358,7 @@ export class Many2XAutocomplete extends Component {
         const domain = this.props.getDomain();
         const context = this.props.context;
         if (
+            !this.props.preventMemoization &&
             this.lastEmptySearch &&
             deepEqual(this.lastEmptySearch.domain, domain) &&
             deepEqual(this.lastEmptySearch.context, context) &&

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -4110,6 +4110,37 @@ test("search typeahead", async () => {
     ]);
 });
 
+test.tags("desktop");
+test("skip name search optimization", async () => {
+    class Parent extends Component {
+        static template = xml`<Many2XAutocomplete
+            value="test"
+            resModel="'partner'"
+            activeActions="{}"
+            fieldString.translate="Field"
+            getDomain.bind="getDomain"
+            update.bind="update"
+            preventMemoization="true"
+        />`;
+        static components = { Many2XAutocomplete };
+        static props = ["*"];
+        getDomain() {
+            return [];
+        }
+        update() {}
+    }
+    await mountWithCleanup(Parent);
+    onRpc("web_name_search", () => expect.step("web_name_search"));
+    await contains(".o_input_dropdown input").edit("wxy", { confirm: false });
+    await runAllTimers();
+    expect.verifySteps(["web_name_search"]);
+    expect(`.o-autocomplete.dropdown li:not(.o_m2o_dropdown_option) a`).toHaveCount(0);
+    await contains(".o_input_dropdown input").edit("wxyz", { confirm: false });
+    expect(`.o-autocomplete.dropdown li:not(.o_m2o_dropdown_option) a`).toHaveCount(0);
+    await runAllTimers();
+    expect.verifySteps(["web_name_search"]);
+});
+
 test("highlight search in many2one", async () => {
     await mountView({
         type: "form",


### PR DESCRIPTION
Steps:
- Create a product with a barcode "12345"
- Create a sale order
- Add a product
- search product with name "12345" without copy/pasting
- no result
- try with copy/pasting
- 1 result

The problem is due to the fact that there is an optimization in Many2XAutocomplete.search which means that if no results are found for “1234,” it will not search for “12345.”
However, product override name_search to returns a product only when the name is exactly equal to its barcode (`=` and not `ilike`), which does not work at all with search optimization.

Since: https://github.com/odoo/odoo/pull/228035

opw-5908011