### PR TITLE
[IMP] mail, portal: support extra params in message fetch methods

### DIFF
--- a/addons/mail/static/src/chatter/web/thread_model_patch.js
+++ b/addons/mail/static/src/chatter/web/thread_model_patch.js
@@ -9,7 +9,7 @@ const threadPatch = {
     async fetchThreadData(requestList) {
         this.isLoadingAttachments =
             this.isLoadingAttachments || requestList.includes("attachments");
-        await super.fetchThreadData(requestList);
+        await super.fetchThreadData(...arguments);
         if (!this.message_main_attachment_id && this.attachmentsInWebClientView.length > 0) {
             this.setMainAttachmentFromIndex(0);
         }

--- a/addons/mail/static/src/chatter/web_portal_project/@types/models.d.ts
+++ b/addons/mail/static/src/chatter/web_portal_project/@types/models.d.ts
@@ -1,5 +1,5 @@
 declare module "models" {
     export interface Thread {
-        fetchThreadData: (requestList: string[]) => Promise<void>;
+        fetchThreadData: (requestList: string[], param0: { messageFetchRouteParams: MessageRouteParams }) => Promise<void>;
     }
 }

--- a/addons/mail/static/src/chatter/web_portal_project/thread_model_patch.js
+++ b/addons/mail/static/src/chatter/web_portal_project/thread_model_patch.js
@@ -2,10 +2,14 @@ import { Thread } from "@mail/core/common/thread_model";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
-    /** @param {string[]} requestList */
-    async fetchThreadData(requestList) {
+    /**
+     * @param {string[]} requestList
+     * @param {Object} [options]
+     * @param {MessageRouteParams} [options.messageFetchRouteParams]
+     */
+    async fetchThreadData(requestList, { messageFetchRouteParams = {} } = {}) {
         if (requestList.includes("messages")) {
-            this.fetchNewMessages();
+            this.fetchNewMessages({ routeParams: messageFetchRouteParams });
         }
         await this.store.fetchStoreData("mail.thread", {
             access_params: this.rpcParams,

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -43,7 +43,7 @@ export class ChatWindow extends Component {
         super.setup();
         useSubEnv({ inChatWindow: true });
         this.store = useService("mail.store");
-        this.messageHighlight = useMessageScrolling();
+        this.messageHighlight = useMessageScrolling({ thread: () => this.channel?.thread });
         this.state = useState({
             actionsMenuOpened: false,
             jumpThreadPresent: 0,

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -34,7 +34,7 @@
             </div>
             <div class="o-mail-Composer-coreHeader">
                 <div t-if="props.composer.replyToMessage" class="text-truncate small p-2">
-                    <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.composer.replyToMessage, props.composer.thread)">
+                    <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.composer.replyToMessage)">
                         Replying to <b t-esc="props.composer.replyToMessage.authorName"/>
                     </span>
                     <span t-if="props.composer.replyToMessage.thread?.notEq(props.composer.thread)">

--- a/addons/mail/static/src/core/common/message_card_list.js
+++ b/addons/mail/static/src/core/common/message_card_list.js
@@ -61,7 +61,7 @@ export class MessageCardList extends Component {
         }
         // Give the time for menus to close before scrolling to the message.
         await new Promise((resolve) => setTimeout(() => requestAnimationFrame(resolve)));
-        await this.env.messageHighlight?.highlightMessage(message, this.props.thread);
+        await this.env.messageHighlight?.highlightMessage(message);
     }
 
     onClickUnpin(message) {

--- a/addons/mail/static/src/core/common/notification_message.js
+++ b/addons/mail/static/src/core/common/notification_message.js
@@ -29,8 +29,7 @@ export class NotificationMessage extends Component {
                     res_id: this.props.thread.id,
                     model: this.props.thread.model,
                     thread: this.props.thread,
-                }),
-                this.props.thread
+                })
             );
         }
     }

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -117,7 +117,9 @@ export class Thread extends Component {
                     this.smoothScrollingDeferred,
                 ]);
                 if (this.loadOlderState.isVisible) {
-                    toRaw(this.props.thread).fetchMoreMessages();
+                    toRaw(this.props.thread).fetchMoreMessages({
+                        routeParams: this.messageFetchRouteParams,
+                    });
                 }
             },
             { ready: false }
@@ -130,7 +132,10 @@ export class Thread extends Component {
                     this.smoothScrollingDeferred,
                 ]);
                 if (this.loadNewerState.isVisible) {
-                    toRaw(this.props.thread).fetchMoreMessages("newer");
+                    toRaw(this.props.thread).fetchMoreMessages({
+                        epoch: "newer",
+                        routeParams: this.messageFetchRouteParams,
+                    });
                 }
             },
             { ready: false }
