### PR TITLE
[IMP] project_timesheet_holidays: make public holiday timesheets non-editable

### DIFF
--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -14,6 +14,9 @@ class AccountAnalyticLine(models.Model):
 
     _timeoff_timesheet_idx = models.Index('(task_id) WHERE (global_leave_id IS NOT NULL OR holiday_id IS NOT NULL) AND project_id IS NOT NULL')
 
+    def _is_readonly(self):
+        return super()._is_readonly() or self.holiday_id or self.global_leave_id
+
     def _get_redirect_action(self):
         leave_form_view_id = self.env.ref('hr_holidays.hr_leave_view_form').id
         action_data = {
@@ -31,7 +34,7 @@ class AccountAnalyticLine(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_leave(self):
         if any(line.global_leave_id for line in self):
-            raise UserError(_('You cannot delete timesheets that are linked to global time off.'))
+            raise UserError(self.env._('Timesheets linked to public holidays cannot be deleted.'))
         elif any(line.holiday_id for line in self):
             error_message = _('You cannot delete timesheets that are linked to time off requests. Please cancel your time off request from the Time Off application instead.')
             if not self.env.user.has_group('hr_holidays.group_hr_holidays_user') and self.env.user not in self.holiday_id.sudo().user_id:
@@ -40,13 +43,15 @@ class AccountAnalyticLine(models.Model):
             raise RedirectWarning(error_message, action, _('View Time Off'))
 
     def _check_can_write(self, values):
+        if not self.env.su and self.global_leave_id:
+            raise UserError(self.env._('Timesheets linked to public holidays cannot be modified.'))
         if not self.env.su and self.holiday_id:
-            raise UserError(_('You cannot modify timesheets that are linked to time off requests. Please use the Time Off application to modify your time off requests instead.'))
+            raise UserError(self.env._('Timesheets related to time off cannot be created or modified. Please manage your requests in the Time Off app instead.'))
         return super()._check_can_write(values)
 
     def _check_can_create(self):
         if not self.env.su and any(task.is_timeoff_task for task in self.task_id):
-            raise UserError(_('You cannot create timesheets for a task that is linked to a time off type. Please use the Time Off application to request new time off instead.'))
+            raise UserError(self.env._('Timesheets related to time off cannot be created or modified. Please manage your requests in the Time Off app instead.'))
         return  super()._check_can_create()
 
     def _get_favorite_project_id_domain(self, employee_id=False):


### PR DESCRIPTION
Timesheet entries generated from public holidays are currently editable by users with minimal rights. Although these entries appear greyed out, they can still be modified, which can lead to inconsistencies in reporting and payroll calculations. This behavior is inconsistent with other time-off–related entries, which are non-editable by default.

Hence, this commit makes global time off timesheet entries non-editable in all views, except the grid, which instead displays a user error if they try to edit the timesheet amount.

task-5360222