### PR TITLE
[FIX] html_builder: remove wrong tooltip for installable snippet groups

### DIFF
--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -104,6 +104,12 @@ export class DisableSnippetsPlugin extends Plugin {
         // Disable the groups containing only disabled snippets.
         if (!areGroupsDisabled) {
             snippetGroups.forEach((snippetGroup) => {
+                // Do not mark uninstalled groups as disabled (unless all
+                // groups are disabled).
+                if (snippetGroup.isInstallable) {
+                    snippetGroup.isDisabled = false;
+                    return;
+                }
                 if (snippetGroup.groupName !== "custom") {
                     snippetGroup.isDisabled = !snippets.find(
                         (snippet) =>


### PR DESCRIPTION
Since this commit [1], installable snippet groups like "Blogs" or
"Events" are shown as “not droppable” on the page when they are not
installed, which is incorrect.

Installable snippet groups should never be marked as “not droppable”
unless all groups are disabled (e.g. in the mega menu).
This commit fixes that.

[1]: https://github.com/odoo/odoo/commit/ae4824640665fc639e03a13c341f18e73060349e