### PR TITLE
[IMP] base_import, *: comprehensive UX cleanup and modernization

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1175,7 +1175,7 @@ class AccountAccount(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Chart of Accounts'),
+            'label': _('Template for Chart of Accounts'),
             'template': '/account/static/xls/coa_import_template.xlsx'
         }]
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -7437,27 +7437,27 @@ class AccountMove(models.Model):
         match move_type:
             case 'entry':
                 return [{
-                    'label': _('Import Template for Misc. Operations'),
+                    'label': _('Template for Misc. Operations'),
                     'template': '/account/static/xls/misc_operations_import_template.xlsx',
                 }]
             case 'out_invoice':
                 return [{
-                    'label': _('Import Template for Invoices'),
+                    'label': _('Template for Invoices'),
                     'template': '/account/static/xls/customer_invoices_credit_notes_import_template.xlsx',
                 }]
             case 'out_refund':
                 return [{
-                    'label': _('Import Template for Credit Notes'),
+                    'label': _('Template for Credit Notes'),
                     'template': '/account/static/xls/customer_invoices_credit_notes_import_template.xlsx',
                 }]
             case 'in_invoice':
                 return [{
-                    'label': _('Import Template for Bills'),
+                    'label': _('Template for Bills'),
                     'template': '/account/static/xls/vendor_bills_refunds_import_template.xlsx',
                 }]
             case 'in_refund':
                 return [{
-                    'label': _('Import Template for Refunds'),
+                    'label': _('Template for Refunds'),
                     'template': '/account/static/xls/vendor_bills_refunds_import_template.xlsx',
                 }]
             case _:

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3551,7 +3551,7 @@ class AccountMoveLine(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Journal Items'),
+            'label': _('Template for Journal Items'),
             'template': '/account/static/xls/aml_import_template.xlsx'
         }]
 

--- a/addons/base_import/static/src/import_action/import_action.js
+++ b/addons/base_import/static/src/import_action/import_action.js
@@ -26,12 +26,12 @@ export class ImportAction extends Component {
     };
     static props = { ...standardActionServiceProps };
     static path = "import";
