### PR TITLE
[FIX] html_editor: preserve code block newlines when container is hidden

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/syntax_highlighting/syntax_highlighting_utils.js
+++ b/addons/html_editor/static/src/others/embedded_components/core/syntax_highlighting/syntax_highlighting_utils.js
@@ -46,10 +46,20 @@ export const newlinesToLineBreaks = (element, doc = element.ownerDocument || doc
  */
 export const getPreValue = (pre) => {
     // Trailing br gives \n in innerText but should not be visible.
-    const trailingBrs = pre.innerHTML.match(/(<br>)+$/)?.length || 0;
-    return pre.innerText
-        .slice(0, pre.innerText.length - (trailingBrs > 1 ? trailingBrs - 1 : trailingBrs))
-        .replace(/[\u200B\uFEFF]/g, "");
+    const html = pre.innerHTML;
+    const hasTrailingBr = /<br\s*\/?>$/i.test(html);
+    let text = html
+        .replace(/<br\s*\/?>/gi, "\n")
+        .replace(/<[^>]+>|[\u200B\uFEFF]/g, "")
+        .replace(
+            /&(amp|lt|gt|#x27|quot|#x60);/g,
+            (_, entity) =>
+                ({ amp: "&", lt: "<", gt: ">", "#x27": "'", quot: '"', "#x60": "`" }[entity])
+        );
+    if (hasTrailingBr && text.endsWith("\n")) {
+        text = text.slice(0, -1);
+    }
+    return text;
 };
 
 /**

--- a/addons/html_editor/static/tests/utils/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/utils/syntax_highlighting.test.js
@@ -1,0 +1,40 @@
+import { getPreValue } from "@html_editor/others/embedded_components/core/syntax_highlighting/syntax_highlighting_utils";
+import { describe, expect, test } from "@odoo/hoot";
+import { insertTestHtml } from "../_helpers/editor";
+
+describe("getPreValue", () => {
+    test("preserves multiple consecutive br as multiple newlines", () => {
+        const [pre] = insertTestHtml("<pre>abc<br><br>def</pre>");
+        expect(getPreValue(pre)).toBe("abc\n\ndef");
+    });
+
+    test("converts br to newlines and removes only trailing br", () => {
+        const [pre] = insertTestHtml("<pre>abc<br>def<br><br></pre>");
+        expect(getPreValue(pre)).toBe("abc\ndef\n");
+    });
+
+    test("returns empty string for empty pre (single br)", () => {
+        const [pre] = insertTestHtml("<pre><br></pre>");
+        expect(getPreValue(pre)).toBe("");
+    });
+
+    test("strips html tags and decodes all entities", () => {
+        const [pre] = insertTestHtml(
+            "<pre><span>&lt;div&gt;</span><br><strong>&amp;</strong><br>&#x27;quote&#x27;<br>&quot;double&quot;<br>&#x60;backtick&#x60;</pre>"
+        );
+        expect(getPreValue(pre)).toBe("<div>\n&\n'quote'\n\"double\"\n`backtick`");
+    });
+
+    test("removes zero-width characters", () => {
+        const [pre] = insertTestHtml("<pre>a\u200Bb\uFEFFc</pre>");
+        expect(getPreValue(pre)).toBe("abc");
+    });
+
+    test("converts br to newlines even when pre has display none", () => {
+        const [container] = insertTestHtml(
+            '<div style="display:none"><pre>hidden<br>content<br><br><br></pre></div>'
+        );
+        const pre = container.querySelector("pre");
+        expect(getPreValue(pre)).toBe("hidden\ncontent\n\n");
+    });
+});


### PR DESCRIPTION
### Steps to Reproduce:

- Create a toggle list and add content.
- Expand the toggle list and insert a code block (e.g.: /code).
- Add multiple lines inside the code block using Enter.
- Refresh the page with the toggle open, content is preserved.
- Close the toggle and refresh then content collapses into one line.

### Description of the issue/feature this PR addresses:

- When the toggle list is closed, the code block is inside `display: none` container. In this state, `innerText` depends on rendered layout and does not preserve newline characters `\n`. As a result, multiline code content is extracted as single line.

### Desired behavior after PR is merged:

- Read html and normalize it into plain text by:
  - Converting `<br>` tags into newline characters.
  - Stripping remaining HTML tags.
  - Decoding HTML entities back to their literal characters.
  - Removing the extra newline introduced by a trailing `<br>`
  - Cleaning up invisible zero-width characters.

task-5909034

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
