### PR TITLE
[FIX] project: prevent project template tasks from appearing in task views

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -1046,7 +1046,7 @@
                 'default_user_ids': [(4, uid)],
             }</field>
             <field name="search_view_id" ref="view_task_search_form"/>
-            <field name="domain">[('user_ids', 'in', uid), ('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('user_ids', 'in', uid), ('has_template_ancestor', '=', False), ('has_project_template', '=', False)]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     No tasks found. Let's create one!
@@ -1096,7 +1096,7 @@
             <field name="res_model">project.task</field>
             <field name="path">all-tasks</field>
             <field name="view_mode">list,kanban,form,calendar,activity,pivot,graph</field>
-            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="domain">[('has_template_ancestor', '=', False), ('has_project_template', '=', False)]</field>
             <field name="context">{'search_default_open_tasks': 1, 'default_user_ids': [(4, uid)]}</field>
             <field name="search_view_id" ref="view_task_search_form"/>
             <field name="help" type="html">


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install Project.
2. Create a project with tasks (T1 and T2).
3. Convert the project into a template.
4. Go to All Tasks and search for these tasks.

Issue:
------
Tasks belonging to a project template are still displayed in the All Tasks view.

Cause:
------
After this commit 369407f, regular tasks were allowed in project templates.
However, the task action domains were not updated accordingly, so template tasks
were still included in All Tasks and My Tasks views.

Solution:
---------
Add an additional condition in the action domains to exclude tasks linked to project templates.

opw-5905768






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
