### PR TITLE
[FIX] mrp: correctly handle unbuild more than manufactured

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -224,6 +224,8 @@ class MrpUnbuild(models.Model):
                     needed_quantity -= taken_quantity
                     qty_already_used[move_line] += taken_quantity
                     unbuild_move_line._apply_putaway_strategy()
+            if move in produce_moves and float_compare(needed_quantity, 0, precision_rounding=move.product_uom.rounding) > 0:
+                move.quantity += needed_quantity
 
         (finished_moves | consume_moves | produce_moves).picked = True
         finished_moves._action_done()

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -1122,3 +1122,45 @@ class TestUnbuild(TestMrpCommon):
                     {'product_id': self.product_2.id, 'quantity': 24, 'state': 'done'},  # Wood
                     {'product_id': self.product_1.id, 'quantity': 48, 'state': 'done'},  # Courage
                 ])
+
+    def test_unbuild_more_than_manufactured(self):
+        mo, bom, p_final, p1, p2 = self.generate_mo()
+
+        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 100)
+        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 5)
+        mo.action_assign()
+
+        mo_form = Form(mo)
+        mo_form.qty_producing = 5.0
+        mo = mo_form.save()
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done', "Production order should be in done state.")
+
+        # Check quantity in stock before unbuild.
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location), 5, 'You should have the 5 final product in stock')
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p1, self.stock_location), 80, 'You should have 80 products in stock')
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p2, self.stock_location), 0, 'You should have consumed all the 5 product in stock')
+
+        # ---------------------------------------------------
+        #       unbuild
+        # ---------------------------------------------------
+
+        x = Form(self.env['mrp.unbuild'])
+        x.product_id = p_final
+        x.bom_id = bom
+        unbuild = x.save()
+
+        unbuild.mo_id = mo.id
+        unbuild.product_qty = 7
+        unbuild.action_unbuild()
+
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p_final, self.stock_location, allow_negative=True), -2, 'You should have 2 less final product in stock than what you started with')
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p1, self.stock_location), 108, 'You should have gained back 8 more products than what you started with')
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(p2, self.stock_location), 7, 'You should have gained back 2 more products than what you started with')
+
+        move_lines = unbuild.produce_line_ids.move_line_ids.sorted(lambda ml: ml.product_id.id)
+        self.assertRecordValues(move_lines, [
+            {'reference': unbuild.name, 'quantity': 7, 'product_id': p_final.id, 'state': 'done'},
+            {'reference': unbuild.name, 'quantity': 28, 'product_id': p1.id, 'state': 'done'},
+            {'reference': unbuild.name, 'quantity': 7, 'product_id': p2.id, 'state': 'done'},
+        ])


### PR DESCRIPTION
# How to reproduce
- Create a BOM for a product
- Create a MO for a set quantity (Exemple: 1) for that product
- Unbuild that MO and ask to unbuild more than what was manufactured (Exemple: 3)
- Confirm the unbuild
- Go to the stock moves of that unbuild via the smart button

# The problem
3 stock move lines are created, 2 in the 'Done' state and 1 in the 'Available' state. This last move line is stuck and cannot be validated

# Why
The cause of this issue is due to a discrepency between the quantity set for the move lines and the quantity set for their respective moves.

When creating the move lines for the produce move, we use the original move of the MO (this is done to keep Lots consistent). If the quantity of product to unbuild is more than the quantity of product built by the MO, the quantity of the move lines will be less than expected.

This will then create a backorder when the produce move is set to done. This backorder will then be unvalidatable because the unbuild it is linked to will be set to 'Done'.

opw-5915981

opw-5449109

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
