### PR TITLE
[FIX] web: include expanded groups at limit

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -841,7 +841,7 @@ class Base(models.AbstractModel):
         ):
             # It doesn't respect the order with aggregates inside
             expand_groups = self._web_read_group_expand(domain, groups, groupby[0], aggregates, order)
-            if not limit or len(expand_groups) < limit:
+            if not limit or len(expand_groups) <= limit:
                 # Ditch the result of expand_groups because the limit is reached and to avoid
                 # returning inconsistent result inside length of web_read_group
                 groups = expand_groups


### PR DESCRIPTION
Versions
--------
- 19.0+

Steps
-----
1. Create exactly 19 rental products.
2. Go to the rental schedule, and group by products.
3. Observe that all 19 product are used as groups.
4. Create one more product. Total: 20.
5. Go to the rental schedule, and group by products.

Issue
-----
Only the products with actual order line linked to them are used as groups, even if there isn't more products than the hard limit set on the gantt view (`sale_renting.sale_order_line_gantt_schedule`).

Cause
-----
In d5a6e97abab04282c7a69093cd790b539a958241, the expanded groups are taken into account only if `len(expand_groups) < limit`. However, this should be a less than _or equal_ condition.

https://github.com/odoo/odoo/blob/d5a6e97abab04282c7a69093cd790b539a958241/addons/web/models/models.py#L345-L349

Solution
--------
Use `<=` as the condition.

opw-5887837

