### PR TITLE
[FIX] web: fix unscheduled event text truncation

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.xml
+++ b/addons/web/static/src/views/calendar/calendar_schedule_section/calendar_schedule_section.xml
@@ -11,7 +11,7 @@
         </div>
         <div t-ref="eventsToSchedule" class="d-flex flex-column" t-att-class="{ 'd-none': this.state.collapsed }">
             <div 
-                class="align-items-center cursor-pointer o_event_to_schedule_draggable py-1"
+                class="align-items-center cursor-pointer o_event_to_schedule_draggable py-1 text-truncate"
                 t-foreach="props.model.data.eventsToSchedule.records"
                 t-as="event"
                 t-key="event.id"
@@ -19,7 +19,7 @@
                 t-on-click="() => this.openRecord(event)"
             >
                 <i class="oi oi-draggable o_event_to_schedule_handle"/>
-                <span class="ps-1 text-truncate" t-out="event.display_name" t-att-title="event.display_name"/>
+                <span class="ps-1" t-out="event.display_name" t-att-title="event.display_name"/>
             </div>
         </div>
         <button t-if="displayLoadMoreButton" class="btn btn-link" t-on-click="() => this.props.model.loadMoreEventsToSchedule()">


### PR DESCRIPTION
Previously, the `text-truncate` class was applied only to the text span of unscheduled events in the calendar side panel. This failed to account for the width of the drag handle, potentially causing layout issues.

This commit moves the truncation class to the parent container, ensuring the text is properly truncated while respecting the space occupied by the drag handle.
