### PR TITLE
[FIX] im_livechat: define chatbot field in core bundle to avoid traceback

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -7,6 +7,7 @@ import { patch } from "@web/core/utils/patch";
 patch(Thread.prototype, {
     setup() {
         super.setup();
+        this.chatbot = fields.One("Chatbot");
         this.livechat_operator_id = fields.One("Persona");
         this.livechatVisitorMember = fields.One("discuss.channel.member", {
             compute() {

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -53,7 +53,6 @@ patch(Thread.prototype, {
          * @type {Deferred}
          */
         this.readyToSwapDeferred = new Deferred();
-        this.chatbot = fields.One("Chatbot");
         this.livechat_active = false;
         this._toggleChatbot = fields.Attr(false, {
             compute() {


### PR DESCRIPTION
Using a chatbot while the website editor is active triggers a traceback. The issue occurs because bus notifications containing `Chatbot` model data are also received by the backend bundle.

In the backend bundle, the `Thread` model did not define the `chatbot` field, so the inverse thread relation on the `Chatbot` model could not be resolved, leading to a crash.

This commit adds the chatbot field to the core bundle so it is available in all contexts and prevents the traceback.

Steps to reproduce:
- Goto localhost:8069/@/contactus
- Start chatbot
- Answer any question -> traceback

task-5924295