### PR TITLE
[FIX] point_of_sale, pos_discount: correctly format tip and discount

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -229,7 +229,7 @@ export class PaymentScreen extends Component {
 
         this.dialog.add(NumberPopup, {
             title: tip.amount > 0 ? _t("Change Tip") : _t("Add Tip"),
-            startingValue: tip.value || amount,
+            startingValue: String(tip.value || amount || 0),
             startingType: tip.type || "fixed",
             types: [
                 { name: "fixed", symbol: this.pos.currency.symbol },
@@ -239,7 +239,7 @@ export class PaymentScreen extends Component {
                 this.onNewTip({ newValue, type, currentTipAmount: tip.amount, change }),
             formatDisplayedValue: (value, type) => {
                 if (type === "fixed") {
-                    return this.env.utils.formatCurrency(value, this.pos.currency);
+                    return this.env.utils.formatCurrency(parseFloat(value), this.pos.currency);
                 }
                 if (type === "percent") {
                     return `${value} %`;

--- a/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -2,12 +2,13 @@ import { _t } from "@web/core/l10n/translation";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 import { ControlButtons } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { patch } from "@web/core/utils/patch";
+import { parseFloat } from "@web/views/fields/parsers";
 
 patch(ControlButtons.prototype, {
     async clickDiscount() {
         this.dialog.add(NumberPopup, {
             title: _t("Discount"),
-            startingValue: this.pos.config.discount_pc,
+            startingValue: String(this.pos.config.discount_pc || 0),
             startingType: "percent",
             types: [
                 { name: "fixed", symbol: this.pos.currency.symbol },
@@ -25,7 +26,7 @@ patch(ControlButtons.prototype, {
             },
             formatDisplayedValue: (value, type) => {
                 if (type === "fixed") {
-                    return this.env.utils.formatCurrency(value);
+                    return this.env.utils.formatCurrency(parseFloat(value));
                 }
                 if (type === "percent") {
                     return `${value} %`;


### PR DESCRIPTION
Before this commit, when the decimal separator was not a dot, the amount in the tip and the discount number popup was not correctly formatted, which could lead to confusion for the user.

opw-5921256

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
