### PR TITLE
[FIX] l10n_es_pos: fix singleton error on refund

### DIFF
--- a/addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/app/screens/payment_screen/payment_screen.js
@@ -67,7 +67,7 @@ patch(PaymentScreen.prototype, {
     async _postPushOrderResolve(order, order_server_ids) {
         if (this.pos.config.is_spanish) {
             const invoiceName = await this.pos.data.call("pos.order", "get_invoice_name", [
-                order_server_ids,
+                order.id,
             ]);
             order.invoice_name = invoiceName;
         }

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -4,6 +4,7 @@ import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
+import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import { registry } from "@web/core/registry";
 import { checkSimplifiedInvoiceNumber, checkCompanyState, pay } from "./utils/receipt_util";
 
@@ -23,6 +24,14 @@ registry.category("web_tour.tours").add("spanish_pos_tour", {
             ProductScreen.addOrderline("Desk Pad", "1", SIMPLIFIED_INVOICE_LIMIT - 1),
             pay(),
             checkSimplifiedInvoiceNumber("0002"),
+            ReceiptScreen.clickNextOrder(),
+
+            //Refund
+            Chrome.clickOrders(),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.selectOrder("0001"),
+            TicketScreen.confirmRefund(),
+            pay(),
             ReceiptScreen.clickNextOrder(),
 
             ProductScreen.addOrderline("Desk Pad", "1", SIMPLIFIED_INVOICE_LIMIT + 1),

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -40,7 +40,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         num_of_simp_invoices = self.env['account.move'].search_count([('journal_id', '=', simp.id), ('l10n_es_is_simplified', '=', True)])
         num_of_regular_invoices = get_number_of_regular_invoices() - initial_number_of_regular_invoices
         self.assertEqual(num_of_simp_invoices, 3)
-        self.assertEqual(num_of_regular_invoices, 1)
+        self.assertEqual(num_of_regular_invoices, 2)
 
     def test_l10n_es_pos_reconcile(self):
         if not self.env["ir.module.module"].search([("name", "=", "pos_settle_due"), ("state", "=", "installed")]):


### PR DESCRIPTION
Step to reproduce:
- install l10n_es_pos
- create a pos, open its setting and set its `Simplified Invoice` with a journal
- start pos, create a order and refund it

Observation:
- we receive a singleton error for account.move

Cause:
- when calling `get_invoice_name` method, we pass `order_server_ids` which contains order and refund order id, hence two ids are passed

Fix:
- instead of using `order_server_ids` we use 'order.id' i.e. current order

opw-5870707



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
