### PR TITLE
[FIX] project_timesheet_holidays: correct timesheet hours for multiple contracts

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_leave.py
+++ b/addons/project_timesheet_holidays/models/hr_leave.py
@@ -33,7 +33,7 @@ class HrLeave(models.Model):
             if not leave.employee_id:
                 continue
 
-            calendar = leave.employee_id.resource_calendar_id
+            calendar = leave.resource_calendar_id
             calendar_timezone = pytz.timezone((calendar or leave.employee_id).tz)
 
             if calendar.flexible_hours and (leave.request_unit_hours or leave.request_unit_half or leave.date_from.date() == leave.date_to.date()):
@@ -52,7 +52,9 @@ class HrLeave(models.Model):
                 work_hours_data = leave.employee_id._list_work_time_per_day(
                     leave.date_from,
                     leave.date_to,
-                    domain=[('id', 'not in', ignored_resource_calendar_leaves)] if ignored_resource_calendar_leaves else None)[leave.employee_id.id]
+                    domain=[('id', 'not in', ignored_resource_calendar_leaves)] if ignored_resource_calendar_leaves else None,
+                    calendar=calendar,
+                )[leave.employee_id.id]
 
             for index, (day_date, work_hours_count) in enumerate(work_hours_data):
                 vals_list.append(leave._timesheet_prepare_line_values(index, work_hours_data, day_date, work_hours_count, project, task))

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -380,3 +380,59 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         time_off.with_user(SUPERUSER_ID)._action_validate()
 
         self.assertEqual(time_off.state, 'validate', "The time off for a fully flexible employee should be validated")
+
+    def test_timesheet_generation_with_past_contract_timeoff(self):
+        """
+        Test that timesheets are correctly generated for time off requests that with past contracts.
+        """
+        # Define attendance lines for the standard 35h/week to prevent auto-generating the default 8h/day schedule.
+        attendance_lines = []
+        for i in range(5):
+            attendance_lines.extend([
+                (0, 0, {'name': 'Morning', 'dayofweek': str(i), 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Afternoon', 'dayofweek': str(i), 'hour_from': 13.0, 'hour_to': 16.0, 'day_period': 'afternoon'}),
+            ])
+        standard_35h_calendar = self.env['resource.calendar'].create({
+            'name': 'Standard 35h/week',
+            'hours_per_day': 7,
+            'attendance_ids': attendance_lines,
+            'flexible_hours': False,
+        })
+        self.env['hr.version'].create([
+            {
+                'name': 'Past Contract 40h',
+                'employee_id': self.empl_employee.id,
+                'resource_calendar_id': self.employee_working_calendar.id,
+                'contract_date_start': '2025-01-01',
+                'contract_date_end': '2025-12-31',
+                'date_version': '2025-01-01',
+            }, {
+                'name': 'Current Contract 35h',
+                'employee_id': self.empl_employee.id,
+                'resource_calendar_id': standard_35h_calendar.id,
+                'contract_date_start': '2026-01-01',
+                'date_version': '2026-01-01',
+            },
+        ])
+        self.empl_employee.resource_calendar_id = standard_35h_calendar.id
+        past_leave, current_leave = self.env['hr.leave'].sudo().create([
+            {
+                'name': "leave with past contract",
+                'holiday_status_id': self.hr_leave_type_with_ts.id,
+                'employee_id': self.empl_employee.id,
+                'request_date_from': datetime(2025, 12, 29, 8, 0),
+                'request_date_to': datetime(2025, 12, 29, 17, 0),
+            }, {
+                'name': "leave with current contract",
+                'holiday_status_id': self.hr_leave_type_with_ts.id,
+                'employee_id': self.empl_employee.id,
+                'request_date_from': datetime(2026, 2, 2, 8, 0),
+                'request_date_to': datetime(2026, 2, 2, 17, 0),
+            },
+        ])
+        (past_leave | current_leave).with_user(SUPERUSER_ID).action_approve()
+
+        self.assertTrue(len(past_leave.timesheet_ids), 1)
+        self.assertTrue(len(current_leave.timesheet_ids), 1)
+        self.assertEqual(past_leave.timesheet_ids.unit_amount, 8, "The timesheet for the past contract should have 8 hours")
+        self.assertEqual(current_leave.timesheet_ids.unit_amount, 7, "The timesheet for the Current contract should have 7 hours")


### PR DESCRIPTION
Currently on creating a time off that falls under a past contract still generates timesheet hours based on the employee's current contract.

### **Steps to Reproduce:**
1) Install `project_timesheet_holidays` module with demo data. 
2) Create an employee with two contracts/versions:
-  Past contract: 1 Jan 2025 to 31 Dec 2025 with standard 40h/week (8h/day).
-  Current contract: 1 Jan 2026 to indefinite with standard 35h/week (7h/day). 
3) Create and validate Time off for this employee in the past (e.g, 29 Dec 2025) 
4) Navigate to `Timesheets>All Timesheets`, search for this employee and switch
   list view for clear view.

### **Observed Behavior:**
7:00 hours are displayed on the timesheet, pulling from the employee's current active contract calendar.

### **Expected Behavior:**
8:00 hours should be displayed, as the leave date falls under the 40h/week past contract.

### **Root Cause:**
In the `_generate_timesheets`, the caledar values is fetched using `employee_id.resource_calendar_id` see[1], which always points to the employee's currently active calendar. Furthermore, this calendar is not explicitly passed to `_list_work_time_per_day` see[1], causing the method to fall back on the current default.

[1]- https://github.com/odoo/odoo/blob/c2595e47e3b36120f4c3da8bfe8c16f6c5969a70/addons/project_timesheet_holidays/models/hr_leave.py#L36-L55

### **Fix:**
Change the logic to use `leave.resource_calendar_id`, which correctly computes and retrieves the resource calendar active during the specific `date_from` and `date_to` of the leave and pass this `calendar` to `_list_work_time_per_day` to ensure the correct historical hours are used for timesheet generation.

**opw-5922695**