@@ -169,10 +174,7 @@ export class Thread extends Component {
         useLayoutEffect(
             () => {
                 if (this.props.thread.highlightMessage && this.state.mountedAndLoaded) {
-                    this.messageHighlight?.highlightMessage(
-                        this.props.thread.highlightMessage,
-                        this.props.thread
-                    );
+                    this.messageHighlight?.highlightMessage(this.props.thread.highlightMessage);
                     this.props.thread.highlightMessage = null;
                 }
             },
@@ -489,8 +491,12 @@ export class Thread extends Component {
         return true;
     }
 
+    get messageFetchRouteParams() {
+        return this.env.messageFetchRouteParams;
+    }
+
     fetchInitialMessages() {
-        toRaw(this.props.thread).fetchNewMessages();
+        toRaw(this.props.thread).fetchNewMessages({ routeParams: this.messageFetchRouteParams });
     }
 
     get viewportEl() {
@@ -515,7 +521,7 @@ export class Thread extends Component {
     }
 
     onClickLoadOlder() {
-        this.props.thread.fetchMoreMessages();
+        this.props.thread.fetchMoreMessages({ routeParams: this.messageFetchRouteParams });
     }
 
     async onClickPreferences() {
@@ -547,7 +553,7 @@ export class Thread extends Component {
     async jumpToPresent({ immediate = false } = {}) {
         this.messageHighlight?.clear();
         if (!immediate || this.props.thread.loadNewer) {
-            await this.props.thread.loadAround();
+            await this.props.thread.loadAround({ routeParams: this.messageFetchRouteParams });
             this.props.thread.loadNewer = false;
             this.state.showJumpPresent = false;
         }

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -33,7 +33,7 @@
                         messageRefs="messageRefs"
                         previousMessage="prevMsg"
                         squashed="isSquashed(msg, prevMsg)"
-                        onParentMessageClick.bind="() => msg.parent_id and env.messageHighlight?.highlightMessage(msg.parent_id, props.thread)"
+                        onParentMessageClick.bind="() => msg.parent_id and env.messageHighlight?.highlightMessage(msg.parent_id)"
                         thread="props.thread"
                         isFirstMessage="msg_first"
                         hasActions="!msg.eq(channel?.from_message_id)"

--- a/addons/mail/static/src/core/public_web/discuss_app/discuss_app.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/discuss_app.js
@@ -25,7 +25,7 @@ export class Discuss extends Component {
     setup() {
         super.setup();
         this.store = useService("mail.store");
-        this.messageHighlight = useMessageScrolling();
+        this.messageHighlight = useMessageScrolling({ thread: () => this.thread });
         this.root = useRef("root");
         this.orm = useService("orm");
         this.effect = useService("effect");

--- a/addons/mail/static/src/discuss/call/common/meeting.js
+++ b/addons/mail/static/src/discuss/call/common/meeting.js
@@ -59,7 +59,7 @@ export class Meeting extends Component {
             },
         });
         this.threadActions = useThreadActions({ thread: () => this.channel.thread });
-        this.messageHighlight = useMessageScrolling();
+        this.messageHighlight = useMessageScrolling({ thread: () => this.channel.thread });
         this.messageSearch = useMessageSearch(this.channel.thread);
         useChildSubEnv({
             closeActionPanel: () => this.threadActions.activeAction?.actionPanelClose(),

--- a/addons/mail/static/src/discuss/core/common/thread_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.js
@@ -59,7 +59,9 @@ const threadPatch = {
     /** @override */
     fetchInitialMessages() {
         if (this.channel?.self_member_id && this.props.thread.scrollUnread) {
-            toRaw(this.props.thread).loadAround(this.channel.self_member_id.new_message_separator);
+            toRaw(this.props.thread).loadAround({
+                messageId: this.channel.self_member_id.new_message_separator,
+            });
         } else {
             super.fetchInitialMessages();
         }
@@ -71,11 +73,10 @@ const threadPatch = {
         return _t("1 new message");
     },
     async onClickUnreadMessagesBanner() {
-        await this.props.thread.loadAround(this.channel.self_member_id.new_message_separator_ui);
-        this.messageHighlight?.highlightMessage(
-            this.props.thread.firstUnreadMessage,
-            this.props.thread
-        );
+        await this.props.thread.loadAround({
+            messageId: this.channel.self_member_id.new_message_separator_ui,
+        });
+        this.messageHighlight?.highlightMessage(this.props.thread.firstUnreadMessage);
     },
 };
 patch(Thread.prototype, threadPatch);

--- a/addons/portal/static/src/chatter/portal/chatter_patch.js
+++ b/addons/portal/static/src/chatter/portal/chatter_patch.js
@@ -33,4 +33,8 @@ patch(Chatter.prototype, {
             () => [this.topRef.el]
         );
     },
+
+    get extraMessageFetchRouteParams() {
+        return super.extraMessageFetchRouteParams;
+    },
 });

--- a/addons/portal/static/src/chatter/portal/portal_chatter.js
+++ b/addons/portal/static/src/chatter/portal/portal_chatter.js
@@ -30,6 +30,6 @@ export class PortalChatter extends Component {
             id: this.props.resId,
             model: this.props.resModel,
         });
-        thread.messages = await thread.fetchMessages();
+        thread.messages = await thread.fetchMessages({ routeParams: this.messageFetchRouteParams });
     }
 }

--- a/addons/project/static/src/project_sharing/chatter/chatter_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/chatter_patch.js
@@ -18,6 +18,10 @@ patch(Chatter.prototype, {
         });
     },
 
+    get extraMessageFetchRouteParams() {
+        return super.extraMessageFetchRouteParams;
+    },
+
     async toggleIsFollower() {
         this.state.isFollower = await this.orm.call(
             this.props.threadModel,


### PR DESCRIPTION
This is a preparation change for replacing the portal chatter fetch route with
the mail fetch route.
Fetch methods can now receive extra fetch params from the caller components if
needed, making it possible to inform the server when a request originates from
the portal. This allows the server to apply specific limitations required for
portal chatter.

The change also involves a minor refactoring of the `useMessageScrolling` hook,
which makes the thread built-in and removes the need to pass it as a parameter
in every call. Extra fetch params could also be passed through another callback
in the same way.

[Enterprise PR](https://github.com/odoo/enterprise/pull/107640)

