### PR TITLE
[IMP] point_of_sale, *: Improve button consistency in navbar

### DIFF
--- a/addons/point_of_sale/static/src/app/components/list_container/list_container.js
+++ b/addons/point_of_sale/static/src/app/components/list_container/list_container.js
@@ -37,17 +37,22 @@ export class ListContainer extends Component {
         class: "",
     };
     static template = xml`
-        <div class="d-flex flex-grow-1" t-attf-class="{{props.class}}" t-att-class="{'overflow-hidden': !isUiSmall}">
-            <button t-if="props.onClickPlus" class="list-plus-btn btn btn-secondary btn-lg me-1 my-2" t-on-click="props.onClickPlus">
+        <div class="d-flex gap-1 align-items-center flex-grow-1" t-attf-class="{{props.class}}" t-att-class="{'overflow-hidden': !isUiSmall}">
+            <button t-if="props.onClickPlus" class="list-plus-btn btn btn-secondary btn-lg flex-shrink-0 lh-lg" t-on-click="props.onClickPlus">
                 <i class="fa fa-fw fa-plus-circle" aria-hidden="true"/>
             </button>
-            <button t-if="this.sizing.isLarger or props.forceSmall" t-on-click="toggle"
-                class="btn btn-secondary mx-1 fa fa-caret-down my-2" />
-            <div class="overflow-hidden w-100 position-relative py-2">
-                <div t-ref="container" class="list-container-items d-flex w-100">
-                    <div t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index" t-att-class="{'invisible': shouldBeInvisible(item_index)}">
+            <span t-if="props.onClickPlus" class="navbar-separator mx-1"/>
+            <div class="overflow-hidden flex-grow-1">
+                <div t-ref="container" class="list-container-items d-flex align-items-center gap-1">
+                    <div t-if="!props.forceSmall" t-foreach="props.items" t-as="item" t-key="item_index" t-att-class="{'invisible order-2': shouldBeInvisible(item_index)}">
                         <t t-slot="default" item="item"/>
                     </div>
+                    <button t-if="this.sizing.isLarger or props.forceSmall" t-on-click="toggle"
+                        class="btn btn-lg btn-secondary order-1 flex-shrink-0 fw-bolder lh-lg"
+                        t-att-class="props.forceSmall ? '' : 'px-3 fw-bold'">
+                        <i t-if="props.forceSmall" class="fa fa-fw fa-caret-down"/>
+                        <t t-else="">+<t t-esc="hiddenCount"/></t>
+                    </button>
                 </div>
             </div>
         </div>
@@ -67,6 +72,9 @@ export class ListContainer extends Component {
     }
     shouldBeInvisible(itemIndex) {
         return itemIndex >= this.sizing.maxItems;
+    }
+    get hiddenCount() {
+        return this.props.items.length - this.sizing.maxItems;
     }
     toggle() {
         this.dialog.add(ListContainerDialog, {

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.scss
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.scss
@@ -1,6 +1,32 @@
+.pos .navbar-separator {
+    height: 1.5rem;
+    width: 1px;
+    background-color: $border-color;
+}
+
+// Reset btn-group gap to default Bootstrap behavior (overlapping borders).
+// The backend adds a positive gap via bootstrap_review_backend.scss which
+// is not desired in POS for the Table/Register/Orders button group.
+.pos .navbar-menu.btn-group {
+    > :not(.btn-check:first-child) + .btn,
+    > .btn-group:not(:first-child) {
+        margin-left: calc(-1 * #{$btn-border-width});
+    }
+
+    > .btn.active {
+        z-index: 2;
+    }
+}
+
 .pos .status-buttons {
     .avatar {
-        height: 24px;
+        height: $pos-avatar-size;
+        width: $pos-avatar-size;
+    }
+
+    > .btn {
+        --btn-border-color: transparent;
+        --btn-active-border-color: transparent;
     }
 }
 
@@ -28,13 +54,4 @@
 
 .pos .o-dropdown--menu .dropdown-item.focus {
     background-color: $o-gray-200;
-}
-
-@include media-breakpoint-up(lg) {
-    .pos-leftheader, .pos-rightheader {
-        max-width: 40%;
-    }
-    .pos .navbar-menu > button {
-        min-width: 96px;
-    }
 }

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -3,21 +3,20 @@
 
     <t t-name="point_of_sale.Navbar">
         <div class="pos-topheader position-relative d-flex align-items-center justify-content-between gap-1 p-2 m-0 bg-view border-bottom">
-            <div class="pos-leftheader d-flex align-items-center flex-grow-1 overflow-auto" t-att-class="{'d-none': ui.isSmall and state.searchBarOpen, 'mw-100': this.pos.getOrder()}">
-                <div class="d-flex flex-shrink-0 align-items-center gap-1 position-relative pe-2" t-att-class="{ 'w-100': !ui.isSmall }">
-                    <div class="navbar-menu d-flex">
-                        <button class="register-label btn btn-lg btn-light lh-lg" t-att-class="{'active': mainButton === 'register'}" t-on-click="() => this.onClickRegister()">
+            <div class="pos-leftheader d-flex align-items-center flex-grow-1 overflow-auto min-w-0" t-att-class="{'d-none': ui.isSmall and state.searchBarOpen, 'mw-100': this.pos.getOrder()}">
+                <div class="d-flex flex-shrink-0 align-items-center gap-2 gap-lg-3 position-relative pe-2 min-w-0" t-att-class="{ 'w-100': !ui.isSmall }">
+                    <div class="navbar-menu btn-group" role="group" aria-label="Navigation Menu">
+                        <button class="register-label btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': mainButton === 'register'}" t-on-click="() => this.onClickRegister()">
                             <span t-if="!ui.isSmall">Register</span>
                             <i t-else="" class="fa fa-fw fa-pencil" t-att-class="{'fa-lg' : !ui.isSmall}"/>
                         </button>
-                        <button class="orders-button btn btn-lg btn-light lh-lg" t-att-class="{'active': mainButton === 'order'}" t-on-click="() => this.onTicketButtonClick()">
+                        <button class="orders-button btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': mainButton === 'order'}" t-on-click="() => this.onTicketButtonClick()">
                             <t t-if="!ui.isSmall">
                                 <span>Orders</span>
                             </t>
                             <i t-else="" class="fa fa-fw fa-book" t-att-class="{'fa-lg' : !ui.isSmall}"/>
                         </button>
                     </div>
-                    <div t-if="!ui.isSmall" class="navbar-separator"/>
                     <OrderTabs orders="getOrderTabs()" class="'h-50'"/>
                     <button class="btn btn-secondary d-flex align-items-center gap-1 h-100 ms-2 p-2 preset-time-btn" t-on-click="openPresetTiming" t-if="shouldDisplayPresetTime">
                         <i class="fa fa-clock-o" aria-hidden="true"/>
@@ -28,9 +27,9 @@
             <div t-if="!this.pos.getOrder()" class="pos-centerheader d-none d-xl-flex justify-content-center overflow-hidden">
                 <div class="pos-logo mw-100" />
             </div>
-            <div class="pos-rightheader flex-grow-1">
-                <div class="status-buttons d-flex flex-grow-1 align-items-center justify-content-end gap-1">
-                    <div t-if="this.pos.data.network.offline or this.pos.data.network.loading" class="oe_status btn btn-light btn-lg lh-lg h-100 pe-none">
+            <div class="pos-rightheader flex-shrink-0">
+                <div class="status-buttons d-flex align-items-center justify-content-end gap-1">
+                    <div t-if="this.pos.data.network.offline or this.pos.data.network.loading" class="oe_status px-3">
                         <span t-if="this.pos.data.network.unsyncData.length > 0" t-esc="this.pos.data.network.unsyncData.length" />
                         <div t-if="this.pos.data.network.offline" class="fa fa-fw fa-chain-broken text-danger"/>
                         <div t-else="" class="fa fa-fw fa-spin fa-circle-o-notch text-warning"/>

--- a/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
+++ b/addons/point_of_sale/static/src/app/components/order_tabs/order_tabs.xml
@@ -12,7 +12,7 @@
                 <button t-esc="order.getName()"
                     t-att-class="{ 'active': pos.getOrder()?.id === order.id }"
                     t-attf-class="{{`o_colorlist_item_color_transparent_${order.preset_id?.color}`}}"
-                    class="btn btn-lg btn-secondary text-truncate mx-1 border-transparent"
+                    class="btn btn-lg btn-secondary px-3 lh-lg text-truncate"
                     style="min-width: 4rem;"
                     t-on-click="() => this.selectFloatingOrder(order)"
                 />

--- a/addons/point_of_sale/static/src/app/hooks/hooks.js
+++ b/addons/point_of_sale/static/src/app/hooks/hooks.js
@@ -177,7 +177,6 @@ export function useIsChildLarger(container) {
         let acc = 0;
         let nbrItems = 0;
         let isLarger = false;
-        const oldLargerState = state.isLarger;
         const containerWidth = container.el.clientWidth - 10;
 
         for (const child of container.el.children) {
@@ -192,8 +191,8 @@ export function useIsChildLarger(container) {
 
         state.isLarger = isLarger;
         state.maxItems = nbrItems;
-        if (!oldLargerState && state.isLarger) {
-            state.maxItems--;
+        if (state.isLarger) {
+            state.maxItems = Math.max(0, state.maxItems - 1);
         }
     };
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -29,7 +29,7 @@
         <t t-else="">
             <div class="payment-screen screen d-flex flex-column h-100 ">
                 <div class="main-content d-flex gap-2 h-100 bg-100 overflow-auto">
-                    <div class="left-content d-flex flex-column col-md-4 p-1 h-100 overflow-hidden gap-1">
+                    <div class="left-content d-flex flex-column col-md-4 p-2 h-100 overflow-hidden gap-1">
                         <div class="flex-grow-1 overflow-auto">
                             <t t-call="point_of_sale.PaymentScreenMethods" />
                         </div>
@@ -116,7 +116,7 @@
     <t t-name="point_of_sale.PaymentScreenButtons">
         <div class="payment-buttons d-flex flex-column gap-1">
         <!-- To make Customer and Invoice button align on a single row -->
-            <div class="d-flex gap-1 w-100">
+            <div class="d-flex gap-2 w-100">
                 <t t-set="hasOptionalButtons" t-value="pos.config.iface_tipproduct and pos.config.tip_product_id or pos.config.iface_cashdrawer or pos.config.ship_later" />
                 <button class="button partner-button btn btn-lg w-100 w-md-50 lh-lg text-truncate"
                     t-att-class="{ 'highlight text-action': currentOrder.getPartner() }"

--- a/addons/point_of_sale/static/src/scss/pos.scss
+++ b/addons/point_of_sale/static/src/scss/pos.scss
@@ -13,18 +13,11 @@ select > option {
     background: $light;
 }
 
-.navbar-menu {
-    :not(.btn-check) + .btn:active, .btn:first-child:active{
-        --btn-active-border-color: transparent;
-    }
-}
-
 .btn-light {
-    --btn-hover-bg: #{$o-gray-100};
-    --btn-hover-border-color: transparent;
+    --btn-border-color: #cccccc;
     --btn-active-bg: #{$o-gray-300};
     --btn-color: #{$o-gray-900};
-    --btn-active-border-color: transparent;
+    --btn-active-border-color: var(--btn-border-color);
 }
 
 .btn-secondary {

--- a/addons/point_of_sale/static/src/scss/pos_variables_extra.scss
+++ b/addons/point_of_sale/static/src/scss/pos_variables_extra.scss
@@ -1,3 +1,4 @@
 $pos-left-pane-width: 450px !default;
 $pos-left-pane-width-tablet: 400px !default;
 $pos-navbar-height: 61px !default;
+$pos-avatar-size: 36px !default;

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -57,8 +57,21 @@ export function selectFloatingOrder(index) {
             run: "click",
         },
         {
-            trigger: `.list-container-items .btn:eq(${index})`,
+            isActive: ["mobile"],
+            trigger: `.modal-dialog .list-container-items .btn:eq(${index})`,
             run: "click",
+        },
+        {
+            isActive: ["desktop"],
+            trigger: `.list-container-items .floating-order-container`,
+            run: () => {
+                const btns = document.querySelectorAll(
+                    ".list-container-items .floating-order-container .btn"
+                );
+                if (btns[index]) {
+                    btns[index].click();
+                }
+            },
         },
     ];
 }
@@ -71,10 +84,26 @@ export function checkFloatingOrderCount(expectedCount) {
             run: "click",
         },
         {
+            isActive: ["mobile"],
             content: `check there are ${expectedCount} floating order`,
-            trigger: ".list-container-items .btn",
+            trigger: ".modal-dialog .list-container-items .btn",
             run: () => {
-                const btns = document.querySelectorAll(".list-container-items .btn");
+                const btns = document.querySelectorAll(".modal-dialog .list-container-items .btn");
+                if (btns.length !== expectedCount) {
+                    throw new Error(
+                        `Expected ${expectedCount} floating order buttons, found ${btns.length}`
+                    );
+                }
+            },
+        },
+        {
+            isActive: ["desktop"],
+            content: `check there are ${expectedCount} floating order`,
+            trigger: ".list-container-items",
+            run: () => {
+                const btns = document.querySelectorAll(
+                    ".list-container-items .floating-order-container .btn"
+                );
                 if (btns.length !== expectedCount) {
                     throw new Error(
                         `Expected ${expectedCount} floating order buttons, found ${btns.length}`

--- a/addons/pos_hr/static/src/app/components/navbar/navbar.xml
+++ b/addons/pos_hr/static/src/app/components/navbar/navbar.xml
@@ -11,7 +11,7 @@
             </attribute>
         </xpath>
         <xpath expr="//CashierName" position="after">
-            <button t-if="pos.config.module_pos_hr and !ui.isSmall" class="lock-screen btn btn-light btn-lg" title="Lock" t-on-click="() => this.pos.showLoginScreen()">
+            <button t-if="pos.config.module_pos_hr and !ui.isSmall" class="lock-screen btn btn-light btn-lg lh-lg" title="Lock" t-on-click="() => this.pos.showLoginScreen()">
                 <i class="fa fa-fw fa-unlock"/>
             </button>
         </xpath>

--- a/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
+++ b/addons/pos_restaurant/static/src/app/components/navbar/navbar.xml
@@ -18,15 +18,15 @@
             <attribute name="t-if">!pos.config.module_pos_restaurant</attribute>
         </xpath>
         <xpath expr="//div[hasclass('pos-leftheader')]//OrderTabs" position="after">
-            <span t-if="pos.config.module_pos_restaurant and pos.getOrder()" t-esc="currentOrderName" class="badge rounded-pill text-bg-info py-2 fs-6 fw-bolder text-truncate"/>
+            <span t-if="pos.config.module_pos_restaurant and pos.getOrder()" t-esc="currentOrderName" class="badge rounded-pill bg-info-subtle border border-info py-2 fs-6 fw-bolder text-truncate"/>
         </xpath>
         <xpath expr="//button[hasclass('register-label')]" position="before">
-            <button t-if="pos.config.module_pos_restaurant" class="table-button btn btn-lg btn-light lh-lg" t-att-class="{'active': mainButton === 'table', 'text-muted': this.pos.getOrder()?.isFilledDirectSale}" t-on-click="() => this.onClickPlanButton()">
+            <button t-if="pos.config.module_pos_restaurant" class="table-button btn btn-outline-secondary btn-lg lh-lg" t-att-class="{'active': mainButton === 'table', 'text-muted': this.pos.getOrder()?.isFilledDirectSale}" t-on-click="() => this.onClickPlanButton()">
                 <span t-if="!ui.isSmall">Tables</span>
                 <img t-else="" src="/pos_restaurant/static/img/plan.svg" class="navbar-icon" t-att-class="{'opacity-50': this.pos.getOrder()?.isFilledDirectSale}" alt="Floor Plan"/>
             </button>
         </xpath>
-        <xpath expr="//div[hasclass('navbar-separator')]" position="after">
+        <xpath expr="//div[hasclass('navbar-menu')]" position="after">
             <div class="d-flex align-items-center" t-if="pos.orderToTransferUuid">
                 <strong class="mx-2 text-warning">
                     Select table to transfer order

--- a/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
+++ b/addons/pos_restaurant/static/src/app/components/popup/edit_order_name_popup/edit_order_name_popup.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_restaurant.EditOrderNamePopup" t-inherit="point_of_sale.TextInputPopup" t-inherit-mode="primary">
         <xpath expr="//textarea" position="replace">
-            <div class="d-flex flex-column-reverse align-content-center">
+            <div class="d-flex flex-column-reverse align-content-center gap-2">
                 <ListContainer
                     t-if="items"
                     items="items"
@@ -13,7 +13,7 @@
                     <t t-set="order" t-value="scope.item" />
                     <div class="position-relative">
                         <button t-esc="order.getName()"
-                            class="btn btn-lg btn-secondary text-truncate me-1"
+                            class="btn btn-lg btn-secondary me-1 px-3 lh-lg text-truncate"
                             style="min-width: 4rem;"
                             t-on-click="() => this.transferOrder(order)"
                         />

--- a/addons/pos_restaurant/static/tests/tours/utils/chrome.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/chrome.js
@@ -2,7 +2,7 @@ export function isTabActive(tabText) {
     return [
         {
             content: "Check if the active tab contains the text" + tabText,
-            trigger: `.pos-leftheader span.text-bg-info:contains(${tabText})`,
+            trigger: `.pos-leftheader span.bg-info-subtle:contains(${tabText})`,
         },
     ];
 }


### PR DESCRIPTION
*: pos_hr, pos_restaurant

Before this commit, the POS navbar had inconsistent button styling where navigation buttons (Register, Orders, Tables, Booking) used different color schemes and border treatments than order management buttons. The secondary buttons had borders added in a recent PR to make the button more visible in light-challenging situations, but the main navigation buttons remained borderless as btn-light. Also, the order overflow indicator showed as a simple caret, providing no information about how many hidden orders existed.

This commit fixes these inconsistencies with a better button hierarchy.

Lastly, the overflow indicator now shows "+N" instead of a caret, clearly indicating how many orders are hidden. The layout calculation was improved to ensure all navigation elements remain visible and accessible.

requires: https://github.com/odoo/enterprise/pull/107166

task-5905481

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
