### PR TITLE
[FIX] stock: prevent traceback when generating serial/lot numbers

### DIFF
--- a/addons/stock/static/src/widgets/lots_dialog.xml
+++ b/addons/stock/static/src/widgets/lots_dialog.xml
@@ -33,7 +33,8 @@
                             </div>
                             <div class="o_cell flex-grow-1 flex-sm-grow-0">
                                 <div name="next_serial_count" class="o_field_widget o_field_integer">
-                                    <input inputmode="numeric" t-ref="nextSerialCount" class="o_input" id="next_serial_count_0" type="text"/>
+                                    <input inputmode="numeric" t-ref="nextSerialCount" class="o_input" id="next_serial_count_0" type="number"
+                                        t-on-keydown="(ev) => ev.key === '.' and ev.preventDefault()"/>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Issue before this commit:
=========================
When generating serial/lot numbers, if a user enters a `string value (e.g. "dhha" or ".")`
in the `Number of SN` field of the Generate Serials/Lots wizard, 
a traceback is raised: `InvalidNumberError: "dhha" is not a correct number`.

Steps to Reproduce:
=========================
- Install the "stock" module.
- Create a receipt for a serial-tracked product.
- Open the detailed operations.
- Click on "Generate Serials/Lots".
- Enter a string value in the "Number of SN" field.

Result: A traceback is raised with:
InvalidNumberError: `"dhha" is not a correct number.`

Cause of the issue:
=========================
The [next_serial_count input](https://github.com/odoo/odoo/blob/17.0/addons/stock/static/src/widgets/lots_dialog.xml#L36) 
field is defined as type="text", which allows users to enter string values, 
even though the field represents a numeric count. The value is later processed using [parseInteger](https://github.com/odoo/odoo/blob/17.0/addons/stock/static/src/widgets/generate_serial.js#L33), 
which throws an error when the input is not a valid integer string, [Here](https://github.com/odoo/odoo/blob/17.0/addons/web/static/src/views/fields/parsers.js#L139).

With This Commit:
=========================
The input type is changed from type="text" to type="number", ensuring that 
only numeric values can be entered. This prevents invalid input and avoids the 
traceback when generating serial or lot numbers.
Additionally, a `t-on-keydown` handler is added to prevent entering a `dot (.)`,
ensuring that only integer values are allowed.