### PR TITLE
[FIX] pos_restaurant: display global discount correctly on split screen

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/split_bill_screen/split_bill_screen.xml
@@ -43,9 +43,9 @@
                                 <t t-esc="this.getNumberOfProducts()" /> product(s) selected
                             </div>
                             <t t-set="discountPc" t-value="getGlobalDiscountPc()" />
-                            <div t-if="discountPc" class="text-dark"
+                            <div t-if="discountPc.value" class="discount text-dark"
                                 t-attf-class="{{ this.ui.isSmall ? 'fs-6' : 'fs-2' }}">
-                                With <t t-esc="discountPc" />% discount
+                                With <t t-esc="discountPc.type === 'percent' ? `${discountPc.value}%` : env.utils.formatCurrency(discountPc.value)" /> discount
                             </div>
                         </div>
 

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -12,6 +12,7 @@ const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 import * as SplitBillScreen from "@pos_restaurant/../tests/tours/utils/split_bill_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import * as combo from "@point_of_sale/../tests/pos/tours/utils/combo_popup_util";
+import * as NumberPopup from "@point_of_sale/../tests/generic_helpers/number_popup_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("SplitBillScreenTour", {
@@ -305,6 +306,18 @@ registry.category("web_tour.tours").add("SplitBillScreenTourTransfer", {
             ProductScreen.clickControlButton("Discount"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas("discount", 1, "-1.80"),
+            ProductScreen.clickControlButton("Split"),
+
+            SplitBillScreen.globalDiscountIs("With 10% discount"),
+            SplitBillScreen.clickBack(),
+            ProductScreen.clickControlButton("Discount"),
+            NumberPopup.clickType("fixed"),
+            Dialog.confirm(),
+            ProductScreen.clickControlButton("Split"),
+            SplitBillScreen.globalDiscountIs("With $ 10.00 discount"),
+            SplitBillScreen.clickBack(),
+            ProductScreen.clickControlButton("Discount"),
+            Dialog.confirm(),
             ProductScreen.clickControlButton("Split"),
 
             // Check if the screen contains all the orderlines

--- a/addons/pos_restaurant/static/tests/tours/utils/split_bill_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/split_bill_screen_util.js
@@ -37,3 +37,12 @@ export function subtotalIs(amount) {
         },
     ];
 }
+
+export function globalDiscountIs(text) {
+    return [
+        {
+            content: `global discount is '${text}'`,
+            trigger: `.splitbill-screen .order-info .discount:contains("${text}")`,
+        },
+    ];
+}


### PR DESCRIPTION
Steps:
---
- Configure Restaurant with a global discount.
- Open a session and add products.
- Apply a global discount.
- Open the control buttons and click Split.

Issue:
---
- The split screen displays the text `With [Object Object]% discount`.

Cause:
---
- The discount object was rendered directly instead of its value.

Fix:
---
- Display the correct discount value based on its type.

task-5905885

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
