### PR TITLE
[FIX] l10n_it_edi: Fix typo in italian edi

### DIFF
--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//block[@id='account_vendor_bills']" position="after">
                 <block title="Italian Electronic Invoicing" invisible="country_code != 'IT' or use_root_proxy_user" id='l10n_it_edi'>
-                    <setting id="l10n_it_edi_setting" string="Fattura Electronica (FatturaPA)">
+                    <setting id="l10n_it_edi_setting" string="Fattura Elettronica (FatturaPA)">
                         <field name="l10n_it_edi_show_purchase_journal_id" invisible="1"/>
                         <div class="mt8 content-group">
                             <div class="content-group d-flex align-items-center gap-2">


### PR DESCRIPTION
The title Fattura Electronica is wrong it should be Fattura Elettornica Asked by TSB

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
