### PR TITLE
[REF] mail, im_livechat: move /messages into /mail/data

### DIFF
--- a/addons/im_livechat/controllers/cors/channel.py
+++ b/addons/im_livechat/controllers/cors/channel.py
@@ -6,11 +6,6 @@ from odoo.addons.im_livechat.tools.misc import force_guest_env
 
 
 class LivechatChannelController(ChannelController):
-    @route("/im_livechat/cors/channel/messages", methods=["POST"], type="jsonrpc", auth="public", cors="*")
-    def livechat_channel_messages(self, guest_token, channel_id, fetch_params=None):
-        force_guest_env(guest_token)
-        return self.discuss_channel_messages(channel_id, fetch_params)
-
     @route("/im_livechat/cors/channel/mark_as_read", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def livechat_channel_mark_as_read(self, guest_token, **kwargs):
         force_guest_env(guest_token)

--- a/addons/im_livechat/static/src/embed/cors/livechat_routing_map.js
+++ b/addons/im_livechat/static/src/embed/cors/livechat_routing_map.js
@@ -11,7 +11,6 @@ import { registry } from "@web/core/registry";
 export const livechatRoutingMap = registry.category("discuss.routing_map");
 
 livechatRoutingMap
-    .add("/discuss/channel/messages", "/im_livechat/cors/channel/messages")
     .add("/discuss/channel/notify_typing", "/im_livechat/cors/channel/notify_typing")
     .add("/discuss/channel/mark_as_read", "/im_livechat/cors/channel/mark_as_read")
     .add("/mail/attachment/delete", "/im_livechat/cors/attachment/delete")

--- a/addons/im_livechat/static/tests/embed/unread_messages.test.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages.test.js
@@ -16,8 +16,8 @@ import {
     triggerHotkey,
     waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, expect, test } from "@odoo/hoot";
-import { Command, onRpc, serverState, withUser } from "@web/../tests/web_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
 
 import { queryFirst } from "@odoo/hoot-dom";
 import { rpc } from "@web/core/network/rpc";
@@ -46,15 +46,22 @@ test("new message from operator displays unread counter", async () => {
         })
     );
     setupChatHub({ opened: [channelId] });
-    onRpc("/discuss/channel/messages", () => expect.step("/discuss/channel/message"));
     const userId = serverState.userId;
-    listenStoreFetch(["init_messaging", "init_livechat", "discuss.channel"]);
+    listenStoreFetch([
+        "init_messaging",
+        "init_livechat",
+        "discuss.channel",
+        "/discuss/channel/messages",
+    ]);
     await start({
         authenticateAs: { ...pyEnv["mail.guest"].read(guestId)[0], _name: "mail.guest" },
     });
