### PR TITLE
[FIX] website, website_sale: avoid timeout dialog actions

### DIFF
--- a/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/add_element_option_plugin.js
@@ -92,6 +92,10 @@ export class AddGridElementAction extends BuilderAction {
     static id = "addGridElement";
     static dependencies = ["addElementOption", "media"];
 
+    setup() {
+        this.canTimeout = false;
+    }
+
     async apply({ editingElement: rowEl, params: { mainParam: elementType } }) {
         if (elementType === "image") {
             // Choose an image with the media dialog.

--- a/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab_plugin.js
@@ -318,6 +318,9 @@ export class ChangeColorPaletteAction extends CustomizeWebsiteVariableAction {
 
 export class EditCustomCodeAction extends BuilderAction {
     static id = "editCustomCode";
+    setup() {
+        this.canTimeout = false;
+    }
     apply() {
         this.services.dialog.add(EditHeadBodyDialog);
     }
@@ -326,6 +329,9 @@ export class EditCustomCodeAction extends BuilderAction {
 export class ConfigureApiKeyAction extends BuilderAction {
     static id = "configureApiKey";
     static dependencies = ["googleMapsOption"];
+    setup() {
+        this.canTimeout = false;
+    }
     apply() {
         this.dependencies.googleMapsOption.configureGMapsAPI("", true);
     }

--- a/addons/website_sale/static/src/website_builder/dynamic_snippet_category_item_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/dynamic_snippet_category_item_option_plugin.js
@@ -24,6 +24,10 @@ class SetCategoryImageAction extends BuilderAction {
     static id = 'setCategoryImage';
     static dependencies = ['media', 'builderOptions'];
 
+    setup() {
+        this.canTimeout = false;
+    }
+
     async apply({ editingElement: el }) {
         const categoryId = el.dataset.categoryId;
         const categoryImage = el.querySelector('[name="category_image"]');

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -321,6 +321,7 @@ export class ProductReplaceMainImageAction extends BaseProductPageAction {
     setup() {
         super.setup();
         this.reload = false;
+        this.canTimeout = false;
     }
     apply({ editingElement: productDetailMainEl }) {
         // Emulate click on the main image of the carousel.
@@ -360,6 +361,10 @@ export class ProductReplaceMainImageAction extends BaseProductPageAction {
 export class ProductAddExtraImageAction extends BaseProductPageAction {
     static id = "productAddExtraImage";
     static dependencies = [...super.dependencies, "media"];
+    setup() {
+        super.setup();
+        this.canTimeout = false;
+    }
     async apply({ editingElement: el }) {
         // Prompts the user for images, then saves the new images.
         if (this.model === "product.template") {


### PR DESCRIPTION
In [0] was added a timeout on operations, as an heuristic to detect when an operation is stuck.
Unfortunately, when an action opens a dialog, waiting for the user to choose may go over the timeout limit, thus triggering the timeout. The timeout should be deactivated for those type of actions.

This commit sets `canTimeout = false` on actions that open a dialog and wait for user choice in the `apply` method.

Steps to reproduce:
- Open website builder
- Drop `s_sidegrid` snippet
- Click on "Add Elements" option: Image
- Wait 10sec
- Bug: It show the error message "A technical issue occurred..."

[0]: https://github.com/odoo/odoo/commit/6df83abb35c95ab42e55d9a08cf6c411efa64b3e
