### PR TITLE
[IMP] (website_)sale(_collect), stock(_sms): smooth pick up in store flow

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -110,7 +110,25 @@
                         <t t-set="tx_sudo" t-value="object.get_portal_last_transaction()"/>
                         Your order <span style="font-weight:bold;" t-out="object.name or ''">S00049</span>
                         <t t-if="object.state == 'sale' or (tx_sudo and tx_sudo.state in ('done', 'authorized'))">
-                            has been confirmed.<br/>
+                            <t
+                                t-if="hasattr(object, 'carrier_id') and object.carrier_id.delivery_type == 'in_store'"
+                            >
+                                <t
+                                    t-if="object.commitment_date and object.commitment_date.date() != object.date_order.date()"
+                                >
+                                    has been confirmed and will be ready on
+                                    <span
+                                        t-field="object.commitment_date"
+                                        t-options='{"widget": "date"}'
+                                    />.<br/>
+                                </t>
+                                <t t-else="">
+                                    has been confirmed and will be ready soon.<br/>
+                                </t>
+                            </t>
+                            <t t-else="">
+                                has been confirmed.<br/>
+                            </t>
                             Thank you for your trust.
                         </t>
                         <t t-elif="tx_sudo and tx_sudo.state == 'pending'">
@@ -311,7 +329,6 @@
                                     <td style="width: 20%; padding-top: 4px; border-top: 1px solid #343a40; opacity: 0.9;" align="left"><strong>Total</strong></td>
                                     <td style="width: 80%; padding-top: 4px; border-top: 1px solid #343a40; font-weight: bold; " align="right">
                                         <span style="display: inline-block; margin-right: 4px; padding: 4px 8px; border: 1px solid #dee2e6; border-radius: 4px;">
-                                            <span style="opacity: 0.9;">Paid with</span>
                                             <span t-attf-style="color: #{color}; font-weight: bold;">
                                                 <t t-out="tx_sudo.provider_id.sudo().name or ''"></t>
                                             </span>
@@ -324,7 +341,11 @@
                         <table t-if="object.partner_shipping_id and not object.only_services" width="295" style="vertical-align: top; font-size: 14px; margin-bottom: 12px;" align="left" role="presentation">
                             <tr>
                                 <td style="padding-bottom: 4px; font-weight: bold;">
-                                    <span style="opacity: 0.9;">Delivery with</span>
+                                    <t
+                                        t-if="not (hasattr(object, 'carrier_id') and object.carrier_id.delivery_type == 'in_store')"
+                                    >
+                                        <span style="opacity: 0.9;">Delivery with</span>
+                                    </t>
                                     <span t-attf-style="color: {{color}}; opacity: 1;"><t t-out="object.carrier_id.name or ''"></t></span>
                                 </td>
                             </tr>

--- a/addons/stock/data/mail_template_data.xml
+++ b/addons/stock/data/mail_template_data.xml
@@ -12,7 +12,12 @@
 <div style="margin: 0px; padding: 0px;">
     <p style="margin: 0px; padding: 0px; font-size: 13px;">
         Hello <t t-out="object.partner_id.name or ''">Brandon Freeman</t>,<br/><br/>
-        We are glad to inform you that your order has been shipped.
+        <t t-if="hasattr(object, 'delivery_type') and object.delivery_type == 'in_store'">
+            Your order has been collected.
+        </t>
+        <t t-else="">
+            We are glad to inform you that your order has been shipped.
+        </t>
         <t t-if="hasattr(object, 'carrier_tracking_ref') and object.carrier_tracking_ref">
             Your tracking reference is
             <strong>

--- a/addons/stock_sms/data/sms_data.xml
+++ b/addons/stock_sms/data/sms_data.xml
@@ -5,7 +5,7 @@
             <field name="name">Delivery: Send by SMS Text Message</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="body">
-                {{ (object.company_id.name + ': We are glad to inform you that your order n° ' + object.origin + ' has been shipped.' if object.origin else object.company_id.name + ': We are glad to inform you that your order has been shipped.') + (' Your tracking reference is ' + (object.carrier_tracking_ref) + '.' if hasattr(object, 'carrier_tracking_ref') and object.carrier_tracking_ref else '') }}
+                {{ (object.company_id.name + ': Your order n° ' + object.origin + ' has been collected.' if object.origin else object.company_id.name + ': Your order has been collected.') if hasattr(object, 'delivery_type') and object.delivery_type == 'in_store' else (object.company_id.name + ': We are glad to inform you that your order n° ' + object.origin + ' has been shipped.' if object.origin else object.company_id.name + ': We are glad to inform you that your order has been shipped.') + (' Your tracking reference is ' + (object.carrier_tracking_ref) + '.' if hasattr(object, 'carrier_tracking_ref') and object.carrier_tracking_ref else '') }}
             </field>
         </record>
     </data>

