### PR TITLE
[FIX] mrp: add 'copy existing operations' button in bom operation tab

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -50,6 +50,9 @@ class MrpBom(models.Model):
     sequence = fields.Integer('Sequence')
     operation_ids = fields.One2many('mrp.routing.workcenter', 'bom_id', 'Operations', copy=True)
     operation_count = fields.Integer('Operations Count', compute='_compute_operation_count')
+    show_copy_operations_button = fields.Boolean(
+        compute="_compute_show_copy_operations_button",
+        help="Technical field used to control the visibility of the 'Copy Existing Operations' button.")
     ready_to_produce = fields.Selection([
         ('all_available', ' When all components are available'),
         ('asap', 'When components for 1st operation are available')], string='Manufacturing Readiness',
@@ -325,6 +328,10 @@ class MrpBom(models.Model):
     def _compute_operation_count(self):
         for bom in self:
             bom.operation_count = len(bom.operation_ids)
+
+    def _compute_show_copy_operations_button(self):
+        exist_operation = bool(self.env['mrp.routing.workcenter'].search_count([], limit=1))
+        self.show_copy_operations_button = exist_operation
 
     def action_compute_bom_days(self):
         company_id = self.env.context.get('default_company_id', self.env.company.id)
@@ -651,6 +658,10 @@ class MrpBom(models.Model):
                 'bom_id_invisible': True,
             },
         }
+
+    def action_copy_existing_operations(self):
+        self.ensure_one()
+        return self.env['mrp.routing.workcenter'].with_context(bom_id=self.id).copy_existing_operations()
 
 
 class MrpBomLine(models.Model):

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2872,6 +2872,18 @@ class TestBoM(TestMrpCommon):
         bom_overview = self.env['report.mrp.report_bom_structure']._get_report_data(bom.id, 1.6)['lines']
         self.assertEqual(bom_overview['operations_time'], 32)
 
+    def test_copy_existing_operations_button_visible_even_for_first_operation(self):
+        """
+        Test that the 'Copy Existing Operations' button is visible
+        once at least one operation exists even on an empty BoM.
+        """
+        self.assertFalse(self.bom_1.operation_ids)
+        self.assertTrue(self.bom_1.show_copy_operations_button, "The copy operations button should be visible even if the current BoM is empty.")
+
+        # Delete all existing operations, the copy operations buttons shouldn't be visible if there is none.
+        self.env['mrp.routing.workcenter'].search([]).unlink()
+        self.assertFalse(self.bom_1.show_copy_operations_button, "The copy operations button should be visible even if the current BoM is empty.")
+
 
 @tagged('-at_install', 'post_install')
 class TestTourBoM(HttpCase):

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -135,9 +135,12 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="d-flex justify-content-center" invisible="operation_ids.length != 0">
+                                <div class="d-flex justify-content-center gap-1" invisible="operation_ids.length != 0">
                                     <button name="action_open_operation_form" type="object" class="btn btn-primary">
                                         <span class="o_stat_text">Add Operation</span>
+                                    </button>
+                                    <button name="action_copy_existing_operations" type="object" invisible="not show_copy_operations_button">
+                                        <span class="o_stat_text">Copy Existing Operations</span>
                                     </button>
                                 </div>
                         </page>


### PR DESCRIPTION
### Steps to reproduce the bug:
- Install mrp
- Go to manufacturing app
- Go to products -> bills of materials
- Create a new bill of material for a product
- Go to the operations tab
- No 'copy existing operations' button appears if at least one operation
 is already created

### The problem:
In version 19.0, the "Copy Existing Operations" button is missing from
the BoM operations tab when no operations have been defined yet for the
current BoM. While this feature was fully functional in version 18.4,
it became inaccessible in 19.0 to users due to a UI reorganization
introduced in commit https://github.com/odoo/odoo/commit/80e6ed658fb43584bc2fad673ca40d9af6cf0ab6 that accidentally omitted the "Copy
Existing Operations" button. Currently, users are forced to manually
create at least one operation before they can see the option to copy
from other BoMs.

### The reason to introduce the fix:
The ability to copy operations is useful also when starting with an
empty BoM if operations in other BoM's have been already created. Since
this fix has already been implemented in version 19.1 via commit https://github.com/odoo/odoo/commit/02e837c959381523170c653da099328e9855a4e4,
this PR backports that changes to 19.0 to restore feature parity and
improve the user experience.

opw-5906667