### PR TITLE
[FIX] pos, l10n_ke_edi_oscu_pos: fix timeout on indexed db

### DIFF
--- a/addons/point_of_sale/static/tests/generic_helpers/utils.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/utils.js
@@ -46,7 +46,14 @@ export function refresh() {
                 }, 305);
 
                 setTimeout(() => {
-                    throw new Error("Timeout waiting indexedDB for transactions to finish");
+                    const activeTx = posmodel.data.indexedDB.activeTransactions;
+                    const storeNames = Array.from(activeTx).flatMap((tx) =>
+                        Array.from(tx.objectStoreName)
+                    );
+                    const uniqueStores = [...new Set(storeNames)].join(", ");
+                    throw new Error(
+                        `Timeout waiting indexedDB for transactions to finish. Stores open: [${uniqueStores}]`
+                    );
                 }, 2000);
             });
         },


### PR DESCRIPTION
There is an issue that seems to only happen on l10n_ke runbot that times out on tests that try to add a product to the cart in pos and then refresh the page.

The l10n_ke_edi_oscu_pos module has a listener added on the order component which tries to automatically add the taxes to the products in the order. This triggers a transaction on indexed db. Since the tour test executes the refresh immediately after adding the product to the cart, it causes a timeout.

I could not reproduce the issue locally, but it's been happening consistently on almost every nightly run, always on the l10n_ke run.

This PR will increase the timeout and add some extra info to the timeout message to help with debugging in the future.

Runbot error: [233525](https://runbot.odoo.com/odoo/runbot.build.error/233525)
Task: [5897379](https://www.odoo.com/odoo/project/1737/tasks/5897379)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
