### PR TITLE
[FIX] iot_drivers: 1 second delay when reading scale

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
@@ -186,6 +186,10 @@ class Toledo8217Driver(ScaleDriver):
             _logger.exception('Error while probing %s with protocol %s', device, protocol.name)
         return False
 
+    @staticmethod
+    def _get_raw_response(connection):
+        return connection.read_until(b"\r")
+
     def _read_status(self, answer):
         """
         Status byte in form of an ascii character (Ex: 'D') is sent if scale is in motion, or is net/gross weight is negative or over capacity.


### PR DESCRIPTION
Before this commit, the `_get_raw_response` method would wait until the read timed out (1 second) before returning the response.

After this commit, for the Toledo scale we instead read until we reach a `\r` character, which is at the end of the response. This eliminates the 1 second delay.

Enterprise PR: https://github.com/odoo/enterprise/pull/107246
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
