### PR TITLE
[FIX] mail,account: Fix unathorized error in audit trail

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -407,6 +407,8 @@ class MailMessage(models.Model):
             forbidden_doc_ids = set()
             try:
                 operation_result = records._check_access(record_operation)
+                if operation_result:
+                    records -= operation_result[0]
                 # Check that records really exist;
                 # lengthy way of checking first in cache and avoiding exists() call.
                 # see test_record_unlinked_orphan_activities


### PR DESCRIPTION
When there is a message on an account that the user has no access to, and the user attempts to access
the audit trail, they are faced with authorization error.

This commit solves this issue by excluding messages of records that the user has no access to.


