### PR TITLE
[IMP] hr: add personal info to My Preferences

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -115,6 +115,20 @@ class ResUsers(models.Model):
     employee_count = fields.Integer(compute='_compute_employee_count')
     employee_resource_calendar_id = fields.Many2one(related='employee_id.resource_calendar_id', string="Employee's Working Hours", readonly=True)
     bank_account_ids = field_employee(fields.Many2many, 'bank_account_ids', comodel_name='res.partner.bank')
+    marital = field_employee(fields.Selection, 'marital', string="Marital Status", user_writeable=True,
+        selection=lambda self: self.env["hr.employee"]._fields["marital"]._description_selection(self.env))
+    spouse_complete_name = field_employee(fields.Char, 'spouse_complete_name', string="Spouse Legal Name", user_writeable=True)
+    spouse_birthdate = field_employee(fields.Date, 'spouse_birthdate', user_writeable=True)
+    children = field_employee(fields.Integer, 'children', string="Dependent Children", user_writeable=True)
+    legal_name = field_employee(fields.Char, 'legal_name', user_writeable=True,
+        help="The employee's official name as per government-issued or legal documents.")
+    birthday = field_employee(fields.Date, 'birthday', user_writeable=True)
+    birthday_public_display = field_employee(fields.Boolean, 'birthday_public_display', string="Show to all employees", user_writeable=True)
+    place_of_birth = field_employee(fields.Char, 'place_of_birth', user_writeable=True)
+    country_of_birth = field_employee(fields.Many2one, 'country_of_birth', comodel_name='res.country', user_writeable=True)
+    sex = field_employee(fields.Selection, 'sex', user_writeable=True,
+        selection=lambda self: self.env["hr.employee"]._fields["sex"]._description_selection(self.env),
+        help="This is the legal sex as recognized by the state, used for official and statutory purposes.")
 
     create_employee = fields.Boolean(store=False, default=False, copy=False, string="Technical field, whether to create an employee")
     create_employee_id = fields.Many2one('hr.employee', store=False, copy=False, string="Technical field, bind user to this employee on create")

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -87,7 +87,7 @@
                 <xpath expr="//page[@name='calendar']" position="after">
                     <page name="private_information" string="Private">
                         <group>
-                            <group string="Private Information">
+                            <group string="Private Address &amp; Contact">
                                 <field name="employee_ids" invisible="1"/>
                                 <label for="private_street" string="Private Address"/>
                                 <div class="o_address_format">
@@ -104,6 +104,31 @@
                             <group string="Emergency Contact">
                                 <field name="emergency_contact" string="Contact Name" placeholder="e.g. John Doe"/>
                                 <field name="emergency_phone" string="Contact Phone" widget="phone"/>
+                            </group>
+                            <group string="Family" name="hr_family_group">
+                                <field name="marital"/>
+                                <field name="spouse_complete_name" invisible="marital not in ['married', 'cohabitant']"/>
+                                <field name="spouse_birthdate" invisible="marital not in ['married', 'cohabitant']"/>
+                                <field name="children"/>
+                            </group>
+                            <group string="Personal Information" name="hr_personal_information">
+                                <field name="legal_name"/>
+                                <label for="birthday"/>
+                                <div class="o_row" name="div_birthday">
+                                    <field name="birthday" class="o_hr_narrow_field"/>
+                                    <span invisible="not birthday">
+                                        <label for="birthday_public_display"
+                                               class="fw-bold text-900 form-check-label ms-3"/>
+                                        <field name="birthday_public_display" class="ms-3"/>
+                                    </span>
+                                </div>
+                                <label for="place_of_birth"/>
+                                <div class="o_row" name="birth_location">
+                                    <field name="place_of_birth" class="oe_inline o_hr_narrow_field" nolabel="1" placeholder="City"/>
+                                    <div class="mx-3 flex-grow-0">─</div>
+                                    <field name="country_of_birth" class="oe_inline o_hr_narrow_field" nolabel="1" placeholder="Country"/>
+                                </div>
+                                <field name="sex" string="Gender"/>
                             </group>
                         </group>
                     </page>


### PR DESCRIPTION
In versions after 18.0, the Personal Info tab on the employee form has been removed for public user, and only a limited set of details is now available under the My Preferences menu. While this keeps the interface minimal, employees should still be able to review and update certain personal details if they are incorrect.

For example, information such as Marital Status or the preference to show birthdays to other employees should remain accessible to the employee.

This commit adds the sections "Family" and "Personal Information" in My Preferences.

task: 5920455

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
