### PR TITLE
[FIX] pos_loyalty: keep reward when loading an order from TicketScreen

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_loyalty/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -11,6 +11,12 @@ patch(TicketScreen.prototype, {
         super.setup(...arguments);
         this.notification = useService("notification");
     },
+    async setOrder(order) {
+        await super.setOrder(...arguments);
+        if (order && this.pos.models["loyalty.program"]?.length) {
+            this.pos.updateRewards();
+        }
+    },
     _onUpdateSelectedOrderline() {
         const order = this.getSelectedOrder();
         if (!order) {

--- a/addons/pos_loyalty/static/tests/unit/screens/ticket_screen.test.js
+++ b/addons/pos_loyalty/static/tests/unit/screens/ticket_screen.test.js
@@ -1,0 +1,44 @@
+import { test, expect } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { addProductLineToOrder } from "@pos_loyalty/../tests/unit/utils";
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+
+definePosModels();
+
+test("TicketScreen.setOrder keeps reward line and triggers pos.updateRewards", async () => {
+    const store = await setupPosEnv();
+    const models = store.models;
+
+    const order = store.addNewOrder();
+    const reward = models["loyalty.reward"].get(1);
+    const coupon = models["loyalty.card"].get(1);
+
+    await addProductLineToOrder(store, order, {
+        is_reward_line: true,
+        reward_id: reward,
+        coupon_id: coupon,
+        reward_identifier_code: "LOAD-ORDER-REWARD",
+        points_cost: 10,
+    });
+    order.uiState.couponPointChanges = {};
+    store.selectedOrderUuid = null;
+
+    let updateRewardsCalled = false;
+    const originalUpdateRewards = store.updateRewards.bind(store);
+    store.updateRewards = () => {
+        updateRewardsCalled = true;
+        return originalUpdateRewards();
+    };
+    const comp = await mountWithCleanup(TicketScreen, {});
+    await comp.setOrder(order);
+
+    expect(updateRewardsCalled).toBe(true);
+    const currentOrder = store.getOrder();
+    expect(currentOrder).toBe(order);
+    const rewardLines = currentOrder.lines.filter((l) => l.is_reward_line);
+    expect(rewardLines.length).toBe(1);
+    expect(rewardLines[0].reward_id.id).toBe(reward.id);
+    expect(rewardLines[0].coupon_id.id).toBe(coupon.id);
+});


### PR DESCRIPTION
Reward disappeared from an order when it was loaded from the Orders tab (TicketScreen) in restaurant mode after working on other tables.

Steps to reproduce:
-------------------
* Configure a Buy X Get Y (or similar) loyalty program and open a POS restaurant session.
* On table A, create an order that triggers the program and confirm the reward line is applied.
* Leave table A, create or edit another order on a different table (so another order becomes current).
* Go to the Orders tab (TicketScreen), select the order from table A and click "Load Order".

> Observation:
The order from table A is loaded without its reward line, even though it was present when the order was first created.

Why the fix:
------------
TicketScreen’s "Load Order" flow was only switching the current order without refreshing loyalty state, so after changing tables and coming back, later loyalty recomputations could drop the existing reward lines.

opw-5909899