### PR TITLE
[FIX] point_of_sale: Calculate the correct cost of products in POS when using AVCO

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1797,7 +1797,7 @@ class PosOrderLine(models.Model):
             cost_currency = product.sudo().cost_currency_id
             if line._is_product_storable_fifo_avco() and stock_moves:
                 moves = line._get_stock_moves_to_consider(stock_moves, product)
-                product_cost = moves._get_price_unit()
+                product_cost = moves.with_context(pos_order_line=line)._get_price_unit()
                 if (cost_currency.is_zero(product_cost) and line.order_id.shipping_date and line.refunded_orderline_id):
                     product_cost = line.refunded_orderline_id.total_cost / line.refunded_orderline_id.qty
             else:

--- a/addons/pos_mrp/models/__init__.py
+++ b/addons/pos_mrp/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import pos_order
+from . import stock_move

--- a/addons/pos_mrp/models/stock_move.py
+++ b/addons/pos_mrp/models/stock_move.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_price_unit(self):
+        """ Returns the unit price to value this stock move """
+        line = self.env.context.get('pos_order_line')
+        if line and any(move.product_id != line.product_id for move in self):
+            product = line.product_id.with_company(self.company_id)
+            bom = product.env['mrp.bom']._bom_find(product, company_id=self.company_id.id, bom_type='phantom')[product]
+            if bom:
+                return self._get_kit_price_unit(product, bom, line.qty)
+        return super()._get_price_unit()

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -7,7 +7,6 @@ from odoo import Command, fields
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-@skip('Temporary to fast merge new valuation')
 class TestPosMrp(CommonPosMrpTest):
     def test_bom_kit_order_total_cost(self):
         order, _ = self.create_backend_pos_order({
@@ -22,6 +21,7 @@ class TestPosMrp(CommonPosMrpTest):
         self.pos_config_usd.current_session_id.action_pos_session_closing_control()
         self.assertEqual(order.lines[0].total_cost, 10.0)
 
+    @skip('Temporary to fast merge new valuation')
     def test_bom_kit_with_kit_invoice_valuation(self):
         self.product_product_kit_one.categ_id = self.category_fifo_realtime
         self.product_product_kit_two.categ_id = self.category_fifo_realtime
@@ -62,6 +62,7 @@ class TestPosMrp(CommonPosMrpTest):
             lambda l: l.product_id == self.product_product_kit_three).debit, 0.0)
         self.pos_config_usd.current_session_id.action_pos_session_closing_control()
 
+    @skip('Temporary to fast merge new valuation')
     def test_bom_kit_different_uom_invoice_valuation(self):
         """This test make sure that when a kit is made of product using UoM A but the bom line uses UoM B
            the price unit is correctly computed on the invoice lines.


### PR DESCRIPTION
Problem:
When using the AVCO method in calculating costs of products in POS
orders, the product cost is calculated incorrectly (sometimes shown as
0)

Cause:
When using AVCO with a product that's configured as a kit, the cost is
calculated incorrectly because the code treats the materials as the
actual product. So, if there is more than 1 material in the BOM, the
cost actually appears as 0 because there is a check that makes sure only
the cost of one product is being calculated. If one material is in the
BOM, the product cost is shown to be the unit cost of the material
(which is incorrect, since the product can use many units of that
material).

Solution:
Override the method that calculates the cost of the product in POS to
take into account the AVCO costing method and the possibility of the
product being a kit.

Steps to reproduce:
- Choose (or create a new product)
- Choose the product's category or (create a new category) that uses
AVCO costing method
- Go to Point of Sale
- Create a new POS order that contains the product.
- Validate the order
- Check the order from the POS backend orders
- See how the cost is 0 or incorrect from the product's actual cost

Based on commit 5a44ae1

opw-5401820