### PR TITLE
[FIX] base,website,test_mass_mailing: pregenerate binary bundles

### DIFF
--- a/addons/test_mass_mailing/models/ir_qweb.py
+++ b/addons/test_mass_mailing/models/ir_qweb.py
@@ -6,6 +6,6 @@ class IrQweb(models.AbstractModel):
     _inherit = "ir.qweb"
 
     def _get_bundles_to_pregenarate(self):
-        js_assets, css_assets = super()._get_bundles_to_pregenarate()
+        js_assets, css_assets, bin_assets = super()._get_bundles_to_pregenarate()
         assets = {'mass_mailing.assets_iframe_style'}
-        return (js_assets | assets, css_assets | assets)
+        return (js_assets | assets, css_assets | assets, bin_assets)

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -209,8 +209,8 @@ class IrQweb(models.AbstractModel):
         return atts
 
     def _get_bundles_to_pregenarate(self):
-        js_assets, css_assets = super()._get_bundles_to_pregenarate()
+        js_assets, css_assets, bin_assets = super()._get_bundles_to_pregenarate()
         assets = {
             'website.assets_all_wysiwyg',
         }
-        return (js_assets | assets, css_assets | assets)
+        return (js_assets | assets, css_assets | assets, bin_assets)


### PR DESCRIPTION
The commit [^1] introducing binary asset bundle support overlooked the pregeneration of said bundles for the tests runs. This leads to hot-regeneration of those bundles during tests runs on the runbot (multiple hundreds of times) instead of only once and reusing them.

This commit adds support for those binary bundles during pregeneration.

[^1]: odoo/odoo@a5c02da5c24bfc85b3bbb7d1410d489d3c7185b8
