### PR TITLE
[FIX] html_editor: turn tabs to four spaces inside monospace banner

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -1,6 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { fillEmpty, fillShrunkPhrasingParent } from "@html_editor/utils/dom";
-import { closestElement } from "@html_editor/utils/dom_traversal";
+import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { withSequence } from "@html_editor/utils/resource";
 import { htmlEscape } from "@odoo/owl";
@@ -108,6 +108,10 @@ export class BannerPlugin extends Plugin {
                 categoryId: "banner",
             },
         ],
+        normalize_handlers: withSequence(
+            5, // before tabs are aligned
+            this.handle_monospace_tab_to_spaces.bind(this)
+        ),
         power_buttons_visibility_predicates: ({ anchorNode }) =>
             !closestElement(anchorNode, ".o_editor_banner"),
         move_node_blacklist_selectors: ".o_editor_banner *",
@@ -190,5 +194,12 @@ export class BannerPlugin extends Plugin {
         bannerElement.replaceWith(baseContainer);
         this.dependencies.selection.setCursorStart(baseContainer);
         return true;
+    }
+
+    handle_monospace_tab_to_spaces(root) {
+        for (const el of selectElements(root, ".font-monospace.o_editor_banner .oe-tabs")) {
+            const spacesElement = document.createTextNode("\u00A0\u00A0\u00A0\u00A0");
+            el.replaceWith(spacesElement);
+        }
     }
 }

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -3,7 +3,7 @@ import { click, manuallyDispatchProgrammaticEvent, press, waitFor } from "@odoo/
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
-import { insertText } from "./_helpers/user_actions";
+import { insertLineBreak, insertText, keydownTab } from "./_helpers/user_actions";
 import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { execCommand } from "./_helpers/userCommands";
 import { unformat } from "./_helpers/format";
@@ -325,6 +325,40 @@ test("Monospace banner should have no emoji", async () => {
             <div class="font-monospace o_editor_banner user-select-none o-contenteditable-false d-flex align-items-center alert alert-secondary pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
                 <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
                     <p>test[]</p>
+                </div>
+            </div>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+});
+
+test("Monospace banner should use spaces instead of tabs", async () => {
+    const { el, editor } = await setupEditor(
+        '<p>test<br><span class="oe-tabs" style="width: 40px;"/>indented[]</p>'
+    );
+    await insertText(editor, "/monospace");
+    await press("enter");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div class="font-monospace o_editor_banner user-select-none o-contenteditable-false d-flex align-items-center alert alert-secondary pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                    <p>test<br>&nbsp;&nbsp;&nbsp;&nbsp;indented[]</p>
+                </div>
+            </div>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        )
+    );
+    insertLineBreak(editor);
+    await keydownTab(editor);
+    await keydownTab(editor);
+    await insertText(editor, "double");
+    expect(unformat(getContent(el))).toBe(
+        unformat(
+            `<p data-selection-placeholder=""><br></p>
+            <div class="font-monospace o_editor_banner user-select-none o-contenteditable-false d-flex align-items-center alert alert-secondary pb-0 pt-3" data-oe-role="status" contenteditable="false" role="status">
+                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3" contenteditable="true">
+                    <p>test<br>&nbsp;&nbsp;&nbsp;&nbsp;indented<br>&nbsp;&nbsp;&nbsp;&nbsp;\u200b&nbsp;&nbsp;&nbsp;&nbsp;\u200bdouble[]</p>
                 </div>
             </div>
             <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`


### PR DESCRIPTION
Tabs are aligned on 40px boundaries. This leads to misalignment of characters when using the monospace banner.

This commit fixes this by replacing all tabs inside monospace banners by four spaces.

Steps to reproduce:
- Go to a "To do" note
- Insert a monospace banner
- Type some text on several lines
- Type tab at the begin of some lines

=> Character columns were misaligned.

task-5916747
