### PR TITLE
[IMP] mail:  Hide files and pinned messages panel when search is open

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -32,7 +32,7 @@
                 <button class="btn btn-link text-action px-1" aria-label="Search Messages" title="Search Messages" t-on-click="onClickSearch">
                     <i class="oi oi-search fa-fw" role="img"/>
                 </button>
-                <button t-if="hasPinnedMessages" class="btn btn-link text-action p-1" aria-label="Pinned Messages" title="Pinned Messages" t-on-click="onClickPinnedMessages">
+                <button t-if="hasPinnedMessages" class="btn btn-link text-action p-1" aria-label="Pinned Messages" title="Pinned Messages" t-on-click="onClickPinnedMessages" t-att-disabled="state.isSearchOpen">
                     <i class="fa fa-fw fa-thumb-tack" role="img"/>
                 </button>
                 <button t-if="props.hasAttachmentPreview and state.thread.attachmentsInWebClientView.length" class="btn btn-link text-action px-1" t-on-click="popoutAttachment">
@@ -68,7 +68,7 @@
         </div>
         <div class="o-mail-Chatter-content d-flex flex-column flex-grow-1 bg-inherit">
             <t>
-                <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative">
+                <div t-if="state.isAttachmentBoxOpened and !state.isSearchOpen" class="o-mail-AttachmentBox position-relative">
                     <div class="d-flex align-items-center">
                         <hr class="flex-grow-1"/>
                         <span class="p-3 fw-bold">
@@ -91,7 +91,7 @@
                         </FileUploader>
                     </div>
                 </div>
-                <div t-if="state.showPinnedMessages and hasPinnedMessages" class="o-mail-pinnedMessages bg-inherit">
+                <div t-if="state.showPinnedMessages and hasPinnedMessages and !state.isSearchOpen" class="o-mail-pinnedMessages bg-inherit">
                     <div class="d-flex align-items-center">
                         <hr class="flex-grow-1"/>
                         <span class="p-3 fw-bold">Pinned Messages</span>

--- a/addons/mail/static/tests/chatter/web/chatter_search.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter_search.test.js
@@ -77,6 +77,34 @@ test("Close button should close the search panel", async () => {
     await contains(".o-mail-SearchMessageInput", { count: 0 });
 });
 
+test("opening search in chatter hides files and pinned messages panels", async () => {
+    patchUiSize({ size: SIZES.XXL });
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
+    pyEnv["mail.message"].create({
+        body: "Pinned message",
+        model: "res.partner",
+        pinned_at: "2025-01-01 00:00:00",
+        res_id: partnerId,
+    });
+    pyEnv["ir.attachment"].create({
+        mimetype: "text/plain",
+        name: "A.txt",
+        res_id: partnerId,
+        res_model: "res.partner",
+    });
+    await start();
+    await openFormView("res.partner", partnerId);
+    await click("button[aria-label='Attach files']");
+    await click("button[title='Pinned Messages']");
+    await contains(".o-mail-AttachmentBox");
+    await contains(".o-mail-pinnedMessages");
+    await click("[title='Search Messages']");
+    await contains(".o_searchview");
+    await contains(".o-mail-AttachmentBox", { count: 0 });
+    await contains(".o-mail-pinnedMessages", { count: 0 });
+});
+
 test("Search in chatter should be hightligted", async () => {
     patchUiSize({ size: SIZES.XXL });
     const pyEnv = await startServer();


### PR DESCRIPTION
When the search view is opened in Chatter, files and pinned messages panels are now hidden to avoid UI clutter and improve focus on search results.

task-[5873731](https://www.odoo.com/odoo/project/1519/tasks/5873731)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
