### PR TITLE
[FIX] html_builder: fix undefined error on unselect button

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.xml
@@ -23,9 +23,9 @@
             class="btn btn-primary fa fa-fw fa-times"
             style="min-width: min-content;"
             t-on-click="() => this.select()"
-            t-on-pointerenter="hasPreview ? () => this.preview() : undefined"
+            t-on-pointerenter="hasPreview ? () => this.preview() : () => {}"
             t-on-pointerleave="revert"
-            t-on-focusin="hasPreview ? () => this.preview() : undefined"
+            t-on-focusin="hasPreview ? () => this.preview() : () => {}"
             t-on-focusout="revert"
         />
     </BuilderComponent>


### PR DESCRIPTION
Issue:
The `BuilderMany2One` component throws an undefined error when hovering over the unselect button.

Steps to reproduce:
1. Create a `BuilderMany2One` component with `allowUnselect=true`
2. Hover over the unselect button
3. Error occurs

Cause:
`undefined` was passed when `hasPreview` is `false`, but a callback function is expected.

Solution:
Pass an empty callback function instead of `undefined` when `hasPreview` is false.