### PR TITLE
[FIX] website: prevent PageBreadcrumb crash without header

### DIFF
--- a/addons/website/static/src/interactions/page_breadcrumb.js
+++ b/addons/website/static/src/interactions/page_breadcrumb.js
@@ -11,12 +11,11 @@ export class PageBreadcrumb extends Interaction {
         const updatePageBreadcrumbOnResize = this.protectSyncAfterAsync(
             this.updatePageBreadcrumbOnResize.bind(this)
         );
-        this.headerObserver = new ResizeObserver(updatePageBreadcrumbOnResize);
-        this.headerObserver.observe(this.headerEl);
-    }
-
-    destroy() {
-        this.headerObserver.disconnect();
+        if (this.headerEl) {
+            this.headerObserver = new ResizeObserver(updatePageBreadcrumbOnResize);
+            this.headerObserver.observe(this.headerEl);
+            this.registerCleanup(() => this.headerObserver.disconnect());
+        }
     }
 
     /**


### PR DESCRIPTION
When the header is disabled globally via the Theme tab in edit mode, navigating to a page containing a breadcrumb caused a crash.

The PageBreadcrumb interaction did not handle the case where no header was present on the page.

This commit updates the interaction to safely handle pages without a header.

Task-ID: 5927177

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
