### PR TITLE
[FIX] point_of_sale: add close option on customer display popup for small device

### DIFF
--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.xml
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.xml
@@ -2,20 +2,24 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.QrCodeCustomerDisplay">
-        <Dialog header="false" footer="false" size="'md'">
+        <Dialog header="this.ui.isSmall" title.translate="Scan QR" footer="false" size="'md'">
             <div class="container">
-                <div class="align-items-center d-inline-flex justify-content-between w-100">
+                <div class="align-items-center d-flex justify-content-center w-100">
                     <t t-if="this.ui.isSmall">
-                        <div class="text-center position-relative pt-5 w-100">
-                            <p class="popup-text w-100 position-absolute top-0 start-50 translate-middle-x">Scan QR</p>
-                            <img id="CustomerDisplayqrCode" t-att-src="getQrCode()" alt="Customer QR Code"
-                                class="img-fluid mb-3 square w-100"/>
+                        <div class="d-flex flex-column align-items-center">
+                            <div class="text-center position-relative w-100 d-flex flex-column">
+                                <img id="CustomerDisplayqrCode" t-att-src="getQrCode()" alt="Customer QR Code"
+                                    class="img-fluid mb-3 square w-75 mx-auto d-block"/>
 
-                            <div class="small mb-3">
-                                <t t-set="customerDisplayURL" t-value="props.customerDisplayURL"/>
-                                <a t-att-href="customerDisplayURL" target="_blank" t-esc="customerDisplayURL" />
-                                <CopyButton content="customerDisplayURL" className="'ms-2 btn-primary'" successText.translate="Link copied to clipboard" icon="'fa-clone'"/>
+                                <div class="small mb-3">
+                                    <t t-set="customerDisplayURL" t-value="props.customerDisplayURL"/>
+                                    <a t-att-href="customerDisplayURL" target="_blank" t-esc="customerDisplayURL" />
+                                    <CopyButton content="customerDisplayURL" className="'ms-2 btn-primary'" successText.translate="Link copied to clipboard" icon="'fa-clone'"/>
+                                </div>
                             </div>
+                            <button t-on-click="props.close" class="button btn btn-secondary mb-3 rounded-3">
+                                Close
+                            </button>
                         </div>
                     </t>
                     <t t-if="!this.ui.isSmall">

--- a/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/customer_display_popup_tour.js
@@ -33,5 +33,10 @@ registry.category("web_tour.tours").add("customer_display_shows_qr_popup", {
                     }
                 },
             },
+            {
+                isActive: ["mobile"],
+                content: "Check that the Qr popup has close button",
+                trigger: ".o-overlay-item .modal .modal-body button.button.btn-secondary",
+            },
         ].flat(),
 });


### PR DESCRIPTION
Before this commit:
===================
On small devices, the customer display popup had no way to be closed, which made it impossible to exit the QR code screen.

After this commit:
==================
Added a header back button and a close action to allow users to dismiss the customer display popup on small devices as well.

Task-5926747


