### PR TITLE
[FIX] mail:  show seen indicator when last message is a notification

### DIFF
--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -181,10 +181,11 @@ const threadPatch = {
                 // starts from most recent persistent messages to find early
                 for (let i = this.persistentMessages.length - 1; i >= 0; i--) {
                     const message = this.persistentMessages[i];
-                    if (!message.isSelfAuthored) {
-                        continue;
-                    }
-                    if (message.id > this.lastMessageSeenByAllId) {
+                    if (
+                        !message.isSelfAuthored ||
+                        message.isNotification ||
+                        message.id > this.lastMessageSeenByAllId
+                    ) {
                         continue;
                     }
                     res = message;

--- a/addons/mail/static/tests/discuss/core/common/message_seen_indicator.test.js
+++ b/addons/mail/static/tests/discuss/core/common/message_seen_indicator.test.js
@@ -659,3 +659,37 @@ test("Show seen indicator on message with only attachment", async () => {
     await contains(".o-mail-MessageSeenIndicator");
     await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
 });
+
+test("show seen indicator on previous message when last message is notification", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo User" });
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "test",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "chat",
+    });
+    const [, notificationMessageId] = pyEnv["mail.message"].create([
+        {
+            author_id: serverState.partnerId,
+            body: "<p>Hello</p>",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+        {
+            author_id: serverState.partnerId,
+            body: "<p>Call started</p>",
+            message_type: "notification",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
+    ]);
+    const memberIds = pyEnv["discuss.channel.member"].search([["channel_id", "=", channelId]]);
+    pyEnv["discuss.channel.member"].write(memberIds, { seen_message_id: notificationMessageId });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-MessageSeenIndicator");
+    await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
+});


### PR DESCRIPTION
Before this PR:
In channels with seen indicators, the indicator is hidden if the user's last message is a notification. Since indicators are not displayed on notifications and the logic does not fall back to the previous message, the user is left with no visible 'seen' status.

After this PR:
The seen indicator now skips notification-type messages and is correctly displayed on the last message sent by the user.

task-5921911


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
