### PR TITLE
[FIX] l10n_fr_fec: use correct company when downloading FEC file

### DIFF
--- a/addons/l10n_fr_fec/controllers/main.py
+++ b/addons/l10n_fr_fec/controllers/main.py
@@ -1,11 +1,15 @@
 from odoo import http
+from odoo.exceptions import AccessDenied
 from odoo.http import request
 
 
 class FecDownloadController(http.Controller):
     @http.route('/download/fec_file/<int:wizard_id>', type='http', auth='user')
-    def download_fec(self, wizard_id):
-        wizard = request.env['account.fr.fec'].browse(wizard_id)
+    def download_fec(self, wizard_id, company_id):
+        company_id = int(company_id)
+        if company_id not in request.env.user.company_ids.ids:
+            raise AccessDenied()
+        wizard = request.env['account.fr.fec'].with_company(company_id).browse(wizard_id)
         content = wizard._get_fec_stream()
 
         return request.make_response(content, [

--- a/addons/l10n_fr_fec/wizard/account_fr_fec.py
+++ b/addons/l10n_fr_fec/wizard/account_fr_fec.py
@@ -458,7 +458,7 @@ class AccountFrFec(models.TransientModel):
         return {
             'name': 'FEC',
             'type': 'ir.actions.act_url',
-            'url': f'/download/fec_file/{self.id}',
+            'url': f'/download/fec_file/{self.id}?company_id={company.id}',
             'target': 'self',
         }
 


### PR DESCRIPTION
The FEC generation spans two HTTP requests: generate_fec (RPC call)
and the download controller (plain GET). RPC calls include
allowed_company_ids in the context, so self.env.company resolves
correctly. But the plain GET to /download/fec_file/<id> carries no
context, so self.env.company falls back to user.company_id (the user's
default company), which may differ from the one selected in the UI.

This commit aims to fix the issue by passing
the company_id from generate_fec through the download URL and restore it in the controller via with_company(), with an access check to ensure the user belongs to that company.

task-5926528