### PR TITLE
[FIX] tools: handle missing CLDR list patterns in Babel

### DIFF
--- a/odoo/tools/i18n.py
+++ b/odoo/tools/i18n.py
@@ -65,7 +65,10 @@ def format_list(
     # Some styles could be unavailable for the chosen locale
     if style not in locale.list_patterns:
         style = "standard"
-    return lists.format_list(lst, style, locale)
+    try:
+        return lists.format_list(lst, style, locale)
+    except KeyError:
+        return lists.format_list(lst, 'standard', locale)
 
 
 def py_to_js_locale(locale: str) -> str:


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install `stock_fleet` module (with demo data).
2.  Set the **Ukrainian** language for the user.
3.  Open Fleet > Vehicle > Click Category

Error:
`KeyError: '2'`

**Cause:**
Babel's CLDR list patterns for some locales (e.g., Ukrainian 'unit-short') do not include the two-item pattern key, so when babel's `format_list` attempts to access patterns, it will raise an error.

**Fix:**
This commit wraps the call in a try/except that handles KeyError and retries formatting with the 'standard' style to avoid the crash.