### PR TITLE
[IMP] mail: add category group in channel search view

### DIFF
--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -145,6 +145,9 @@
                     <filter string="Not Joined" name="filter_not_joined" domain="[('is_member', '=', False)]"/>
                     <separator/>
                     <filter string="Archived" name="filter_archived" domain="[('active', '=', False)]"/>
+                    <group>
+                        <filter string="Categories" name="group_by_categories" context="{'group_by': 'discuss_category_id'}"/>
+                    </group>
                 </search>
             </field>
         </record>


### PR DESCRIPTION
Purpose of this commit:
To add category based group-by in channel search view.

task-5264898
