### PR TITLE
[FIX] web: prevent useless loading effect mutations

### DIFF
--- a/addons/web/static/src/legacy/js/public/minimal_dom.js
+++ b/addons/web/static/src/legacy/js/public/minimal_dom.js
@@ -80,11 +80,11 @@ export function makeButtonHandler(fct, preventDefault, stopPropagation, stopImme
     fct = makeAsyncHandler(fct, preventDefault, stopPropagation, stopImmediatePropagation);
 
     return function (ev) {
-        const result = fct.apply(this, arguments);
+        const handlerResult = fct.apply(this, arguments);
 
         const buttonEl = ev.target.closest(BUTTON_HANDLER_SELECTOR);
         if (!(buttonEl instanceof HTMLElement)) {
-            return result;
+            return handlerResult;
         }
 
         // Disable the button for the duration of the handler's action
@@ -92,12 +92,21 @@ export function makeButtonHandler(fct, preventDefault, stopPropagation, stopImme
         // a 'real' debounce creation useless. Also, during the debouncing
         // part, the button is disabled without any visual effect.
         buttonEl.classList.add("pe-none");
-        new Promise(resolve => setTimeout(resolve, DEBOUNCE)).then(() => {
+        let showDebouncedLoading = false;
+        const addLoadingIfPending = () => {
             buttonEl.classList.remove("pe-none");
-            const restore = addLoadingEffect(buttonEl);
-            return Promise.resolve(result).then(restore, restore);
-        });
+            if (showDebouncedLoading) {
+                const restore = addLoadingEffect(buttonEl);
+                Promise.resolve(handlerResult).then(restore, restore);
+            }
+        };
+        Promise.race([
+            handlerResult,
+            new Promise((resolve) => setTimeout(resolve, DEBOUNCE)).then(() => {
+                showDebouncedLoading = true;
+            }),
+        ]).then(addLoadingIfPending, addLoadingIfPending);
 
-        return result;
+        return handlerResult;
     };
 }

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -2403,23 +2403,64 @@ describe("locked", () => {
         expect(queryFirst("span")).toBe(null);
     });
 
-    test("locked add a loading icon when the execution takes more than 400ms", async () => {
-        class Test extends Interaction {
-            static selector = ".test";
-            dynamicContent = {
-                button: {
-                    "t-on-click": this.locked(this.onClickLong, true),
-                },
-            };
-            async onClickLong() {
-                await new Promise((resolve) => setTimeout(resolve, 5000));
+    describe("loading effect", () => {
+        let handlerDuration = 5000;
+
+        beforeEach(async () => {
+            class Test extends Interaction {
+                static selector = ".test";
+                dynamicContent = {
+                    button: {
+                        "t-on-click": this.locked(this.onClickLong, true),
+                    },
+                };
+                async onClickLong() {
+                    await new Promise((resolve) => setTimeout(resolve, handlerDuration));
+                    expect.step("handler done");
+                }
             }
-        }
-        await startInteraction(Test, TemplateTestDoubleButton);
-        expect(queryFirst("span")).toBe(null);
-        await click("button");
-        await advanceTime(500);
-        expect(queryFirst("span")).not.toBe(null);
+
+            await startInteraction(Test, TemplateTestDoubleButton, {
+                waitForStart: false,
+            });
+
+            const observer = new MutationObserver((mutations) => {
+                for (const m of mutations) {
+                    if ([...m.addedNodes].some((node) => node.tagName === "SPAN")) {
+                        expect.step("loading added");
+                    }
+                }
+            });
+            observer.observe(queryFirst("button"), { childList: true });
+        });
+
+        test("should be added when the handler takes more than 400ms", async () => {
+            expect("span.fa-spin").toHaveCount(0);
+            await click("button");
+            // Advance time more than the debounce delay of makeButtonHandler
+            // (400ms) but less than the handler duration.
+            await advanceTime(500);
+            expect("span.fa-spin").toHaveCount(1);
+            expect.verifySteps(["loading added"]);
+            await advanceTime(handlerDuration);
+            expect.verifySteps(["handler done"]);
+        });
+
+        test("should never be added when the handler takes less than 400ms", async () => {
+            handlerDuration = 100;
+            expect("span.fa-spin").toHaveCount(0);
+            await click("button");
+            // Advance time more than the handler duration but less than the
+            // debounce delay of makeButtonHandler (400ms).
+            await advanceTime(200);
+            expect.verifySteps(["handler done"]);
+            await advanceTime(1000);
+            expect("span.fa-spin").toHaveCount(0);
+            expect.verifySteps([], {
+                message:
+                    "Loading effect should never be added in the DOM for handlers shorter than 400ms",
+            });
+        });
     });
 
     test("locked automatically binds functions", async () => {


### PR DESCRIPTION
__Before commit__
When using `makeButtonHandler`, a loading effect is applied to the
button if the handler takes more than 400ms to execute. However, if
the handler finishes sooner, the effect is still briefly added and
removed, triggering a DOM mutation.

If a button is clicked and the website builder opens immediately
after, this mutation may be recorded in the current history step
despite being unnecessary.

This causes the `design-themes` tour `theme_menu_hierarchies` to fail
in a non-deterministic way with the following warning:
"should not have any 'characterData', 'remove' or 'add' mutations in
current step when you update the selection"

__Fix__
Ensure the loading effect is never added if the handler execution
time is shorter than the debounce duration.

This fix is applied to both `makeButtonHandler` functions in the
codebase. The test case is only added for the interaction use case,
as the other instance resides in legacy code.

runbot-229803