### PR TITLE
[FIX] crm: fix meeting display date with timezone

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -537,10 +537,10 @@ class Lead(models.Model):
                 lead.meeting_display_date = False
                 lead.meeting_display_label = _('No Meeting')
             elif lead_meeting_info['next_meeting_date']:
-                lead.meeting_display_date = lead_meeting_info['next_meeting_date']
+                lead.meeting_display_date = fields.Datetime.context_timestamp(lead, lead_meeting_info['next_meeting_date'])
                 lead.meeting_display_label = _('Next Meeting')
             else:
-                lead.meeting_display_date = lead_meeting_info['last_meeting_date']
+                lead.meeting_display_date = fields.Datetime.context_timestamp(lead, lead_meeting_info['last_meeting_date'])
                 lead.meeting_display_label = _('Last Meeting')
 
     @api.depends('email_domain_criterion', 'email_normalized', 'partner_id',

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -336,6 +336,20 @@ class TestCRMLead(TestCrmCommon):
             self.assertEqual(lead.meeting_display_label, 'No Meeting')
 
     @users('user_sales_manager')
+    def test_crm_lead_meeting_display_fields_with_timezone(self):
+        self.env.user.tz = "America/Grand_Turk"
+        lead = self.env['crm.lead'].create({'name': 'Lead With Meetings'})
+        self.env['calendar.event'].create([{
+            'name': 'Meeting 1 of Lead',
+            'opportunity_id': lead.id,
+            'start': '2022-07-12 01:00:00',
+            'stop': '2022-07-12 01:30:00',
+        }])
+
+        with freeze_time('2022-07-13 11:00:00'):
+            self.assertEqual(lead.meeting_display_date, fields.Date.from_string("2022-07-11"))
+
+    @users('user_sales_manager')
     def test_crm_lead_partner_sync(self):
         lead, partner = self.lead_1.with_user(self.env.user), self.contact_2
         partner_email, partner_phone = self.contact_2.email, self.contact_2.phone


### PR DESCRIPTION
# How to reproduce
- Use a browser extension to manage your browser's timezone
- Set your browser's timezone to a timezone with quite a big delay (like "America/Grand_Turk" if you live in Europe)
- Go to the form view of an opportunity
- Click on the smart button for meetings (Should be "No Meeting" if it is a new Opportunity)
- In the calendar view, add a new meeting for very late in the day (Example : 2026-02-10 22:00:00 => 23:00:00)
- Go back to the opportunity for view

# The problem
The date displayed is a day after the meeting that was just set up. Taking back our example, the date displayed would be 2026-02-11

# Why
The calendar view uses the browser's timezone to manage the dates. The smart button does not.

It is not possible to make the smart button use the browser's timezone, atleast in a clean way. That is because the smart button's data is managed by a python template, which does not have access to the browser's data. Trying to change the data displayed by the framework would be clunky as the html would need to be edited directly.

The fix that I implemented follows what the hr_appraisal module does for it's smart button with a date: use the timezone set in the user's preferences.

opw-5898520

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
