### PR TITLE
[FIX] html_editor: allow cropping images not linked to any attachment

### DIFF
--- a/addons/html_editor/static/src/main/media/image_crop.js
+++ b/addons/html_editor/static/src/main/media/image_crop.js
@@ -72,10 +72,7 @@ export class ImageCrop extends Component {
         );
 
         onMounted(() => {
-            this.hasModifiedImageClass = this.media.classList.contains("o_modified_image_to_save");
-            if (this.hasModifiedImageClass) {
-                this.media.classList.remove("o_modified_image_to_save");
-            }
+            this.media.classList.remove("o_modified_image_to_save");
             this.show();
         });
         onWillDestroy(this.closeCropper);
@@ -87,11 +84,13 @@ export class ImageCrop extends Component {
         }
         this.cropper?.destroy?.();
         this.media.setAttribute("src", this.initialSrc);
-        if (
-            this.hasModifiedImageClass &&
-            !this.media.classList.contains("o_modified_image_to_save")
-        ) {
-            this.media.classList.add("o_modified_image_to_save");
+        if (this.media.src.startsWith("data:")) {
+            this.media.classList.add(
+                this.media.dataset.originalId ? "o_modified_image_to_save" : "o_b64_image_to_save"
+            );
+            this.media.classList.remove(
+                this.media.dataset.originalId ? "o_b64_image_to_save" : "o_modified_image_to_save"
+            );
         }
         this.props?.onClose?.();
         this.isCropperActive = false;

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -275,10 +275,18 @@ export class ImagePostProcessPlugin extends Plugin {
         return [url, newDataset];
     }
     updateImageAttributes(el, url, newDataset) {
-        el.classList.add("o_modified_image_to_save");
         if (el.tagName === "IMG") {
+            if (url.startsWith("data:")) {
+                el.classList.add(
+                    el.dataset.originalId ? "o_modified_image_to_save" : "o_b64_image_to_save"
+                );
+                el.classList.remove(
+                    el.dataset.originalId ? "o_b64_image_to_save" : "o_modified_image_to_save"
+                );
+            }
             el.setAttribute("src", url);
         } else {
+            el.classList.add("o_modified_image_to_save");
             this.dependencies.style.setBackgroundImageUrl(el, url);
         }
         for (const key in newDataset) {

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -62,7 +62,7 @@ test("Double click on image and replace it", async () => {
     await waitSidebarUpdated();
     await waitForNone(".o_select_media_dialog");
     expect(".o_select_media_dialog").toHaveCount(0);
-    expect(":iframe img").toHaveClass("o_modified_image_to_save");
+    expect(":iframe img").toHaveClass("o_b64_image_to_save");
     expect(".options-container[data-container-title='Image']").toHaveCount(1);
 });
 

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -88,7 +88,7 @@ registerWebsitePreviewTour(
             {
                 content: "eLearning: is the Corgi set ?",
                 trigger:
-                    ':iframe img.o_wslides_course_pict.o_modified_image_to_save[data-original-src$="GoldWinnerPembrookeWelshCorgi.jpg"][src^="data:image"]',
+                    ':iframe img.o_wslides_course_pict.o_b64_image_to_save[data-original-src$="GoldWinnerPembrookeWelshCorgi.jpg"][src^="data:image"]',
                 run: "click",
             },
             {


### PR DESCRIPTION
Currently, when a user edits an image using the image cropper, the script transforms the image, converts it to base 64, and stores it in the image's `src` attribute.

The script then adds the `o_modified_image_to_save` class. When the document is saved, the script retrieves all images with this class, creates a copy of the original attachment containing the modified image, and replaces the image src with the URL of the new attachment.

The problem occurs when the image is not linked to any attachment (for example, when the image uses an external URL). In this case, the method crashes and the document cannot be saved.

Steps to reproduce:

1. Open Mass Mailing
2. Insert a snippet containing an image (with an external url)
3. Click on the image
4. Click on the "Style" tab
5. Click on the crop icon
6. Resize the image
7. Click on "Apply" to save the transformation
8. Save the record

=> An error appears in the console when calling:
   `/html_editor/modify_image/undefined`

When the image does not have a `data-original-id` attribute, use the CSS class `o_b64_image_to_save` instead of `o_modified_image_to_save`. This ensures that the script automatically creates an attachment for the modified image when no original attachment exists.

Task-6128841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
