### PR TITLE
[IMP] account: improve duplicate detection

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -751,7 +751,9 @@ class AccountMove(models.Model):
         groups="account.group_account_invoice,account.group_account_readonly",
     )
     duplicated_ref_ids = fields.Many2many(comodel_name='account.move', compute='_compute_duplicated_ref_ids')
+    # used to check if any moves in duplicated_ref_ids are in the 'Draft' state.
     is_draft_duplicated_ref_ids = fields.Boolean(compute="_compute_is_draft_duplicated_ref_ids")
+    is_exact_move_duplicate = fields.Boolean(compute='_compute_is_draft_duplicated_ref_ids')
     need_cancel_request = fields.Boolean(compute='_compute_need_cancel_request')
 
     show_update_fpos = fields.Boolean(string="Has Fiscal Position Changed", store=False)  # True if the fiscal position was changed
@@ -2054,7 +2056,7 @@ class AccountMove(models.Model):
         for move in self:
             move.quick_encoding_vals = move._get_quick_edit_suggestions()
 
-    @api.depends('ref', 'move_type', 'partner_id', 'invoice_date', 'tax_totals')
+    @api.depends('ref', 'move_type', 'partner_id', 'invoice_date', 'tax_totals', 'currency_id')
     def _compute_duplicated_ref_ids(self):
         move_to_duplicate_move = self._fetch_duplicate_reference()
         for move in self:
@@ -2067,7 +2069,7 @@ class AccountMove(models.Model):
         if not moves:
             return {}
 
-        used_fields = ("company_id", "partner_id", "commercial_partner_id", "ref", "move_type", "invoice_date", "state", "amount_total")
+        used_fields = ("company_id", "partner_id", "commercial_partner_id", "ref", "move_type", "invoice_date", "state", "amount_total", "currency_id")
 
         self.env["account.move"].flush_model(used_fields)
 
@@ -2144,6 +2146,7 @@ class AccountMove(models.Model):
                    AND move.id != duplicate_move.id
                    AND duplicate_move.state IN %(matching_states)s
                    AND move.move_type = duplicate_move.move_type
