### PR TITLE
[FIX] tests: guard issubclass on non-class inputs

### DIFF
--- a/odoo/addons/test_testing_utilities/tests/test_methods.py
+++ b/odoo/addons/test_testing_utilities/tests/test_methods.py
@@ -120,6 +120,11 @@ First differing element 0:
         self.env.cr.execute("SHOW test_testing_utilities.a_flag")
         self.assertEqual(self.env.cr.fetchone(), ('',))
 
+    def test_assertRaises_invalid_exception_type(self):
+        with self.assertRaisesRegex(TypeError, "exception type"):
+            with self.assertRaises("not a class"):
+                pass
+
     def test_assertRaises_error_at_setup(self):
         """Checks that an exception raised during the *setup* of assertRaises
         bubbles up correctly.

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -534,7 +534,12 @@ class BaseCase(case.TestCase):
         with ExitStack() as init:
             if self.env:
                 init.enter_context(self.env.cr.savepoint())
-                if issubclass(exception, AccessError):
+                access_error_types = ()
+                if isinstance(exception, type):
+                    access_error_types = (exception,)
+                elif isinstance(exception, tuple):
+                    access_error_types = tuple(exc for exc in exception if isinstance(exc, type))
+                if access_error_types and any(issubclass(exc, AccessError) for exc in access_error_types):
                     # The savepoint() above calls flush(), which leaves the
                     # record cache with lots of data.  This can prevent
                     # access errors to be detected. In order to avoid this

--- a/odoo/tests/result.py
+++ b/odoo/tests/result.py
@@ -143,7 +143,7 @@ class OdooTestResult(object):
 
     def addSubTest(self, test, subtest, err):
         if err is not None:
-            if issubclass(err[0], test.failureException):
+            if isinstance(err[0], type) and issubclass(err[0], test.failureException):
                 self.addFailure(subtest, err)
             else:
                 self.addError(subtest, err)


### PR DESCRIPTION
Avoid TypeError in the test framework by validating exception types before issubclass checks, and add coverage for invalid assertRaises usage.

Description of the issue/feature this PR addresses:
Odoo’s test framework can raise TypeError: issubclass() arg 1 must be a class when issubclass is called with non-class objects during error handling or assert helper setup.

Current behavior before PR:
The framework calls issubclass without validating the input types, leading to a TypeError in some test setups when non-class exception inputs are involved.

Desired behavior after PR is merged:
The framework safely validates exception types before calling issubclass, avoiding the TypeError, and includes a regression test for invalid assertRaises usage.

issue: #235939 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
