### PR TITLE
[IMP] hr, hr_attendance: improve overtime ruleset mass edit

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -662,6 +662,20 @@ class HrVersion(models.Model):
             ('divorced', self.env._('Divorced')),
         ]
 
+    @api.model
+    def _get_current_versions_domain(self):
+        """
+        Returns employee versions that are currently active
+        """
+        today = fields.Date.today()
+        return [
+            ("contract_date_start", "<=", today),
+            "|",
+                ("contract_date_end", "=", False),
+                ("contract_date_end", ">=", today),
+            ('employee_id', '!=', False),
+        ]
+
     def _inverse_resource_calendar_id(self):
         for employee, versions in self.grouped('employee_id').items():
             current_version = employee.current_version_id

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -583,6 +583,20 @@ class HrVersion(models.Model):
             ('divorced', self.env._('Divorced')),
         ]
 
+    @api.model
+    def _get_current_versions_domain(self):
+        """
+        Returns employee versions that are currently active
+        """
+        today = fields.Date.today()
+        return [
+            ("contract_date_start", "<=", today),
+            "|",
+                ("contract_date_end", "=", False),
+                ("contract_date_end", ">=", today),
+            ('employee_id', '!=', False),
+        ]
+
     def _inverse_resource_calendar_id(self):
         for employee, versions in self.grouped('employee_id').items():
             current_version = employee.current_version_id

--- a/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_ruleset.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
+from odoo.fields import Domain
 
 
 class HrAttendanceOvertimeRuleset(models.Model):
@@ -35,16 +36,8 @@ class HrAttendanceOvertimeRuleset(models.Model):
     version_ids = fields.One2many('hr.version', 'ruleset_id')
     versions_count = fields.Integer(compute="_compute_versions_count")
 
-    def _get_current_versions_domain(self):
-        today = fields.Date.today()
-        return [
-            ("ruleset_id", "in", self.ids),
-            ("contract_date_start", "<=", today),
-            "|",
-                ("contract_date_end", "=", False),
-                ("contract_date_end", ">=", today),
-            ('employee_id', '!=', False),
-        ]
+    def _get_versions_with_current_ruleset_domain(self):
+        return Domain.AND([[("ruleset_id", "in", self.ids)], self.env["hr.version"]._get_current_versions_domain()])
 
     def _compute_rules_count(self):
         for ruleset in self:
@@ -52,7 +45,7 @@ class HrAttendanceOvertimeRuleset(models.Model):
 
     def _compute_versions_count(self):
         count_by_ruleset = dict(self.env['hr.version']._read_group(
-                domain=self._get_current_versions_domain(),
+                domain=self._get_versions_with_current_ruleset_domain(),
                 groupby=['ruleset_id'],
                 aggregates=['__count'],
             ))
@@ -75,9 +68,18 @@ class HrAttendanceOvertimeRuleset(models.Model):
 
     def action_show_versions(self):
         self.ensure_one()
+
+        ctx = {'default_ruleset_id': self.id}
+
+        if not self.versions_count:
+            action = self.env['ir.actions.act_window']._for_xml_id('hr_attendance.hr_version_list_view_add')
+            action['domain'] = self.env["hr.version"]._get_current_versions_domain()
+            action['context'] = ctx
+            return action
+
         action = self.env['ir.actions.act_window']._for_xml_id('hr_attendance.hr_version_list_view')
-        action['domain'] = self._get_current_versions_domain()
-        action['context'] = {'default_ruleset_id': self.id}
+        action['domain'] = self._get_versions_with_current_ruleset_domain()
+        action['context'] = ctx
         return action
 
     def copy_data(self, default=None):

--- a/addons/hr_attendance/models/hr_version.py
+++ b/addons/hr_attendance/models/hr_version.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, fields
+from odoo.fields import Domain
 
 
 class HrVersion(models.Model):
@@ -31,6 +32,13 @@ class HrVersion(models.Model):
          default=_default_ruleset_id,
     )
 
+    has_ruleset_id = fields.Boolean(compute="_compute_has_ruleset_id", groups="hr.group_hr_user")
+
+    @api.depends("ruleset_id")
+    def _compute_has_ruleset_id(self):
+        for version in self:
+            version.has_ruleset_id = version.ruleset_id
+
     @api.model
     def _get_versions_by_employee_and_date(self, employee_dates):
         # for `employee_dates` a dict[employee] -> dates
@@ -60,21 +68,17 @@ class HrVersion(models.Model):
 
     def action_open_version_selector(self):
         action = self.env['ir.actions.act_window']._for_xml_id('hr_attendance.hr_version_list_view_add')
-        today = fields.Date.today()
-        action['domain'] = [
-            ("ruleset_id", "=", False),
-            ("contract_date_start", "<=", today),
-            "|",
-            ("contract_date_end", "=", False),
-            ("contract_date_end", ">=", today),
-            ("employee_id", "!=", False),
-        ]
-        action['context'] = {'default_ruleset_id': self.env.context.get('default_ruleset_id', False)}
+        ruleset_id = self.env.context.get('default_ruleset_id', False)
+        action['domain'] = Domain.AND([[("ruleset_id", "!=", ruleset_id)], self.env["hr.version"]._get_current_versions_domain()])
+        action['context'] = {'default_ruleset_id': ruleset_id}
         return action
 
     def action_unassign_ruleset(self):
         self.ruleset_id = False
 
     def action_assign_ruleset(self):
-        if ruleset_id := self.env.context.get('default_ruleset_id', False):
-            self.ruleset_id = ruleset_id
+        ruleset_id = self.env.context.get('default_ruleset_id', False)
+        if not ruleset_id:
+            return
+
+        self.ruleset_id = ruleset_id

