### PR TITLE
[FIX] point_of_sale,pos_mrp: fix total cost and margin for kit-type product

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1821,6 +1821,10 @@ class PosOrderLine(models.Model):
         self.ensure_one()
         return self.product_id.is_storable and self.product_id.cost_method in ['fifo', 'average']
 
+    def _get_product_cost_with_moves(self, moves):
+        self.ensure_one()
+        return moves._get_price_unit()
+
     def _compute_total_cost(self, stock_moves):
         """
         Compute the total cost of the order lines.
@@ -1829,9 +1833,9 @@ class PosOrderLine(models.Model):
         for line in self.filtered(lambda l: not l.is_total_cost_computed):
             product = line.product_id
             cost_currency = product.sudo().cost_currency_id
-            if line._is_product_storable_fifo_avco() and stock_moves:
-                moves = line._get_stock_moves_to_consider(stock_moves, product)
-                product_cost = moves._get_price_unit()
+            moves = line._get_stock_moves_to_consider(stock_moves, product) if stock_moves else None
+            if moves and line._is_product_storable_fifo_avco():
+                product_cost = line._get_product_cost_with_moves(moves)
                 if cost_currency.is_zero(product_cost) and line.order_id.shipping_date:
                     if line.refunded_orderline_id:
                         product_cost = line.refunded_orderline_id.total_cost / line.refunded_orderline_id.qty

--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -18,6 +18,14 @@ class PosOrderLine(models.Model):
         ml_product_to_consider = (product.bom_ids and [comp[0].product_id.id for comp in components]) or [product.id]
         return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and (ml.bom_line_id.id in bom_line_ids)).with_context(pos_order_line_id=self.id, bom_id=bom.id)
 
+    def _get_product_cost_with_moves(self, moves):
+        self.ensure_one()
+        product = self.product_id
+        if any(bom.type == 'phantom' for bom in product.bom_ids):
+            bom = self.env['mrp.bom']._bom_find(product, company_id=self.company_id.id, bom_type='phantom')[product]
+            return moves._get_kit_price_unit(product, bom, self.qty)
+        return super()._get_product_cost_with_moves(moves)
+
 
 class PosOrder(models.Model):
     _inherit = "pos.order"

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -11,7 +11,7 @@ class TestPosMrp(CommonPosMrpTest):
     def test_bom_kit_order_total_cost(self):
         order, _ = self.create_backend_pos_order({
             'line_data': [
-                {'product_id': self.product_product_kit_one.id}
+                {'product_id': self.product_product_kit_two.id}
             ],
             'payment_data': [
                 {'payment_method_id': self.cash_payment_method.id}
@@ -19,7 +19,7 @@ class TestPosMrp(CommonPosMrpTest):
         })
 
         self.pos_config_usd.current_session_id.action_pos_session_closing_control()
-        self.assertEqual(order.lines[0].total_cost, 10.0)
+        self.assertEqual(order.lines[0].total_cost, 20.0)
 
     @skip('Temporary to fast merge new valuation')
     def test_bom_kit_with_kit_invoice_valuation(self):


### PR DESCRIPTION
Steps to reproduce:
=
- Create a product with type = Goods and Track Inventory by Quantity 
- Go to product category > inventory valuation > costing method -> FIFO 
- Create a BOM for the product with BOM Type = Kit.
- Create and validate a POS order.
- Open the order in the backend.

Issue:
=
- The total cost was shown as 0.0 for kit products. Also, the margin amount and margin percentage were incorrect.

Fix:
=
- Ensure that the total cost and margin are correctly computed for kit-type products in POS orders.

task-5924559