### PR TITLE
[FIX] project: preserve privacy_visibility during share flow

### DIFF
--- a/addons/project/models/project_collaborator.py
+++ b/addons/project/models/project_collaborator.py
@@ -7,7 +7,7 @@ class ProjectCollaborator(models.Model):
     _name = 'project.collaborator'
     _description = 'Collaborators in project shared'
 
-    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', '=', 'portal'), ('is_template', '=', False)], required=True, readonly=True, export_string_translation=False)
+    project_id = fields.Many2one('project.project', 'Project Shared', domain=[('privacy_visibility', 'in', ['portal', 'invited_users']), ('is_template', '=', False)], required=True, readonly=True, export_string_translation=False)
     partner_id = fields.Many2one('res.partner', 'Collaborator', required=True, readonly=True, export_string_translation=False)
     partner_email = fields.Char(related='partner_id.email', export_string_translation=False)
     limited_access = fields.Boolean('Limited Access', default=False, export_string_translation=False)

--- a/addons/project/wizard/project_share_wizard.py
+++ b/addons/project/wizard/project_share_wizard.py
@@ -154,7 +154,6 @@ class ProjectShareWizard(models.TransientModel):
         }
 
     def action_send_mail(self):
-        self.env['project.project'].browse(self.res_id).privacy_visibility = 'portal'
         result = {
             'type': 'ir.actions.client',
             'tag': 'display_notification',


### PR DESCRIPTION
Steps to reproduce:
- Create/open any project
- Set visibility to `Invited internal users and portal users`.
- Share project with a portal user
- Visibility changes to `All internal users and invited portal users`.

Cause:
- Previously, this behavior was implemented specifically for sharing the project from the cog menu. However, the `Share Project` option has now been removed from the cog menu.

- After introducing the new `invited_users` visibility option, the existing share logic was not updated to support this new value; as a result, the project's existing visibility is unintentionally overwritten.

Solution:
- Remove the hardcoded update of `privacy_visibility` in the `action_send_mail` method.

task-5924243


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
