### PR TITLE
[FIX] l10n_my_edi_pos: include all orders for invoice consolidation

### DIFF
--- a/addons/l10n_my_edi_pos/models/myinvois_document_pos.py
+++ b/addons/l10n_my_edi_pos/models/myinvois_document_pos.py
@@ -240,7 +240,7 @@ class MyInvoisDocumentPoS(models.Model):
             if continuous_orders:
                 config_lines.append(self.env["pos.order"].browse(continuous_orders))
                 continuous_orders = []
-            lines_per_config[config] = config_lines
+            lines_per_config.setdefault(config, []).extend(config_lines)
 
         return lines_per_config
 


### PR DESCRIPTION
Step to Reproduce:
* Install l10n_my_edi_pos and switch to that company
* Configure two POS sessions (POS 1 and POS 2)
* Create orders as follows:

POS 1:
* 2 uninvoiced orders
* 1 invoiced order
* Close POS 1

POS 2:
* 1 uninvoiced order
* 1 invoiced order
* Close POS 2

Reopen POS 1:
* 1 uninvoiced order
* Close POS 1

Reopen POS 2:
* 1 uninvoiced order

Close POS 2
* Go to Orders → Consolidated Invoice
* Create a consolidated invoice using the correct date range

Observation:
* Two documents are created
* No. of orders linked to each document are incorrect

Cause:
* `_split_pos_orders_in_lines` overwrites entries in the `lines_per_config` dictionary
* Previous orders for the same config are lost

Fix:
* Extend the existing recordset in `lines_per_config`  instead of overwriting it

Before
<img width="1230" height="231" alt="order consolidation bug" src="https://github.com/user-attachments/assets/26657f34-998e-41c4-a68a-0939cbe6de1d" />

After
<img width="1265" height="206" alt="consolidated order fixed" src="https://github.com/user-attachments/assets/7c703416-ac3b-412e-bb28-0d6f73fa25f2" />


opw-5904420

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
