### PR TITLE
[FIX] mail: prevent error on closing mail composer

### DIFF
--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -44,14 +44,19 @@ export class MailComposerFormRenderer extends formView.Renderer {
             () => [this.props.record.isInEdition, this.root.el, this.props.record.resId]
         );
 
-        const getActiveMailThreads = () =>
-            JSON.parse(this.props.record.data.res_ids).map((resId) => {
+        const getActiveMailThreads = () => {
+            // composer does not store res_ids past a certain limit, assume active_ids is used
+            const resIds = this.props.record.data.res_ids
+                ? JSON.parse(this.props.record.data.res_ids)
+                : this.props.record.context.active_ids;
+            return resIds.map((resId) => {
                 const thread = this.mailStore.Thread.insert({
                     model: this.props.record.data.model,
                     id: resId,
                 });
                 return thread;
             });
+        };
 
         // Add file dropzone on full mail composer:
         this.attachmentUploadService = useService("mail.attachment_upload");

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -25,6 +25,7 @@ import { Deferred, animationFrame, tick } from "@odoo/hoot-mock";
 import {
     Command,
     getService,
+    makeDialogMockEnv,
     onRpc,
     patchWithCleanup,
     serverState,
@@ -797,6 +798,35 @@ test("remove an uploading attachment", async () => {
     await contains(".o-mail-AttachmentCard.o-isUploading:contains(text.txt)");
     await click(".o-mail-AttachmentCard-unlink");
     await contains(".o-mail-Composer .o-mail-AttachmentCard", { count: 0 });
+});
+
+test("Can dismiss mail composer with 500+ active_ids", async () => {
+    // When there are more than 500 active_ids, _compute_res_ids
+    // short-circuits and leaves res_ids empty for performance reasons.
+    // In that case, the code must rely on active_ids and dismissing
+    // the dialog must not crash.
+    const pyEnv = await startServer();
+    const env = await makeDialogMockEnv();
+    const partnerId = pyEnv["res.partner"].create({ name: "Partner" });
+    registerArchs({
+        "mail.compose.message,false,form": `
+            <form string="Compose Email" js_class="mail_composer_form">
+                <field name="model"/>
+                <field name="partner_ids"/>
+            </form>`,
+    });
+    await start();
+    const composerId = pyEnv["mail.compose.message"].create({
+        model: "res.partner",
+        res_ids: "", // simulate >500 active_ids case
+        partner_ids: [],
+    });
+    await openFormView("mail.compose.message", composerId, {
+        context: { active_ids: [partnerId] },
+    });
+    expect(env.dialogData).not.toBeEmpty()
+    // Dialog is closed without errors
+    await env.dialogData.dismiss()
 });
 
 test("Uploading multiple files in the composer create multiple temporary attachments", async () => {


### PR DESCRIPTION
Steps to reproduce:
1. Install `crm`
2. Create leads more than 500.
3. Select all and try to send email
4. Not close the wizard by "X"

Issue:
- Traceback occurs: `Uncaught Promise > Unexpected end of JSON input`

Cause:
- res_ids is not set on the composer when more than 500 records are selected. This is expected, as the compute method `_compute_res_ids()` does not write `res_ids` when the number of `active_ids` exceeds 500 (to avoid storing large payloads on the field). Because of this, the code trying to JSON.parse(res_ids) fails while dismissing the wizard at `onCloseWizardModal`

Solution:
- Fallback to context.active_ids when res_ids is not available

opw-5891862