--- a/addons/hr_attendance/static/src/views/hr_version_list_view.js
+++ b/addons/hr_attendance/static/src/views/hr_version_list_view.js
@@ -1,0 +1,48 @@
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { ListController } from "@web/views/list/list_controller";
+import { listView } from "@web/views/list/list_view";
+import { _t } from "@web/core/l10n/translation";
+
+
+export class VersionOvertimeRulesetListController extends ListController {
+    setup() {
+        super.setup(...arguments);
+        this.orm = useService("orm");
+        this.actionService = useService("action");
+        this.dialogService = useService("dialog");
+    }
+    async onAdd() {
+        const records = this.model.root.selection;
+        if (records && records.some((record) => record.data.has_ruleset_id)) {
+            this.dialogService.add(ConfirmationDialog, {
+                body: _t("One or more selected records already have a ruleset assigned (highlighted in yellow). Do you want to overwrite them?"),
+                confirmLabel: _t("Overwrite"),
+                confirm: async () => {
+                    return this.assignRuleset();
+                },
+                cancel: () => { },
+            });
+        } else {
+            return this.assignRuleset();
+        }
+    }
+    async assignRuleset() {
+        await this.orm.call(
+            "hr.version",
+            "action_assign_ruleset",
+            [this.model.root.selection.map((record) => record.resId)],
+            { context: { default_ruleset_id: this.props.context.default_ruleset_id } }
+        );
+        await this.actionService.doAction({ type: 'ir.actions.act_window_close' });
+    }
+}
+
+export const versionOvertimeRulesetListView = {
+    ...listView,
+    buttonTemplate: 'hr_attendance.AssignVersionToRuleset.buttons',
+    Controller: VersionOvertimeRulesetListController,
+};
+
+registry.category("views").add("version_overtime_ruleset_list_view", versionOvertimeRulesetListView)

--- a/addons/hr_attendance/static/src/views/hr_version_list_view.xml
+++ b/addons/hr_attendance/static/src/views/hr_version_list_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <t t-name="hr_attendance.AssignVersionToRuleset.buttons" t-inherit="web.ListView.Buttons" t-inherit-mode="primary">
+        <xpath expr="." position="inside">
+            <button type="button" class="btn btn-primary" t-on-click="this.onAdd">
+                Add
+            </button>
+        </xpath>
+    </t>
+</odoo>

--- a/addons/hr_attendance/views/hr_version_views.xml
+++ b/addons/hr_attendance/views/hr_version_views.xml
@@ -8,6 +8,9 @@
         <field name="arch" type="xml">
             <field name="date_version" position="replace"/>
             <field name="resource_calendar_id" position="replace"/>
+            <field name="department_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
             <field name="job_id" position="after">
                 <field name="resource_calendar_id" optional="show"/>
             </field>
@@ -20,11 +23,13 @@
         <field name="inherit_id" ref="hr_version_list_view_enhanced_hr_attendance_base"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//list" position="inside">
-                <header>
-                    <button display="always" name="action_assign_ruleset" type="object" string="Add" class="btn-primary"/>
-                </header>
+            <xpath expr="//list" position="attributes">
+                <attribute name="decoration-warning">has_ruleset_id</attribute>
+                <attribute name="js_class">version_overtime_ruleset_list_view</attribute>
             </xpath>
+            <field name="resource_calendar_id" position="after">
+                <field name="ruleset_id" groups="hr.group_hr_manager"/>
+            </field>
         </field>
     </record>
 
@@ -81,7 +86,7 @@
             <p class="o_view_nocontent_smiling_face">
                 No Records.
             </p><p>
-                There are no employees without an overtime ruleset.
+                There are no employees without this overtime ruleset.
             </p>
         </field>
     </record>

--- a/addons/hr_attendance/views/hr_version_views.xml
+++ b/addons/hr_attendance/views/hr_version_views.xml
@@ -8,6 +8,9 @@
         <field name="arch" type="xml">
             <field name="date_version" position="replace"/>
             <field name="resource_calendar_id" position="replace"/>
+            <field name="department_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
             <field name="job_id" position="after">
                 <field name="resource_calendar_id" optional="show"/>
             </field>
@@ -20,11 +23,13 @@
         <field name="inherit_id" ref="hr_version_list_view_enhanced_hr_attendance_base"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//list" position="inside">
-                <header>
-                    <button display="always" name="action_assign_ruleset" type="object" string="Add" class="btn-primary"/>
-                </header>
+            <xpath expr="//list" position="attributes">
+                <attribute name="decoration-warning">has_ruleset_id</attribute>
+                <attribute name="js_class">version_overtime_ruleset_list_view</attribute>
             </xpath>
+            <field name="resource_calendar_id" position="after">
+                <field name="ruleset_id" groups="hr.group_hr_manager"/>
+            </field>
         </field>
     </record>
 
@@ -77,11 +82,12 @@
         <field name="target">new</field>
         <field name="view_id" ref="hr_attendance.hr_version_list_view_enhanced_hr_attendance_add"/>
         <field name="search_view_id" ref="hr_attendance.hr_version_search_view_enhanced_hr_attendance"/>
+        <!-- <field name="group_ids" eval="[(4, ref('hr.group_hr_manager'))]"/> -->
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Records.
             </p><p>
-                There are no employees without an overtime ruleset.
+                There are no employees without this overtime ruleset.
             </p>
         </field>
     </record>


### PR DESCRIPTION
Allow overwrite (with warning) of employees' overtime rulesets in the "Add employees" list. Also make the "Employees" smart button on the ruleset form go to the add employees list directly when no employees are assigned to the ruleset. Finally hide the department column in the rulest list

Task-5921345