### PR TITLE
[FIX] stock{,_landed_costs},mrp_subcontracting: create aml correct va…

### DIFF
--- a/addons/mrp_subcontracting_landed_costs/models/__init__.py
+++ b/addons/mrp_subcontracting_landed_costs/models/__init__.py
@@ -1,1 +1,2 @@
+from . import stock_landed_cost
 from . import stock_move

--- a/addons/mrp_subcontracting_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_subcontracting_landed_costs/models/stock_landed_cost.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.tools import OrderedSet
+
+
+class StockLandedCost(models.Model):
+    _inherit = 'stock.landed.cost'
+
+    def _get_targeted_move_ids(self):
+        res = super()._get_targeted_move_ids()
+        target_moves_ids = OrderedSet()
+        for move in res:
+            if move.is_subcontract:
+                target_moves_ids.update(move.move_orig_ids.ids)
+            else:
+                target_moves_ids.add(move.id)
+        return self.env['stock.move'].browse(target_moves_ids)

--- a/addons/mrp_subcontracting_landed_costs/models/stock_move.py
+++ b/addons/mrp_subcontracting_landed_costs/models/stock_move.py
@@ -6,8 +6,4 @@ class StockMove(models.Model):
 
     def _get_stock_valuation_layer_ids(self):
         self.ensure_one()
-        stock_valuation_layer_ids = super()._get_stock_valuation_layer_ids()
-        subcontracted_productions = self._get_subcontract_production()
-        if self.is_subcontract and subcontracted_productions:
-            return subcontracted_productions.move_finished_ids.stock_valuation_layer_ids
-        return stock_valuation_layer_ids
+        return super()._get_stock_valuation_layer_ids()

--- a/addons/mrp_subcontracting_landed_costs/tests/test_subcontracting_landed_costs.py
+++ b/addons/mrp_subcontracting_landed_costs/tests/test_subcontracting_landed_costs.py
@@ -20,7 +20,7 @@ class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
             'order_line': [(0, 0, {
                 'name': self.finished.name,
                 'product_id': self.finished.id,
-                'product_uom_qty': 10,
+                'product_qty': 10,
                 'product_uom': self.finished.uom_id.id,
                 'price_unit': 10,
             })],
@@ -32,16 +32,16 @@ class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
 
         action = po.action_view_picking()
         in_picking = self.env[action['res_model']].browse(action['res_id'])
-        in_picking.move_ids.quantity = 10
         in_picking.move_ids.picked = True
         in_picking.button_validate()
+        self.assertEqual(self.finished.standard_price, 10)
+        self.assertEqual(len(mo.move_finished_ids.stock_valuation_layer_ids), 1)
 
         # create a landed cost for the incoming picking
-        default_vals = self.env['stock.landed.cost'].default_get(list(self.env['stock.landed.cost'].fields_get()))
         freight_charges = self.env['product.product'].create({
             'name': 'Freight Charges',
         })
