### PR TITLE
[IMP] resource: clean up working schedule UI

### DIFF
--- a/addons/resource/views/resource_calendar_attendance_views.xml
+++ b/addons/resource/views/resource_calendar_attendance_views.xml
@@ -8,8 +8,8 @@
                 <field name="sequence" widget="handle"/>
                 <field name="dayofweek"/>
                 <field name="duration_hours" sum="Hours per Week" force_save="1" widget="float_time"/>
-                <field name="hour_from" widget="float_time" optional="hidden"/>
-                <field name="hour_to" widget="float_time" optional="hidden"/>
+                <field name="hour_from" widget="float_time" optional="hidden" decoration-muted="hour_from == hour_to"/>
+                <field name="hour_to" widget="float_time" optional="hidden" decoration-muted="hour_from == hour_to"/>
                 <field name="week_type" readonly="1" force_save="1" optional="hide"/>
             </list>
         </field>
@@ -26,8 +26,8 @@
                     <field name="week_type"/>
                     <label for="hour_from" string="Hours"/>
                     <div id="resource_attendance_hours" class="o_row">
-                        <field name="hour_from" widget="float_time"/> -
-                        <field name="hour_to" widget="float_time"/>
+                        <field name="hour_from" widget="float_time" decoration-muted="hour_from == hour_to"/> -
+                        <field name="hour_to" widget="float_time" decoration-muted="hour_from == hour_to"/>
                     </div>
                 </group>
                 </sheet>

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -82,22 +82,6 @@
                     </group>
                     <notebook>
                         <page string="Working Hours" name="working_hours" invisible="two_weeks_calendar">
-                            <group>
-                                <group>
-                                    <label for="hours_per_day" string="Avg"/>
-                                    <div class="d-flex">
-                                        <field name="hours_per_day" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
-                                        <span class="ms-2">hours/day</span>
-                                    </div>
-                                </group>
-                                <group>
-                                    <label for="hours_per_week" string="Total"/>
-                                    <div class="d-flex">
-                                        <field name="hours_per_week" nolabel="1" style="width: 6ch;" widget="float_time" readonly="1"/>
-                                        <span class="ms-2">hours/week</span>
-                                    </div>
-                                </group>
-                            </group>
                             <field name="attendance_ids"/>
                         </page>
                         <page string="Week 1 Working Hours" name="working_hours" invisible="not two_weeks_calendar">


### PR DESCRIPTION
Removed redundant fields displayed above the attendance list in the resource calendar form view (average hours per day and total hours per week). Additionally, added text-muted decoration to hour_from and hour_to fields when they are equal.

task-5925043

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
