### PR TITLE
[FIX] base: fix reference date of `test_01_code_and_format`

### DIFF
--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -5,7 +5,7 @@ import datetime
 import os.path
 from zoneinfo import ZoneInfo
 
-from odoo.tests.common import tagged, BaseCase, TransactionCase
+from odoo.tests.common import tagged, BaseCase, TransactionCase, freeze_time
 from odoo.tools import config, misc, urls
 from odoo.tools.mail import validate_url
 from odoo.tools.misc import file_open, file_path, merge_sequences, remove_accents
@@ -70,6 +70,7 @@ class TestFormatLangDate(TransactionCase):
         self.assertEqual(misc.format_time(self.env, False, time_format=t_medium), '')
         self.assertEqual(misc.format_time(self.env, None, time_format=t_medium), '')
 
+    @freeze_time('2017-01-31')
     def test_01_code_and_format(self):
         date_str = '2017-01-31'
         lang = self.env['res.lang']


### PR DESCRIPTION
If provided a `datetime.time`, `babel.dates.time_format` needs to complete it to a datetime in order to resolve timezone offsets (and legacy names). In order to do that, it ultimately uses "now" as the reference: [`format_time`] calls [`DateTimePattern.apply`] which calls [`DateTimeFormat.__getitem__`] which calls
[`DateTimeFormat.format_timezone`] which calls [`get_timezone_gmt`] which calls [`_get_datetime`], which for a `datetime.time()` input resolves:

    return datetime.datetime.combine(datetime.date.today(), instant)

This means DST changes impact the timezone being resolved timezone (offset or legacy name), which is what occurred here: S summer time starts on the second sunday of March at 0200 local which for 2026 is 2026-03-08 0200, faketime builds started failing with a virtual time of 2026-03-08 12:00 UTC which is well past 0200 local in America/New_York, and thus into the summer timezone, with an offset of -0400, thus different from the reference offset of -0500.

The reference date can be fixed to anything which results in standard time in all the timezones being checked, so between the first sunday of november (end of DST in the US) and the last sunday of march (start of DST in Europe), in the past (to ensure no DST rules change). Just use the reference date of the test itself as it's fine enough.

Now why did this test pass before #236660? This was hinted at when I needed to fix the offset from -0504 to -0500 but it didn't register as it was a minor edit: because the timezone was associated via `tzinfo` rather than `localize`, `pytz` was not able to select the correct timezone so would just select some prehistorical timezone, which doesn't have DST rules associated, and so would remain on standard time year round.

With the switch to zoneinfo the timezone can be interpreted dynamically, leading to the timezone offset varying when the reference date changes, and thus the issue revealing itself.

And `odoo.misc.format_time(datetime)` has a similar issue, because it strips out the `date` part of a `datetime` input, so similarly babel itself receives a lone zoned time, which it resolves using the date at the time of the test running. Which is funny because `babel.dates.format_time` itself can take a `datetime` and will use that directly for its timezone resolution, so on this bit we shot ourselves in the foot.

https://runbot.odoo.com/odoo/runbot.build.error/238900

[`format_time`]: https://github.com/python-babel/babel/blob/56c63caf50b18b152541b5dcafd51f645d867074/babel/dates.py#L841
[`DateTimePattern.apply`]: https://github.com/python-babel/babel/blob/56c63caf50b18b152541b5dcafd51f645d867074/babel/dates.py#L1424
[`DateTimeFormat.__getitem__`]: https://github.com/python-babel/babel/blob/56c63caf50b18b152541b5dcafd51f645d867074/babel/dates.py#L1487
[`DateTimeFormat.format_timezone`]: https://github.com/python-babel/babel/blob/56c63caf50b18b152541b5dcafd51f645d867074/babel/dates.py#L1675
[`get_timezone_gmt`]: https://github.com/python-babel/babel/blob/56c63caf50b18b152541b5dcafd51f645d867074/babel/dates.py#L459
[`_get_datetime`]: https://github.com/python-babel/babel/blob/56c63caf50b18b152541b5dcafd51f645d867074/babel/dates.py#L158
