### PR TITLE
[FIX] website_sale: products configurator "Add to cart" text-wrap

### DIFF
--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -9,7 +9,7 @@
         </QuantityButtons>
         <button name="sale_product_configurator_add_button" position="attributes">
             <attribute name="t-if">this.props.can_be_sold</attribute>
-            <attribute name="class" remove="btn-secondary" add="btn-outline-primary" separator=" "/>
+            <attribute name="class" remove="btn-secondary" add="btn-outline-primary text-nowrap" separator=" "/>
         </button>
         <xpath
             expr="//button[@name='sale_product_configurator_add_button']/*[hasclass('oi-plus')]"
@@ -18,7 +18,7 @@
             <attribute name="class" remove="oi oi-plus" add="fa fa-shopping-cart" separator=" "/>
         </xpath>
         <span name="add_button" position="replace">
-            <span name="add_button" class="ms-2 d-none d-md-inline">Add to Cart</span>
+            <span name="add_button" class="ms-2 d-none d-lg-inline">Add to Cart</span>
         </span>
 
         <button name="sale_product_configurator_add_button" position="after">

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -23,7 +23,7 @@
                 <button
                     t-if="!this.props.options.isBuyNow"
                     name="website_sale_product_configurator_continue_button"
-                    class="btn btn-primary w-100"
+                    class="btn btn-primary w-100 text-nowrap"
                     t-on-click="() => this.onConfirm({goToCart: false})"
                     t-att-disabled="!isPossibleConfiguration() || !canBeSold()"
                 >


### PR DESCRIPTION
This commit fixes some text wrapping issues for the buttons inside the product configurator:

- Change "Add to Cart" text visibility from d-md-inline to d-lg-inline for better mobile layout and prevent text wrapping
- Add text-nowrap class to configurator's footer primary button to prevent text wrapping

task-5896776

| Before | After |
|--------|--------|
| <img width="1029" height="781" alt="image" src="https://github.com/user-attachments/assets/fa9106df-c8ee-4ade-a8ce-466549b8e816" /> | <img width="1029" height="781" alt="image" src="https://github.com/user-attachments/assets/70de2a6a-b6d8-43da-bbdb-97e1b921078b" /> | 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
