### PR TITLE
[ADD] *: Kuwait localization data

### DIFF
--- a/addons/hr_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_holidays/data/hr_leave_type_data.xml
@@ -549,6 +549,49 @@
         <field name="country_id" ref="base.jo"/>
     </record>
 
+<!-- KW : Kuwait -->
+    <record id="l10n_kw_leave_type_maternity_leave" model="hr.leave.type">
+        <field name="name">Maternity Leave</field>
+        <field name="requires_allocation">no</field>
+        <field name="leave_validation_type">hr</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
+    <record id="l10n_kw_leave_type_study_leave" model="hr.leave.type">
+        <field name="name">Study Leave</field>
+        <field name="requires_allocation">no</field>
+        <field name="leave_validation_type">hr</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
+    <record id="l10n_kw_leave_type_hajj_leave" model="hr.leave.type">
+        <field name="name">Hajj Leave</field>
+        <field name="requires_allocation">no</field>
+        <field name="leave_validation_type">hr</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
+    <record id="l10n_kw_leave_type_compassionate_leave" model="hr.leave.type">
+        <field name="name">Compassionate Leave</field>
+        <field name="requires_allocation">no</field>
+        <field name="leave_validation_type">hr</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
+    <record id="l10n_kw_leave_type_sick_leave" model="hr.leave.type">
+        <field name="name">Sick Leave</field>
+        <field name="requires_allocation">no</field>
+        <field name="leave_validation_type">both</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
+    <record id="l10n_kw_leave_type_annual_leave" model="hr.leave.type">
+        <field name="name">Annual Leave</field>
+        <field name="requires_allocation">yes</field>
+        <field name="leave_validation_type">both</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
 <!-- LU : Luxemburg -->
     <record id="l10n_lu_leave_type_situational_unemployment" model="hr.leave.type">
         <field name="name">Unemployment (Weather / Situational)</field>

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -763,6 +763,23 @@
         <field name="amount_rate">1</field>  <!-- Unpaid, but treated in a separate rule -->
     </record>
 
+<!-- KW : Kuwait -->
+    <record id="l10n_kw_work_entry_type_paid_leave" model="hr.work.entry.type">
+        <field name="name">Kuwait: Paid Leave</field>
+        <field name="code">KWLEAVE</field>
+        <field name="color">3</field>
+        <field name="is_leave">True</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
+    <record id="l10n_kw_work_entry_type_sick_leave" model="hr.work.entry.type">
+        <field name="name">Kuwait: Sick Leave</field>
+        <field name="code">KWSICK</field>
+        <field name="color">4</field>
+        <field name="is_leave">True</field>
+        <field name="country_id" ref="base.kw"/>
+    </record>
+
 <!-- LU : Luxemburg -->
     <record id="l10n_lu_work_entry_type_situational_unemployment" model="hr.work.entry.type">
         <field name="name">Situational Unemployment</field>

--- a/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
@@ -198,6 +198,30 @@
         <field name="work_entry_type_id" ref="hr_work_entry.l10n_jo_work_entry_type_sick_leave_unpaid"/>
     </record>
 
+<!-- KW : Kuwait -->
+    <record id="hr_holidays.l10n_kw_leave_type_maternity_leave" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.l10n_kw_work_entry_type_paid_leave"/>
+    </record>
+    <record id="hr_holidays.l10n_kw_leave_type_study_leave" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.l10n_kw_work_entry_type_paid_leave"/>
+    </record>
+
+    <record id="hr_holidays.l10n_kw_leave_type_hajj_leave" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.l10n_kw_work_entry_type_paid_leave"/>
+    </record>
+
+    <record id="hr_holidays.l10n_kw_leave_type_compassionate_leave" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.l10n_kw_work_entry_type_paid_leave"/>
+    </record>
+
+    <record id="hr_holidays.l10n_kw_leave_type_sick_leave" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.l10n_kw_work_entry_type_sick_leave"/>
+    </record>
+
+    <record id="hr_holidays.l10n_kw_leave_type_annual_leave" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_legal_leave"/>
+    </record>
+
 <!-- LU : Luxembourg -->
     <record id="hr_holidays.l10n_lu_leave_type_situational_unemployment" model="hr.leave.type">
         <field name="work_entry_type_id" ref="hr_work_entry.l10n_lu_work_entry_type_situational_unemployment"/>


### PR DESCRIPTION
* = {hr_holidays, hr_work_entry, hr_work_entry_holidays}

Introduce standard leave types and work entry types for the Kuwait localization in the standard modules. This ensures that Kuwaiti companies have the legally required leave types available out-of-the-box and that they map correctly to work entries for payroll purposes.

Technical summary:

hr_holidays:
- Added Kuwait-specific Leave Types restricted by country_id:
  - Maternity Leave
  - Study Leave
  - Hajj Leave
  - Compassionate Leave
  - Sick Leave
  - Annual Leave

hr_work_entry:
- Added Kuwait-specific Work Entry Types:
  - Kuwait: Paid Leave (KWLEAVE)
  - Kuwait: Sick Leave (KWSICK)

hr_work_entry_holidays:
- Linked the new Leave Types to their corresponding Work Entry Types:
  - Maternity, Study, Hajj, Compassionate -> Kuwait: Paid Leave
  - Sick Leave -> Kuwait: Sick Leave
  - Annual Leave -> Standard Legal Leave

task-5116274

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
