### PR TITLE
[FIX] api_doc: Clean tooltips

### DIFF
--- a/addons/api_doc/static/src/components/doc_method.js
+++ b/addons/api_doc/static/src/components/doc_method.js
@@ -27,7 +27,7 @@ export class DocMethod extends Component {
                     value: "annotation" in options ? options.annotation : "-",
                 },
                 { type: TABLE_TYPES.Code, value: this.getDefaultValue(options) },
-                { type: TABLE_TYPES.Tooltip, value: markup(options.doc) || "" },
+                { type: TABLE_TYPES.Tooltip, value: options.doc ? markup(options.doc) : "" },
             ]),
         };
     }

--- a/addons/api_doc/static/src/components/doc_model.js
+++ b/addons/api_doc/static/src/components/doc_model.js
@@ -242,7 +242,7 @@ export class DocModel extends Component {
                     },
                     {
                         type: TABLE_TYPES.Tooltip,
-                        value: fieldData.help,
+                        value: fieldData.help || "",
                     },
                     {
                         type: TABLE_TYPES.Code,

--- a/addons/api_doc/static/src/components/doc_table.js
+++ b/addons/api_doc/static/src/components/doc_table.js
@@ -17,16 +17,16 @@ export class DocTable extends Component {
     setup() {
         this.subTableRef = useRef("subTableRef");
         this.tooltipRef = useRef("tooltipRef");
-        this.hideTooltipTimeout = null;
         this.state = useState({
             sortBy: 0,
             sortOrder: "desc",
             subTable: undefined,
             tooltipContent: "",
             tooltipStyle: "",
-            lastTooltipLeft: 0,
-            lastTooltipTop: 0,
         });
+        this.isHovering = false;
+        this.hideTimeout = null;
+        this.requestAnim = null;
 
         onWillRender(() => {
             this.items = this.computeItems();
@@ -46,52 +46,56 @@ export class DocTable extends Component {
     }
 
     showDynamicTooltip(event, content) {
-        if (this.hideTooltipTimeout) {
-            clearTimeout(this.hideTooltipTimeout);
-            this.hideTooltipTimeout = null;
-        }
-        this.state.tooltipContent = content;
+        if (this.requestAnim) cancelAnimationFrame(this.requestAnim);
+        if (this.hideTimeout) clearTimeout(this.hideTimeout);
+
+        this.activeHoverTarget = event.target;
+        this.isHovering = true;
+
         const triggerRect = event.target.getBoundingClientRect();
-        this.state.tooltipStyle = `
-            opacity: 0;
-            pointer-events: none;
-        `;
-        requestAnimationFrame(() => {
-            if (!this.tooltipRef.el) {
+
+        this.requestAnim = requestAnimationFrame(() => {
+            if (!this.tooltipRef.el || !this.isHovering) {
                 return;
             }
-            const tooltipRect = this.tooltipRef.el.getBoundingClientRect();
-            const top = triggerRect.top - tooltipRect.height - 10;
-            const left = triggerRect.left - tooltipRect.width / 2;
+            const top = triggerRect.top;
+            const left = triggerRect.left + 20;
+
+            this.state.tooltipContent = content;
             this.state.tooltipStyle = `
                 top: ${top}px;
                 left: ${left}px;
-                position: fixed;
                 opacity: 1;
                 pointer-events: auto;
             `;
-            this.state.lastTooltipTop = top;
-            this.state.lastTooltipLeft = left;
         });
     }
 
-    hideDynamicTooltip() {
-        if (this.hideTooltipTimeout) {
-            clearTimeout(this.hideTooltipTimeout);
-            this.hideTooltipTimeout = null;
-        }
-        const top = this.state.lastTooltipTop;
-        const left = this.state.lastTooltipLeft;
-        this.state.tooltipStyle = `
-            top: ${top}px;
-            left: ${left}px;
-            position: fixed;
-            opacity: 0;
-            pointer-events: none;
-        `;
-        this.hideTooltipTimeout = setTimeout(() => {
-            this.state.tooltipContent = "";
-        }, 200);
+    scheduleHide(event) {
+        if (this.hideTimeout) clearTimeout(this.hideTimeout);
+        const currentTarget = event.target;
+        this.isHovering = false;
+
+        this.hideTimeout = setTimeout(() => {
+            if (!this.isHovering) {
+                this.state.tooltipStyle = `
+                    top: ${this.tooltipRef.el ? this.tooltipRef.el.style.top : 0};
+                    left: ${this.tooltipRef.el ? this.tooltipRef.el.style.left : 0};
+                    opacity: 0;
+                    pointer-events: none;
+                `;
+                setTimeout(() => {
+                    if (currentTarget === this.activeHoverTarget) {
+                        this.state.tooltipContent = "";
+                    }
+                }, 200);
+            }
+        }, 100);
+    }
+
+    keepAlive() {
+        if (this.hideTimeout) clearTimeout(this.hideTimeout);
+        this.isHovering = true;
     }
 
     computeItems() {

--- a/addons/api_doc/static/src/components/doc_table.xml
+++ b/addons/api_doc/static/src/components/doc_table.xml
@@ -42,13 +42,13 @@
                         t-on-click="(ev) => this.showSubTable(ev, row.subData)"
                     />
 
-                    <t t-if="row and row.type == 'tooltip'">
+                    <t t-if="row and row.type == 'tooltip' and row.value">
                         <i
-                            class="fa fa-question-circle"
+                            class="fa fa-question-circle p-1 "
                             aria-hidden="true"
                             t-if="row.value"
-                            t-on-mouseover="(ev) => this.showDynamicTooltip(ev, row.value)"
-                            t-on-mouseleave="() => this.hideDynamicTooltip()"
+                            t-on-mouseenter="(ev) => this.showDynamicTooltip(ev, row.value)"
+                            t-on-mouseleave="(ev) => this.scheduleHide(ev)"
                         ></i>
                     </t>
                     <t t-else="" t-tag="getTag(row)" t-att-class="getClass(row)" t-out="getValue(row)"/>
@@ -87,9 +87,11 @@
         <DocTable data="state.subTable"/>
     </div>
     <div
-        class="o-doc-dynamic-tooltip"
+        class="o-doc-dynamic-tooltip p-3 border overflow-auto"
         t-att-style="state.tooltipStyle"
         t-ref="tooltipRef"
+        t-on-mouseenter="() => this.keepAlive()"
+        t-on-mouseleave="(ev) => this.scheduleHide(ev)"
     >
         <t t-out="state.tooltipContent"/>
     </div>

--- a/addons/api_doc/static/src/doc_client.css
+++ b/addons/api_doc/static/src/doc_client.css
@@ -237,17 +237,23 @@ pre {
 
 .o-doc-dynamic-tooltip {
     position: fixed;
+    font-size: .85em;
     z-index: 1000;
     min-width: 10rem;
-    max-width: 25rem;
+    max-width: 35rem;
     background-color: var(--background);
     color: var(--text);
-    padding: .3rem .5rem;
     border-radius: 6px;
-    text-align: center;
+    text-align: left;
+    max-height: 300px;
     box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.3);
     opacity: 0;
     transition: opacity 0.2s ease-in-out;
+    pointer-events: none;
+
+    p {
+        margin-bottom: 0 !important;
+    }
 }
 
 .btn-sm {


### PR DESCRIPTION
In api_doc, the method parameters tooltips were broken.

This commit fixes them by:
- aligning the text to the left
- improving the hideTooltip behavior
- preventing `undefined` tooltip content from being displayed

task-5246075