### PR TITLE
[FIX] web: image_field: avoid some nondeterministic error

### DIFF
--- a/addons/web/static/tests/views/fields/image_field.test.js
+++ b/addons/web/static/tests/views/fields/image_field.test.js
@@ -348,14 +348,7 @@ test("ImageField preview is updated when an image is uploaded", async () => {
     await click(".o_select_file_button");
     await setInputFiles(imageFile);
     // It can take some time to encode the data as a base64 url
-    await runAllTimers();
-    // Wait for a render
-    await animationFrame();
-    expect("div[name=document] img").toHaveAttribute(
-        "data-src",
-        `data:image/png;base64,${MY_IMAGE}`,
-        { message: "the image should have the new src" }
-    );
+    await waitFor(`div[name=document] img[data-src="data:image/png;base64,${MY_IMAGE}"]`);
 });
 
 test("clicking save manually after uploading new image should change the unique of the image src", async () => {


### PR DESCRIPTION
Encoding the data to base64 can take some times.
Before this commit we used this code:
```js
await runAllTimers();
await animationFrame();
```
Now we explicitly wait for the change to happen as awaiting an animation frame can't be enough.

runbot-error-237568

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
