### PR TITLE
[PERF] sale_stock, stock_account: improve performance of stock valuation report

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -229,10 +229,7 @@ class ResCompany(models.Model):
 
         extra_balance = self._get_extra_balance(extra_aml_vals_list)
 
-        if 'inventory_data' in self.env.context:
-            inventory_data = self.env.context.get('inventory_data')
-        else:
-            inventory_data = self.stock_value(accounts_by_product, at_date)
+        inventory_data = self.env.context.get('inventory_data') or self.stock_value(accounts_by_product, at_date)
         accounting_data = self.stock_accounting_value(accounts_by_product, at_date)
 
         accounts = inventory_data.keys() | accounting_data.keys()

--- a/addons/stock_account/report/stock_valuation_report.py
+++ b/addons/stock_account/report/stock_valuation_report.py
@@ -32,12 +32,9 @@ class StockValuationReport(models.AbstractModel):
             date = fields.Date.from_string(date)
         if date == fields.Date.today():
             date = False
-        if not date:
-            inventory_data = company.stock_value()
-            accounting_data = company.stock_accounting_value()
-        else:
-            inventory_data = company.stock_value(at_date=date)
-            accounting_data = company.stock_accounting_value(at_date=date)
+
+        inventory_data = company.stock_value(at_date=date)
+        accounting_data = company.stock_accounting_value(at_date=date)
 
         accounts = inventory_data.keys() | accounting_data.keys()
         account_ids = {acc.id for acc in accounts}
@@ -77,7 +74,8 @@ class StockValuationReport(models.AbstractModel):
             date, location_domain=[('usage', '=', 'inventory')],
         )
         stock_valuation_account_vals = company.with_context(inventory_data=inventory_data)._get_stock_valuation_account_vals(
-            accounts_by_product, date, company._get_location_valuation_vals(date))
+            accounts_by_product, date, company._get_location_valuation_vals(date)
+        )
 
         report_data = {
             'company_id': company.id,


### PR DESCRIPTION
Problem:
When there are many products, stock moves, and sale orders, running the Stock Valuation report can take several minutes, or result in a memory error. This is caused by 2 things:
1. `_compute_goods_delivered_not_invoiced` repeatedly runs `filtered` on a large volume of sale order lines
2. `company.stock_value()`, which recomputes every product's total value, is called twice

Solution:
We will reduce the memory usage by only fetching the `order_id` on the sale order lines, and speed things up by replacing the `filtered` call with a more intentional `search_fetch`. We will also add a way to circumvent the second `stock_value()` call in `_get_stock_valuation_account_vals`, since it is the same as the first call.

Benchmarks:
| Products | Stock Moves | Sale Order Lines | Before | After |
|---|---|---|---|---|
|9,278|228,066|203,403|7.2min|32.32s|

A 93% speed improvement.

opw-5472879