### PR TITLE
[FIX] account: conditionally apply table-responsive-sm on invoice report

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -169,7 +169,7 @@
                         <t t-set="display_taxes" t-value="any(l.tax_ids for l in o.invoice_line_ids)"/>
                         <div class="oe_structure"></div>
                         <t t-set="has_long_desc" t-value="any(line.name and line.name.count('\n') > 30 for line in o.invoice_line_ids if line.name)"/>
-                        <div class="table-responsive-sm overflow-visible">
+                        <div t-attf-class="{{ 'table-responsive-sm' if report_type == 'html' else '' }}">
                             <table class="o_has_total_table table o_main_table table-borderless mb-0" name="invoice_line_table">
                                 <thead t-attf-style="#{has_long_desc and 'display: table-row-group;' or ''}">
                                     <tr>


### PR DESCRIPTION
This commit:
https://github.com/odoo/odoo/commit/ad6351c

Wrapped the invoice line table in a `<div class="table-responsive-sm">` to enable horizontal scrolling on mobile. However, Bootstrap's `table-responsive-sm` sets `overflow-x:auto` on the container, which prevents wkhtmltopdf from repeating the `<thead>` across page breaks. On pages 2+, the header row (Description, Quantity, Unit Price, Amount) renders on top of the first data row instead of appearing as a separate repeated header.

Made the `table-responsive-sm` class conditional on `report_type == 'html'` so it only applies in HTML views where mobile scrolling is needed, and is omitted for PDF rendering. This follows the same pattern already used throughout the invoice template for other responsive classes.

Steps to reproduce:
1. Create an invoice with enough lines to span multiple pages
2. Print the invoice as PDF

=> On page 2+, the table header overlaps with the first data row, making both unreadable.

Ticket [link](https://www.odoo.com/odoo/action-4043/5867972)
opw-5867972

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