-        default_vals.update({
+        stock_landed_cost = self.env['stock.landed.cost'].create({
             'picking_ids': [in_picking.id],
             'cost_lines': [(0, 0, {
                 'product_id': freight_charges.id,
@@ -50,8 +50,6 @@ class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
                 'price_unit': 99,
             })],
         })
-        stock_landed_cost = self.env['stock.landed.cost'].create(default_vals)
-
         # compute the landed cost using compute button
         stock_landed_cost.compute_landed_cost()
 
@@ -66,17 +64,22 @@ class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
 
         # confirm the landed cost
         stock_landed_cost.button_validate()
+        self.assertEqual(self.finished.standard_price, 19.9)
         self.assertEqual(stock_landed_cost.state, "done")
-
-        self.assertEqual(len(in_picking.move_ids.stock_valuation_layer_ids), 1)
-        self.assertEqual(in_picking.move_ids.stock_valuation_layer_ids.value, 99)
+        self.assertEqual(len(mo.move_finished_ids.stock_valuation_layer_ids), 2)
+        self.assertRecordValues(mo.move_finished_ids.stock_valuation_layer_ids, [
+            # the original svl from the MO
+            {'value': 100},
+            # the svl added after the landed cost validation
+            {'value': 99},
+        ])
 
         new_po = self.env['purchase.order'].create({
             'partner_id': self.subcontractor_partner1.id,
             'order_line': [(0, 0, {
                 'name': self.finished.name,
                 'product_id': self.finished.id,
-                'product_uom_qty': 10,
+                'product_qty': 10,
                 'product_uom': self.finished.uom_id.id,
                 'price_unit': 10,
             })],
@@ -99,7 +102,6 @@ class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
 
         action = new_po.action_view_picking()
         in_picking = self.env[action['res_model']].browse(action['res_id'])
-        in_picking.move_ids.quantity = 10
         in_picking.move_ids.picked = True
         in_picking.button_validate()
 
@@ -130,3 +132,68 @@ class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
         # confirm the landed cost
         stock_landed_cost.button_validate()
         self.assertEqual(stock_landed_cost.state, "done")
+
+    def test_subcontracting_landed_cost_pro_rata_product_out(self):
+        """
+            This test verifies that the account move line created after the validation
+            of a landed cost applied to the receipt of  subcontracted product take into
+            account the pro rata of the products still in stock.
+        """
+        product_category_all = self.env.ref('product.product_category_all')
+        self._setup_category_stock_journals()
+        product_category_all.property_cost_method = 'average'
+        product_category_all.property_valuation = 'real_time'
+        self.finished.categ_id = product_category_all
+
+        # create and confirm PO
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [(0, 0, {
+                'name': self.finished.name,
+                'product_id': self.finished.id,
+                'product_qty': 10,
+                'product_uom': self.finished.uom_id.id,
+                'price_unit': 10,
+            })],
+        })
+        po.button_confirm()
+
+        # validate move
+        receipt = po.picking_ids[0]
+        receipt.button_validate()
+
+        # simulate only partial quantity remaining
+        mo = receipt._get_subcontract_production()
+        mo.move_finished_ids.stock_valuation_layer_ids.remaining_qty = 7
+
+        # create a landed cost for the incoming picking
+        freight_charges = self.env['product.product'].create({
+            'name': 'Freight Charges',
+        })
+
+        stock_landed_cost = self.env['stock.landed.cost'].create({
+            'picking_ids': [receipt.id],
+            'cost_lines': [(0, 0, {
+                'product_id': freight_charges.id,
+                'name': 'equal split',
+                'split_method': 'equal',
+                'price_unit': 10,
+            })],
+        })
+        # compute the landed cost using compute button
+        stock_landed_cost.compute_landed_cost()
+        stock_landed_cost.button_validate()
+
+        # check the amls created
+        stock_in_acc_id = product_category_all.property_stock_account_input_categ_id.id
+        stock_out_acc_id = product_category_all.property_stock_account_output_categ_id.id
+        stock_valu_acc_id = product_category_all.property_stock_valuation_account_id.id
+        expense_acc_id = product_category_all.property_account_expense_categ_id.id
+        self.assertRecordValues(stock_landed_cost.account_move_id.line_ids, [
+            {'account_id': stock_valu_acc_id,   'product_id': self.finished.id,    'debit': 10.0,  'credit': 0.0},
+            {'account_id': stock_in_acc_id,     'product_id': self.finished.id,    'debit': 0.0,   'credit': 10.0},
+            {'account_id': stock_out_acc_id,    'product_id': self.finished.id,    'debit': 3.0,   'credit': 0.0},
+            {'account_id': stock_valu_acc_id,   'product_id': self.finished.id,    'debit': 0.0,   'credit': 3.0},
+            {'account_id': expense_acc_id,    'product_id': self.finished.id,    'debit': 3.0,  'credit': 0.0},
+            {'account_id': stock_out_acc_id,   'product_id': self.finished.id,    'debit': 0.0,   'credit': 3.0},
+        ])


### PR DESCRIPTION
…lues landed cost sbc

**Problem:**
account move line created from a landed cost on a  subcontracted 
receipt do not take into account already out quantity.

**Steps to reproduce:**
- create a tracked product with avco auto category
- create a subcontracted bom for this product with no comp
- create and confirm a PO for 10 unit of this product 
with the same partner as the subcontractor of the bom
- validate the receipt
- create and validate a delivery for 4 unit of your product
- navigate to inventory/operations/adjustments/landed costs
- create a new landed cost
- select the receipt from the PO
- add a landed cost of 10$ and validate
- select the valuation smart button
- a 6$ svl was created (which is correct because 6 out 10 products
of the receipt are still in stock)
- click on the book widget to open the account move view

**Current behavior:**
Only two account move lines were created both with a value 
of 10
One crediting sotck interim received
On debiting stock valuation

**Expected behavior:**
4 extra account move lines (all with a value of 4) should have been 
created to compensate the out quantity like it is the case for 
non subcontracted product.
One debiting stock interim delivered
One crediting stock valuation 
One debiting expenses
One crediting stock interim delivered

**Cause of the issue:**
_is_in() will return false for the move of a subcontracted receipt
https://github.com/odoo/odoo/blob/7462ec423e8b106a5175a71ac009176d16cdf225/addons/stock_landed_costs/models/stock_landed_cost.py#L185
This is wanted and happens because _should_be_valued()
will return true when called on the subcontracted location
https://github.com/odoo/odoo/blob/7462ec423e8b106a5175a71ac009176d16cdf225/addons/stock_account/models/stock_move.py#L129

As a consequence, qty_out stays 0
https://github.com/odoo/odoo/blob/7462ec423e8b106a5175a71ac009176d16cdf225/addons/stock_landed_costs/models/stock_landed_cost.py#L185-L186
and we do not append the values for the extra amls 
inside _create_account_move_line()
https://github.com/odoo/odoo/blob/7462ec423e8b106a5175a71ac009176d16cdf225/addons/stock_landed_costs/models/stock_landed_cost.py#L465-L466

**fix:**
if we make sure the the adjustment line is linked to the move 
of the MO instead of the move of the receipt, this problem does 
not happen because _is_in() returns true for the move of the MO. 
Also in this case we don't need _get_stock_valuation_layer_ids()
which was introduced by this PR https://github.com/odoo/odoo/pull/166107
to solve the same issue. 
That is because the move used in button_validate is the move linked
to the adjustment line, which will, after this fix, be the one of 
the MO, so we can directly take its stock valuation layers.

opw-5723126