### PR TITLE
[FIX] account,product,purchase,sale: remove product name in invoice line

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -111,6 +111,7 @@ class AccountMoveLine(models.Model):
         compute='_compute_name', store=True, readonly=False, precompute=True,
         tracking=True,
     )
+    translated_product_name = fields.Text(compute='_compute_translated_product_name')
     debit = fields.Monetary(
         string='Debit',
         compute='_compute_debit_credit', inverse='_inverse_debit', store=True, precompute=True,
@@ -573,6 +574,13 @@ class AccountMoveLine(models.Model):
 
             if not line.name or line._origin.name == get_name(line._origin) or line.product_id != line._origin.product_id:
                 line.name = get_name(line)
+
+    @api.depends('product_id')
+    def _compute_translated_product_name(self):
+        for line in self:
+            line.translated_product_name = line.product_id.with_context(
+                lang=line.partner_id.lang,
+            ).display_name
 
     def _compute_account_id(self):
         term_lines = self.filtered(lambda line: line.display_type == 'payment_term')

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -42,15 +42,24 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         return this.isSection || this.isSubSection;
     }
 
+    get translatedProductName() {
+        return this.props.record.data.translated_product_name;
+    }
+
+    get label() {
+        let label = this.props.record.data[this.descriptionColumn];
+        if (this.translatedProductName && label.startsWith(this.translatedProductName)) {
+            label = label.slice(this.translatedProductName.length + 1);
+        }
+        else if (this.productName && label.startsWith(this.productName)) {
+            label = label.slice(this.productName.length + 1);
+        }
+        return label;
+    }
+
     isNote(record = null) {
         record = record || this.props.record;
         return record.data.display_type === "line_note";
-    }
-
-    parseLabel(value) {
-        return (this.productName && value && this.productName.concat("\n", value))
-            || (this.productName && !value && this.productName)
-            || (value || "");
     }
 
     shouldShowWarning() {
@@ -60,6 +69,16 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
             !this.isSectionOrSubSection &&
             !this.isNote()
         );
+    }
+
+    parseLabel(value) {
+        if(!value){
+            return this.productName;
+        }
+        if(this.translatedProductName){
+            return this.translatedProductName.concat("\n", value);
+        }
+        return this.productName.concat("\n", value);
     }
 }
 
@@ -80,6 +99,9 @@ export const productLabelSectionAndNoteField = {
         props.show_label_warning = options.show_label_warning;
         return props;
     },
+    fieldDependencies: [
+        { name: 'translated_product_name', type: 'char' },
+    ],
 };
 registry
     .category("fields")

--- a/addons/product/static/src/product_name_and_description/product_name_and_description.js
+++ b/addons/product/static/src/product_name_and_description/product_name_and_description.js
@@ -104,14 +104,6 @@ export class ProductNameAndDescriptionField extends Component {
         return this.props.record.data[this.props.name].display_name || "";
     }
 
-    get label() {
-        let label = this.props.record.data[this.descriptionColumn];
-        if (label.includes(this.productName)) {
-            label = label.replace(this.productName, "");
-        }
-        return label.trim();
-    }
-
     get m2oProps() {
         const p = computeM2OProps(this.props);
         let value = p.value && { ...p.value };
@@ -138,10 +130,6 @@ export class ProductNameAndDescriptionField extends Component {
     switchLabelVisibility() {
         this.labelVisibility.value = !this.labelVisibility.value;
         this.switchToLabel = true;
-    }
-
-    parseLabel(value) {
-        return value || this.productName;
     }
 
     /**

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -137,28 +137,6 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         };
     }
 
-    get label() {
-        let label = this.props.record.data.name;
-        if (this.translatedProductName && label.startsWith(this.translatedProductName)) {
-            // Remove the translated name as it is already shown to the salesman on the SOL.
-            label = label.slice(this.translatedProductName.length + 1);  // + "\n"
-        } else {
-            label = super.label;
-        }
-        return label;
-    }
-
-    get translatedProductName() {
-        return this.props.record.data.translated_product_name;
-    }
-
-    parseLabel(value) {
-        if (!this.translatedProductName) {
-            return super.parseLabel(value);
-        }
-        return value && this.translatedProductName.concat("\n", value) || this.translatedProductName;
-    }
-
     get m2oProps() {
         const p = super.m2oProps;
         const value = p.value && { ...p.value };
@@ -459,11 +437,11 @@ export const saleOrderLineProductField = {
         };
     },
     fieldDependencies: [
+        ...(productLabelSectionAndNoteField.fieldDependencies || []),
         { name: 'is_configurable_product', type: 'boolean' },
         { name: 'product_type', type: 'selection' },
         { name: 'service_tracking', type: 'selection' },
         { name: 'product_template_attribute_value_ids', type: 'many2many' },
-        { name: 'translated_product_name', type: 'char' },
     ],
 };
 


### PR DESCRIPTION
**Steps to reproduce:
1. Install invoicing app
2. Add French language in the settings
3. Create a customer with language set as French
4. Create a product and define french translations of the name and the description in Sales tab
5. Create an invoice for that customer and choose the product you created
6. You will find the translated product name and description under the product name
7. Edit the description, save and preview the invoice
8. The invoice line will contain [Product Name EN] [Product Name FR] [Product Description FR]

**Description of the issue:
When creating an invoice for a customer whose language differs from the user's account language, manually editing the product description on an invoice line causes the original product name to be prepended to the description. The same issue happens in a RFQ in Purchase.

**Expected behaviour:
User can edit the product description in the invoice line and the output in the invoice should only be the translated name and description, without the original product name.

**Why this happens?
1. When the product is selected in the invoice line, the label is loaded from _compute_name method in account_move_line, which holds the translated name and description.
2. After editing the description and escaping the field (clicking outside it), the parseLabel method is called, which prepends the original name to the label, making the invoice output as [original name] [translated name] [translated desc.]

**The fix
Added translated_product_name computed field to follow a similar flow as the sale quotation which is already working as intended. Fix is done in Invoice and Purchase.

opw-5480494