### PR TITLE
[FIX] base,html_editor: add missing check_translations context

### DIFF
--- a/addons/html_editor/models/ir_ui_view.py
+++ b/addons/html_editor/models/ir_ui_view.py
@@ -172,6 +172,8 @@ class IrUiView(models.Model):
 
         # 1. Get translations
         records_from.flush_model([name_field_from])
+        records_from = records_from.with_context(check_translations=True)
+        record_to = record_to.with_context(check_translations=True)
         existing_translation_dictionary = field_to.get_translation_dictionary(
             record_to[name_field_to],
             {lang: record_to.with_context(prefetch_langs=True, lang=lang)[name_field_to] for lang in langs if lang != lang_env}
@@ -202,7 +204,7 @@ class IrUiView(models.Model):
         }
         record_to.env.cache.update_raw(record_to, field_to, [new_value], dirty=True)
         # Call `write` to trigger compute etc (`modified()`)
-        record_to[name_field_to] = new_value[lang_env]
+        record_to.with_context(check_translations=False)[name_field_to] = new_value[lang_env]
 
     @api.model
     def _save_oe_structure_hook(self):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -216,8 +216,8 @@ actual arch.
             return re.sub(r'(?P<prefix>[^%])%\((?P<xmlid>.*?)\)[ds]', replacer, arch_fs)
 
         lang = self.env.lang or 'en_US'
-        env_en = self.with_context(edit_translations=None, lang='en_US').env
-        env_lang = self.with_context(lang=lang).env
+        env_en = self.with_context(edit_translations=None, lang='en_US', check_translations=True).env
+        env_lang = self.with_context(lang=lang, check_translations=True).env
         field_arch_db = self._fields['arch_db']
         for view in self:
             arch_fs = None


### PR DESCRIPTION
Add missing ``check_translations`` context when translating fields. This prevents fetching dalay translation values that may have a different number of terms and cause inconsistencies.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
