### PR TITLE
[FIX] pos_online_payment: only delete online payments

### DIFF
--- a/addons/pos_online_payment/models/pos_order.py
+++ b/addons/pos_online_payment/models/pos_order.py
@@ -21,7 +21,7 @@ class PosOrder(models.Model):
 
     def _clean_payment_lines(self):
         self.ensure_one()
-        order_payments = self.env['pos.payment'].search(['&', ('pos_order_id', '=', self.id), ('online_account_payment_id', '=', False)])
+        order_payments = self.env['pos.payment'].search(['&', ('pos_order_id', '=', self.id), ('online_account_payment_id', '=', False), ('payment_method_id.is_online_payment', '=', True)])
         order_payments.unlink()
 
     def get_and_set_online_payments_data(self, next_online_payment_amount=False):


### PR DESCRIPTION
Before this commit, if an order had a terminal payment and an online payment was added accidentally, and then get removed, the terminal payment would get removed from server, while it won't be removed from the UI, resulting in a mismatch between the server and the UI, and the order would no be synced correctly.

opw-5911699

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
