### PR TITLE
[FIX] im_livechat: prevent traceback on tab press in chatter

### DIFF
--- a/addons/im_livechat/static/src/core/web/composer_patch.js
+++ b/addons/im_livechat/static/src/core/web/composer_patch.js
@@ -9,7 +9,7 @@ const composerPatch = {
         super.onKeydown(ev);
         if (
             ev.key === "Tab" &&
-            this.thread?.channel.channel_type === "livechat" &&
+            this.thread?.channel?.channel_type === "livechat" &&
             !this.props.composer.composerText
         ) {
             const threadChanged = this.store.goToOldestUnreadLivechatThread();


### PR DESCRIPTION
**Steps to Reproduce:**
Install 'Live Chat'
Open any record with a chatter
Click Send Message to focus the composer
Press the 'Tab' key on the keyboard

**Current behavior before PR:**
A traceback occurs because the code attempts to read 'channel_type' from a 
channel field that is undefined in standard threads.

**Desired behavior after PR is merged:**
A guard is added to the channel field. Pressing Tab no longer causes an error.

task-5925393

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
