### PR TITLE
[FIX] website: test_website_force_domain_redirect works w/o demo


### DIFF
--- a/addons/website/tests/test_controllers.py
+++ b/addons/website/tests/test_controllers.py
@@ -201,6 +201,7 @@ class TestControllers(tests.HttpCase):
         """
         Test that /website/force/{website.id} redirects domain correctly
         """
+        self.env.user.groups_id += self.env.ref('website.group_multi_website')
         website = self.env['website'].search([], limit=1)
         website.domain = self.base_url()
         with MockRequest(self.env, website=website, url_root='http://example.com') as mock_request:


### PR DESCRIPTION
Commit f86f6f6a3dc6bbeb8c68308aab2462b9c7bb935d (6th February 2026)
added the test test_website_force_domain_redirect but it doesn't work
without demo data because it was requiring "website.group_multi_website"
group to be enabled.

Fix: add the group for the test case in case it's not enabled.

runbot-[238897](https://runbot.odoo.com/odoo/runbot.build.error/238897)
opw-5441957

Note: this was noticed in saas-18.3 forward port so this is only
necessary up to saas-18.2 version.
