### PR TITLE
[FIX] purchase_stock: avoid extra product return during backorder

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -94,7 +94,8 @@ class PurchaseOrderLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         lines = super().create(vals_list)
-        lines.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()
+        if not self.env.context.get('bypass_move_update'):
+            lines.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()
         return lines
 
     def write(self, vals):

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -89,7 +89,7 @@ class StockMove(models.Model):
                 po_line_vals['price_unit'] = 0
             purchase_order_lines_vals.append(po_line_vals)
         if purchase_order_lines_vals:
-            self.env['purchase.order.line'].create(purchase_order_lines_vals)
+            self.env['purchase.order.line'].with_context(bypass_move_update=True).create(purchase_order_lines_vals)
         return super()._action_synch_order()
 
     def _should_ignore_pol_price(self):

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -39,6 +39,9 @@ class TestCreatePicking(ProductVariantsCommon):
         }
 
     def test_00_create_picking(self):
+        """
+        Check that purchase orders and receipts are properly synchronized.
+        """
 
         # Draft purchase order created
         self.po = self.env['purchase.order'].create(self.po_vals)
@@ -54,9 +57,9 @@ class TestCreatePicking(ProductVariantsCommon):
         self.assertEqual(len(self.po.order_line.move_ids), 1, 'The two moves should be merged in one')
 
         # Validate first shipment
-        self.picking = self.po.picking_ids[0]
-        self.picking.move_ids.picked = True
-        self.picking._action_done()
+        receipt_1 = self.po.picking_ids[0]
+        receipt_1.move_ids.picked = True
+        receipt_1._action_done()
         self.assertEqual(self.po.order_line.mapped('qty_received'), [7.0], 'Purchase: all products should be received')
 
         # create new order line
@@ -71,6 +74,24 @@ class TestCreatePicking(ProductVariantsCommon):
         self.assertEqual(self.po.incoming_picking_count, 2, 'New picking should be created')
         moves = self.po.order_line.mapped('move_ids').filtered(lambda x: x.state not in ('done', 'cancel'))
         self.assertEqual(len(moves), 1, 'One moves should have been created')
+        # In second receipt, add product which is not in the PO.
+        receipt_2 = self.po.picking_ids - receipt_1
+        receipt_2.move_ids.quantity = 1
+        receipt_2_form = Form(receipt_2)
+        with receipt_2_form.move_ids.new() as move:
+            move.product_id = self.product_sofa_blue
+            move.quantity = 1.0
+        receipt_2 = receipt_2_form.save()
+        Form.from_action(self.env, receipt_2.button_validate()).save().process()
+        backorder = receipt_2.backorder_ids
+        receipt_type_id = self.ref('stock.picking_type_in')
+
+        self.assertEqual(self.po.picking_ids, receipt_1 | receipt_2 | backorder)
+        self.assertRecordValues(receipt_2.move_line_ids, [
+            {'product_id': self.product_id_2.id, 'quantity': 1, 'picking_type_id': receipt_type_id},
+            {'product_id': self.product_sofa_blue.id, 'quantity': 1, 'picking_type_id': receipt_type_id}])
+        self.assertRecordValues(backorder.move_line_ids, [
+            {'product_id': self.product_id_2.id, 'quantity': 4, 'picking_type_id': receipt_type_id}])
 
     def test_01_check_double_validation(self):
 


### PR DESCRIPTION
When creating a backorder because of missing product, if there is an extra product received it will create a return also create a return for that product.

### Steps to reproduce:

* Create and confirm a purchase ordre for 2 products (A & B)
* Add a product C to the picking order and reduce the quantity of product B received
* Validate the picking ordre
* Create a backorder
* Go back on the PO and open the linked pickings 
-> There is delivery linked for product C

### Observation:

When processing the backorder, it will sync the delivery and the PO with _action_synch_order where it will add the new product to the PO: https://github.com/odoo/odoo/blob/1a62c4333de61a4e1358ef8e229b2e0f5a3e9826/addons/purchase_stock/models/stock_move.py#L88-L89 
The create that is started by the creation of the new POL will trigger _create_or_update_picking that will create a stock move and a picking: https://github.com/odoo/odoo/blob/2855f0f2b0ffbc340e2af4785dde5bf465579ee8/addons/purchase_stock/models/purchase_order_line.py#L97 https://github.com/odoo/odoo/blob/2855f0f2b0ffbc340e2af4785dde5bf465579ee8/addons/purchase_stock/models/purchase_order_line.py#L197-L198

opw-5868172