+                   AND move.currency_id = duplicate_move.currency_id
                    AND (
                            move.commercial_partner_id = duplicate_move.commercial_partner_id
                            OR (move.commercial_partner_id IS NULL AND duplicate_move.state = 'draft')
@@ -2166,6 +2169,15 @@ class AccountMove(models.Model):
     def _compute_is_draft_duplicated_ref_ids(self):
         for move in self:
             move.is_draft_duplicated_ref_ids = any(duplicate_move.state == 'draft' for duplicate_move in move.duplicated_ref_ids)
+            move.is_exact_move_duplicate = any(
+                move.ref and move.ref == dup.ref
+                and move.move_type == dup.move_type
+                and move.partner_id == dup.partner_id
+                and move.invoice_date == dup.invoice_date
+                and move.amount_total == dup.amount_total
+                and move.is_purchase_document()
+                for dup in move.duplicated_ref_ids
+            )
 
     @api.depends('company_id')
     def _compute_display_qr_code(self):
@@ -5245,13 +5257,16 @@ class AccountMove(models.Model):
         self.ensure_one()
         if self.env.context.get('name_as_amount_total'):
             currency_amount = self.currency_id.format(self.amount_total)
-            if self.state == 'posted':
+            if self.is_sale_document(include_receipts=True) and self.state == "posted":
                 ref = f" - {self.ref}" if self.ref else ""
                 return _("%(name)s%(ref)s at %(currency_amount)s", name=(self.name), ref=ref, currency_amount=currency_amount)
-            if self.name:
-                return _("%(name)s - Draft at (%(currency_amount)s)", name=(self.name), currency_amount=currency_amount)
-            else:
-                return _("Draft (%(currency_amount)s)", currency_amount=currency_amount)
+            label = (self.ref or self.name or "") if self.is_purchase_document(include_receipts=True) else (self.name or "")
+            if label:
+                if self.state == 'draft':
+                    return _("%(label)s at %(currency_amount)s (Draft)", label=label, currency_amount=currency_amount)
+                return _("%(label)s at %(currency_amount)s", label=label, currency_amount=currency_amount)
+            return _("Draft (%(currency_amount)s)", currency_amount=currency_amount)
+
         name = ''
         if self.state == 'draft':
             name += {

--- a/addons/account/static/src/views/account_move_list/account_move_list_renderer.js
+++ b/addons/account/static/src/views/account_move_list/account_move_list_renderer.js
@@ -12,7 +12,11 @@ export class AccountMoveListRenderer extends FileUploadListRenderer {
     getCellClass(column, record) {
         const classNames = super.getCellClass(column, record);
         if (column.name === 'ref' && record.data.duplicated_ref_ids && record.data.duplicated_ref_ids.count !== 0) {
-            return `${classNames} table-warning`;
+            if (record.data.is_exact_move_duplicate) {
+                return `${classNames} table-danger`;
+            } else if (record.data.state === 'draft') {
+                return `${classNames} table-warning`;
+            }
         }
         return classNames;
     }

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -525,6 +525,7 @@
                     </header>
                     <field name="made_sequence_gap" column_invisible="True"/>
                     <field name="duplicated_ref_ids" column_invisible="True"/>  <!-- Needed for custome view account_tree-->
+                    <field name="is_exact_move_duplicate" column_invisible="True"/>  <!-- Needed for custome view account_tree-->
                     <field name="name" decoration-bf="1" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field_to_check" placeholder="/"/>
                     <field name="checked" column_invisible="True" groups="account.group_account_user"/> <!-- To be used for Reviewed badge display, see char_with_placeholder_field_to_check -->
                     <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" groups="base.group_user" string="Vendor" />
@@ -799,7 +800,19 @@
                         <field name="alerts" class="o_field_html" widget="actionable_errors"/>
                     </div>
                     <!--Duplicate check-->
-                    <div class="d-flex alert alert-warning w-100 d-flex align-items-center gap-1" invisible="not duplicated_ref_ids"  role="alert">
+                    <div class="d-flex alert alert-danger w-100 d-flex align-items-center gap-1" invisible="not is_exact_move_duplicate"  role="alert">
+                        <span>This document might be a duplicate of</span>
+                        <field name="duplicated_ref_ids" widget="x2many_buttons" nb_records_shown="1" string="Duplicated Documents" context="{'name_as_amount_total': True}"/>
+                        <button name="action_delete_duplicates"
+                                type="object"
+                                class="btn btn-link text-danger ms-auto d-flex align-items-center gap-1"
+                                invisible="not is_draft_duplicated_ref_ids">
+                            <i class="fa fa-trash text-danger"/>
+                            <span class="text-danger" invisible="duplicated_ref_ids.length == 1">Delete all duplicates</span>
+                            <span class="text-danger" invisible="duplicated_ref_ids.length &gt; 1">Delete duplicate</span>
+                        </button>
+                    </div>
+                    <div class="d-flex alert alert-warning w-100 d-flex align-items-center gap-1" invisible="not duplicated_ref_ids or is_exact_move_duplicate or state != 'draft'"  role="alert">
                         <span>This document might be a duplicate of</span>
                         <field name="duplicated_ref_ids" widget="x2many_buttons" nb_records_shown="1" string="Duplicated Documents" context="{'name_as_amount_total': True}"/>
                         <button name="action_delete_duplicates"


### PR DESCRIPTION
In this commit for bills:
- Highlight the reference in red when it is identical and in yellow when references are different. Apply the same logic to the duplicate document warning in the form view.
- In the form view duplicate warning, use the Bill Reference if available, then the Move Name, then "Draft".
- Yellow warnings are restricted to Draft moves; only red warnings remain visible once Posted.

task-5916255