### PR TITLE
[IMP] mail,im_livechat:  add escalation notifications for visitors

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -756,6 +756,13 @@ class DiscussChannel(models.Model):
                 channel.sudo().livechat_status = "in_progress"
         return all_new_members
 
+    def _get_member_join_notification(self, member):
+        if self.channel_type == "livechat":
+            if member.is_self:
+                return self.env._("joined the conversation")
+            return self.env._("invited %s to the conversation", member._get_html_link(for_persona=True))
+        return super()._get_member_join_notification(member)
+
     def _message_post_after_hook(self, message, msg_vals):
         """
         This method is called just before _notify_thread() method which is sending the message data.

--- a/addons/im_livechat/static/src/embed/common/message_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/message_model_patch.js
@@ -13,7 +13,7 @@ const messagePatch = {
         if (this.thread.channel?.channel_type !== "livechat" || !this.notificationType) {
             return super.notificationHidden;
         }
-        return ["channel-joined", "channel-left"].includes(this.notificationType);
+        return this.notificationType === "channel-left";
     },
 };
 patch(Message.prototype, messagePatch);

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -207,7 +207,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                         "markup",
                         (
                             '<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="'
-                            f'{self.partner_employee.id}">@Ernest Employee</a> to the channel</div>'
+                            f'{self.partner_employee.id}">@Ernest Employee</a> to the conversation</div>'
                         ),
                     ],
                     # thread not renamed yet at this step

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -22,7 +22,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
         channel._add_members(users=john)
         self.assertEqual(
             channel.message_ids[-1].body,
-            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{john.partner_id.id}">@ELOPERADOR</a> to the channel</div>',
+            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{john.partner_id.id}">@ELOPERADOR</a> to the conversation</div>',
         )
 
     def test_user_livechat_username_reactions(self):

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -652,11 +652,7 @@ class DiscussChannel(models.Model):
                     payload["invited_by_user_id"] = self.env.user.id
                 member._bus_send("discuss.channel/joined", payload)
                 if channel.channel_type != "channel" and post_joined_message:
-                    notification = (
-                        _("joined the channel")
-                        if member.is_self
-                        else _("invited %s to the channel", member._get_html_link(for_persona=True))
-                    )
+                    notification = member.channel_id._get_member_join_notification(member)
                     member.channel_id.message_post(
                         author_id=inviting_partner.id or None,
                         body=Markup('<div class="o_mail_notification" data-oe-type="channel-joined">%s</div>') % notification,
@@ -682,6 +678,11 @@ class DiscussChannel(models.Model):
                     # sudo: discuss.channel.rtc.session - current user can invite new members in call
                     current_channel_member.sudo()._rtc_invite_members(member_ids=new_members.ids)
         return all_new_members
+
+    def _get_member_join_notification(self, member):
+        if member.is_self:
+            return self.env._("joined the channel")
+        return self.env._("invited %s to the channel", member._get_html_link(for_persona=True))
 
     def invite_by_email(self, emails):
         """

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -128,7 +128,7 @@ class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
             ("I will transfer you to a human", operator, False),
             (
                 'invited <a href="#" data-oe-model="res.partner" data-oe-id="'
-                f'{operator_member.partner_id.id}">@El Deboulonnator</a> to the channel',
+                f'{operator_member.partner_id.id}">@El Deboulonnator</a> to the conversation',
                 self.chatbot_script.operator_partner_id,
                 False,
             ),


### PR DESCRIPTION
**Purpose of this PR:**

Visitors can now see when an agent joins the conversation, providing reassurance that the chatbot has forwarded or escalated their request.

task-5873770

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
