### PR TITLE
[FIX] mail: restore spacing between avatar and name in Discuss search

### DIFF
--- a/addons/mail/static/src/core/common/discuss_avatar.xml
+++ b/addons/mail/static/src/core/common/discuss_avatar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussAvatar">
-        <svg t-att-width="props.size" t-att-height="props.size" viewBox="0 0 32 32" class="overflow-visible">
+        <svg t-att-width="props.size" t-att-height="props.size" viewBox="0 0 32 32" class="overflow-visible" t-att-class="props.className">
             <mask t-att-id="uniqueId" width="32" height="32">
                 <rect x="0" y="0" height="32" width="32" fill="white"/>
                 <rect t-if="showIcon" color="black" t-att-x="isTyping ? 15 : 19" y="19" t-att-width="isTyping ? 24 : 16" t-att-height="isTyping ? 15 : 16" rx="8" ry="8"/>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
----------------------------------------------
In master, conversation search results in Discuss (mentions and recent
sections) display no spacing between the avatar and the conversation
name.

**Current behavior before PR:**
----------------------------------------------
- The DiscussAvatar component receives a spacing class (e.g. me-2) from its parent (DiscussCommand).
- This class is not applied to the avatar root element.
- As a result, the avatar appears directly adjacent to the name withno spacing.

**Desired behavior after PR is merged:**
----------------------------------------------
- The className prop passed to DiscussAvatar is applied to the root element.
- Bootstrap spacing utilities are correctly rendered.
- Proper spacing between avatar and conversation name is restoredin Discuss search results.

since: https://github.com/odoo/odoo/pull/246182
Task-5923094

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr