### PR TITLE
[IMP] account: add a country-specific check for structured reference validity

### DIFF
--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -9,6 +9,7 @@ from odoo.addons.account.tools import (
     is_valid_structured_reference_si,
     is_valid_structured_reference_iso,
     is_valid_structured_reference,
+    is_valid_structured_reference_for_country,
 )
 
 
@@ -168,3 +169,18 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference('1234567898'))  # NO-SE
         self.assertFalse(is_valid_structured_reference('6000056789012345'))  # NL
         self.assertFalse(is_valid_structured_reference("SI01 19-1235-84504"))  # SI
+
+    def test_structured_reference_for_country(self):
+        # Valid structured references for supported countries
+        self.assertTrue(is_valid_structured_reference_for_country('***020/3430/57642***', 'BE'))
+        self.assertTrue(is_valid_structured_reference_for_country('2023 0000 98', 'FI'))
+        self.assertTrue(is_valid_structured_reference_for_country('1234 5678 97', 'NO'))
+        self.assertTrue(is_valid_structured_reference_for_country('1234 5678 97', 'SE'))
+        self.assertTrue(is_valid_structured_reference_for_country('5000056789012345', 'NL'))
+        self.assertTrue(is_valid_structured_reference_for_country('SI01 25-20-85', 'SI'))
+
+        # Fallback to ISO 11649 for unsupported countries
+        self.assertTrue(is_valid_structured_reference_for_country('RF18 5390 0754 7034 ', 'FR'))
+
+        # Returns False for invalid references
+        self.assertFalse(is_valid_structured_reference_for_country(''))

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -168,3 +168,25 @@ def is_valid_structured_reference(reference):
         is_valid_structured_reference_si(reference) or
         is_valid_structured_reference_iso(reference)
     )
+
+
+def is_valid_structured_reference_for_country(reference, country_code=''):
+    """Check the validity of the reference's structure for a specific country or ISO 11649 as a fallback.
+
+    :param reference: the reference to check
+    :param country_code: the country code to check against
+    :return: True if reference is a structured reference for the given country or ISO 11649, False otherwise
+    """
+    check_per_country = {
+        'BE': is_valid_structured_reference_be,
+        'FI': is_valid_structured_reference_fi,
+        'NO': is_valid_structured_reference_no_se,
+        'SE': is_valid_structured_reference_no_se,
+        'NL': is_valid_structured_reference_nl,
+        'SI': is_valid_structured_reference_si,
+    }
+
+    reference = sanitize_structured_reference(reference or '')
+    if check := check_per_country.get(country_code.upper()):
+        return check(reference)
+    return is_valid_structured_reference_iso(reference)


### PR DESCRIPTION
Currently, when initiating a payment, we check if the reference is a
structured one by using `is_valid_structured_reference` which checks
the validity of the structure accross all supported countries.

This can lead to issues when it matches formats accepted by other
countries but not the one of the bank account.

With this commit, we replace this check by a call to a new function that
checks the structure validity according to the country of the bank account,
with a fallback to the generic check (ISO 11649) if the country is not supported.

opw-5387269
