### PR TITLE
[FIX] hr_holidays: skip disabled calendar slots in tour

### DIFF
--- a/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
@@ -16,7 +16,7 @@ registry.category("web_tour.tours").add("time_off_request_calendar_view", {
             content: "Click on the first Thursday of the year",
             trigger: ".fc-daygrid-day.fc-day-thu",
             run: () => {
-                const el = document.querySelector(".fc-daygrid-day.fc-day-thu").firstChild;
+                const el = document.querySelector(".fc-daygrid-day.fc-day-thu:not(.fc-day-disabled)").firstChild;
                 el.scrollIntoView();
 
                 const fromPosition = el.getBoundingClientRect();


### PR DESCRIPTION
Before, the tour attempted to click the “first Thursday” by selecting the first .fc-day-thu element in the DOM. The yearly calendar sometimes renders an initial “empty”/disabled weekday cell (when Jan 1 is Fri/Sat/Sun), so the first .fc-day-thu can be a disabled slot with no actionable element. That makes firstChild de-facto empty and the tour fails (seen reproducibly when the server date is set to years like 2027/2028, for example). Excluding .fc-day-disabled makes the selector target the first real Thursday cell

task-5930501

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
