### PR TITLE
[FIX] l10n_pl_edi: enable KSeF auth with encrypted private keys

### DIFF
--- a/addons/l10n_pl_edi/models/res_config_settings.py
+++ b/addons/l10n_pl_edi/models/res_config_settings.py
@@ -85,8 +85,9 @@ class ResConfigSettings(models.TransientModel):
 
         key_bytes = base64.b64decode(self.l10n_pl_edi_certificate.private_key_id.pem_key)
         cert_bytes = base64.b64decode(self.l10n_pl_edi_certificate.pem_certificate)
+        private_key_password = (self.l10n_pl_edi_certificate.private_key_id.password or "").encode("utf-8") or None
         if key_bytes and cert_bytes:
-            signer = XadesSigner(key_bytes, cert_bytes)
+            signer = XadesSigner(key_bytes, cert_bytes, private_key_password)
         else:
             raise UserError(self.env._("KSeF certificate and private key are not set."))
 

--- a/addons/l10n_pl_edi/tools/xades_signer.py
+++ b/addons/l10n_pl_edi/tools/xades_signer.py
@@ -13,8 +13,8 @@ class XadesSigner:
     """
     Handles the creation of XAdES-BES signatures for KSeF authentication challenges.
     """
-    def __init__(self, key_pem, cert_pem):
-        self.private_key = serialization.load_pem_private_key(key_pem, password=None)
+    def __init__(self, key_pem, cert_pem, private_key_password=None):
+        self.private_key = serialization.load_pem_private_key(key_pem, password=private_key_password)
         self.cert = x509.load_pem_x509_certificate(cert_pem)
 
     @staticmethod


### PR DESCRIPTION
In Odoo 19.0 (Master), the handling of KSeF certificates introduced an issue where uploading an encrypted private key caused a server crash, blocking the configuration of KSeF. This functionality worked correctly in v18 (where keys were often unencrypted).

The `XadesSigner` class was not designed to accept a password argument. The `serialization.load_pem_private_key` method would fail with a `TypeError` because the password was not passed to the underlying

Updated the `XadesSigner.__init__` method to accept a `private_key_password` argument. Passed this password correctly to `serialization.load_pem_private_key`.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
