### PR TITLE
[FIX] html_builder: fix typo in dropzone selectors

### DIFF
--- a/addons/html_builder/static/src/core/disable_snippets_plugin.js
+++ b/addons/html_builder/static/src/core/disable_snippets_plugin.js
@@ -130,20 +130,14 @@ export class DisableSnippetsPlugin extends Plugin {
     getDropAreas(editableAreaEls, rootEl) {
         const dropAreasBySelector = [];
         this.getResource("dropzone_selector").forEach((dropzoneSelector) => {
-            const {
-                selector,
-                exclude = false,
-                dropIn,
-                dropNear,
-                excludeNearParent,
-            } = dropzoneSelector;
+            const { selector, exclude = false, dropIn, dropNear, excludeParent } = dropzoneSelector;
 
             const dropAreaEls = [];
             if (dropNear) {
                 dropAreaEls.push(
                     ...this.dependencies.dropzone.getSelectorSiblings(editableAreaEls, rootEl, {
                         selector: dropNear,
-                        excludeNearParent,
+                        excludeParent,
                     })
                 );
             }

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -10,7 +10,7 @@ import { _t } from "@web/core/l10n/translation";
  *     exclude: CSSSelector;
  *     dropIn: CSSSelector;
  *     dropNear: CSSSelector;
- *     excludeNearParent: CSSSelector;
+ *     excludeParent: CSSSelector;
  * }} DropzoneSelector
  *
  * @typedef { Object } DropZoneShared
@@ -108,14 +108,14 @@ export class DropZonePlugin extends Plugin {
                 dropNear,
                 dropLockWithin,
                 excludeAncestor,
-                excludeNearParent,
+                excludeParent,
             } = dropzoneSelector;
             if (snippetEl.matches(selector) && !snippetEl.matches(exclude)) {
                 if (dropNear) {
                     selectorSiblings.push(
                         ...this.getSelectorSiblings(editableAreaEls, rootEl, {
                             selector: dropNear,
-                            excludeNearParent,
+                            excludeParent,
                         })
                     );
                 }

--- a/addons/html_builder/static/src/core/dropzone_selector_plugin.js
+++ b/addons/html_builder/static/src/core/dropzone_selector_plugin.js
@@ -46,7 +46,7 @@ export class DropZoneSelectorPlugin extends Plugin {
                         .getResource("so_content_addition_selector")
                         .join(", ")}, .s_card:not(${special_cards_selector})`;
                 },
-                excludeNearParent: so_snippet_addition_drop_in,
+                excludeParent: so_snippet_addition_drop_in,
             },
             {
                 selector: ".row > div",

--- a/addons/html_builder/static/tests/drop_zone.test.js
+++ b/addons/html_builder/static/tests/drop_zone.test.js
@@ -37,3 +37,43 @@ test("drop beside dropzone inserts the snippet", async () => {
     </div>
 </section>`);
 });
+
+test("excludeParent correctly disables dropzones", async () => {
+    const snippetContent = [
+        `<div name="button" data-oe-snippet-id="123">
+            <a class="btn btn-primary" href="#" data-snippet="s_button">Button</a>
+        </div>`,
+    ];
+    const dropzoneSelectors = [
+        {
+            selector: "a",
+            dropNear: "strong",
+            excludeParent: ".drop_disabled",
+        },
+    ];
+    const { contentEl } = await setupHTMLBuilder(
+        `<p class="drop_enabled">
+            <strong>Can drop an 'a' element as a sibling here </strong>
+        </p>
+        <p class="drop_disabled">
+            <strong>Can't drop an 'a' element as a sibling here </strong>
+        </p>`,
+        {
+            snippetContent,
+            dropzoneSelectors,
+        }
+    );
+    const { moveTo, drop } = await contains(
+        ".o-snippets-menu #snippet_content .o_snippet_thumbnail[data-snippet='s_button']"
+    ).drag();
+
+    // .drop_disabled element shouldn't have any dropzones
+    expect(":iframe .drop_disabled .oe_drop_zone").toHaveCount(0);
+    expect(":iframe .drop_enabled .oe_drop_zone").toHaveCount(2);
+
+    await moveTo(contentEl.querySelector(".drop_disabled"));
+    await drop();
+    // should drop it inside the drop_enabled element
+    expect(":iframe .drop_disabled a.btn").toHaveCount(0);
+    expect(":iframe .drop_enabled a.btn").toHaveCount(1);
+});

--- a/addons/website/static/tests/builder/website_builder/button_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/button_option.test.js
@@ -39,11 +39,11 @@ test("Drag & drop a 'Button' snippet in a <div> should put it inside a <p>", asy
 
 test("Drag & drop a 'Button' snippet should align the button style with the button before it", async () => {
     const { getEditableContent } = await setupWebsiteBuilder(
-        `<a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a>`
+        `<p><a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a></p>`
     );
     const contentEl = getEditableContent();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a>`
+        `<p><a href="http://test.com" class="btn btn-fill-secondary" style="line-height: 50px;">ButtonStyled</a></p>`
     );
     expect(".o-website-builder_sidebar .fa-undo").not.toBeEnabled();
 
@@ -61,20 +61,24 @@ test("Drag & drop a 'Button' snippet should align the button style with the butt
     await drop(getDragHelper());
     await waitForEndOfOperation();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary mb-2" style="line-height: 50px;"> ButtonStyled </a> <a class="btn mb-2 btn-fill-secondary" href="#"> Button </a>`
+        `<p><a href="http://test.com" class="btn btn-fill-secondary mb-2" style="line-height: 50px;"> ButtonStyled </a> <a class="btn mb-2 btn-fill-secondary" href="#"> Button </a></p>`
     );
     expect(".o-website-builder_sidebar .fa-undo").toBeEnabled();
 });
 
 test("Drag & drop a 'Button' snippet over a dropzone should preview it correctly", async () => {
     const { getEditableContent } = await setupWebsiteBuilder(
-        `<a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
-         <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p>`
+        `<div>
+            <a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
+            <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p>
+        </div>`
     );
     const contentEl = getEditableContent();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
-         <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p>`
+        `<div>
+            <a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled</a>
+            <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary">ButtonStyled in a p</a></p>
+        </div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").not.toBeEnabled();
 
@@ -98,9 +102,11 @@ test("Drag & drop a 'Button' snippet over a dropzone should preview it correctly
     await drop(getDragHelper());
     await waitForEndOfOperation();
     expect(contentEl).toHaveInnerHTML(
-        `<a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled </a>
-         <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled in a p </a></p>
-         <p><a class="btn btn-primary" href="#"> Button </a></p>`
+        `<div>
+            <a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled </a>
+            <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled in a p </a></p>
+            <p><a class="btn btn-primary" href="#"> Button </a></p>
+         </div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").toBeEnabled();
 });


### PR DESCRIPTION
In [html_builder refactoring], `excludeNearParent` was passed to
`getSelectorSiblings`, but `excludeParent` was expected, and so because
of this, we couldn't exclude the parents where it wasn't possible to
have a dropzone. Luckily, it wasn't used extensively, so no known
issues were found, but this might have caused unexpected issues in
future, so that's why it was renamed to `excludeParent` in order to
work correctly.

Button option tests were adapted as they had buttons directly inside of
the .oe_structure, which shouldn't be allowed, so we had to wrap them
in paragraph or div elements.

[html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

task-5932797