-    static displayName = _t("Import a File");
+    static displayName = _t("Import");
 
     setup() {
         this.actionService = useService("action");
         this.notification = useService("notification");
-        this.env.config.setDisplayName(this.props.action.name || _t("Import a File"));
+        this.env.config.setDisplayName(this.props.action.name || _t("Import"));
         this.model = useImportModel({
             env: this.env,
             context: this.props.action.params?.context || {},
@@ -197,12 +197,6 @@ export class ImportAction extends Component {
         this.model.unblock();
     }
 
-    async reload() {
-        this.model.block();
-        await this.model.updateData();
-        this.model.unblock();
-    }
-
     //--------------------------------------------------------------------------
     // File
     //--------------------------------------------------------------------------
@@ -213,6 +207,7 @@ export class ImportAction extends Component {
         }
 
         this.state.filename = files[0].name;
+        this.env.config.setDisplayName(_t("Import") + ` ${this.state.filename}`);
         this.state.importMessages = [];
 
         this.model.block(_t("Loading file..."));

--- a/addons/base_import/static/src/import_action/import_action.scss
+++ b/addons/base_import/static/src/import_action/import_action.scss
@@ -1,3 +1,6 @@
 .o_import_action {
     grid-template-rows: auto 1fr;
+    .o_view_nocontent .o_nocontent_help {
+        font-size: 105% !important;
+    }
 }

--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -23,10 +23,9 @@
                         resModel="this.resModel"
                         route="this.uploadFilesRoute"
                     >
-                        <button t-if="isPreviewing" type="button" class="btn btn-secondary">Load Data File</button>
-                        <button t-else="" type="button" class="btn btn-primary o_import_file">Upload Data File</button>
+                        <button t-if="isPreviewing" type="button" class="btn btn-secondary">Re-Upload</button>
+                        <button t-else="" type="button" class="btn btn-primary o_import_file">Upload</button>
                     </FileInput>
-                    <button t-on-click="cancel" type="button" class="btn btn-secondary">Discard</button>
                 </t>
                 <t t-if="isPreviewing">
                     <ImportDataSidepanel
@@ -36,7 +35,6 @@
                         importTemplates="importTemplates"
                         isBatched="isBatched"
                         onOptionChanged.bind="onOptionChanged"
-                        onReload.bind="reload"
                         hasBinaryFields="hasBinaryFields"
                         binaryFilesParams="model.binaryFilesParams"
                         onBinaryFilesParamsChanged.bind="(name, value) => model.onBinaryFilesParamsChanged(name, value)"
@@ -54,20 +52,24 @@
                 <div t-else="" class="o_view_nocontent">
                     <div class="o_nocontent_help">
                         <p class="o_view_nocontent_smiling_face">
-                            Drop or upload a file to import
+                            <FileInput
+                                acceptedFileExtensions="'.csv, .xls, .xlsx, .xlsm, .ods'"
+                                onUpload.bind="(data, files) => this.handleFilesUpload(files)"
+                                resId="model.id"
+                                resModel="this.resModel"
+                                route="this.uploadFilesRoute"
+                            >
+                                <button type="button" class="btn btn-primary o_import_file">Upload</button>
+                            </FileInput>
+                            <span class="text-muted fw-normal"> or drag a file</span>
                         </p>
-                        <p>
-                            Excel files are recommended as formatting is automatic.<br/>
-                            But, you can also use .csv files
-                        </p>
-                        <div class="mt16 mb4">
-                            Need Help? <DocumentationLink path="'/applications/general/export_import_data.html'" label.translate="Import FAQ"/>
-                        </div>
-                        <div t-foreach="importTemplates" t-as="template" t-key="template.template">
-                            <a class="btn btn-outline-primary my8" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
-                                <i class="fa fa-download"/> <span><t t-esc="template.label"/></span>
+                        <div class="mb-2" t-foreach="importTemplates" t-as="template" t-key="template.template">
+                            <a t-att-href="template.template" aria-label="Download" data-tooltip="Download">
+                                <i class="fa fa-download pe-1"/>
+                                <span><t t-esc="template.label"/></span>
                             </a>
                         </div>
+                        <DocumentationLink path="'/applications/general/export_import_data.html'" label.translate="Documentation" icon="'fa-question-circle'"/>
                     </div>
                 </div>
             </Layout>

--- a/addons/base_import/static/src/import_data_content/import_data_content.js
+++ b/addons/base_import/static/src/import_data_content/import_data_content.js
@@ -24,6 +24,7 @@ export class ImportDataContent extends Component {
     getGroups(column) {
         const groups = [
             { choices: this.makeChoices(column.fields.basic) },
+            { choices: this.makeChoices(column.fields.required), label: _t("Required Fields") },
             { choices: this.makeChoices(column.fields.suggested), label: _t("Suggested Fields") },
             {
                 choices: this.makeChoices(column.fields.additional),
@@ -82,6 +83,7 @@ export class ImportDataContent extends Component {
     onFieldChanged(column, fieldPath) {
         const fields = [
             ...column.fields.basic,
+            ...column.fields.required,
             ...column.fields.suggested,
             ...column.fields.additional,
             ...column.fields.relational,

--- a/addons/base_import/static/src/import_data_content/import_data_content.scss
+++ b/addons/base_import/static/src/import_data_content/import_data_content.scss
@@ -9,6 +9,7 @@
 
     > table {
         thead {
+            box-shadow: inset 0 -1px 0 0 $border-color;
             th:nth-child(1) {
                 min-width: 20rem;
             }

--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -31,11 +31,11 @@
                 </t>
             </div>
             <table t-if="!props.previewError" class="table table-borderless w-100 bg-view">
-                <thead>
-                    <tr class="border-bottom">
+                <thead class="bg-100 sticky-top">
+                    <tr>
                         <th scope="col">File Column</th>
                         <th scope="col">Odoo Field</th>
-                        <th scope="col">Comments</th>
+                        <th scope="col"/>
                     </tr>
                 </thead>
                 <tbody>

--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js
@@ -13,7 +13,6 @@ export class ImportDataSidepanel extends Component {
         importTemplates: { type: Array, optional: true },
         isBatched: { type: Boolean, optional: true },
         onOptionChanged: { type: Function },
-        onReload: { type: Function },
         hasBinaryFields: { type: Boolean },
         binaryFilesParams: { type: Object },
         onBinaryFilesParamsChanged: { type: Function },
@@ -25,6 +24,28 @@ export class ImportDataSidepanel extends Component {
 
     get fileExtension() {
         return "." + this.props.filename.split(".").pop();
+    }
+
+    get attachmentsTooltip() {
+        return _t(
+            "Upload attachments such as images or files that can be mapped with imported data"
+        );
+    }
+
+    get batchLimitTooltip() {
+        return _t(
+            "Defines the number of records that will be imported in one transaction. Reduce the batch size in case of heavy imports"
+        );
+    }
+
+    get headersTooltip() {
+        return _t("If checked, the first row of the sheet will not be imported");
+    }
+
+    get trackingTooltip() {
+        return _t(
+            "If checked, the changes are tracked in the chatter and notifications can be sent to followers, which could slow down the import"
+        );
     }
 
     getOptionValue(name) {

--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.scss
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.scss
@@ -1,6 +1,5 @@
 .o_import_data_sidepanel {
-    min-width: 15rem;
-    max-width: 350px;
+    width: 262px;
     overflow-y: auto;
 
     .o_import_grid {
@@ -9,6 +8,10 @@
 
         .o_grid_span_2 {
             grid-column: span 2;
+        }
+
+        .o_import_grid_col {
+            align-content: center;
         }
     }
 

--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="ImportDataSidepanel">
-        <div class="o_import_data_sidepanel p-3 bg-view">
-            <div class="pb-4">
-                <h4>Data to import</h4>
-                <div class="mb-2 d-flex align-items-center">
-                    <i class="fa fa-file white me-2"></i>
-                    <div class="fst-italic truncate"><t t-esc="fileName"/></div>
-                    <span class="fst-italic"><t t-esc="fileExtension"/></span>
-                </div>
-
-                <div t-if="props.options.sheets.length > 0" class="flex-row my-2">
+        <div class="o_import_data_sidepanel p-3 bg-view flex-shrink-0">
+            <div class="pb-3">
+                <div t-if="props.options.sheets.length > 1" class="flex-row my-2">
                     <label for="o_import_sheet">Sheet:</label>
                     <select
                         class="o_select o_import_sheet w-100 mb-3 form-select"
@@ -24,10 +17,22 @@
                     </select>
                 </div>
                 <CheckBox value="props.options.has_headers" onChange.bind="isChecked => this.props.onOptionChanged('has_headers', isChecked)">
-                    Use first row as header
+                    Use first row as header<sup class="text-info p-1 cursor-default" t-att-data-tooltip="headersTooltip" t-esc="'?'" />
                 </CheckBox>
+                <CheckBox value="!props.options.tracking_disable" onChange.bind="(isChecked) => this.props.onOptionChanged('tracking_disable', !isChecked)">
+                    Track changes in chatter<sup class="text-info p-1 cursor-default" t-att-data-tooltip="trackingTooltip" t-esc="'?'" />
+                </CheckBox>
+                <div t-if="props.isBatched and env.debug" class="o_import_grid gap-1">
+                    <div class="o_import_grid_col">
+                        <label for="o_import_batch_limit">Batch size</label>
+                        <sup class="text-info p-1 cursor-default" t-att-data-tooltip="batchLimitTooltip" t-esc="'?'"/>
+                    </div>
+                    <div class="o_import_grid_col">
+                        <input class="w-100 border rounded-2" type="number" id="o_import_batch_limit" t-att-value="getOptionValue('limit')" t-on-change="(ev) => this.setOptionValue('limit', ev.target.value || 1)" />
+                    </div>
+                </div>
             </div>
-            <div t-if="fileExtension.toLowerCase() === '.csv'" class="o_import_formatting pt-3 pb-4 border-top">
+            <div t-if="fileExtension.toLowerCase() === '.csv'" class="o_import_formatting pt-3 border-top">
                 <h4>Formatting</h4>
                 <div t-foreach="Object.entries(props.formattingOptions)" t-as="option" t-key="`${option[0]}-${option_index}`" class="o_import_options">
                     <label t-att-for="`${option[0]}-${option_index}`">
@@ -38,8 +43,9 @@
                         t-if="option[1].type === 'input'"
                         t-att-id="`${option[0]}-${option_index}`"
                         t-att-list="option[1].options ? `list-${ option_index }` : null"
-                        t-attf-class="o_import_#{option[0]} o_import_dropdown w-100 mb-3"
+                        t-attf-class="o_import_#{option[0]} o_import_dropdown w-100 mb-3 border rounded-2 p-1 bg-view"
                         t-att-value="option[1].value"
+                        t-att-placeholder="option[1].placeholder"
                         t-on-change="(ev) => this.setOptionValue(option[0], ev.target.value)"
                     />
                     <datalist t-if="option[1].type === 'input' and option[1].options" t-att-id="`list-${ option_index }`">
@@ -49,7 +55,7 @@
                     </datalist>
                     <select
                         t-elif="option[1].type === 'select'"
-                        t-att-class="`o_select form-select w-100 mb-3 o_import_${option[0]} o_import_dropdown`"
+                        t-att-class="`o_select form-select w-100 mb-3 o_import_${option[0]} o_import_dropdown p-1`"
                         t-att-name="`${option[0]}-${option_index}`"
                         t-on-change="(ev) => this.setOptionValue(option[0], ev.target.value)"
                     >
@@ -57,53 +63,46 @@
                             <t t-esc="opt.label ? opt.label : opt" />
                         </option>
                     </select>
-                </div>
-                <button class="btn btn-primary w-100" t-on-click="() => this.props.onReload()">Reimport</button>
-            </div>
-            <div t-if="props.isBatched" class="pt-3 pb-4 border-top" >
-                <h4>Batch Import</h4>
-                <div class="o_import_batch_alert fw-bold pb-2">
-                    The file will be imported by batches
-                </div>
-                <div class="d-flex">
-                    <div class="o_import_batch_limit w-50 pe-1">
-                        <label class="mb-1" for="o_import_batch_limit">Batch limit</label>
-                        <input class="w-100" id="o_import_batch_limit" t-att-value="getOptionValue('limit')" t-on-change="(ev) => this.setOptionValue('limit', ev.target.value || 1)" />
-                    </div>
-                    <div class="w-50 ps-1" data-tooltip="Warning: ignores the labels line, empty lines and lines composed only of empty cells">
-                        <label class="mb-1" for="o_import_row_start">Start at line</label>
-                        <input class="w-100" id="o_import_row_start" t-att-value="getOptionValue('skip')" t-on-change="onLimitChange" />
-                    </div>
+                    <input
+                        t-if="option[1].other?.length and !option[1].other.includes(option[1].value)"
+                        t-attf-class="o_import_#{option[0]}_other w-100 mb-3 border rounded-2 p-1 bg-view"
+                        t-att-value="option[1].value"
+                        t-on-change="(ev) => this.setOptionValue(option[0], ev.target.value)"
+                        t-att-placeholder="option[1].label"
+                    />
                 </div>
             </div>
-            <div t-if="props.hasBinaryFields" class="pt-3 pb-4 border-top o_import_file">
-                <h4>Files to import</h4>
+            <div t-if="props.hasBinaryFields" class="py-3 border-top o_import_file">
+                <h4>Attachments<sup class="text-info p-1" t-att-data-tooltip="attachmentsTooltip" t-esc="'?'" /></h4>
                 <div class="o_import_grid gap-1">
                     <!-- First row-->
                     <div class="o_import_grid_col">
                         <label>
-                            <span class="btn btn-sm btn-primary">Upload your files</span>
+                            <span class="btn btn-sm btn-primary">Upload</span>
                             <input type="file" multiple="multiple" hidden="hidden"
                                    t-on-change="(event) => this.props.onBinaryFilesParamsChanged('binaryFiles', event.target.files)"/>
                         </label>
                     </div>
-                    <div class="o_import_grid_col o_grid_span_2">
+                    <div class="o_import_grid_col o_grid_span_2 align-content-center">
                         <t t-esc="binaryFilesLabel"/>
                     </div>
 
                     <!-- Second row-->
                     <t t-if="env.debug">
                         <div class="o_import_grid_col">
-                            <label for="o_input_maxSizePerBatch">Max size per batch</label>
+                            <label for="o_input_maxSizePerBatch">Batch max size</label>
                             <sup t-if="props.binaryFilesParams.maxSizePerBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="props.binaryFilesParams.maxSizePerBatch.help" t-esc="'?'"/>
                         </div>
                         <div class="o_import_grid_col">
-                                <input type="number"
-                                       id="o_input_maxSizePerBatch"
-                                       t-att-value="props.binaryFilesParams.maxSizePerBatch.value"
-                                       t-att-max="props.binaryFilesParams.maxSizePerBatch.max"
-                                       t-att-min="props.binaryFilesParams.maxSizePerBatch.min"
-                                       t-on-change="(event) => this.props.onBinaryFilesParamsChanged('maxSizePerBatch', event.target.value)"/>
+                                <input 
+                                    type="number"
+                                    id="o_input_maxSizePerBatch"
+                                    class="border rounded-2"
+                                    t-att-value="props.binaryFilesParams.maxSizePerBatch.value"
+                                    t-att-max="props.binaryFilesParams.maxSizePerBatch.max"
+                                    t-att-min="props.binaryFilesParams.maxSizePerBatch.min"
+                                    t-on-change="(event) => this.props.onBinaryFilesParamsChanged('maxSizePerBatch', event.target.value)"
+                                />
                         </div>
                         <div class="o_import_grid_col">
                             <label for="o_input_maxSizePerBatch">Mb</label>
@@ -111,15 +110,18 @@
 
                         <!-- Third row-->
                         <div class="o_import_grid_col">
-                            <label for="o_input_delayAfterEachBatch">Delay after each batch</label>
+                            <label for="o_input_delayAfterEachBatch">Batch interval</label>
                             <sup t-if="props.binaryFilesParams.delayAfterEachBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="props.binaryFilesParams.delayAfterEachBatch.help" t-esc="'?'"/>
                         </div>
                         <div class="o_import_grid_col">
-                                <input type="number"
-                                       id="o_input_delayAfterEachBatch"
-                                       t-att-value="props.binaryFilesParams.delayAfterEachBatch.value"
-                                       t-att-min="props.binaryFilesParams.delayAfterEachBatch.min"
-                                       t-on-change="(event) => this.props.onBinaryFilesParamsChanged('delayAfterEachBatch', event.target.value)"/>
+                                <input 
+                                    type="number"
+                                    id="o_input_delayAfterEachBatch"
+                                    class="border rounded-2"
+                                    t-att-value="props.binaryFilesParams.delayAfterEachBatch.value"
+                                    t-att-min="props.binaryFilesParams.delayAfterEachBatch.min"
+                                    t-on-change="(event) => this.props.onBinaryFilesParamsChanged('delayAfterEachBatch', event.target.value)"
+                                />
                         </div>
                         <div class="o_import_grid_col">
                             <label for="o_input_delayAfterEachBatch">seconds</label>
@@ -128,25 +130,14 @@
                 </div>
 
             </div>
-            <div t-if="env.debug" class="o_import_debug_options pt-3 pb-4 border-top">
-                <h4>Advanced</h4>
-                <div data-tooltip="If the model uses openchatter, history tracking will set up subscriptions and send notifications during the import, but lead to a slower import.">
-                    <CheckBox value="!props.options.tracking_disable" onChange.bind="(isChecked) => this.props.onOptionChanged('tracking_disable', !isChecked)">
-                        Track history during import
-                    </CheckBox>
-                </div>
-                <CheckBox value="props.options.advanced" onChange.bind="(isChecked) => this.props.onOptionChanged('advanced', isChecked)">
-                    Allow matching with subfields
-                </CheckBox>
-            </div>
-            <div class="pt-3 pb-4 border-top">
+            <div class="py-3 border-top">
                 <h4>Help</h4>
                 <t t-foreach="props.importTemplates" t-as="template" t-key="template">
                     <a class="d-block my-2" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
                         <i class="fa fa-download"/> <span><t t-esc="template.label"/></span>
                     </a>
                 </t>
-                <DocumentationLink path="'/applications/general/export_import_data.html'" icon="'fa-external-link'" label.translate="Go to Import FAQ"/>
+                <DocumentationLink path="'/applications/general/export_import_data.html'" label.translate="Documentation" icon="'fa-question-circle'"/>
             </div>
         </div>
     </t>

--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -1,11 +1,12 @@
 import { useState } from "@web/owl2/utils";
+import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
+import { groupBy, sortBy } from "@web/core/utils/arrays";
 import { checkFileSize, DEFAULT_MAX_FILE_SIZE } from "@web/core/utils/files";
+import { memoize } from "@web/core/utils/functions";
 import { useService } from "@web/core/utils/hooks";
 import { pick } from "@web/core/utils/objects";
-import { groupBy, sortBy } from "@web/core/utils/arrays";
-import { memoize } from "@web/core/utils/functions";
 import { session } from "@web/session";
 import { ImportBlockUI } from "./import_block_ui";
 import { BinaryFileManager } from "./binary_file_manager";
@@ -98,7 +99,6 @@ export class BaseImportModel {
         this.importOptionsValues = {
             ...this.formattingOptionsValues,
             advanced: {
-                reloadParse: true,
                 value: true,
             },
             has_headers: {
@@ -133,15 +133,13 @@ export class BaseImportModel {
                 value: {},
             },
             maxSizePerBatch: {
-                help: _t("Defines how many megabytes can be imported in each batch import"),
+                help: _t("Defines how many megabytes can be imported in each batch"),
                 value: 10,
                 max: Math.round(maxUploadSize / 1024 / 1024),
                 min: 0,
             },
             delayAfterEachBatch: {
-                help: _t(
-                    "After each batch import, this delay is applied to avoid unthrottled calls"
-                ),
+                help: _t("Delay applied after each batch to prevent unthrottled calls"),
                 value: 1,
                 min: 1,
             },
@@ -509,7 +507,10 @@ export class BaseImportModel {
             this._addMessage(sortedMessages[0].type, [sortedMessages[0].message]);
             delete sortedMessages[0];
         } else {
-            this._addMessage("danger", [_t("The file contains blocking errors (see below)")]);
+            this.notificationService.add(_t("Import failed: see errors below"), {
+                type: "danger",
+                autocloseDelay: 4000,
+            });
         }
 
         for (const [columnFieldId, errors] of Object.entries(sortedMessages)) {
@@ -671,6 +672,7 @@ export class BaseImportModel {
         const advanced = this.importOptionsValues.advanced.value;
         const fields = {
             basic: [],
+            required: [],
             suggested: [],
             additional: [],
             relational: [],
@@ -696,9 +698,11 @@ export class BaseImportModel {
             field.label = ancestors.map((f) => f.string).join(" / ");
 
             // Get field respective category
-            if (!collection) {
-                if (field.name === "id") {
+            if (!collection || collection === fields.required) {
+                if (field.name === "id" && ancestors.length === 1) {
                     collection = fields.basic;
+                } else if (field.required && ancestors.length === 1) {
+                    collection = fields.required;
                 } else if (isRegular(field.fields)) {
                     collection = hasType(types, field) ? fields.suggested : fields.additional;
                 } else {
@@ -742,7 +746,17 @@ export class BaseImportModel {
             if (!column.fieldInfo) {
                 continue;
             }
-
+            if (
+                column.fieldInfo.name === "id" &&
+                column.previews.some((p) => Number.isInteger(Number(p)))
+            ) {
+                column.comments.push({
+                    type: "warning",
+                    content: _t(
+                        `Use unique key across objects for External ID's, for example "lead_1" instead of "1"`
+                    ),
+                });
+            }
             // Fields of type "char", "text" or "many2many" can be specified multiple
             // times and they will be concatenated, fields of other types must be unique.
             if (["char", "text", "html", "many2many"].includes(column.fieldInfo.type)) {
@@ -778,7 +792,7 @@ export class BaseImportModel {
     _getCSVFormattingOptions() {
         return {
             encoding: {
-                label: _t("Encoding:"),
+                label: _t("Encoding"),
                 type: "select",
                 value: "",
                 options: [
@@ -795,57 +809,27 @@ export class BaseImportModel {
                 ],
             },
             separator: {
-                label: _t("Separator:"),
+                label: _t("Separator"),
                 type: "select",
                 value: "",
                 options: [
+                    { value: "", label: _t("Other") },
                     { value: ",", label: _t("Comma") },
                     { value: ";", label: _t("Semicolon") },
                     { value: "\t", label: _t("Tab") },
                     { value: " ", label: _t("Space") },
                 ],
+                other: [",", ";", "\t", " "],
             },
             quoting: {
-                label: _t("Text Delimiter:"),
+                label: _t("Delimiter"),
                 type: "input",
                 value: '"',
             },
-            date_format: {
-                help: _t(
-                    "Use YYYY to represent the year, MM for the month and DD for the day. Include separators such as a dot, forward slash or dash. You can use a custom format in addition to the suggestions provided. Leave empty to let Odoo guess the format (recommended)"
-                ),
-                label: _t("Date Format:"),
-                type: "input",
-                value: "",
-                options: [
-                    "YYYY-MM-DD",
-                    "YYYY/MM/DD",
-                    "DD/MM/YYYY",
-                    "DDMMYYYY",
-                    "MM/DD/YYYY",
-                    "MMDDYYYY",
-                ],
-            },
-            datetime_format: {
-                help: _t(
-                    "Use HH for hours in a 24h system, use II in conjonction with 'p' for a 12h system. You can use a custom format in addition to the suggestions provided. Leave empty to let Odoo guess the format (recommended)"
-                ),
-                label: _t("Datetime Format:"),
-                type: "input",
-                value: "",
-                options: [
-                    "YYYY-MM-DD HH:mm:SS",
-                    "YYYY/MM/DD HH:mm:SS",
-                    "DD/MM/YYYY HH:mm:SS",
-                    "DDMMYYYY HH:mm:SS",
-                    "MM/DD/YYYY II:mm:SS p",
-                    "MMDDYYYY II:mm:SS p",
-                ],
-            },
             float_thousand_separator: {
-                label: _t("Thousands Separator:"),
+                label: _t("Thousands Separator"),
                 type: "select",
-                value: ",",
+                value: localization.thousandsSep,
                 options: [
                     { value: ",", label: _t("Comma") },
                     { value: ".", label: _t("Dot") },
@@ -853,12 +837,49 @@ export class BaseImportModel {
                 ],
             },
             float_decimal_separator: {
-                label: _t("Decimals Separator:"),
+                label: _t("Decimals Separator"),
                 type: "select",
-                value: ".",
+                value: localization.decimalPoint,
                 options: [
                     { value: ",", label: _t("Comma") },
                     { value: ".", label: _t("Dot") },
+                ],
+            },
+            date_format: {
+                label: _t("Date Format"),
+                help: _t(
+                    "Use YYYY to represent the year, MM for the month and DD for the day. Include separators such as a dot, forward slash or dash. You can use a custom format in addition to the suggestions provided. Leave empty to let Odoo guess the format (recommended)"
+                ),
+                type: "input",
+                value: "",
+                placeholder: _t("No date detected"),
+                options: [
+                    "DD/MM/YYYY",
+                    "MM/DD/YYYY",
+                    "YYYY/MM/DD",
+                    "DD-MM-YYYY",
+                    "MM-DD-YYYY",
+                    "YYYY-MM-DD",
+                    "DD.MM.YYYY",
+                    "MM.DD.YYYY",
+                    "YYYY.MM.DD",
+                ],
+            },
+            datetime_format: {
+                label: _t("Datetime Format"),
+                help: _t(
+                    "Use HH for hours in a 24h system, use II in conjonction with 'p' for a 12h system. You can use a custom format in addition to the suggestions provided. Leave empty to let Odoo guess the format (recommended)"
+                ),
+                type: "input",
+                value: "",
+                placeholder: _t("No datetime detected"),
+                options: [
+                    "YYYY-MM-DD HH:mm:SS",
+                    "YYYY/MM/DD HH:mm:SS",
+                    "DD/MM/YYYY HH:mm:SS",
+                    "DDMMYYYY HH:mm:SS",
+                    "MM/DD/YYYY II:mm:SS p",
+                    "MMDDYYYY II:mm:SS p",
                 ],
             },
         };

--- a/addons/base_import/static/src/import_records/import_records.xml
+++ b/addons/base_import/static/src/import_records/import_records.xml
@@ -3,7 +3,7 @@
 
     <t t-name="base_import.ImportRecords">
         <DropdownItem class="'o_import_menu'" onSelected.bind="importRecords">
-            <i class="fa fa-fw fa-download me-1"/>Import records
+            <i class="fa fa-fw fa-download me-1"/>Import
         </DropdownItem>
     </t>
 

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2148,7 +2148,7 @@ class CrmLead(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Leads & Opportunities'),
+            'label': _('Template for Leads & Opportunities'),
             'template': '/crm/static/xls/crm_lead.xls'
         }]
 

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -2059,7 +2059,7 @@ class HrEmployee(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Employees'),
+            'label': _('Template for Employees'),
             'template': '/hr/static/xls/hr_employee.xls'
         }]
 

--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -546,7 +546,7 @@ class AccountAnalyticLine(models.Model):
     def get_import_templates(self):
         if self.env.context.get('is_timesheet'):
             return [{
-                'label': _('Import Template for Timesheets'),
+                'label': _('Template for Timesheets'),
                 'template': '/hr_timesheet/static/xls/timesheets_import_template.xlsx',
             }]
         return []

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -194,7 +194,7 @@ class MailingContact(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Mailing List Contacts'),
+            'label': _('Template for Mailing List Contacts'),
             'template': '/mass_mailing/static/xls/mailing_contact.xls'
         }]
 

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -465,7 +465,7 @@ class MrpBom(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Bills of Materials'),
+            'label': _('Template for Bills of Materials'),
             'template': '/mrp/static/xls/mrp_bom.xls'
         }]
 

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -388,7 +388,7 @@ class ProductPricelist(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Pricelists'),
+            'label': _('Template for Pricelists'),
             'template': '/product/static/xls/product_pricelist.xls'
         }]
 

--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -94,7 +94,7 @@ class ProductSupplierinfo(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Vendor Pricelists'),
+            'label': _('Template for Vendor Pricelists'),
             'template': '/product/static/xls/product_supplierinfo.xls'
         }]
 

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1565,7 +1565,7 @@ class ProductTemplate(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Products'),
+            'label': _('Template for Products'),
             'template': '/product/static/xls/products_import_template.xlsx'
         }]
 

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2204,6 +2204,6 @@ class ProjectTask(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Tasks'),
+            'label': _('Template for Tasks'),
             'template': '/project/static/xls/tasks_import_template.xlsx',
         }]

--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -40,7 +40,7 @@ class ProductTemplate(models.Model):
         res = super(ProductTemplate, self).get_import_templates()
         if self.env.context.get('purchase_product_template'):
             return [{
-                'label': _('Import Template for Products'),
+                'label': _('Template for Products'),
                 'template': '/purchase/static/xls/products_import_template.xlsx'
             }]
         return res

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1423,7 +1423,7 @@ class PurchaseOrder(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Requests for Quotation'),
+            'label': _('Template for Requests for Quotation'),
             'template': '/purchase/static/xls/requests_for_quotation_import_template.xlsx',
         }]
 

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2436,7 +2436,7 @@ class SaleOrder(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Quotations'),
+            'label': _('Template for Quotations'),
             'template': '/sale/static/xls/quotations_import_template.xlsx',
         }]
 

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -339,7 +339,7 @@ class StockQuant(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Inventory Adjustments'),
+            'label': _('Template for Inventory Adjustments'),
             'template': '/stock/static/xlsx/stock_quant.xlsx'
         }]
 

--- a/addons/test_import_export/tests/test_load.py
+++ b/addons/test_import_export/tests/test_load.py
@@ -480,7 +480,7 @@ class test_required_string_field(ImporterCase):
         result = self.import_(['value'], [[]])
         self.assertEqual(len(result['messages']), 1)
         result_message = result['messages'][0]
-        expected_message = message("Missing required value for the field 'Value' (value)")
+        expected_message = message("Missing required field 'Value' (value)")
         self.assertIn(expected_message.pop('message'), result_message.pop('message'))
         self.assertEqual(result_message, expected_message)
         self.assertIs(result['ids'], False)
@@ -490,7 +490,7 @@ class test_required_string_field(ImporterCase):
         result = self.import_(['const'], [['12']])
         self.assertEqual(len(result['messages']), 1)
         result_message = result['messages'][0]
-        expected_message = message("Missing required value for the field 'Value' (value)")
+        expected_message = message("Missing required field 'Value' (value)")
         self.assertIn(expected_message.pop('message'), result_message.pop('message'))
         self.assertEqual(result_message, expected_message)
         self.assertIs(result['ids'], False)
@@ -502,7 +502,7 @@ class test_required_string_field(ImporterCase):
         self.assertEqual(len(result['messages']), 11)
         for m in result['messages'][:-1]:
             self.assertEqual(m['type'], 'error')
-            self.assertIn("Missing required value for the field 'Value' (value)", m['message'])
+            self.assertIn("Missing required field 'Value' (value)", m['message'])
         last = result['messages'][-1]
         self.assertEqual(last['type'], 'warning')
         self.assertEqual(

--- a/addons/web/static/src/views/list/export_all/export_all.xml
+++ b/addons/web/static/src/views/list/export_all/export_all.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.ExportAll">
         <DropdownItem class="'o_export_all_menu'" onSelected.bind="onDirectExportData">
-            <i class="fa fa-fw fa-upload me-1"/>Export All
+            <i class="fa fa-fw fa-upload me-1"/>Export
         </DropdownItem>
     </t>
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1133,7 +1133,7 @@ test(`list view: action button in controlPanel basic rendering on mobile`, async
     });
     expect(`.o_control_panel_actions > *`).toHaveCount(0);
     await contains(".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog").click();
-    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual(["Export All"]);
+    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual(["Export"]);
     await clickRecordSelector();
     await contains(".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog").click();
     expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual([
@@ -1144,7 +1144,7 @@ test(`list view: action button in controlPanel basic rendering on mobile`, async
     ]);
     await clickRecordSelector();
     await contains(".o_control_panel_breadcrumbs .o_cp_action_menus .fa-cog").click();
-    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual(["Export All"]);
+    expect(queryAllTexts(`.o-dropdown--menu .o-dropdown-item`)).toEqual(["Export"]);
 });
 
 test.tags("desktop");

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1193,7 +1193,7 @@ class ResPartner(models.Model):
     @api.model
     def get_import_templates(self):
         return [{
-            'label': _('Import Template for Contacts'),
+            'label': _('Template for Contacts'),
             'template': '/base/static/xls/contacts_import_template.xlsx',
         }]
 

--- a/odoo/addons/test_http/tests/test_error_rpc.py
+++ b/odoo/addons/test_http/tests/test_error_rpc.py
@@ -39,13 +39,7 @@ class TestError(common.HttpCase):
 
         e = ctx.exception
         self.assertIn("The operation cannot be completed:", e.faultString)
-        self.assertIn("create/update: a mandatory field is not set", e.faultString)
-        self.assertIn(
-            "delete: another model requires the record being deleted",
-            e.faultString,
-        )
-        self.assertIn("Model: 'Model B' (test_rpc.model_b)", e.faultString)
-        self.assertIn("field 'Name' (name)", e.faultString)
+        self.assertIn("Missing required field 'Name' (name) for model 'Model B' (test_rpc.model_b)", e.faultString)
 
     def test_02_delete(self):
         """ Delete: NOT NULL and ON DELETE RESTRICT constraints """

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2558,10 +2558,7 @@ class BaseModel(metaclass=MetaModel):
 
         if isinstance(exc, psycopg2.errors.NotNullViolation):
             return self.env._(
-                "Missing required value for the field %(field_display)s.\n"
-                "Model: %(model_display)s\n"
-                "- create/update: a mandatory field is not set\n"
-                "- delete: another model requires the record being deleted, you can archive it instead\n",
+                "Missing required field %(field_display)s for model %(model_display)s",
                 **info,
             )
 


### PR DESCRIPTION
*: account, crm, hr, hr_timesheet, mass_mailing, mrp, product, project, purchase, sale, stock, web, base

This commit introduces a wide range of UI/UX improvements to the import records feature:

**UI/Layout:**
* **Revamped Initial View:** The import view prior to file selection has been redesigned for clarity (includes shortening the template import button text).
* **Breadcrumbs:** The file name now appears in the action breadcrumb instead of the side panel.
* **Input Styling:** Updated input fields to use rounded borders, matching the standard design.
* **Sticky Headers:** Column list headers are now sticky to improve usability on long lists.
* **Tooltips:** Moved several help tooltips to `<sup>` elements and updated their content.

**Workflow & Logic:**
* **Simplification:** Shortened overly verbose button names.
* **Sheet Selection:** Automatically hides the sheet selection input if the file contains only one sheet.
* **Advanced Options:** Removed the "Advanced" side panel section. The "Track History" option has been renamed and moved to the main section.
* **Separators:** Default float separators are now determined by the user's active language locale. Added "Other" option for CSV separators to customize the value beyond the default select options using an
additional input.
* **Batch options:** Batch customization has been reduced to the batch
size, got moved to the main section and is only accessible in debug mode.

**Field Mapping:**
* **Required Fields:** Required fields are now grouped at the top of the field selection dropdown.
* **External ID Warning:** Added a warning when the External ID column contains simple integers.
* **Error Messages:** Simplified the error message for missing required values.

task-5242240