### PR TITLE
[FIX] spreadsheet: fix zoomable chart cursor

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_zoomable_component.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_zoomable_component.js
@@ -1,0 +1,14 @@
+import { components } from "@odoo/o-spreadsheet";
+import { patch } from "@web/core/utils/patch";
+
+patch(components.ZoomableChartJsComponent.prototype, {
+    getMasterChartConfiguration(chartData) {
+        const config = super.getMasterChartConfiguration(chartData);
+        config.options = {
+            ...config.options,
+            onHover: undefined,
+            onClick: undefined,
+        };
+        return config;
+    },
+});

--- a/addons/spreadsheet/static/src/chart/odoo_menu/odoo_menu_chartjs_plugin.js
+++ b/addons/spreadsheet/static/src/chart/odoo_menu/odoo_menu_chartjs_plugin.js
@@ -7,13 +7,14 @@ export const chartOdooMenuPlugin = {
     id: "chartOdooMenuPlugin",
     afterEvent(chart, { event }, { env, menu }) {
         const isDashboard = env?.model.getters.isDashboard();
-        event.native.target.style.cursor = menu && isDashboard ? "pointer" : "";
+        if (!menu || !isDashboard) {
+            return;
+        }
+        event.native.target.style.cursor = "pointer";
 
         const middleClick = isChartJSMiddleClick(event);
         if (
             (event.type !== "click" && !middleClick) ||
-            !menu ||
-            !isDashboard ||
             event.native.defaultPrevented
         ) {
             return;


### PR DESCRIPTION
## Description

These changes aims to fix some bad behaviors with the cursor for the zoomable chart, caused by the `onOdooChartItemHover` method and the odoo menu link for the Odoo chart.
This fix removes the `onHover` and `onClick` options for the master chart in zoomable chart, and add an early return for the menu link plugin in case of no menu or no dashboard mode.

## Related Task

Task: [5012198](https://www.odoo.com/odoo/project/2328/tasks/5012198)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
