### PR TITLE
[FIX] web: kanban: ribbon misplaced when `ALT` is pressed

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.scss
+++ b/addons/web/static/src/views/kanban/kanban_record.scss
@@ -181,14 +181,15 @@
 }
 
 .o_kanban_selection_available .o_kanban_record.o_record_selection_available {
-    background-color: rgba(0, 0, 0, 0.1) !important;
-    > *:not(.o_record_selection_tooltip) {
-        filter: brightness(0.9);
+    &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-color: rgba(0, 0, 0, 0.1);
     }
     &:hover {
-        background-color: rgba(0, 0, 0, 0.5) !important;
-        > *:not(.o_record_selection_tooltip) {
-            filter: brightness(0.6);
+        &::after {
+            background-color: rgba(0, 0, 0, 0.5);
         }
         .o_record_selection_tooltip {
             display: block !important;


### PR DESCRIPTION
The CSS rules of `.o_record_selection_available` are used to add a selection overlay on kanban cards.
These rules relied on `filter: brightness()` to slightly dim all child elements when pressing `ALT`.

However, using filter creates a new stacking context. As a result, when a ribbon is present, it no longer sticks to the card border and becomes misplaced.

This commit updates the rules to avoid that behavior and keep the ribbon correctly positioned.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