-    await waitStoreFetch(["init_messaging", "init_livechat", "discuss.channel"], {
-        stepsAfter: ["/discuss/channel/message"],
-    });
+    await waitStoreFetch([
+        "init_messaging",
+        "init_livechat",
+        "discuss.channel",
+        "/discuss/channel/messages",
+    ]);
     // send after init_messaging because bus subscription is done after init_messaging
     await withUser(userId, () =>
         rpc("/mail/message/post", {

--- a/addons/im_livechat/tests/test_cors_livechat.py
+++ b/addons/im_livechat/tests/test_cors_livechat.py
@@ -56,10 +56,11 @@ class TestCorsLivechat(HttpCase):
         )
         self.authenticate(None, None)
         self.make_jsonrpc_request(
-            "/im_livechat/cors/channel/messages",
+            "/im_livechat/cors/channel/mark_as_read",
             {
                 "guest_token": data["store_data"]["Store"]["guest_token"],
                 "channel_id": data["channel_id"],
+                "last_message_id": 0,
             },
         )
 
@@ -75,9 +76,10 @@ class TestCorsLivechat(HttpCase):
         self.authenticate(None, None)
         with self.assertRaises(JsonRpcException, msg="werkzeug.exceptions.NotFound"):
             self.make_jsonrpc_request(
-                "/im_livechat/cors/channel/messages",
+                "/im_livechat/cors/channel/mark_as_read",
                 {
                     "guest_token": guest.access_token,
                     "channel_id": data["channel_id"],
+                    "last_message_id": 0,
                 },
             )

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -58,16 +58,6 @@ class ThreadController(http.Controller):
     # main routes
     # ------------------------------------------------------------
 
-    @http.route("/mail/thread/messages", methods=["POST"], type="jsonrpc", auth="user")
-    def mail_thread_messages(self, thread_model, thread_id, fetch_params=None):
-        thread = self._get_thread_with_access(thread_model, thread_id, mode="read")
-        res = request.env["mail.message"]._message_fetch(domain=None, thread=thread, **(fetch_params or {}))
-        messages = res.pop("messages")
-        if not request.env.user._is_public():
-            messages.set_message_done()
-        store = Store().add(messages, "_store_message_fields")
-        return {**res, "data": store.get_result(), "messages": messages.ids}
-
     @http.route("/mail/thread/recipients", methods=["POST"], type="jsonrpc", auth="user")
     def mail_thread_recipients(self, thread_model, thread_id, message_id=None):
         """ Fetch discussion-based suggested recipients, creating partners on the fly """

--- a/addons/mail/static/src/chatter/web/form_controller.js
+++ b/addons/mail/static/src/chatter/web/form_controller.js
@@ -20,14 +20,14 @@ patch(FormController.prototype, {
         useSubEnv({
             chatter: {
                 fetchThreadData: true,
-                fetchMessages: true,
+                shouldFetchMessages: true,
             },
         });
     },
     onWillLoadRoot(nextConfiguration) {
         super.onWillLoadRoot(...arguments);
         this.env.chatter.fetchThreadData = true;
-        this.env.chatter.fetchMessages = true;
+        this.env.chatter.shouldFetchMessages = true;
         const isSameThread =
             this.model.root?.resId === nextConfiguration.resId &&
             this.model.root?.resModel === nextConfiguration.resModel;

--- a/addons/mail/static/src/core/common/data_response_model.js
+++ b/addons/mail/static/src/core/common/data_response_model.js
@@ -65,6 +65,7 @@ export class DataResponse extends Record {
     /** @type {number} */
     count;
     message = fields.One("mail.message");
+    messages = fields.Many("mail.message");
     partners = fields.Many("res.partner");
 }
 

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -678,19 +678,22 @@ export class Store extends BaseStore {
      * @param {true|false|undefined} is_notification
      */
     async searchMessagesInThread(searchTerm, thread, before, is_notification) {
-        const { count, data, messages } = await rpc(thread.getFetchRoute(), {
-            ...thread.getFetchParams(),
-            fetch_params: {
-                is_notification,
-                search_term: await prettifyMessageText(searchTerm), // formatted like message_post
-                before,
+        const { count, messages } = await this.fetchStoreData(
+            thread.getFetchRoute(),
+            {
+                ...thread.getFetchParams(),
+                fetch_params: {
+                    is_notification,
+                    search_term: await prettifyMessageText(searchTerm), // formatted like message_post
+                    before,
+                },
             },
-        });
-        this.insert(data);
+            { readonly: thread.model === "mail.box", requestData: true }
+        );
         return {
             count,
             loadMore: messages.length === this.FETCH_LIMIT,
-            messages: this["mail.message"].insert(messages),
+            messages,
         };
     }
 }

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -192,11 +192,11 @@ export class Thread extends Component {
             () => [this.state.mountedAndLoaded]
         );
         onMounted(() => {
-            if (!this.env.chatter || this.env.chatter?.fetchMessages) {
+            if (!this.env.chatter || this.env.chatter?.shouldFetchMessages) {
                 if (this.env.chatter) {
-                    this.env.chatter.fetchMessages = false;
+                    this.env.chatter.shouldFetchMessages = false;
                 }
-                this.fetchMessages();
+                this.fetchInitialMessages();
             }
         });
         onWillUnmount(() => {
@@ -242,9 +242,9 @@ export class Thread extends Component {
             if (nextProps.thread.notEq(this.props.thread)) {
                 this.lastJumpPresent = nextProps.jumpPresent;
             }
-            if (!this.env.chatter || this.env.chatter?.fetchMessages) {
+            if (!this.env.chatter || this.env.chatter?.shouldFetchMessages) {
                 if (this.env.chatter) {
-                    this.env.chatter.fetchMessages = false;
+                    this.env.chatter.shouldFetchMessages = false;
                 }
                 toRaw(nextProps.thread).fetchNewMessages();
             }
@@ -465,7 +465,7 @@ export class Thread extends Component {
         }
     }
 
-    fetchMessages() {
+    fetchInitialMessages() {
         toRaw(this.props.thread).fetchNewMessages();
     }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -415,7 +415,10 @@ export class Thread extends Record {
         return msgs;
     }
 
-    /** @param {{after: Number, before: Number}} */
+    /**
+     * @param {{after: Number, before: Number}}
+     * @returns {Promise<{data: any, messages: number[]}>}
+     */
     async fetchMessagesData({ after, around, before } = {}) {
         // ordered messages received: newest to oldest
         return await rpc(this.getFetchRoute(), {

--- a/addons/mail/static/src/discuss/core/common/thread_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.js
@@ -56,11 +56,11 @@ const threadPatch = {
         }
     },
     /** @override */
-    fetchMessages() {
+    fetchInitialMessages() {
         if (this.channel?.self_member_id && this.props.thread.scrollUnread) {
             toRaw(this.props.thread).loadAround(this.channel.self_member_id.new_message_separator);
         } else {
-            super.fetchMessages();
+            super.fetchInitialMessages();
         }
     },
     get newMessageBannerText() {

--- a/addons/mail/static/tests/chat_window/chat_hub.test.js
+++ b/addons/mail/static/tests/chat_window/chat_hub.test.js
@@ -2,13 +2,14 @@ import {
     click,
     contains,
     defineMailModels,
-    onRpcBefore,
+    listenStoreFetch,
     patchUiSize,
     setupChatHub,
     start,
     startServer,
+    waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, test } from "@odoo/hoot";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -37,7 +38,7 @@ test("chat window does not fetch messages if hidden", async () => {
         },
     ]);
     patchUiSize({ width: 900 }); // enough for 2 open chat windows max
-    onRpcBefore("/discuss/channel/messages", () => expect.step("fetch_messages"));
+    listenStoreFetch("/discuss/channel/messages");
     setupChatHub({ opened: [channelId3, channelId2, channeId1] });
     await start();
     await contains(".o-mail-ChatWindow", { count: 2 });
@@ -45,7 +46,7 @@ test("chat window does not fetch messages if hidden", async () => {
     await contains(".o-mail-Message-content:text('Banana')");
     await contains(".o-mail-Message-content:text('Apple')");
     await contains(".o-mail-Message-content:contains('Orange')", { count: 0 });
-    await expect.waitForSteps(["fetch_messages", "fetch_messages"]);
+    await waitStoreFetch(["/discuss/channel/messages", "/discuss/channel/messages"]);
 });
 
 test("click on hidden chat window should fetch its messages", async () => {
@@ -72,18 +73,18 @@ test("click on hidden chat window should fetch its messages", async () => {
         },
     ]);
     patchUiSize({ width: 900 }); // enough for 2 open chat windows max
-    onRpcBefore("/discuss/channel/messages", () => expect.step("fetch_messages"));
     setupChatHub({ opened: [channelId3, channelId2, channeId1] });
+    listenStoreFetch("/discuss/channel/messages");
     await start();
     await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatBubble", { count: 1 });
     await contains(".o-mail-Message-content:text('Banana')");
     await contains(".o-mail-Message-content:text('Apple')");
     await contains(".o-mail-Message-content:contains('Orange')", { count: 0 });
-    await expect.waitForSteps(["fetch_messages", "fetch_messages"]);
+    await waitStoreFetch(["/discuss/channel/messages", "/discuss/channel/messages"]);
     await click(".o-mail-ChatBubble");
     await contains(".o-mail-Message-content:text('Orange')");
     await contains(".o-mail-Message-content:text('Banana')");
     await contains(".o-mail-Message-content:contains('Apple')", { count: 0 });
-    await expect.waitForSteps(["fetch_messages"]);
+    await waitStoreFetch(["/discuss/channel/messages"]);
 });

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -835,9 +835,11 @@ test("mark as read when opening chat window", async () => {
             Command.create({ partner_id: bobPartnerId }),
         ],
     });
+    listenStoreFetch("/discuss/channel/messages");
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem-name:text('bob')");
+    await waitStoreFetch("/discuss/channel/messages"); // ensure messages are loaded before doing message post
     await contains(".o-mail-ChatWindow .o-mail-ChatWindow-header:text('bob')");
     // composer is focused by default, we remove that focus
     await contains(".o-mail-Composer-input:focus");

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -44,7 +44,7 @@ test("simple chatter on a record", async () => {
             expect.step(`${route} - ${JSON.stringify(args)}`);
         }
     });
-    listenStoreFetch(undefined, { logParams: ["mail.thread"] });
+    listenStoreFetch(undefined, { logParams: ["mail.thread", "/mail/thread/messages"] });
     await start();
     await waitStoreFetch(["failures", "systray_get_activities", "init_messaging"]);
     const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
@@ -70,13 +70,12 @@ test("simple chatter on a record", async () => {
                     thread_model: "res.partner",
                 },
             ],
-        ],
-        {
-            ignoreOrder: true,
-            stepsAfter: [
-                `/mail/thread/messages - {"thread_id":${partnerId},"thread_model":"res.partner","fetch_params":{"limit":30}}`,
+            [
+                "/mail/thread/messages",
+                { thread_id: partnerId, thread_model: "res.partner", fetch_params: { limit: 30 } },
             ],
-        }
+        ],
+        { ignoreOrder: true }
     );
 });
 

--- a/addons/portal_rating/controllers/thread.py
+++ b/addons/portal_rating/controllers/thread.py
@@ -2,13 +2,15 @@
 
 from odoo.fields import Domain
 
-from odoo.addons.portal.controllers.thread import PortalThreadController
+from odoo.addons.portal.controllers.thread import PortalWebClientController
 
 
-class PortalRatingThreadController(PortalThreadController):
+class PortalRatingThreadController(PortalWebClientController):
+    @classmethod
     def _get_non_empty_message_domain(self):
         return super()._get_non_empty_message_domain() | Domain("rating_value", "!=", False)
 
+    @classmethod
     def _setup_portal_message_fetch_extra_domain(self, data):
         domain = super()._setup_portal_message_fetch_extra_domain(data)
         if data.get('rating_value', False) is not False:

--- a/addons/test_discuss_full/tests/test_performance_inbox.py
+++ b/addons/test_discuss_full/tests/test_performance_inbox.py
@@ -79,4 +79,4 @@ class TestInboxPerformance(HttpCase, MailCommon):
             )
         self.authenticate(self.user_employee.login, self.user_employee.password)
         with self.assertQueryCount(42):
-            self.make_jsonrpc_request("/mail/inbox/messages")
+            self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -981,9 +981,9 @@ class UnfollowLinkTest(MailCommon, HttpCase):
         )
         # The user doesn't follow the record
         self.authenticate(self.env.user.login, self.env.user.login)
-        message_data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
-        self.assertFalse(message_data["mail.thread"][0]["selfFollower"])
-        self.assertFalse(message_data.get("mail.followers"), "Should not have void followers data")
+        data = self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})
+        self.assertFalse(data["mail.thread"][0]["selfFollower"])
+        self.assertFalse(data.get("mail.followers"), "Should not have void followers data")
         self.assertFalse(test_record.with_user(self.user_employee).message_is_follower)
 
         # The user follows the record
@@ -991,15 +991,15 @@ class UnfollowLinkTest(MailCommon, HttpCase):
         follower = test_record.message_follower_ids.filtered(
             lambda follower: follower.partner_id == self.env.user.partner_id
         )
-        message_data = self.make_jsonrpc_request("/mail/inbox/messages")["data"]
-        self.assertEqual(message_data["mail.followers"], [
+        data = self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})
+        self.assertEqual(data["mail.followers"], [
             {
                 "id": follower.id,
                 "is_active": True,
                 "partner_id": self.env.user.partner_id.id,
             },
         ])
-        self.assertEqual(message_data["mail.thread"][0]["selfFollower"], follower.id, "Should have follower ID")
+        self.assertEqual(data["mail.thread"][0]["selfFollower"], follower.id, "Should have follower ID")
 
     @mute_logger('odoo.addons.base.models', 'odoo.addons.mail.controllers.mail', 'odoo.http', 'odoo.models')
     def test_notification_email_unfollow_link(self):

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -112,19 +112,19 @@ class TestMessageHelpersRobustness(MailCommon, HttpCase):
         # set notifications to unread, so that we can simulate inbox usage
         p2_notifications = self.env['mail.notification'].search([('res_partner_id', '=', self.partner_employee_2.id)])
         p2_notifications.is_read = False
-
         self.authenticate(self.user_employee_2.login, self.user_employee_2.login)
-        result = self.make_jsonrpc_request("/mail/inbox/messages", {})['data']
+        data = self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/inbox/messages"]})
         self.assertEqual(
-            {r['thread']['id'] for r in result['mail.message']}, set(self.test_records_simple.ids),
-            'Currently reading message on missing record, crash avoided'
+            {r["thread"]["id"] for r in data["mail.message"]},
+            set(self.test_records_simple.ids),
+            "Currently reading message on missing record, crash avoided",
         )
         p2_notifications.with_user(self.user_employee_2).mail_message_id.set_message_done()
-
-        result = self.make_jsonrpc_request("/mail/history/messages", {})['data']
+        data = self.make_jsonrpc_request("/mail/data", {"fetch_params": ["/mail/history/messages"]})
         self.assertEqual(
-            {r['thread']['id'] for r in result['mail.message']}, set(self.test_records_simple.ids),
-            'Currently reading message on missing record, crash avoided'
+            {r["thread"]["id"] for r in data["mail.message"]},
+            set(self.test_records_simple.ids),
+            "Currently reading message on missing record, crash avoided",
         )
 
     def test_notify_cancel_by_type(self):


### PR DESCRIPTION
Allow grouping this RPC with others, which implies less processing all around: less requests, less queries, less duplicate entries in results.

task-4685447

https://github.com/odoo/enterprise/pull/107182

Example: open messaging menu: grouped channels as member and inbox messages

<img width="407" height="437" alt="image" src="https://github.com/user-attachments/assets/c241cf2c-0236-4440-bea4-0e7ba1134f8b" />

Example: chatter: often grouping thread/data and messages (depends on form view/chatter rendering speed)

<img width="305" height="691" alt="image" src="https://github.com/user-attachments/assets/ae481940-396c-4d50-89d5-70d2e0af9c1b" />

