### PR TITLE
[FIX] base: remove aggregation in device models

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -187,11 +187,11 @@ class ResDevice(models.Model):
             SELECT
                 MAX(L.id) as id,
                 L.session_identifier as session_identifier,
-                MIN(L.user_id) as user_id,
+                L.user_id as user_id,
                 L.ip_address as ip_address,
                 L.user_agent as user_agent,
-                MAX(L.country) as country,
-                MAX(L.city) as city,
+                L.country as country,
+                L.city as city,
                 MIN(L.first_activity) as first_activity,
                 MAX(L.last_activity) as last_activity,
                 bool_and(L.revoked) as revoked
@@ -201,8 +201,11 @@ class ResDevice(models.Model):
                 L.revoked IS NOT TRUE
             GROUP BY
                 session_identifier,
+                user_id,
                 ip_address,
-                user_agent
+                user_agent,
+                country,
+                city
         """
 
     def init(self):
@@ -272,14 +275,15 @@ class ResSession(models.Model):
             SELECT
                 MAX(D.id) as id,
                 D.session_identifier as session_identifier,
-                MIN(D.user_id) as user_id,
+                D.user_id as user_id,
                 MIN(D.first_activity) as first_activity,
                 MAX(D.last_activity) as last_activity,
                 bool_and(D.revoked) as revoked
             FROM
                 res_device D
             GROUP BY
-                session_identifier
+                session_identifier,
+                user_id
         """
 
     @check_identity


### PR DESCRIPTION
Invariants:
- For a given session identifier, the user will always be the same (otherwise the session is no longer valid).
- For a given device determined by a session identifier, an IP address, and a user agent, the country and city will remain the same, as these are determined when the device is first detected.

It is therefore possible to no longer aggregate these values and place them directly in the `GROUP BY` clause in order to improve the performance[^1] of `res.device` and `res.session` models.

[^1]: Aggregate computations (`MIN`/`MAX`) force the database to perform redundant comparisons for every row in the group. By placing these columns directly in the `GROUP BY` clause, the query reduces per-row processing. This lead to a more efficient execution plan (especially on large datasets).

Task-5928301