### PR TITLE
[FIX] html_editor: put cursor inside button after entering backspace

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -244,6 +244,7 @@ export class LinkPlugin extends Plugin {
         split_element_block_overrides: this.handleSplitBlock.bind(this),
         insert_line_break_element_overrides: this.handleInsertLineBreak.bind(this),
         delete_image_overrides: this.deleteImageLink.bind(this),
+        delete_backward_overrides: withSequence(15, this.handleDeleteBackward.bind(this)),
     };
     setup() {
         this.overlay = this.dependencies.overlay.createOverlay(LinkPopover, {}, { sequence: 50 });
@@ -955,6 +956,25 @@ export class LinkPlugin extends Plugin {
         [targetNode, targetOffset] = edge === "start" ? leftPos(targetNode) : rightPos(targetNode);
         blockToSplit = targetNode;
         splitOrLineBreakCallback({ ...params, targetNode, targetOffset, blockToSplit });
+        return true;
+    }
+
+    handleDeleteBackward({ startContainer, startOffset, endContainer, endOffset }) {
+        // Detect if selection is around FEFF after the end edge of a button.
+        if (startContainer !== endContainer || startOffset !== 0 || endOffset !== 1) {
+            return;
+        }
+        if (startContainer.nodeType !== Node.TEXT_NODE || startContainer.textContent != "\uFEFF") {
+            return;
+        }
+        if (!startContainer.previousSibling?.matches("a.btn")) {
+            return;
+        }
+        // Move before inner FEFF of the button.
+        this.dependencies.selection.setSelection({
+            anchorNode: startContainer.previousSibling,
+            anchorOffset: startContainer.previousSibling.childNodes.length - 1,
+        });
         return true;
     }
 }

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -353,16 +353,39 @@ test("should remove zwnbsp from middle of the link (2)", async () => {
     });
 });
 
-test("should zwnbps-pad links with .btn class", async () => {
-    await testEditor({
-        contentBefore: '<p><a class="btn">content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a class="btn">\ufeffcontent\ufeff</a>\ufeff</p>',
+describe("button", () => {
+    test("should zwnbps-pad links with .btn class", async () => {
+        await testEditor({
+            contentBefore: '<p><a class="btn">content</a></p>',
+            contentBeforeEdit: '<p>\ufeff<a class="btn">\ufeffcontent\ufeff</a>\ufeff</p>',
+        });
     });
-});
 
-test("should not add visual indication to a button", async () => {
-    await testEditor({
-        contentBefore: '<p><a class="btn">[]content</a></p>',
-        contentBeforeEdit: '<p>\ufeff<a class="btn">\ufeffcontent\ufeff</a>\ufeff</p>',
+    test("should not add visual indication to a button", async () => {
+        await testEditor({
+            contentBefore: '<p><a class="btn">[]content</a></p>',
+            contentBeforeEdit: '<p>\ufeff<a class="btn">\ufeffcontent\ufeff</a>\ufeff</p>',
+        });
+    });
+
+    test("should type inside button after backspacing into it", async () => {
+        const { editor, el } = await setupEditor(
+            '<p>before<a class="btn" href="#/">in</a>x[]after</p>'
+        );
+        expect(getContent(el)).toBe(
+            '<p>before\ufeff<a class="btn" href="#/">\ufeffin\ufeff</a>\ufeffx[]after</p>'
+        );
+        deleteBackward(editor);
+        expect(getContent(el)).toBe(
+            '<p>before\ufeff<a class="btn" href="#/">\ufeffin\ufeff</a>\ufeff[]after</p>'
+        );
+        deleteBackward(editor);
+        expect(getContent(el)).toBe(
+            '<p>before\ufeff<a class="btn" href="#/">\ufeffin[]\ufeff</a>\ufeffafter</p>'
+        );
+        await insertText(editor, "side");
+        expect(getContent(el)).toBe(
+            '<p>before\ufeff<a class="btn" href="#/">\ufeffinside[]\ufeff</a>\ufeffafter</p>'
+        );
     });
 });


### PR DESCRIPTION
When using backspace after a button, the cursor is visually displayed as being inside the button, but it a character is typed, it is inserted after the button, while it should be inside.

What actually happens is that after backspace after a button, the selection is set around the FEFF that follows the button.

This commit fixes this by putting the selection before the FEFF inside the button instead.

Steps to reproduce:
- Go to a "To do" note
- Insert a button
- Insert text after the button
- Put cursor before text after button
- Press backspace: the cursor is displayed inside the button
- Type a letter

=> The letter was inserted after the button.

task-5928806
