### PR TITLE
[FIX] project: ensure archived subtasks are not copied during task duplication

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -819,7 +819,7 @@ class Task(models.Model):
                     'dependent_ids': False,
                     'parent_id': False,
                 }
-                vals['child_ids'] = [Command.create(child_id.copy_data(default)[0]) for child_id in task.child_ids]
+                vals['child_ids'] = [Command.create(child_id.copy_data(default)[0]) for child_id in task.child_ids.filtered(lambda c: c.active)]
         return vals_list
 
     def _create_task_mapping(self, copied_tasks):

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -523,3 +523,18 @@ class TestProjectBase(TestProjectCommon):
         task.active = False
         copy_task2 = task.copy()
         self.assertTrue(copy_task2.active, "Archived task should be active when duplicating an archived task")
+
+    def test_archived_subtask_not_copied_during_parent_task_duplication(self):
+        """Test that archived subtasks are not copied when duplicating a parent task."""
+        parent_task = self.env['project.task'].create({
+            'name': 'Parent Task',
+            'project_id': self.project_pigs.id,
+            'child_ids': [
+                Command.create({
+                    'name': 'child task',
+                    'project_id': self.project_pigs.id,
+                }),
+            ],
+        })
+        parent_task.child_ids.active = False
+        self.assertFalse(parent_task.copy().child_ids, "Archived subtask should not be copied")


### PR DESCRIPTION
Currently, when duplicating a task that contains `archived subtasks`, 
the archived subtasks are also duplicated.

**Steps to reproduce:**
- Install the `project` module.
- Open any `project` and create a task with a subtask.
- `Archive` the subtask.
- `Duplicate` the parent task.

**Observation:**
The duplicated task contains a copy of the archived subtask, 
even though it is inactive.

**Root Cause:**
At [1], subtasks are duplicated without checking their active status. As a 
result, archived (`active=False`) subtasks are also copied during duplication.

**Fix:**
This commit ensures that archived subtasks are not copied when duplicating a task.

[1]:
https://github.com/odoo/odoo/blob/531b887aec92c2fbf57495992be9fbc32d9ea20e/addons/project/models/project_task.py#L822

opw-5926009