### PR TITLE
[FIX] mail: incorrect badge icon mapping

### DIFF
--- a/addons/hr_homeworking_calendar/wizard/homework_location_wizard.xml
+++ b/addons/hr_homeworking_calendar/wizard/homework_location_wizard.xml
@@ -21,9 +21,8 @@
                                nolabel="1"
                                widget="selection_badge_icons"
                                options="{
-                                    'icon_mapping': {'office': 'fa-building-o', 'home': 'fa-home'},
+                                    'icon_mapping': {'office': 'fa-building-o', 'home': 'fa-home', 'other': 'fa-map-marker'},
                                     'related_icon_field': 'location_type',
-                                    'default_icon': 'fa-map-marker'
                                }"/>
                     </div>
                 </group>

--- a/addons/mail/static/src/views/fields/badge_selection_icons/badge_selection_icons_field.js
+++ b/addons/mail/static/src/views/fields/badge_selection_icons/badge_selection_icons_field.js
@@ -49,10 +49,7 @@ export class BadgeSelectionWithIconsField extends BadgeSelectionField {
                 return ret.map((opt) => {
                     const relatedFieldValue = opt[props.relatedIconField];
                     // In case the icon value is a selection, we can specify a mapping too
-                    const iconValue =
-                        relatedFieldValue && props.iconMapping
-                            ? props.iconMapping[relatedFieldValue]
-                            : relatedFieldValue;
+                    const iconValue = relatedFieldValue && (props.iconMapping?.[relatedFieldValue] ?? relatedFieldValue);
                     return [opt.id, opt.name, iconValue || props.defaultIcon];
                 });
             });


### PR DESCRIPTION
**Before this commit:**
In `selection_badge_icons` widget, badge icons correctly fell back to the default value when no icon mapping existed.

**Technical:**
After commit [1], when iconMapping was an empty object, the icon value became undefined instead of falling back to the related field value.

The logic relied on the truthiness of iconMapping. Since empty objects are truthy in JavaScript, the mapped branch was taken even when no key existed, resulting in an undefined value.

**After this commit:**
The resolution logic now directly checks the mapped value using optional chaining and nullish coalescing, ensuring a correct fallback to the related field value when the mapping is missing or empty.

[1]: https://github.com/odoo/odoo/commit/7714b55eb9386d3cedd79d3ce4de7475b09af69a

Task-5925890