### PR TITLE
[FIX] website_sale: fix products carousel arrow size

### DIFF
--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -11,6 +11,7 @@
         .carousel-control-prev {
             aspect-ratio: var(--o-wsale-card-thumb-aspect-ratio, 1/1);
             width: var(--o-wsale-dynamic-snippet-col-size) !important;
+            --o-wsale-dynamic-snippet-control-scale: 0.2;
             transform: scaleX(.2);
             bottom: auto;
             isolation: isolate;
@@ -77,14 +78,14 @@
         }
     }
 }
-.s_dynamic_snippet_products .container-fluid .s_dynamic_snippet_content {
+.s_dynamic_snippet_products .container-fluid .s_dynamic_snippet_title_aside + .s_dynamic_snippet_content {
     @include media-breakpoint-up(md) {
         // Prevented horizontal overflow of control buttons.
         .carousel-control-prev {
-            transform: translateX(50%); 
+            transform: translateX(50%) scaleX(var(--o-wsale-dynamic-snippet-control-scale, 1));
         }
         .carousel-control-next {
-            transform: translateX(-50%); 
+            transform: translateX(-50%) scaleX(var(--o-wsale-dynamic-snippet-control-scale, 1));
         }
     }
 }


### PR DESCRIPTION
**Problem:**
When a "Products" block on the website is set to the full-width (extended)
content option, the previous/next carousel navigation arrows render at an
abnormally large size instead of their intended compact appearance.

**Steps to reproduce:**
1. Go to Website > Edit a page
2. Add a "Products" block
3. Set the content width to the rightmost (full-width) option
4. Observe the carousel navigation arrows

**Current behavior:**
The carousel navigation arrows appear oversized and stretched.

**Expected behavior:**
The carousel navigation arrows should display at their normal size.

**Cause of the issue:**
The carousel control buttons have a `transform: scaleX(0.2)` to counteract
the inner chevron icon's `transform: scaleX(5)`, keeping
the visible arrow at its intended size. In full-width mode, a positional
`transform: translateX(...)` is applied to the same parent element. Since
`transform` is a single CSS property, this completely overrides the
`scaleX(0.2)`, leaving the chevron's `scaleX(5)` unopposed and causing the
arrows to render at 500% of their expected width.

**Fix:**
Both the positional offset and the scale compensation must coexist in the same
`transform` declaration on the parent. Extracting the scale value into a CSS
variable allows the full-width rule to reference it directly, combining
`translateX()` and `scaleX()` in one `transform` without duplicating the magic
value. This also preserves RTL compatibility, as `transform: translateX()` is
correctly mirrored by rtlcss, unlike the standalone `translate` property.

opw-5917549