### PR TITLE
[FIX] {sale_,}mrp: create separate child MOs for shared components

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -154,6 +154,8 @@ class StockRule(models.Model):
             ('user_id', '=', False),
             ('reference_ids', '=', procurement.values.get('reference_ids', self.env['stock.reference']).ids),
         )
+        if production_group_id := procurement.values.get('production_group_id'):
+            domain += (('production_group_id.parent_ids', '=', production_group_id),)
         if procurement.values.get('orderpoint_id'):
             procurement_date = datetime.combine(
                 fields.Date.to_date(procurement.values['date_planned']) - relativedelta(days=int(bom.produce_delay)),

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2698,3 +2698,47 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         self.assertEqual(sale_picking.move_ids.quantity, 2)
         sale_picking.button_validate()
         self.assertEqual(sale_order.order_line.qty_delivered, 2.0)
+
+    def test_separate_child_mo_for_shared_component(self):
+        """Ensure that when confirming a Sale Order with multiple MTO products
+        sharing the same component (which has its own BOM), each parent
+        manufacturing order generates its own dedicated child MO instead of
+        reusing or updating an existing one.
+
+        This verifies that child MOs are created per parent MO (based on the
+        parent production group), so that each manufactured product is tracked
+        independently.
+        """
+        route_mto = self.env.ref('stock.route_warehouse0_mto').id
+        (self.product_a | self.product_b | self.product).route_ids = [route_mto]
+        self.env["mrp.bom"].create([
+            {
+                "product_tmpl_id": self.product_a.product_tmpl_id.id,
+                "bom_line_ids": [(0, 0, {"product_id": self.product.id, "product_qty": 1.0})],
+            },
+            {
+                "product_tmpl_id": self.product_b.product_tmpl_id.id,
+                "bom_line_ids": [(0, 0, {"product_id": self.product.id, "product_qty": 1.0})],
+            },
+            {
+                "product_tmpl_id": self.product.product_tmpl_id.id,
+                "bom_line_ids": [(0, 0, {"product_id": self.component_a.id, "product_qty": 1.0})],
+            },
+        ])
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1,
+                }),
+                Command.create({
+                    'product_id': self.product_b.id,
+                    'product_uom_qty': 1,
+                }),
+            ],
+        })
+        so.action_confirm()
+        self.assertEqual(so.mrp_production_count, 2)
+        self.assertEqual(so.mrp_production_ids[0].mrp_production_child_count, 1)
+        self.assertEqual(so.mrp_production_ids[1].mrp_production_child_count, 1)

--- a/addons/sale_mrp/tests/test_sale_mrp_procurement.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_procurement.py
@@ -174,7 +174,12 @@ class TestSaleMrpProcurement(TransactionCase):
         # Verify buttons are working as expected
         self.assertEqual(sale_order_so0.mrp_production_count, 2, "2 Mos for the 2 sale order line")
         self.assertEqual(sale_order_so0.mrp_production_ids[0].product_qty, 1)
-        self.assertEqual(sale_order_so0.mrp_production_ids[1].product_qty, 2)
+        self.assertEqual(sale_order_so0.mrp_production_ids[0].mrp_production_child_count, 1)
+        self.assertRecordValues(sale_order_so0.mrp_production_ids[0]._get_children(), [{
+            'product_id': self.finished_product.id,
+            'product_qty': 1,
+        }])
+        self.assertEqual(sale_order_so0.mrp_production_ids[1].product_qty, 1)
 
         pickings = sale_order_so0.picking_ids
 


### PR DESCRIPTION
Currently, when a user creates a Sale Order for MTO products that share the same component (which itself has a BOM), the system does not create a separate child MO for each manufacturing order.

## Steps to produce:
- Install Sales and Manufacturing
- Go to Settings and turn on Replenish on Order (MTO).
- Create products 'Wooden Arrow' and 'Wooden Rod' with a BOM that includes:
   - 'Stick', which itself has a BOM with 'Raw stick'.
- On each product page, go to Inventory and enable the MTO route, except for 'Raw Stick' .
- Create a Sale Order for Wooden Arrow and Wooden Rod for Customer 'Administrator'.
- Confirm the Sale Order.
- Go to Manufacturing > Open and check both Manufacturing Orders.

## Observed Behavior:
Currently, the manufacturing order for 'Wooden Arrow' has a child MO, but the order for 'Wooden Rod' does not.

The child MO under 'Wooden Arrow' produces two sticks at once. However, each manufacturing order should have its own separate child MO so that every item is produced and tracked individually.

## Root cause:
The issue happens because when a Sale Order is confirmed, [_run_manufacture](https://github.com/odoo/odoo/blob/7c7c6663e28974834d1569b27605f6ce400c7b16/addons/mrp/models/stock_rule.py#L81-L120) is called. This method creates a new MO or updates an existing one based on the domain returned by `_make_mo_get_domain` [1].

For 'Wooden Arrow' and 'Wooden Rod; new MOs are created because no existing MO matches their BOM ID, product ID, or reference.
They are added to `new_productions_values_by_company` [2], which is then used to create the MOs [3].

When `_run_manufacture` runs for 'Stick', it is triggered twice since both MOs require it as a component. The first time, no MO matches the domain, so a new one is created. The second time, the domain matches the existing MO (same BOM ID and product ID), so that MO is updated instead [4]. Because of this, `new_productions_values_by_company` is not filled again, and no second child MO is created.

[1]-
https://github.com/odoo/odoo/blob/c2595e47e3b36120f4c3da8bfe8c16f6c5969a70/addons/mrp/models/stock_rule.py#L146-L165 
[2]-
https://github.com/odoo/odoo/blob/c2595e47e3b36120f4c3da8bfe8c16f6c5969a70/addons/mrp/models/stock_rule.py#L98-L103 
[3]-
https://github.com/odoo/odoo/blob/c2595e47e3b36120f4c3da8bfe8c16f6c5969a70/addons/mrp/models/stock_rule.py#L113-L115 
[4]-
https://github.com/odoo/odoo/blob/c2595e47e3b36120f4c3da8bfe8c16f6c5969a70/addons/mrp/models/stock_rule.py#L105-L110

## Solution:
To resolve this issue, the domain has been tightened to include the parent production group ID. Since the parent MO’s group ID is passed through the procurement variable when `_run_manufacture` is executed for its component products, this group ID can be used to ensure the correct MO is matched.

**Why modify the existing test case?:**
With this change, in the `test_sale_mrp_pickings` test case, a new child MO for 'Stick' is created under the MO for 'Arrow' instead of modifying another parent MO for 'Stick'. The test case has been updated accordingly. (Confirmed the new behavior with CRL and TAGO)



opw-5480133