### PR TITLE
[FIX] pos_self_order: prevent already sent items in Pay-After-Meal kitchen print

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -499,9 +499,17 @@ export class SelfOrder extends Reactive {
                 order,
                 Object.values(printer.config.product_categories_ids)
             );
+            const lastsentlines = order.uiState.lastSentPreparationChange?.lines || {};
             if (orderlines.length > 0) {
                 const printingChanges = {
-                    new: orderlines,
+                    new: orderlines
+                        .map((line) => ({
+                            qty: line.qty - (lastsentlines[line.uuid]?.quantity || 0),
+                            full_product_name: line.full_product_name,
+                            customer_note: line.customer_note,
+                            combo_parent_id: line.combo_parent_id,
+                        }))
+                        .filter((line) => line.qty > 0),
                     tracker: order.table_stand_number,
                     trackingNumber: order.tracking_number || "unknown number",
                     name: order.pos_reference || "unknown order",
@@ -649,6 +657,9 @@ export class SelfOrder extends Reactive {
             const tableIdentifier = this.router.getTableIdentifier([]);
             let uuid = this.selectedOrderUuid;
             this.currentOrder.recomputeOrderData();
+            this.currentOrder.uiState.lastSentPreparationChange = JSON.parse(
+                JSON.stringify(this.currentOrder.last_order_preparation_change)
+            );
             if (this.shouldUpdateLastOrderChange()) {
                 this.currentOrder.updateLastOrderChange();
             }


### PR DESCRIPTION

Steps to Reproduce:
-------------------
1. Place a self-order (Mobile / Pay-After-Meal).
2. Add a second order.
3. Kitchen print shows old + new items instead of only the new ones.

Issue:
-------------
Pay-After-Meal flow, kitchen prints included previously sent items. 

Cause:
-----------
all orderlines were sent to the kitchen instead of only new changes.

Fix:
------------
Send only newly added/updated lines to the kitchen

Task-5929555
Related PR: https://github.com/odoo/enterprise/pull/107129
