### PR TITLE
[FIX] pos_account_tax_python: FIX test race condition

### DIFF
--- a/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
+++ b/addons/pos_account_tax_python/static/tests/tours/test_taxes_tax_totals_summary.js
@@ -30,6 +30,7 @@ export function assertTaxTotals(baseAmount, taxAmount, totalAmount) {
         PaymentScreen.remainingIs("0.0"),
 
         PaymentScreen.clickInvoiceButton(),
+        PaymentScreen.isInvoiceButtonChecked(),
         PaymentScreen.clickValidate(),
 
         ReceiptScreen.receiptAmountTotalIs(totalAmount),


### PR DESCRIPTION
The `test_point_of_sale_custom_tax_with_extra_product_field` test does a `PaymentScreen.clickInvoiceButton()` and then directly after that a `PaymentScreen.clickValidate()`. In l10n scenarios, the logic behind triggering the `toInvoice` field can take longer. This would cause the validation to execute before the `toggleIsToInvoice` finishes executing and then it would throw an error that the order was already finalized.

This PR ads an extra wait on the `Invoice` button to make sure that the toggle is executed properly before finalizing the order.

Runbot Error: [233024](https://runbot.odoo.com/odoo/runbot.build.error/233024)
Task: [5897371](https://www.odoo.com/odoo/project/1737/tasks/5897371)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
