### PR TITLE
[FIX] html_builder: restore image src when discarding image transformation

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -159,6 +159,15 @@ export class ResetCropAction extends BuilderAction {
         const newDataset = Object.fromEntries(
             cropperDataFieldsWithAspectRatio.map((field) => [field, undefined])
         );
+        if (img.dataset.originalSrc) {
+            // Restore the original image source:
+            return () =>
+                this.dependencies.imagePostProcess.updateImageAttributes(
+                    img,
+                    img.dataset.originalSrc,
+                    newDataset
+                );
+        }
         return this.dependencies.imagePostProcess.processImage({ img, newDataset });
     }
     apply({ loadResult: updateImageAttributes }) {

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -45,7 +45,7 @@ export const DEFAULT_IMAGE_QUALITY = "92";
 export class ImagePostProcessPlugin extends Plugin {
     static id = "imagePostProcess";
     static dependencies = ["style"];
-    static shared = ["processImage", "getProcessedImageSize"];
+    static shared = ["processImage", "updateImageAttributes", "getProcessedImageSize"];
 
     /**
      * Applies data-attributes modifications to an img tag and returns a dataURL


### PR DESCRIPTION
When a user crops an image and reset the transformation using the right panel, the system does not restore the original image's src (from `data-image-src`). Instead, it replaces it with a base 64 encoded version of the original image without any transformation.

Later, when the user saves the document, the system converts this base 64 image into a new attachment, even though the original attachment already exists or the image is loaded from an external url.

Steps to reproduce:
1. Open Mass Mailing
2. Drag and drop a snippet containing a croppable image
3. Click on the image
4. Crop the image
5. Click on the "Reset" button from the right panel

=> The image is encoded in base 64 instead of reusing the original image src.

To fix this issue, we will modify the `resetCropAction` so that it restores the image's src (stored in `data-original-src`) instead of calling the method to process the image and convert it to base 64, etc.

Task-6140227