### PR TITLE
[MOV] http: move serving outside request

### DIFF
--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -35,7 +35,7 @@ class Session(Controller):
 
         with ExitStack() as stack:
             if not request.db or request.db != db:
-                # Use a new env only when no db on the request, which means the env was not set on in through `_serve_db`
+                # Use a new env only when no db on the request, which means the env was not set on in through `serve_db`
                 # or the db is different than the request db
                 cr = stack.enter_context(odoo.modules.registry.Registry(db).cursor())
                 env = odoo.api.Environment(cr, None, {})

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -23,6 +23,7 @@ from odoo import _, fields, http, models, release, tools
 from odoo.exceptions import AccessError, UserError
 from odoo.fields import Domain
 from odoo.http import request
+from odoo.http.router import serve_ir_http
 from odoo.http.session import SessionExpiredException
 from odoo.http.stream import STATIC_CACHE_LONG
 from odoo.tools import OrderedSet, escape_psql, py_to_js_locale
@@ -138,7 +139,7 @@ class Website(Home):
         if homepage_url and homepage_url != '/':
             try:
                 rule, args = request.env['ir.http']._match(homepage_url)
-                return request._serve_ir_http(rule, args)
+                return serve_ir_http(request, rule, args)
             except (AccessError, NotFound, SessionExpiredException):
                 pass
 

--- a/odoo/addons/test_http/tests/test_common.py
+++ b/odoo/addons/test_http/tests/test_common.py
@@ -45,7 +45,7 @@ class TestHttpBase(HttpCaseWithUserDemo):
         assert len(dblist) >= 2, "There should be at least 2 databases"
         with patch('odoo.http.router.db_list') as db_list, \
              patch('odoo.http.router.db_filter') as db_filter, \
-             patch('odoo.http.requestlib.Registry') as Registry:  # TODO @juc: router
+             patch('odoo.http.router.Registry') as Registry:
             db_list.return_value = dblist
             db_filter.side_effect = lambda dbs, host=None: [db for db in dbs if db in dblist]
             Registry.return_value = self.registry


### PR DESCRIPTION
Now that the http module has been split, it makes sense to move the
serving logic to the `router.py` module.

These functions do not need to be exposed from a `Request` instance.

Task-5926433