### PR TITLE
[FIX] account_edi_ubl_cii: rounding issues with imported charges

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -3,7 +3,7 @@ from markupsafe import Markup
 from odoo import _, api, models
 from odoo.addons.base.models.res_bank import sanitize_account_number
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import float_is_zero, float_repr, format_list
+from odoo.tools import float_compare, float_is_zero, float_repr, format_list
 from odoo.tools.float_utils import float_round
 from odoo.tools.misc import clean_context, formatLang, html_escape
 from odoo.tools.xml_utils import find_xml_value
@@ -817,7 +817,7 @@ class AccountEdiCommon(models.AbstractModel):
         #   * unit price = 1, qty = 0, but price_subtotal = -200
         # for instance, when filling a down payment as an document line. The equation in the docstring is not
         # respected, and the result will not be correct, so we just follow the simple rule below:
-        if net_price_unit is not None and price_subtotal != net_price_unit * (delivered_qty / basis_qty) - allow_charge_amount:
+        if net_price_unit is not None and float_compare(price_subtotal, net_price_unit * (delivered_qty / basis_qty) - allow_charge_amount, currency.decimal_places):
             if net_price_unit == 0 and delivered_qty == 0:
                 quantity = 1
                 price_unit = price_subtotal


### PR DESCRIPTION
Whenever a line with price `0.0` with `AllowanceCharge`s got imported, Odoo used to update the `price_unit` to the sum of price, allowance and charges, because of a wrong float comparison condition between this sum and the XML total.

So the product price was increased, but the allowances were maintained.
The total imported in Odoo became double the one in the XML.

Step to reproduce:
- Import vendor bill from XML with a product:
	- price: `0.00`
	- quantity: `1`
	- an AllowanceCharge, amount: `0.2`
	- an AllowanceCharge, amount: `0.1`
- `0.0 + 0.2 + 0.1 (sum of price and allowances) != 0.3 (subtotal)`
  (but `float_compare(0.1 + 0.2, 0.3, precision_digits=4) == 0`)
- `price_unit` is updated to `0.3`
- Total in Odoo is `0.6`

Ticket [link](https://www.odoo.com/odoo/project.task/5499525)
opw-5499525