### PR TITLE
[REF] website: generate HeaderTemplateOption from resource

### DIFF
--- a/addons/website/static/src/@types/plugins.d.ts
+++ b/addons/website/static/src/@types/plugins.d.ts
@@ -18,6 +18,7 @@ declare module "plugins" {
     import { footer_templates_providers, FooterOptionShared } from "@website/builder/plugins/options/footer_option_plugin";
     import { gallery_items_providers, reorder_items_processors } from "@website/builder/plugins/options/gallery_element_option_plugin";
     import { GoogleMapsOptionShared } from "@website/builder/plugins/options/google_maps_option/google_maps_option_plugin";
+    import { header_templates_providers, HeaderOptionShared } from "@website/builder/plugins/options/header/header_option_plugin";
     import { ImageGalleryOptionShared } from "@website/builder/plugins/options/image_gallery_option_plugin";
     import { InstagramOptionShared } from "@website/builder/plugins/options/instagram_option_plugin";
     import { MegaMenuOptionShared } from "@website/builder/plugins/options/mega_menu_option_plugin";
@@ -48,6 +49,7 @@ declare module "plugins" {
         edit_interaction: EditInteractionShared;
         footerOption: FooterOptionShared;
         googleMapsOption: GoogleMapsOptionShared;
+        headerOption: HeaderOptionShared;
         imageGalleryOption: ImageGalleryOptionShared;
         imageHover: ImageHoverShared;
         instagramOption: InstagramOptionShared;
@@ -89,6 +91,7 @@ declare module "plugins" {
         // Providers
         footer_templates_providers: footer_templates_providers;
         gallery_items_providers: gallery_items_providers;
+        header_templates_providers: header_templates_providers;
 
         // Data
         searchbar_option_display_items: searchbar_option_display_items;

--- a/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_option_plugin.js
@@ -5,12 +5,27 @@ import {
 } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { HeaderElementsOption } from "./header_elements_option";
 import { HeaderFontOption } from "./header_font_option";
-import { HeaderTemplateOption } from "./header_template_option";
+import { HeaderTemplateChoice, HeaderTemplateOption } from "./header_template_option";
 import { HeaderIconBackgroundOption } from "./header_icon_background_option";
 import { HeaderTopOptions } from "./header_top_options";
+
+/** @typedef {import("@odoo/owl").Component} Component */
+
+/**
+ * @typedef { Object } HeaderOptionShared
+ * @property { HeaderOptionPlugin['getHeaderTemplates'] } getHeaderTemplates
+ */
+/**
+ * @typedef {(() => {
+ *     key: string,
+ *     Component: Component,
+ *     props: any,
+ * }[])[]} header_templates_providers
+ */
 
 const [
     HEADER_TEMPLATE,
@@ -39,6 +54,7 @@ export {
 export class HeaderOptionPlugin extends Plugin {
     static id = "headerOption";
     static dependencies = ["customizeWebsite", "menuDataPlugin"];
+    static shared = ["getHeaderTemplates"];
 
     /** @type {import("plugins").WebsiteResources} */
     resources = {
@@ -63,7 +79,56 @@ export class HeaderOptionPlugin extends Plugin {
         // this button if it's empty
         are_inlines_allowed_at_root_predicates: (node) =>
             node.matches("#o_main_nav .oe_structure_solo .oe_unremovable [contenteditable='true']"),
+        header_templates_providers: [
+            () =>
+                [
+                    { name: "default", title: _t("Default") },
+                    {
+                        name: "hamburger",
+                        title: _t("Hamburger Menu"),
+                        extraViews: ["website.no_autohide_menu"],
+                    },
+                    { name: "boxed", title: _t("Rounded Box Menu") },
+                    { name: "stretch", title: _t("Stretch Menu") },
+                    { name: "vertical", title: _t("Vertical") },
+                    { name: "search", title: _t("Menu with Search Bar") },
+                    { name: "sales_one", title: _t("Menu - Sales 1") },
+                    { name: "sales_two", title: _t("Menu - Sales 2") },
+                    { name: "sales_three", title: _t("Menu - Sales 3") },
+                    { name: "sales_four", title: _t("Menu - Sales 4") },
+                    {
+                        name: "sidebar",
+                        title: _t("Sidebar"),
+                        extraViews: ["website.no_autohide_menu"],
+                        menuShadowClass: "shadow-lg",
+                    },
+                ].map((info) => {
+                    const view = info.view ?? `website.template_header_${info.name}`;
+                    return {
+                        key: info.name,
+                        Component: HeaderTemplateChoice,
+                        props: {
+                            id: `header_${info.name}_opt`,
+                            imgSrc: `/website/static/src/img/snippets_options/header_template_${info.name}.svg`,
+                            menuShadowClass: info.menuShadowClass ?? "shadow-sm",
+                            title: info.title,
+                            varName: info.name,
+                            views: [view, ...(info.extraViews || [])],
+                        },
+                    };
+                }),
+        ],
     };
+
+    setup() {
+        this.headerTemplates = this.getResource("header_templates_providers").flatMap((provider) =>
+            provider()
+        );
+    }
+
+    getHeaderTemplates() {
+        return this.headerTemplates;
+    }
 }
 
 registry.category("website-plugins").add(HeaderOptionPlugin.id, HeaderOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/header/header_template_option.js
+++ b/addons/website/static/src/builder/plugins/options/header/header_template_option.js
@@ -3,6 +3,12 @@ import { basicHeaderOptionSettings } from "./basicHeaderOptionSettings";
 
 export class HeaderTemplateOption extends BaseOptionComponent {
     static template = "website.HeaderTemplateOption";
+    static dependencies = ["headerOption"];
+
+    setup() {
+        super.setup();
+        this.headerTemplates = this.dependencies.headerOption.getHeaderTemplates();
+    }
 
     hasSomeOptions(opts) {
         return opts.some((opt) => this.isActiveItem(opt));
@@ -10,3 +16,15 @@ export class HeaderTemplateOption extends BaseOptionComponent {
 }
 
 Object.assign(HeaderTemplateOption, basicHeaderOptionSettings);
+
+export class HeaderTemplateChoice extends BaseOptionComponent {
+    static template = "website.HeaderTemplateChoice";
+    static props = {
+        title: String,
+        views: Array,
+        varName: String,
+        imgSrc: String,
+        id: String,
+        menuShadowClass: String,
+    };
+}

--- a/addons/website/static/src/builder/plugins/options/header/header_template_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_template_option.xml
@@ -3,171 +3,9 @@
     <t t-name="website.HeaderTemplateOption">
         <BuilderRow label.translate="Template">
             <BuilderSelect action="'reloadComposite'">
-                <BuilderSelectItem
-                    id="'header_default_opt'"
-                    title.translate="Default"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_default'],
-                                vars: { 'header-template': 'default', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);' }" src="'/website/static/src/img/snippets_options/header_template_default.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_hamburger_opt'"
-                    title.translate="Hamburger Menu"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_hamburger', 'website.no_autohide_menu'],
-                                vars: { 'header-template': 'hamburger', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);' }" src="'/website/static/src/img/snippets_options/header_template_hamburger.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_boxed_opt'"
-                    title.translate="Rounded Box Menu"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_boxed'],
-                                vars: { 'header-template': 'boxed', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style:' width: calc(100% - 0.5rem);' }" src="'/website/static/src/img/snippets_options/header_template_boxed.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_stretch_opt'"
-                    title.translate="Stretch Menu"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_stretch'],
-                                vars: { 'header-template': 'stretch', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);' }" src="'/website/static/src/img/snippets_options/header_template_stretch.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_vertical_opt'"
-                    title.translate="Vertical"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_vertical'],
-                                vars: { 'header-template': 'vertical', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);'}" src="'/website/static/src/img/snippets_options/header_template_vertical.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_search_opt'"
-                    title.translate="Menu with Search Bar"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_search'],
-                                vars: { 'header-template': 'search', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);'}" src="'/website/static/src/img/snippets_options/header_template_search.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_sales_one_opt'"
-                    title.translate="Menu - Sales 1"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_sales_one'],
-                                vars: { 'header-template': 'sales_one', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);'}" src="'/website/static/src/img/snippets_options/header_template_sales_one.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_sales_two_opt'"
-                    title.translate="Menu - Sales 2"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_sales_two'],
-                                vars: { 'header-template': 'sales_two', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);'}" src="'/website/static/src/img/snippets_options/header_template_sales_two.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_sales_three_opt'"
-                    title.translate="Menu - Sales 3"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_sales_three'],
-                                vars: { 'header-template': 'sales_three', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);'}" src="'/website/static/src/img/snippets_options/header_template_sales_three.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_sales_four_opt'"
-                    title.translate="Menu - Sales 4"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_sales_four'],
-                                vars: { 'header-template': 'sales_four', 'menu-shadow-class': 'shadow-sm', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);'}" src="'/website/static/src/img/snippets_options/header_template_sales_four.svg'"/>
-                </BuilderSelectItem>
-                <BuilderSelectItem
-                    id="'header_sidebar_opt'"
-                    title.translate="Sidebar"
-                    actionParam="[
-                        {
-                            action: 'websiteConfig',
-                            actionParam: {
-                                views: ['website.template_header_sidebar', 'website.no_autohide_menu'],
-                                vars: { 'header-template': 'sidebar', 'menu-shadow-class': 'shadow-lg', 'menu-box-shadow-style': null },
-                                checkVars: false,
-                            }
-                        }
-                    ]">
-                    <Image attrs="{ style: 'width: calc(100% - 0.5rem);'}" src="'/website/static/src/img/snippets_options/header_template_sidebar.svg'"/>
-                </BuilderSelectItem>
+                <t t-foreach="headerTemplates" t-as="template" t-key="template.key">
+                    <t t-component="template.Component" t-props="template.props"/>
+                </t>
             </BuilderSelect>
         </BuilderRow>
 
@@ -317,5 +155,27 @@
                 </BuilderSelectItem>
             </BuilderSelect>
         </BuilderRow>
+    </t>
+
+    <t t-name="website.HeaderTemplateChoice">
+        <BuilderSelectItem
+            id="props.id"
+            title="props.title"
+            actionParam="[
+                {
+                    action: 'websiteConfig',
+                    actionParam: {
+                        views: props.views,
+                        vars: {
+                            'header-template': props.varName,
+                            'menu-shadow-class': props.menuShadowClass,
+                            'menu-box-shadow-style': null,
+                        },
+                        checkVars: false,
+                    },
+                }
+            ]">
+            <Image attrs="{ style: 'width: calc(100% - 0.5rem);' }" src="props.imgSrc"/>
+        </BuilderSelectItem>
     </t>
 </templates>


### PR DESCRIPTION
This commit refactors `HeaderTemplateOption` to use a provider-based resource instead of a hardcoded list in the template.

Previously, adding new header templates required using XPath to inject elements into the 'website.HeaderTemplateOption' template. This was inconsistent with the footer's implementation, which uses a resource provider.

This commit introduces the 'header_templates_providers' resource. The header option now iterates over provided templates, aligning the API with 'footer_templates_providers' and offering a cleaner extension point for customisation.

No functional changes are introduced.

task-5928790