### PR TITLE
[FIX] core: ignore AssetsLoadingError after tour termination

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -112,6 +112,7 @@ TEST_CURSOR_COOKIE_NAME = 'test_request_key'
 IGNORED_MSGS = re.compile(r"""
     failed\ to\ fetch  # base error
   | connectionlosterror:  # conversion by offlineFailToFetchErrorHandler
+  | assetsloadingerror: # lazy loaded bundle
 """, flags=re.VERBOSE | re.IGNORECASE).search
 
 def get_db_name():

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -109,6 +109,11 @@ CHECK_BROWSER_ITERATIONS = 100
 BROWSER_WAIT = CHECK_BROWSER_SLEEP * CHECK_BROWSER_ITERATIONS # seconds
 TEST_CURSOR_COOKIE_NAME = 'test_request_key'
 
+IGNORED_MSGS = re.compile(r"""
+    failed\ to\ fetch  # base error
+  | connectionlosterror:  # conversion by offlineFailToFetchErrorHandler
+""", flags=re.VERBOSE | re.IGNORECASE).search
+
 def get_db_name():
     db = odoo.tools.config['db_name']
     # If the database name is not provided on the command-line,
@@ -1417,7 +1422,7 @@ class ChromeBrowser:
 
         log_type = type
         _logger = self._logger.getChild('browser')
-        if self._result.done() and 'failed to fetch' in message.casefold():
+        if self._result.done() and IGNORED_MSGS(message):
             log_type = 'dir'
         _logger.log(
             self._TO_LEVEL.get(log_type, logging.INFO),
@@ -1492,7 +1497,7 @@ which leads to stray network requests and inconsistencies."""
             message += '\n' + stack
 
         if self._result.done():
-            if 'failed to fetch' not in message.casefold():
+            if not IGNORED_MSGS(message):
                 self._logger.getChild('browser').error(
                     "Exception received after termination: %s", message)
             return


### PR DESCRIPTION
Similarly to commit https://github.com/odoo/odoo/commit/493bab4f460dd4069d5cb6805933b8088067ff17
hiding "failed to fetch" errors, this commit adds AssetsLoadingError as
those represents "just" another category of failed assets request (i.e.
lazy loaded) after tour termination.

runbot-233826