### PR TITLE
[IMP] mail: refine ChannelActionDialog header spacing

### DIFF
--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -74,7 +74,7 @@
         }
         &.o-tag-JOIN_LEAVE_CALL.o-dropdown-item i {
             font-size: 0.7em !important;
-            &.fa-phone::before {
+            &:is(.fa-phone, .fa-video-camera)::before {
                 transform: translateY(1px);
             }
         }

--- a/addons/mail/static/src/discuss/core/common/channel_action_dialog.js
+++ b/addons/mail/static/src/discuss/core/common/channel_action_dialog.js
@@ -6,7 +6,7 @@ export class ChannelActionDialog extends Component {
     static components = { Dialog };
     static props = ["title", "contentComponent", "contentProps", "close?", "contentClass?"];
     static template = xml`
-        <Dialog size="'md'" title="props.title" footer="false" contentClass="'o-bg-body '+ props.contentClass" bodyClass="'p-1'">
+        <Dialog size="'md'" title="props.title" footer="false" contentClass="'o-bg-body o-discuss-ChannelActionDialog '+ props.contentClass" bodyClass="'p-1'">
             <t t-component="props.contentComponent" t-props="props.contentProps"/>
         </Dialog>
     `;

--- a/addons/mail/static/src/discuss/core/common/channel_action_dialog.scss
+++ b/addons/mail/static/src/discuss/core/common/channel_action_dialog.scss
@@ -1,0 +1,10 @@
+.o-discuss-ChannelActionDialog .modal-header {
+    --modal-header-border-width: 1px;
+    --modal-header-padding: calc(var(--modal-padding) * 0.4) calc(var(--modal-padding) * 0.7);
+
+    .btn-close {
+        position: static !important;
+        padding: 0px;
+        margin: 0px !important;
+    }
+}


### PR DESCRIPTION
**Current behavior before PR:**
The `ChannelActionDialog` header used the default spacing, resulting in suboptimal padding, a misaligned close button, also the `fa-video-camera` icon in the channel actions was not centered.

**Desired behavior after PR is merged:**
The `ChannelActionDialog` header now has refined spacing, ensuring proper padding and correct alignment of the close button, and the `fa-video-camera` icon in the channel actions is now centered.

Before
<img width="1046" height="519" alt="image" src="https://github.com/user-attachments/assets/6108471e-0532-4e7b-8eef-ff04a34d6778" />
<img width="314" height="98" alt="image" src="https://github.com/user-attachments/assets/94c46c62-490a-4095-8cf8-830964213f27" />


After
<img width="979" height="446" alt="image" src="https://github.com/user-attachments/assets/12436ea8-9436-4d1f-a5fe-a93e7fdb4748" />
<img width="310" height="104" alt="image" src="https://github.com/user-attachments/assets/4351cea1-c42c-4cb2-aeb1-0a7f7efb6424" />


task-[5382647](https://www.odoo.com/odoo/project/1519/tasks/5382647)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
