### PR TITLE
[IMP] pos_restaurant: make Pay button secondary in mobile restaurant POS

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
@@ -40,7 +40,7 @@
                 <t t-else="">
                     <button
                         class="btn-switchpane pay-button pay-small btn btn-lg flex-grow-1 lh-sm"
-                        t-attf-class="{{ currentOrder.isEmpty() ? 'btn-light' : 'btn-primary' }}"
+                        t-attf-class="{{ this.pos.config.module_pos_restaurant ? 'btn-secondary' : 'btn-primary' }}"
                         t-on-click="() => this.pos.pay()"
                         t-att-disabled="currentOrder.isEmpty()">
                         <span class="d-block">Pay</span>

--- a/addons/pos_restaurant/static/tests/unit/components/product_screen.test.js
+++ b/addons/pos_restaurant/static/tests/unit/components/product_screen.test.js
@@ -1,5 +1,5 @@
-import { test, expect } from "@odoo/hoot";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { describe, test, expect } from "@odoo/hoot";
+import { contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
 import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
@@ -40,4 +40,47 @@ test("addProductToOrder", async () => {
 
     expect(order.getOrderlines()).toHaveLength(3);
     expect(order.courses).toHaveLength(2);
+});
+
+describe("Mobile Pay Button", () => {
+    test.tags("mobile");
+    test("Restaurant - Pay button with no preparation resource", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+        // Remove preparation resources (printers)
+        store.models["pos.printer"].forEach((printer) => printer.delete());
+        const screen = await mountWithCleanup(ProductScreen, {
+            props: { orderUuid: order.uuid },
+        });
+
+        expect(Boolean(screen.swapButton)).toBe(false);
+        expect("button:contains('cart')").toHaveClass("btn-primary");
+        expect(".pay-button:contains('Pay')").toHaveCount(1);
+        expect(".pay-button:contains('Pay')").toHaveClass("btn-secondary");
+        expect(".pay-button:contains('Pay')").toHaveAttribute("disabled");
+
+        await contains(".product:contains('TEST')").click();
+        expect(".pay-button:contains('Pay')").toHaveClass("btn-secondary");
+        expect(".pay-button:contains('Pay')").not.toHaveAttribute("disabled");
+    });
+
+    test.tags("mobile");
+    test("Retail - Pay button behavior", async () => {
+        const store = await setupPosEnv();
+        store.config.module_pos_restaurant = false;
+        const order = store.addNewOrder();
+        const screen = await mountWithCleanup(ProductScreen, {
+            props: { orderUuid: order.uuid },
+        });
+
+        expect(Boolean(screen.swapButton)).toBe(false);
+        expect("button:contains('cart')").toHaveClass("btn-secondary");
+        expect(".pay-button:contains('Pay')").toHaveCount(1);
+        expect(".pay-button:contains('Pay')").toHaveClass("btn-primary");
+        expect(".pay-button:contains('Pay')").toHaveAttribute("disabled");
+
+        await contains(".product:contains('TEST')").click();
+        expect(".pay-button:contains('Pay')").toHaveClass("btn-primary");
+        expect(".pay-button:contains('Pay')").not.toHaveAttribute("disabled");
+    });
 });


### PR DESCRIPTION
On the mobile product screen, the `Pay` button was highlighted in the same way as the `Cart` button, which could lead to user confusion.

This change updates the `Pay` button to a secondary style, clearly differentiating it from the `Cart` button.
Additionally, the `Pay` button now consistently appears as a proper button even when the cart is empty.


When             | Before             |  After
:-------------------------:|:-------------------------:|:-------------------------:
With products in cart and no preparation printer/display | <img width="393" height="130" alt="003" src="https://github.com/user-attachments/assets/5a19922b-e405-476a-83ba-d9ad6a2e254c" /> | <img width="392" height="140" alt="004" src="https://github.com/user-attachments/assets/30f29083-f10a-4908-ac5f-975cb4de10f0" />
Empty cart | <img width="393" height="133" alt="001" src="https://github.com/user-attachments/assets/9979a13e-99bd-4dec-a2fc-6563d6a4bb45" /> | <img width="389" height="148" alt="002" src="https://github.com/user-attachments/assets/f0a848ae-7e12-40bc-a079-8b418d3ecad9" />


Task-5896161
