### PR TITLE
[IMP] orm: allow upercase letters on regex_alphanumeric matching

### DIFF
--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -7,7 +7,7 @@ import dateutil.relativedelta
 from odoo.exceptions import ValidationError
 from odoo.tools import SQL
 
-regex_alphanumeric = re.compile(r'^[a-z0-9_]+$')
+regex_alphanumeric = re.compile(r'^[a-z0-9_]+$', re.IGNORECASE)
 regex_object_name = re.compile(r'^[a-z0-9_.]+$')
 regex_pg_name = re.compile(r'^[a-z_][a-z0-9_$]*$', re.IGNORECASE)
 # match private methods, to prevent their remote invocation


### PR DESCRIPTION
Relax the condition on regex_alphanumeric to allow for uppercase letters A-Z along with already allowed lowercase letters and underscores.

Currently it is only used by field properties to verify property names