### PR TITLE
[IMP] web: core: expression editor supports contains for char fields

### DIFF
--- a/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
+++ b/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
@@ -17,5 +17,11 @@ const EXPRESSION_VALID_OPERATORS = [
 
 export function getExpressionDisplayedOperators(fieldDef) {
     const operators = getDomainDisplayedOperators(fieldDef);
-    return operators.filter((operator) => EXPRESSION_VALID_OPERATORS.includes(operator));
+    const validOperators = Object.fromEntries(EXPRESSION_VALID_OPERATORS.map((o) => [o, true]));
+    if (["char", "html", "text"].includes(fieldDef?.type)) {
+        for (const op of ["ilike", "not ilike"]) {
+            validOperators[op] = true;
+        }
+    }
+    return operators.filter((operator) => validOperators[operator]);
 }

--- a/addons/web/static/src/core/tree_editor/construct_expression_from_tree.js
+++ b/addons/web/static/src/core/tree_editor/construct_expression_from_tree.js
@@ -1,6 +1,6 @@
 import { formatAST } from "@web/core/py_js/py";
 import { isValidPath, not } from "./ast_utils";
-import { Expression, astFromValue, isTree } from "./condition_tree";
+import { Expression, astFromValue, isTree, expressionContainsString } from "./condition_tree";
 import { COMPARATORS, TERM_OPERATORS_NEGATION } from "./operators";
 
 function getNormalizedCondition(condition) {
@@ -70,6 +70,12 @@ function _constructExpressionFromTree(tree, options, isRoot = false) {
 
     if (path instanceof Expression && operator === "=" && value === 1) {
         return path.toString();
+    }
+    if ( // we can assume that negate = false here: "ilike" and "not ilike" have negation defined
+        ["ilike", "not ilike"].includes(operator) &&
+        expressionContainsString.isPathSupported(path, options.getFieldDef)
+    ) {
+        return expressionContainsString.toString(path, value, operator);
     }
 
     const op = operator === "=" ? "==" : operator; // do something about is ?

--- a/addons/web/static/src/core/tree_editor/construct_tree_from_expression.js
+++ b/addons/web/static/src/core/tree_editor/construct_tree_from_expression.js
@@ -1,6 +1,13 @@
 import { formatAST, parseExpr } from "@web/core/py_js/py";
 import { isNot, isValidPath, not } from "./ast_utils";
-import { addChild, complexCondition, condition, connector, toValue } from "./condition_tree";
+import {
+    addChild,
+    complexCondition,
+    condition,
+    connector,
+    toValue,
+    expressionContainsString,
+} from "./condition_tree";
 import { COMPARATORS } from "./operators";
 
 const EXCHANGE = {
@@ -45,6 +52,11 @@ function _getConditionFromComparator(ast, options) {
     let operator = ast.op;
     if (operator === "==") {
         operator = "=";
+    }
+
+    const isIlike = expressionContainsString.unpackAst(ast);
+    if (isIlike && expressionContainsString.isPathSupported(isIlike.path, options.getFieldDef)) {
+        return condition(isIlike.path, isIlike.operator, isIlike.value, isIlike.negate);
     }
 
     let left = ast.left;


### PR DESCRIPTION
Before this commit the `contains` operator (alias `ilike`) was not supported
by the expression editor, so the use of char fields in a field's invisible
expression was limited.

After this commit, we implement limited support for this.

task-5189106