### PR TITLE
[IMP] point_of_sale: Rename cash rounding setting

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -169,8 +169,8 @@ class PosConfig(models.Model):
     current_user_id = fields.Many2one('res.users', string='Current Session Responsible', compute='_compute_current_session_user')
     other_devices = fields.Boolean(string="Other Devices", help="Connect devices to your PoS without an IoT Box.")
     preparation_devices = fields.Boolean(string="Preparation devices", help="Connect preparation printers to print to the bar, kitchen,...")
-    rounding_method = fields.Many2one('account.cash.rounding', string="Cash rounding")
-    cash_rounding = fields.Boolean(string="Cash Rounding")
+    rounding_method = fields.Many2one('account.cash.rounding', string="Rounding Method")
+    cash_rounding = fields.Boolean(string="Total Rounding")
     only_round_cash_method = fields.Boolean(string="Only apply rounding on cash")
     has_active_session = fields.Boolean(compute='_compute_current_session')
     manual_discount = fields.Boolean(string="Line Discounts", default=True)
@@ -450,7 +450,7 @@ class PosConfig(models.Model):
                         selection_value = val
                         break
                 raise ValidationError(_(
-                    "The cash rounding strategy of the point of sale %(pos)s must be: '%(value)s'",
+                    "The rounding strategy of the point of sale %(pos)s must be: '%(value)s'",
                     pos=config.name,
                     value=selection_value,
                 ))

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1551,7 +1551,7 @@ class AccountCashRounding(models.Model):
         open_session = self.env['pos.session'].search([('config_id.rounding_method', 'in', self.ids), ('state', '!=', 'closed')], limit=1)
         if open_session:
             raise ValidationError(
-                _("You are not allowed to change the cash rounding configuration while a pos session using it is already opened."))
+                _("You are not allowed to change the rounding configuration while a pos session using it is already opened."))
 
     @api.model
     def _load_pos_data_domain(self, data, config):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -62,7 +62,7 @@ class ResConfigSettings(models.TransientModel):
     pos_amount_authorized_diff = fields.Float(related='pos_config_id.amount_authorized_diff', readonly=False)
     pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_pricelist_id', readonly=False, store=True)
     pos_cash_control = fields.Boolean(related='pos_config_id.cash_control')
-    pos_cash_rounding = fields.Boolean(related='pos_config_id.cash_rounding', readonly=False, string="Cash Rounding (PoS)")
+    pos_cash_rounding = fields.Boolean(related='pos_config_id.cash_rounding', readonly=False, string="Total Rounding (PoS)")
     pos_company_has_template = fields.Boolean(related='pos_config_id.company_has_template')
     pos_default_bill_ids = fields.Many2many(related='pos_config_id.default_bill_ids', readonly=False)
     pos_default_fiscal_position_id = fields.Many2one('account.fiscal.position', string='Default Fiscal Position', compute='_compute_pos_fiscal_positions', readonly=False, store=True, check_company=True)

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -87,7 +87,7 @@
                                 <setting string="Automatically validate order" help="Automatically validates orders paid with a payment terminal.">
                                     <field name="pos_auto_validate_terminal_payment"/>
                                 </setting>
-                                <setting string="Cash Rounding" invisible="use_kiosk_mode" documentation="/applications/sales/point_of_sale/pricing/cash_rounding.html" help="Define the smallest coinage of the currency used to pay by cash">
+                                <setting string="Total Rounding" invisible="use_kiosk_mode" documentation="/applications/sales/point_of_sale/pricing/cash_rounding.html" help="Define the smallest coinage of the currency used to pay by cash">
                                     <field name="pos_cash_rounding" readonly="pos_has_active_session"/>
                                     <div class="content-group mt16" invisible="not pos_cash_rounding">
                                         <div class="row mt16">
@@ -97,13 +97,13 @@
                                         <div class="row mt16">
                                             <div class="col">
                                                 <field name="pos_only_round_cash_method" readonly="pos_has_active_session"/>
-                                                <label string="Only on cash methods" for="pos_only_round_cash_method" class="o_light_label" />
+                                                <label string="Apply only on cash methods" for="pos_only_round_cash_method" class="o_light_label" />
                                             </div>
                                         </div>
                                     </div>
                                     <div class="mt8">
                                         <button name="%(account.rounding_list_action)d" icon="oi-arrow-right"
-                                                type="action" string="Cash Roundings" class="btn-link"
+                                                type="action" string="Roundings" class="btn-link"
                                                 invisible="not group_cash_rounding"/>
                                     </div>
                                 </setting>


### PR DESCRIPTION
In this commit we rename `Cash Rounding` to `Rounding` since rounding is no longer only used for cash methods.

Task: 5925260




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
