### PR TITLE
[FIX] website: allow copyright bg color when footer has no bg color

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -421,7 +421,7 @@ $-header-nav-link-height: $nav-link-height;
     @include o-add-gradient('footer-gradient');
 
     .o_footer_copyright {
-        $-footer-color: o-color('footer-custom') or o-color('footer');
+        $-footer-color: o-color('footer-custom') or o-color('footer') or rgba(0, 0, 0, 0);
         @include o-apply-colors('copyright', $background: $-footer-color);
         @include o-apply-colors('copyright-custom', $background: $-footer-color);
         @include o-add-gradient('copyright-gradient');


### PR DESCRIPTION
Before this commit, a css error would happen when the user tried to change the copyright background color if the footer had no background color.

This was due to $-footer-color not having a fallback value when neither o-color('footer-custom') nor o-color('footer') was defined.

This commit adds a fallback value to fix the issue.

task-5452457