--- a/addons/website_sale/templates/checkout/confirmation_templates.xml
+++ b/addons/website_sale/templates/checkout/confirmation_templates.xml
@@ -112,14 +112,19 @@
             t-att-data-order-tracking-info="json.dumps(order_tracking_info)"
         >
             <t t-set="tx_sudo" t-value="order.get_portal_last_transaction()"/>
-            <div
-                t-if="tx_sudo"
-                t-attf-class="alert px-3 pb-0 pt-3 #{
+            <t
+                t-set="alert_class"
+                t-value="
                     (tx_sudo.state == 'pending' and 'alert-info') or
                     (tx_sudo.state == 'done' and order.amount_total == tx_sudo.amount and 'alert-success') or
                     (tx_sudo.state == 'done' and order.amount_total != tx_sudo.amount and 'alert-warning') or
                     (tx_sudo.state == 'authorized' and 'alert-success') or
-                    'alert-danger'}"
+                    'alert-danger'"
+            />
+            <div
+                id="order_confirmation_banner"
+                t-if="tx_sudo"
+                t-attf-class="alert px-3 pb-0 pt-3 #{alert_class}"
                 role="alert"
             >
                 <a

--- a/addons/website_sale_collect/data/payment_provider_data.xml
+++ b/addons/website_sale_collect/data/payment_provider_data.xml
@@ -19,11 +19,6 @@
             file="website_sale_collect/static/description/icon.png"
         />
         <field name="redirect_form_view_id" ref="payment.generic_redirect_form"/>
-        <field name="pending_msg" type="html">
-            <p>
-                <i>Your order has been confirmed.</i><br/>Please come to the store to pay for your products.
-            </p>
-        </field>
     </record>
 
 </odoo>

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -5,13 +5,29 @@
         id="payment_confirmation_status"
         inherit_id="website_sale.payment_confirmation_status"
     >
+        <t t-set="alert_class" position="after">
+            <t
+                t-if="tx_sudo.state == 'pending' and tx_sudo.provider_id.custom_mode == 'on_site'"
+                t-set="alert_class"
+                t-value="'alert-success'"
+            />
+        </t>
+        <t t-out="tx_sudo.provider_id.sudo().pending_msg" position="replace" >
+            <t t-if="tx_sudo.provider_id.custom_mode == 'on_site'">
+                <t t-if="order.commitment_date and order.commitment_date.date() != order.date_order.date()">
+                    Your order will be ready on <span t-field="order.commitment_date" t-options='{"widget": "date"}'/>.
+                </t>
+                <t t-else="">
+                    Your order will be ready soon.
+                </t>
+            </t>
+            <t t-else="">
+                <t>$0</t> <!-- Replaced by old content. -->
+            </t>
+        </t>
         <div id="order_reference" position="replace">
             <t t-if="tx_sudo.provider_id.custom_mode == 'on_site'">
-                <div class="mt-2">
-                    <div class="o_header_carrier_message">
-                        <b t-out="order.carrier_id.name"/>
-                        <span class="text-muted"> (In-store pickup)</span>
-                    </div>
+                <div class="mt-2 mb-3">
                     <div class="o_body_carrier_message">
                         <t t-out="order.carrier_id.website_description"/>
                     </div>

--- a/addons/website_sale_stock/views/checkout_templates.xml
+++ b/addons/website_sale_stock/views/checkout_templates.xml
@@ -11,7 +11,7 @@
          </t>
          <div name="address_summary_container" position="replace">
              <t t-if="order.partner_shipping_id.pickup_location_data">
-                <p t-att-class="delivery_title_classes">Deliver to pickup point</p>
+                <p t-att-class="delivery_title_classes">Pickup point</p>
                 <div
                     class="fw-bold" t-out="order.partner_shipping_id.pickup_location_data.get('name', '')"
                 />


### PR DESCRIPTION
The Pick up in store has some friction because everything was thought for delivery flows. In this commit, we do some adaptations to smoothen the flow. 

For the templates customization, several approaches were considered. In order to avoid template duplication, we edit the existing templates after the `website_sale_collect` module is installed by adding logic if none exists yet.

task-5896806